### PR TITLE
fix(all-events): Ensure pagination caption is always correct

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -60,7 +60,6 @@ const AllEventsTable = (props: Props) => {
       routes={routes}
       excludedTags={excludedTags}
       projectSlug={group.project.slug}
-      totalEventCount={group.count}
       customColumns={['minidump']}
       setError={(msg: string | undefined) => setError(msg ?? '')}
       transactionName=""

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -44,13 +44,11 @@ describe('Performance Transaction Events Content', function () {
   let data;
   let transactionName;
   let eventView;
-  let totalEventCount;
   let initialData;
   const query =
     'transaction.duration:<15m event.type:transaction transaction:/api/0/organizations/{organization_slug}/events/';
   beforeEach(function () {
     transactionName = 'transactionName';
-    totalEventCount = '200';
     fields = [
       'id',
       'user.display',
@@ -103,6 +101,29 @@ describe('Performance Transaction Events Content', function () {
         'spans.total.time': 600,
       },
     ];
+    // Total events count response
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      headers: {
+        Link:
+          '<http://localhost/api/0/organizations/org-slug/events/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
+          '<http://localhost/api/0/organizations/org-slug/events/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
+      },
+      body: {
+        meta: {
+          fields: {
+            'count()': 'integer',
+          },
+        },
+        data: [{'count()': 200}],
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('count()');
+        },
+      ],
+    });
+
     // Transaction list response
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
@@ -158,7 +179,6 @@ describe('Performance Transaction Events Content', function () {
     render(
       <OrganizationContext.Provider value={initialData.organization}>
         <EventsPageContent
-          totalEventCount={totalEventCount}
           eventView={eventView}
           organization={initialData.organization}
           location={initialData.router.location}
@@ -199,7 +219,6 @@ describe('Performance Transaction Events Content', function () {
     render(
       <OrganizationContext.Provider value={initialData.organization}>
         <EventsPageContent
-          totalEventCount={totalEventCount}
           eventView={eventView}
           organization={initialData.organization}
           location={initialData.router.location}

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -38,7 +38,6 @@ type Props = {
   projects: Project[];
   setError: SetStateAction<string | undefined>;
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
-  totalEventCount: string;
   transactionName: string;
   percentileValues?: Record<EventsDisplayFilterName, number>;
   webVital?: WebVital;
@@ -62,7 +61,6 @@ function EventsContent(props: Props) {
     spanOperationBreakdownFilter,
     webVital,
     setError,
-    totalEventCount,
     projectId,
     projects,
   } = props;
@@ -96,7 +94,6 @@ function EventsContent(props: Props) {
     <Layout.Main fullWidth>
       <Search {...props} />
       <EventsTable
-        totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}
         routes={routes}

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -90,7 +90,6 @@ describe('Performance GridEditable Table', function () {
     t('trace id'),
     t('timestamp'),
   ];
-  const totalEventCount = '100';
   let fields = EVENTS_TABLE_RESPONSE_FIELDS;
   const organization = TestStubs.Organization();
   const transactionName = 'transactionName';
@@ -116,6 +115,30 @@ describe('Performance GridEditable Table', function () {
     });
 
     data = MOCK_EVENTS_TABLE_DATA;
+
+    // Total events count response
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      headers: {
+        Link:
+          '<http://localhost/api/0/organizations/org-slug/events/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
+          '<http://localhost/api/0/organizations/org-slug/events/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
+      },
+      body: {
+        meta: {
+          fields: {
+            'count()': 'integer',
+          },
+        },
+        data: [{'count()': 100}],
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('count()');
+        },
+      ],
+    });
+
     // Transaction list response
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
@@ -168,7 +191,6 @@ describe('Performance GridEditable Table', function () {
 
     render(
       <EventsTable
-        totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}
         routes={initialData.router.routes}
@@ -223,7 +245,6 @@ describe('Performance GridEditable Table', function () {
 
     const {container} = render(
       <EventsTable
-        totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}
         routes={initialData.router.routes}
@@ -260,7 +281,6 @@ describe('Performance GridEditable Table', function () {
 
     render(
       <EventsTable
-        totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}
         routes={initialData.router.routes}
@@ -307,7 +327,6 @@ describe('Performance GridEditable Table', function () {
 
     const {container} = render(
       <EventsTable
-        totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}
         routes={initialData.router.routes}

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -77,11 +77,7 @@ function EventsContentWrapper(props: ChildProps) {
   const spanOperationBreakdownFilter = decodeFilterFromLocation(location);
   const webVital = getWebVital(location);
 
-  const totalEventsView = eventView.clone();
   const percentilesView = getPercentilesEventView(eventView);
-
-  totalEventsView.sorts = [];
-  totalEventsView.fields = [{field: 'count()', width: -1}];
 
   const getFilteredEventView = (percentiles: PercentileValues) => {
     const filter = getEventsFilterOptions(spanOperationBreakdownFilter, percentiles)[
@@ -161,58 +157,39 @@ function EventsContentWrapper(props: ChildProps) {
 
   return (
     <DiscoverQuery
-      eventView={totalEventsView}
+      eventView={percentilesView}
       orgSlug={organization.slug}
       location={location}
-      setError={error => setError(error?.message)}
-      referrer="api.performance.transaction-summary"
-      cursor="0:0:0"
+      referrer="api.performance.transaction-events"
     >
-      {({isLoading: isTotalEventsLoading, tableData: table}) => {
-        const totalEventCount: string =
-          table?.data[0]?.['count()']?.toLocaleString() || '';
+      {({isLoading, tableData}) => {
+        if (isLoading) {
+          return (
+            <Layout.Main fullWidth>
+              <LoadingIndicator />
+            </Layout.Main>
+          );
+        }
 
+        const percentileData = tableData?.data?.[0];
+        const percentiles = mapPercentileValues(percentileData);
+        const filteredEventView = getFilteredEventView(percentiles);
         return (
-          <DiscoverQuery
-            eventView={percentilesView}
-            orgSlug={organization.slug}
+          <EventsContent
             location={location}
-            referrer="api.performance.transaction-events"
-          >
-            {({isLoading, tableData}) => {
-              if (isTotalEventsLoading || isLoading) {
-                return (
-                  <Layout.Main fullWidth>
-                    <LoadingIndicator />
-                  </Layout.Main>
-                );
-              }
-
-              const percentileData = tableData?.data?.[0];
-              const percentiles = mapPercentileValues(percentileData);
-              const filteredEventView = getFilteredEventView(percentiles);
-              return (
-                <EventsContent
-                  totalEventCount={totalEventCount}
-                  location={location}
-                  organization={organization}
-                  eventView={filteredEventView}
-                  transactionName={transactionName}
-                  spanOperationBreakdownFilter={spanOperationBreakdownFilter}
-                  onChangeSpanOperationBreakdownFilter={
-                    onChangeSpanOperationBreakdownFilter
-                  }
-                  eventsDisplayFilterName={eventsDisplayFilterName}
-                  onChangeEventsDisplayFilter={onChangeEventsDisplayFilter}
-                  percentileValues={percentiles}
-                  projectId={projectId}
-                  projects={projects}
-                  webVital={webVital}
-                  setError={setError}
-                />
-              );
-            }}
-          </DiscoverQuery>
+            organization={organization}
+            eventView={filteredEventView}
+            transactionName={transactionName}
+            spanOperationBreakdownFilter={spanOperationBreakdownFilter}
+            onChangeSpanOperationBreakdownFilter={onChangeSpanOperationBreakdownFilter}
+            eventsDisplayFilterName={eventsDisplayFilterName}
+            onChangeEventsDisplayFilter={onChangeEventsDisplayFilter}
+            percentileValues={percentiles}
+            projectId={projectId}
+            projects={projects}
+            webVital={webVital}
+            setError={setError}
+          />
         );
       }}
     </DiscoverQuery>


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/42658

`<EventsTable/>`, which is shared between the issues page and performance, was accepting a `totalEventCount` prop, which was using `group.count` in issue details. Unfortunately, that count includes _all_ events seen for that issue, which is often more events than are actually available. And it also doesn't account for filtering down that list with the search bar.

The performance usage already made an extra call to get the total number of events, so I moved that logic into `<EventsTable/>` so both places will fetch the count by default.

Before:

https://sentry.io/organizations/sentry-test/issues/3527575447/events/?project=5270453

![CleanShot 2023-01-04 at 10 37 31](https://user-images.githubusercontent.com/10888943/210626067-0caf8702-66fa-43b9-a383-cb78648b7c4b.png)

After:

https://sentry-bwmx66ig1.sentry.dev/organizations/sentry-test/issues/3527575447/events/?project=5270453

![CleanShot 2023-01-04 at 10 37 17](https://user-images.githubusercontent.com/10888943/210626048-72694ea1-7081-4b6d-85e5-73db3a037953.png)
