### PR TITLE
feat(alerts): Switch default alert action to email

### DIFF
--- a/static/app/views/projectInstall/issueAlertOptions.spec.jsx
+++ b/static/app/views/projectInstall/issueAlertOptions.spec.jsx
@@ -1,7 +1,7 @@
 import selectEvent from 'react-select-event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import IssueAlertOptions from 'sentry/views/projectInstall/issueAlertOptions';
 
@@ -113,5 +113,27 @@ describe('IssueAlertOptions', function () {
 
     render(<IssueAlertOptions {...props} />);
     expect(screen.getByTestId('range-input')).toHaveValue(null);
+  });
+
+  it('should provide fallthroughType with issue action for issue-alert-fallback-targeting', () => {
+    MockApiClient.addMockResponse({
+      url: URL,
+      body: TestStubs.MOCK_RESP_VERBOSE,
+    });
+    const org = {...organization, features: ['issue-alert-fallback-targeting']};
+
+    render(<IssueAlertOptions {...props} organization={org} />);
+    userEvent.click(screen.getByLabelText(/When there are more than/i));
+    expect(props.onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [
+          {
+            id: 'sentry.mail.actions.NotifyEmailAction',
+            targetType: 'IssueOwners',
+            fallthroughType: 'ActiveMembers',
+          },
+        ],
+      })
+    );
   });
 });

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -11,6 +11,7 @@ import PageHeading from 'sentry/components/pageHeading';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
+import {IssueAlertRuleAction} from 'sentry/types/alerts';
 import withOrganization from 'sentry/utils/withOrganization';
 
 enum MetricValues {
@@ -27,9 +28,15 @@ const UNIQUE_USER_FREQUENCY_CONDITION =
   'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition';
 const EVENT_FREQUENCY_CONDITION =
   'sentry.rules.conditions.event_frequency.EventFrequencyCondition';
-const NOTIFY_EVENT_ACTION = 'sentry.rules.actions.notify_event.NotifyEventAction';
 export const EVENT_FREQUENCY_PERCENT_CONDITION =
   'sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition';
+const ISSUE_ALERT_DEFAULT_ACTION: Omit<
+  IssueAlertRuleAction,
+  'label' | 'name' | 'prompt'
+> = {
+  id: 'sentry.mail.actions.NotifyEmailAction',
+  targetType: 'IssueOwners',
+};
 
 const METRIC_CONDITION_MAP = {
   [MetricValues.ERRORS]: EVENT_FREQUENCY_CONDITION,
@@ -57,7 +64,7 @@ type State = AsyncComponent['state'] & {
 
 type RequestDataFragment = {
   actionMatch: string;
-  actions: {id: string}[];
+  actions: Omit<IssueAlertRuleAction, 'label' | 'name' | 'prompt'>[];
   conditions: {id: string; interval: string; value: string}[] | undefined;
   defaultRules: boolean;
   frequency: number;
@@ -217,7 +224,14 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
               ),
             ]
           : undefined,
-      actions: [{id: NOTIFY_EVENT_ACTION}],
+      actions: [
+        {
+          ...ISSUE_ALERT_DEFAULT_ACTION,
+          ...(this.props.organization.features.includes('issue-alert-fallback-targeting')
+            ? {fallthroughType: 'ActiveMembers'}
+            : {}),
+        },
+      ],
       actionMatch: 'all',
       frequency: 5,
     };


### PR DESCRIPTION
Switches the default "more than xx occurrences alert" to use the notify issue owners action and add the fallback behind a flag.

This area of the project creation, the others are created on the backend.
![image](https://user-images.githubusercontent.com/1400464/210670648-7d3a8d08-7d68-4fb8-9ea5-5c9694e753ec.png)

[WOR-2538](https://getsentry.atlassian.net/browse/WOR-2538)

[WOR-2538]: https://getsentry.atlassian.net/browse/WOR-2538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WOR-2538]: https://getsentry.atlassian.net/browse/WOR-2538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ