### PR TITLE
ref(span-tree): Use `useEffect` instead of `useLayoutEffect`

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -1,4 +1,4 @@
-import React, {Component, useLayoutEffect, useRef} from 'react';
+import React, {Component, useEffect, useRef} from 'react';
 import {
   AutoSizer,
   CellMeasurer,
@@ -712,7 +712,6 @@ class SpanTree extends Component<PropType> {
     this.setState((prevState: StateType) => {
       const newSpanRows = {...prevState.spanRows};
       delete newSpanRows[spanId];
-
       return {spanRows: newSpanRows};
     });
   };
@@ -836,16 +835,7 @@ function SpanRow(props: SpanRowProps) {
   const rowRef = useRef<HTMLDivElement>(null);
   const spanNode = spanTree[index];
 
-  // Lifecycle management for row refs, we need to separately do this in useLayoutEffect since
-  // we won't have access to the refs in useEffect.
-  // From React's useLayoutEffect docs:
-
-  // "Updates scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint."
-
-  // In `useEffect`, the return function for cleanup isn't able to remove the ref from the map since the component no longer has access
-  // to it, since the return function is executed after the browser paints and so the DOM node is removed.
-
-  useLayoutEffect(() => {
+  useEffect(() => {
     // Gap spans do not have IDs, so we can't really store them. This should not be a big deal, since
     // we only need to keep track of spans to calculate an average depth, a few missing spans will not
     // throw off the calculation too hard


### PR DESCRIPTION
Previously we were using `useLayoutEffect` because `spanRows` was a map that used the row refs as keys. I eventually refactored to the implementation we have now, which is to use span IDs as the key for the map. Since we're using IDs to store refs at this point, we don't need access to the DOM immediately and can just use a regular `useEffect`