### PR TITLE
fix(performance): landing page error with empty search empty

### DIFF
--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -189,7 +189,7 @@ function SearchBar(props: SearchBarProps) {
   const handleSearch = (query: string) => {
     setSearchResults([]);
     setSearchString(query);
-    onSearch(`transaction:${query}`);
+    onSearch(query ? `transaction:${query}` : '');
     closeDropdown();
   };
 

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -20,7 +20,7 @@ import {PerformanceLanding} from 'sentry/views/performance/landing';
 import {REACT_NATIVE_COLUMN_TITLES} from 'sentry/views/performance/landing/data';
 import {LandingDisplayField} from 'sentry/views/performance/landing/utils';
 
-const searchHanlderMock = jest.fn();
+const searchHandlerMock = jest.fn();
 
 const WrappedComponent = ({data, withStaticFilters = false}) => {
   const eventView = generatePerformanceEventView(data.router.location, data.projects, {
@@ -44,7 +44,7 @@ const WrappedComponent = ({data, withStaticFilters = false}) => {
             projects={data.projects}
             selection={eventView.getPageFilters()}
             onboardingProject={undefined}
-            handleSearch={searchHanlderMock}
+            handleSearch={searchHandlerMock}
             handleTrendsClick={() => {}}
             setError={() => {}}
             withStaticFilters={withStaticFilters}
@@ -322,7 +322,7 @@ describe('Performance > Landing > Index', function () {
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
       userEvent.type(screen.getByPlaceholderText('Search Transactions'), '{enter}');
-      expect(searchHanlderMock).toHaveBeenCalledWith('', 'transactionsOnly');
+      expect(searchHandlerMock).toHaveBeenCalledWith('', 'transactionsOnly');
     });
 
     it('renders the search bar', async function () {

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -22,14 +22,6 @@ import {LandingDisplayField} from 'sentry/views/performance/landing/utils';
 
 const searchHanlderMock = jest.fn();
 
-const expectDiscoverQueryContaining = (query: string) => {
-  return expect.objectContaining({
-    query: expect.objectContaining({
-      query,
-    }),
-  });
-};
-
 const WrappedComponent = ({data, withStaticFilters = false}) => {
   const eventView = generatePerformanceEventView(data.router.location, data.projects, {
     withStaticFilters,
@@ -326,36 +318,11 @@ describe('Performance > Landing > Index', function () {
         ],
       });
 
-      wrapper = render(
-        <WrappedComponent data={data} withStaticFilters />,
-        data.routerContext
-      );
+      render(<WrappedComponent data={data} withStaticFilters />, data.routerContext);
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
       userEvent.type(screen.getByPlaceholderText('Search Transactions'), '{enter}');
       expect(searchHanlderMock).toHaveBeenCalledWith('', 'transactionsOnly');
-    });
-
-    it('searches for events while typing', async function () {
-      const data = initializeData({
-        features: [
-          'performance-transaction-name-only-search',
-          'performance-transaction-name-only-search-indexed',
-        ],
-      });
-
-      wrapper = render(
-        <WrappedComponent data={data} withStaticFilters />,
-        data.routerContext
-      );
-
-      await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
-      userEvent.type(screen.getByPlaceholderText('Search Transactions'), 'test');
-      expect(eventsMock).toHaveBeenLastCalledWith(
-        '/organizations/org-slug/events/',
-        expectDiscoverQueryContaining('transaction:*test* event.type:transaction')
-      );
-      expect(searchHanlderMock).not.toHaveBeenCalled();
     });
 
     it('renders the search bar', async function () {


### PR DESCRIPTION
Fixes PERF-1895
and address issue 1 of #42692 

When the user clicks enter on an empty search bar, we would search for a transaction with the value `""` causing missing data
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/44422760/210013115-2c329cf8-c525-4505-892c-3e699f2e6d1d.png">

Now we just bring the user back to no transaction filters (as it is when you just click on the performance tab)
