### PR TITLE
fix(ecosystem): Remove unused codeowners api call

### DIFF
--- a/static/app/components/group/suggestedOwners/suggestedOwners.spec.jsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.spec.jsx
@@ -18,10 +18,6 @@ describe('SuggestedOwners', function () {
     TeamStore.init();
     MemberListStore.loadInitialData([user, TestStubs.CommitAuthor()]);
     Client.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/codeowners/`,
-      body: [],
-    });
-    Client.addMockResponse({
       url: `/prompts-activity/`,
       body: {},
     });

--- a/static/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -1,13 +1,6 @@
 import {assignToActor, assignToUser} from 'sentry/actionCreators/group';
 import AsyncComponent from 'sentry/components/asyncComponent';
-import type {
-  Actor,
-  CodeOwner,
-  Committer,
-  Group,
-  Organization,
-  Project,
-} from 'sentry/types';
+import type {Actor, Committer, Group, Organization, Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import useCommitters from 'sentry/utils/useCommitters';
@@ -27,7 +20,6 @@ type Props = {
 } & AsyncComponent['props'];
 
 type State = {
-  codeowners: CodeOwner[] | null;
   eventOwners: {owners: Array<Actor>; rules: Rules} | null;
 } & AsyncComponent['state'];
 
@@ -36,7 +28,6 @@ class SuggestedOwners extends AsyncComponent<Props, State> {
     return {
       ...super.getDefaultState(),
       event: {rules: [], owners: []},
-      codeowners: [],
     };
   }
 
@@ -48,12 +39,6 @@ class SuggestedOwners extends AsyncComponent<Props, State> {
         `/projects/${organization.slug}/${project.slug}/events/${event.id}/owners/`,
       ],
     ];
-    if (organization.features.includes('integrations-codeowners')) {
-      endpoints.push([
-        `codeowners`,
-        `/projects/${organization.slug}/${project.slug}/codeowners/`,
-      ]);
-    }
 
     return endpoints as ReturnType<AsyncComponent['getEndpoints']>;
   }


### PR DESCRIPTION
In suggested assignees, this was used in the codeowners prompt that was removed