### PR TITLE
fix(ui): Detach thread selector

### DIFF
--- a/static/app/components/events/interfaces/threads/threadSelector/index.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/index.tsx
@@ -66,6 +66,7 @@ const ThreadSelector = ({
     <ClassNames>
       {({css}) => (
         <StyledDropdownAutoComplete
+          detached
           data-test-id="thread-selector"
           items={getItems()}
           onSelect={item => {


### PR DESCRIPTION
We removed most other 'detached' props except these

Before
<img width="628" alt="image" src="https://user-images.githubusercontent.com/1421724/210914334-ff2a811c-b832-42fb-8d34-32fc1c290c57.png">


After
<img width="570" alt="image" src="https://user-images.githubusercontent.com/1421724/210914093-f2a0eac3-5e3d-4570-b930-1fa13c127d8c.png">
