### PR TITLE
feat(profiling): findHoveredNode optimization

### DIFF
--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -311,13 +311,9 @@ export class Rect {
 
   containsRect(rect: Rect): boolean {
     return (
-      // left bound
       this.left <= rect.left &&
-      // right bound
       rect.right <= this.right &&
-      // top bound
       this.top <= rect.top &&
-      // bottom bound
       rect.bottom <= this.bottom
     );
   }

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -382,6 +382,19 @@ class FlamegraphRenderer {
   }
 
   findHoveredNode(configSpaceCursor: vec2): FlamegraphFrame | null {
+    // ConfigSpace origin is at top of rectangle, so we need to offset bottom by 1
+    // to account for size of renderered rectangle.
+    if (configSpaceCursor[1] > this.flamegraph.configSpace.bottom + 1) {
+      return null;
+    }
+
+    if (
+      configSpaceCursor[0] < this.flamegraph.configSpace.left ||
+      configSpaceCursor[0] > this.flamegraph.configSpace.right
+    ) {
+      return null;
+    }
+
     let hoveredNode: FlamegraphFrame | null = null;
     const queue = [...this.roots];
 

--- a/static/app/utils/profiling/renderers/spansRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansRenderer.tsx
@@ -46,6 +46,19 @@ export class SpanChartRenderer2D {
   }
 
   findHoveredNode(configSpaceCursor: vec2): SpanChartNode | null {
+    // ConfigSpace origin is at top of rectangle, so we need to offset bottom by 1
+    // to account for size of renderered rectangle.
+    if (configSpaceCursor[1] > this.spanChart.configSpace.bottom + 1) {
+      return null;
+    }
+
+    if (
+      configSpaceCursor[0] < this.spanChart.configSpace.left ||
+      configSpaceCursor[0] > this.spanChart.configSpace.right
+    ) {
+      return null;
+    }
+
     let hoveredNode: SpanChartNode | null = null;
     const queue = [...this.spanChart.root.children];
 


### PR DESCRIPTION
If the cursor falls outside of the model space we can skip iterating over everything