### PR TITLE
fix(ui): Icon sizes in stack trace drop downs

### DIFF
--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -245,7 +245,7 @@ export function TraceEventDataSection({
                 )}
                 <CompactSelect
                   triggerProps={{
-                    icon: <IconSort />,
+                    icon: <IconSort size="xs" />,
                     size: 'xs',
                     title: sortByTooltip,
                   }}
@@ -262,7 +262,7 @@ export function TraceEventDataSection({
                 />
                 <CompositeSelect
                   triggerProps={{
-                    icon: <IconEllipsis />,
+                    icon: <IconEllipsis size="xs" />,
                     size: 'xs',
                     showChevron: false,
                     'aria-label': t('Options'),


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/211114475-9b9dc4ee-ca30-4c47-ba14-b9470d8820a3.png)

After
![image](https://user-images.githubusercontent.com/1421724/211114488-feb34d4a-660d-43be-aa8a-2d4e141cd444.png)
