### PR TITLE
ref(theme): Update drop shadow keys & values

### DIFF
--- a/static/app/components/banner.tsx
+++ b/static/app/components/banner.tsx
@@ -95,7 +95,7 @@ const BannerWrapper = styled('div')<BannerWrapperProps>`
   justify-content: center;
   position: relative;
   margin-bottom: ${space(2)};
-  box-shadow: ${p => p.theme.dropShadowLight};
+  box-shadow: ${p => p.theme.dropShadowMedium};
   border-radius: ${p => p.theme.borderRadius};
   height: 180px;
   color: ${p => p.theme.white};

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -288,9 +288,9 @@ const getBoxShadow = ({
   }
 
   return `
-      box-shadow: ${translucentBorderString} ${theme.dropShadowLight};
+      box-shadow: ${translucentBorderString} ${theme.dropShadowMedium};
       &:active {
-        box-shadow: ${translucentBorderString} inset ${theme.dropShadowLight};
+        box-shadow: ${translucentBorderString} inset ${theme.dropShadowMedium};
       }
     `;
 };

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -105,7 +105,7 @@ const StyledCheckbox = styled('div')<{
   align-items: center;
   justify-content: center;
   color: inherit;
-  box-shadow: ${p => p.theme.dropShadowLight} inset;
+  box-shadow: ${p => p.theme.dropShadowMedium} inset;
   width: ${p => checkboxSizeMap[p.size].box};
   height: ${p => checkboxSizeMap[p.size].box};
   border-radius: ${p => checkboxSizeMap[p.size].borderRadius};

--- a/static/app/components/dropdownBubble.tsx
+++ b/static/app/components/dropdownBubble.tsx
@@ -91,7 +91,7 @@ const DropdownBubble = styled(
   `
       : `
     top: calc(100% - 1px);
-    box-shadow: ${p.theme.dropShadowLight};
+    box-shadow: ${p.theme.dropShadowMedium};
   `};
 
   ${getMenuBorderRadius};

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -124,7 +124,7 @@ const BadgeContainer = styled('div')`
   background: ${p => p.theme.background};
   border-radius: 2.25rem;
   padding: ${space(0.75)} ${space(0.75)} ${space(0.75)} ${space(1)};
-  box-shadow: ${p => p.theme.dropShadowLightest};
+  box-shadow: ${p => p.theme.dropShadowLight};
   gap: 0 ${space(0.25)};
 `;
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/type/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/type/index.tsx
@@ -56,6 +56,6 @@ const IconWrapper = styled('div')<Pick<Props, 'color'>>`
   border-radius: 50%;
   color: ${p => p.theme.white};
   background: ${p => p.theme[p.color] ?? p.color};
-  box-shadow: ${p => p.theme.dropShadowLightest};
+  box-shadow: ${p => p.theme.dropShadowLight};
   position: relative;
 `;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -252,7 +252,7 @@ const Frames = styled('ul')<{isHoverPreviewed?: boolean}>`
   background: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px ${p => 'solid ' + p.theme.border};
-  box-shadow: ${p => p.theme.dropShadowLight};
+  box-shadow: ${p => p.theme.dropShadowMedium};
   margin-bottom: ${space(2)};
   position: relative;
   display: grid;

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -64,7 +64,7 @@ export const OpenInContainer = styled('div')<{columnQuantity: number}>`
   font-family: ${p => p.theme.text.family};
   border-bottom: 1px solid ${p => p.theme.border};
   padding: ${space(0.25)} ${space(3)};
-  box-shadow: ${p => p.theme.dropShadowLightest};
+  box-shadow: ${p => p.theme.dropShadowLight};
   text-indent: initial;
   overflow: auto;
   white-space: nowrap;

--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -204,7 +204,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
           color: theme.formText,
           background: theme.background,
           border: `1px solid ${theme.border}`,
-          boxShadow: theme.dropShadowLight,
+          boxShadow: theme.dropShadowMedium,
         },
         borderRadius: theme.borderRadius,
         transition: 'border 0.1s, box-shadow 0.1s',

--- a/static/app/components/forms/controls/selectOption.tsx
+++ b/static/app/components/forms/controls/selectOption.tsx
@@ -97,7 +97,7 @@ const CheckWrap = styled('div')<{isMultiple: boolean; isSelected: boolean}>`
       border: solid 1px ${p.theme.border};
       background: ${p.theme.backgroundElevated};
       border-radius: 2px;
-      box-shadow: inset ${p.theme.dropShadowLight};
+      box-shadow: inset ${p.theme.dropShadowMedium};
       ${
         p.isSelected &&
         `

--- a/static/app/components/forms/fields/datePickerField.tsx
+++ b/static/app/components/forms/fields/datePickerField.tsx
@@ -92,7 +92,7 @@ const StyledInput = styled(Input)`
 
   &:focus:not(.focus-visible) {
     border-color: ${p => p.theme.border};
-    box-shadow: inset ${p => p.theme.dropShadowLight};
+    box-shadow: inset ${p => p.theme.dropShadowMedium};
   }
 `;
 

--- a/static/app/components/input.tsx
+++ b/static/app/components/input.tsx
@@ -20,7 +20,7 @@ export const inputStyles = (p: InputStylesProps & {theme: Theme}) => css`
   background: ${p.theme.background};
   border: 1px solid ${p.theme.border};
   border-radius: ${p.theme.borderRadius};
-  box-shadow: inset ${p.theme.dropShadowLight};
+  box-shadow: inset ${p.theme.dropShadowMedium};
   resize: vertical;
   transition: border 0.1s, box-shadow 0.1s;
 

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -116,7 +116,7 @@ const OpenInDiscoverButton = styled(Button)`
 
 const Container = styled('div')`
   border: 1px solid ${p => p.theme.border};
-  box-shadow: inset ${p => p.theme.dropShadowLight};
+  box-shadow: inset ${p => p.theme.dropShadowMedium};
   background: ${p => p.theme.backgroundSecondary};
   padding: 7px ${space(1)};
   position: relative;

--- a/static/app/components/panels/panel.tsx
+++ b/static/app/components/panels/panel.tsx
@@ -22,7 +22,7 @@ const Panel = styled(
   border-radius: ${p => p.theme.panelBorderRadius};
   border: 1px
     ${p => (p.dashedBorder ? 'dashed' + p.theme.gray300 : 'solid ' + p.theme.border)};
-  box-shadow: ${p => (p.dashedBorder ? 'none' : p.theme.dropShadowLight)};
+  box-shadow: ${p => (p.dashedBorder ? 'none' : p.theme.dropShadowMedium)};
   margin-bottom: ${space(2)};
   position: relative;
 `;

--- a/static/app/components/performance/waterfall/treeConnector.tsx
+++ b/static/app/components/performance/waterfall/treeConnector.tsx
@@ -78,7 +78,7 @@ export const TreeToggle = styled('div')<SpanTreeTogglerAndDivProps>`
   font-size: 10px;
   line-height: 0;
   z-index: 1;
-  box-shadow: ${p => p.theme.dropShadowLightest};
+  box-shadow: ${p => p.theme.dropShadowLight};
 
   ${p => getToggleTheme(p)}
 `;

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -144,7 +144,7 @@ const StyledPill = styled('li')<{type?: PillType}>`
   margin: 0 ${space(1)} ${space(1)} 0;
   display: flex;
   border-radius: ${p => p.theme.borderRadius};
-  box-shadow: ${p => p.theme.dropShadowLightest};
+  box-shadow: ${p => p.theme.dropShadowLight};
   line-height: 1.2;
   max-width: 100%;
   :last-child {

--- a/static/app/components/radio.tsx
+++ b/static/app/components/radio.tsx
@@ -28,7 +28,7 @@ const Radio = styled('input')<CheckedProps>`
   align-items: center;
   justify-content: center;
   border: 1px solid ${p => p.theme.border};
-  box-shadow: inset ${p => p.theme.dropShadowLight};
+  box-shadow: inset ${p => p.theme.dropShadowMedium};
   background: none;
   appearance: none;
   transition: border 0.1s, box-shadow 0.1s;

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -173,7 +173,7 @@ const IconNode = styled('div')<{colors: Color[]; crumbCount: number}>`
   border-radius: 50%;
   color: ${p => p.theme.white};
   ${getBackgroundGradient}
-  box-shadow: ${p => p.theme.dropShadowLightest};
+  box-shadow: ${p => p.theme.dropShadowLight};
   user-select: none;
 `;
 

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -28,7 +28,7 @@ const Panel = styled(FluidHeight)`
   background: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
-  box-shadow: ${p => p.theme.dropShadowLight};
+  box-shadow: ${p => p.theme.dropShadowMedium};
 `;
 
 export default ReplayView;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1937,7 +1937,7 @@ export {SmartSearchBar, Props as SmartSearchBarProps};
 const Container = styled('div')<{inputHasFocus: boolean}>`
   min-height: ${p => p.theme.form.md.height}px;
   border: 1px solid ${p => p.theme.border};
-  box-shadow: inset ${p => p.theme.dropShadowLight};
+  box-shadow: inset ${p => p.theme.dropShadowMedium};
   background: ${p => p.theme.background};
   padding: 6px ${space(1)};
   position: relative;

--- a/static/app/components/switchButton.tsx
+++ b/static/app/components/switchButton.tsx
@@ -69,7 +69,7 @@ const SwitchButton = styled('button')<StyleProps>`
   padding: 0;
   border: 1px solid ${p => p.theme.border};
   position: relative;
-  box-shadow: inset ${p => p.theme.dropShadowLight};
+  box-shadow: inset ${p => p.theme.dropShadowMedium};
   height: ${getSize}px;
   width: ${p => getSize(p) * 1.875}px;
   border-radius: ${getSize}px;

--- a/static/app/styles/deprecatedInput.tsx
+++ b/static/app/styles/deprecatedInput.tsx
@@ -41,7 +41,7 @@ const inputStyles = (props: Props) =>
     background: ${props.theme.background};
     border: 1px solid ${props.theme.border};
     border-radius: ${props.theme.borderRadius};
-    box-shadow: inset ${props.theme.dropShadowLight};
+    box-shadow: inset ${props.theme.dropShadowMedium};
     padding: ${INPUT_PADDING}px;
     resize: vertical;
     height: 40px;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -119,14 +119,14 @@ export const darkColors = {
 };
 
 const lightShadows = {
-  dropShadowLightest: '0 0 2px rgba(43, 34, 51, 0.04)',
-  dropShadowLight: '0 1px 4px rgba(43, 34, 51, 0.04)',
+  dropShadowLight: '0 0 1px rgba(43, 34, 51, 0.04)',
+  dropShadowMedium: '0 1px 2px rgba(43, 34, 51, 0.04)',
   dropShadowHeavy: '0 4px 24px rgba(43, 34, 51, 0.12)',
 };
 
 const darkShadows = {
-  dropShadowLightest: '0 0 2px rgba(10, 8, 12, 0.2)',
-  dropShadowLight: '0 1px 4px rgba(10, 8, 12, 0.2)',
+  dropShadowLight: '0 0 1px rgba(10, 8, 12, 0.2)',
+  dropShadowMedium: '0 1px 2px rgba(10, 8, 12, 0.2)',
   dropShadowHeavy: '0 4px 24px rgba(10, 8, 12, 0.36)',
 };
 

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -242,7 +242,7 @@ const ControlsWrapper = styled('div')<{showEnvironment?: boolean}>`
 
 const StyledTeamSelector = styled(TeamSelector)`
   & > div {
-    box-shadow: ${p => p.theme.dropShadowLight};
+    box-shadow: ${p => p.theme.dropShadowMedium};
   }
 `;
 

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -174,7 +174,7 @@ const IconWrapper = styled('div')<Required<Pick<SVGIconProps, 'color'>>>`
   border-radius: 50%;
   color: ${p => p.theme.white};
   background: ${p => p.theme[p.color] ?? p.color};
-  box-shadow: ${p => p.theme.dropShadowLightest};
+  box-shadow: ${p => p.theme.dropShadowLight};
   position: relative;
   z-index: ${p => p.theme.zIndex.initial};
 `;

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -205,7 +205,7 @@ const SourceGroup = styled('div')<{isExpanded: boolean}>`
     `
     border-radius: ${p.theme.borderRadius};
     border: 1px solid ${p.theme.border};
-    box-shadow: ${p.theme.dropShadowLight};
+    box-shadow: ${p.theme.dropShadowMedium};
     margin: ${space(2)} 0 ${space(3)} 0;
     padding: ${space(2)};
     height: 180px;

--- a/static/app/views/settings/components/settingsSearch/index.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.tsx
@@ -58,7 +58,7 @@ const SearchInput = styled('input')`
   border-radius: 30px;
   height: 28px;
 
-  box-shadow: inset ${p => p.theme.dropShadowLight};
+  box-shadow: inset ${p => p.theme.dropShadowMedium};
 
   &:focus {
     outline: none;

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -133,7 +133,7 @@ const BooleanFilter = ({onChange, value, label}: BooleanFilterProps) => (
 const FilterContainer = styled('div')`
   border-radius: 4px;
   background: ${p => p.theme.background};
-  box-shadow: ${p => p.theme.dropShadowLight};
+  box-shadow: ${p => p.theme.dropShadowMedium};
   border: 1px solid ${p => p.theme.border};
 `;
 


### PR DESCRIPTION
 - **Change drop shadow names**:  from `dropShadowLight` to `dropShadowMedium` and from `dropShadowLightest` to `dropShadowLight`. This makes the drop shadow options more balanced and intuitive. Currently we have an odd set of names: `…Lightest`, `…Light`, and `…Heavy`. Having a `…Medium` key helps suggest that it is the default key that should be used in most cases.
 - **Reduce (by half) the blur values** of `dropShadowLight` and `dropShadowMedium`. This makes the shadows sharper and slightly more prominent, since the pigment is condensed into a smaller area. The visual effect is small but it does add up.

**Before:**
<img width="475" alt="Screenshot 2023-01-06 at 11 21 59 AM" src="https://user-images.githubusercontent.com/44172267/211084380-2381b1ce-0241-4a2b-8f57-e260b2a6878a.png">


**After:**
<img width="475" alt="Screenshot 2023-01-06 at 11 21 46 AM" src="https://user-images.githubusercontent.com/44172267/211084348-ae237f24-3a6d-4cc5-a7be-0c89be15d036.png">
