### PR TITLE
chore(issue-details): Add setup source maps analytics

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
@@ -47,11 +47,6 @@ export function shouldDisplaySetupSourceMapsAlert(
   projectId: string | undefined,
   event: Event | undefined
 ): boolean {
-  const eventPlatform = event?.platform ?? 'other';
-  const eventFromBrowserJavaScriptSDK = isEventFromBrowserJavaScriptSDK(
-    event as EventTransaction
-  );
-
   if (!defined(projectId) || !defined(event)) {
     return false;
   }
@@ -59,6 +54,11 @@ export function shouldDisplaySetupSourceMapsAlert(
   if (!organization.features?.includes('source-maps-cta')) {
     return false;
   }
+
+  const eventPlatform = event?.platform ?? 'other';
+  const eventFromBrowserJavaScriptSDK = isEventFromBrowserJavaScriptSDK(
+    event as EventTransaction
+  );
 
   // We would like to filter out all platforms that do not have the concept of source maps
   if (

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -6,6 +6,7 @@ import * as PropTypes from 'prop-types';
 
 import {fetchOrganizationEnvironments} from 'sentry/actionCreators/environments';
 import {Client} from 'sentry/api';
+import {shouldDisplaySetupSourceMapsAlert} from 'sentry/components/events/interfaces/crashContent/exception/setupSourceMapsAlert';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -160,7 +161,7 @@ class GroupDetails extends Component<Props, State> {
 
   trackView(project: Project) {
     const {group, event} = this.state;
-    const {params, location} = this.props;
+    const {params, location, organization, router} = this.props;
     const {alert_date, alert_rule_id, alert_type} = location.query;
 
     this.props.setEventNames('issue_details.viewed', 'Issue Details: Viewed');
@@ -190,6 +191,11 @@ class GroupDetails extends Component<Props, State> {
       alert_rule_id: typeof alert_rule_id === 'string' ? alert_rule_id : undefined,
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
       has_otel: event?.contexts?.otel !== undefined,
+      has_setup_source_maps_alert: shouldDisplaySetupSourceMapsAlert(
+        organization,
+        router.location.query.project,
+        event
+      ),
     });
   }
 


### PR DESCRIPTION
We are already tracking clicking on this alert:
<img width="915" alt="image" src="https://user-images.githubusercontent.com/9060071/211347033-66fe4caf-3bd7-4c95-bc53-547fc890ed20.png">

This PR adds `has_setup_source_maps_alert` boolean to the page view event.