### PR TITLE
fix(metrics): Remove feature flag from tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -1590,7 +1590,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert meta["isMetricsData"]
 
     def test_environment_query(self):
-        self.features["organizations:use-metrics-layer"] = True
         self.create_environment(self.project, name="staging")
         self.store_transaction_metric(
             1,
@@ -1747,7 +1746,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert field_meta["apdex()"] == "number"
 
     def test_apdex_project_threshold(self):
-        self.features["organizations:use-metrics-layer"] = True
         ProjectTransactionThreshold.objects.create(
             project=self.project,
             organization=self.project.organization,


### PR DESCRIPTION
This PR aims a fixing a small problem I introduced in `test_organization_events_mep` in which the feature flag for the metrics layer was enabled in test where is should have been disabled.