### PR TITLE
fix(ui): Use borderless over priority="link" for admin env info

### DIFF
--- a/static/app/views/admin/adminEnvironment.tsx
+++ b/static/app/views/admin/adminEnvironment.tsx
@@ -49,7 +49,7 @@ export default class AdminEnvironment extends AsyncView<{}, State> {
                     "You're running an old version of Sentry, did you know %s is available?",
                     version.latest
                   )}
-                  priority="link"
+                  borderless
                   href="https://github.com/getsentry/sentry/releases"
                   icon={<IconQuestion size="sm" />}
                   size="sm"


### PR DESCRIPTION
I'm not really worried if this looks weird, it's in the very little used admin pages