### PR TITLE
ref(replays): Refactor Transaction counts to use new /replay-count/ endpoint

### DIFF
--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -54,7 +54,7 @@ describe('useReplaysCount', () => {
 
   it('should query for groupIds', async () => {
     const replayCountRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issue-replay-count/`,
+      url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
       body: {},
     });
@@ -69,7 +69,7 @@ describe('useReplaysCount', () => {
 
     expect(result.current).toEqual({});
     expect(replayCountRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/issue-replay-count/',
+      '/organizations/org-slug/replay-count/',
       expect.objectContaining({
         query: {
           query: `issue.id:[${mockGroupIds.join(',')}]`,
@@ -84,7 +84,7 @@ describe('useReplaysCount', () => {
 
   it('should return the count of each groupId, or zero if not included in the response', async () => {
     const replayCountRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issue-replay-count/`,
+      url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
       body: {
         123: 42,
@@ -112,7 +112,7 @@ describe('useReplaysCount', () => {
 
   it('should request the count for a group only once', async () => {
     const replayCountRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issue-replay-count/`,
+      url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
       body: {},
     });
@@ -129,7 +129,7 @@ describe('useReplaysCount', () => {
 
     expect(replayCountRequest).toHaveBeenCalledTimes(1);
     expect(replayCountRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/issue-replay-count/',
+      '/organizations/org-slug/replay-count/',
       expect.objectContaining({
         query: {
           query: `issue.id:[123,456]`,
@@ -153,7 +153,7 @@ describe('useReplaysCount', () => {
 
     expect(replayCountRequest).toHaveBeenCalledTimes(2);
     expect(replayCountRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/issue-replay-count/',
+      '/organizations/org-slug/replay-count/',
       expect.objectContaining({
         query: {
           query: `issue.id:[789]`,
@@ -171,7 +171,7 @@ describe('useReplaysCount', () => {
 
   it('should not request anything if there are no new ids to query', async () => {
     const replayCountRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issue-replay-count/`,
+      url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
       body: {},
     });
@@ -188,7 +188,7 @@ describe('useReplaysCount', () => {
 
     expect(replayCountRequest).toHaveBeenCalledTimes(1);
     expect(replayCountRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/issue-replay-count/',
+      '/organizations/org-slug/replay-count/',
       expect.objectContaining({
         query: {
           query: `issue.id:[123,456]`,
@@ -216,10 +216,10 @@ describe('useReplaysCount', () => {
   });
 
   it('should query for transactionNames', async () => {
-    const countRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
-      body: {data: []},
+      body: {},
     });
 
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
@@ -231,18 +231,13 @@ describe('useReplaysCount', () => {
     });
 
     expect(result.current).toEqual({});
-    expect(countRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/replay-count/',
       expect.objectContaining({
         query: {
-          environment: [],
-          field: ['count_unique(replayId)', 'transaction'],
-          per_page: 50,
-          project: [String(project.id)],
-          query: `!replayId:"" event.type:transaction transaction:[${mockTransactionNames.join(
-            ','
-          )}]`,
+          query: `event.type:transaction transaction:[${mockTransactionNames.join(',')}]`,
           statsPeriod: '14d',
+          project: [2],
         },
       })
     );
@@ -252,15 +247,10 @@ describe('useReplaysCount', () => {
 
   it('should return the count of each transactionName, or zero if not included in the response', async () => {
     const countRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
+      url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
       body: {
-        data: [
-          {
-            'count_unique(replayId)': 42,
-            transaction: '/home',
-          },
-        ],
+        '/home': 42,
       },
     });
 

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -1,11 +1,7 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
-import {Location} from 'history';
 
 import {Organization} from 'sentry/types';
-import {TableData} from 'sentry/utils/discover/discoverQuery';
-import EventView from 'sentry/utils/discover/eventView';
-import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import toArray from 'sentry/utils/toArray';
 import useApi from 'sentry/utils/useApi';
 
@@ -28,6 +24,13 @@ function useReplaysCount({
 
   const [replayCounts, setReplayCounts] = useState<CountState>({});
 
+  const filterUnseen = useCallback(
+    (ids: string | string[]) => {
+      return toArray(ids).filter(id => !(id in replayCounts));
+    },
+    [replayCounts]
+  );
+
   const zeroCounts = useMemo(() => {
     const ids = toArray(groupIds || []);
     const names = toArray(transactionNames || []);
@@ -46,40 +49,30 @@ function useReplaysCount({
         'Unable to query both groupId and transactionName simultaneously in useReplaysCount()'
       );
     }
-    if (groupIds && groupIds.length) {
-      const groupsToFetch = toArray(groupIds).filter(gid => !(gid in replayCounts));
-      if (!groupsToFetch.length) {
-        return null;
-      }
 
-      return {
-        field: 'issue.id' as const,
-        conditions: `issue.id:[${groupsToFetch.join(',')}]`,
-      };
+    if (groupIds && groupIds.length) {
+      const groupsToFetch = filterUnseen(groupIds);
+      if (groupsToFetch.length) {
+        return {
+          field: 'issue.id' as const,
+          conditions: `issue.id:[${groupsToFetch.join(',')}]`,
+        };
+      }
+      return null;
     }
+
     if (transactionNames && transactionNames.length) {
-      return {
-        field: 'transaction' as const,
-        conditions: `event.type:transaction transaction:[${toArray(transactionNames).join(
-          ','
-        )}]`,
-      };
+      const txnsToFetch = filterUnseen(transactionNames);
+      if (txnsToFetch.length) {
+        return {
+          field: 'transaction' as const,
+          conditions: `event.type:transaction transaction:[${txnsToFetch.join(',')}]`,
+        };
+      }
+      return null;
     }
     return null;
-  }, [replayCounts, groupIds, transactionNames]);
-
-  const eventView = useMemo(
-    () =>
-      EventView.fromSavedQuery({
-        id: '',
-        name: `Errors within replay`,
-        version: 2,
-        fields: ['count_unique(replayId)', String(query?.field)],
-        query: `!replayId:"" ${query?.conditions}`,
-        projects: projectIds,
-      }),
-    [projectIds, query]
-  );
+  }, [filterUnseen, groupIds, transactionNames]);
 
   const fetchReplayCount = useCallback(async () => {
     try {
@@ -87,37 +80,21 @@ function useReplaysCount({
         return;
       }
 
-      if (query.field === 'issue.id') {
-        const response = await api.requestPromise(
-          `/organizations/${organization.slug}/issue-replay-count/`,
-          {
-            query: {
-              query: query.conditions,
-              statsPeriod: '14d',
-              project: projectIds,
-            },
-          }
-        );
-        setReplayCounts({...zeroCounts, ...response});
-      } else {
-        const [data] = await doDiscoverQuery<TableData>(
-          api,
-          `/organizations/${organization.slug}/events/`,
-          eventView.getEventsAPIPayload({query: {}} as Location<any>)
-        );
-
-        const counts = data.data.reduce((obj, record) => {
-          const key = record[query.field] as string;
-          const val = record['count_unique(replayId)'] as number;
-          obj[key] = val;
-          return obj;
-        }, zeroCounts);
-        setReplayCounts(counts);
-      }
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/replay-count/`,
+        {
+          query: {
+            query: query.conditions,
+            statsPeriod: '14d',
+            project: projectIds,
+          },
+        }
+      );
+      setReplayCounts({...zeroCounts, ...response});
     } catch (err) {
       Sentry.captureException(err);
     }
-  }, [api, organization.slug, query, zeroCounts, eventView, projectIds]);
+  }, [api, organization.slug, query, zeroCounts, projectIds]);
 
   useEffect(() => {
     const hasSessionReplay = organization.features.includes('session-replay-ui');

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -92,6 +92,13 @@ describe('TransactionReplays', () => {
       url: '/organizations/org-slug/events-has-measurements/',
       body: {measurements: false},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replay-count/',
+      body: {
+        data: [],
+      },
+      statusCode: 200,
+    });
     eventsMockApi = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {


### PR DESCRIPTION

Depends on https://github.com/getsentry/sentry/pull/42793
Fixes #42375
