### PR TITLE
feat(profiling): wire up span interactions

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -301,9 +301,9 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
     }
 
     const onConfigViewChange = (rect: Rect) => {
-      flamegraphView.setConfigView(rect);
+      flamegraphView.setConfigView(rect.withHeight(flamegraphView.configView.height));
       if (spansView) {
-        spansView.setConfigView(rect);
+        spansView.setConfigView(rect.withHeight(spansView.configView.height));
       }
       canvasPoolManager.draw();
     };

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -27,7 +27,10 @@ import {
 import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
 import {FlamegraphZoomViewMinimap} from 'sentry/components/profiling/flamegraph/flamegraphZoomViewMinimap';
 import {defined} from 'sentry/utils';
-import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {
+  CanvasPoolManager,
+  useCanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
@@ -107,7 +110,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
   const [spansCanvasRef, setSpansCanvasRef] = useState<HTMLCanvasElement | null>(null);
 
   const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);
-  const scheduler = useMemo(() => new CanvasScheduler(), []);
+  const scheduler = useCanvasScheduler(canvasPoolManager);
 
   const profile = useMemo(() => {
     return props.profiles.profiles.find(p => p.threadId === threadId);
@@ -357,11 +360,6 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
     spansCanvas,
     spansView,
   ]);
-
-  useEffect(() => {
-    canvasPoolManager.registerScheduler(scheduler);
-    return () => canvasPoolManager.unregisterScheduler(scheduler);
-  }, [canvasPoolManager, scheduler]);
 
   useLayoutEffect(() => {
     if (

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -276,7 +276,7 @@ export function FlamegraphTreeTable({
           <div ref={hoveredGhostRowRef} />
           <div ref={clickedGhostRowRef} />
           <div
-            ref={ref => setScrollContainerRef(ref)}
+            ref={setScrollContainerRef}
             style={scrollContainerStyles}
             onContextMenu={contextMenu.handleContextMenu}
           >

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -1,20 +1,34 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {mat3, vec2} from 'gl-matrix';
+import {vec2} from 'gl-matrix';
 
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
 import {t} from 'sentry/locale';
-import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {
+  CanvasPoolManager,
+  useCanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
-import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {formatColorForSpan, Rect} from 'sentry/utils/profiling/gl/utils';
+import {
+  formatColorForSpan,
+  getConfigViewTranslationBetweenVectors,
+  getPhysicalSpacePositionFromOffset,
+  Rect,
+} from 'sentry/utils/profiling/gl/utils';
 import {SelectedFrameRenderer} from 'sentry/utils/profiling/renderers/selectedFrameRenderer';
 import {SpanChartRenderer2D} from 'sentry/utils/profiling/renderers/spansRenderer';
 import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
-import usePrevious from 'sentry/utils/usePrevious';
+import {useProfileTransaction} from 'sentry/views/profiling/profileGroupProvider';
 
+import {useCanvasScroll} from './interactions/useCanvasScroll';
+import {useCanvasZoomOrScroll} from './interactions/useCanvasZoomOrScroll';
+import {useDrawHoveredBorderEffect} from './interactions/useDrawHoveredBorderEffect';
+import {useDrawSelectedBorderEffect} from './interactions/useDrawSelectedBorderEffect';
+import {useInteractionViewCheckPoint} from './interactions/useInteractionViewCheckPoint';
+import {useWheelCenterZoom} from './interactions/useWheelCenterZoom';
 import {
   FlamegraphTooltipColorIndicator,
   FlamegraphTooltipFrameMainInfo,
@@ -47,19 +61,17 @@ export function FlamegraphSpans({
   spansCanvasRef,
   setSpansCanvasRef,
 }: FlamegraphSpansProps) {
-  const dispatch = useDispatchFlamegraphState();
   const flamegraphTheme = useFlamegraphTheme();
-  const scheduler = useMemo(() => new CanvasScheduler(), []);
+  const scheduler = useCanvasScheduler(canvasPoolManager);
+  const profiledTransaction = useProfileTransaction();
 
   const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
-  const [startPanVector, setStartPanVector] = useState<vec2 | null>(null);
+  const [startInteractionVector, setStartInteractionVector] = useState<vec2 | null>(null);
   const [lastInteraction, setLastInteraction] = useState<
     'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null
   >(null);
 
-  const previousInteraction = usePrevious(lastInteraction);
-  const beforeInteractionConfigView = useRef<Rect | null>(null);
-  const selectedFramesRef = useRef<SpanChartNode[] | null>(null);
+  const selectedSpansRef = useRef<SpanChartNode[] | null>(null);
 
   const spansRenderer = useMemo(() => {
     if (!spansCanvasRef) {
@@ -85,33 +97,6 @@ export function FlamegraphSpans({
   }, [configSpaceCursor, spansRenderer]);
 
   useEffect(() => {
-    if (!spansView) {
-      return;
-    }
-
-    // Check if we are starting a new interaction
-    if (previousInteraction === null && lastInteraction) {
-      beforeInteractionConfigView.current = spansView.configView.clone();
-      return;
-    }
-
-    if (
-      beforeInteractionConfigView.current &&
-      !beforeInteractionConfigView.current.equals(spansView.configView)
-    ) {
-      dispatch({
-        type: 'checkpoint',
-        payload: spansView.configView.clone(),
-      });
-    }
-  }, [lastInteraction, spansView, dispatch, previousInteraction]);
-
-  useEffect(() => {
-    canvasPoolManager.registerScheduler(scheduler);
-    return () => canvasPoolManager.unregisterScheduler(scheduler);
-  }, [canvasPoolManager, scheduler]);
-
-  useEffect(() => {
     if (!spansCanvas || !spansView || !spansRenderer) {
       return undefined;
     }
@@ -121,7 +106,6 @@ export function FlamegraphSpans({
     };
 
     drawSpans();
-
     scheduler.registerBeforeFrameCallback(drawSpans);
 
     return () => {
@@ -129,99 +113,33 @@ export function FlamegraphSpans({
     };
   }, [spansCanvas, spansRenderer, scheduler, spansView]);
 
-  useEffect(() => {
-    if (!spansCanvasRef || !spansView || !spansCanvas || !selectedSpanRenderer) {
-      return undefined;
-    }
-
-    const drawHoveredSpanBorder = () => {
-      if (hoveredNode) {
-        selectedSpanRenderer.draw(
-          [
-            new Rect(
-              hoveredNode.start,
-              hoveredNode.depth,
-              hoveredNode.end - hoveredNode.start,
-              1
-            ),
-          ],
-          {
-            BORDER_COLOR: flamegraphTheme.COLORS.HOVERED_FRAME_BORDER_COLOR,
-            BORDER_WIDTH: flamegraphTheme.SIZES.HOVERED_FRAME_BORDER_WIDTH,
-          },
-          spansView.fromTransformedConfigView(spansCanvas.physicalSpace)
-        );
-      }
-    };
-
-    scheduler.registerAfterFrameCallback(drawHoveredSpanBorder);
-    scheduler.draw();
-
-    return () => {
-      scheduler.unregisterAfterFrameCallback(drawHoveredSpanBorder);
-    };
-  }, [
-    spansCanvas,
-    spansView,
-    selectedSpanRenderer,
-    scheduler,
-    spansCanvasRef,
-    flamegraphTheme,
-    hoveredNode,
-  ]);
-
   const onMouseDrag = useCallback(
     (evt: React.MouseEvent<HTMLCanvasElement>) => {
-      if (!spansCanvas || !spansView || !startPanVector) {
+      if (!spansCanvas || !spansView || !startInteractionVector) {
         return;
       }
 
-      const logicalMousePos = vec2.fromValues(
+      const configDelta = getConfigViewTranslationBetweenVectors(
         evt.nativeEvent.offsetX,
-        evt.nativeEvent.offsetY
+        evt.nativeEvent.offsetY,
+        startInteractionVector,
+        spansView,
+        spansCanvas
       );
 
-      const physicalMousePos = vec2.scale(
-        vec2.create(),
-        logicalMousePos,
-        window.devicePixelRatio
-      );
-
-      const physicalDelta = vec2.subtract(
-        vec2.create(),
-        startPanVector,
-        physicalMousePos
-      );
-
-      if (physicalDelta[0] === 0 && physicalDelta[1] === 0) {
+      if (!configDelta) {
         return;
       }
 
-      const physicalToConfig = mat3.invert(
-        mat3.create(),
-        spansView.fromConfigView(spansCanvas.physicalSpace)
+      canvasPoolManager.dispatch('transform config view', [configDelta]);
+      setStartInteractionVector(
+        getPhysicalSpacePositionFromOffset(
+          evt.nativeEvent.offsetX,
+          evt.nativeEvent.offsetY
+        )
       );
-      const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
-
-      const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
-        m00,
-        m01,
-        m02,
-        m10,
-        m11,
-        m12,
-        0,
-        0,
-        0,
-      ]);
-
-      canvasPoolManager.dispatch('transform config view', [
-        mat3.fromTranslation(mat3.create(), configDelta),
-      ]);
-
-      setStartPanVector(physicalMousePos);
     },
-    [spansCanvas, spansView, startPanVector, canvasPoolManager]
+    [spansCanvas, spansView, startInteractionVector, canvasPoolManager]
   );
 
   const onCanvasMouseMove = useCallback(
@@ -237,14 +155,14 @@ export function FlamegraphSpans({
 
       setConfigSpaceCursor(configSpaceMouse);
 
-      if (startPanVector) {
+      if (startInteractionVector) {
         onMouseDrag(evt);
         setLastInteraction('pan');
       } else {
         setLastInteraction(null);
       }
     },
-    [spansCanvas, spansView, onMouseDrag, startPanVector]
+    [spansCanvas, spansView, onMouseDrag, startInteractionVector]
   );
 
   const onMinimapCanvasMouseUp = useCallback(() => {
@@ -252,144 +170,42 @@ export function FlamegraphSpans({
     setLastInteraction(null);
   }, []);
 
-  const onMinimapZoom = useCallback(
-    (evt: WheelEvent) => {
-      if (!spansCanvas || !spansView) {
-        return;
-      }
+  const onWheelCenterZoom = useWheelCenterZoom(spansCanvas, spansView, canvasPoolManager);
+  const onCanvasScroll = useCanvasScroll(spansCanvas, spansView, canvasPoolManager);
 
-      const identity = mat3.identity(mat3.create());
-      const scale = 1 - evt.deltaY * 0.001 * -1; // -1 to invert scale
+  useCanvasZoomOrScroll({
+    lastInteraction,
+    configSpaceCursor,
+    setConfigSpaceCursor,
+    setLastInteraction,
+    handleWheel: onWheelCenterZoom,
+    handleScroll: onCanvasScroll,
+    canvas: spansCanvasRef,
+  });
 
-      const mouseInConfigSpace = spansView.getTransformedConfigViewCursor(
-        vec2.fromValues(evt.offsetX, evt.offsetY),
-        spansCanvas
-      );
+  useDrawSelectedBorderEffect({
+    scheduler,
+    selectedRef: selectedSpansRef,
+    canvas: spansCanvas,
+    view: spansView,
+    eventKey: 'highlight span',
+    theme: flamegraphTheme,
+    renderer: selectedSpanRenderer,
+  });
 
-      const configCenter = vec2.fromValues(mouseInConfigSpace[0], spansView.configView.y);
+  useDrawHoveredBorderEffect({
+    scheduler,
+    hoveredNode,
+    canvas: spansCanvas,
+    view: spansView,
+    theme: flamegraphTheme,
+    renderer: selectedSpanRenderer,
+  });
 
-      const invertedConfigCenter = vec2.multiply(
-        vec2.create(),
-        vec2.fromValues(-1, -1),
-        configCenter
-      );
-
-      const translated = mat3.translate(mat3.create(), identity, configCenter);
-      const scaled = mat3.scale(mat3.create(), translated, vec2.fromValues(scale, 1));
-      const translatedBack = mat3.translate(mat3.create(), scaled, invertedConfigCenter);
-
-      canvasPoolManager.dispatch('transform config view', [translatedBack]);
-    },
-    [spansCanvas, spansView, canvasPoolManager]
-  );
-
-  const onMinimapScroll = useCallback(
-    (evt: WheelEvent) => {
-      if (!spansCanvas || !spansView) {
-        return;
-      }
-
-      {
-        const physicalDelta = vec2.fromValues(evt.deltaX * 0.8, evt.deltaY);
-        const physicalToConfig = mat3.invert(
-          mat3.create(),
-          spansView.fromConfigView(spansCanvas.physicalSpace)
-        );
-        const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
-
-        const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
-          m00,
-          m01,
-          m02,
-          m10,
-          m11,
-          m12,
-          0,
-          0,
-          0,
-        ]);
-
-        const translate = mat3.fromTranslation(mat3.create(), configDelta);
-        canvasPoolManager.dispatch('transform config view', [translate]);
-      }
-    },
-    [spansCanvas, spansView, canvasPoolManager]
-  );
-
-  useEffect(() => {
-    if (!spansCanvas || !spansView || !selectedSpanRenderer) {
-      return undefined;
-    }
-
-    const onNodeHighlight = (
-      node: SpanChartNode[] | null,
-      mode: 'hover' | 'selected'
-    ) => {
-      if (mode === 'selected') {
-        selectedFramesRef.current = node;
-      }
-      scheduler.draw();
-    };
-
-    const drawSelectedFrameBorder = () => {
-      if (selectedFramesRef.current) {
-        selectedSpanRenderer.draw(
-          selectedFramesRef.current.map(frame => {
-            return new Rect(frame.start, frame.depth, frame.end - frame.start, 1);
-          }),
-          {
-            BORDER_COLOR: flamegraphTheme.COLORS.SELECTED_FRAME_BORDER_COLOR,
-            BORDER_WIDTH: flamegraphTheme.SIZES.FRAME_BORDER_WIDTH,
-          },
-          spansView.fromTransformedConfigView(spansCanvas.physicalSpace)
-        );
-      }
-    };
-
-    scheduler.on('highlight span', onNodeHighlight);
-    scheduler.registerAfterFrameCallback(drawSelectedFrameBorder);
-    scheduler.draw();
-
-    return () => {
-      scheduler.off('highlight span', onNodeHighlight);
-      scheduler.unregisterAfterFrameCallback(drawSelectedFrameBorder);
-    };
-  }, [spansCanvas, spansView, selectedSpanRenderer, scheduler, flamegraphTheme]);
-
-  useEffect(() => {
-    if (!spansCanvasRef) {
-      return undefined;
-    }
-
-    let wheelStopTimeoutId: number | undefined;
-    function onCanvasWheel(evt: WheelEvent) {
-      window.clearTimeout(wheelStopTimeoutId);
-      wheelStopTimeoutId = window.setTimeout(() => {
-        setLastInteraction(null);
-      }, 300);
-
-      evt.preventDefault();
-
-      // When we zoom, we want to clear cursor so that any tooltips
-      // rendered on the flamegraph are removed from the view
-      setConfigSpaceCursor(null);
-
-      if (evt.metaKey || evt.ctrlKey) {
-        onMinimapZoom(evt);
-        setLastInteraction('zoom');
-      } else {
-        onMinimapScroll(evt);
-        setLastInteraction('scroll');
-      }
-    }
-
-    spansCanvasRef.addEventListener('wheel', onCanvasWheel);
-
-    return () => {
-      window.clearTimeout(wheelStopTimeoutId);
-      spansCanvasRef.removeEventListener('wheel', onCanvasWheel);
-    };
-  }, [spansCanvasRef, onMinimapZoom, onMinimapScroll]);
+  useInteractionViewCheckPoint({
+    view: spansView,
+    lastInteraction,
+  });
 
   useEffect(() => {
     window.addEventListener('mouseup', onMinimapCanvasMouseUp);
@@ -401,24 +217,15 @@ export function FlamegraphSpans({
 
   const onCanvasMouseLeave = useCallback(() => {
     setConfigSpaceCursor(null);
-    setStartPanVector(null);
+    setStartInteractionVector(null);
     setLastInteraction(null);
   }, []);
 
   const onCanvasMouseDown = useCallback((evt: React.MouseEvent<HTMLCanvasElement>) => {
-    const logicalMousePos = vec2.fromValues(
-      evt.nativeEvent.offsetX,
-      evt.nativeEvent.offsetY
-    );
-
-    const physicalMousePos = vec2.scale(
-      vec2.create(),
-      logicalMousePos,
-      window.devicePixelRatio
-    );
-
     setLastInteraction('click');
-    setStartPanVector(physicalMousePos);
+    setStartInteractionVector(
+      getPhysicalSpacePositionFromOffset(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY)
+    );
   }, []);
 
   const onCanvasMouseUp = useCallback(
@@ -428,7 +235,7 @@ export function FlamegraphSpans({
 
       if (!configSpaceCursor) {
         setLastInteraction(null);
-        setStartPanVector(null);
+        setStartInteractionVector(null);
         return;
       }
 
@@ -437,10 +244,10 @@ export function FlamegraphSpans({
       if (lastInteraction === 'click') {
         if (
           hoveredNode &&
-          selectedFramesRef.current?.length === 1 &&
-          selectedFramesRef.current[0] === hoveredNode
+          selectedSpansRef.current?.length === 1 &&
+          selectedSpansRef.current[0] === hoveredNode
         ) {
-          selectedFramesRef.current = [hoveredNode];
+          selectedSpansRef.current = [hoveredNode];
           // If double click is fired on a node, then zoom into it
           canvasPoolManager.dispatch('set config view', [
             // nextPosition.withHeight(flamegraphView.configView.height),
@@ -455,7 +262,7 @@ export function FlamegraphSpans({
       }
 
       setLastInteraction(null);
-      setStartPanVector(null);
+      setStartInteractionVector(null);
     },
     [configSpaceCursor, hoveredNode, canvasPoolManager, lastInteraction]
   );
@@ -469,6 +276,17 @@ export function FlamegraphSpans({
         onMouseUp={onCanvasMouseUp}
         onMouseDown={onCanvasMouseDown}
       />
+      {/* transaction loads after profile, so we want to show loading even if it's in initial state */}
+      {profiledTransaction.type === 'loading' ||
+      profiledTransaction.type === 'initial' ? (
+        <LoadingIndicatorContainer>
+          <LoadingIndicator size={42} />
+        </LoadingIndicatorContainer>
+      ) : profiledTransaction.type === 'errored' ? (
+        <MessageContainer>{t('No associated transaction found')}</MessageContainer>
+      ) : profiledTransaction.type === 'resolved' && spanChart.spans.length <= 1 ? (
+        <MessageContainer>{t('Transaction has no spans')}</MessageContainer>
+      ) : null}
       {hoveredNode && spansRenderer && configSpaceCursor && spansCanvas && spansView ? (
         <BoundTooltip
           bounds={canvasBounds}
@@ -499,6 +317,26 @@ export function FlamegraphSpans({
     </Fragment>
   );
 }
+
+const MessageContainer = styled('p')`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  color: ${p => p.theme.subText};
+`;
+
+const LoadingIndicatorContainer = styled('div')`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+`;
 
 const Canvas = styled('canvas')`
   width: 100%;

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -1,28 +1,32 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {CSSProperties, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {mat3, vec2} from 'gl-matrix';
+import {vec2} from 'gl-matrix';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {FlamegraphContextMenu} from 'sentry/components/profiling/flamegraph/flamegraphContextMenu';
 import {FlamegraphTooltip} from 'sentry/components/profiling/flamegraph/flamegraphTooltip';
 import {t} from 'sentry/locale';
-import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {
+  CanvasPoolManager,
+  useCanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {handleFlamegraphKeyboardNavigation} from 'sentry/utils/profiling/flamegraph/flamegraphKeyboardNavigation';
 import {useFlamegraphSearch} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphSearch';
 import {
   useDispatchFlamegraphState,
   useFlamegraphState,
 } from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
-import {
-  Direction,
-  selectNearestFrame,
-} from 'sentry/utils/profiling/flamegraph/selectNearestFrame';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
-import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {
+  getConfigViewTranslationBetweenVectors,
+  getPhysicalSpacePositionFromOffset,
+  Rect,
+} from 'sentry/utils/profiling/gl/utils';
 import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
 import {useInternalFlamegraphDebugMode} from 'sentry/utils/profiling/hooks/useInternalFlamegraphDebugMode';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
@@ -30,9 +34,14 @@ import {GridRenderer} from 'sentry/utils/profiling/renderers/gridRenderer';
 import {SampleTickRenderer} from 'sentry/utils/profiling/renderers/sampleTickRenderer';
 import {SelectedFrameRenderer} from 'sentry/utils/profiling/renderers/selectedFrameRenderer';
 import {TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
-import usePrevious from 'sentry/utils/usePrevious';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
-import {requestAnimationFrameTimeout} from 'sentry/views/profiling/utils';
+
+import {useCanvasScroll} from './interactions/useCanvasScroll';
+import {useCanvasZoomOrScroll} from './interactions/useCanvasZoomOrScroll';
+import {useDrawHoveredBorderEffect} from './interactions/useDrawHoveredBorderEffect';
+import {useDrawSelectedBorderEffect} from './interactions/useDrawSelectedBorderEffect';
+import {useInteractionViewCheckPoint} from './interactions/useInteractionViewCheckPoint';
+import {useWheelCenterZoom} from './interactions/useWheelCenterZoom';
 
 function isHighlightingAllOccurences(
   node: FlamegraphFrame | null,
@@ -79,14 +88,14 @@ function FlamegraphZoomView({
   const isInternalFlamegraphDebugModeEnabled = useInternalFlamegraphDebugMode();
 
   const [lastInteraction, setLastInteraction] = useState<
-    'pan' | 'click' | 'zoom' | 'scroll' | null
+    'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null
   >(null);
 
   const dispatch = useDispatchFlamegraphState();
-  const scheduler = useMemo(() => new CanvasScheduler(), []);
+  const scheduler = useCanvasScheduler(canvasPoolManager);
 
   const [flamegraphState, {previousState, nextState}] = useFlamegraphState();
-  const [startPanVector, setStartPanVector] = useState<vec2 | null>(null);
+  const [startInteractionVector, setStartInteractionVector] = useState<vec2 | null>(null);
   const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
 
   const textRenderer: TextRenderer | null = useMemo(() => {
@@ -142,6 +151,158 @@ function FlamegraphZoomView({
     }
     return flamegraphRenderer.findHoveredNode(configSpaceCursor);
   }, [configSpaceCursor, flamegraphRenderer]);
+
+  useEffect(() => {
+    if (!flamegraphRenderer) {
+      return;
+    }
+    flamegraphRenderer.setSearchResults(flamegraphSearch.results);
+  }, [flamegraphRenderer, flamegraphSearch.results]);
+
+  useEffect(() => {
+    if (
+      !flamegraphCanvas ||
+      !flamegraphView ||
+      !textRenderer ||
+      !gridRenderer ||
+      !flamegraphRenderer
+    ) {
+      return undefined;
+    }
+
+    const clearOverlayCanvas = () => {
+      textRenderer.context.clearRect(
+        0,
+        0,
+        textRenderer.canvas.width,
+        textRenderer.canvas.height
+      );
+    };
+
+    const drawText = () => {
+      textRenderer.draw(
+        flamegraphView.configView.transformRect(flamegraphView.configSpaceTransform),
+        // flamegraphView.configView,
+        flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace),
+        flamegraphSearch.results
+      );
+    };
+
+    const drawGrid = () => {
+      gridRenderer.draw(
+        flamegraphView.configView,
+        flamegraphCanvas.physicalSpace,
+        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
+        flamegraphView.toConfigView(flamegraphCanvas.logicalSpace)
+      );
+    };
+
+    const drawInternalSampleTicks = () => {
+      if (!sampleTickRenderer) {
+        return;
+      }
+      sampleTickRenderer.draw(
+        flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace),
+        flamegraphView.configView
+      );
+    };
+
+    const drawRectangles = () => {
+      flamegraphRenderer.draw(
+        flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace)
+      );
+    };
+
+    scheduler.registerBeforeFrameCallback(drawRectangles);
+    scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
+    scheduler.registerAfterFrameCallback(drawText);
+    scheduler.registerAfterFrameCallback(drawGrid);
+    scheduler.registerAfterFrameCallback(drawInternalSampleTicks);
+
+    scheduler.draw();
+
+    return () => {
+      scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
+      scheduler.unregisterAfterFrameCallback(drawText);
+      scheduler.unregisterAfterFrameCallback(drawGrid);
+      scheduler.unregisterAfterFrameCallback(drawInternalSampleTicks);
+      scheduler.unregisterBeforeFrameCallback(drawRectangles);
+    };
+  }, [
+    flamegraphCanvas,
+    flamegraphView,
+    scheduler,
+    flamegraph,
+    flamegraphTheme,
+    textRenderer,
+    gridRenderer,
+    flamegraphRenderer,
+    sampleTickRenderer,
+    canvasPoolManager,
+    flamegraphSearch,
+  ]);
+
+  const selectedFramesRef = useRef<FlamegraphFrame[] | null>(null);
+
+  useEffect(() => {
+    if (flamegraphState.profiles.highlightFrames) {
+      selectedFramesRef.current = flamegraph.findAllMatchingFrames(
+        flamegraphState.profiles.highlightFrames.name,
+        flamegraphState.profiles.highlightFrames.package
+      );
+    } else {
+      selectedFramesRef.current = null;
+    }
+  }, [flamegraph, flamegraphState.profiles.highlightFrames]);
+
+  useInteractionViewCheckPoint({
+    view: flamegraphView,
+    lastInteraction,
+  });
+
+  useDrawSelectedBorderEffect({
+    scheduler,
+    selectedRef: selectedFramesRef,
+    canvas: flamegraphCanvas,
+    view: flamegraphView,
+    eventKey: 'highlight frame',
+    theme: flamegraphTheme,
+    renderer: selectedFrameRenderer,
+  });
+
+  useDrawHoveredBorderEffect({
+    scheduler,
+    hoveredNode,
+    canvas: flamegraphCanvas,
+    view: flamegraphView,
+    theme: flamegraphTheme,
+    renderer: selectedFrameRenderer,
+  });
+
+  useEffect(() => {
+    if (!flamegraphCanvas || !flamegraphView) {
+      return undefined;
+    }
+
+    const onResetZoom = () => {
+      setConfigSpaceCursor(null);
+    };
+
+    const onZoomIntoFrame = (frame: FlamegraphFrame, _strategy: 'min' | 'exact') => {
+      if (frame) {
+        selectedFramesRef.current = [frame];
+      }
+      setConfigSpaceCursor(null);
+    };
+
+    scheduler.on('reset zoom', onResetZoom);
+    scheduler.on('zoom at frame', onZoomIntoFrame);
+
+    return () => {
+      scheduler.off('reset zoom', onResetZoom);
+      scheduler.off('zoom at frame', onZoomIntoFrame);
+    };
+  }, [flamegraphCanvas, canvasPoolManager, dispatch, scheduler, flamegraphView]);
 
   useEffect(() => {
     const onKeyDown = (evt: KeyboardEvent) => {
@@ -214,263 +375,11 @@ function FlamegraphZoomView({
     flamegraph.inverted,
   ]);
 
-  const previousInteraction = usePrevious(lastInteraction);
-  const beforeInteractionConfigView = useRef<Rect | null>(null);
-
-  useEffect(() => {
-    if (!flamegraphView) {
-      return;
-    }
-
-    // Check if we are starting a new interaction
-    if (previousInteraction === null && lastInteraction) {
-      beforeInteractionConfigView.current = flamegraphView.configView.clone();
-      return;
-    }
-
-    if (
-      beforeInteractionConfigView.current &&
-      !beforeInteractionConfigView.current.equals(flamegraphView.configView)
-    ) {
-      dispatch({type: 'checkpoint', payload: flamegraphView.configView.clone()});
-    }
-  }, [dispatch, lastInteraction, previousInteraction, flamegraphView]);
-
-  useEffect(() => {
-    flamegraphRenderer?.setSearchResults(flamegraphSearch.results);
-  }, [flamegraphRenderer, flamegraphSearch.results]);
-
-  useEffect(() => {
-    if (!flamegraphCanvas || !flamegraphView || !flamegraphRenderer) {
-      return undefined;
-    }
-
-    const drawRectangles = () => {
-      flamegraphRenderer.draw(
-        flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace)
-      );
-    };
-
-    scheduler.registerBeforeFrameCallback(drawRectangles);
-    scheduler.draw();
-
-    return () => {
-      scheduler.unregisterBeforeFrameCallback(drawRectangles);
-    };
-  }, [flamegraphCanvas, flamegraphRenderer, scheduler, flamegraphView]);
-
-  useEffect(() => {
-    if (!flamegraphCanvas || !flamegraphView || !textRenderer || !gridRenderer) {
-      return undefined;
-    }
-
-    const clearOverlayCanvas = () => {
-      textRenderer.context.clearRect(
-        0,
-        0,
-        textRenderer.canvas.width,
-        textRenderer.canvas.height
-      );
-    };
-
-    const drawText = () => {
-      textRenderer.draw(
-        flamegraphView.toOriginConfigView(flamegraphView.configView),
-        flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace),
-        flamegraphSearch.results
-      );
-    };
-
-    const drawGrid = () => {
-      gridRenderer.draw(
-        flamegraphView.configView,
-        flamegraphCanvas.physicalSpace,
-        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
-        flamegraphView.toConfigView(flamegraphCanvas.logicalSpace)
-      );
-    };
-
-    const drawInternalSampleTicks = () => {
-      if (!sampleTickRenderer) {
-        return;
-      }
-      sampleTickRenderer.draw(
-        flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace),
-        flamegraphView.configView
-      );
-    };
-
-    scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
-    scheduler.registerAfterFrameCallback(drawText);
-    scheduler.registerAfterFrameCallback(drawGrid);
-    scheduler.registerAfterFrameCallback(drawInternalSampleTicks);
-
-    scheduler.draw();
-
-    return () => {
-      scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
-      scheduler.unregisterAfterFrameCallback(drawText);
-      scheduler.unregisterAfterFrameCallback(drawGrid);
-      scheduler.unregisterAfterFrameCallback(drawInternalSampleTicks);
-    };
-  }, [
-    flamegraphCanvas,
-    flamegraphView,
-    scheduler,
-    flamegraph,
-    flamegraphTheme,
-    textRenderer,
-    gridRenderer,
-    sampleTickRenderer,
-    canvasPoolManager,
-    flamegraphSearch,
-  ]);
-
-  const selectedFramesRef = useRef<FlamegraphFrame[] | null>(null);
-
-  useEffect(() => {
-    if (flamegraphState.profiles.highlightFrames) {
-      selectedFramesRef.current = flamegraph.findAllMatchingFrames(
-        flamegraphState.profiles.highlightFrames.name,
-        flamegraphState.profiles.highlightFrames.package
-      );
-    } else {
-      selectedFramesRef.current = null;
-    }
-  }, [flamegraph, flamegraphState.profiles.highlightFrames]);
-
-  useEffect(() => {
-    if (!flamegraphCanvas || !flamegraphView || !selectedFrameRenderer) {
-      return undefined;
-    }
-
-    const onNodeHighlight = (
-      node: FlamegraphFrame[] | null,
-      mode: 'hover' | 'selected'
-    ) => {
-      if (mode === 'selected') {
-        selectedFramesRef.current = node;
-      }
-      scheduler.draw();
-    };
-
-    const drawSelectedFrameBorder = () => {
-      if (selectedFramesRef.current) {
-        selectedFrameRenderer.draw(
-          selectedFramesRef.current.map(frame => {
-            return new Rect(frame.start, frame.depth, frame.end - frame.start, 1);
-          }),
-          {
-            BORDER_COLOR: flamegraphTheme.COLORS.SELECTED_FRAME_BORDER_COLOR,
-            BORDER_WIDTH: flamegraphTheme.SIZES.FRAME_BORDER_WIDTH,
-          },
-          flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace)
-        );
-      }
-    };
-
-    scheduler.on('highlight frame', onNodeHighlight);
-    scheduler.registerAfterFrameCallback(drawSelectedFrameBorder);
-    scheduler.draw();
-
-    return () => {
-      scheduler.off('highlight frame', onNodeHighlight);
-      scheduler.unregisterAfterFrameCallback(drawSelectedFrameBorder);
-    };
-  }, [
-    flamegraphView,
-    flamegraphCanvas,
-    scheduler,
-    flamegraph,
-    flamegraphState.profiles.highlightFrames,
-    selectedFrameRenderer,
-    flamegraphTheme,
-  ]);
-
-  useEffect(() => {
-    if (!flamegraphCanvas || !flamegraphView || !selectedFrameRenderer) {
-      return undefined;
-    }
-
-    const drawHoveredFrameBorder = () => {
-      if (hoveredNode) {
-        selectedFrameRenderer.draw(
-          [
-            new Rect(
-              hoveredNode.start,
-              hoveredNode.depth,
-              hoveredNode.end - hoveredNode.start,
-              1
-            ),
-          ],
-          {
-            BORDER_COLOR: flamegraphTheme.COLORS.HOVERED_FRAME_BORDER_COLOR,
-            BORDER_WIDTH: flamegraphTheme.SIZES.HOVERED_FRAME_BORDER_WIDTH,
-          },
-          flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace)
-        );
-      }
-    };
-
-    scheduler.registerAfterFrameCallback(drawHoveredFrameBorder);
-    scheduler.draw();
-
-    return () => {
-      scheduler.unregisterAfterFrameCallback(drawHoveredFrameBorder);
-    };
-  }, [
-    flamegraphView,
-    flamegraphCanvas,
-    scheduler,
-    hoveredNode,
-    selectedFrameRenderer,
-    flamegraphTheme,
-  ]);
-
-  useEffect(() => {
-    if (!flamegraphCanvas || !flamegraphView) {
-      return undefined;
-    }
-
-    const onResetZoom = () => {
-      setConfigSpaceCursor(null);
-    };
-
-    const onZoomIntoFrame = (frame: FlamegraphFrame, _strategy: 'min' | 'exact') => {
-      if (frame) {
-        selectedFramesRef.current = [frame];
-      }
-      setConfigSpaceCursor(null);
-    };
-
-    scheduler.on('reset zoom', onResetZoom);
-    scheduler.on('zoom at frame', onZoomIntoFrame);
-
-    return () => {
-      scheduler.off('reset zoom', onResetZoom);
-      scheduler.off('zoom at frame', onZoomIntoFrame);
-    };
-  }, [flamegraphCanvas, canvasPoolManager, dispatch, scheduler, flamegraphView]);
-
-  useEffect(() => {
-    canvasPoolManager.registerScheduler(scheduler);
-    return () => canvasPoolManager.unregisterScheduler(scheduler);
-  }, [canvasPoolManager, scheduler]);
-
   const onCanvasMouseDown = useCallback((evt: React.MouseEvent<HTMLCanvasElement>) => {
-    const logicalMousePos = vec2.fromValues(
-      evt.nativeEvent.offsetX,
-      evt.nativeEvent.offsetY
-    );
-
-    const physicalMousePos = vec2.scale(
-      vec2.create(),
-      logicalMousePos,
-      window.devicePixelRatio
-    );
-
     setLastInteraction('click');
-    setStartPanVector(physicalMousePos);
+    setStartInteractionVector(
+      getPhysicalSpacePositionFromOffset(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY)
+    );
   }, []);
 
   const onCanvasMouseUp = useCallback(
@@ -480,7 +389,7 @@ function FlamegraphZoomView({
 
       if (!configSpaceCursor) {
         setLastInteraction(null);
-        setStartPanVector(null);
+        setStartInteractionVector(null);
         return;
       }
 
@@ -508,63 +417,37 @@ function FlamegraphZoomView({
       }
 
       setLastInteraction(null);
-      setStartPanVector(null);
+      setStartInteractionVector(null);
     },
     [configSpaceCursor, dispatch, hoveredNode, canvasPoolManager, lastInteraction]
   );
 
   const onMouseDrag = useCallback(
     (evt: React.MouseEvent<HTMLCanvasElement>) => {
-      if (!flamegraphCanvas || !flamegraphView || !startPanVector) {
+      if (!flamegraphCanvas || !flamegraphView || !startInteractionVector) {
         return;
       }
-
-      const logicalMousePos = vec2.fromValues(
+      const configDelta = getConfigViewTranslationBetweenVectors(
         evt.nativeEvent.offsetX,
-        evt.nativeEvent.offsetY
+        evt.nativeEvent.offsetY,
+        startInteractionVector,
+        flamegraphView,
+        flamegraphCanvas
       );
 
-      const physicalMousePos = vec2.scale(
-        vec2.create(),
-        logicalMousePos,
-        window.devicePixelRatio
-      );
-
-      const physicalDelta = vec2.subtract(
-        vec2.create(),
-        startPanVector,
-        physicalMousePos
-      );
-
-      if (physicalDelta[0] === 0 && physicalDelta[1] === 0) {
+      if (!configDelta) {
         return;
       }
 
-      const physicalToConfig = mat3.invert(
-        mat3.create(),
-        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
+      canvasPoolManager.dispatch('transform config view', [configDelta]);
+      setStartInteractionVector(
+        getPhysicalSpacePositionFromOffset(
+          evt.nativeEvent.offsetX,
+          evt.nativeEvent.offsetY
+        )
       );
-      const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
-
-      const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
-        m00,
-        m01,
-        m02,
-        m10,
-        m11,
-        m12,
-        0,
-        0,
-        0,
-      ]);
-
-      canvasPoolManager.dispatch('transform config view', [
-        mat3.fromTranslation(mat3.create(), configDelta),
-      ]);
-
-      setStartPanVector(physicalMousePos);
     },
-    [flamegraphCanvas, flamegraphView, startPanVector, canvasPoolManager]
+    [flamegraphCanvas, flamegraphView, startInteractionVector, canvasPoolManager]
   );
 
   const onCanvasMouseMove = useCallback(
@@ -573,133 +456,55 @@ function FlamegraphZoomView({
         return;
       }
 
-      const newConfigSpaceCursor = flamegraphView.getTransformedConfigViewCursor(
-        vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
-        flamegraphCanvas
+      setConfigSpaceCursor(
+        flamegraphView.getTransformedConfigViewCursor(
+          vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
+          flamegraphCanvas
+        )
       );
 
-      setConfigSpaceCursor(newConfigSpaceCursor);
-
-      if (startPanVector) {
+      if (startInteractionVector) {
         onMouseDrag(evt);
         setLastInteraction('pan');
       } else {
         setLastInteraction(null);
       }
     },
-    [flamegraphCanvas, flamegraphView, setConfigSpaceCursor, onMouseDrag, startPanVector]
+    [
+      flamegraphCanvas,
+      flamegraphView,
+      setConfigSpaceCursor,
+      onMouseDrag,
+      startInteractionVector,
+    ]
   );
 
   const onCanvasMouseLeave = useCallback(() => {
     setConfigSpaceCursor(null);
-    setStartPanVector(null);
+    setStartInteractionVector(null);
     setLastInteraction(null);
   }, []);
 
-  const zoom = useCallback(
-    (evt: WheelEvent) => {
-      if (!flamegraphCanvas || !flamegraphView) {
-        return;
-      }
-
-      const identity = mat3.identity(mat3.create());
-      const scale = 1 - evt.deltaY * 0.01 * -1; // -1 to invert scale
-
-      const configSpaceMouse = flamegraphView.getConfigViewCursor(
-        vec2.fromValues(evt.offsetX, evt.offsetY),
-        flamegraphCanvas
-      );
-
-      const configCenter = vec2.fromValues(
-        configSpaceMouse[0],
-        flamegraphView.configView.y
-      );
-
-      const invertedConfigCenter = vec2.multiply(
-        vec2.create(),
-        vec2.fromValues(-1, -1),
-        configCenter
-      );
-
-      const translated = mat3.translate(mat3.create(), identity, configCenter);
-      const scaled = mat3.scale(mat3.create(), translated, vec2.fromValues(scale, 1));
-      const translatedBack = mat3.translate(mat3.create(), scaled, invertedConfigCenter);
-
-      canvasPoolManager.dispatch('transform config view', [translatedBack]);
-    },
-    [flamegraphCanvas, flamegraphView, canvasPoolManager]
+  const onWheelCenterZoom = useWheelCenterZoom(
+    flamegraphCanvas,
+    flamegraphView,
+    canvasPoolManager
+  );
+  const onCanvasScroll = useCanvasScroll(
+    flamegraphCanvas,
+    flamegraphView,
+    canvasPoolManager
   );
 
-  const scroll = useCallback(
-    (evt: WheelEvent) => {
-      if (!flamegraphCanvas || !flamegraphView) {
-        return;
-      }
-
-      const physicalDelta = vec2.fromValues(evt.deltaX, evt.deltaY);
-      const physicalToConfig = mat3.invert(
-        mat3.create(),
-        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
-      );
-      const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
-
-      const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
-        m00,
-        m01,
-        m02,
-        m10,
-        m11,
-        m12,
-        0,
-        0,
-        0,
-      ]);
-
-      const translate = mat3.fromTranslation(mat3.create(), configDelta);
-      canvasPoolManager.dispatch('transform config view', [translate]);
-    },
-    [flamegraphCanvas, flamegraphView, canvasPoolManager]
-  );
-
-  useEffect(() => {
-    if (!flamegraphCanvasRef) {
-      return undefined;
-    }
-
-    let wheelStopTimeoutId: {current: number | undefined} = {current: undefined};
-    function onCanvasWheel(evt: WheelEvent) {
-      if (wheelStopTimeoutId.current !== undefined) {
-        window.cancelAnimationFrame(wheelStopTimeoutId.current);
-      }
-      wheelStopTimeoutId = requestAnimationFrameTimeout(() => {
-        setLastInteraction(null);
-      }, 300);
-
-      evt.preventDefault();
-
-      // When we zoom, we want to clear cursor so that any tooltips
-      // rendered on the flamegraph are removed from the flamegraphView
-      setConfigSpaceCursor(null);
-
-      // pinch to zoom is recognized as `ctrlKey + wheelEvent`
-      if (evt.metaKey || evt.ctrlKey) {
-        zoom(evt);
-        setLastInteraction('zoom');
-      } else {
-        scroll(evt);
-        setLastInteraction('scroll');
-      }
-    }
-
-    flamegraphCanvasRef.addEventListener('wheel', onCanvasWheel);
-
-    return () => {
-      if (wheelStopTimeoutId.current !== undefined) {
-        window.cancelAnimationFrame(wheelStopTimeoutId.current);
-      }
-      flamegraphCanvasRef.removeEventListener('wheel', onCanvasWheel);
-    };
-  }, [flamegraphCanvasRef, zoom, scroll]);
+  useCanvasZoomOrScroll({
+    lastInteraction,
+    configSpaceCursor,
+    setConfigSpaceCursor,
+    setLastInteraction,
+    handleWheel: onWheelCenterZoom,
+    handleScroll: onCanvasScroll,
+    canvas: flamegraphCanvasRef,
+  });
 
   const hoveredNodeOnContextMenuOpen = useRef<FlamegraphFrame | null>(null);
   const contextMenu = useContextMenu({container: flamegraphCanvasRef});
@@ -771,21 +576,16 @@ function FlamegraphZoomView({
   return (
     <CanvasContainer>
       <Canvas
-        ref={canvas => setFlamegraphCanvasRef(canvas)}
+        ref={setFlamegraphCanvasRef}
         onMouseDown={onCanvasMouseDown}
         onMouseUp={onCanvasMouseUp}
         onMouseMove={onCanvasMouseMove}
         onMouseLeave={onCanvasMouseLeave}
         onContextMenu={handleContextMenuOpen}
-        style={{cursor: lastInteraction === 'pan' ? 'grab' : 'default'}}
+        cursor={lastInteraction === 'pan' ? 'grabbing' : 'default'}
         tabIndex={1}
       />
-      <Canvas
-        ref={canvas => setFlamegraphOverlayCanvasRef(canvas)}
-        style={{
-          pointerEvents: 'none',
-        }}
-      />
+      <Canvas ref={setFlamegraphOverlayCanvasRef} pointerEvents="none" />
       <FlamegraphContextMenu
         contextMenu={contextMenu}
         profileGroup={profileGroup.type === 'resolved' ? profileGroup.data : null}
@@ -824,58 +624,22 @@ const CanvasContainer = styled('div')`
   position: relative;
 `;
 
-const Canvas = styled('canvas')`
+const Canvas = styled('canvas')<{
+  cursor?: CSSProperties['cursor'];
+  pointerEvents?: CSSProperties['pointerEvents'];
+}>`
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
   user-select: none;
   position: absolute;
+  pointer-events: ${p => p.pointerEvents || 'auto'};
+  cursor: ${p => p.cursor || 'default'};
 
   &:focus {
     outline: none;
   }
 `;
-
-// loosely based spreadsheet navigation
-const keyDirectionMap: Record<string, Direction> = {
-  ArrowUp: 'up',
-  ArrowDown: 'down',
-  ArrowLeft: 'left',
-  ArrowRight: 'right',
-  Tab: 'down',
-  'Shift+Tab': 'up',
-  w: 'up',
-  s: 'down',
-  a: 'left',
-  d: 'right',
-} as const;
-
-function handleFlamegraphKeyboardNavigation(
-  evt: KeyboardEvent,
-  currentFrame: FlamegraphFrame | undefined,
-  inverted: boolean = false
-) {
-  if (!currentFrame) {
-    return null;
-  }
-
-  const key = evt.shiftKey ? `Shift+${evt.key}` : evt.key;
-  let direction = keyDirectionMap[key];
-
-  // if the key is not mapped, don't handle it
-  if (!direction) {
-    return null;
-  }
-  if (inverted && (direction === 'up' || direction === 'down')) {
-    direction = direction === 'up' ? 'down' : 'up';
-  }
-  const nextSelection = selectNearestFrame(currentFrame, direction);
-  if (nextSelection === currentFrame) {
-    return null;
-  }
-  evt.preventDefault();
-  return nextSelection;
-}
 
 export {FlamegraphZoomView};

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -32,8 +32,7 @@ import {SelectedFrameRenderer} from 'sentry/utils/profiling/renderers/selectedFr
 import {TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
 import usePrevious from 'sentry/utils/usePrevious';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
-
-import {requestAnimationFrameTimeout} from '../../../views/profiling/utils';
+import {requestAnimationFrameTimeout} from 'sentry/views/profiling/utils';
 
 function isHighlightingAllOccurences(
   node: FlamegraphFrame | null,
@@ -167,9 +166,7 @@ function FlamegraphZoomView({
             // because the height may have changed due to window resizing and
             // calling it with the old height may result in the flamegraph
             // being drawn into a very small or very large area.
-            canvasPoolManager.dispatch('set config view', [
-              previousPosition.withHeight(flamegraphView.configView.height),
-            ]);
+            canvasPoolManager.dispatch('set config view', [previousPosition]);
           }
         }
 
@@ -181,9 +178,7 @@ function FlamegraphZoomView({
             // because the height may have changed due to window resizing and
             // calling it with the old height may result in the flamegraph
             // being drawn into a very small or very large area.
-            canvasPoolManager.dispatch('set config view', [
-              nextPosition.withHeight(flamegraphView.configView.height),
-            ]);
+            canvasPoolManager.dispatch('set config view', [nextPosition]);
           }
         }
 

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -1,19 +1,28 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {mat3, vec2} from 'gl-matrix';
+import {vec2} from 'gl-matrix';
 
-import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {
+  CanvasPoolManager,
+  useCanvasScheduler,
+} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
-import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {
+  getConfigSpaceTranslationBetweenVectors,
+  getMinimapCanvasCursor,
+  getPhysicalSpacePositionFromOffset,
+  Rect,
+} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {PositionIndicatorRenderer} from 'sentry/utils/profiling/renderers/positionIndicatorRenderer';
-import usePrevious from 'sentry/utils/usePrevious';
 
-import {requestAnimationFrameTimeout} from '../../../views/profiling/utils';
+import {useCanvasScroll} from './interactions/useCanvasScroll';
+import {useCanvasZoomOrScroll} from './interactions/useCanvasZoomOrScroll';
+import {useInteractionViewCheckPoint} from './interactions/useInteractionViewCheckPoint';
+import {useWheelCenterZoom} from './interactions/useWheelCenterZoom';
 
 interface FlamegraphZoomViewMinimapProps {
   canvasPoolManager: CanvasPoolManager;
@@ -45,10 +54,10 @@ function FlamegraphZoomViewMinimap({
     'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null
   >(null);
 
-  const dispatch = useDispatchFlamegraphState();
-
+  const [startInteractionVector, setStartInteractionVector] = useState<vec2 | null>(null);
+  const [lastDragVector, setLastDragVector] = useState<vec2 | null>(null);
   const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
-  const scheduler = useMemo(() => new CanvasScheduler(), []);
+  const scheduler = useCanvasScheduler(canvasPoolManager);
 
   const miniMapConfigSpaceBorderSize = useMemo(() => {
     if (!flamegraphMiniMapView || !flamegraphMiniMapCanvas?.physicalSpace) {
@@ -87,36 +96,8 @@ function FlamegraphZoomViewMinimap({
     if (
       !flamegraphMiniMapCanvas ||
       !flamegraphMiniMapView ||
+      !positionIndicatorRenderer ||
       !flamegraphMiniMapRenderer
-    ) {
-      return undefined;
-    }
-
-    const drawRectangles = () => {
-      flamegraphMiniMapRenderer.draw(
-        flamegraphMiniMapView.fromTransformedConfigSpace(
-          flamegraphMiniMapCanvas.physicalSpace
-        )
-      );
-    };
-
-    scheduler.registerBeforeFrameCallback(drawRectangles);
-
-    return () => {
-      scheduler.unregisterBeforeFrameCallback(drawRectangles);
-    };
-  }, [
-    flamegraphMiniMapCanvas,
-    flamegraphMiniMapRenderer,
-    scheduler,
-    flamegraphMiniMapView,
-  ]);
-
-  useEffect(() => {
-    if (
-      !flamegraphMiniMapCanvas ||
-      !flamegraphMiniMapView ||
-      !positionIndicatorRenderer
     ) {
       return undefined;
     }
@@ -138,7 +119,16 @@ function FlamegraphZoomViewMinimap({
       );
     };
 
+    const drawRectangles = () => {
+      flamegraphMiniMapRenderer.draw(
+        flamegraphMiniMapView.fromTransformedConfigSpace(
+          flamegraphMiniMapCanvas.physicalSpace
+        )
+      );
+    };
+
     scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
+    scheduler.registerBeforeFrameCallback(drawRectangles);
     scheduler.registerAfterFrameCallback(drawPosition);
 
     scheduler.draw();
@@ -146,46 +136,20 @@ function FlamegraphZoomViewMinimap({
     return () => {
       scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
       scheduler.unregisterAfterFrameCallback(drawPosition);
+      scheduler.unregisterBeforeFrameCallback(drawRectangles);
     };
   }, [
     flamegraphMiniMapCanvas,
     flamegraphMiniMapView,
+    flamegraphMiniMapRenderer,
     scheduler,
     positionIndicatorRenderer,
   ]);
 
-  const previousInteraction = usePrevious(lastInteraction);
-  const beforeInteractionConfigView = useRef<Rect | null>(null);
-
-  useEffect(() => {
-    if (!flamegraphMiniMapView) {
-      return;
-    }
-
-    // Check if we are starting a new interaction
-    if (previousInteraction === null && lastInteraction) {
-      beforeInteractionConfigView.current = flamegraphMiniMapView.configView.clone();
-      return;
-    }
-
-    if (
-      beforeInteractionConfigView.current &&
-      !beforeInteractionConfigView.current.equals(flamegraphMiniMapView.configView)
-    ) {
-      dispatch({
-        type: 'checkpoint',
-        payload: flamegraphMiniMapView.configView.clone(),
-      });
-    }
-  }, [lastInteraction, flamegraphMiniMapView, dispatch, previousInteraction]);
-
-  const [startDragVector, setStartDragConfigSpaceCursor] = useState<vec2 | null>(null);
-  const [lastDragVector, setLastDragVector] = useState<vec2 | null>(null);
-
-  useEffect(() => {
-    canvasPoolManager.registerScheduler(scheduler);
-    return () => canvasPoolManager.unregisterScheduler(scheduler);
-  }, [scheduler, canvasPoolManager]);
+  useInteractionViewCheckPoint({
+    view: flamegraphMiniMapView,
+    lastInteraction,
+  });
 
   const onMouseDrag = useCallback(
     (evt: React.MouseEvent<HTMLCanvasElement>) => {
@@ -193,44 +157,28 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
-      const logicalMousePos = vec2.fromValues(
+      const configDelta = getConfigSpaceTranslationBetweenVectors(
         evt.nativeEvent.offsetX,
-        evt.nativeEvent.offsetY
-      );
-      const physicalMousePos = vec2.scale(
-        vec2.create(),
-        logicalMousePos,
-        window.devicePixelRatio
-      );
-
-      const physicalDelta = vec2.subtract(
-        vec2.create(),
-        physicalMousePos,
-        lastDragVector
+        evt.nativeEvent.offsetY,
+        lastDragVector,
+        flamegraphMiniMapView,
+        flamegraphMiniMapCanvas,
+        true
       );
 
-      if (physicalDelta[0] === 0 && physicalDelta[1] === 0) {
+      if (!configDelta) {
         return;
       }
 
-      const physicalToConfig = mat3.invert(
-        mat3.create(),
-        flamegraphMiniMapView.fromConfigSpace(flamegraphMiniMapCanvas.physicalSpace)
+      canvasPoolManager.dispatch('transform config view', [configDelta]);
+      setLastDragVector(
+        getPhysicalSpacePositionFromOffset(
+          evt.nativeEvent.offsetX,
+          evt.nativeEvent.offsetY
+        )
       );
-
-      const configDelta = vec2.transformMat3(
-        vec2.create(),
-        physicalDelta,
-        physicalToConfig
-      );
-
-      canvasPoolManager.dispatch('transform config view', [
-        mat3.fromTranslation(mat3.create(), configDelta),
-      ]);
-
-      setLastDragVector(physicalMousePos);
     },
-    [flamegraphMiniMapCanvas, flamegraphMiniMapView, lastDragVector, canvasPoolManager]
+    [lastDragVector, flamegraphMiniMapCanvas, flamegraphMiniMapView, canvasPoolManager]
   );
 
   const prevConfigSpaceCursor = useRef<vec2 | null>(vec2.fromValues(0, 0));
@@ -240,12 +188,16 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
-      const configSpaceMouse = flamegraphMiniMapView.getConfigSpaceCursor(
+      const configSpaceMouse = flamegraphMiniMapView.getTransformedConfigSpaceCursor(
         vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
         flamegraphMiniMapCanvas
       );
 
       setConfigSpaceCursor(configSpaceMouse);
+
+      if (!prevConfigSpaceCursor.current) {
+        return;
+      }
 
       if (lastDragVector) {
         onMouseDrag(evt);
@@ -270,14 +222,23 @@ function FlamegraphZoomViewMinimap({
           configView.width + dragDelta * dragDirection,
           configView.height
         );
+
         canvasPoolManager.dispatch('set config view', [rect]);
         prevConfigSpaceCursor.current = configSpaceMouse;
         return;
       }
 
-      if (startDragVector) {
-        const start = vec2.min(vec2.create(), startDragVector, configSpaceMouse);
-        const end = vec2.max(vec2.create(), startDragVector, configSpaceMouse);
+      if (startInteractionVector) {
+        const start = vec2.min(
+          vec2.create(),
+          prevConfigSpaceCursor.current,
+          configSpaceMouse
+        );
+        const end = vec2.max(
+          vec2.create(),
+          prevConfigSpaceCursor.current,
+          configSpaceMouse
+        );
 
         const rect = new Rect(
           start[0],
@@ -285,6 +246,7 @@ function FlamegraphZoomViewMinimap({
           end[0] - start[0],
           flamegraphMiniMapView.configView.height
         );
+
         canvasPoolManager.dispatch('set config view', [rect]);
         setLastInteraction('select');
         return;
@@ -299,80 +261,35 @@ function FlamegraphZoomViewMinimap({
       canvasPoolManager,
       lastDragVector,
       onMouseDrag,
-      startDragVector,
+      startInteractionVector,
       lastInteraction,
     ]
   );
 
-  const onMinimapScroll = useCallback(
-    (evt: WheelEvent) => {
-      if (!flamegraphMiniMapCanvas || !flamegraphMiniMapView) {
-        return;
-      }
-
-      {
-        const physicalDelta = vec2.fromValues(evt.deltaX * 0.8, evt.deltaY);
-        const physicalToConfig = mat3.invert(
-          mat3.create(),
-          flamegraphMiniMapView.fromConfigView(flamegraphMiniMapCanvas.physicalSpace)
-        );
-        const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
-
-        const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
-          m00,
-          m01,
-          m02,
-          m10,
-          m11,
-          m12,
-          0,
-          0,
-          0,
-        ]);
-
-        const translate = mat3.fromTranslation(mat3.create(), configDelta);
-        canvasPoolManager.dispatch('transform config view', [translate]);
-      }
-    },
-    [flamegraphMiniMapCanvas, flamegraphMiniMapView, canvasPoolManager]
+  const onWheelCenterZoom = useWheelCenterZoom(
+    flamegraphMiniMapCanvas,
+    flamegraphMiniMapView,
+    canvasPoolManager
   );
 
-  const onMinimapZoom = useCallback(
-    (evt: WheelEvent) => {
-      if (!flamegraphMiniMapCanvas || !flamegraphMiniMapView) {
-        return;
-      }
-
-      const identity = mat3.identity(mat3.create());
-      const scale = 1 - evt.deltaY * 0.001 * -1; // -1 to invert scale
-
-      const cursorInConfigSpace = flamegraphMiniMapView.getTransformedConfigSpaceCursor(
-        vec2.fromValues(evt.offsetX, evt.offsetY),
-        flamegraphMiniMapCanvas
-      );
-
-      const configCenter = vec2.fromValues(
-        cursorInConfigSpace[0],
-        flamegraphMiniMapView.configView.y
-      );
-
-      const invertedConfigCenter = vec2.multiply(
-        vec2.create(),
-        vec2.fromValues(-1, -1),
-        configCenter
-      );
-
-      const translated = mat3.translate(mat3.create(), identity, configCenter);
-      const scaled = mat3.scale(mat3.create(), translated, vec2.fromValues(scale, 1));
-      const translatedBack = mat3.translate(mat3.create(), scaled, invertedConfigCenter);
-
-      canvasPoolManager.dispatch('transform config view', [translatedBack]);
-    },
-    [flamegraphMiniMapCanvas, flamegraphMiniMapView, canvasPoolManager]
+  const onCanvasScroll = useCanvasScroll(
+    flamegraphMiniMapCanvas,
+    flamegraphMiniMapView,
+    canvasPoolManager
   );
+
+  useCanvasZoomOrScroll({
+    lastInteraction,
+    configSpaceCursor,
+    setConfigSpaceCursor,
+    setLastInteraction,
+    handleWheel: onWheelCenterZoom,
+    handleScroll: onCanvasScroll,
+    canvas: flamegraphMiniMapCanvasRef,
+  });
 
   const onMinimapCanvasMouseDown = useCallback(
-    evt => {
+    (evt: React.MouseEvent<HTMLCanvasElement>) => {
       if (
         !configSpaceCursor ||
         !flamegraphMiniMapCanvas ||
@@ -382,15 +299,6 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
-      const logicalMousePos = vec2.fromValues(
-        evt.nativeEvent.offsetX,
-        evt.nativeEvent.offsetY
-      );
-      const physicalMousePos = vec2.scale(
-        vec2.create(),
-        logicalMousePos,
-        window.devicePixelRatio
-      );
       if (
         miniMapConfigSpaceBorderSize >=
         Math.min(
@@ -399,19 +307,33 @@ function FlamegraphZoomViewMinimap({
         )
       ) {
         setLastInteraction('resize');
+        setStartInteractionVector(
+          getPhysicalSpacePositionFromOffset(
+            evt.nativeEvent.offsetX,
+            evt.nativeEvent.offsetY
+          )
+        );
         return;
       }
 
       if (flamegraphMiniMapView.configView.contains(configSpaceCursor)) {
-        setLastDragVector(physicalMousePos);
-      } else {
-        const startConfigSpaceCursor = flamegraphMiniMapView.getConfigSpaceCursor(
-          vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
-          flamegraphMiniMapCanvas
+        setLastInteraction('pan');
+        setLastDragVector(
+          getPhysicalSpacePositionFromOffset(
+            evt.nativeEvent.offsetX,
+            evt.nativeEvent.offsetY
+          )
         );
-        setStartDragConfigSpaceCursor(startConfigSpaceCursor);
+        return;
       }
+
       setLastInteraction('select');
+      setStartInteractionVector(
+        getPhysicalSpacePositionFromOffset(
+          evt.nativeEvent.offsetX,
+          evt.nativeEvent.offsetY
+        )
+      );
     },
     [
       configSpaceCursor,
@@ -424,50 +346,10 @@ function FlamegraphZoomViewMinimap({
 
   const onMinimapCanvasMouseUp = useCallback(() => {
     setConfigSpaceCursor(null);
-    setStartDragConfigSpaceCursor(null);
-    setLastDragVector(null);
+    setStartInteractionVector(null);
     setLastInteraction(null);
+    setLastDragVector(null);
   }, []);
-
-  useEffect(() => {
-    if (!flamegraphMiniMapCanvasRef) {
-      return undefined;
-    }
-
-    let wheelStopTimeoutId: {current: number | undefined} = {current: undefined};
-
-    function onCanvasWheel(evt: WheelEvent) {
-      if (wheelStopTimeoutId.current !== undefined) {
-        window.cancelAnimationFrame(wheelStopTimeoutId.current);
-      }
-      wheelStopTimeoutId = requestAnimationFrameTimeout(() => {
-        setLastInteraction(null);
-      }, 300);
-
-      evt.preventDefault();
-
-      // When we zoom, we want to clear cursor so that any tooltips
-      // rendered on the flamegraph are removed from the view
-      setConfigSpaceCursor(null);
-
-      if (evt.metaKey || evt.ctrlKey) {
-        onMinimapZoom(evt);
-        setLastInteraction('zoom');
-      } else {
-        onMinimapScroll(evt);
-        setLastInteraction('scroll');
-      }
-    }
-
-    flamegraphMiniMapCanvasRef.addEventListener('wheel', onCanvasWheel);
-
-    return () => {
-      if (wheelStopTimeoutId.current !== undefined) {
-        window.cancelAnimationFrame(wheelStopTimeoutId.current);
-      }
-      flamegraphMiniMapCanvasRef.removeEventListener('wheel', onCanvasWheel);
-    };
-  }, [flamegraphMiniMapCanvasRef, onMinimapZoom, onMinimapScroll]);
 
   useEffect(() => {
     window.addEventListener('mouseup', onMinimapCanvasMouseUp);
@@ -480,44 +362,19 @@ function FlamegraphZoomViewMinimap({
   return (
     <Fragment>
       <Canvas
-        ref={c => setFlamegraphMiniMapCanvasRef(c)}
+        ref={setFlamegraphMiniMapCanvasRef}
         onMouseDown={onMinimapCanvasMouseDown}
         onMouseMove={onMinimapCanvasMouseMove}
         onMouseLeave={onMinimapCanvasMouseUp}
-        cursor={getCanvasCursor(
+        cursor={getMinimapCanvasCursor(
           flamegraphMiniMapView?.configView,
           configSpaceCursor,
           miniMapConfigSpaceBorderSize
         )}
       />
-      <OverlayCanvas ref={c => setFlamegraphMiniMapOverlayCanvasRef(c)} />
+      <OverlayCanvas ref={setFlamegraphMiniMapOverlayCanvasRef} />
     </Fragment>
   );
-}
-
-function getCanvasCursor(
-  configView: Rect | undefined,
-  configSpaceCursor: vec2 | null,
-  borderWidth: number
-) {
-  if (!configView || !configSpaceCursor) {
-    return 'col-resize';
-  }
-
-  const nearestEdge = Math.min(
-    Math.abs(configView.left - configSpaceCursor[0]),
-    Math.abs(configView.right - configSpaceCursor[0])
-  );
-  const isWithinBorderSize = nearestEdge <= borderWidth;
-  if (isWithinBorderSize) {
-    return 'ew-resize';
-  }
-
-  if (configView.contains(configSpaceCursor)) {
-    return 'grab';
-  }
-
-  return 'col-resize';
 }
 
 const Canvas = styled('canvas')<{cursor?: React.CSSProperties['cursor']}>`

--- a/static/app/components/profiling/flamegraph/interactions/useCanvasScroll.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useCanvasScroll.tsx
@@ -1,0 +1,47 @@
+import {useCallback} from 'react';
+import {mat3, vec2} from 'gl-matrix';
+
+import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+
+export function useCanvasScroll(
+  canvas: FlamegraphCanvas | null,
+  view: CanvasView<any> | null,
+  canvasPoolManager: CanvasPoolManager
+) {
+  const onCanvasScroll = useCallback(
+    (evt: WheelEvent) => {
+      if (!canvas || !view) {
+        return;
+      }
+
+      {
+        const physicalDelta = vec2.fromValues(evt.deltaX * 0.8, evt.deltaY);
+        const physicalToConfig = mat3.invert(
+          mat3.create(),
+          view.fromConfigView(canvas.physicalSpace)
+        );
+        const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
+
+        const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+          m00,
+          m01,
+          m02,
+          m10,
+          m11,
+          m12,
+          0,
+          0,
+          0,
+        ]);
+
+        const translate = mat3.fromTranslation(mat3.create(), configDelta);
+        canvasPoolManager.dispatch('transform config view', [translate]);
+      }
+    },
+    [canvas, view, canvasPoolManager]
+  );
+
+  return onCanvasScroll;
+}

--- a/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
@@ -1,0 +1,71 @@
+import React, {useEffect} from 'react';
+import {vec2} from 'gl-matrix';
+
+import {requestAnimationFrameTimeout} from 'sentry/views/profiling/utils';
+
+export function useCanvasZoomOrScroll({
+  handleWheel,
+  handleScroll,
+  canvas,
+  configSpaceCursor,
+  setConfigSpaceCursor,
+  lastInteraction,
+  setLastInteraction,
+}: {
+  canvas: HTMLCanvasElement | null;
+  configSpaceCursor: vec2 | null;
+  handleScroll: (evt: WheelEvent) => void;
+  handleWheel: (evt: WheelEvent) => void;
+  lastInteraction: 'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null;
+  setConfigSpaceCursor: React.Dispatch<React.SetStateAction<vec2 | null>>;
+  setLastInteraction: React.Dispatch<
+    React.SetStateAction<'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null>
+  >;
+}) {
+  useEffect(() => {
+    if (!canvas) {
+      return undefined;
+    }
+
+    let wheelStopTimeoutId: {current: number | undefined} = {current: undefined};
+    function onCanvasWheel(evt: WheelEvent) {
+      if (wheelStopTimeoutId.current !== undefined) {
+        window.cancelAnimationFrame(wheelStopTimeoutId.current);
+      }
+      wheelStopTimeoutId = requestAnimationFrameTimeout(() => {
+        setLastInteraction(null);
+      }, 300);
+
+      // When we zoom, we want to clear cursor so that any tooltips
+      // rendered on the flamegraph are removed from the flamegraphView
+      setConfigSpaceCursor(null);
+
+      // pinch to zoom is recognized as `ctrlKey + wheelEvent`
+      if (evt.metaKey || evt.ctrlKey) {
+        handleWheel(evt);
+        setLastInteraction('zoom');
+      } else {
+        handleScroll(evt);
+        setLastInteraction('scroll');
+      }
+    }
+
+    const options: AddEventListenerOptions & EventListenerOptions = {passive: true};
+    canvas.addEventListener('wheel', onCanvasWheel, options);
+
+    return () => {
+      if (wheelStopTimeoutId.current !== undefined) {
+        window.cancelAnimationFrame(wheelStopTimeoutId.current);
+      }
+      canvas.removeEventListener('wheel', onCanvasWheel, options);
+    };
+  }, [
+    canvas,
+    handleWheel,
+    handleScroll,
+    configSpaceCursor,
+    lastInteraction,
+    setConfigSpaceCursor,
+    setLastInteraction,
+  ]);
+}

--- a/static/app/components/profiling/flamegraph/interactions/useDrawHoveredBorderEffect.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useDrawHoveredBorderEffect.tsx
@@ -1,0 +1,60 @@
+import {useEffect} from 'react';
+
+import {CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {SelectedFrameRenderer} from 'sentry/utils/profiling/renderers/selectedFrameRenderer';
+import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
+
+export function useDrawHoveredBorderEffect({
+  scheduler,
+  view,
+  theme,
+  canvas,
+  renderer,
+  hoveredNode,
+}: {
+  canvas: FlamegraphCanvas | null;
+  hoveredNode: FlamegraphFrame | SpanChartNode | null;
+  renderer: SelectedFrameRenderer | null;
+  scheduler: CanvasScheduler;
+  theme: FlamegraphTheme;
+  view: CanvasView<Flamegraph | SpanChart> | null;
+}) {
+  useEffect(() => {
+    if (!canvas || !view || !renderer) {
+      return undefined;
+    }
+
+    const drawHoveredFrameBorder = () => {
+      if (hoveredNode) {
+        renderer.draw(
+          [
+            new Rect(
+              hoveredNode.start,
+              hoveredNode.depth,
+              hoveredNode.end - hoveredNode.start,
+              1
+            ),
+          ],
+          {
+            BORDER_COLOR: theme.COLORS.HOVERED_FRAME_BORDER_COLOR,
+            BORDER_WIDTH: theme.SIZES.HOVERED_FRAME_BORDER_WIDTH,
+          },
+          view.fromTransformedConfigView(canvas.physicalSpace)
+        );
+      }
+    };
+
+    scheduler.registerAfterFrameCallback(drawHoveredFrameBorder);
+    scheduler.draw();
+
+    return () => {
+      scheduler.unregisterAfterFrameCallback(drawHoveredFrameBorder);
+    };
+  }, [view, canvas, scheduler, hoveredNode, renderer, theme]);
+}

--- a/static/app/components/profiling/flamegraph/interactions/useDrawSelectedBorderEffect.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useDrawSelectedBorderEffect.tsx
@@ -1,0 +1,68 @@
+import {useEffect} from 'react';
+
+import {CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+import {SelectedFrameRenderer} from 'sentry/utils/profiling/renderers/selectedFrameRenderer';
+import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
+
+export function useDrawSelectedBorderEffect({
+  scheduler,
+  view,
+  theme,
+  canvas,
+  eventKey,
+  renderer,
+  selectedRef,
+}: {
+  canvas: FlamegraphCanvas | null;
+  eventKey: 'highlight frame' | 'highlight span';
+  renderer: SelectedFrameRenderer | null;
+  scheduler: CanvasScheduler;
+  selectedRef: React.MutableRefObject<FlamegraphFrame[] | SpanChartNode[] | null>;
+  theme: FlamegraphTheme;
+  view: CanvasView<Flamegraph | SpanChart> | null;
+}) {
+  useEffect(() => {
+    if (!canvas || !view || !renderer) {
+      return undefined;
+    }
+    function onHighlight(
+      node: FlamegraphFrame[] | SpanChartNode[] | null,
+      mode: 'hover' | 'selected'
+    ) {
+      if (mode === 'selected') {
+        selectedRef.current = node;
+      }
+      scheduler.draw();
+    }
+
+    const drawSelectedFrameBorder = () => {
+      if (selectedRef.current) {
+        renderer.draw(
+          selectedRef.current.map(frame => {
+            return new Rect(frame.start, frame.depth, frame.end - frame.start, 1);
+          }),
+          {
+            BORDER_COLOR: theme.COLORS.SELECTED_FRAME_BORDER_COLOR,
+            BORDER_WIDTH: theme.SIZES.FRAME_BORDER_WIDTH,
+          },
+          view.fromTransformedConfigView(canvas.physicalSpace)
+        );
+      }
+    };
+
+    scheduler.on(eventKey, onHighlight);
+    scheduler.registerAfterFrameCallback(drawSelectedFrameBorder);
+    scheduler.draw();
+
+    return () => {
+      scheduler.off(eventKey, onHighlight);
+      scheduler.unregisterAfterFrameCallback(drawSelectedFrameBorder);
+    };
+  }, [view, canvas, scheduler, renderer, eventKey, theme, selectedRef]);
+}

--- a/static/app/components/profiling/flamegraph/interactions/useInteractionViewCheckPoint.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useInteractionViewCheckPoint.tsx
@@ -1,0 +1,38 @@
+import {useEffect, useRef} from 'react';
+
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
+import {Rect} from 'sentry/utils/profiling/gl/utils';
+import usePrevious from 'sentry/utils/usePrevious';
+
+export function useInteractionViewCheckPoint({
+  view,
+  lastInteraction,
+}: {
+  lastInteraction: 'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null;
+  view: CanvasView<any> | null;
+}) {
+  const previousInteraction = usePrevious(lastInteraction);
+  const beforeInteractionConfigView = useRef<Rect | null>(null);
+
+  const dispatch = useDispatchFlamegraphState();
+
+  useEffect(() => {
+    if (!view) {
+      return;
+    }
+
+    // Check if we are starting a new interaction
+    if (previousInteraction === null && lastInteraction) {
+      beforeInteractionConfigView.current = view.configView.clone();
+      return;
+    }
+
+    if (
+      beforeInteractionConfigView.current &&
+      !beforeInteractionConfigView.current.equals(view.configView)
+    ) {
+      dispatch({type: 'checkpoint', payload: view.configView.clone()});
+    }
+  }, [dispatch, lastInteraction, previousInteraction, view]);
+}

--- a/static/app/components/profiling/flamegraph/interactions/useWheelCenterZoom.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useWheelCenterZoom.tsx
@@ -1,0 +1,28 @@
+import {useCallback} from 'react';
+
+import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {getCenterScaleMatrix} from 'sentry/utils/profiling/gl/utils';
+
+export function useWheelCenterZoom(
+  canvas: FlamegraphCanvas | null,
+  view: CanvasView<any> | null,
+  canvasPoolManager: CanvasPoolManager
+) {
+  const zoom = useCallback(
+    (evt: WheelEvent) => {
+      if (!canvas || !view) {
+        return;
+      }
+
+      const scale = 1 - evt.deltaY * 0.01 * -1; // -1 to invert scale
+      canvasPoolManager.dispatch('transform config view', [
+        getCenterScaleMatrix(scale, evt.offsetX, evt.offsetY, view, canvas),
+      ]);
+    },
+    [canvas, view, canvasPoolManager]
+  );
+
+  return zoom;
+}

--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -2,6 +2,7 @@ import {mat3} from 'gl-matrix';
 
 import {Rect} from './gl/utils';
 import {FlamegraphFrame} from './flamegraphFrame';
+import {SpanChartNode} from './spanChart';
 
 type DrawFn = () => void;
 type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
@@ -11,11 +12,13 @@ export interface FlamegraphEvents {
     frame: FlamegraphFrame[] | null,
     mode: 'hover' | 'selected'
   ) => void;
+  ['highlight span']: (frame: SpanChartNode[] | null, mode: 'hover' | 'selected') => void;
   ['reset zoom']: () => void;
   ['set config view']: (configView: Rect) => void;
   ['show in table view']: (frame: FlamegraphFrame) => void;
   ['transform config view']: (transform: mat3) => void;
   ['zoom at frame']: (frame: FlamegraphFrame, strategy: 'min' | 'exact') => void;
+  ['zoom at span']: (frame: SpanChartNode, strategy: 'min' | 'exact') => void;
 }
 
 type EventStore = {[K in keyof FlamegraphEvents]: Set<FlamegraphEvents[K]>};
@@ -31,9 +34,11 @@ export class CanvasScheduler {
     ['show in table view']: new Set<FlamegraphEvents['show in table view']>(),
     ['reset zoom']: new Set<FlamegraphEvents['reset zoom']>(),
     ['highlight frame']: new Set<FlamegraphEvents['highlight frame']>(),
+    ['highlight span']: new Set<FlamegraphEvents['highlight span']>(),
     ['set config view']: new Set<FlamegraphEvents['set config view']>(),
     ['transform config view']: new Set<FlamegraphEvents['transform config view']>(),
     ['zoom at frame']: new Set<FlamegraphEvents['zoom at frame']>(),
+    ['zoom at span']: new Set<FlamegraphEvents['zoom at span']>(),
   };
 
   onDispose(cb: () => void): void {

--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -1,3 +1,4 @@
+import {useEffect, useMemo} from 'react';
 import {mat3} from 'gl-matrix';
 
 import {Rect} from './gl/utils';
@@ -176,4 +177,21 @@ export class CanvasPoolManager {
       scheduler.draw();
     }
   }
+}
+
+/**
+ * Creates a new instance of CanvasScheduler and registers it
+ * with the provided CanvasPoolManager.
+ * @param canvasPoolManager
+ * @returns
+ */
+export function useCanvasScheduler(canvasPoolManager: CanvasPoolManager) {
+  const scheduler = useMemo(() => new CanvasScheduler(), []);
+
+  useEffect(() => {
+    canvasPoolManager.registerScheduler(scheduler);
+    return () => canvasPoolManager.unregisterScheduler(scheduler);
+  }, [canvasPoolManager, scheduler]);
+
+  return scheduler;
 }

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -133,10 +133,14 @@ function defaultFrameSort(a: FlamegraphFrame, b: FlamegraphFrame): number {
   return defaultFrameSortKey(a) > defaultFrameSortKey(b) ? 1 : -1;
 }
 
-export function makeColorBucketTheme(lch: LCH) {
-  return (t: number): ColorChannels => {
+export function makeColorBucketTheme(
+  lch: LCH,
+  spectrum = 360,
+  offset = 0
+): (t: number) => ColorChannels {
+  return t => {
     const x = triangle(30.0 * t);
-    const H = 360.0 * (0.9 * t);
+    const H = spectrum < 360 ? offset + spectrum * (0.9 * t) : spectrum * 0.9 * t;
     const C = lch.C_0 + lch.C_d * x;
     const L = lch.L_0 - lch.L_d * x;
     return fromLumaChromaHue(L, C, H);

--- a/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.spec.ts
+++ b/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.spec.ts
@@ -2,7 +2,7 @@ import {DeepPartial} from 'sentry/types/utils';
 
 import {FlamegraphFrame} from '../flamegraphFrame';
 
-import {selectNearestFrame} from './selectNearestFrame';
+import {selectNearestFrame} from './flamegraphKeyboardNavigation';
 
 function createFlamegraphFrame(frame?: DeepPartial<FlamegraphFrame>) {
   const {

--- a/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
+++ b/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
@@ -139,3 +139,44 @@ function getSibling(frame: FlamegraphFrame, directionX: DirectionX) {
 
   return null;
 }
+
+// loosely based spreadsheet navigation
+const keyDirectionMap: Record<string, Direction> = {
+  ArrowUp: 'up',
+  ArrowDown: 'down',
+  ArrowLeft: 'left',
+  ArrowRight: 'right',
+  Tab: 'down',
+  'Shift+Tab': 'up',
+  w: 'up',
+  s: 'down',
+  a: 'left',
+  d: 'right',
+} as const;
+
+export function handleFlamegraphKeyboardNavigation(
+  evt: KeyboardEvent,
+  currentFrame: FlamegraphFrame | undefined,
+  inverted: boolean = false
+) {
+  if (!currentFrame) {
+    return null;
+  }
+
+  const key = evt.shiftKey ? `Shift+${evt.key}` : evt.key;
+  let direction = keyDirectionMap[key];
+
+  // if the key is not mapped, don't handle it
+  if (!direction) {
+    return null;
+  }
+  if (inverted && (direction === 'up' || direction === 'down')) {
+    direction = direction === 'up' ? 'down' : 'up';
+  }
+  const nextSelection = selectNearestFrame(currentFrame, direction);
+  if (nextSelection === currentFrame) {
+    return null;
+  }
+  evt.preventDefault();
+  return nextSelection;
+}

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -51,6 +51,7 @@ export interface FlamegraphTheme {
     SAMPLE_TICK_COLOR: ColorChannels;
     SEARCH_RESULT_FRAME_COLOR: string;
     SELECTED_FRAME_BORDER_COLOR: string;
+    SPAN_COLOR_BUCKET: (t: number) => ColorChannels;
     SPAN_FALLBACK_COLOR: [number, number, number, number];
     SPAN_FRAME_BACKGROUND: string;
     SPAN_FRAME_BORDER: string;
@@ -136,6 +137,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
   COLORS: {
     BAR_LABEL_FONT_COLOR: '#000',
     COLOR_BUCKET: makeColorBucketTheme(LCH_LIGHT),
+    SPAN_COLOR_BUCKET: makeColorBucketTheme(LCH_LIGHT, 60, 260),
     COLOR_MAP: makeColorMap,
     CURSOR_CROSSHAIR: '#bbbbbb',
     DIFFERENTIAL_DECREASE: [0.309, 0.2058, 0.98],
@@ -165,6 +167,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
   COLORS: {
     BAR_LABEL_FONT_COLOR: 'rgb(255 255 255 / 80%)',
     COLOR_BUCKET: makeColorBucketTheme(LCH_DARK),
+    SPAN_COLOR_BUCKET: makeColorBucketTheme(LCH_DARK, 120, 240),
     COLOR_MAP: makeColorMap,
     CURSOR_CROSSHAIR: '#828285',
     DIFFERENTIAL_DECREASE: [0.309, 0.2058, 0.98],

--- a/static/app/utils/profiling/renderers/spansRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansRenderer.tsx
@@ -1,9 +1,6 @@
 import {mat3, vec2} from 'gl-matrix';
 
-import {
-  FlamegraphTheme,
-  LCH_LIGHT,
-} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {
   getContext,
   Rect,
@@ -11,7 +8,7 @@ import {
 } from 'sentry/utils/profiling/gl/utils';
 import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
 
-import {makeColorBucketTheme, makeSpansColorMapByOpAndDescription} from '../colors/utils';
+import {makeSpansColorMapByOpAndDescription} from '../colors/utils';
 
 // Convert color component from 0-1 to 0-255 range
 function colorComponentsToRgba(color: number[]): string {
@@ -38,7 +35,7 @@ export class SpanChartRenderer2D {
     this.context = getContext(this.canvas, '2d');
     this.colors = makeSpansColorMapByOpAndDescription(
       this.spans,
-      makeColorBucketTheme(LCH_LIGHT)
+      this.theme.COLORS.SPAN_COLOR_BUCKET
     );
 
     this.init();

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -42,16 +42,21 @@ class SpanChart {
     spanTree: SpanTree,
     options: {unit: Profile['unit']; configSpace?: Rect} = {unit: 'milliseconds'}
   ) {
-    this.spanTree = spanTree;
+    // Units need to be init before any profile iteration is done
     this.toFinalUnit = makeFormatTo('seconds', options.unit);
-    this.spans = this.collectSpanNodes();
     this.timelineFormatter = makeTimelineFormatter(options.unit);
+    this.formatter = makeFormatter(options.unit);
+
+    this.spanTree = spanTree;
+    this.spans = this.collectSpanNodes();
 
     const duration = this.toFinalUnit(
       this.spanTree.root.span.timestamp - this.spanTree.root.span.start_timestamp
     );
 
     this.configSpace = new Rect(0, 0, duration, this.depth);
+    this.root.end = duration;
+    this.root.duration = duration;
   }
 
   // Bfs over the span tree while keeping track of level depth and calling the cb fn

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -93,11 +93,12 @@ class SpanChart {
           this.root.children.push(spanChartNode);
         }
 
-        const nodesWithParent = node.children.map(
-          // @todo use satisfies here when available
-          child => [spanChartNode, child] as [SpanChartNode, SpanTreeNode]
+        queue.push(
+          ...node.children.map(
+            // @todo use satisfies here when available
+            child => [spanChartNode, child] as [SpanChartNode, SpanTreeNode]
+          )
         );
-        queue.push(...nodesWithParent);
       }
       depth++;
     }

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -97,8 +97,10 @@ class SpanTree {
     this.buildCollapsedSpanTree(spans);
   }
 
-  static Empty(): SpanTree {
-    return new SpanTree(EmptyEventTransaction, []);
+  static Empty = new SpanTree(EmptyEventTransaction, []);
+
+  isEmpty(): boolean {
+    return this === SpanTree.Empty;
   }
 
   buildCollapsedSpanTree(spans: RawSpanType[]) {

--- a/static/app/utils/profiling/units/units.ts
+++ b/static/app/utils/profiling/units/units.ts
@@ -37,6 +37,9 @@ export function formatTo(
 }
 
 const format = (v: number, abbrev: string, precision: number) => {
+  if (v === 0) {
+    return '0' + abbrev;
+  }
   return v.toFixed(precision) + abbrev;
 };
 

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -65,7 +65,7 @@ const LoadingGroup: ProfileGroup = {
   profiles: [Profile.Empty],
 };
 
-const LoadingSpanTree = SpanTree.Empty();
+const LoadingSpanTree = SpanTree.Empty;
 
 function ProfileFlamegraph(): React.ReactElement {
   const organization = useOrganization();


### PR DESCRIPTION
Wire up hover (render outline) and click (single = blue outline, double = zoom to timeline) span interactions. Unfortunately, copy paste strikes again, but I will be abstracting these interactions into separate util fns

https://user-images.githubusercontent.com/9317857/210399038-acf1cb9d-bd14-4f2b-8c06-7f1c1dfd7c18.mp4

