### PR TITLE
Revert "ref(hybrid-cloud): use organization_slug in org invite link url"

### DIFF
--- a/fixtures/emails/invitation.txt
+++ b/fixtures/emails/invitation.txt
@@ -4,6 +4,6 @@ Your teammates at Example are using Sentry to track and debug software errors.
 
 Join your team by visiting the following url:
 
-    http://testserver/accept/example/1/None/
+    http://testserver/accept/1/None/
 
 Check out the Sentry website (https://sentry.io) if you'd like to learn more before diving in.

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -83,7 +83,7 @@ class AcceptOrganizationInvite(Endpoint):
             # When SSO is required do *not* set a next_url to return to accept
             # invite. The invite will be accepted after SSO is completed.
             url = (
-                reverse("sentry-accept-invite-with-org", args=[organization_slug, member_id, token])
+                reverse("sentry-accept-invite", args=[member_id, token])
                 if not auth_provider
                 else "/"
             )

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -245,9 +245,8 @@ class OrganizationMember(Model):
             return None
         return absolute_uri(
             reverse(
-                "sentry-accept-invite-with-org",
+                "sentry-accept-invite",
                 kwargs={
-                    "organization_slug": self.organization.slug,
                     "member_id": self.id,
                     "token": self.token or self.legacy_token,
                 },

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -638,8 +638,8 @@ def invitation(request):
             "organization": org,
             "url": absolute_uri(
                 reverse(
-                    "sentry-accept-invite-with-org",
-                    kwargs={"organization_slug": org.slug, "member_id": om.id, "token": om.token},
+                    "sentry-accept-invite",
+                    kwargs={"member_id": om.id, "token": om.token},
                 )
             ),
         },


### PR DESCRIPTION
Reverts getsentry/sentry#42297

AcceptOrganizationInvite will actually be a control silo endpoint, so there is no need to change the invite link to use the org slug in the url.

For HC-511

[HC-511]: https://getsentry.atlassian.net/browse/HC-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ