### PR TITLE
Revert GCB to GHA cutover for self-hosted e2e tests

### DIFF
--- a/.github/workflows/self-hosted-e2e-tests.yml
+++ b/.github/workflows/self-hosted-e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
           filters: .github/file-filters.yml
       - name: Run Sentry self-hosted e2e CI
         if: steps.changes.outputs.backend_all == 'true'
-        uses: getsentry/action-self-hosted-e2e-tests@4ff2dbfdd5c986a4670efaa16d82e460598359eb
+        uses: getsentry/action-self-hosted-e2e-tests@697a3ca95a72f93e3a1ebdb8f967be38d1f029f6
         with:
           project_name: sentry
           image_url: us.gcr.io/sentryio/sentry:${{ github.event.pull_request.head.sha || github.sha }} 

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -32,6 +32,63 @@ steps:
         './docker/Dockerfile',
       ]
     timeout: 300s
+  - name: 'gcr.io/$PROJECT_ID/docker-compose'
+    id: get-self-hosted-repo
+    waitFor: ['-']
+    entrypoint: 'bash'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        mkdir self-hosted && cd self-hosted
+        curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar xzf - --strip-components=1
+        echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
+  - name: 'gcr.io/$PROJECT_ID/docker-compose'
+    id: e2e-test
+    waitFor:
+      - runtime-image
+      - get-self-hosted-repo
+    entrypoint: 'bash'
+    dir: self-hosted
+    env:
+      - 'REPORT_SELF_HOSTED_ISSUES=0'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        ./install.sh
+        set +e
+        ./test.sh
+        test_return=$?
+        set -e
+        if [[ $test_return -ne 0 ]]; then
+          echo "Test failed.";
+          docker-compose ps;
+          docker-compose logs;
+          exit $test_return;
+        fi
+    timeout: 900s
+  - name: 'gcr.io/cloud-builders/docker'
+    id: docker-push
+    waitFor:
+      - e2e-test
+    secretEnv: ['DOCKER_PASSWORD']
+    entrypoint: 'bash'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        # Only push to Docker Hub from master
+        [ "$BRANCH_NAME" != "master" ] && exit 0
+        # Need to pull the image first due to Kaniko
+        docker pull $$SENTRY_IMAGE
+        echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$SHORT_SHA
+        docker push $$DOCKER_REPO:$SHORT_SHA
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$COMMIT_SHA
+        docker push $$DOCKER_REPO:$COMMIT_SHA
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly
+        docker push $$DOCKER_REPO:nightly
 timeout: 2640s
 artifacts:
   objects:
@@ -41,4 +98,16 @@ options:
   # We need more memory for Webpack builds & e2e self-hosted tests
   machineType: 'E2_HIGHCPU_8'
   env:
+    - 'CI=1'
     - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
+    - 'DOCKER_REPO=getsentry/sentry'
+    - 'SENTRY_TEST_HOST=http://nginx'
+secrets:
+  - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
+    secretEnv:
+      # This is a personal access token for the sentrybuilder account, encrypted using the
+      # short guide at http://bit.ly/2Pg6uw9
+      DOCKER_PASSWORD: |
+        CiQAE8gN7y3OMxn+a1kofmK4Bi8jQZtdRFj2lYYwaZHVeIIBUzMSTQA9tvn8XCv2vqj6u8CHoeSP
+        TVW9pLvSCorKoeNtOp0eb+6V1yNJW/+JC07DNO1KLbTbodbuza6jKJHU5xeAJ4kGQI78UY5Vu1Gp
+        QcMK


### PR DESCRIPTION
This reverts commit 8889fb83b24eeb22e6f3947eacfe457cfc6a1520.

Due to https://github.com/getsentry/self-hosted/issues/1899 we are failing CI regularly. We are not requiring the check so master is showing green, but we depend in subsequent PR runs on the nightly tag in Docker, which is not getting updated due.

Here is the [action at 697a3ca9](https://github.com/getsentry/action-self-hosted-e2e-tests/blob/697a3ca95a72f93e3a1ebdb8f967be38d1f029f6/action.yml), it posts to `-tmp` (so shouldn't clobber GCB).

Do we need to revert in Relay and Snuba as well?