### PR TITLE
ref(profiling): cleanup onboarding platform typings

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -3,22 +3,20 @@ import partition from 'lodash/partition';
 import {PlatformKey, profiling} from 'sentry/data/platformCategories';
 import {Project} from 'sentry/types/project';
 
-export const supportedProfilingPlatforms = [
+export const supportedProfilingPlatforms = profiling;
+export const supportedProfilingPlatformSDKs = [
   'android',
   'apple-ios',
   'node',
   'python',
   'rust',
 ] as const;
+export type SupportedProfilingPlatform = typeof supportedProfilingPlatforms[number];
+export type SupportedProfilingPlatformSDK = typeof supportedProfilingPlatformSDKs[number];
 
-export type SupportedProfilingPlatform = Extract<
-  typeof profiling[number],
-  typeof supportedProfilingPlatforms[number]
->;
-
-const platformToDocsPlatform: Record<
-  typeof profiling[number],
-  typeof supportedProfilingPlatforms[number]
+const platformToDocsPlatformSDK: Record<
+  SupportedProfilingPlatform,
+  SupportedProfilingPlatformSDK
 > = {
   android: 'android',
   'apple-ios': 'apple-ios',
@@ -39,7 +37,7 @@ const platformToDocsPlatform: Record<
 
 export function isProfilingSupportedOrProjectHasProfiles(project: Project): boolean {
   return !!(
-    (project.platform && platformToDocsPlatform[project.platform]) ||
+    (project.platform && platformToDocsPlatformSDK[project.platform]) ||
     // If this project somehow managed to send profiles, then profiling is supported for this project.
     // Sometimes and for whatever reason, platform can also not be set on a project so the above check alone would fail
     project.hasProfiles
@@ -57,7 +55,7 @@ export const profilingOnboardingDocKeys = [
 type ProfilingOnboardingDocKeys = typeof profilingOnboardingDocKeys[number];
 
 export const supportedPlatformExpectedDocKeys: Record<
-  SupportedProfilingPlatform,
+  SupportedProfilingPlatformSDK,
   ProfilingOnboardingDocKeys[]
 > = {
   android: ['1-install', '2-configure-performance', '3-configure-profiling', '4-upload'],
@@ -78,11 +76,11 @@ function makeDocKey(platformId: PlatformKey, key: string) {
 
 type DocKeyMap = Record<typeof profilingOnboardingDocKeys[number], string>;
 export function makeDocKeyMap(platformId: PlatformKey | undefined) {
-  if (!platformId || !platformToDocsPlatform[platformId]) {
+  if (!platformId || !platformToDocsPlatformSDK[platformId]) {
     return null;
   }
 
-  const docsPlatform = platformToDocsPlatform[platformId];
+  const docsPlatform = platformToDocsPlatformSDK[platformId];
 
   const expectedDocKeys: ProfilingOnboardingDocKeys[] =
     supportedPlatformExpectedDocKeys[docsPlatform];
@@ -98,7 +96,7 @@ export function splitProjectsByProfilingSupport(projects: Project[]): {
 } {
   const [supported, unsupported] = partition(
     projects,
-    project => project.platform && platformToDocsPlatform[project.platform]
+    project => project.platform && platformToDocsPlatformSDK[project.platform]
   );
 
   return {supported, unsupported};

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -233,7 +233,9 @@ export const profiling = [
   'python-pylons',
   'python-pyramid',
   'python-tornado',
-];
+  // rust
+  'rust',
+] as const;
 
 export const releaseHealth: PlatformKey[] = [
   // frontend


### PR DESCRIPTION
## Summary
We had types that mapped platforms to platforms. This is an attempt to make a distinction between a sentry specific platform variant (ie. `python-*`) and a profiling platform SDK (ie. `python`).