### PR TITLE
ref(hybrid-cloud): use organization_slug in SharedGroupDetails

### DIFF
--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -16,7 +18,9 @@ from sentry.models import Group
 class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
     permission_classes = ()
 
-    def get(self, request: Request, share_id) -> Response:
+    def get(
+        self, request: Request, organization_slug: str | None = None, share_id: str | None = None
+    ) -> Response:
         """
         Retrieve an aggregate
 
@@ -33,6 +37,10 @@ class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
             group = Group.objects.from_share_id(share_id)
         except Group.DoesNotExist:
             raise ResourceDoesNotExist
+
+        if organization_slug:
+            if organization_slug != group.organization.slug:
+                return ResourceDoesNotExist
 
         if group.organization.flags.disable_shared_issues:
             raise ResourceDoesNotExist

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2320,7 +2320,7 @@ urlpatterns = [
     # Groups
     url(r"^(?:issues|groups)/", include(GROUP_URLS)),
     url(
-        r"^issues/(?P<organization_slug>[^\/]+)/(?P<issue_id>[^\/]+)/participants/$",
+        r"^organizations/(?P<organization_slug>[^\/]+)/issues/(?P<issue_id>[^\/]+)/participants/$",
         GroupParticipantsEndpoint.as_view(),
         name="sentry-api-0-group-stats-with-org",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2319,6 +2319,7 @@ urlpatterns = [
     ),
     # Groups
     url(r"^(?:issues|groups)/", include(GROUP_URLS)),
+    # TODO: include in the /organizations/ route tree + remove old dupe once hybrid cloud launches
     url(
         r"^organizations/(?P<organization_slug>[^\/]+)/issues/(?P<issue_id>[^\/]+)/participants/$",
         GroupParticipantsEndpoint.as_view(),
@@ -2329,15 +2330,16 @@ urlpatterns = [
         GroupParticipantsEndpoint.as_view(),
         name="sentry-api-0-group-stats",
     ),
-    url(
-        r"^shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
-        SharedGroupDetailsEndpoint.as_view(),
-        name="sentry-api-0-shared-group-details",
-    ),
+    # TODO: include in the /organizations/ route tree + remove old dupe once hybrid cloud launches
     url(
         r"^organizations/(?P<organization_slug>[^\/]+)/shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
         SharedGroupDetailsEndpoint.as_view(),
         name="sentry-api-0-shared-group-details-with-org",
+    ),
+    url(
+        r"^shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
+        SharedGroupDetailsEndpoint.as_view(),
+        name="sentry-api-0-shared-group-details",
     ),
     # Sentry Apps
     url(r"^sentry-apps/$", SentryAppsEndpoint.as_view(), name="sentry-api-0-sentry-apps"),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2334,6 +2334,11 @@ urlpatterns = [
         SharedGroupDetailsEndpoint.as_view(),
         name="sentry-api-0-shared-group-details",
     ),
+    url(
+        r"^shared/(?P<organization_slug>[^\/]+)/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
+        SharedGroupDetailsEndpoint.as_view(),
+        name="sentry-api-0-shared-group-details-with-org",
+    ),
     # Sentry Apps
     url(r"^sentry-apps/$", SentryAppsEndpoint.as_view(), name="sentry-api-0-sentry-apps"),
     url(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2335,7 +2335,7 @@ urlpatterns = [
         name="sentry-api-0-shared-group-details",
     ),
     url(
-        r"^shared/(?P<organization_slug>[^\/]+)/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
+        r"^organizations/(?P<organization_slug>[^\/]+)/shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
         SharedGroupDetailsEndpoint.as_view(),
         name="sentry-api-0-shared-group-details-with-org",
     ),

--- a/tests/sentry/api/endpoints/test_shared_group_details.py
+++ b/tests/sentry/api/endpoints/test_shared_group_details.py
@@ -4,8 +4,14 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class SharedGroupDetailsTest(APITestCase):
+    def _get_path_functions(self):
+        return (
+            lambda share_id: f"/api/0/shared/issues/{share_id}/",
+            lambda share_id: f"/api/0/shared/{self.organization.slug}/issues/{share_id}/",
+        )
+
     def test_simple(self):
         self.login_as(user=self.user)
 
@@ -21,14 +27,15 @@ class SharedGroupDetailsTest(APITestCase):
         share_id = group.get_share_id()
         assert share_id is not None
 
-        url = f"/api/0/shared/issues/{share_id}/"
-        response = self.client.get(url, format="json")
+        for path_func in self._get_path_functions():
+            path = path_func(share_id)
+            response = self.client.get(path, format="json")
 
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == str(group.id)
-        assert response.data["latestEvent"]["id"] == str(event.event_id)
-        assert response.data["project"]["slug"] == group.project.slug
-        assert response.data["project"]["organization"]["slug"] == group.organization.slug
+            assert response.status_code == 200, response.content
+            assert response.data["id"] == str(group.id)
+            assert response.data["latestEvent"]["id"] == str(event.event_id)
+            assert response.data["project"]["slug"] == group.project.slug
+            assert response.data["project"]["organization"]["slug"] == group.organization.slug
 
     def test_feature_disabled(self):
         self.login_as(user=self.user)
@@ -46,10 +53,11 @@ class SharedGroupDetailsTest(APITestCase):
         share_id = group.get_share_id()
         assert share_id is not None
 
-        url = f"/api/0/shared/issues/{share_id}/"
-        response = self.client.get(url, format="json")
+        for path_func in self._get_path_functions():
+            path = path_func(share_id)
+            response = self.client.get(path, format="json")
 
-        assert response.status_code == 404
+            assert response.status_code == 404
 
     def test_permalink(self):
         group = self.create_group()
@@ -62,14 +70,16 @@ class SharedGroupDetailsTest(APITestCase):
         share_id = group.get_share_id()
         assert share_id is not None
 
-        url = f"/api/0/shared/issues/{share_id}/"
-        response = self.client.get(url, format="json")
+        for path_func in self._get_path_functions():
+            path = path_func(share_id)
+            response = self.client.get(path, format="json")
 
-        assert response.status_code == 200, response.content
-        assert not response.data["permalink"]  # not show permalink when not logged in
+            assert response.status_code == 200, response.content
+            assert not response.data["permalink"]  # not show permalink when not logged in
 
         self.login_as(user=self.user)
-        response = self.client.get(url, format="json")
+        for path_func in self._get_path_functions():
+            response = self.client.get(path, format="json")
 
-        assert response.status_code == 200, response.content
-        assert response.data["permalink"]  # show permalink when logged in
+            assert response.status_code == 200, response.content
+            assert response.data["permalink"]  # show permalink when logged in

--- a/tests/sentry/api/endpoints/test_shared_group_details.py
+++ b/tests/sentry/api/endpoints/test_shared_group_details.py
@@ -9,7 +9,7 @@ class SharedGroupDetailsTest(APITestCase):
     def _get_path_functions(self):
         return (
             lambda share_id: f"/api/0/shared/issues/{share_id}/",
-            lambda share_id: f"/api/0/shared/{self.organization.slug}/issues/{share_id}/",
+            lambda share_id: f"/api/0/organizations/{self.organization.slug}/shared/issues/{share_id}/",
         )
 
     def test_simple(self):


### PR DESCRIPTION
Adds organization_slug to the url for the SharedGroupDetails endpoint. Keeps the original orgless URL for now.

Also fixes the GroupParticipants url with organization_slug to have the `/organizations/{organization_slug}/`... format

For HC-516

[HC-516]: https://getsentry.atlassian.net/browse/HC-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ