### PR TITLE
feat(replays): Save Replay>Network sort field/dir into the url

### DIFF
--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -107,7 +107,7 @@ const MutationListItem = styled('div')<{
       p.isCurrent ? p.theme.purple300 : p.isHovered ? p.theme.purple200 : 'transparent'};
 
   &:hover {
-    background-color: ${p => p.theme.backgroundSecondary};
+    background-color: ${p => p.theme.hover};
   }
 
   /*

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -1,21 +1,10 @@
-import {useEffect, useRef, useState} from 'react';
-import {
-  AutoSizer,
-  CellMeasurer,
-  CellMeasurerCache,
-  GridCellProps,
-  MultiGrid,
-} from 'react-virtualized';
+import {useRef, useState} from 'react';
+import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
-import FileSize from 'sentry/components/fileSize';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {relativeTimeInMs} from 'sentry/components/replays/utils';
-import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
 import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
@@ -24,10 +13,11 @@ import NetworkHeaderCell, {
   COLUMN_COUNT,
   HEADER_HEIGHT,
 } from 'sentry/views/replays/detail/network/networkHeaderCell';
+import NetworkTableCell from 'sentry/views/replays/detail/network/networkTableCell';
 import useNetworkFilters from 'sentry/views/replays/detail/network/useNetworkFilters';
 import useSortNetwork from 'sentry/views/replays/detail/network/useSortNetwork';
 import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
-import TimestampButton from 'sentry/views/replays/detail/timestampButton';
+import useVirtualizedGrid from 'sentry/views/replays/detail/useVirtualizedGrid';
 import type {NetworkSpan} from 'sentry/views/replays/types';
 
 type Props = {
@@ -35,19 +25,8 @@ type Props = {
   startTimestampMs: number;
 };
 
-type SortDirection = 'asc' | 'desc';
-
-const cache = new CellMeasurerCache({
-  defaultWidth: 100,
-  fixedHeight: true,
-});
-
 function NetworkList({networkSpans, startTimestampMs}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
-
-  const [scrollBarWidth, setScrollBarWidth] = useState(0);
-  const multiGridRef = useRef<MultiGrid>(null);
-  const networkTableRef = useRef<HTMLDivElement>(null);
 
   const filterProps = useNetworkFilters({networkSpans: networkSpans || []});
   const {items: filteredItems, searchTerm, setSearchTerm} = filterProps;
@@ -73,97 +52,18 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
       })
     : null;
 
-  useEffect(() => {
-    let observer: ResizeObserver | null;
-
-    if (networkTableRef.current) {
-      // Observe the network table for width changes
-      observer = new ResizeObserver(() => {
-        // Recompute the column widths
-        multiGridRef.current?.recomputeGridSize({columnIndex: 1});
-      });
-
-      observer.observe(networkTableRef.current);
-    }
-
-    return () => {
-      observer?.disconnect();
-    };
-  }, [networkTableRef, searchTerm]);
-
-  const getNetworkColumnValue = (network: NetworkSpan, column: number) => {
-    const networkStartTimestamp = network.startTimestamp * 1000;
-    const networkEndTimestamp = network.endTimestamp * 1000;
-    const statusCode = network.data.statusCode;
-
-    const columnProps = {
-      onMouseEnter: () => handleMouseEnter(network),
-      onMouseLeave: () => handleMouseLeave(network),
-      isStatusError: typeof statusCode === 'number' && statusCode >= 400,
-      isCurrent: network.id === current?.id,
-      isHovered: network.id === hovered?.id,
-      hasOccurred:
-        currentTime >= relativeTimeInMs(networkStartTimestamp, startTimestampMs),
-      timestampSortDir:
-        sortConfig.by === 'startTimestamp'
-          ? ((sortConfig.asc ? 'asc' : 'desc') as SortDirection)
-          : undefined,
-    };
-
-    const columnValues = [
-      <Item key="statusCode" {...columnProps}>
-        {statusCode ? statusCode : <EmptyText>---</EmptyText>}
-      </Item>,
-      <Item key="description" {...columnProps}>
-        {network.description ? (
-          <Tooltip
-            title={network.description}
-            isHoverable
-            overlayStyle={{
-              maxWidth: '500px !important',
-            }}
-            showOnlyOnOverflow
-          >
-            <Text>{network.description}</Text>
-          </Tooltip>
-        ) : (
-          <EmptyText>({t('No value')})</EmptyText>
-        )}
-      </Item>,
-      <Item key="type" {...columnProps}>
-        <Tooltip
-          title={network.op.replace('resource.', '')}
-          isHoverable
-          overlayStyle={{
-            maxWidth: '500px !important',
-          }}
-          showOnlyOnOverflow
-        >
-          <Text>{network.op.replace('resource.', '')}</Text>
-        </Tooltip>
-      </Item>,
-      <Item key="size" {...columnProps} numeric>
-        {defined(network.data.size) ? (
-          <FileSize bytes={network.data.size} />
-        ) : (
-          <EmptyText>({t('No value')})</EmptyText>
-        )}
-      </Item>,
-      <Item key="duration" {...columnProps} numeric>
-        {`${(networkEndTimestamp - networkStartTimestamp).toFixed(2)}ms`}
-      </Item>,
-      <Item key="timestamp" {...columnProps} numeric>
-        <TimestampButton
-          format="mm:ss.SSS"
-          onClick={() => handleClick(network)}
-          startTimestampMs={startTimestampMs}
-          timestampMs={networkStartTimestamp}
-        />
-      </Item>,
-    ];
-
-    return columnValues[column];
-  };
+  const [scrollBarWidth, setScrollBarWidth] = useState(0);
+  const gridRef = useRef<MultiGrid>(null);
+  const tableRef = useRef<HTMLDivElement>(null);
+  const {cache} = useVirtualizedGrid({
+    cellMeasurer: {
+      defaultWidth: 100,
+      fixedHeight: true,
+    },
+    ref: gridRef,
+    wrapperRef: tableRef,
+    deps: [items, searchTerm],
+  });
 
   const renderTableRow = ({columnIndex, rowIndex, key, style, parent}: GridCellProps) => {
     const network = items[rowIndex - 1];
@@ -176,17 +76,27 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
         parent={parent}
         rowIndex={rowIndex}
       >
-        <div key={key} style={style}>
-          {rowIndex === 0 ? (
-            <NetworkHeaderCell
-              handleSort={handleSort}
-              index={columnIndex}
-              sortConfig={sortConfig}
-            />
-          ) : (
-            getNetworkColumnValue(network, columnIndex)
-          )}
-        </div>
+        {rowIndex === 0 ? (
+          <NetworkHeaderCell
+            handleSort={handleSort}
+            index={columnIndex}
+            sortConfig={sortConfig}
+            style={style}
+          />
+        ) : (
+          <NetworkTableCell
+            columnIndex={columnIndex}
+            handleClick={handleClick}
+            handleMouseEnter={handleMouseEnter}
+            handleMouseLeave={handleMouseLeave}
+            isCurrent={network.id === current?.id}
+            isHovered={network.id === hovered?.id}
+            sortConfig={sortConfig}
+            span={network}
+            startTimestampMs={startTimestampMs}
+            style={style}
+          />
+        )}
       </CellMeasurer>
     );
   };
@@ -194,12 +104,12 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
   return (
     <NetworkContainer>
       <NetworkFilters networkSpans={networkSpans} {...filterProps} />
-      <NetworkTable ref={networkTableRef}>
+      <NetworkTable ref={tableRef}>
         {networkSpans ? (
           <AutoSizer>
             {({width, height}) => (
               <MultiGrid
-                ref={multiGridRef}
+                ref={gridRef}
                 columnCount={COLUMN_COUNT}
                 columnWidth={({index}) => {
                   if (index === 1) {
@@ -215,21 +125,10 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
 
                   return cache.columnWidth({index});
                 }}
-                deferredMeasurementCache={cache}
-                height={height}
-                overscanRowCount={5}
                 cellRenderer={renderTableRow}
-                rowCount={items.length + 1}
-                rowHeight={({index}) => (index === 0 ? HEADER_HEIGHT : 28)}
-                width={width}
+                deferredMeasurementCache={cache}
                 fixedRowCount={1}
-                onScrollbarPresenceChange={({vertical, size}) => {
-                  if (vertical) {
-                    setScrollBarWidth(size);
-                  } else {
-                    setScrollBarWidth(0);
-                  }
-                }}
+                height={height}
                 noContentRenderer={() => (
                   <NoRowRenderer
                     unfilteredItems={networkSpans}
@@ -238,6 +137,14 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
                     {t('No network requests recorded')}
                   </NoRowRenderer>
                 )}
+                onScrollbarPresenceChange={({vertical, size}) =>
+                  setScrollBarWidth(vertical ? size : 0)
+                }
+                overscanColumnCount={COLUMN_COUNT}
+                overscanRowCount={5}
+                rowCount={items.length + 1}
+                rowHeight={({index}) => (index === 0 ? HEADER_HEIGHT : 28)}
+                width={width}
               />
             )}
           </AutoSizer>
@@ -253,82 +160,12 @@ const NetworkContainer = styled(FluidHeight)`
   height: 100%;
 `;
 
-const Text = styled('p')`
-  padding: 0;
-  margin: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-`;
-
-const EmptyText = styled(Text)`
-  font-style: italic;
-  color: ${p => p.theme.subText};
-`;
-
-const fontColor = p =>
-  p.isStatusError
-    ? p.theme.alert.error.iconColor
-    : p.hasOccurred
-    ? 'inherit'
-    : p.theme.gray300;
-
-const Item = styled('div')<{
-  hasOccurred: boolean;
-  isCurrent: boolean;
-  isHovered: boolean;
-  isStatusError: boolean;
-  timestampSortDir: SortDirection | undefined;
-  numeric?: boolean;
-}>`
-  display: flex;
-  align-items: center;
-  padding: ${space(0.75)} ${space(1.5)};
-
-  font-size: ${p => p.theme.fontSizeSmall};
-  max-height: 28px;
-  font-variant-numeric: tabular-nums;
-  ${p => (p.numeric ? 'justify-content: flex-end;' : '')};
-
-  background-color: ${p =>
-    p.isStatusError ? p.theme.alert.error.backgroundLight : 'inherit'};
-
-  border-bottom: 1px solid
-    ${p =>
-      p.timestampSortDir === 'asc'
-        ? p.isCurrent
-          ? p.theme.purple300
-          : p.isHovered
-          ? p.theme.purple200
-          : 'transparent'
-        : 'transparent'};
-
-  border-top: 1px solid
-    ${p =>
-      p.timestampSortDir === 'desc'
-        ? p.isCurrent
-          ? p.theme.purple300
-          : p.isHovered
-          ? p.theme.purple200
-          : 'transparent'
-        : 'transparent'};
-
-  color: ${fontColor};
-
-  ${EmptyText} {
-    color: ${fontColor};
-  }
-`;
-
 const NetworkTable = styled('div')`
-  list-style: none;
   position: relative;
   height: 100%;
   overflow: hidden;
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
-  padding-left: 0;
-  margin-bottom: 0;
 `;
 
 export default NetworkList;

--- a/static/app/views/replays/detail/network/networkHeaderCell.tsx
+++ b/static/app/views/replays/detail/network/networkHeaderCell.tsx
@@ -1,3 +1,4 @@
+import {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
 import {IconArrow} from 'sentry/icons';
@@ -5,39 +6,34 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useSortNetwork from 'sentry/views/replays/detail/network/useSortNetwork';
 
+type SortConfig = ReturnType<typeof useSortNetwork>['sortConfig'];
 type Props = {
   handleSort: ReturnType<typeof useSortNetwork>['handleSort'];
   index: number;
-  sortConfig: ReturnType<typeof useSortNetwork>['sortConfig'];
+  sortConfig: SortConfig;
+  style: CSSProperties;
 };
 
 export const HEADER_HEIGHT = 25;
 
-const COLUMNS = [
-  {
-    key: 'status',
-    label: t('Status'),
-    field: 'status',
-    sortFn: row => row.data.statusCode,
-  },
-  {key: 'path', label: t('Path'), field: 'description'},
-  {key: 'type', label: t('Type'), field: 'op'},
-  {key: 'size', label: t('Size'), field: 'size', sortFn: row => row.data.size},
-  {
-    key: 'duration',
-    label: t('Duration'),
-    field: 'duration',
-    sortFn: row => row.endTimestamp - row.startTimestamp,
-  },
-  {key: 'timestamp', label: t('Timestamp'), field: 'startTimestamp'},
+const COLUMNS: {
+  field: SortConfig['by'];
+  label: string;
+}[] = [
+  {field: 'status', label: t('Status')},
+  {field: 'description', label: t('Path')},
+  {field: 'op', label: t('Type')},
+  {field: 'size', label: t('Size')},
+  {field: 'duration', label: t('Duration')},
+  {field: 'startTimestamp', label: t('Timestamp')},
 ];
 
 export const COLUMN_COUNT = COLUMNS.length;
 
-function NetworkHeaderCell({handleSort, index, sortConfig}: Props) {
-  const {field, label, sortFn} = COLUMNS[index];
+function NetworkHeaderCell({handleSort, index, sortConfig, style}: Props) {
+  const {field, label} = COLUMNS[index];
   return (
-    <HeaderButton onClick={() => handleSort(field, sortFn)}>
+    <HeaderButton style={style} onClick={() => handleSort(field)}>
       {label}
       <IconArrow
         color="gray300"

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -1,0 +1,179 @@
+import {CSSProperties} from 'react';
+import styled from '@emotion/styled';
+
+import FileSize from 'sentry/components/fileSize';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {relativeTimeInMs} from 'sentry/components/replays/utils';
+import Tooltip from 'sentry/components/tooltip';
+import space from 'sentry/styles/space';
+import useSortNetwork from 'sentry/views/replays/detail/network/useSortNetwork';
+import TimestampButton from 'sentry/views/replays/detail/timestampButton';
+import type {NetworkSpan} from 'sentry/views/replays/types';
+
+const EMPTY_CELL = '\u00A0';
+
+type Props = {
+  columnIndex: number;
+  handleClick: (span: NetworkSpan) => void;
+  handleMouseEnter: (span: NetworkSpan) => void;
+  handleMouseLeave: (span: NetworkSpan) => void;
+  isCurrent: boolean;
+  isHovered: boolean;
+  sortConfig: ReturnType<typeof useSortNetwork>['sortConfig'];
+  span: NetworkSpan;
+  startTimestampMs: number;
+  style: CSSProperties;
+};
+
+function NetworkTableCell({
+  columnIndex,
+  handleClick,
+  handleMouseEnter,
+  handleMouseLeave,
+  isCurrent,
+  isHovered,
+  sortConfig,
+  span,
+  startTimestampMs,
+  style,
+}: Props) {
+  const {currentTime} = useReplayContext();
+
+  const startMs = span.startTimestamp * 1000;
+  const endMs = span.endTimestamp * 1000;
+  const statusCode = span.data.statusCode;
+
+  const isByTimestamp = sortConfig.by === 'startTimestamp';
+  const columnProps = {
+    hasOccurred: isByTimestamp
+      ? currentTime >= relativeTimeInMs(span.startTimestamp * 1000, startTimestampMs)
+      : undefined,
+    hasOccurredAsc: isByTimestamp ? sortConfig.asc : undefined,
+    isCurrent,
+    isHovered,
+    isStatusError: typeof statusCode === 'number' && statusCode >= 400,
+    onMouseEnter: () => handleMouseEnter(span),
+    onMouseLeave: () => handleMouseLeave(span),
+    style,
+  };
+
+  const renderFns = [
+    () => (
+      <Cell {...columnProps}>
+        <Text>{statusCode ? statusCode : EMPTY_CELL}</Text>
+      </Cell>
+    ),
+    () => (
+      <Cell {...columnProps}>
+        <Tooltip
+          title={span.description}
+          isHoverable
+          showOnlyOnOverflow
+          overlayStyle={{maxWidth: '500px !important'}}
+        >
+          <Text>{span.description || EMPTY_CELL}</Text>
+        </Tooltip>
+      </Cell>
+    ),
+    () => (
+      <Cell {...columnProps}>
+        <Tooltip title={span.op.replace('resource.', '')} isHoverable showOnlyOnOverflow>
+          <Text>{span.op.replace('resource.', '')}</Text>
+        </Tooltip>
+      </Cell>
+    ),
+    () => (
+      <Cell {...columnProps} numeric>
+        <Text>
+          {span.data.size === undefined ? (
+            EMPTY_CELL
+          ) : (
+            <FileSize bytes={span.data.size} />
+          )}
+        </Text>
+      </Cell>
+    ),
+    () => (
+      <Cell {...columnProps} numeric>
+        <Text>{`${(endMs - startMs).toFixed(2)}ms`}</Text>
+      </Cell>
+    ),
+    () => (
+      <Cell {...columnProps} numeric>
+        <TimestampButton
+          format="mm:ss.SSS"
+          onClick={() => handleClick(span)}
+          startTimestampMs={startTimestampMs}
+          timestampMs={startMs}
+        />
+      </Cell>
+    ),
+  ];
+
+  return renderFns[columnIndex]();
+}
+
+const cellBackground = p => {
+  if (p.hasOccurred === undefined && !p.isStatusError) {
+    return `background-color: ${p.isHovered ? p.theme.hover : 'inherit'};`;
+  }
+  const color = p.isStatusError ? p.theme.alert.error.backgroundLight : 'inherit';
+  return `background-color: ${color};`;
+};
+
+const cellBorder = p => {
+  if (p.hasOccurred === undefined) {
+    return null;
+  }
+  const color = p.isCurrent
+    ? p.theme.purple300
+    : p.isHovered
+    ? p.theme.purple200
+    : 'transparent';
+  return p.hasOccurredAsc
+    ? `border-bottom: 1px solid ${color};`
+    : `border-top: 1px solid ${color};`;
+};
+
+const cellColor = p => {
+  const colors = p.isStatusError
+    ? [p.theme.alert.error.borderHover, p.theme.alert.error.iconColor]
+    : ['inherit', p.theme.gray300];
+  if (p.hasOccurred === undefined) {
+    return `color: ${colors[0]};`;
+  }
+  return `color: ${p.hasOccurred ? colors[0] : colors[1]};`;
+};
+
+const Cell = styled('div')<{
+  hasOccurred: boolean | undefined;
+  hasOccurredAsc: boolean | undefined;
+  isCurrent: boolean;
+  isHovered: boolean;
+  isStatusError: boolean;
+  numeric?: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  padding: ${space(0.75)} ${space(1.5)};
+  font-size: ${p => p.theme.fontSizeSmall};
+
+  ${cellBackground}
+  ${cellBorder}
+  ${cellColor}
+
+  ${p =>
+    p.numeric &&
+    `
+    font-variant-numeric: tabular-nums;
+    justify-content: flex-end;
+  `};
+`;
+
+const Text = styled('div')`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+export default NetworkTableCell;

--- a/static/app/views/replays/detail/network/useSortNetwork.spec.tsx
+++ b/static/app/views/replays/detail/network/useSortNetwork.spec.tsx
@@ -6,6 +6,22 @@ import type {NetworkSpan} from 'sentry/views/replays/types';
 
 import useSortNetwork from './useSortNetwork';
 
+jest.mock('react-router');
+jest.mock('sentry/utils/useUrlParams', () => {
+  const map = new Map();
+  return (name, dflt) => {
+    if (!map.has(name)) {
+      map.set(name, dflt);
+    }
+    return {
+      getParamValue: () => map.get(name),
+      setParamValue: value => {
+        map.set(name, value);
+      },
+    };
+  };
+});
+
 const SPAN_0_NAVIGATE = {
   id: '0',
   timestamp: 1663131080555.4,
@@ -216,7 +232,7 @@ describe('useSortNetwork', () => {
     });
 
     act(() => {
-      result.current.handleSort('size', row => row.data.size);
+      result.current.handleSort('size');
     });
 
     rerender({items});

--- a/static/app/views/replays/detail/useVirtualizedGrid.tsx
+++ b/static/app/views/replays/detail/useVirtualizedGrid.tsx
@@ -1,0 +1,38 @@
+import {DependencyList, RefObject, useEffect, useMemo} from 'react';
+import {CellMeasurerCache, CellMeasurerCacheParams, MultiGrid} from 'react-virtualized';
+
+type Opts = {
+  cellMeasurer: CellMeasurerCacheParams;
+  deps: DependencyList;
+  ref: RefObject<MultiGrid>;
+  wrapperRef: RefObject<HTMLDivElement>;
+};
+function useVirtualizedGrid({cellMeasurer, deps, ref, wrapperRef}: Opts) {
+  const cache = useMemo(() => new CellMeasurerCache(cellMeasurer), [cellMeasurer]);
+
+  // Clear cache when items changes
+  useEffect(() => {
+    cache.clearAll();
+    ref.current?.recomputeGridSize({columnIndex: 1});
+  }, [cache, ref, deps]);
+
+  // Clear cache when wrapper div is resized
+  useEffect(() => {
+    if (!wrapperRef.current) {
+      return () => {};
+    }
+
+    const observer = new ResizeObserver(() => {
+      ref.current?.recomputeGridSize({columnIndex: 1});
+    });
+    observer.observe(wrapperRef.current);
+
+    return () => observer.disconnect();
+  }, [ref, wrapperRef, deps]);
+
+  return {
+    cache,
+  };
+}
+
+export default useVirtualizedGrid;


### PR DESCRIPTION
This is a bit more than just saving the sort config into the url, most things related to the network table are refactored, but that's one of the few behavior changes.
Other behavior changes relate to the current/hover state of the table. I've made sure the hover state is works correctly when the table is sorted by the `startTimestamp` column (in either direction). Also when the table is sorted by any other column, I've added a background on hover, so it's easier to see what row you're looking at (there is no hoverTime border).

I also refactored to create `<NetworkTableCell>`, which is similar to `<NetworkHeaderCell>` i guess. Inside of there I cleaned up some things, mostly converting that array of react elements into an array of element-factories; and also looking at the css for background-color, border, and color props of each row. 


Fixes #38948
