### PR TITLE
ref(crons): Add page view empty_state analytic parameter

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -80,9 +80,13 @@ class Monitors extends AsyncView<Props, State> {
     return `Monitors - ${this.orgSlug}`;
   }
 
-  componentDidMount() {
+  onRequestSuccess(response): void {
     this.props.setEventNames('monitors.page_viewed', 'Monitors: Page Viewed');
+    this.props.setRouteAnalyticsParams({
+      empty_state: response.data.length === 0,
+    });
   }
+
   handleSearch = (query: string) => {
     const {location, router} = this.props;
     router.push({


### PR DESCRIPTION
Changed crons page view analytics to add parameter based on if the user is viewing the empty landing page state, or a list of previously created cron monitors.

https://github.com/getsentry/reload/pull/301

Closes: https://github.com/getsentry/team-crons/issues/10