### PR TITLE
ref(perf): Delete unified span view flag backend

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -156,7 +156,6 @@ default_manager.add("organizations:transaction-name-normalize", OrganizationFeat
 default_manager.add("organizations:transaction-name-clusterer", OrganizationFeature)
 default_manager.add("organizations:transaction-name-sanitization", OrganizationFeature, False)
 default_manager.add("organizations:transaction-metrics-extraction", OrganizationFeature)
-default_manager.add("organizations:unified-span-view", OrganizationFeature, True)
 default_manager.add("organizations:use-metrics-layer", OrganizationFeature, True)
 default_manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, True)
 default_manager.add("organizations:u2f-superuser-form", OrganizationFeature, True)


### PR DESCRIPTION
The ability to expand embedded transactions within the span tree was gated behind this outdated feature flag. The feature flag was set to be available only to orgs with the am1 plan, which is why we haven't been able to see it anymore since we've upgraded to am2.

This flag is obsolete now and we want it to be available to all performance users, so I am deleting the flag

[Frontend PR](https://github.com/getsentry/sentry/pull/42812)