### PR TITLE
Mock KafkaPublisher in replays test

### DIFF
--- a/tests/sentry/replays/test_organization_replay_events_meta.py
+++ b/tests/sentry/replays/test_organization_replay_events_meta.py
@@ -65,4 +65,4 @@ class OrganizationEventsMetaTest(APITestCase, SnubaTestCase):
         ]
 
         assert response.status_code == 200, response.content
-        assert response.data["data"] == expected
+        assert sorted(response.data["data"], key=lambda v: v["id"]) == expected

--- a/tests/sentry/replays/test_project_replay_details.py
+++ b/tests/sentry/replays/test_project_replay_details.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 from io import BytesIO
 from unittest.mock import Mock
@@ -8,12 +7,13 @@ import pytest
 from django.urls import reverse
 
 from sentry.models import File
+from sentry.replays import tasks
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.testutils import assert_expected_response, mock_expected_response, mock_replay
 from sentry.testutils import APITestCase, ReplaysSnubaTestCase
 from sentry.testutils.helpers import TaskRunner
 from sentry.testutils.silo import region_silo_test
-from sentry.utils import kafka_config, pubsub
+from sentry.utils import kafka_config
 
 REPLAYS_FEATURES = {"organizations:session-replay": True}
 
@@ -22,10 +22,7 @@ REPLAYS_FEATURES = {"organizations:session-replay": True}
 def setup(monkeypatch, settings):
     # Rely on the fact that the publisher is initialized lazily
     monkeypatch.setattr(kafka_config, "get_kafka_producer_cluster_options", Mock())
-    monkeypatch.setattr(pubsub, "KafkaPublisher", Mock())
-
-    # Settings fixture does not restore nested mutable attributes
-    settings.KAFKA_TOPICS = copy.deepcopy(settings.KAFKA_TOPICS)
+    monkeypatch.setattr(tasks, "KafkaPublisher", Mock())
 
 
 @region_silo_test

--- a/tests/sentry/replays/test_project_replay_details.py
+++ b/tests/sentry/replays/test_project_replay_details.py
@@ -1,6 +1,6 @@
 import datetime
 from io import BytesIO
-from unittest.mock import Mock
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -19,10 +19,10 @@ REPLAYS_FEATURES = {"organizations:session-replay": True}
 
 
 @pytest.fixture(autouse=True)
-def setup(monkeypatch, settings):
-    # Rely on the fact that the publisher is initialized lazily
-    monkeypatch.setattr(kafka_config, "get_kafka_producer_cluster_options", Mock())
-    monkeypatch.setattr(tasks, "KafkaPublisher", Mock())
+def setup():
+    with mock.patch.object(kafka_config, "get_kafka_producer_cluster_options"):
+        with mock.patch.object(tasks, "KafkaPublisher"):
+            yield
 
 
 @region_silo_test


### PR DESCRIPTION
The flush() call in src/sentry/utils/pubsub.py resulted in a ~5 min block in the test_delete test case. With this change the test drops to completing in ~5S.

Create profile:
```
python3 -m cProfile -o profile -m pytest tests/sentry/replays/test_project_replay_details.py
```

View results:
```
gprof2dot -f pstats profile | dot -Tpng -o output.png
```

![output](https://user-images.githubusercontent.com/112419115/210851810-7c168c4a-968c-4230-875a-99fc5aa95843.png)

For run time differences compare a recent master branch run vs this PR (Backend test 2 is the group with the long running / altered test):

Backend test (0) - *Before*: [14m 11s][before-0]    *After*: [11m24s][after-0]
Backend test (1) - *Before*: [18m 15s][before-1]    *After*: [17m 25s][after-1]
**Backend test (2) - *Before*: [24m 38s][before-2]    *After*: [15m 8s][after-2]**
Backend test (3) - *Before*: [17m 18s][before-3]    *After*: [13m 15s][after-3]

[before-0]:https://github.com/getsentry/sentry/actions/runs/3841823945/jobs/6542483394
[before-1]:https://github.com/getsentry/sentry/actions/runs/3841823945/jobs/6542483531
[before-2]:https://github.com/getsentry/sentry/actions/runs/3841823945/jobs/6542483635
[before-3]:https://github.com/getsentry/sentry/actions/runs/3841823945/jobs/6542483741

[after-0]:https://github.com/getsentry/sentry/actions/runs/3841849476/jobs/6542538202
[after-1]:https://github.com/getsentry/sentry/actions/runs/3841849476/jobs/6542538327
[after-2]:https://github.com/getsentry/sentry/actions/runs/3841849476/jobs/6542538445
[after-3]:https://github.com/getsentry/sentry/actions/runs/3841849476/jobs/6542538570