### PR TITLE
fix(profiling): Selected frame renderer incorrect width

### DIFF
--- a/static/app/utils/profiling/renderers/selectedFrameRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/selectedFrameRenderer.spec.tsx
@@ -31,6 +31,6 @@ describe('SelectedFrameRenderer', () => {
     expect(context.beginPath).toHaveBeenCalled();
     expect(context.strokeStyle).toBe('red');
     expect(context.lineWidth).toBe(1);
-    expect(context.strokeRect).toHaveBeenLastCalledWith(0.5, 0.5, 198, 198);
+    expect(context.strokeRect).toHaveBeenLastCalledWith(1, 1, 198, 198);
   });
 });

--- a/static/app/utils/profiling/renderers/selectedFrameRenderer.tsx
+++ b/static/app/utils/profiling/renderers/selectedFrameRenderer.tsx
@@ -25,18 +25,16 @@ class SelectedFrameRenderer {
     for (let i = 0; i < frames.length; i++) {
       const frameInPhysicalSpace = frames[i].transformRect(configViewToPhysicalSpace);
 
-      // We draw the border in the center of the flamegraph, so we need to increase
-      // the width by border width and negatively offset it by half the border width
-      const borderRect = frameInPhysicalSpace
-        .withWidth(frameInPhysicalSpace.width - style.BORDER_WIDTH * 2)
-        .withHeight(frameInPhysicalSpace.height - style.BORDER_WIDTH * 2)
-        .translate(
-          frameInPhysicalSpace.x + style.BORDER_WIDTH / 2,
-          frameInPhysicalSpace.y + style.BORDER_WIDTH / 2
-        );
-
       context.beginPath();
-      context.strokeRect(borderRect.x, borderRect.y, borderRect.width, borderRect.height);
+
+      // We draw the border in the center of the flamegraph, so we need to decrease
+      // the width by border width and negatively offset it by half the border width
+      context.strokeRect(
+        frameInPhysicalSpace.x + style.BORDER_WIDTH,
+        frameInPhysicalSpace.y + style.BORDER_WIDTH,
+        frameInPhysicalSpace.width - style.BORDER_WIDTH * 2,
+        frameInPhysicalSpace.height - style.BORDER_WIDTH * 2
+      );
     }
   }
 }


### PR DESCRIPTION
When translating, we only need to translate by the width of the border once since it's drawn once on each side. Also removes the extract rectangles that are being created unnecessarily via `withWidth`, `withHeight` and `translate`.