### PR TITLE
fix(profiling): messaging for undefined platform

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/proflingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/proflingOnboardingSidebar.tsx
@@ -211,6 +211,26 @@ function OnboardingContent({
     return <LoadingIndicator />;
   }
 
+  if (!currentPlatform) {
+    return (
+      <Fragment>
+        <div>
+          {t(
+            `Your project's platform has not been set. Please select your project's platform before proceeding.`
+          )}
+        </div>
+        <div>
+          <Button
+            size="sm"
+            to={`/settings/${organization.slug}/projects/${currentProject.slug}/`}
+          >
+            {t('Go to Project Settings')}
+          </Button>
+        </div>
+      </Fragment>
+    );
+  }
+
   if (!isSupported) {
     // this content will only be presented if the org only has one project and its not supported
     // in these scenarios we will auto-select the unsupported project and render this message
@@ -231,7 +251,7 @@ function OnboardingContent({
     );
   }
 
-  if (!currentPlatform || !docKeysMap || !hasOnboardingContents) {
+  if (!docKeysMap || !hasOnboardingContents) {
     return (
       <Fragment>
         <div>


### PR DESCRIPTION
##  Summary
Adds messaging for edge cases where a project's platform has not been set.

![image](https://user-images.githubusercontent.com/7349258/210441106-72bd45d9-a1c4-4721-b028-952b63b307b9.png)


See also: https://github.com/getsentry/sentry/pull/42735
