### PR TITLE
feat(issue-details): Hide suggested assignees when already assigned

### DIFF
--- a/static/app/components/group/suggestedOwners/suggestedOwners.spec.jsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.spec.jsx
@@ -150,4 +150,21 @@ describe('SuggestedOwners', function () {
       expect(container).toBeEmptyDOMElement();
     });
   });
+
+  it('hides when there is already an assignee', async () => {
+    const {container} = render(
+      <SuggestedOwners
+        project={project}
+        event={event}
+        group={TestStubs.Group({
+          assignedTo: {type: 'team', id: '123', name: 'team-name'},
+        })}
+      />,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
 });

--- a/static/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -188,7 +188,7 @@ function SuggestedOwnersWrapper(props: Omit<Props, 'committers' | 'organization'
       eventId: props.event.id,
       projectSlug: props.project.slug,
     },
-    {notifyOnChangeProps: ['data']}
+    {notifyOnChangeProps: ['data'], enabled: !defined(props.group.assignedTo)}
   );
 
   if (defined(props.group.assignedTo)) {

--- a/static/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -9,6 +9,7 @@ import type {
   Project,
 } from 'sentry/types';
 import type {Event} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
 import useCommitters from 'sentry/utils/useCommitters';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -189,6 +190,10 @@ function SuggestedOwnersWrapper(props: Omit<Props, 'committers' | 'organization'
     },
     {notifyOnChangeProps: ['data']}
   );
+
+  if (defined(props.group.assignedTo)) {
+    return null;
+  }
 
   return (
     <SuggestedOwners


### PR DESCRIPTION
Closes https://github.com/getsentry/team-coreui/issues/14

Adds an early return statement so that the suggested assignees component is never loaded. So nothing will be rendered and no requests will be made.