### PR TITLE
Revert "ref(hybrid-cloud): use monitor urls with org slug frontend"

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -35,13 +35,7 @@ class MonitorDetails extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {params, location} = this.props;
-    return [
-      [
-        'monitor',
-        `/monitors/${this.orgSlug}/${params.monitorId}/`,
-        {query: location.query},
-      ],
-    ];
+    return [['monitor', `/monitors/${params.monitorId}/`, {query: location.query}]];
   }
 
   getTitle() {
@@ -74,14 +68,14 @@ class MonitorDetails extends AsyncView<Props, State> {
                   <DatePageFilter alignDropdown="left" />
                 </StyledPageFilterBar>
 
-                <MonitorStats monitor={monitor} orgId={this.orgSlug} />
+                <MonitorStats monitor={monitor} />
 
                 <MonitorIssues monitor={monitor} orgId={this.orgSlug} />
 
                 <Panel>
                   <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
 
-                  <MonitorCheckIns monitor={monitor} orgId={this.orgSlug} />
+                  <MonitorCheckIns monitor={monitor} />
                 </Panel>
               </Fragment>
             )}

--- a/static/app/views/monitors/monitorCheckIns.tsx
+++ b/static/app/views/monitors/monitorCheckIns.tsx
@@ -21,21 +21,16 @@ type CheckIn = {
 
 type Props = {
   monitor: Monitor;
-  orgId: string;
 };
 
 type State = {
   checkInList: CheckIn[];
 };
 
-const MonitorCheckIns = ({monitor, orgId}: Props) => {
+const MonitorCheckIns = ({monitor}: Props) => {
   const {data, hasError, renderComponent} = useApiRequests<State>({
     endpoints: [
-      [
-        'checkInList',
-        `/monitors/${orgId}/${monitor.id}/checkins/`,
-        {query: {per_page: '10'}},
-      ],
+      ['checkInList', `/monitors/${monitor.id}/checkins/`, {query: {per_page: '10'}}],
     ],
   });
 

--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -17,14 +17,13 @@ import {Monitor, MonitorStat} from './types';
 
 type Props = {
   monitor: Monitor;
-  orgId: string;
 };
 
 type State = {
   stats: MonitorStat[] | null;
 };
 
-const MonitorStats = ({monitor, orgId}: Props) => {
+const MonitorStats = ({monitor}: Props) => {
   const {selection} = usePageFilters();
   const {start, end, period} = selection.datetime;
 
@@ -42,7 +41,7 @@ const MonitorStats = ({monitor, orgId}: Props) => {
     endpoints: [
       [
         'stats',
-        `/monitors/${orgId}/${monitor.id}/stats/`,
+        `/monitors/${monitor.id}/stats/`,
         {
           query: {
             since: since.toString(),


### PR DESCRIPTION
Reverts getsentry/sentry#42728

The slugs should be `organization/{org_slug}/monitors/...` which is not the case at the moment, so these should be reverted to their original orgless urls until the backend part is completed correctly.