### PR TITLE
ref(crons): Add MonitorCheckIn to cleanup.py

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -180,6 +180,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             (models.GroupEmailThread, "date", None),
             (models.GroupRuleStatus, "date_added", None),
             (models.RuleFireHistory, "date_added", None),
+            (models.MonitorCheckIn, "date_added", None),
         ] + EXTRA_BULK_QUERY_DELETES
 
         # Deletions that use the `deletions` code path (which handles their child relations)
@@ -187,7 +188,6 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
         DELETES = [
             (models.EventAttachment, "date_added", "date_added"),
             (replay_models.ReplayRecordingSegment, "date_added", "date_added"),
-            (models.MonitorCheckIn, "date_added", "date_added"),
         ]
         # Deletions that we run per project. In some cases we can't use an index on just the date
         # column, so as an alternative we use `(project_id, <date_col>)` instead

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -187,6 +187,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
         DELETES = [
             (models.EventAttachment, "date_added", "date_added"),
             (replay_models.ReplayRecordingSegment, "date_added", "date_added"),
+            (models.MonitorCheckIn, "date_added", "date_added"),
         ]
         # Deletions that we run per project. In some cases we can't use an index on just the date
         # column, so as an alternative we use `(project_id, <date_col>)` instead


### PR DESCRIPTION
Should automatically clean these up after 90 days.

Accompanied by https://github.com/getsentry/ops/pull/5850

Fixes: https://github.com/getsentry/team-crons/issues/6