### PR TITLE
fix: useQuerystringState

### DIFF
--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -211,7 +211,12 @@ export function ProfileDetailsTable() {
         location={location}
       />
 
-      <Pagination pageLinks={pageLinks} />
+      <Pagination
+        pageLinks={pageLinks}
+        onCursor={cur => {
+          setPaginationCursor(cur);
+        }}
+      />
     </Fragment>
   );
 }

--- a/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
@@ -17,12 +17,6 @@ export function useQuerystringState<T extends string | string[] = string>({
     (location.query[key] as T) ?? (initialState as T)
   );
 
-  // there is a chance that a key we're tracking is not explicitly set
-  // via this hook's setState, at which point we must always keep state in sync here
-  if (location.query[key] !== state) {
-    setState(location.query[key] as T);
-  }
-
   const createLocationDescriptor = useCallback(
     (nextState: T | undefined) => {
       // we can't use the result of `useLocation` here

--- a/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
@@ -17,6 +17,12 @@ export function useQuerystringState<T extends string | string[] = string>({
     (location.query[key] as T) ?? (initialState as T)
   );
 
+  // there is a chance that a key we're tracking is not explicitly set
+  // via this hook's setState, at which point we must always keep state in sync here
+  if (location.query[key] !== state) {
+    setState(location.query[key] as T);
+  }
+
   const createLocationDescriptor = useCallback(
     (nextState: T | undefined) => {
       // we can't use the result of `useLocation` here


### PR DESCRIPTION
## Summary
This fix ensures we always keep `state` and the value of `location.query[key]` in sync when we're tracking any querystring state.

 