### PR TITLE
jb/ref/gl mat3 identity

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -200,7 +200,7 @@ export function FlamegraphSpans({
         return;
       }
 
-      const identity = mat3.identity(mat3.create());
+      const identity = mat3.create();
       const scale = 1 - evt.deltaY * 0.001 * -1; // -1 to invert scale
 
       const mouseInConfigSpace = spansView.getConfigSpaceCursor(

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -607,7 +607,7 @@ function FlamegraphZoomView({
         return;
       }
 
-      const identity = mat3.identity(mat3.create());
+      const identity = mat3.create();
       const scale = 1 - evt.deltaY * 0.01 * -1; // -1 to invert scale
 
       const mouseInConfigView = flamegraphView.getConfigViewCursor(

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -341,7 +341,7 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
-      const identity = mat3.identity(mat3.create());
+      const identity = mat3.create();
       const scale = 1 - evt.deltaY * 0.001 * -1; // -1 to invert scale
 
       const mouseInConfigSpace = flamegraphMiniMapView.getConfigSpaceCursor(

--- a/static/app/utils/profiling/renderers/positionIndicatorRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/positionIndicatorRenderer.spec.tsx
@@ -27,7 +27,7 @@ describe('PositionIndicatorRenderer', () => {
       canvas as HTMLCanvasElement,
       LightFlamegraphTheme
     );
-    renderer.draw(configView, configSpace, mat3.identity(mat3.create()));
+    renderer.draw(configView, configSpace, mat3.create());
 
     expect(context.beginPath).not.toHaveBeenCalled();
   });

--- a/static/app/utils/profiling/renderers/selectedFrameRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/selectedFrameRenderer.spec.tsx
@@ -25,7 +25,7 @@ describe('SelectedFrameRenderer', () => {
     renderer.draw(
       [new Rect(0, 0, 100, 100)],
       {BORDER_COLOR: 'red', BORDER_WIDTH: 1},
-      mat3.scale(mat3.create(), mat3.identity(mat3.create()), vec2.fromValues(2, 2))
+      mat3.scale(mat3.create(), mat3.create(), vec2.fromValues(2, 2))
     );
 
     expect(context.beginPath).toHaveBeenCalled();

--- a/static/app/utils/profiling/renderers/textRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.spec.tsx
@@ -116,7 +116,7 @@ describe('TextRenderer', () => {
 
     const textRenderer = new TextRenderer(canvas as HTMLCanvasElement, flamegraph, Theme);
 
-    textRenderer.draw(new Rect(0, 0, 200, 2), mat3.identity(mat3.create()), new Map());
+    textRenderer.draw(new Rect(0, 0, 200, 2), mat3.create(), new Map());
 
     expect(context.fillText).toHaveBeenCalledTimes(2);
   });
@@ -156,7 +156,7 @@ describe('TextRenderer', () => {
 
     textRenderer.draw(
       new Rect(0, 0, Math.floor(longFrameName.length / 2), 10),
-      mat3.identity(mat3.create()),
+      mat3.create(),
       new Map()
     );
 
@@ -211,7 +211,7 @@ describe('TextRenderer', () => {
         Math.floor(longFrameName.length / 2 / 2),
         10
       ),
-      mat3.identity(mat3.create()),
+      mat3.create(),
       new Map()
     );
 


### PR DESCRIPTION
- fix(jira): Fix assignee outbound sync (#42588)
- bug(replays): Fetch errors on Replay Details in chunks (#42509)
- ref(hybrid-cloud): add organization_slug to GroupParticipants (#42403)
- feat(hybrid-cloud): Move Identity to Control and implement IdentityService (#42677)
- fix(workflow): Remove metrics-performance flags (#42674)
- feat(indexer): Consumer builder using routing strategy (#42024)
- Revert "fix(profiling): Fix frames disappearing from profile" (#42732)
- fix(profiling): Selected frame renderer incorrect width (#42731)
- Revert "bug(replays): Trust the Replay api response `duration` field … (#42734)
- fix(profiling): messaging for undefined platform (#42735)
- feat(replays): Implement isHovered states for DOM and Network tabs (#42558)
- ref(hybrid-cloud): use monitor urls with org slug frontend (#42728)
- ref(js): Minor cleanup to Button (#42722)
- bug(replays): Do not suppress MessageRejected error (#42738)
- ref(js): Simplify form source require regex (#42741)
- style(js): Fix comment wording on form field types (#42742)
- fix(checkbox): Remove hover/active states when disabled (#42726)
- fix(ui): Django templating leaking into HTML (#42745)
- feat(workflow): Remove release activity endpoint (#42736)
- ref(js): Some fixup to avatarCropper (#42748)
- fix(js): Default `type="button"` for buttons (#42746)
- feat(issue-details): Hide suggested assignees when already assigned (#42749)
- fix(ui): Re-enable performance issue query fields (#42751)
- fix(issue-details): Fix right padding in suggested assignee button (#42753)
- ref(metrics): Improve and standardize metrics test suite (#42713)
- chore(deps): bump @sentry SDK dependencies from 7.25.0 to 7.28.1 (#42714)
- ref(span-tree): Use `useEffect` instead of `useLayoutEffect` (#42733)
- ref(profiling): add content spacing and adjust markup in profilingOnboardingSidebar (#42740)
- ref(profiling): cleanup onboarding platform typings (#42739)
- ref(profiling): fix setting identity on identity matrix
