### PR TITLE
fix(ui): Replace double loading spinner with placeholders

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -9,9 +9,9 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import Radio from 'sentry/components/radio';
 import {t} from 'sentry/locale';
@@ -244,9 +244,7 @@ const TagsSideBar = (props: {
         />
       </StyledSectionHeading>
       {isLoading ? (
-        <Center>
-          <LoadingIndicator mini />
-        </Center>
+        <Placeholder height="200px" />
       ) : suspectTags.length ? (
         suspectTags.map(tag => (
           <RadioLabel key={tag}>
@@ -273,9 +271,7 @@ const TagsSideBar = (props: {
       </StyledSectionHeading>
 
       {isLoading ? (
-        <Center>
-          <LoadingIndicator mini />
-        </Center>
+        <Placeholder height="200px" />
       ) : otherTags.length ? (
         otherTags.map(tag => (
           <RadioLabel key={tag}>
@@ -293,12 +289,6 @@ const TagsSideBar = (props: {
     </StyledSide>
   );
 };
-
-const Center = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
 
 const RadioLabel = styled('label')`
   cursor: pointer;


### PR DESCRIPTION
Before:

![CleanShot 2023-01-09 at 10 13 56](https://user-images.githubusercontent.com/10888943/211390024-c2775fbc-9fff-46b6-aa76-1ac35af1601d.gif)

After:

![CleanShot 2023-01-09 at 11 29 20](https://user-images.githubusercontent.com/10888943/211391842-c8e5eb8c-a25c-434c-9e9e-9ca54625f9f2.gif)
