### PR TITLE
feat(profiling): add span messaging

### DIFF
--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -93,11 +93,12 @@ class SpanChart {
           this.root.children.push(spanChartNode);
         }
 
-        const nodesWithParent = node.children.map(
-          // @todo use satisfies here when available
-          child => [spanChartNode, child] as [SpanChartNode, SpanTreeNode]
+        queue.push(
+          ...node.children.map(
+            // @todo use satisfies here when available
+            child => [spanChartNode, child] as [SpanChartNode, SpanTreeNode]
+          )
         );
-        queue.push(...nodesWithParent);
       }
       depth++;
     }

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -97,8 +97,10 @@ class SpanTree {
     this.buildCollapsedSpanTree(spans);
   }
 
-  static Empty(): SpanTree {
-    return new SpanTree(EmptyEventTransaction, []);
+  static Empty = new SpanTree(EmptyEventTransaction, []);
+
+  isEmpty(): boolean {
+    return this === SpanTree.Empty;
   }
 
   buildCollapsedSpanTree(spans: RawSpanType[]) {

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -65,7 +65,7 @@ const LoadingGroup: ProfileGroup = {
   profiles: [Profile.Empty],
 };
 
-const LoadingSpanTree = SpanTree.Empty();
+const LoadingSpanTree = SpanTree.Empty;
 
 function ProfileFlamegraph(): React.ReactElement {
   const organization = useOrganization();


### PR DESCRIPTION
Display some messaging for when we fail to fetch the associated transaction or if the transaction has no spans.