### PR TITLE
feat(ci/codecov): Enable pull request check failures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,15 +6,13 @@ coverage:
     patch:
       default: false
       frontend:
-        # codecov should not fail status checks
-        informational: true
+        # codecov will not fail status checks for master
         only_pulls: true
         target: 60%
         flags:
         - frontend
       backend:
-        # codecov should not fail status checks
-        informational: true
+        # codecov will not fail status checks for master
         only_pulls: true
         target: 90%
         flags:


### PR DESCRIPTION
Back in the day, codecov failed a lot on `master` and to only run it informationally on PRs.

Unfortunately, this prevents developers from meeting a minimum coverage for their diffs and allows our code coverage to keep dropping over time.

I would like to make PRs fail if we do not meet the minimum diff coverage. We can then re-evaluate again how reliable it is.