### PR TITLE
ref(hybrid-cloud): fix monitor urls using organization_slug

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -698,6 +698,7 @@ urlpatterns = [
             ]
         ),
     ),
+    # TODO: include in the /organizations/ route tree + remove old dupes once hybrid cloud launches
     url(
         r"^organizations/(?P<organization_slug>[^\/]+)/monitors/",
         include(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -695,18 +695,25 @@ urlpatterns = [
                     MonitorStatsEndpoint.as_view(),
                     name="sentry-api-0-monitor-stats",
                 ),
+            ]
+        ),
+    ),
+    url(
+        r"^organizations/(?P<organization_slug>[^\/]+)/monitors/",
+        include(
+            [
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<monitor_id>[^\/]+)/$",
+                    r"^(?P<monitor_id>[^\/]+)/$",
                     MonitorDetailsEndpoint.as_view(),
                     name="sentry-api-0-monitor-details-with-org",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<monitor_id>[^\/]+)/checkins/$",
+                    r"^(?P<monitor_id>[^\/]+)/checkins/$",
                     MonitorCheckInsEndpoint.as_view(),
                     name="sentry-api-0-monitor-check-in-index-with-org",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<monitor_id>[^\/]+)/stats/$",
+                    r"^(?P<monitor_id>[^\/]+)/stats/$",
                     MonitorStatsEndpoint.as_view(),
                     name="sentry-api-0-monitor-stats-with-org",
                 ),

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -156,7 +156,7 @@ class CreateMonitorCheckInTest(MonitorTestCase):
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        path = f"/api/0/monitors/asdf/{monitor.guid}/checkins/"
+        path = f"/api/0/organizations/asdf/monitors/{monitor.guid}/checkins/"
         self.login_as(user=self.user)
 
         resp = self.client.post(path)

--- a/tests/sentry/api/endpoints/test_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_details.py
@@ -24,7 +24,7 @@ class MonitorDetailsTest(MonitorTestCase):
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        path = f"/api/0/monitors/asdf/{monitor.guid}/"
+        path = f"/api/0/organizations/asdf/monitors/{monitor.guid}/"
         self.login_as(user=self.user)
 
         resp = self.client.get(path)
@@ -230,7 +230,7 @@ class UpdateMonitorTest(MonitorTestCase):
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        path = f"/api/0/monitors/asdf/{monitor.guid}/"
+        path = f"/api/0/organizations/asdf/monitors/{monitor.guid}/"
         self.login_as(user=self.user)
 
         resp = self.client.put(
@@ -267,7 +267,7 @@ class DeleteMonitorTest(MonitorTestCase):
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        path = f"/api/0/monitors/asdf/{monitor.guid}/"
+        path = f"/api/0/organizations/asdf/monitors/{monitor.guid}/"
         self.login_as(user=self.user)
 
         resp = self.client.delete(path)


### PR DESCRIPTION
The format of the url should be `/api/0/organization/{organization_slug}/monitors/...`

For HC-512, HC-513, HC-514