### PR TITLE
fix(replays): dont capture MessageRejected Errors

### DIFF
--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -45,7 +45,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         partitions: Mapping[Partition, int],
     ) -> Any:
         return LogExceptionStep(
-            message="Invalid recording specified.",
+            message="Error in Replay Recording Processor",
             logger=logger,
             next_step=TransformStep(
                 function=move_chunks_to_cache_or_skip,

--- a/src/sentry/replays/lib/consumer.py
+++ b/src/sentry/replays/lib/consumer.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+from arroyo.errors import MessageRejected
 from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import Message, TPayload
 
@@ -22,6 +23,10 @@ class LogExceptionStep(ProcessingStrategy[TPayload]):
 
         try:
             self.__next_step.submit(message)
+        except MessageRejected:
+            # if we reject due to backpressure, we should not log an exception
+            # as this can cause an extreme amount of exceptions to be generated
+            return
         except Exception:
             self.__logger.exception(self.__exception_message)
 


### PR DESCRIPTION
In cases where arroyo throttles, we do not want to raise an error because this causes a tremendous amount of errors to be generated in Sentry and likely contributes CPU spiking in our consumer.

relevant error:
https://sentry.io/organizations/sentry/issues/3814192954/?project=1&query=logger%3Asentry.replays.consumers.recording&referrer=issue-stream&statsPeriod=14d