### PR TITLE
feat(scim): fix disabled remove member button text

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -191,7 +191,13 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               <Button
                 disabled
                 size="sm"
-                title={t('You do not have access to remove members')}
+                title={
+                  isIdpProvisioned
+                    ? t(
+                        "This user is managed through your organization's identity provider."
+                      )
+                    : t('You do not have access to remove members')
+                }
                 icon={<IconSubtract isCircled size="xs" />}
               >
                 {t('Remove')}
@@ -211,27 +217,20 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               </Confirm>
             )}
 
-            {showLeaveButton && !memberCanLeave && !isIdpProvisioned && (
+            {showLeaveButton && !memberCanLeave && (
               <Button
                 size="sm"
                 icon={<IconClose size="xs" />}
                 disabled
-                title={t(
-                  'You cannot leave this organization as you are the only organization owner.'
-                )}
-              >
-                {t('Leave')}
-              </Button>
-            )}
-
-            {showLeaveButton && !memberCanLeave && isIdpProvisioned && (
-              <Button
-                size="sm"
-                icon={<IconClose size="xs" />}
-                disabled
-                title={t(
-                  "This user is managed through your organization's identity provider."
-                )}
+                title={
+                  isIdpProvisioned
+                    ? t(
+                        "Your account is managed through your organization's identity provider."
+                      )
+                    : t(
+                        'You cannot leave this organization as you are the only organization owner.'
+                      )
+                }
               >
                 {t('Leave')}
               </Button>


### PR DESCRIPTION
Specify the reason why you can't remove a member if they're `idp:provisioned`.