### PR TITLE
fix(checkbox): Set ref on input so indeterminate state is set correctly

### DIFF
--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -51,6 +51,7 @@ const Checkbox = ({
   return (
     <Wrapper {...{className, checked, size}}>
       <HiddenInput
+        ref={checkboxRef}
         css={inputCss}
         checked={checked !== 'indeterminate' && checked}
         type="checkbox"


### PR DESCRIPTION
My bad, missed the ref here so `indeterminate` wasn't actually getting set 😬 