### PR TITLE
feat(perf-issues): Define project option for N+1 API Calls rollout rate

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -17,6 +17,9 @@ class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
     n_plus_one_db_duration_threshold = serializers.IntegerField(
         required=False, min_value=0, max_value=MAX_VALUE
     )
+    n_plus_one_api_calls_detection_rate = serializers.FloatField(
+        required=False, min_value=0, max_value=1
+    )
 
 
 @region_silo_endpoint

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -102,7 +102,7 @@ register(
         "render_blocking_fcp_min": 2000.0,
         "render_blocking_fcp_max": 10000.0,
         "render_blocking_fcp_ratio": 0.33,
-        "n_plus_one_api_calls_detection_rate": 0,
+        "n_plus_one_api_calls_detection_rate": 1.0,
     },
 )
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -102,6 +102,7 @@ register(
         "render_blocking_fcp_min": 2000.0,
         "render_blocking_fcp_max": 10000.0,
         "render_blocking_fcp_ratio": 0.33,
+        "n_plus_one_api_calls_detection_rate": 0,
     },
 )
 

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -200,6 +200,15 @@ class ProjectPerformance extends AsyncView<Props, State> {
         max: 1000000.0,
         defaultValue: 500,
       },
+      {
+        name: 'n_plus_one_api_calls_detection_rate',
+        type: 'range',
+        label: t('N+1 API Calls Detection Rate'),
+        min: 0.0,
+        max: 1.0,
+        step: 0.01,
+        defaultValue: 0,
+      },
     ];
   }
 

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -200,15 +200,6 @@ class ProjectPerformance extends AsyncView<Props, State> {
         max: 1000000.0,
         defaultValue: 500,
       },
-      {
-        name: 'n_plus_one_api_calls_detection_rate',
-        type: 'range',
-        label: t('N+1 API Calls Detection Rate'),
-        min: 0.0,
-        max: 1.0,
-        step: 0.01,
-        defaultValue: 0,
-      },
     ];
   }
 


### PR DESCRIPTION
This allows individual project to turn off this issue type, or turn it down.

- Set up the option
- Allow the option to be changed via endpoint
- Set default detection rate to 1.0
