### PR TITLE
ref(ts): Fix re-exporting types `InputProps`, `TextAreaProp`

### DIFF
--- a/static/app/components/inputGroup.tsx
+++ b/static/app/components/inputGroup.tsx
@@ -70,7 +70,7 @@ export function InputGroup({children, ...props}: React.HTMLAttributes<HTMLDivEle
   );
 }
 
-export {InputProps};
+export type {InputProps};
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({size, disabled, ...props}, ref) => {
     const {leadingWidth, trailingWidth, setInputProps} = useContext(InputGroupContext);
@@ -92,7 +92,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   }
 );
 
-export {TextAreaProps};
+export type {TextAreaProps};
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({size, disabled, ...props}, ref) => {
     const {leadingWidth, trailingWidth, setInputProps} = useContext(InputGroupContext);


### PR DESCRIPTION
webpack does not like re-exporting types. add `type` keyword to signal that we are re-exporting a type.


![image](https://user-images.githubusercontent.com/79684/210873201-56ebd31b-7038-4357-890f-6b67df15fc35.png)
