### PR TITLE
fix(domains) Fix redirects with context picker

### DIFF
--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -32,7 +32,7 @@ export function navigateTo(
           configUrl={configUrl}
           onFinish={path => {
             modalProps.closeModal();
-            return window.setTimeout(() => router.push(path), 0);
+            return window.setTimeout(() => router.push(normalizeUrl(path)), 0);
           }}
         />
       ),


### PR DESCRIPTION
When the context picker is used to choose a project we need to normalize the generated URL.