### PR TITLE
fix(ui): Fix up visuals of Modal CloseButton

### DIFF
--- a/static/app/components/globalModal/components.tsx
+++ b/static/app/components/globalModal/components.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Button, {ButtonPropsWithAriaLabel} from 'sentry/components/button';
+import Button, {ButtonProps} from 'sentry/components/button';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -29,17 +29,19 @@ const ModalHeader = styled('header')`
   }
 `;
 
-const CloseButton = styled((p: ButtonPropsWithAriaLabel) => (
-  <Button size="zero" icon={<IconClose size="10px" />} {...p} />
+const CloseButton = styled((p: Omit<ButtonProps, 'aria-label'>) => (
+  <Button
+    aria-label={t('Close Modal')}
+    icon={<IconClose size="10px" />}
+    size="zero"
+    {...p}
+  />
 ))`
   position: absolute;
   top: 0;
   right: 0;
   transform: translate(50%, -50%);
   border-radius: 50%;
-  border: none;
-  box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder};
-  background: ${p => p.theme.background};
   height: 24px;
   width: 24px;
 `;
@@ -86,9 +88,7 @@ const makeClosableHeader = (closeModal: () => void) => {
   }) => (
     <ModalHeader {...props}>
       {children}
-      {closeButton ? (
-        <CloseButton aria-label={t('Close Modal')} onClick={closeModal} />
-      ) : null}
+      {closeButton ? <CloseButton onClick={closeModal} /> : null}
     </ModalHeader>
   );
 
@@ -101,8 +101,8 @@ const makeClosableHeader = (closeModal: () => void) => {
  * Creates a CloseButton component that is connected to the provided closeModal trigger
  */
 const makeCloseButton =
-  (closeModal: () => void): React.FC<Omit<ButtonPropsWithAriaLabel, 'aria-label'>> =>
+  (closeModal: () => void): React.FC<Omit<ButtonProps, 'aria-label'>> =>
   props =>
-    <CloseButton {...props} aria-label={t('Close Modal')} onClick={closeModal} />;
+    <CloseButton {...props} onClick={closeModal} />;
 
 export {makeClosableHeader, makeCloseButton, ModalBody, ModalFooter};


### PR DESCRIPTION
Overriding the box-shadow messed with focus state

Before
![image](https://user-images.githubusercontent.com/1421724/211082062-880a492a-3c61-4e9c-a1be-459a42916dbf.png)


After
![image](https://user-images.githubusercontent.com/1421724/211082024-5b031806-dc28-4ab0-b6c6-8e7002abbf55.png)
