### PR TITLE
fix(workflow): Stacktrace value could be an object and error

### DIFF
--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -34,16 +34,19 @@ function KeyValueList({
     <Table className="table key-value" onClick={onClick} {...props}>
       <tbody>
         {keyValueData.map(
-          ({
-            key,
-            subject,
-            value = null,
-            meta,
-            subjectIcon,
-            subjectDataTestId,
-            actionButton,
-            isContextData: valueIsContextData,
-          }) => {
+          (
+            {
+              key,
+              subject,
+              value = null,
+              meta,
+              subjectIcon,
+              subjectDataTestId,
+              actionButton,
+              isContextData: valueIsContextData,
+            },
+            idx
+          ) => {
             const valueProps = {
               isContextData: valueIsContextData || isContextData,
               meta,
@@ -53,7 +56,7 @@ function KeyValueList({
             };
 
             return (
-              <tr key={`${key}.${value}`}>
+              <tr key={`${key}-${idx}`}>
                 <TableSubject className="key" wide={longKeys}>
                   {subject}
                 </TableSubject>


### PR DESCRIPTION
key by index instead

example error https://sentry.io/organizations/sentry/issues/3854093849/
![image](https://user-images.githubusercontent.com/1400464/210894183-87aab1c1-14ef-4a98-9e22-95cb3ddaeb10.png)


fixes JAVASCRIPT-28SG