### PR TITLE
ref(tests): Refactor Slack activity tests

### DIFF
--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -13,6 +13,17 @@ from sentry.types.integrations import ExternalProviders
 
 
 class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
+    def create_notification(self, group, notification):
+        return notification(
+            Activity(
+                project=self.project,
+                group=group,
+                user=self.user,
+                type=ActivityType.ASSIGNED,
+                data={"assignee": self.user.id},
+            )
+        )
+
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_multiple_identities(self, mock_func):
@@ -46,17 +57,8 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             content_type="application/json",
         )
 
-        notification = AssignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": self.user.id},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(self.group, AssignedActivityNotification).send()
 
         assert len(responses.calls) >= 2
         data = parse_qs(responses.calls[0].request.body)
@@ -104,17 +106,8 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             content_type="application/json",
         )
 
-        notification = AssignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": self.user.id},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(self.group, AssignedActivityNotification).send()
 
         assert len(responses.calls) == 1
         data = parse_qs(responses.calls[0].request.body)
@@ -128,17 +121,8 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         """
         Test that a Slack message is sent with the expected payload when an issue is assigned
         """
-        notification = AssignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": self.user.id},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(self.group, AssignedActivityNotification).send()
         attachment, text = get_attachment()
         assert text == f"Issue assigned to {self.name} by themselves"
         assert attachment["title"] == self.group.title
@@ -163,24 +147,12 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
         event = event.for_group(event.groups[0])
 
-        notification = AssignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": self.user.id},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group, AssignedActivityNotification).send()
         attachment, text = get_attachment()
         assert text == f"Issue assigned to {self.name} by themselves"
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"
+        self.assert_generic_issue_attachments(
+            attachment, self.project.slug, "assigned_activity-slack-user"
         )
 
     @responses.activate
@@ -190,28 +162,13 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         Test that a Slack message is sent with the expected payload when a performance issue is assigned
         """
         event = self.create_performance_issue()
-        notification = AssignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": self.user.id},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group, AssignedActivityNotification).send()
 
         attachment, text = get_attachment()
         assert text == f"Issue assigned to {self.name} by themselves"
-        assert attachment["title"] == "N+1 Query"
-        assert (
-            attachment["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"
+        self.assert_performance_issue_attachments(
+            attachment, self.project.slug, "assigned_activity-slack-user"
         )
 
     def test_automatic_assignment(self):

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -93,14 +93,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification.send()
 
         attachment, text = get_attachment()
-        assert attachment["title"] == "N+1 Query"
-        assert (
-            attachment["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
+        self.assert_performance_issue_attachments(
+            attachment, self.project.slug, "issue_alert-slack-user", "alerts"
         )
 
     @responses.activate
@@ -124,11 +118,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification.send()
 
         attachment, text = get_attachment()
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
+        self.assert_generic_issue_attachments(
+            attachment, self.project.slug, "issue_alert-slack-user", "alerts"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -11,21 +11,24 @@ from sentry.types.activity import ActivityType
 
 
 class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
+    def create_notification(self, group):
+        return NoteActivityNotification(
+            Activity(
+                project=self.project,
+                group=group,
+                user=self.user,
+                type=ActivityType.NOTE,
+                data={"text": "text", "mentions": []},
+            )
+        )
+
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_note(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when a comment is made on an issue
         """
-        notification = NoteActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.NOTE,
-                data={"text": "text", "mentions": []},
-            )
-        )
+        notification = self.create_notification(self.group)
         with self.tasks():
             notification.send()
 
@@ -50,15 +53,8 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         Test that a Slack message is sent with the expected payload when a comment is made on a performance issue
         """
         event = self.create_performance_issue()
-        notification = NoteActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.NOTE,
-                data={"text": "text", "mentions": []},
-            )
-        )
+        notification = self.create_notification(event.group)
+
         with self.tasks():
             notification.send()
 
@@ -90,15 +86,8 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
             data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
         )
         event = event.for_group(event.groups[0])
-        notification = NoteActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.NOTE,
-                data={"text": "text", "mentions": []},
-            )
-        )
+        notification = self.create_notification(event.group)
+
         with self.tasks():
             notification.send()
 

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -11,23 +11,25 @@ from sentry.types.activity import ActivityType
 
 
 class SlackRegressionNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
+    def create_notification(self, group):
+        return RegressionActivityNotification(
+            Activity(
+                project=self.project,
+                group=group,
+                user=self.user,
+                type=ActivityType.SET_REGRESSION,
+                data={},
+            )
+        )
+
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_regression(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
         """
-        notification = RegressionActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.SET_REGRESSION,
-                data={},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(self.group).send()
 
         attachment, text = get_attachment()
         assert text == "Issue marked as regression"
@@ -45,28 +47,13 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         Test that a Slack message is sent with the expected payload when a performance issue regresses
         """
         event = self.create_performance_issue()
-        notification = RegressionActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.SET_REGRESSION,
-                data={},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group).send()
 
         attachment, text = get_attachment()
         assert text == "Issue marked as regression"
-        assert attachment["title"] == "N+1 Query"
-        assert (
-            attachment["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
+        self.assert_performance_issue_attachments(
+            attachment, self.project.slug, "regression_activity-slack-user"
         )
 
     @responses.activate
@@ -84,23 +71,12 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
         )
         event = event.for_group(event.groups[0])
-        notification = RegressionActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.SET_REGRESSION,
-                data={},
-            )
-        )
+
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group).send()
 
         attachment, text = get_attachment()
         assert text == "Issue marked as regression"
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
+        self.assert_generic_issue_attachments(
+            attachment, self.project.slug, "regression_activity-slack-user"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -11,23 +11,25 @@ from sentry.types.activity import ActivityType
 
 
 class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
+    def create_notification(self, group):
+        return ResolvedActivityNotification(
+            Activity(
+                project=self.project,
+                group=group,
+                user=self.user,
+                type=ActivityType.SET_RESOLVED,
+                data={"assignee": ""},
+            )
+        )
+
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_resolved(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved
         """
-        notification = ResolvedActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.SET_RESOLVED,
-                data={"assignee": ""},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(self.group).send()
 
         attachment, text = get_attachment()
         assert (
@@ -46,31 +48,16 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         Test that a Slack message is sent with the expected payload when a performance issue is resolved
         """
         event = self.create_performance_issue()
-        notification = ResolvedActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.SET_RESOLVED,
-                data={"assignee": ""},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group).send()
 
         attachment, text = get_attachment()
         assert (
             text
             == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=activity_notification|{self.project.slug.upper()}-{event.group.short_id}> as resolved"
         )
-        assert attachment["title"] == "N+1 Query"
-        assert (
-            attachment["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
+        self.assert_performance_issue_attachments(
+            attachment, self.project.slug, "resolved_activity-slack-user"
         )
 
     @responses.activate
@@ -88,26 +75,14 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
         )
         event = event.for_group(event.groups[0])
-        notification = ResolvedActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.SET_RESOLVED,
-                data={"assignee": ""},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group).send()
 
         attachment, text = get_attachment()
         assert (
             text
             == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=activity_notification|{self.project.slug.upper()}-{event.group.short_id}> as resolved"
         )
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
+        self.assert_generic_issue_attachments(
+            attachment, self.project.slug, "resolved_activity-slack-user"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -13,21 +13,24 @@ from sentry.types.activity import ActivityType
 class SlackResolvedInReleaseNotificationTest(
     SlackActivityNotificationTest, PerformanceIssueTestCase
 ):
+    def create_notification(self, group):
+        return ResolvedInReleaseActivityNotification(
+            Activity(
+                project=self.project,
+                group=group,
+                user=self.user,
+                type=ActivityType.SET_RESOLVED_IN_RELEASE,
+                data={"version": "meow"},
+            )
+        )
+
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_resolved_in_release(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved in a release
         """
-        notification = ResolvedInReleaseActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.SET_RESOLVED_IN_RELEASE,
-                data={"version": "meow"},
-            )
-        )
+        notification = self.create_notification(self.group)
         with self.tasks():
             notification.send()
 
@@ -46,29 +49,15 @@ class SlackResolvedInReleaseNotificationTest(
         Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
         """
         event = self.create_performance_issue()
-        notification = ResolvedInReleaseActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.SET_RESOLVED_IN_RELEASE,
-                data={"version": "meow"},
-            )
-        )
+        notification = self.create_notification(event.group)
         with self.tasks():
             notification.send()
 
         attachment, text = get_attachment()
         release_name = notification.activity.data["version"]
         assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        assert attachment["title"] == "N+1 Query"
-        assert (
-            attachment["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
+        self.assert_performance_issue_attachments(
+            attachment, self.project.slug, "resolved_in_release_activity-slack-user"
         )
 
     @responses.activate
@@ -86,24 +75,13 @@ class SlackResolvedInReleaseNotificationTest(
             data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
         )
         event = event.for_group(event.groups[0])
-        notification = ResolvedInReleaseActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.SET_RESOLVED_IN_RELEASE,
-                data={"version": "meow"},
-            )
-        )
+        notification = self.create_notification(event.group)
         with self.tasks():
             notification.send()
 
         attachment, text = get_attachment()
         release_name = notification.activity.data["version"]
         assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
+        self.assert_generic_issue_attachments(
+            attachment, self.project.slug, "resolved_in_release_activity-slack-user"
         )

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -11,23 +11,25 @@ from sentry.types.activity import ActivityType
 
 
 class SlackUnassignedNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
+    def create_notification(self, group):
+        return UnassignedActivityNotification(
+            Activity(
+                project=self.project,
+                group=group,
+                user=self.user,
+                type=ActivityType.ASSIGNED,
+                data={"assignee": ""},
+            )
+        )
+
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_unassignment(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is unassigned
         """
-        notification = UnassignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=self.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": ""},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(self.group).send()
 
         attachment, text = get_attachment()
         assert text == f"Issue unassigned by {self.name}"
@@ -44,28 +46,13 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         Test that a Slack message is sent with the expected payload when a performance issue is unassigned
         """
         event = self.create_performance_issue()
-        notification = UnassignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": ""},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group).send()
 
         attachment, text = get_attachment()
         assert text == f"Issue unassigned by {self.name}"
-        assert attachment["title"] == "N+1 Query"
-        assert (
-            attachment["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
+        self.assert_performance_issue_attachments(
+            attachment, self.project.slug, "unassigned_activity-slack-user"
         )
 
     @responses.activate
@@ -83,23 +70,11 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
             data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
         )
         event = event.for_group(event.groups[0])
-        notification = UnassignedActivityNotification(
-            Activity(
-                project=self.project,
-                group=event.group,
-                user=self.user,
-                type=ActivityType.ASSIGNED,
-                data={"assignee": ""},
-            )
-        )
         with self.tasks():
-            notification.send()
+            self.create_notification(event.group).send()
 
         attachment, text = get_attachment()
         assert text == f"Issue unassigned by {self.name}"
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
+        self.assert_generic_issue_attachments(
+            attachment, self.project.slug, "unassigned_activity-slack-user"
         )


### PR DESCRIPTION
Move repeated code into a shared location to dry up the Slack activity tests. As we've added new issue types it's become evident how much is repeated.

Closes #42227