### PR TITLE
fix(ui): Better loading placeholder height for issue seen stats

### DIFF
--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -51,7 +51,7 @@ const GroupReleaseStats = ({
   return (
     <div>
       {!group || !allEnvironments ? (
-        <Placeholder height="288px" />
+        <Placeholder height="346px" bottomGutter={4} />
       ) : (
         <Fragment>
           <GraphContainer>


### PR DESCRIPTION
Matches the loaded content to get less layout shift

Before:

![CleanShot 2023-01-06 at 17 11 59](https://user-images.githubusercontent.com/10888943/211124418-94ebb1ff-fc54-4b1e-85e1-5ec7cc1ba7e6.gif)

After:

![CleanShot 2023-01-06 at 17 11 13](https://user-images.githubusercontent.com/10888943/211124469-64435866-5511-46a5-8058-6daa406129fb.gif)

