### PR TITLE
fix(all-events): error state cannot be removed

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {Location} from 'history';
 
 import LoadingError from 'sentry/components/loadingError';
@@ -22,13 +22,16 @@ const AllEventsTable = (props: Props) => {
   const {location, organization, issueId, excludedTags, group} = props;
   const [error, setError] = useState<string>('');
   const routes = useRoutes();
-
   const {fields, columnTitles} = getColumns(group, organization);
 
   const eventView: EventView = EventView.fromLocation(props.location);
   eventView.fields = fields.map(fieldName => ({field: fieldName}));
 
   eventView.sorts = decodeSorts(location).filter(sort => fields.includes(sort.field));
+
+  useEffect(() => {
+    setError('');
+  }, [eventView.query]);
 
   if (!eventView.sorts.length) {
     eventView.sorts = [{field: 'timestamp', kind: 'desc'}];
@@ -43,7 +46,7 @@ const AllEventsTable = (props: Props) => {
   eventView.statsPeriod = '90d';
 
   if (error) {
-    return <LoadingError message={error} />;
+    return <LoadingError message={error} onRetry={() => setError('')} />;
   }
 
   const isReplayEnabled = organization.features.includes('session-replay-ui');


### PR DESCRIPTION
Fixes PERF-1806

If an error occurs in the events tab, the following will show,
<img width="773" alt="image" src="https://user-images.githubusercontent.com/44422760/210105565-d24c3ca6-3fae-406d-992c-7989447c9f08.png">
The user cannot retry the search if it failed, and they cannot change or remove the search. 
The table becomes permanently in an error state.

This PR adds a retry button and fixes the inability to update the query once an error state is reached.
