### PR TITLE
feat(perf-issues): Add N+1 API Calls detector system options to management UI

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -21,6 +21,10 @@ const optionsAvailable = [
   'performance.issues.n_plus_one_db_ext.problem-creation',
   'performance.issues.n_plus_one_db.count_threshold',
   'performance.issues.n_plus_one_db.duration_threshold',
+  'performance.issues.n_plus_one_api_calls.problem-creation',
+  'performance.issues.n_plus_one_api_calls.la-rollout',
+  'performance.issues.n_plus_one_api_calls.ea-rollout',
+  'performance.issues.n_plus_one_api_calls.ga-rollout',
 ];
 
 type Field = ReturnType<typeof getOption>;
@@ -100,6 +104,13 @@ export default class AdminSettings extends AsyncView<{}, State> {
               {fields['performance.issues.n_plus_one_db_ext.problem-creation']}
               {fields['performance.issues.n_plus_one_db.count_threshold']}
               {fields['performance.issues.n_plus_one_db.duration_threshold']}
+            </Panel>
+            <Panel>
+              <PanelHeader>Performance Issues - N+1 API Calls Detector</PanelHeader>
+              {fields['performance.issues.n_plus_one_api_calls.problem-creation']}
+              {fields['performance.issues.n_plus_one_api_calls.la-rollout']}
+              {fields['performance.issues.n_plus_one_api_calls.ea-rollout']}
+              {fields['performance.issues.n_plus_one_api_calls.ga-rollout']}
             </Panel>
           </Feature>
         </Form>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -174,6 +174,38 @@ const performanceOptionDefinitions: Field[] = [
     max: Number.MAX_SAFE_INTEGER,
     step: 1,
   },
+  {
+    key: 'performance.issues.n_plus_one_api_calls.problem-creation',
+    label: t('N+1 API Calls Problem Creation Rate'),
+    help: t(
+      'Controls the overall rate at which performance problems are detected by the N+1 API Calls detector.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.n_plus_one_api_calls.la-rollout',
+    label: t('Limited Availability Detection Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the N+1 API Calls detector for LA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.n_plus_one_api_calls.ea-rollout',
+    label: t('Early Adopter Detection Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the N+1 API Calls detector for EA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.n_plus_one_api_calls.ga-rollout',
+    label: t('General Availability Detection Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the for N+1 API Calls detector for GA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
 ];
 
 // This are ordered based on their display order visually


### PR DESCRIPTION
Moves PERF-1867 along. Adds the options I declared in #42778 to the `/management/settings` UI, so I can roll out gradually.

**e.g.,**
![Screen Shot 2023-01-05 at 11 54 11 AM](https://user-images.githubusercontent.com/989898/210855860-10e6debf-b341-4415-92ef-c9ee7140c5e3.png)
