### PR TITLE
ref(perf): Delete unified span view flag

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -873,10 +873,6 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
   ): React.ReactNode {
     const {toggleEmbeddedChildren, organization, showEmbeddedChildren} = this.props;
 
-    if (!organization.features.includes('unified-span-view')) {
-      return null;
-    }
-
     if (transactions && transactions.length === 1) {
       const transaction = transactions[0];
       return (

--- a/static/app/components/events/interfaces/spans/traceView.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.spec.tsx
@@ -222,9 +222,7 @@ describe('TraceView', () => {
 
     // TODO: This test can be converted later to use the TransactionEventBuilder instead
     it('should allow expanding of embedded transactions', async () => {
-      const {organization, project, location} = initializeData({
-        features: ['unified-span-view'],
-      });
+      const {organization, project, location} = initializeData({});
 
       const event = generateSampleEvent();
       generateSampleSpan(


### PR DESCRIPTION
The ability to expand embedded transactions within the span tree was gated behind this outdated feature flag. The feature flag was set to be available only to orgs with the `am1` plan, which is why we haven't been able to see it anymore since we've upgraded to `am2`. 

This flag is obsolete now and we want it to be available to all performance users, so I am deleting the flag

[Backend PR](https://github.com/getsentry/sentry/pull/42813)