### PR TITLE
feat(profiling): configSpaceCursor is redundant dep

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -189,8 +189,6 @@ export function FlamegraphSpans({
   const onCanvasScroll = useCanvasScroll(spansCanvas, spansView, canvasPoolManager);
 
   useCanvasZoomOrScroll({
-    lastInteraction,
-    configSpaceCursor,
     setConfigSpaceCursor,
     setLastInteraction,
     handleWheel: onWheelCenterZoom,

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -496,8 +496,6 @@ function FlamegraphZoomView({
   );
 
   useCanvasZoomOrScroll({
-    lastInteraction,
-    configSpaceCursor,
     setConfigSpaceCursor,
     setLastInteraction,
     handleWheel: onWheelCenterZoom,

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -279,8 +279,6 @@ function FlamegraphZoomViewMinimap({
   );
 
   useCanvasZoomOrScroll({
-    lastInteraction,
-    configSpaceCursor,
     setConfigSpaceCursor,
     setLastInteraction,
     handleWheel: onWheelCenterZoom,

--- a/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
@@ -7,16 +7,12 @@ export function useCanvasZoomOrScroll({
   handleWheel,
   handleScroll,
   canvas,
-  configSpaceCursor,
   setConfigSpaceCursor,
-  lastInteraction,
   setLastInteraction,
 }: {
   canvas: HTMLCanvasElement | null;
-  configSpaceCursor: vec2 | null;
   handleScroll: (evt: WheelEvent) => void;
   handleWheel: (evt: WheelEvent) => void;
-  lastInteraction: 'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null;
   setConfigSpaceCursor: React.Dispatch<React.SetStateAction<vec2 | null>>;
   setLastInteraction: React.Dispatch<
     React.SetStateAction<'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null>
@@ -61,13 +57,5 @@ export function useCanvasZoomOrScroll({
       }
       canvas.removeEventListener('wheel', onCanvasWheel);
     };
-  }, [
-    canvas,
-    handleWheel,
-    handleScroll,
-    configSpaceCursor,
-    lastInteraction,
-    setConfigSpaceCursor,
-    setLastInteraction,
-  ]);
+  }, [canvas, handleWheel, handleScroll, setConfigSpaceCursor, setLastInteraction]);
 }


### PR DESCRIPTION
These were both redundant deps that caused us to reattach the listener on each mousemove