### PR TITLE
fix(ui): ProjectSelector checkbox alignment in firefox

### DIFF
--- a/static/app/components/organizations/pageFilterRow.tsx
+++ b/static/app/components/organizations/pageFilterRow.tsx
@@ -60,9 +60,9 @@ function PageFilterRow({
 const checkboxInputStyles = css`
   /* Make the hitbox of the checkbox a bit larger */
   top: -${space(2)};
-  right: -${space(1.5)};
-  bottom: -${space(2)};
   left: -${space(2)};
+  width: 48px;
+  height: 48px;
 `;
 
 const MultiselectCheckbox = styled(Checkbox)`


### PR DESCRIPTION
The inset doesn't work the same as it does in chrome