### PR TITLE
fix(replays): Fix Replay Console and Dom tabs resetting scroll position on hover

### DIFF
--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -1,9 +1,14 @@
+import {CSSProperties, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {IconFire, IconWarning} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
+import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import MessageFormatter from 'sentry/views/replays/detail/console/messageFormatter';
 import {breadcrumbHasIssue} from 'sentry/views/replays/detail/console/utils';
 import ViewIssueLink from 'sentry/views/replays/detail/console/viewIssueLink';
@@ -11,27 +16,51 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 type Props = {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
-  hasOccurred: boolean;
-  isCurrent: boolean;
-  isHovered: boolean;
-  onClickTimestamp: any;
-  onMouseEnter: any;
-  onMouseLeave: any;
+  breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[];
   startTimestampMs: number;
-  style: any;
+  style: CSSProperties;
 };
 
-function ConsoleMessage({
-  breadcrumb,
-  hasOccurred,
-  isCurrent,
-  isHovered,
-  onClickTimestamp,
-  onMouseEnter,
-  onMouseLeave,
-  startTimestampMs = 0,
-  style,
-}: Props) {
+function ConsoleMessage({breadcrumb, breadcrumbs, startTimestampMs, style}: Props) {
+  const {currentTime, currentHoverTime} = useReplayContext();
+
+  const {handleMouseEnter, handleMouseLeave, handleClick} =
+    useCrumbHandlers(startTimestampMs);
+
+  const onClickTimestamp = useCallback(
+    () => handleClick(breadcrumb),
+    [handleClick, breadcrumb]
+  );
+  const onMouseEnter = useCallback(
+    () => handleMouseEnter(breadcrumb),
+    [handleMouseEnter, breadcrumb]
+  );
+  const onMouseLeave = useCallback(
+    () => handleMouseLeave(breadcrumb),
+    [handleMouseLeave, breadcrumb]
+  );
+
+  const current = getPrevReplayEvent({
+    items: breadcrumbs,
+    targetTimestampMs: startTimestampMs + currentTime,
+    allowEqual: true,
+    allowExact: true,
+  });
+
+  const hovered = currentHoverTime
+    ? getPrevReplayEvent({
+        items: breadcrumbs,
+        targetTimestampMs: startTimestampMs + currentHoverTime,
+        allowEqual: true,
+        allowExact: true,
+      })
+    : undefined;
+
+  const hasOccurred =
+    currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);
+  const isCurrent = breadcrumb.id === current?.id;
+  const isHovered = breadcrumb.id === hovered?.id;
+
   return (
     <ConsoleLog
       hasOccurred={hasOccurred}
@@ -90,8 +119,8 @@ const ConsoleLog = styled('div')<{
     ['warning', 'error'].includes(p.level)
       ? p.theme.alert[p.level].iconColor
       : p.hasOccurred
-      ? p.theme.gray300
-      : 'inherit'};
+      ? 'inherit'
+      : p.theme.gray300};
 
   & ${IssueLinkWrapper} {
     visibility: hidden;

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {memo, useRef} from 'react';
 import {
   AutoSizer,
   CellMeasurer,
@@ -8,12 +8,8 @@ import {
 import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {t} from 'sentry/locale';
 import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
-import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
-import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import ConsoleFilters from 'sentry/views/replays/detail/console/consoleFilters';
 import ConsoleLogRow from 'sentry/views/replays/detail/console/consoleLogRow';
 import useConsoleFilters from 'sentry/views/replays/detail/console/useConsoleFilters';
@@ -27,30 +23,9 @@ interface Props {
 }
 
 function Console({breadcrumbs, startTimestampMs}: Props) {
-  const {currentTime, currentHoverTime} = useReplayContext();
-
   const filterProps = useConsoleFilters({breadcrumbs: breadcrumbs || []});
   const {items, setSearchTerm} = filterProps;
   const clearSearchTerm = () => setSearchTerm('');
-
-  const {handleMouseEnter, handleMouseLeave, handleClick} =
-    useCrumbHandlers(startTimestampMs);
-
-  const current = getPrevReplayEvent({
-    items,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
-        items,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
-        allowEqual: true,
-        allowExact: true,
-      })
-    : null;
 
   const listRef = useRef<ReactVirtualizedList>(null);
   const {cache} = useVirtualizedList({
@@ -74,15 +49,8 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
         rowIndex={index}
       >
         <ConsoleLogRow
-          hasOccurred={
-            currentTime < relativeTimeInMs(item.timestamp || 0, startTimestampMs)
-          }
-          isCurrent={item.id === current?.id}
-          isHovered={item.id === hovered?.id}
           breadcrumb={item}
-          onClickTimestamp={() => handleClick(item)}
-          onMouseEnter={() => handleMouseEnter(item)}
-          onMouseLeave={() => handleMouseLeave(item)}
+          breadcrumbs={items}
           startTimestampMs={startTimestampMs}
           style={style}
         />
@@ -137,4 +105,4 @@ const ConsoleLogContainer = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
 `;
 
-export default Console;
+export default memo(Console);

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -1,0 +1,197 @@
+import {CSSProperties, useCallback} from 'react';
+import styled from '@emotion/styled';
+
+import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
+import HTMLCode from 'sentry/components/htmlCode';
+import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {relativeTimeInMs} from 'sentry/components/replays/utils';
+import {SVGIconProps} from 'sentry/icons/svgIcon';
+import space from 'sentry/styles/space';
+import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import type {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
+import TimestampButton from 'sentry/views/replays/detail/timestampButton';
+
+type Props = {
+  mutation: Extraction;
+  mutations: Extraction[];
+  startTimestampMs: number;
+  style: CSSProperties;
+};
+
+function DomMutationRow({mutation, mutations, startTimestampMs, style}: Props) {
+  const {html, crumb: breadcrumb} = mutation;
+
+  const {currentTime, currentHoverTime} = useReplayContext();
+
+  const {handleMouseEnter, handleMouseLeave, handleClick} =
+    useCrumbHandlers(startTimestampMs);
+
+  const onClickTimestamp = useCallback(
+    () => handleClick(breadcrumb),
+    [handleClick, breadcrumb]
+  );
+  const onMouseEnter = useCallback(
+    () => handleMouseEnter(breadcrumb),
+    [handleMouseEnter, breadcrumb]
+  );
+  const onMouseLeave = useCallback(
+    () => handleMouseLeave(breadcrumb),
+    [handleMouseLeave, breadcrumb]
+  );
+
+  const breadcrumbs = mutations.map(({crumb}) => crumb);
+  const current = getPrevReplayEvent({
+    items: breadcrumbs,
+    targetTimestampMs: startTimestampMs + currentTime,
+    allowEqual: true,
+    allowExact: true,
+  });
+
+  const hovered = currentHoverTime
+    ? getPrevReplayEvent({
+        items: breadcrumbs,
+        targetTimestampMs: startTimestampMs + currentHoverTime,
+        allowEqual: true,
+        allowExact: true,
+      })
+    : undefined;
+
+  const hasOccurred =
+    currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);
+  const isCurrent = breadcrumb.id === current?.id;
+  const isHovered = breadcrumb.id === hovered?.id;
+
+  const {title} = getDetails(breadcrumb);
+
+  return (
+    <MutationListItem
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={style}
+      isCurrent={isCurrent}
+      isHovered={isHovered}
+    >
+      <IconWrapper color={breadcrumb.color} hasOccurred={hasOccurred}>
+        <BreadcrumbIcon type={breadcrumb.type} />
+      </IconWrapper>
+      <List>
+        <Row>
+          <Title hasOccurred={hasOccurred}>{title}</Title>
+          <TimestampButton
+            onClick={onClickTimestamp}
+            startTimestampMs={startTimestampMs}
+            timestampMs={breadcrumb.timestamp || ''}
+          />
+        </Row>
+        <Selector>{breadcrumb.message}</Selector>
+        <CodeContainer>
+          <HTMLCode code={html} />
+        </CodeContainer>
+      </List>
+    </MutationListItem>
+  );
+}
+
+const MutationListItem = styled('div')<{
+  isCurrent: boolean;
+  isHovered: boolean;
+}>`
+  display: flex;
+  gap: ${space(1)};
+  padding: ${space(1)} ${space(1.5)};
+
+  border-bottom: 1px solid
+    ${p =>
+      p.isCurrent ? p.theme.purple300 : p.isHovered ? p.theme.purple200 : 'transparent'};
+
+  &:hover {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+
+  /*
+  Draw a vertical line behind the breadcrumb icon.
+  The line connects each row together, but is truncated for the first and last items.
+  */
+  position: relative;
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    /* $padding + $half_icon_width - $space_for_the_line */
+    left: calc(${space(1.5)} + (24px / 2) - 1px);
+    width: 1px;
+    height: 100%;
+    background: ${p => p.theme.gray200};
+  }
+
+  &:first-of-type::after {
+    top: ${space(1)};
+    bottom: 0;
+  }
+
+  &:last-of-type::after {
+    top: 0;
+    height: ${space(1)};
+  }
+
+  &:only-of-type::after {
+    height: 0;
+  }
+`;
+
+const List = styled('div')`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  width: 100%;
+`;
+
+const Row = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+/**
+ * Taken `from events/interfaces/.../breadcrumbs/types`
+ */
+const IconWrapper = styled('div')<
+  {hasOccurred: boolean} & Required<Pick<SVGIconProps, 'color'>>
+>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  color: ${p => p.theme.white};
+  background: ${p => (p.hasOccurred ? p.theme[p.color] ?? p.color : p.theme.purple200)};
+
+  /* Make sure the icon is above the line through the back */
+  z-index: ${p => p.theme.zIndex.initial};
+`;
+
+const Title = styled('span')<{hasOccurred?: boolean}>`
+  color: ${p => (p.hasOccurred ? p.theme.gray400 : p.theme.gray300)};
+  font-weight: bold;
+  line-height: ${p => p.theme.text.lineHeightBody};
+  text-transform: capitalize;
+  ${p => p.theme.overflowEllipsis};
+`;
+
+const Selector = styled('p')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin-bottom: 0;
+`;
+
+const CodeContainer = styled('div')`
+  margin-top: ${space(1)};
+  max-height: 400px;
+  max-width: 100%;
+  overflow: auto;
+`;
+
+export default DomMutationRow;

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {memo, useRef} from 'react';
 import {
   AutoSizer,
   CellMeasurer,
@@ -7,24 +7,15 @@ import {
 } from 'react-virtualized';
 import styled from '@emotion/styled';
 
-import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
-import HTMLCode from 'sentry/components/htmlCode';
 import Placeholder from 'sentry/components/placeholder';
-import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {relativeTimeInMs} from 'sentry/components/replays/utils';
-import {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
-import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
-import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedCrumbHtml from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import DomFilters from 'sentry/views/replays/detail/domMutations/domFilters';
+import DomMutationRow from 'sentry/views/replays/detail/domMutations/domMutationRow';
 import useDomFilters from 'sentry/views/replays/detail/domMutations/useDomFilters';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
-import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 import useVirtualizedList from 'sentry/views/replays/detail/useVirtualizedList';
 
 type Props = {
@@ -33,32 +24,11 @@ type Props = {
 };
 
 function DomMutations({replay, startTimestampMs}: Props) {
-  const {currentTime, currentHoverTime} = useReplayContext();
   const {isLoading, actions} = useExtractedCrumbHtml({replay});
 
   const filterProps = useDomFilters({actions: actions || []});
   const {items, setSearchTerm} = filterProps;
   const clearSearchTerm = () => setSearchTerm('');
-
-  const {handleMouseEnter, handleMouseLeave, handleClick} =
-    useCrumbHandlers(startTimestampMs);
-
-  const crumbs = items.map(mutation => mutation.crumb);
-  const current = getPrevReplayEvent({
-    items: crumbs,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
-        items: crumbs,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
-        allowEqual: true,
-        allowExact: true,
-      })
-    : null;
 
   const listRef = useRef<ReactVirtualizedList>(null);
   const {cache} = useVirtualizedList({
@@ -72,11 +42,6 @@ function DomMutations({replay, startTimestampMs}: Props) {
 
   const renderRow = ({index, key, style, parent}: ListRowProps) => {
     const mutation = items[index];
-    const {html, crumb} = mutation;
-    const {title} = getDetails(crumb);
-
-    const hasOccurred =
-      currentTime >= relativeTimeInMs(crumb.timestamp || '', startTimestampMs);
 
     return (
       <CellMeasurer
@@ -86,35 +51,12 @@ function DomMutations({replay, startTimestampMs}: Props) {
         parent={parent}
         rowIndex={index}
       >
-        <MutationListItem
-          onMouseEnter={() => handleMouseEnter(crumb)}
-          onMouseLeave={() => handleMouseLeave(crumb)}
+        <DomMutationRow
+          mutation={mutation}
+          mutations={items}
+          startTimestampMs={startTimestampMs}
           style={style}
-          isCurrent={crumb.id === current?.id}
-          isHovered={crumb.id === hovered?.id}
-        >
-          <IconWrapper color={crumb.color} hasOccurred={hasOccurred}>
-            <BreadcrumbIcon type={crumb.type} />
-          </IconWrapper>
-          <MutationContent>
-            <MutationDetailsContainer>
-              <div>
-                <TitleContainer>
-                  <Title hasOccurred={hasOccurred}>{title}</Title>
-                </TitleContainer>
-                <MutationMessage>{crumb.message}</MutationMessage>
-              </div>
-              <TimestampButton
-                onClick={() => handleClick(crumb)}
-                startTimestampMs={startTimestampMs}
-                timestampMs={crumb.timestamp || ''}
-              />
-            </MutationDetailsContainer>
-            <CodeContainer>
-              <HTMLCode code={html} />
-            </CodeContainer>
-          </MutationContent>
-        </MutationListItem>
+        />
       </CellMeasurer>
     );
   };
@@ -122,18 +64,15 @@ function DomMutations({replay, startTimestampMs}: Props) {
   return (
     <MutationContainer>
       <DomFilters actions={actions} {...filterProps} />
-      <MutationList>
+      <MutationItemContainer>
         {isLoading || !actions ? (
           <Placeholder height="100%" />
         ) : (
           <AutoSizer>
             {({width, height}) => (
               <ReactVirtualizedList
-                ref={listRef}
                 deferredMeasurementCache={cache}
                 height={height}
-                overscanRowCount={5}
-                rowCount={items.length}
                 noRowsRenderer={() => (
                   <NoRowRenderer
                     unfilteredItems={actions}
@@ -142,6 +81,9 @@ function DomMutations({replay, startTimestampMs}: Props) {
                     {t('No DOM events recorded')}
                   </NoRowRenderer>
                 )}
+                overscanRowCount={5}
+                ref={listRef}
+                rowCount={items.length}
                 rowHeight={cache.rowHeight}
                 rowRenderer={renderRow}
                 width={width}
@@ -149,7 +91,7 @@ function DomMutations({replay, startTimestampMs}: Props) {
             )}
           </AutoSizer>
         )}
-      </MutationList>
+      </MutationItemContainer>
     </MutationContainer>
   );
 }
@@ -158,115 +100,12 @@ const MutationContainer = styled(FluidHeight)`
   height: 100%;
 `;
 
-const MutationList = styled('ul')`
-  list-style: none;
+const MutationItemContainer = styled('div')`
   position: relative;
   height: 100%;
   overflow: hidden;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  padding-left: 0;
-  margin-bottom: 0;
 `;
 
-const MutationContent = styled('div')`
-  overflow: hidden;
-  width: 100%;
-
-  display: flex;
-  flex-direction: column;
-  gap: ${space(1)};
-`;
-
-const MutationDetailsContainer = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  flex-grow: 1;
-`;
-
-/**
- * Taken `from events/interfaces/.../breadcrumbs/types`
- */
-const IconWrapper = styled('div')<
-  {hasOccurred?: boolean} & Required<Pick<SVGIconProps, 'color'>>
->`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  min-width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  color: ${p => p.theme.white};
-  background: ${p => (p.hasOccurred ? p.theme[p.color] ?? p.color : p.theme.purple200)};
-  box-shadow: ${p => p.theme.dropShadowLightest};
-  z-index: 2;
-`;
-
-const MutationListItem = styled('li')<{isCurrent: boolean; isHovered: boolean}>`
-  display: flex;
-  gap: ${space(1)};
-  flex-grow: 1;
-  padding: ${space(1)} ${space(1.5)};
-  position: relative;
-  border-bottom: 1px solid
-    ${p =>
-      p.isCurrent ? p.theme.purple300 : p.isHovered ? p.theme.purple200 : 'transparent'};
-
-  &:hover {
-    background-color: ${p => p.theme.backgroundSecondary};
-  }
-
-  /* Draw a vertical line behind the breadcrumb icon. The line connects each row together, but is truncated for the first and last items */
-  &::after {
-    content: '';
-    position: absolute;
-    left: 23.5px;
-    top: 0;
-    width: 1px;
-    background: ${p => p.theme.gray200};
-    height: 100%;
-  }
-
-  &:first-of-type::after {
-    top: ${space(1)};
-    bottom: 0;
-  }
-
-  &:last-of-type::after {
-    top: 0;
-    height: ${space(1)};
-  }
-
-  &:only-of-type::after {
-    height: 0;
-  }
-`;
-
-const TitleContainer = styled('div')`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const Title = styled('span')<{hasOccurred?: boolean}>`
-  ${p => p.theme.overflowEllipsis};
-  text-transform: capitalize;
-  color: ${p => (p.hasOccurred ? p.theme.gray400 : p.theme.gray300)};
-  font-weight: bold;
-  line-height: ${p => p.theme.text.lineHeightBody};
-`;
-
-const MutationMessage = styled('p')`
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeSmall};
-  margin-bottom: 0;
-`;
-
-const CodeContainer = styled('div')`
-  max-height: 400px;
-  max-width: 100%;
-  overflow: auto;
-`;
-
-export default DomMutations;
+export default memo(DomMutations);


### PR DESCRIPTION
I noticed that the <Console> component was re-rendering whenever the `hoverTime` gets updated. This means all the items get re-rendered, but also re-measured, which causes scroll to be reset. DomMutations have the same problem, it's more obviously when the html snippets are different heights from each other.

So to deal with that I added `memo()` to the component, and refactored the ConsoleLogRow props so that they're much more static. (Basically moved useReplayContext into the row component). So when the `hoverTime` is updated each row will re-render, and each row has to do some repeated work, but since things are virtualized there's not that many rows displayed at at time. 

I also made some simplifications to the css inside DomMutationRow to remove an extra div and rename things.

Fixes https://github.com/getsentry/getsentry/issues/9151