### PR TITLE
ref(hybrid-cloud): use correct monitor urls with org slug frontend

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -39,7 +39,13 @@ class MonitorDetails extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {params, location} = this.props;
-    return [['monitor', `/monitors/${params.monitorId}/`, {query: location.query}]];
+    return [
+      [
+        'monitor',
+        `/organizations/${this.orgSlug}/monitors/${params.monitorId}/`,
+        {query: location.query},
+      ],
+    ];
   }
 
   getTitle() {
@@ -82,14 +88,14 @@ class MonitorDetails extends AsyncView<Props, State> {
                   <DatePageFilter alignDropdown="left" />
                 </StyledPageFilterBar>
 
-                <MonitorStats monitor={monitor} />
+                <MonitorStats monitor={monitor} orgId={this.orgSlug} />
 
                 <MonitorIssues monitor={monitor} orgId={this.orgSlug} />
 
                 <Panel>
                   <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
 
-                  <MonitorCheckIns monitor={monitor} />
+                  <MonitorCheckIns monitor={monitor} orgId={this.orgSlug} />
                 </Panel>
               </Fragment>
             )}

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -25,7 +25,7 @@ class EditMonitor extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {params} = this.props;
-    return [['monitor', `/monitors/${params.monitorId}/`]];
+    return [['monitor', `/organizations/${this.orgSlug}/monitors/${params.monitorId}/`]];
   }
 
   onUpdate = (data: Monitor) =>
@@ -56,7 +56,7 @@ class EditMonitor extends AsyncView<Props, State> {
           <MonitorForm
             monitor={monitor}
             apiMethod="PUT"
-            apiEndpoint={`/monitors/${monitor.id}/`}
+            apiEndpoint={`/organizations/${this.orgSlug}/monitors/${monitor.id}/`}
             onSubmitSuccess={this.onSubmitSuccess}
           />
         </Layout.Main>

--- a/static/app/views/monitors/monitorCheckIns.tsx
+++ b/static/app/views/monitors/monitorCheckIns.tsx
@@ -21,16 +21,21 @@ type CheckIn = {
 
 type Props = {
   monitor: Monitor;
+  orgId: string;
 };
 
 type State = {
   checkInList: CheckIn[];
 };
 
-const MonitorCheckIns = ({monitor}: Props) => {
+const MonitorCheckIns = ({monitor, orgId}: Props) => {
   const {data, hasError, renderComponent} = useApiRequests<State>({
     endpoints: [
-      ['checkInList', `/monitors/${monitor.id}/checkins/`, {query: {per_page: '10'}}],
+      [
+        'checkInList',
+        `/organizations/${orgId}/monitors/${monitor.id}/checkins/`,
+        {query: {per_page: '10'}},
+      ],
     ],
   });
 

--- a/static/app/views/monitors/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/monitorHeaderActions.tsx
@@ -32,7 +32,7 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
     addLoadingMessage(t('Deleting Monitor...'));
 
     api
-      .requestPromise(`/monitors/${monitor.id}/`, {
+      .requestPromise(`/organizations/${orgId}/monitors/${monitor.id}/`, {
         method: 'DELETE',
       })
       .then(() => {
@@ -46,7 +46,7 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
   const updateMonitor = (data: Partial<Monitor>) => {
     addLoadingMessage();
     api
-      .requestPromise(`/monitors/${monitor.id}/`, {
+      .requestPromise(`/organizations/${orgId}/monitors/${monitor.id}/`, {
         method: 'PUT',
         data,
       })

--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -17,13 +17,14 @@ import {Monitor, MonitorStat} from './types';
 
 type Props = {
   monitor: Monitor;
+  orgId: string;
 };
 
 type State = {
   stats: MonitorStat[] | null;
 };
 
-const MonitorStats = ({monitor}: Props) => {
+const MonitorStats = ({monitor, orgId}: Props) => {
   const {selection} = usePageFilters();
   const {start, end, period} = selection.datetime;
 
@@ -41,7 +42,7 @@ const MonitorStats = ({monitor}: Props) => {
     endpoints: [
       [
         'stats',
-        `/monitors/${monitor.id}/stats/`,
+        `/organizations/${orgId}/monitors/${monitor.id}/stats/`,
         {
           query: {
             since: since.toString(),


### PR DESCRIPTION
MonitorStats, MonitorDetails, and MonitorCheckIns will be region silo endpoints and thus will need org slugs in the url to be able to proxy to the correct region. Updates the frontend to use the urls with the org slug.

For HC-512, HC-513, and HC-514