### PR TITLE
fix(domains) Don't use params.orgId in settings views

### DIFF
--- a/static/app/views/settings/organizationApiKeys/index.tsx
+++ b/static/app/views/settings/organizationApiKeys/index.tsx
@@ -11,11 +11,7 @@ import AsyncView from 'sentry/views/asyncView';
 import OrganizationApiKeysList from './organizationApiKeysList';
 import {DeprecatedApiKey} from './types';
 
-type RouteParams = {
-  orgId: string;
-};
-
-type Props = RouteComponentProps<RouteParams, {}> & {
+type Props = RouteComponentProps<{}, {}> & {
   organization: Organization;
 };
 

--- a/static/app/views/settings/organizationApiKeys/index.tsx
+++ b/static/app/views/settings/organizationApiKeys/index.tsx
@@ -28,7 +28,8 @@ type State = {
  */
 class OrganizationApiKeys extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    return [['keys', `/organizations/${this.props.params.orgId}/api-keys/`]];
+    const {organization} = this.props;
+    return [['keys', `/organizations/${organization.slug}/api-keys/`]];
   }
 
   getTitle() {
@@ -36,6 +37,7 @@ class OrganizationApiKeys extends AsyncView<Props, State> {
   }
 
   handleRemove = async (id: string) => {
+    const {organization} = this.props;
     const oldKeys = [...this.state.keys];
 
     this.setState(state => ({
@@ -44,7 +46,7 @@ class OrganizationApiKeys extends AsyncView<Props, State> {
 
     try {
       await this.api.requestPromise(
-        `/organizations/${this.props.params.orgId}/api-keys/${id}/`,
+        `/organizations/${organization.slug}/api-keys/${id}/`,
         {
           method: 'DELETE',
           data: {},
@@ -60,10 +62,11 @@ class OrganizationApiKeys extends AsyncView<Props, State> {
     this.setState({
       busy: true,
     });
+    const {organization} = this.props;
 
     try {
       const data = await this.api.requestPromise(
-        `/organizations/${this.props.params.orgId}/api-keys/`,
+        `/organizations/${organization.slug}/api-keys/`,
         {
           method: 'POST',
           data: {},

--- a/static/app/views/settings/organizationApiKeys/index.tsx
+++ b/static/app/views/settings/organizationApiKeys/index.tsx
@@ -73,7 +73,7 @@ class OrganizationApiKeys extends AsyncView<Props, State> {
         this.setState({busy: false});
         browserHistory.push(
           recreateRoute(`${data.id}/`, {
-            params: this.props.params,
+            params: {orgId: organization.slug},
             routes: this.props.routes,
           })
         );
@@ -89,14 +89,18 @@ class OrganizationApiKeys extends AsyncView<Props, State> {
   }
 
   renderBody() {
+    const {organization} = this.props;
+    const params = {orgId: organization.slug};
+
     return (
       <OrganizationApiKeysList
+        {...this.props}
+        params={params}
         loading={this.state.loading}
         busy={this.state.busy}
         keys={this.state.keys}
         onRemove={this.handleRemove}
         onAddApiKey={this.handleAddApiKey}
-        {...this.props}
       />
     );
   }

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.tsx
@@ -35,10 +35,11 @@ type State = AsyncView['state'] & {
 
 class OrganizationApiKeyDetails extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
+    const {organization} = this.props;
     return [
       [
         'apiKey',
-        `/organizations/${this.props.params.orgId}/api-keys/${this.props.params.apiKey}/`,
+        `/organizations/${organization.slug}/api-keys/${this.props.params.apiKey}/`,
       ],
     ];
   }
@@ -65,6 +66,7 @@ class OrganizationApiKeyDetails extends AsyncView<Props, State> {
   };
 
   renderBody() {
+    const {organization} = this.props;
     return (
       <div>
         <SettingsPageHeader title={t('Edit API Key')} />
@@ -73,7 +75,7 @@ class OrganizationApiKeyDetails extends AsyncView<Props, State> {
           <PanelHeader>{t('API Key')}</PanelHeader>
           <ApiForm
             apiMethod="PUT"
-            apiEndpoint={`/organizations/${this.props.params.orgId}/api-keys/${this.props.params.apiKey}/`}
+            apiEndpoint={`/organizations/${organization.slug}/api-keys/${this.props.params.apiKey}/`}
             initialData={this.state.apiKey}
             onSubmitSuccess={this.handleSubmitSuccess}
             onSubmitError={this.handleSubmitError}

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.tsx
@@ -22,7 +22,6 @@ const API_CHOICES: Choices = API_ACCESS_SCOPES.map(s => [s, s]);
 
 type RouteParams = {
   apiKey: string;
-  orgId: string;
 };
 
 type Props = RouteComponentProps<RouteParams, {}> & {

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -138,8 +138,12 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
 
   handleAddTeam = (team: Team) => {
     const {member} = this.state;
-    if (!member!.teams.includes(team.slug)) {
-      member!.teams.push(team.slug);
+    if (!member) {
+      return;
+    }
+    const teams = member.teams;
+    if (!teams.includes(team.slug)) {
+      member.teams = [...teams, team.slug];
     }
     this.setState({member});
   };

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.jsx
@@ -40,27 +40,18 @@ const roles = [
 describe('OrganizationMembersList', function () {
   const members = TestStubs.Members();
   const currentUser = members[1];
-  const defaultProps = {
-    orgId: 'org-slug',
-    orgName: 'Organization Name',
-    status: '',
-    router: {routes: []},
-    requireLink: false,
-    memberCanLeave: false,
-    canAddMembers: false,
-    canRemoveMembers: false,
-    currentUser,
-    onSendInvite: () => {},
-    onRemove: () => {},
-    onLeave: () => {},
-    location: {query: {}},
-  };
   const organization = TestStubs.Organization({
     access: ['member:admin', 'org:admin', 'member:write'],
     status: {
       id: 'active',
     },
   });
+  const defaultProps = {
+    organization,
+    params: {orgId: organization.slug},
+    router: {routes: []},
+    location: {query: {}},
+  };
 
   jest.spyOn(ConfigStore, 'get').mockImplementation(() => currentUser);
 
@@ -71,17 +62,17 @@ describe('OrganizationMembersList', function () {
   beforeEach(function () {
     Client.clearMockResponses();
     Client.addMockResponse({
-      url: '/organizations/org-id/members/me/',
+      url: '/organizations/org-slug/members/me/',
       method: 'GET',
       body: {roles},
     });
     Client.addMockResponse({
-      url: '/organizations/org-id/members/',
+      url: '/organizations/org-slug/members/',
       method: 'GET',
       body: TestStubs.Members(),
     });
     Client.addMockResponse({
-      url: '/organizations/org-id/access-requests/',
+      url: '/organizations/org-slug/access-requests/',
       method: 'GET',
       body: [
         {
@@ -102,7 +93,7 @@ describe('OrganizationMembersList', function () {
       ],
     });
     Client.addMockResponse({
-      url: '/organizations/org-id/auth-provider/',
+      url: '/organizations/org-slug/auth-provider/',
       method: 'GET',
       body: {
         ...TestStubs.AuthProvider(),
@@ -110,12 +101,12 @@ describe('OrganizationMembersList', function () {
       },
     });
     Client.addMockResponse({
-      url: '/organizations/org-id/teams/',
+      url: '/organizations/org-slug/teams/',
       method: 'GET',
       body: TestStubs.Team(),
     });
     Client.addMockResponse({
-      url: '/organizations/org-id/invite-requests/',
+      url: '/organizations/org-slug/invite-requests/',
       method: 'GET',
       body: [],
     });
@@ -125,11 +116,11 @@ describe('OrganizationMembersList', function () {
 
   it('can remove a member', async function () {
     const deleteMock = MockApiClient.addMockResponse({
-      url: `/organizations/org-id/members/${members[0].id}/`,
+      url: `/organizations/org-slug/members/${members[0].id}/`,
       method: 'DELETE',
     });
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: TestStubs.routerContext([{organization}]),
     });
 
@@ -147,12 +138,12 @@ describe('OrganizationMembersList', function () {
 
   it('displays error message when failing to remove member', async function () {
     const deleteMock = MockApiClient.addMockResponse({
-      url: `/organizations/org-id/members/${members[0].id}/`,
+      url: `/organizations/org-slug/members/${members[0].id}/`,
       method: 'DELETE',
       statusCode: 500,
     });
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: TestStubs.routerContext([{organization}]),
     });
 
@@ -170,11 +161,11 @@ describe('OrganizationMembersList', function () {
 
   it('can leave org', async function () {
     const deleteMock = Client.addMockResponse({
-      url: `/organizations/org-id/members/${members[1].id}/`,
+      url: `/organizations/org-slug/members/${members[1].id}/`,
       method: 'DELETE',
     });
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: TestStubs.routerContext([{organization}]),
     });
 
@@ -192,7 +183,7 @@ describe('OrganizationMembersList', function () {
 
   it('can redirect to remaining org after leaving', async function () {
     const deleteMock = Client.addMockResponse({
-      url: `/organizations/org-id/members/${members[1].id}/`,
+      url: `/organizations/org-slug/members/${members[1].id}/`,
       method: 'DELETE',
     });
     const secondOrg = TestStubs.Organization({
@@ -203,7 +194,7 @@ describe('OrganizationMembersList', function () {
     });
     OrganizationsStore.addOrReplace(secondOrg);
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: TestStubs.routerContext([{organization}]),
     });
 
@@ -222,12 +213,12 @@ describe('OrganizationMembersList', function () {
 
   it('displays error message when failing to leave org', async function () {
     const deleteMock = Client.addMockResponse({
-      url: `/organizations/org-id/members/${members[1].id}/`,
+      url: `/organizations/org-slug/members/${members[1].id}/`,
       method: 'DELETE',
       statusCode: 500,
     });
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: TestStubs.routerContext([{organization}]),
     });
 
@@ -245,14 +236,14 @@ describe('OrganizationMembersList', function () {
 
   it('can re-send SSO link to member', function () {
     const inviteMock = MockApiClient.addMockResponse({
-      url: `/organizations/org-id/members/${members[0].id}/`,
+      url: `/organizations/org-slug/members/${members[0].id}/`,
       method: 'PUT',
       body: {
         id: '1234',
       },
     });
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: TestStubs.routerContext([{organization}]),
     });
 
@@ -264,14 +255,14 @@ describe('OrganizationMembersList', function () {
 
   it('can re-send invite to member', function () {
     const inviteMock = MockApiClient.addMockResponse({
-      url: `/organizations/org-id/members/${members[1].id}/`,
+      url: `/organizations/org-slug/members/${members[1].id}/`,
       method: 'PUT',
       body: {
         id: '1234',
       },
     });
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: TestStubs.routerContext([{organization}]),
     });
 
@@ -283,20 +274,20 @@ describe('OrganizationMembersList', function () {
 
   it('can search organization members', function () {
     const searchMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-id/members/',
+      url: '/organizations/org-slug/members/',
       body: [],
     });
 
     const routerContext = TestStubs.routerContext();
 
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: routerContext,
     });
 
     userEvent.type(screen.getByPlaceholderText('Search Members'), 'member');
 
     expect(searchMock).toHaveBeenLastCalledWith(
-      '/organizations/org-id/members/',
+      '/organizations/org-slug/members/',
       expect.objectContaining({
         method: 'GET',
         query: {
@@ -312,11 +303,11 @@ describe('OrganizationMembersList', function () {
 
   it('can filter members', function () {
     const searchMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-id/members/',
+      url: '/organizations/org-slug/members/',
       body: [],
     });
     const routerContext = TestStubs.routerContext();
-    render(<OrganizationMembersList {...defaultProps} params={{orgId: 'org-id'}} />, {
+    render(<OrganizationMembersList {...defaultProps} />, {
       context: routerContext,
     });
 
@@ -324,7 +315,7 @@ describe('OrganizationMembersList', function () {
     userEvent.click(screen.getByRole('checkbox', {name: 'Member'}));
 
     expect(searchMock).toHaveBeenLastCalledWith(
-      '/organizations/org-id/members/',
+      '/organizations/org-slug/members/',
       expect.objectContaining({
         method: 'GET',
         query: {query: 'role:member'},
@@ -341,7 +332,7 @@ describe('OrganizationMembersList', function () {
       userEvent.click(screen.getByRole('checkbox', {name: `Enable ${label} filter`}));
 
       expect(searchMock).toHaveBeenLastCalledWith(
-        '/organizations/org-id/members/',
+        '/organizations/org-slug/members/',
         expect.objectContaining({
           method: 'GET',
           query: {query: `${filter}:true`},
@@ -351,7 +342,7 @@ describe('OrganizationMembersList', function () {
       userEvent.click(screen.getByRole('checkbox', {name: `Toggle ${label}`}));
 
       expect(searchMock).toHaveBeenLastCalledWith(
-        '/organizations/org-id/members/',
+        '/organizations/org-slug/members/',
         expect.objectContaining({
           method: 'GET',
           query: {query: `${filter}:false`},
@@ -387,20 +378,20 @@ describe('OrganizationMembersList', function () {
         },
       });
       MockApiClient.addMockResponse({
-        url: '/organizations/org-id/invite-requests/',
+        url: '/organizations/org-slug/invite-requests/',
         method: 'GET',
         body: [inviteRequest],
       });
       MockApiClient.addMockResponse({
-        url: `/organizations/org-id/invite-requests/${inviteRequest.id}/`,
+        url: `/organizations/org-slug/invite-requests/${inviteRequest.id}/`,
         method: 'PUT',
       });
 
       render(
         <OrganizationMembersList
           {...defaultProps}
-          params={{orgId: 'org-id'}}
           organization={org}
+          params={{orgId: org.slug}}
         />,
         {context: TestStubs.routerContext([{organization: org}])}
       );
@@ -417,23 +408,18 @@ describe('OrganizationMembersList', function () {
         },
       });
       MockApiClient.addMockResponse({
-        url: '/organizations/org-id/invite-requests/',
+        url: '/organizations/org-slug/invite-requests/',
         method: 'GET',
         body: [inviteRequest],
       });
       MockApiClient.addMockResponse({
-        url: `/organizations/org-id/invite-requests/${inviteRequest.id}/`,
+        url: `/organizations/org-slug/invite-requests/${inviteRequest.id}/`,
         method: 'PUT',
       });
 
-      render(
-        <OrganizationMembersList
-          {...defaultProps}
-          params={{orgId: 'org-id'}}
-          organization={org}
-        />,
-        {context: TestStubs.routerContext([{organization: org}])}
-      );
+      render(<OrganizationMembersList {...defaultProps} />, {
+        context: TestStubs.routerContext([{organization: org}]),
+      });
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
 
@@ -462,23 +448,18 @@ describe('OrganizationMembersList', function () {
         },
       });
       MockApiClient.addMockResponse({
-        url: '/organizations/org-id/invite-requests/',
+        url: '/organizations/org-slug/invite-requests/',
         method: 'GET',
         body: [joinRequest],
       });
       MockApiClient.addMockResponse({
-        url: `/organizations/org-id/invite-requests/${joinRequest.id}/`,
+        url: `/organizations/org-slug/invite-requests/${joinRequest.id}/`,
         method: 'DELETE',
       });
 
-      render(
-        <OrganizationMembersList
-          {...defaultProps}
-          params={{orgId: 'org-id'}}
-          organization={org}
-        />,
-        {context: TestStubs.routerContext([{organization: org}])}
-      );
+      render(<OrganizationMembersList {...defaultProps} />, {
+        context: TestStubs.routerContext([{organization: org}]),
+      });
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
 
@@ -501,24 +482,19 @@ describe('OrganizationMembersList', function () {
         },
       });
       MockApiClient.addMockResponse({
-        url: '/organizations/org-id/invite-requests/',
+        url: '/organizations/org-slug/invite-requests/',
         method: 'GET',
         body: [inviteRequest],
       });
 
       const updateWithApprove = MockApiClient.addMockResponse({
-        url: `/organizations/org-id/invite-requests/${inviteRequest.id}/`,
+        url: `/organizations/org-slug/invite-requests/${inviteRequest.id}/`,
         method: 'PUT',
       });
 
-      render(
-        <OrganizationMembersList
-          {...defaultProps}
-          params={{orgId: 'org-id'}}
-          organization={org}
-        />,
-        {context: TestStubs.routerContext([{organization: org}])}
-      );
+      render(<OrganizationMembersList {...defaultProps} />, {
+        context: TestStubs.routerContext([{organization: org}]),
+      });
 
       await selectEvent.select(screen.getAllByRole('textbox')[1], ['Admin']);
 
@@ -528,7 +504,7 @@ describe('OrganizationMembersList', function () {
       userEvent.click(screen.getByTestId('confirm-button'));
 
       expect(updateWithApprove).toHaveBeenCalledWith(
-        `/organizations/org-id/invite-requests/${inviteRequest.id}/`,
+        `/organizations/org-slug/invite-requests/${inviteRequest.id}/`,
         expect.objectContaining({data: expect.objectContaining({role: 'admin'})})
       );
     });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -68,24 +68,24 @@ class OrganizationMembersList extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {orgId} = this.props.params;
+    const {organization} = this.props;
 
     return [
-      ['members', `/organizations/${orgId}/members/`, {}, {paginate: true}],
+      ['members', `/organizations/${organization.slug}/members/`, {}, {paginate: true}],
       [
         'member',
-        `/organizations/${orgId}/members/me/`,
+        `/organizations/${organization.slug}/members/me/`,
         {},
         {allowError: error => error.status === 404},
       ],
       [
         'authProvider',
-        `/organizations/${orgId}/auth-provider/`,
+        `/organizations/${organization.slug}/auth-provider/`,
         {},
         {allowError: error => error.status === 403},
       ],
 
-      ['inviteRequests', `/organizations/${orgId}/invite-requests/`],
+      ['inviteRequests', `/organizations/${organization.slug}/invite-requests/`],
     ];
   }
 
@@ -95,9 +95,9 @@ class OrganizationMembersList extends AsyncView<Props, State> {
   }
 
   removeMember = async (id: string) => {
-    const {orgId} = this.props.params;
+    const {organization} = this.props;
 
-    await this.api.requestPromise(`/organizations/${orgId}/members/${id}/`, {
+    await this.api.requestPromise(`/organizations/${organization.slug}/members/${id}/`, {
       method: 'DELETE',
       data: {},
     });
@@ -140,10 +140,11 @@ class OrganizationMembersList extends AsyncView<Props, State> {
     this.setState(state => ({
       invited: {...state.invited, [id]: 'loading'},
     }));
+    const {organization} = this.props;
 
     try {
       await resendMemberInvite(this.api, {
-        orgId: this.props.params.orgId,
+        orgId: organization.slug,
         memberId: id,
         regenerate: expired,
       });
@@ -179,7 +180,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
     errorMessage,
     eventKey,
   }) => {
-    const {params, organization} = this.props;
+    const {organization} = this.props;
 
     this.setState(state => ({
       inviteRequestBusy: {...state.inviteRequestBusy, [inviteRequest.id]: true},
@@ -187,7 +188,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
 
     try {
       await this.api.requestPromise(
-        `/organizations/${params.orgId}/invite-requests/${inviteRequest.id}/`,
+        `/organizations/${organization.slug}/invite-requests/${inviteRequest.id}/`,
         {
           method,
           data,

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -34,7 +34,7 @@ import OrganizationMemberRow from './organizationMemberRow';
 
 type Props = {
   organization: Organization;
-} & RouteComponentProps<{orgId: string}, {}>;
+} & RouteComponentProps<{}, {}>;
 
 type State = AsyncView['state'] & {
   inviteRequests: Member[];

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -32,7 +32,6 @@ import AsyncView from 'sentry/views/asyncView';
 import TeamMembersRow from './teamMembersRow';
 
 type RouteParams = {
-  orgId: string;
   teamId: string;
 };
 

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -74,13 +74,15 @@ class TeamMembers extends AsyncView<Props, State> {
   );
 
   fetchMembersRequest = async (query: string) => {
-    const {params, api} = this.props;
-    const {orgId} = params;
+    const {organization, api} = this.props;
 
     try {
-      const data = await api.requestPromise(`/organizations/${orgId}/members/`, {
-        query: {query},
-      });
+      const data = await api.requestPromise(
+        `/organizations/${organization.slug}/members/`,
+        {
+          query: {query},
+        }
+      );
       this.setState({
         orgMembers: data,
         dropdownBusy: false,
@@ -97,12 +99,12 @@ class TeamMembers extends AsyncView<Props, State> {
   };
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {params} = this.props;
+    const {organization, params} = this.props;
 
     return [
       [
         'teamMembers',
-        `/teams/${params.orgId}/${params.teamId}/members/`,
+        `/teams/${organization.slug}/${params.teamId}/members/`,
         {},
         {paginate: true},
       ],
@@ -110,7 +112,7 @@ class TeamMembers extends AsyncView<Props, State> {
   }
 
   addTeamMember = (selection: Item) => {
-    const {params} = this.props;
+    const {organization, params} = this.props;
     const {orgMembers, teamMembers} = this.state;
 
     this.setState({loading: true});
@@ -121,7 +123,7 @@ class TeamMembers extends AsyncView<Props, State> {
     joinTeam(
       this.props.api,
       {
-        orgId: params.orgId,
+        orgId: organization.slug,
         teamId: params.teamId,
         memberId: selection.value,
       },
@@ -147,12 +149,12 @@ class TeamMembers extends AsyncView<Props, State> {
   };
 
   removeTeamMember = (member: Member) => {
-    const {params} = this.props;
+    const {organization, params} = this.props;
     const {teamMembers} = this.state;
     leaveTeam(
       this.props.api,
       {
-        orgId: params.orgId,
+        orgId: organization.slug,
         teamId: params.teamId,
         memberId: member.id,
       },
@@ -172,8 +174,9 @@ class TeamMembers extends AsyncView<Props, State> {
   };
 
   updateTeamMemberRole = (member: Member, newRole: string) => {
-    const {orgId, teamId} = this.props.params;
-    const endpoint = `/organizations/${orgId}/members/${member.id}/teams/${teamId}/`;
+    const {organization} = this.props;
+    const {teamId} = this.props.params;
+    const endpoint = `/organizations/${organization.slug}/members/${member.id}/teams/${teamId}/`;
 
     this.props.api.request(endpoint, {
       method: 'PUT',
@@ -252,7 +255,7 @@ class TeamMembers extends AsyncView<Props, State> {
             : selection =>
                 openTeamAccessRequestModal({
                   teamId: params.teamId,
-                  orgId: params.orgId,
+                  orgId: organization.slug,
                   memberId: selection.value,
                 })
         }

--- a/static/app/views/settings/project/projectEnvironments.spec.jsx
+++ b/static/app/views/settings/project/projectEnvironments.spec.jsx
@@ -17,6 +17,7 @@ function renderComponent(isHidden) {
         projectId: project.slug,
       }}
       location={{pathname}}
+      organization={org}
       routes={[]}
     />
   );

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -15,7 +15,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {ALL_ENVIRONMENTS_KEY} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Environment, Project} from 'sentry/types';
+import {Environment, Organization, Project} from 'sentry/types';
 import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import withApi from 'sentry/utils/withApi';
@@ -24,6 +24,7 @@ import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
 type Props = {
   api: Client;
+  organization: Organization;
 } & RouteComponentProps<{orgId: string; projectId: string}, {}>;
 
 type State = {
@@ -59,8 +60,9 @@ class ProjectEnvironments extends Component<Props, State> {
       this.setState({isLoading: true});
     }
 
-    const {orgId, projectId} = this.props.params;
-    this.props.api.request(`/projects/${orgId}/${projectId}/environments/`, {
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
+    this.props.api.request(`/projects/${organization.slug}/${projectId}/environments/`, {
       query: {
         visibility: isHidden ? 'hidden' : 'visible',
       },
@@ -71,8 +73,9 @@ class ProjectEnvironments extends Component<Props, State> {
   }
 
   fetchProjectDetails() {
-    const {orgId, projectId} = this.props.params;
-    this.props.api.request(`/projects/${orgId}/${projectId}/`, {
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
+    this.props.api.request(`/projects/${organization.slug}/${projectId}/`, {
       success: project => {
         this.setState({project});
       },
@@ -81,10 +84,13 @@ class ProjectEnvironments extends Component<Props, State> {
 
   // Toggle visibility of environment
   toggleEnv = (env: Environment, shouldHide: boolean) => {
-    const {orgId, projectId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
 
     this.props.api.request(
-      `/projects/${orgId}/${projectId}/environments/${getUrlRoutingName(env)}/`,
+      `/projects/${organization.slug}/${projectId}/environments/${getUrlRoutingName(
+        env
+      )}/`,
       {
         method: 'PUT',
         data: {

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -25,7 +25,7 @@ import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 type Props = {
   api: Client;
   organization: Organization;
-} & RouteComponentProps<{orgId: string; projectId: string}, {}>;
+} & RouteComponentProps<{projectId: string}, {}>;
 
 type State = {
   environments: null | Environment[];

--- a/static/app/views/settings/project/projectFilters/index.spec.jsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.jsx
@@ -21,6 +21,7 @@ describe('ProjectFilters', function () {
         params={{projectId: project.slug, orgId: org.slug}}
         location={{}}
         project={project}
+        organization={org}
       />
     );
   }
@@ -200,6 +201,7 @@ describe('ProjectFilters', function () {
   it('has custom inbound filters with flag + can change', function () {
     render(
       <ProjectFilters
+        organization={org}
         params={{projectId: project.slug, orgId: org.slug}}
         location={{}}
         project={{
@@ -240,8 +242,9 @@ describe('ProjectFilters', function () {
 
     render(
       <ProjectFilters
-        params={{projectId: project.slug, orgId: org.slug}}
+        organization={org}
         location={{}}
+        params={{projectId: project.slug, orgId: org.slug}}
         project={project}
       />,
       {context}
@@ -255,6 +258,7 @@ describe('ProjectFilters', function () {
   it('shows disclaimer if error message filter is populated', function () {
     render(
       <ProjectFilters
+        organization={org}
         params={{projectId: project.slug, orgId: org.slug}}
         project={{
           ...project,
@@ -283,6 +287,7 @@ describe('ProjectFilters', function () {
 
     render(
       <ProjectFilters
+        organization={org}
         params={{
           projectId: discardProject.slug,
           orgId: discardOrg.slug,

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -17,7 +17,7 @@ import ProjectFiltersSettings from 'sentry/views/settings/project/projectFilters
 type Props = {
   organization: Organization;
   project: Project;
-} & RouteComponentProps<{filterType: string; orgId: string; projectId: string}, {}>;
+} & RouteComponentProps<{filterType: string; projectId: string}, {}>;
 
 function ProjectFilters(props: Props) {
   const {organization, project, params, location} = props;
@@ -41,7 +41,7 @@ function ProjectFilters(props: Props) {
       </TextBlock>
 
       <div>
-        <ProjectFiltersChart project={project} params={params} />
+        <ProjectFiltersChart project={project} organization={organization} />
 
         {features.has('discard-groups') && (
           <NavTabs underlined style={{paddingTop: '30px'}}>

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -5,7 +5,7 @@ import Link from 'sentry/components/links/link';
 import NavTabs from 'sentry/components/navTabs';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {Project} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -15,12 +15,13 @@ import ProjectFiltersChart from 'sentry/views/settings/project/projectFilters/pr
 import ProjectFiltersSettings from 'sentry/views/settings/project/projectFilters/projectFiltersSettings';
 
 type Props = {
+  organization: Organization;
   project: Project;
 } & RouteComponentProps<{filterType: string; orgId: string; projectId: string}, {}>;
 
 function ProjectFilters(props: Props) {
-  const {project, params, location} = props;
-  const {orgId, projectId, filterType} = params;
+  const {organization, project, params, location} = props;
+  const {projectId, filterType} = params;
   if (!project) {
     return null;
   }
@@ -58,9 +59,18 @@ function ProjectFilters(props: Props) {
         )}
 
         {filterType === 'discarded-groups' ? (
-          <GroupTombstones orgId={orgId} projectId={project.slug} location={location} />
+          <GroupTombstones
+            orgId={organization.slug}
+            projectId={project.slug}
+            location={location}
+          />
         ) : (
-          <ProjectFiltersSettings project={project} params={params} features={features} />
+          <ProjectFiltersSettings
+            organization={organization}
+            project={project}
+            params={params}
+            features={features}
+          />
         )}
       </div>
     </Fragment>

--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -7,14 +7,14 @@ import LoadingError from 'sentry/components/loadingError';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
-import {Project} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import theme from 'sentry/utils/theme';
 import withApi from 'sentry/utils/withApi';
 
 type Props = {
   api: Client;
-  params: {orgId: string; projectId: string};
+  organization: Organization;
   project: Project;
 };
 
@@ -79,13 +79,12 @@ class ProjectFiltersChart extends Component<Props, State> {
 
   getFilterStats() {
     const statOptions = Object.keys(STAT_OPS);
-    const {project} = this.props;
-    const {orgId} = this.props.params;
+    const {organization, project} = this.props;
 
     const until = Math.floor(new Date().getTime() / 1000);
     const since = until - 3600 * 24 * 30;
 
-    const statEndpoint = `/projects/${orgId}/${project.slug}/stats/`;
+    const statEndpoint = `/projects/${organization.slug}/${project.slug}/stats/`;
     const query = {
       since,
       until,

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -194,7 +194,6 @@ type Props = {
   features: Set<string>;
   organization: Organization;
   params: {
-    orgId: string;
     projectId: string;
   };
   project: Project;

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -28,7 +28,7 @@ import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import space from 'sentry/styles/space';
-import {Project} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 
 const LEGACY_BROWSER_SUBFILTERS = {
   ie_pre_9: {
@@ -192,6 +192,7 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
 
 type Props = {
   features: Set<string>;
+  organization: Organization;
   params: {
     orgId: string;
     projectId: string;
@@ -212,8 +213,9 @@ class ProjectFiltersSettings extends AsyncComponent<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {orgId, projectId} = this.props.params;
-    return [['filterList', `/projects/${orgId}/${projectId}/filters/`]];
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
+    return [['filterList', `/projects/${organization.slug}/${projectId}/filters/`]];
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
@@ -292,10 +294,10 @@ class ProjectFiltersSettings extends AsyncComponent<Props, State> {
     );
 
   renderBody() {
-    const {features, params, project} = this.props;
-    const {orgId, projectId} = params;
+    const {features, organization, params, project} = this.props;
+    const {projectId} = params;
 
-    const projectEndpoint = `/projects/${orgId}/${projectId}/`;
+    const projectEndpoint = `/projects/${organization.slug}/${projectId}/`;
     const filtersEndpoint = `${projectEndpoint}filters/`;
 
     return (

--- a/static/app/views/settings/project/projectKeys/details/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/details/index.spec.jsx
@@ -86,6 +86,7 @@ describe('ProjectKeyDetails', function () {
     render(
       <ProjectKeyDetails
         routes={[]}
+        organization={org}
         params={{
           keyId: projectKeys[0].id,
           orgId: org.slug,

--- a/static/app/views/settings/project/projectKeys/details/index.tsx
+++ b/static/app/views/settings/project/projectKeys/details/index.tsx
@@ -14,7 +14,6 @@ type Props = {
 } & RouteComponentProps<
   {
     keyId: string;
-    orgId: string;
     projectId: string;
   },
   {}

--- a/static/app/views/settings/project/projectKeys/details/index.tsx
+++ b/static/app/views/settings/project/projectKeys/details/index.tsx
@@ -1,6 +1,7 @@
 import {browserHistory, RouteComponentProps} from 'react-router';
 
 import {t} from 'sentry/locale';
+import {Organization} from 'sentry/types';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
@@ -8,7 +9,9 @@ import KeySettings from 'sentry/views/settings/project/projectKeys/details/keySe
 import KeyStats from 'sentry/views/settings/project/projectKeys/details/keyStats';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
-type Props = RouteComponentProps<
+type Props = {
+  organization: Organization;
+} & RouteComponentProps<
   {
     keyId: string;
     orgId: string;
@@ -27,18 +30,23 @@ export default class ProjectKeyDetails extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {keyId, orgId, projectId} = this.props.params;
-    return [['data', `/projects/${orgId}/${projectId}/keys/${keyId}/`]];
+    const {organization} = this.props;
+    const {keyId, projectId} = this.props.params;
+    return [['data', `/projects/${organization.slug}/${projectId}/keys/${keyId}/`]];
   }
 
   handleRemove = () => {
-    const {orgId, projectId} = this.props.params;
-    browserHistory.push(`/${orgId}/${projectId}/settings/keys/`);
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
+    browserHistory.push(`/${organization.slug}/${projectId}/settings/keys/`);
   };
 
   renderBody() {
     const {data} = this.state;
-    const {params} = this.props;
+    const params = {
+      ...this.props.params,
+      orgId: this.props.organization.slug,
+    };
 
     return (
       <div data-test-id="key-details">

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -1,5 +1,4 @@
 import {Component, Fragment} from 'react';
-import {RouteComponentProps} from 'react-router';
 
 import {
   addErrorMessage,
@@ -29,17 +28,12 @@ type Props = {
   api: Client;
   data: ProjectKey;
   onRemove: () => void;
-} & Pick<
-  RouteComponentProps<
-    {
-      keyId: string;
-      orgId: string;
-      projectId: string;
-    },
-    {}
-  >,
-  'params'
->;
+  params: {
+    keyId: string;
+    orgId: string;
+    projectId: string;
+  };
+};
 
 type State = {
   error: boolean;

--- a/static/app/views/settings/project/projectKeys/list/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.jsx
@@ -39,7 +39,11 @@ describe('ProjectKeys', function () {
     });
 
     render(
-      <ProjectKeys routes={[]} params={{orgId: org.slug, projectId: project.slug}} />
+      <ProjectKeys
+        routes={[]}
+        params={{orgId: org.slug, projectId: project.slug}}
+        organization={org}
+      />
     );
 
     expect(
@@ -51,6 +55,7 @@ describe('ProjectKeys', function () {
     render(
       <ProjectKeys
         routes={[]}
+        organization={org}
         params={{orgId: org.slug, projectId: project.slug}}
         project={TestStubs.Project()}
       />
@@ -66,6 +71,7 @@ describe('ProjectKeys', function () {
     render(
       <ProjectKeys
         routes={[]}
+        organization={org}
         params={{orgId: org.slug, projectId: project.slug}}
         project={TestStubs.Project()}
       />
@@ -82,6 +88,7 @@ describe('ProjectKeys', function () {
     render(
       <ProjectKeys
         routes={[]}
+        organization={org}
         params={{orgId: org.slug, projectId: project.slug}}
         project={TestStubs.Project()}
       />

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -136,7 +136,7 @@ class ProjectKeys extends AsyncView<Props, State> {
 
   renderResults() {
     const {location, organization, routes, params} = this.props;
-    const {orgId, projectId} = params;
+    const {projectId} = params;
     const access = new Set(organization.access);
 
     return (
@@ -145,7 +145,7 @@ class ProjectKeys extends AsyncView<Props, State> {
           <KeyRow
             access={access}
             key={key.id}
-            orgId={orgId}
+            orgId={organization.slug}
             projectId={`${projectId}`}
             data={key}
             onToggle={this.handleToggleKey}

--- a/static/app/views/settings/project/projectServiceHookDetails.tsx
+++ b/static/app/views/settings/project/projectServiceHookDetails.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {browserHistory, RouteComponentProps} from 'react-router';
+import {browserHistory} from 'react-router';
 
 import {
   addErrorMessage,
@@ -15,13 +15,17 @@ import Field from 'sentry/components/forms/field';
 import {Panel, PanelAlert, PanelBody, PanelHeader} from 'sentry/components/panels';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t} from 'sentry/locale';
-import {ServiceHook} from 'sentry/types';
+import {Organization, ServiceHook} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import ServiceHookSettingsForm from 'sentry/views/settings/project/serviceHookSettingsForm';
 
-type Params = {hookId: string; orgId: string; projectId: string};
+type Params = {
+  hookId: string;
+  orgId: string;
+  projectId: string;
+};
 
 type StatsProps = {
   params: Params;
@@ -95,25 +99,32 @@ class HookStats extends AsyncComponent<StatsProps, StatsState> {
   }
 }
 
-type Props = RouteComponentProps<Params, {}>;
+type Props = {
+  organization: Organization;
+  params: Params;
+};
 type State = {
   hook: ServiceHook | null;
 } & AsyncView['state'];
 
 export default class ProjectServiceHookDetails extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {orgId, projectId, hookId} = this.props.params;
-    return [['hook', `/projects/${orgId}/${projectId}/hooks/${hookId}/`]];
+    const {organization} = this.props;
+    const {projectId, hookId} = this.props.params;
+    return [['hook', `/projects/${organization.slug}/${projectId}/hooks/${hookId}/`]];
   }
 
   onDelete = () => {
-    const {orgId, projectId, hookId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId, hookId} = this.props.params;
     addLoadingMessage(t('Saving changes\u2026'));
-    this.api.request(`/projects/${orgId}/${projectId}/hooks/${hookId}/`, {
+    this.api.request(`/projects/${organization.slug}/${projectId}/hooks/${hookId}/`, {
       method: 'DELETE',
       success: () => {
         clearIndicators();
-        browserHistory.push(`/settings/${orgId}/projects/${projectId}/hooks/`);
+        browserHistory.push(
+          `/settings/${organization.slug}/projects/${projectId}/hooks/`
+        );
       },
       error: () => {
         addErrorMessage(t('Unable to remove application. Please try again.'));
@@ -122,22 +133,24 @@ export default class ProjectServiceHookDetails extends AsyncView<Props, State> {
   };
 
   renderBody() {
-    const {orgId, projectId, hookId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId, hookId} = this.props.params;
     const {hook} = this.state;
     if (!hook) {
       return null;
     }
+    const params = {...this.props.params, orgId: organization.slug};
 
     return (
       <Fragment>
         <SettingsPageHeader title={t('Service Hook Details')} />
 
         <ErrorBoundary>
-          <HookStats params={this.props.params} />
+          <HookStats params={params} />
         </ErrorBoundary>
 
         <ServiceHookSettingsForm
-          orgId={orgId}
+          orgId={organization.slug}
           projectId={projectId}
           hookId={hookId}
           initialData={{

--- a/static/app/views/settings/project/projectSettingsLayout.tsx
+++ b/static/app/views/settings/project/projectSettingsLayout.tsx
@@ -45,12 +45,12 @@ function InnerProjectSettingsLayout({
   );
 }
 
-function ProjectSettingsLayout({params, ...props}: Props) {
-  const {orgId, projectId} = params;
-
+function ProjectSettingsLayout({organization, params, ...props}: Props) {
   return (
-    <ProjectContext orgId={orgId} projectId={projectId}>
-      {({project}) => <InnerProjectSettingsLayout {...{params, project, ...props}} />}
+    <ProjectContext orgId={organization.slug} projectId={params.projectId}>
+      {({project}) => (
+        <InnerProjectSettingsLayout {...{params, project, organization, ...props}} />
+      )}
     </ProjectContext>
   );
 }

--- a/static/app/views/settings/project/projectTeams.spec.jsx
+++ b/static/app/views/settings/project/projectTeams.spec.jsx
@@ -58,6 +58,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
+        project={project}
       />
     );
 
@@ -89,6 +90,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
+        project={project}
       />
     );
 
@@ -160,6 +162,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
+        project={project}
       />
     );
 
@@ -207,6 +210,7 @@ describe('ProjectTeams', function () {
       <ProjectTeams
         params={{orgId: org.slug, projectId: project.slug}}
         organization={org}
+        project={project}
       />
     );
 

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -26,8 +26,8 @@ type State = {
 
 class ProjectTeams extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {orgId, projectId} = this.props.params;
-    return [['projectTeams', `/projects/${orgId}/${projectId}/teams/`]];
+    const {organization, project} = this.props;
+    return [['projectTeams', `/projects/${organization.slug}/${project.slug}/teams/`]];
   }
 
   getTitle() {
@@ -48,9 +48,9 @@ class ProjectTeams extends AsyncView<Props, State> {
       return;
     }
 
-    const {orgId, projectId} = this.props.params;
+    const {organization, project} = this.props;
 
-    removeTeamFromProject(this.api, orgId, projectId, teamSlug)
+    removeTeamFromProject(this.api, organization.slug, project.slug, teamSlug)
       .then(() => this.handleRemovedTeam(teamSlug))
       .catch(() => {
         addErrorMessage(t('Could not remove the %s team', teamSlug));
@@ -76,9 +76,9 @@ class ProjectTeams extends AsyncView<Props, State> {
     if (this.state.loading) {
       return;
     }
-    const {orgId, projectId} = this.props.params;
+    const {organization, project} = this.props;
 
-    addTeamToProject(this.api, orgId, projectId, team).then(
+    addTeamToProject(this.api, organization.slug, project.slug, team).then(
       () => {
         this.handleAddedTeam(team);
       },
@@ -114,13 +114,13 @@ class ProjectTeams extends AsyncView<Props, State> {
   };
 
   renderBody() {
-    const {params, organization} = this.props;
+    const {project, organization} = this.props;
 
     const canCreateTeam = this.canCreateTeam();
     const hasAccess = organization.access.includes('project:write');
     const confirmRemove = t(
       'This is the last team with access to this project. Removing it will mean only organization owners and managers will be able to access the project pages. Are you sure you want to remove this team from the project %s?',
-      params.projectId
+      project.slug
     );
     const {projectTeams} = this.state;
 
@@ -145,7 +145,7 @@ class ProjectTeams extends AsyncView<Props, State> {
 
     return (
       <div>
-        <SettingsPageHeader title={t('%s Teams', params.projectId)} />
+        <SettingsPageHeader title={t('%s Teams', project.slug)} />
         <TeamSelect
           organization={organization}
           selectedTeams={projectTeams ?? []}

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -18,7 +18,7 @@ import TeamSelect from 'sentry/views/settings/components/teamSelect';
 type Props = {
   organization: Organization;
   project: Project;
-} & RouteComponentProps<{orgId: string; projectId: string}, {}>;
+} & RouteComponentProps<{projectId: string}, {}>;
 
 type State = {
   projectTeams: null | Team[];

--- a/static/app/views/settings/projectAlerts/settings.spec.jsx
+++ b/static/app/views/settings/projectAlerts/settings.spec.jsx
@@ -34,6 +34,7 @@ describe('ProjectAlertSettings', () => {
         canEditRule
         params={{orgId: organization.slug, projectId: project.slug}}
         organization={organization}
+        project={project}
         routes={[]}
       />
     );

--- a/static/app/views/settings/projectAlerts/settings.spec.jsx
+++ b/static/app/views/settings/projectAlerts/settings.spec.jsx
@@ -34,7 +34,6 @@ describe('ProjectAlertSettings', () => {
         canEditRule
         params={{orgId: organization.slug, projectId: project.slug}}
         organization={organization}
-        project={project}
         routes={[]}
       />
     );

--- a/static/app/views/settings/projectAlerts/settings.tsx
+++ b/static/app/views/settings/projectAlerts/settings.tsx
@@ -22,7 +22,6 @@ type Props = RouteComponentProps<RouteParams, {}> &
   AsyncView['props'] & {
     canEditRule: boolean;
     organization: Organization;
-    project: Project;
   };
 
 type State = AsyncView['state'] & {
@@ -40,16 +39,16 @@ class Settings extends AsyncView<Props, State> {
   }
 
   getProjectEndpoint() {
-    const {organization, project} = this.props;
-    return `/projects/${organization.slug}/${project.slug}/`;
+    const {organization, params} = this.props;
+    return `/projects/${organization.slug}/${params.projectId}/`;
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {organization, project} = this.props;
+    const {organization, params} = this.props;
     const projectEndpoint = this.getProjectEndpoint();
     return [
       ['project', projectEndpoint],
-      ['pluginList', `/projects/${organization.slug}/${project.slug}/plugins/`],
+      ['pluginList', `/projects/${organization.slug}/${params.projectId}/plugins/`],
     ];
   }
 

--- a/static/app/views/settings/projectAlerts/settings.tsx
+++ b/static/app/views/settings/projectAlerts/settings.tsx
@@ -17,6 +17,7 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
 type RouteParams = {orgId: string; projectId: string};
+
 type Props = RouteComponentProps<RouteParams, {}> &
   AsyncView['props'] & {
     canEditRule: boolean;
@@ -37,17 +38,18 @@ class Settings extends AsyncView<Props, State> {
       pluginList: [],
     };
   }
-  getProjectEndpoint({orgId, projectId}: RouteParams) {
-    return `/projects/${orgId}/${projectId}/`;
+
+  getProjectEndpoint() {
+    const {organization, project} = this.props;
+    return `/projects/${organization.slug}/${project.slug}/`;
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {params} = this.props;
-    const {orgId, projectId} = params;
-    const projectEndpoint = this.getProjectEndpoint(params);
+    const {organization, project} = this.props;
+    const projectEndpoint = this.getProjectEndpoint();
     return [
       ['project', projectEndpoint],
-      ['pluginList', `/projects/${orgId}/${projectId}/plugins/`],
+      ['pluginList', `/projects/${organization.slug}/${project.slug}/plugins/`],
     ];
   }
 
@@ -85,15 +87,14 @@ class Settings extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {canEditRule, organization, params} = this.props;
-    const {orgId} = params;
+    const {canEditRule, organization} = this.props;
     const {project, pluginList} = this.state;
 
     if (!project) {
       return null;
     }
 
-    const projectEndpoint = this.getProjectEndpoint(params);
+    const projectEndpoint = this.getProjectEndpoint();
 
     return (
       <Fragment>
@@ -102,7 +103,7 @@ class Settings extends AsyncView<Props, State> {
           action={
             <Button
               to={{
-                pathname: `/organizations/${orgId}/alerts/rules/`,
+                pathname: `/organizations/${organization.slug}/alerts/rules/`,
                 query: {project: project.id},
               }}
               size="sm"

--- a/static/app/views/settings/projectAlerts/settings.tsx
+++ b/static/app/views/settings/projectAlerts/settings.tsx
@@ -16,7 +16,7 @@ import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
-type RouteParams = {orgId: string; projectId: string};
+type RouteParams = {projectId: string};
 
 type Props = RouteComponentProps<RouteParams, {}> &
   AsyncView['props'] & {

--- a/static/app/views/settings/projectDataForwarding.tsx
+++ b/static/app/views/settings/projectDataForwarding.tsx
@@ -116,9 +116,10 @@ class ProjectDataForwarding extends AsyncComponent<Props, State> {
   onDisablePlugin = (plugin: Plugin) => this.updatePlugin(plugin, false);
 
   renderBody() {
-    const {params, organization, project} = this.props;
+    const {organization, project} = this.props;
     const plugins = this.forwardingPlugins;
     const hasAccess = organization.access.includes('project:write');
+    const params = {...this.props.params, orgId: organization.slug};
 
     const pluginsPanel =
       plugins.length > 0 ? (

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -40,8 +40,13 @@ class ProjectIssueGrouping extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {projectId, orgId} = this.props.params;
-    return [['groupingConfigs', `/projects/${orgId}/${projectId}/grouping-configs/`]];
+    const {organization, project} = this.props;
+    return [
+      [
+        'groupingConfigs',
+        `/projects/${organization.slug}/${project.slug}/grouping-configs/`,
+      ],
+    ];
   }
 
   handleSubmit = (response: Project) => {
@@ -52,8 +57,7 @@ class ProjectIssueGrouping extends AsyncView<Props, State> {
   renderBody() {
     const {groupingConfigs} = this.state;
     const {organization, project, params, location} = this.props;
-    const {orgId, projectId} = params;
-    const endpoint = `/projects/${orgId}/${projectId}/`;
+    const endpoint = `/projects/${organization.slug}/${project.slug}/`;
     const access = new Set(organization.access);
     const jsonFormProps = {
       additionalFieldProps: {

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -53,17 +53,20 @@ class ProjectPerformance extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {params, organization} = this.props;
-    const {orgId, projectId} = params;
+    const {projectId} = params;
 
     const endpoints: ReturnType<AsyncView['getEndpoints']> = [
-      ['threshold', `/projects/${orgId}/${projectId}/transaction-threshold/configure/`],
-      ['project', `/projects/${orgId}/${projectId}/`],
+      [
+        'threshold',
+        `/projects/${organization.slug}/${projectId}/transaction-threshold/configure/`,
+      ],
+      ['project', `/projects/${organization.slug}/${projectId}/`],
     ];
 
     if (organization.features.includes('performance-issues-dev')) {
       const performanceIssuesEndpoint = [
         'performance_issue_settings',
-        `/projects/${orgId}/${projectId}/performance-issues/configure/`,
+        `/projects/${organization.slug}/${projectId}/performance-issues/configure/`,
       ] as [string, string];
 
       endpoints.push(performanceIssuesEndpoint);

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -71,8 +71,14 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {projectId, orgId, pluginId} = this.props.params;
-    return [['pluginDetails', `/projects/${orgId}/${projectId}/plugins/${pluginId}/`]];
+    const {organization} = this.props;
+    const {projectId, pluginId} = this.props.params;
+    return [
+      [
+        'pluginDetails',
+        `/projects/${organization.slug}/${projectId}/plugins/${pluginId}/`,
+      ],
+    ];
   }
 
   trimSchema(value) {
@@ -80,7 +86,8 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
   }
 
   handleReset = () => {
-    const {projectId, orgId, pluginId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId, pluginId} = this.props.params;
 
     addLoadingMessage(t('Saving changes\u2026'));
     trackIntegrationAnalytics('integrations.uninstall_clicked', {
@@ -90,7 +97,7 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
       organization: this.props.organization,
     });
 
-    this.api.request(`/projects/${orgId}/${projectId}/plugins/${pluginId}/`, {
+    this.api.request(`/projects/${organization.slug}/${projectId}/plugins/${pluginId}/`, {
       method: 'POST',
       data: {reset: true},
       success: pluginDetails => {

--- a/static/app/views/settings/projectPlugins/projectPlugins.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPlugins.spec.tsx
@@ -9,6 +9,7 @@ describe('ProjectPlugins', function () {
 
     const {container} = render(
       <ProjectPlugins
+        organization={organization}
         params={{
           orgId: organization.slug,
         }}
@@ -37,6 +38,7 @@ describe('ProjectPlugins', function () {
 
     render(
       <ProjectPlugins
+        organization={organization}
         params={{
           orgId: organization.slug,
         }}

--- a/static/app/views/settings/projectPlugins/projectPlugins.tsx
+++ b/static/app/views/settings/projectPlugins/projectPlugins.tsx
@@ -12,7 +12,7 @@ import {
   PanelItem,
 } from 'sentry/components/panels';
 import {t, tct} from 'sentry/locale';
-import {Plugin, Project} from 'sentry/types';
+import {Organization, Plugin, Project} from 'sentry/types';
 import RouteError from 'sentry/views/routeError';
 
 import ProjectPluginRow from './projectPluginRow';
@@ -21,14 +21,15 @@ type Props = {
   error: React.ComponentProps<typeof RouteError>['error'];
   loading: boolean;
   onChange: React.ComponentProps<typeof ProjectPluginRow>['onChange'];
+  organization: Organization;
   plugins: Plugin[];
   project: Project;
 } & RouteComponentProps<{orgId: string}, {}>;
 
 class ProjectPlugins extends Component<Props> {
   render() {
-    const {plugins, loading, error, onChange, routes, params, project} = this.props;
-    const {orgId} = this.props.params;
+    const {plugins, loading, error, onChange, routes, organization, params, project} =
+      this.props;
     const hasError = error;
     const isLoading = !hasError && loading;
 
@@ -54,7 +55,7 @@ class ProjectPlugins extends Component<Props> {
                   ? tct(
                       "Legacy Integrations must be configured per-project. It's recommended to prefer organization integrations over the legacy project integrations when available. Visit the [link:organization integrations] settings to manage them.",
                       {
-                        link: <Link to={`/settings/${orgId}/integrations`} />,
+                        link: <Link to={`/settings/${organization.slug}/integrations`} />,
                       }
                     )
                   : t(

--- a/static/app/views/settings/projectSourceMaps/list/index.tsx
+++ b/static/app/views/settings/projectSourceMaps/list/index.tsx
@@ -50,9 +50,9 @@ class ProjectSourceMaps extends AsyncView<Props, State> {
   }
 
   getArchivesUrl() {
-    const {orgId, projectId} = this.props.params;
+    const {organization, project} = this.props;
 
-    return `/projects/${orgId}/${projectId}/files/source-maps/`;
+    return `/projects/${organization.slug}/${project.slug}/files/source-maps/`;
   }
 
   handleSearch = (query: string) => {
@@ -98,20 +98,18 @@ class ProjectSourceMaps extends AsyncView<Props, State> {
 
   renderArchives() {
     const {archives} = this.state;
-    const {params} = this.props;
-    const {orgId, projectId} = params;
-
     if (!archives.length) {
       return null;
     }
+    const {organization, project} = this.props;
 
     return archives.map(a => {
       return (
         <SourceMapsArchiveRow
           key={a.name}
           archive={a}
-          orgId={orgId}
-          projectId={projectId}
+          orgId={organization.slug}
+          projectId={project.slug}
           onDelete={this.handleDelete}
         />
       );


### PR DESCRIPTION
Under customer-domains settings routes no longer have `params.orgId` available as the organization slug is no longer a path parameter. Instead we have to use the organization prop to access the organization slug.

I've also fixed a problem on the member details view where adding a team would not trigger a UI rebuild as `member.teams` was mutated in-place.

Fixes #42705