### PR TITLE
ref(hybrid-cloud): use GroupParticipants url with org slug

### DIFF
--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -33,7 +33,7 @@ class GroupPermission(ProjectPermission):
 class GroupEndpoint(Endpoint):
     permission_classes = (GroupPermission,)
 
-    def convert_args(self, request: Request, issue_id, organization_slug=None, *args, **kwargs):
+    def convert_args(self, request: Request, issue_id, organization_slug, *args, **kwargs):
         # TODO(tkaemming): Ideally, this would return a 302 response, rather
         # than just returning the data that is bound to the new group. (It
         # technically shouldn't be a 301, since the response could change again
@@ -44,17 +44,14 @@ class GroupEndpoint(Endpoint):
         # string replacement, or making the endpoint aware of the URL pattern
         # that caused it to be dispatched, and reversing it with the correct
         # `issue_id` keyword argument.
-        if organization_slug:
-            try:
-                organization = Organization.objects.get_from_cache(slug=organization_slug)
-            except Organization.DoesNotExist:
-                raise ResourceDoesNotExist
+        try:
+            organization = Organization.objects.get_from_cache(slug=organization_slug)
+        except Organization.DoesNotExist:
+            raise ResourceDoesNotExist
 
-            bind_organization_context(organization)
+        bind_organization_context(organization)
 
-            request._request.organization = organization
-        else:
-            organization = None
+        request._request.organization = organization
 
         try:
             group, _ = get_group_with_redirect(

--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -33,7 +33,7 @@ class GroupPermission(ProjectPermission):
 class GroupEndpoint(Endpoint):
     permission_classes = (GroupPermission,)
 
-    def convert_args(self, request: Request, issue_id, organization_slug, *args, **kwargs):
+    def convert_args(self, request: Request, issue_id, organization_slug=None, *args, **kwargs):
         # TODO(tkaemming): Ideally, this would return a 302 response, rather
         # than just returning the data that is bound to the new group. (It
         # technically shouldn't be a 301, since the response could change again
@@ -44,14 +44,17 @@ class GroupEndpoint(Endpoint):
         # string replacement, or making the endpoint aware of the URL pattern
         # that caused it to be dispatched, and reversing it with the correct
         # `issue_id` keyword argument.
-        try:
-            organization = Organization.objects.get_from_cache(slug=organization_slug)
-        except Organization.DoesNotExist:
-            raise ResourceDoesNotExist
+        if organization_slug:
+            try:
+                organization = Organization.objects.get_from_cache(slug=organization_slug)
+            except Organization.DoesNotExist:
+                raise ResourceDoesNotExist
 
-        bind_organization_context(organization)
+            bind_organization_context(organization)
 
-        request._request.organization = organization
+            request._request.organization = organization
+        else:
+            organization = None
 
         try:
             group, _ = get_group_with_redirect(

--- a/src/sentry/api/endpoints/group_participants.py
+++ b/src/sentry/api/endpoints/group_participants.py
@@ -11,7 +11,7 @@ from sentry.services.hybrid_cloud.user import user_service
 
 @region_silo_endpoint
 class GroupParticipantsEndpoint(GroupEndpoint):
-    def get(self, request: Request, group, organization_slug: str | None = None) -> Response:
+    def get(self, request: Request, group) -> Response:
         participants = GroupSubscriptionManager.get_participating_user_ids(group)
 
         return Response(user_service.serialize_users(user_ids=participants, as_user=request.user))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2322,11 +2322,6 @@ urlpatterns = [
     url(
         r"^issues/(?P<organization_slug>[^\/]+)/(?P<issue_id>[^\/]+)/participants/$",
         GroupParticipantsEndpoint.as_view(),
-        name="sentry-api-0-group-stats-with-org",
-    ),
-    url(
-        r"^issues/(?P<issue_id>[^\/]+)/participants/$",
-        GroupParticipantsEndpoint.as_view(),
         name="sentry-api-0-group-stats",
     ),
     url(

--- a/tests/sentry/api/endpoints/test_group_participants.py
+++ b/tests/sentry/api/endpoints/test_group_participants.py
@@ -11,24 +11,15 @@ class GroupParticipantsTest(APITestCase):
         super().setUp()
         self.login_as(self.user)
 
-    def _get_path_functions(self):
-        return (
-            lambda group: reverse("sentry-api-0-group-stats", args=[group.id]),
-            lambda group: reverse(
-                "sentry-api-0-group-stats-with-org", args=[self.organization.slug, group.id]
-            ),
-        )
-
     def test_simple(self):
         group = self.create_group()
         GroupSubscription.objects.create(
             user=self.user, group=group, project=group.project, is_active=True
         )
 
-        for path_func in self._get_path_functions():
-            path = path_func(group)
+        path = reverse("sentry-api-0-group-stats", args=[self.organization.slug, group.id])
 
-            response = self.client.get(path)
+        response = self.client.get(path)
 
-            assert len(response.data) == 1
-            assert response.data[0]["id"] == str(self.user.id)
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.user.id)


### PR DESCRIPTION
Remove the orgless url for the GroupParticipants API!

This url doesn't actually appear to be directly called by the frontend at the moment.

For HC-515

[HC-515]: https://getsentry.atlassian.net/browse/HC-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ