### PR TITLE
ci[acceptence] Fix race condition in acceptance test

### DIFF
--- a/fixtures/page_objects/issue_list.py
+++ b/fixtures/page_objects/issue_list.py
@@ -33,6 +33,7 @@ class IssueListPage(BasePage):
         self.browser.click('[aria-label="Resolve"]')
 
     def wait_for_resolved_issue(self):
+        self.browser.wait_until_not('[data-test-id="toast-loading"]')
         self.browser.wait_until('[data-test-id="resolved-issue"]')
 
     def wait_for_issue_removal(self):


### PR DESCRIPTION
I believe this will fix these two issues:

- https://sentry.io/organizations/sentry/issues/2729552033/?project=2423079&query=pytest_environ.GITHUB_REPOSITORY%3Agetsentry%2Fsentry&referrer=issue-stream
- https://sentry.io/organizations/sentry/issues/2559088320/?project=2423079&query=pytest_environ.GITHUB_REPOSITORY%3Agetsentry%2Fsentry&referrer=issue-stream

The test resolves two issues through the UI and waits for the state to change such that the items are marked as resolved, however the JS resolves the issues immediately and uses a toast to indicate network activity (i.e. the API is being made to resolve the issue).

By not waiting for the API call, a race condition can be introduced between Django cleaning up the database and the API call attempting to update the issues.

A more general solution I'll look into is seeing if there is an API to wait for network requests in the browser to stop/complete, this could be down in the test fixture before allow Django to perform cleanup.