### PR TITLE
Use a copy of events to prevent shuffle errors

### DIFF
--- a/src/sentry/testutils/performance_issues/event_generators.py
+++ b/src/sentry/testutils/performance_issues/event_generators.py
@@ -1,5 +1,7 @@
 import os
+from copy import deepcopy
 
+from sentry.eventstore.models import Event
 from sentry.testutils.factories import get_fixture_path
 from sentry.utils import json
 
@@ -28,6 +30,12 @@ for (dirpath, dirnames, filenames) in os.walk(_fixture_path):
             event["project"] = PROJECT_ID
 
         EVENTS[full_event_name] = event
+
+
+def get_event(event_name) -> Event:
+    # Create copy to avoid the risk of tests altering the event and affecting
+    # other tests.
+    return deepcopy(EVENTS[event_name])
 
 
 # Duration is in ms

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -9,12 +9,12 @@ from sentry.sdk_updates import SdkIndexState
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 from sentry.utils.samples import load_data
 from tests.sentry.event_manager.test_event_manager import make_event
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
-from tests.sentry.utils.performance_issues.test_performance_detection import EVENTS
 
 
 @region_silo_test
@@ -400,7 +400,7 @@ class DetailedEventSerializerTest(TestCase):
     def test_performance_problem(self):
         self.project.update_option("sentry:performance_issue_creation_rate", 1.0)
         with mock.patch("sentry_sdk.tracing.Span.containing_transaction"):
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             event = manager.save(self.project.id)
         group_event = event.for_group(event.groups[0])
@@ -435,7 +435,7 @@ class DetailedEventSerializerTest(TestCase):
         with mock.patch("sentry_sdk.tracing.Span.containing_transaction"), mock.patch(
             "sentry.event_manager.EventPerformanceProblem"
         ):
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             event = manager.save(self.project.id)
         group_event = event.for_group(event.groups[0])

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -76,6 +76,7 @@ from sentry.testutils import (
 )
 from sentry.testutils.helpers import apply_feature_flag_on_cls, override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.issues import GroupCategory, GroupType
@@ -88,7 +89,6 @@ from sentry.utils.performance_issues.performance_detection import (
 )
 from sentry.utils.samples import load_data
 from tests.sentry.integrations.github.test_repository import stub_installation_token
-from tests.sentry.utils.performance_issues.test_performance_detection import EVENTS
 
 
 def make_event(**kwargs):
@@ -2224,7 +2224,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
         self.project.update_option("sentry:performance_issue_creation_rate", 1.0)
 
         with mock.patch("sentry_sdk.tracing.Span.containing_transaction"):
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             event = manager.save(self.project.id)
             data = event.data
@@ -2304,7 +2304,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
         self.project.update_option("sentry:performance_issue_creation_rate", 1.0)
 
         with mock.patch("sentry_sdk.tracing.Span.containing_transaction"):
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             event = manager.save(self.project.id)
             group = event.groups[0]
@@ -2320,7 +2320,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
             assert group.location() == "hi"
             assert group.title == "lol"
 
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             with self.tasks():
                 manager.save(self.project.id)
@@ -2347,7 +2347,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
                 "projects:performance-suspect-spans-ingestion": True,
             }
         ):
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             event = manager.save(self.project.id)
             assert len(event.groups) == 1
@@ -2356,7 +2356,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
             group = event.groups[0]
             group.type = GroupType.ERROR.value
             group.save()
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             event = manager.save(self.project.id)
 
@@ -2397,7 +2397,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
                 "projects:performance-suspect-spans-ingestion": True,
             }
         ):
-            manager = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager.normalize()
             event = manager.save(self.project.id)
             data = event.data
@@ -2414,9 +2414,9 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
                 "projects:performance-suspect-spans-ingestion": True,
             }
         ):
-            manager1 = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
-            manager2 = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
-            manager3 = EventManager(make_event(**EVENTS["n-plus-one-in-django-index-view"]))
+            manager1 = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
+            manager2 = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
+            manager3 = EventManager(make_event(**get_event("n-plus-one-in-django-index-view")))
             manager1.normalize()
             manager2.normalize()
             manager3.normalize()

--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -5,9 +5,9 @@ import pytest
 
 from sentry.eventstore.models import Event
 from sentry.testutils.performance_issues.event_generators import (
-    EVENTS,
     create_event,
     create_span,
+    get_event,
     modify_span_start,
 )
 from sentry.testutils.silo import region_silo_test
@@ -141,7 +141,7 @@ class ConsecutiveDbDetectorTest(unittest.TestCase):
         assert problems == []
 
     def test_detects_consecutive_db_in_query_waterfall_event(self):
-        event = EVENTS["query-waterfall-in-django-random-view"]
+        event = get_event("query-waterfall-in-django-random-view")
 
         problems = self.find_problems(event)
 

--- a/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call
 import pytest
 
 from sentry.eventstore.models import Event
-from sentry.testutils.performance_issues.event_generators import EVENTS
+from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
 from sentry.types.issues import GroupType
 from sentry.utils.performance_issues.performance_detection import (
@@ -30,7 +30,7 @@ class MNPlusOneDBDetectorTest(unittest.TestCase):
         return list(detector.stored_problems.values())
 
     def test_detects_parallel_m_n_plus_one(self):
-        event = EVENTS["m-n-plus-one-db/m-n-plus-one-graphql"]
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
 
         problems = self.find_problems(event)
         assert problems == [
@@ -72,15 +72,15 @@ class MNPlusOneDBDetectorTest(unittest.TestCase):
         assert problems[0].title == "MN+1 Query"
 
     def test_does_not_detect_truncated_m_n_plus_one(self):
-        event = EVENTS["m-n-plus-one-db/m-n-plus-one-graphql-truncated"]
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql-truncated")
         assert self.find_problems(event) == []
 
     def test_does_not_detect_n_plus_one(self):
-        event = EVENTS["n-plus-one-in-django-index-view"]
+        event = get_event("n-plus-one-in-django-index-view")
         assert self.find_problems(event) == []
 
     def test_m_n_plus_one_detector_enabled(self):
-        event = EVENTS["m-n-plus-one-db/m-n-plus-one-graphql"]
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
         sdk_span_mock = Mock()
         _detect_performance_problems(event, sdk_span_mock)
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 
 from sentry.eventstore.models import Event
-from sentry.testutils.performance_issues.event_generators import EVENTS
+from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
 from sentry.types.issues import GroupType
 from sentry.utils.performance_issues.performance_detection import (
@@ -28,7 +28,7 @@ class NPlusOneAPICallsDetectorTest(unittest.TestCase):
         return list(detector.stored_problems.values())
 
     def test_detects_problems_with_many_concurrent_calls_to_same_url(self):
-        event = EVENTS["n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream"]
+        event = get_event("n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream")
 
         problems = self.find_problems(event)
         assert self.find_problems(event) == [
@@ -71,7 +71,7 @@ class NPlusOneAPICallsDetectorTest(unittest.TestCase):
         assert problems[0].title == "N+1 API Calls"
 
     def test_does_not_detect_problem_with_concurrent_calls_to_different_urls(self):
-        event = EVENTS["n-plus-one-api-calls/not-n-plus-one-api-calls"]
+        event = get_event("n-plus-one-api-calls/not-n-plus-one-api-calls")
         assert self.find_problems(event) == []
 
 
@@ -160,7 +160,7 @@ def test_rejects_ineligible_spans(span):
 
 @pytest.mark.parametrize(
     "event",
-    [EVENTS["n-plus-one-api-calls/not-n-plus-one-api-calls"]],
+    [get_event("n-plus-one-api-calls/not-n-plus-one-api-calls")],
 )
 def test_allows_eligible_events(event):
     assert NPlusOneAPICallsDetector.is_event_eligible(event)

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 import pytest
 
 from sentry.eventstore.models import Event
-from sentry.testutils.performance_issues.event_generators import EVENTS
+from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.performance_issues.performance_detection import (
     DetectorType,
@@ -35,37 +35,37 @@ class NPlusOneDbDetectorTest(unittest.TestCase):
         return list(detector.stored_problems.values())
 
     def test_does_not_detect_issues_in_fast_transaction(self):
-        event = EVENTS["no-issue-in-django-detail-view"]
+        event = get_event("no-issue-in-django-detail-view")
         assert self.find_problems(event) == []
 
     def test_does_not_detect_n_plus_one_with_unparameterized_query_with_parameterized_detector(
         self,
     ):
-        event = EVENTS["n-plus-one-in-django-index-view-unparameterized"]
+        event = get_event("n-plus-one-in-django-index-view-unparameterized")
         assert self.find_problems(event) == []
 
     def test_does_not_detect_n_plus_one_with_source_redis_query_with_noredis_detector(
         self,
     ):
-        event = EVENTS["n-plus-one-in-django-index-view-source-redis"]
+        event = get_event("n-plus-one-in-django-index-view-source-redis")
         assert self.find_problems(event) == []
 
     def test_does_not_detect_n_plus_one_with_repeating_redis_query_with_noredis_detector(
         self,
     ):
-        event = EVENTS["n-plus-one-in-django-index-view-repeating-redis"]
+        event = get_event("n-plus-one-in-django-index-view-repeating-redis")
         assert self.find_problems(event) == []
 
     def test_ignores_fast_n_plus_one(self):
-        event = EVENTS["fast-n-plus-one-in-django-new-view"]
+        event = get_event("fast-n-plus-one-in-django-new-view")
         assert self.find_problems(event) == []
 
     def test_detects_slow_span_but_not_n_plus_one_in_query_waterfall(self):
-        event = EVENTS["query-waterfall-in-django-random-view"]
+        event = get_event("query-waterfall-in-django-random-view")
         assert self.find_problems(event) == []
 
     def test_finds_n_plus_one_with_db_dot_something_spans(self):
-        event = EVENTS["n-plus-one-in-django-index-view-activerecord"]
+        event = get_event("n-plus-one-in-django-index-view-activerecord")
         assert self.find_problems(event) == [
             PerformanceProblem(
                 fingerprint="1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
@@ -92,8 +92,8 @@ class NPlusOneDbDetectorTest(unittest.TestCase):
     def test_n_plus_one_db_detector_has_different_fingerprints_for_different_n_plus_one_events(
         self,
     ):
-        index_n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
-        new_n_plus_one_event = EVENTS["n-plus-one-in-django-new-view"]
+        index_n_plus_one_event = get_event("n-plus-one-in-django-index-view")
+        new_n_plus_one_event = get_event("n-plus-one-in-django-new-view")
 
         index_problems = self.find_problems(index_n_plus_one_event)
         new_problems = self.find_problems(new_n_plus_one_event)
@@ -106,7 +106,7 @@ class NPlusOneDbDetectorTest(unittest.TestCase):
         assert index_fingerprint != new_fingerprint
 
     def test_detects_n_plus_one_with_multiple_potential_sources(self):
-        event = EVENTS["n-plus-one-in-django-with-odd-db-sources"]
+        event = get_event("n-plus-one-in-django-with-odd-db-sources")
 
         assert self.find_problems(event, {"duration_threshold": 0}) == [
             PerformanceProblem(

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -7,7 +7,7 @@ from sentry import projectoptions
 from sentry.eventstore.models import Event
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_options
-from sentry.testutils.performance_issues.event_generators import EVENTS
+from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
 from sentry.types.issues import GroupType
 from sentry.utils.performance_issues.performance_detection import (
@@ -72,7 +72,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @override_options(BASE_DETECTOR_OPTIONS)
     def test_project_option_overrides_default(self):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
+        n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
@@ -87,7 +87,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @override_options(BASE_DETECTOR_OPTIONS)
     def test_n_plus_one_extended_detection_no_parent_span(self):
-        n_plus_one_event = EVENTS["n-plus-one-db-root-parent-span"]
+        n_plus_one_event = get_event("n-plus-one-db-root-parent-span")
         sdk_span_mock = Mock()
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
@@ -116,7 +116,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @override_options(BASE_DETECTOR_OPTIONS)
     def test_n_plus_one_extended_detection_matches_previous_group(self):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
+        n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
         with override_options({"performance.issues.n_plus_one_db.problem-creation": 0.0}):
@@ -133,7 +133,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @override_options(BASE_DETECTOR_OPTIONS)
     def test_overlap_detector_problems(self):
-        n_plus_one_event = EVENTS["n-plus-one-db-root-parent-span"]
+        n_plus_one_event = get_event("n-plus-one-db-root-parent-span")
         sdk_span_mock = Mock()
 
         n_plus_one_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
@@ -142,7 +142,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @override_options(BASE_DETECTOR_OPTIONS_OFF)
     def test_system_option_disables_detector_issue_creation(self):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
+        n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
@@ -150,7 +150,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @override_options(BASE_DETECTOR_OPTIONS)
     def test_system_option_used_when_project_option_is_default(self):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
+        n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
         self.project_option_mock.return_value = projectoptions.get_well_known_default(
@@ -176,7 +176,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
     def test_detects_multiple_performance_issues_in_n_plus_one_query(self):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
+        n_plus_one_event = get_event("n-plus-one-in-django-index-view")
         sdk_span_mock = Mock()
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
@@ -217,14 +217,14 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     @patch("sentry.utils.metrics.incr")
     def test_does_not_report_metric_on_non_truncated_n_plus_one_query(self, incr_mock):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-new-view"]
+        n_plus_one_event = get_event("n-plus-one-in-django-new-view")
         _detect_performance_problems(n_plus_one_event, Mock())
         unexpected_call = call("performance.performance_issue.truncated_np1_db")
         assert unexpected_call not in incr_mock.mock_calls
 
     @patch("sentry.utils.metrics.incr")
     def test_reports_metric_on_truncated_query_n_plus_one(self, incr_mock):
-        truncated_duplicates_event = EVENTS["n-plus-one-in-django-new-view-truncated-duplicates"]
+        truncated_duplicates_event = get_event("n-plus-one-in-django-new-view-truncated-duplicates")
         _detect_performance_problems(truncated_duplicates_event, Mock())
         incr_mock.assert_has_calls([call("performance.performance_issue.truncated_np1_db")])
 

--- a/tests/sentry/utils/performance_issues/test_slow_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_slow_span_detector.py
@@ -4,7 +4,11 @@ from typing import List
 import pytest
 
 from sentry.eventstore.models import Event
-from sentry.testutils.performance_issues.event_generators import EVENTS, create_event, create_span
+from sentry.testutils.performance_issues.event_generators import (
+    create_event,
+    create_span,
+    get_event,
+)
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.performance_issues.performance_detection import (
     GroupType,
@@ -70,7 +74,7 @@ class SlowSpanDetectorTest(unittest.TestCase):
         ]
 
     def test_detects_slow_span_in_solved_n_plus_one_query(self):
-        n_plus_one_event = EVENTS["solved-n-plus-one-in-django-index-view"]
+        n_plus_one_event = get_event("solved-n-plus-one-in-django-index-view")
 
         assert self.find_problems(n_plus_one_event) == [
             PerformanceProblem(

--- a/tests/sentry/web/frontend/test_newest_performance_issue.py
+++ b/tests/sentry/web/frontend/test_newest_performance_issue.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from sentry.event_manager import EventManager
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_options
-from sentry.testutils.performance_issues.event_generators import EVENTS
+from sentry.testutils.performance_issues.event_generators import get_event
 
 
 def make_event(**kwargs):
@@ -23,7 +23,7 @@ def make_event(**kwargs):
     return result
 
 
-nplus_one_no_timestamp = {**EVENTS["n-plus-one-in-django-index-view"]}
+nplus_one_no_timestamp = {**get_event("n-plus-one-in-django-index-view")}
 del nplus_one_no_timestamp["timestamp"]
 
 


### PR DESCRIPTION
This should prevent errors like this: https://github.com/getsentry/sentry/actions/runs/3722676630/jobs/6313697915