### PR TITLE
fix(test): Fix flaky performance issue email test

### DIFF
--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -197,7 +197,7 @@ def make_performance_event(project):
         perf_data = dict(
             load_data(
                 "transaction-n-plus-one",
-                timestamp=datetime(2022, 11, 11, 21, 39, 23, 30723),
+                timestamp=datetime(2017, 9, 6, 0, 0),
             )
         )
         perf_data["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
@@ -205,6 +205,8 @@ def make_performance_event(project):
         perf_event_manager.normalize()
         perf_data = perf_event_manager.get_data()
         perf_event = perf_event_manager.save(project.id)
+        # Prevent CI screenshot from constantly changing
+        perf_event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
 
     perf_event = perf_event.for_group(perf_event.groups[0])
     return perf_event

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -19,7 +19,7 @@ EMAILS = (
     ("/debug/mail/unable-to-fetch-commits/", "unable to fetch commits"),
     ("/debug/mail/unable-to-delete-repo/", "unable to delete repo"),
     ("/debug/mail/error-alert/", "alert"),
-    # ("/debug/mail/performance-alert/", "performance"), TODO: Flaky: GRW-778
+    ("/debug/mail/performance-alert/", "performance"),
     ("/debug/mail/digest/", "digest"),
     ("/debug/mail/invalid-identity/", "invalid identity"),
     ("/debug/mail/invitation/", "invitation"),


### PR DESCRIPTION
Hardcode the date (again?) for a performance event in an attempt to make this test not flaky. 

(Hopefully) Closes #42402 and [GRW-778](https://getsentry.atlassian.net/browse/GRW-778)

[GRW-778]: https://getsentry.atlassian.net/browse/GRW-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRW-778]: https://getsentry.atlassian.net/browse/GRW-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ