### PR TITLE
feat(profiling): add profiling-dashboard-redesign flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1003,6 +1003,8 @@ SENTRY_FEATURES = {
     "organizations:profiling": False,
     # Enable performance spans in flamecharts
     "organizations:profiling-flamechart-spans": False,
+    # Enable the profiling dashboard redesign
+    "organizations:profiling-dashboard-redesign": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -129,6 +129,7 @@ default_manager.add("organizations:performance-consecutive-db-issue", Organizati
 default_manager.add("organizations:performance-slow-db-issue", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature)
 default_manager.add("organizations:profiling-flamechart-spans", OrganizationFeature, True)
+default_manager.add("organizations:profiling-dashboard-redesign", OrganizationFeature, True)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:project-stats", OrganizationFeature, True)
 default_manager.add("organizations:related-events", OrganizationFeature)


### PR DESCRIPTION
## Summary

Adds the initial `profiling-dashboard-redesign` flag. We will add additional flags as necessary if needed.

Related: https://github.com/getsentry/team-profiling/issues/138