### PR TITLE
feat(perf-issues): Skip truncated queries in slow db span detection

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -576,7 +576,8 @@ class SlowSpanDetector(PerformanceDetector):
         if not description:
             return False
 
-        if description.strip()[:6].upper() != "SELECT":
+        description = description.strip()
+        if description[:6].upper() != "SELECT":
             return False
 
         if description.endswith("..."):

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -576,7 +576,6 @@ class SlowSpanDetector(PerformanceDetector):
         if not description:
             return False
 
-        description = description.strip()
         if description.strip()[:6].upper() != "SELECT":
             return False
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -545,13 +545,11 @@ class SlowSpanDetector(PerformanceDetector):
         if not fingerprint:
             return
 
-        description = span.get("description", None)
-        if not description:
+        if not SlowSpanDetector.is_span_eligible(span):
             return
 
+        description = span.get("description", None)
         description = description.strip()
-        if description.strip()[:6].upper() != "SELECT":
-            return
 
         if span_duration >= timedelta(
             milliseconds=duration_threshold
@@ -571,6 +569,21 @@ class SlowSpanDetector(PerformanceDetector):
                 parent_span_ids=[],
                 offender_span_ids=spans_involved,
             )
+
+    @classmethod
+    def is_span_eligible(cls, span: Span) -> bool:
+        description = span.get("description", None)
+        if not description:
+            return False
+
+        description = description.strip()
+        if description.strip()[:6].upper() != "SELECT":
+            return False
+
+        if description.endswith("..."):
+            return False
+
+        return True
 
     def _fingerprint(self, transaction_name, span_op, hash, problem_class):
         signature = (str(transaction_name) + str(span_op) + str(hash)).encode("utf-8")

--- a/tests/sentry/utils/performance_issues/test_slow_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_slow_span_detector.py
@@ -83,3 +83,24 @@ class SlowSpanDetectorTest(unittest.TestCase):
                 offender_span_ids=["a05754d3fde2db29"],
             )
         ]
+
+    def test_skips_truncated_queries(self):
+        slow_span_event_with_truncated_query = create_event(
+            [create_span("db", 1005, "SELECT `product`.`id` FROM `products` ...")] * 1
+        )
+        slow_span_event = create_event(
+            [create_span("db", 1005, "SELECT `product`.`id` FROM `products`")] * 1
+        )
+
+        assert self.find_problems(slow_span_event_with_truncated_query) == []
+        assert self.find_problems(slow_span_event) == [
+            PerformanceProblem(
+                fingerprint="1-GroupType.PERFORMANCE_SLOW_SPAN-020e34d374ab4b5cd00a6a1b4f76f325209f7263",
+                op="db",
+                desc="SELECT `product`.`id` FROM `products`",
+                type=GroupType.PERFORMANCE_SLOW_SPAN,
+                parent_span_ids=None,
+                cause_span_ids=None,
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+            )
+        ]


### PR DESCRIPTION
If we detect on truncated queries, we can't guarantee that the fingerprint is unique to the same query. This PR changes the slow span detector to skip DB spans with queries that are truncated