### PR TITLE
fix(ui): button over priority="link" for manage upgrade button

### DIFF
--- a/static/app/views/admin/adminEnvironment.tsx
+++ b/static/app/views/admin/adminEnvironment.tsx
@@ -45,16 +45,13 @@ export default class AdminEnvironment extends AsyncView<{}, State> {
                     "You're running an old version of Sentry, did you know %s is available?",
                     version.latest
                   )}
-                  aria-label={t(
-                    "You're running an old version of Sentry, did you know %s is available?",
-                    version.latest
-                  )}
-                  priority="link"
                   href="https://github.com/getsentry/sentry/releases"
-                  icon={<IconQuestion size="sm" />}
-                  size="sm"
+                  icon={<IconQuestion size="xs" />}
+                  size="xs"
                   external
-                />
+                >
+                  {t('Upgrade to Sentry %s', version.latest)}
+                </Button>
               )}
             </VersionLabel>
             <dd>


### PR DESCRIPTION
Just trying to reduce unnecessary `Button priority="link"`

Before
![image](https://user-images.githubusercontent.com/1421724/211083408-a8059daa-0765-41df-81da-12a071b4c7f1.png)


After
![image](https://user-images.githubusercontent.com/1421724/211083329-419d1154-2057-4f7f-b029-1e6708ac328c.png)

It's a bit more aggressive but I think that's OK
