### PR TITLE
fix(crons): Match permissions on the checkin details endpoint

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkin_details.py
+++ b/src/sentry/api/endpoints/monitor_checkin_details.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import Endpoint, pending_silo_endpoint
+from sentry.api.bases.monitor import MonitorEndpoint
 from sentry.api.bases.project import ProjectPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.empty_integer import EmptyIntegerField
@@ -36,7 +37,7 @@ class CheckInSerializer(serializers.Serializer):
 
 @pending_silo_endpoint
 class MonitorCheckInDetailsEndpoint(Endpoint):
-    authentication_classes = Endpoint.authentication_classes + (DSNAuthentication,)
+    authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
     permission_classes = (ProjectPermission,)
 
     # TODO(dcramer): this code needs shared with other endpoints as its security focused


### PR DESCRIPTION
Match this permission class with the endpoint here.

https://github.com/getsentry/sentry/blob/7cfdb82b2fd1dcba5aeea3b317db67a192716e2f/src/sentry/api/endpoints/monitor_checkins.py#L30

In the future we can share this endpoint code more, but for now just doing this to resolve: https://github.com/getsentry/team-crons/issues/8