### PR TITLE
chore(vscode): Hide model-manifest from search results

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
     "htmlcov": true,
     "node_modules": true,
     "src/sentry/locale": true,
-    "src/sentry/static/sentry/dist/": true
+    "src/sentry/static/sentry/dist/": true,
+    "model-manifest.json": true,
   },
   "search.followSymlinks": false,
   "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
Not sure what this file is, but its annoying when searching for things since it lists tons of models and classes
