### PR TITLE
Change how settings are altered in deprecation tests

### DIFF
--- a/tests/sentry/helpers/test_deprecation.py
+++ b/tests/sentry/helpers/test_deprecation.py
@@ -45,6 +45,7 @@ class TestDeprecationDecorator(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         settings.SENTRY_SELF_HOSTED = False
+        settings.SENTRY_OPTIONS = {}
 
     def assert_deprecation_metadata(self, request: Request, response: Response):
         assert "X-Sentry-Deprecation-Date" in response

--- a/tests/sentry/helpers/test_deprecation.py
+++ b/tests/sentry/helpers/test_deprecation.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 import isodate
 from croniter import croniter
-from django.conf import settings
 from freezegun import freeze_time
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/tests/sentry/helpers/test_deprecation.py
+++ b/tests/sentry/helpers/test_deprecation.py
@@ -44,8 +44,6 @@ dummy_endpoint = DummyEndpoint.as_view()
 class TestDeprecationDecorator(APITestCase):
     def setUp(self) -> None:
         super().setUp()
-        settings.SENTRY_SELF_HOSTED = False
-        settings.SENTRY_OPTIONS = {}
 
     def assert_deprecation_metadata(self, request: Request, response: Response):
         assert "X-Sentry-Deprecation-Date" in response
@@ -76,93 +74,123 @@ class TestDeprecationDecorator(APITestCase):
         self.assert_deprecation_metadata(request, resp)
 
     def test_before_deprecation_date(self):
-        with freeze_time(test_date - timedelta(seconds=1)):
-            self.assert_allowed_request("GET")
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            with freeze_time(test_date - timedelta(seconds=1)):
+                self.assert_allowed_request("GET")
 
     def test_after_deprecation_date(self):
-        with freeze_time(test_date):
-            self.assert_allowed_request("GET")
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            with freeze_time(test_date):
+                self.assert_allowed_request("GET")
 
-        brownout_start = timeiter.get_next(datetime)
-        with freeze_time(brownout_start):
-            self.assert_denied_request("GET")
+            brownout_start = timeiter.get_next(datetime)
+            with freeze_time(brownout_start):
+                self.assert_denied_request("GET")
 
-        mid_brownout = brownout_start + timedelta(seconds=1)
-        with freeze_time(mid_brownout):
-            self.assert_denied_request("GET")
+            mid_brownout = brownout_start + timedelta(seconds=1)
+            with freeze_time(mid_brownout):
+                self.assert_denied_request("GET")
 
-        brownout_end = brownout_start + timedelta(minutes=1)
-        with freeze_time(brownout_end):
-            self.assert_allowed_request("GET")
+            brownout_end = brownout_start + timedelta(minutes=1)
+            with freeze_time(brownout_end):
+                self.assert_allowed_request("GET")
 
     def test_self_hosted(self):
-        settings.SENTRY_SELF_HOSTED = True
-        self.assert_not_deprecated("GET")
+        with self.settings(SENTRY_SELF_HOSTED=True):
+            self.assert_not_deprecated("GET")
 
     def test_no_decorator(self):
-        self.assert_not_deprecated("HEAD")
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.assert_not_deprecated("HEAD")
 
     def test_default_key(self):
-        options.delete("api.deprecation.brownout-cron")
-        options.delete("api.deprecation.brownout-duration")
-        settings.SENTRY_OPTIONS.update({"api.deprecation.brownout-cron": custom_cron})
-        settings.SENTRY_OPTIONS.update({"api.deprecation.brownout-duration": custom_duration})
+        with self.settings(
+            SENTRY_SELF_HOSTED=False,
+            SENTRY_OPTIONS={
+                "api.deprecation.brownout-duration": custom_duration,
+                "api.deprecation.brownout-cron": custom_cron,
+            },
+        ):
+            options.delete("api.deprecation.brownout-cron")
+            options.delete("api.deprecation.brownout-duration")
 
-        custom_time_iter = croniter(custom_cron, test_date)
-        custom_duration_timedelta = isodate.parse_duration(custom_duration)
-        old_brownout_start = timeiter.get_next(datetime)
-        with freeze_time(old_brownout_start):
-            self.assert_allowed_request("GET")
+            custom_time_iter = croniter(custom_cron, test_date)
+            custom_duration_timedelta = isodate.parse_duration(custom_duration)
+            old_brownout_start = timeiter.get_next(datetime)
+            with freeze_time(old_brownout_start):
+                self.assert_allowed_request("GET")
 
-        new_brownout_start = custom_time_iter.get_next(datetime)
-        with freeze_time(new_brownout_start):
-            self.assert_denied_request("GET")
+            new_brownout_start = custom_time_iter.get_next(datetime)
+            with freeze_time(new_brownout_start):
+                self.assert_denied_request("GET")
 
-        old_brownout_end = new_brownout_start + default_duration
-        with freeze_time(old_brownout_end):
-            self.assert_denied_request("GET")
+            old_brownout_end = new_brownout_start + default_duration
+            with freeze_time(old_brownout_end):
+                self.assert_denied_request("GET")
 
-        new_brownout_end = new_brownout_start + custom_duration_timedelta
-        with freeze_time(new_brownout_end):
-            self.assert_allowed_request("GET")
+            new_brownout_end = new_brownout_start + custom_duration_timedelta
+            with freeze_time(new_brownout_end):
+                self.assert_allowed_request("GET")
 
     def test_custom_key(self):
-        old_brownout_start = timeiter.get_next(datetime)
-        with freeze_time(old_brownout_start):
-            self.assert_denied_request("POST")
+        with self.settings(
+            SENTRY_SELF_HOSTED=False,
+        ):
+            old_brownout_start = timeiter.get_next(datetime)
+            with freeze_time(old_brownout_start):
+                self.assert_denied_request("POST")
 
-        register("override-cron", default=custom_cron)
-        register("override-duration", default=custom_duration)
-        custom_time_iter = croniter(custom_cron, test_date)
-        custom_duration_timedelta = isodate.parse_duration(custom_duration)
+            register("override-cron", default=custom_cron)
+            register("override-duration", default=custom_duration)
+            custom_time_iter = croniter(custom_cron, test_date)
+            custom_duration_timedelta = isodate.parse_duration(custom_duration)
 
-        with freeze_time(old_brownout_start):
-            self.assert_allowed_request("POST")
+            with freeze_time(old_brownout_start):
+                self.assert_allowed_request("POST")
 
-        new_brownout_start = custom_time_iter.get_next(datetime)
-        with freeze_time(new_brownout_start):
-            self.assert_denied_request("POST")
+            new_brownout_start = custom_time_iter.get_next(datetime)
+            with freeze_time(new_brownout_start):
+                self.assert_denied_request("POST")
 
-        new_brownout_end = new_brownout_start + custom_duration_timedelta
-        with freeze_time(new_brownout_end):
-            self.assert_allowed_request("POST")
+            new_brownout_end = new_brownout_start + custom_duration_timedelta
+            with freeze_time(new_brownout_end):
+                self.assert_allowed_request("POST")
 
     def test_bad_schedule_format(self):
-        options.delete("api.deprecation.brownout-duration")
-        settings.SENTRY_OPTIONS.update({"api.deprecation.brownout-duration": "bad duration"})
-
         brownout_start = timeiter.get_next(datetime)
         with freeze_time(brownout_start):
-            self.assert_allowed_request("GET")
+            with self.settings(
+                SENTRY_SELF_HOSTED=False,
+                SENTRY_OPTIONS={
+                    "api.deprecation.brownout-duration": "bad duration",
+                },
+            ):
+                options.delete("api.deprecation.brownout-duration")
+                self.assert_allowed_request("GET")
 
-            options.delete("api.deprecation.brownout-duration")
-            settings.SENTRY_OPTIONS.update({"api.deprecation.brownout-duration": "PT1M"})
-            self.assert_denied_request("GET")
+            with self.settings(
+                SENTRY_SELF_HOSTED=False,
+                SENTRY_OPTIONS={
+                    "api.deprecation.brownout-duration": "PT1M",
+                },
+            ):
+                options.delete("api.deprecation.brownout-duration")
+                self.assert_denied_request("GET")
 
-            options.delete("api.deprecation.brownout-cron")
-            settings.SENTRY_OPTIONS.update({"api.deprecation.brownout-cron": "bad schedule"})
-            self.assert_allowed_request("GET")
+            with self.settings(
+                SENTRY_SELF_HOSTED=False,
+                SENTRY_OPTIONS={
+                    "api.deprecation.brownout-cron": "bad schedule",
+                },
+            ):
+                options.delete("api.deprecation.brownout-cron")
+                self.assert_allowed_request("GET")
 
-            options.delete("api.deprecation.brownout-cron")
-            settings.SENTRY_OPTIONS.update({"api.deprecation.brownout-cron": "0 12 * * *"})
-            self.assert_denied_request("GET")
+            with self.settings(
+                SENTRY_SELF_HOSTED=False,
+                SENTRY_OPTIONS={
+                    "api.deprecation.brownout-cron": "0 12 * * *",
+                },
+            ):
+                options.delete("api.deprecation.brownout-cron")
+                self.assert_denied_request("GET")


### PR DESCRIPTION
This was an error that was bubbling up when shuffling tests: https://github.com/getsentry/sentry/actions/runs/3814606626/jobs/6489034033#step:4:736