### PR TITLE
feat(perf-issues): Add UI for N+1 API Calls rollout rate project option

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -200,6 +200,15 @@ class ProjectPerformance extends AsyncView<Props, State> {
         max: 1000000.0,
         defaultValue: 500,
       },
+      {
+        name: 'n_plus_one_api_calls_detection_rate',
+        type: 'range',
+        label: t('N+1 API Calls Detection Rate'),
+        min: 0.0,
+        max: 1.0,
+        step: 0.01,
+        defaultValue: 0,
+      },
     ];
   }
 


### PR DESCRIPTION
Depends on #42966. Adds the editable field to the UI. Closes PERF-1877.

**e.g.,**
![Screen Shot 2023-01-09 at 12 41 40 PM](https://user-images.githubusercontent.com/989898/211375446-558eae5b-2cb1-4d43-939d-d65753998fe8.png)
