### PR TITLE
feat(perf): Add ability to scroll horizontally on transaction trace view

### DIFF
--- a/static/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/static/app/views/performance/traceDetails/transactionGroup.tsx
@@ -61,6 +61,7 @@ class TransactionGroup extends Component<Props, State> {
       barColor,
       addContentSpanBarRef,
       removeContentSpanBarRef,
+      onWheel,
     } = this.props;
     const {isExpanded} = this.state;
 
@@ -82,6 +83,7 @@ class TransactionGroup extends Component<Props, State> {
           barColor={barColor}
           addContentSpanBarRef={addContentSpanBarRef}
           removeContentSpanBarRef={removeContentSpanBarRef}
+          onWheel={onWheel}
         />
         {isExpanded && renderedChildren}
       </Fragment>


### PR DESCRIPTION
We weren't able to use a trackpad or mousewheel to scroll horizontally on the transaction trace view. It works on the span tree, but not here, so I've added that functionality to keep behavioural consistency.