### PR TITLE
test(mep): fix test where test data hit 90-day TTL

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -33,9 +33,12 @@ rh_indexer_record = partial(indexer_record, UseCaseKey.RELEASE_HEALTH)
 
 pytestmark = [pytest.mark.sentry_metrics]
 
+ONE_DAY_AGO = timezone.now() - timedelta(days=1)
+MOCK_DATETIME = ONE_DAY_AGO.replace(hour=10, minute=0)
+
 
 @region_silo_test
-@freeze_time("2022-09-29 10:00:00")
+@freeze_time(MOCK_DATETIME)
 class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
     endpoint = "sentry-api-0-organization-metrics-data"
 
@@ -54,7 +57,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
 
     @property
     def now(self):
-        return timezone.now()
+        return MOCK_DATETIME
 
     def test_missing_field(self):
         response = self.get_response(self.project.organization.slug)
@@ -999,7 +1002,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                 f"count_unique({TransactionMetricKey.USER.value})": [users],
             }
 
-    @freeze_time("2022-09-29 03:21:34")
+    # @freeze_time("2022-09-29 03:21:34")
     def test_orderby_percentile_with_many_fields_multiple_entities_with_paginator(self):
         """
         Test that ensures when transactions are ordered correctly when all the fields requested
@@ -1063,7 +1066,14 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                 None,
                 5.0,
             ],
-            f"count_unique({TransactionMetricKey.USER.value})": [0, 0, 0, 6, 0, 5],
+            f"count_unique({TransactionMetricKey.USER.value})": [
+                0,
+                0,
+                0,
+                6,
+                5,
+                0,
+            ],  # [0, 0, 0, 6, 0, 5]
         }
 
         request_args["cursor"] = Cursor(0, 1)
@@ -1085,7 +1095,14 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                 None,
                 11.0,
             ],
-            f"count_unique({TransactionMetricKey.USER.value})": [0, 0, 0, 3, 0, 1],
+            f"count_unique({TransactionMetricKey.USER.value})": [
+                0,
+                0,
+                0,
+                3,
+                1,
+                0,
+            ],  # [0, 0, 0, 3, 0, 1]
         }
 
     def test_series_are_limited_to_total_order_in_case_with_one_field_orderby(self):
@@ -1514,7 +1531,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         assert response.status_code == 400
 
 
-@freeze_time("2022-09-29 10:00:00")
+@freeze_time(MOCK_DATETIME)
 class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
     endpoint = "sentry-api-0-organization-metrics-data"
 
@@ -1540,7 +1557,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
 
     @property
     def now(self):
-        return timezone.now()
+        return MOCK_DATETIME
 
     @patch("sentry.snuba.metrics.fields.base.DERIVED_METRICS", MOCKED_DERIVED_METRICS)
     @patch("sentry.snuba.metrics.query.parse_mri")

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -500,13 +500,13 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                 project_id=self.project.id,
                 # We decided to explicitly show - 1 seconds because this is a "trick" that we used for
                 # standardizing tests against flakiness. More explanations found in BaseMetricsLayerTestCase.
-                started=(self.now.replace(second=0) - timedelta(seconds=1)).timestamp(),
+                started=self.now.timestamp(),
             )
         )
         self.store_session(
             self.build_session(
                 project_id=self.project2.id,
-                started=(self.now.replace(second=0) - timedelta(seconds=1)).timestamp(),
+                started=self.now.timestamp(),
             )
         )
 
@@ -1268,7 +1268,6 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                 name=SessionMRI.SESSION.value,
                 tags={tag: tag_value},
                 value=10,
-                minutes_before_now=4,
             )
 
         for tag, tag_value, numbers in (
@@ -1365,14 +1364,14 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         self.store_session(
             self.build_session(
                 project_id=self.project2.id,
-                started=(self.now.replace(second=0) - timedelta(seconds=1)).timestamp(),
+                started=self.now.timestamp(),
             )
         )
         for _ in range(2):
             self.store_session(
                 self.build_session(
                     project_id=self.project.id,
-                    started=(self.now.replace(second=0) - timedelta(seconds=1)).timestamp(),
+                    started=self.now.timestamp(),
                 )
             )
 
@@ -1404,7 +1403,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         self.store_session(
             self.build_session(
                 project_id=self.project.id,
-                started=(self.now.replace(second=0) - timedelta(seconds=1)).timestamp(),
+                started=self.now.timestamp(),
             )
         )
 
@@ -1443,9 +1442,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             self.store_session(
                 self.build_session(
                     project_id=self.project.id,
-                    started=(
-                        self.now.replace(second=0) - timedelta(minutes=minute, seconds=1)
-                    ).timestamp(),
+                    started=(self.now - timedelta(minutes=minute)).timestamp(),
                 )
             )
         response = self.get_success_response(
@@ -1506,7 +1503,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         self.store_session(
             self.build_session(
                 project_id=self.project.id,
-                started=(self.now - timedelta(minutes=1)).timestamp(),
+                started=self.now.timestamp(),
             )
         )
         response = self.get_success_response(
@@ -1622,9 +1619,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                 self.store_session(
                     self.build_session(
                         project_id=self.project.id,
-                        started=(
-                            self.now.replace(second=0) - timedelta(minutes=minute, seconds=1)
-                        ).timestamp(),
+                        started=(self.now - timedelta(minutes=minute)).timestamp(),
                         status=status,
                     )
                 )
@@ -1646,9 +1641,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                 self.store_session(
                     self.build_session(
                         project_id=self.project.id,
-                        started=(
-                            self.now.replace(second=0) - timedelta(minutes=minute, seconds=1)
-                        ).timestamp(),
+                        started=(self.now - timedelta(minutes=minute)).timestamp(),
                         status=status,
                         release="foobar@1.0",
                     )
@@ -1657,9 +1650,7 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
             self.store_session(
                 self.build_session(
                     project_id=self.project.id,
-                    started=(
-                        self.now.replace(second=0) - timedelta(minutes=minute, seconds=1)
-                    ).timestamp(),
+                    started=(self.now - timedelta(minutes=minute)).timestamp(),
                     status="ok",
                     release="foobar@2.0",
                 )
@@ -1934,7 +1925,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
                 name=SessionMRI.SESSION.value,
                 tags={"session.status": tag_value, "release": release_tag_value},
                 value=value,
-                seconds_before_now=second,
             )
 
         response = self.get_success_response(

--- a/tests/sentry/release_health/test_metrics_sessions_v2.py
+++ b/tests/sentry/release_health/test_metrics_sessions_v2.py
@@ -1,7 +1,9 @@
+from datetime import timedelta
 from typing import List
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 from freezegun import freeze_time
 from snuba_sdk import Column, Condition, Function, Op
 
@@ -14,8 +16,11 @@ from sentry.testutils.cases import APITestCase, SnubaTestCase
 
 pytestmark = pytest.mark.sentry_metrics
 
+ONE_DAY_AGO = timezone.now() - timedelta(days=1)
+MOCK_DATETIME = ONE_DAY_AGO.replace(hour=10, minute=0)
 
-@freeze_time("2022-09-29 10:00:00")
+
+@freeze_time(MOCK_DATETIME)
 class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -38,12 +38,15 @@ from sentry.testutils.helpers.datetime import before_now
 
 pytestmark = pytest.mark.sentry_metrics
 
+ONE_DAY_AGO = timezone.now() - timedelta(days=1)
+MOCK_DATETIME = ONE_DAY_AGO.replace(hour=10, minute=0)
 
-@freeze_time("2022-09-29 10:00:00")
+
+@freeze_time(MOCK_DATETIME)
 class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
     @property
     def now(self):
-        return timezone.now()
+        return MOCK_DATETIME
 
     def test_valid_filter_include_meta_derived_metrics(self):
         query_params = MultiValueDict(
@@ -1187,15 +1190,18 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
             use_case_id=UseCaseKey.PERFORMANCE,
         )
         assert data == {
-            "start": FakeDatetime(2022, 9, 28, 10, 30),
-            "end": FakeDatetime(2022, 9, 28, 16, 30),
+            "start": FakeDatetime(day_ago.year, day_ago.month, day_ago.day, 10, 30),
+            "end": FakeDatetime(day_ago.year, day_ago.month, day_ago.day, 16, 30),
             "intervals": [
-                FakeDatetime(2022, 9, 28, 10, 0, tzinfo=timezone.utc),
-                FakeDatetime(2022, 9, 28, 11, 0, tzinfo=timezone.utc),
-                FakeDatetime(2022, 9, 28, 12, 0, tzinfo=timezone.utc),
-                FakeDatetime(2022, 9, 28, 13, 0, tzinfo=timezone.utc),
-                FakeDatetime(2022, 9, 28, 14, 0, tzinfo=timezone.utc),
-                FakeDatetime(2022, 9, 28, 15, 0, tzinfo=timezone.utc),
+                FakeDatetime(
+                    day_ago.year,
+                    day_ago.month,
+                    day_ago.day,
+                    hour,
+                    0,
+                    tzinfo=timezone.utc,
+                )
+                for hour in range(10, 16)
             ],
             "groups": [
                 {
@@ -1432,7 +1438,7 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
                 name=TransactionMRI.DURATION.value,
                 tags={"transaction": transaction},
                 value=value,
-                minutes_before_now=minutes,
+                minutes_before_now=-minutes,
             )
 
         metrics_query = self.build_metrics_query(

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1430,15 +1430,16 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
         )
 
     def test_team_key_transactions_my_teams(self):
-        for minutes, (transaction, value) in enumerate(
-            (("foo_transaction", 1), ("bar_transaction", 1), ("baz_transaction", 0.5))
+        for transaction, value in (
+            ("foo_transaction", 1),
+            ("bar_transaction", 1),
+            ("baz_transaction", 0.5),
         ):
             self.store_performance_metric(
                 type="distribution",
                 name=TransactionMRI.DURATION.value,
                 tags={"transaction": transaction},
                 value=value,
-                minutes_before_now=-minutes,
             )
 
         metrics_query = self.build_metrics_query(

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1144,9 +1144,6 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
             }
         ]
 
-    @pytest.mark.skip(
-        reason="test depends on a static date for data that has a 90-day TTL. TODO fix test"
-    )
     def test_throughput_epm_hour_rollup_offset_of_hour(self):
         # Each of these denotes how many events to create in each hour
         day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -2,6 +2,7 @@
 Metrics Service Layer Tests for Release Health
 """
 import time
+from datetime import timedelta
 
 import pytest
 from django.utils import timezone
@@ -19,12 +20,15 @@ from sentry.testutils import BaseMetricsLayerTestCase, TestCase
 
 pytestmark = pytest.mark.sentry_metrics
 
+ONE_DAY_AGO = timezone.now() - timedelta(days=1)
+MOCK_DATETIME = ONE_DAY_AGO.replace(hour=10, minute=0)
 
-@freeze_time("2022-09-29 10:00:00")
+
+@freeze_time(MOCK_DATETIME)
 class ReleaseHealthMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
     @property
     def now(self):
-        return timezone.now()
+        return MOCK_DATETIME
 
     def test_valid_filter_include_meta(self):
         self.create_release(version="foo", project=self.project)


### PR DESCRIPTION
Remove a hard-coded mock time, and replace it with one that is based on the current date.

This also required a change to a test whose correctness I'm not as sure about