### PR TITLE
Revert "bug(replays): Trust the Replay api response `duration` field …

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -1,3 +1,5 @@
+import {duration} from 'moment';
+
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import {
   breadcrumbFactory,
@@ -5,6 +7,7 @@ import {
   isMemorySpan,
   isNetworkSpan,
   mapRRWebAttachments,
+  replayTimestamps,
   rrwebEventListFactory,
   spansFactory,
 } from 'sentry/utils/replays/replayDataUtils';
@@ -51,6 +54,20 @@ export default class ReplayReader {
     errors,
   }: RequiredNotNull<ReplayReaderParams>) {
     const {breadcrumbs, rrwebEvents, spans} = mapRRWebAttachments(attachments);
+
+    // TODO(replays): We should get correct timestamps from the backend instead
+    // of having to fix them up here.
+    const {startTimestampMs, endTimestampMs} = replayTimestamps(
+      replayRecord,
+      rrwebEvents,
+      breadcrumbs,
+      spans
+    );
+    replayRecord.startedAt = new Date(startTimestampMs);
+    replayRecord.finishedAt = new Date(endTimestampMs);
+    replayRecord.duration = duration(
+      replayRecord.finishedAt.getTime() - replayRecord.startedAt.getTime()
+    );
 
     const sortedSpans = spansFactory(spans);
     this.networkSpans = sortedSpans.filter(isNetworkSpan);


### PR DESCRIPTION
…and dont re-compute it on the frontend (#42346)"

This reverts commit 4fdbd4bccb3babb68bbdbeb42de7d05f7009a99b.


Fixes #42632
