### PR TITLE
[CI] Reset settings between runs

### DIFF
--- a/tests/sentry/helpers/test_deprecation.py
+++ b/tests/sentry/helpers/test_deprecation.py
@@ -45,6 +45,7 @@ class TestDeprecationDecorator(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         settings.SENTRY_SELF_HOSTED = False
+        settings.SENTRY_OPTIONS = {}
 
     def assert_deprecation_metadata(self, request: Request, response: Response):
         assert "X-Sentry-Deprecation-Date" in response


### PR DESCRIPTION
This was an error that was bubbling up when shuffling tests: https://github.com/getsentry/sentry/actions/runs/3814606626/jobs/6489034033#step:4:736