### PR TITLE
feat(replays): Include replays on the stats page

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -227,6 +227,7 @@ export const DATA_CATEGORY_NAMES = {
   [DataCategory.TRANSACTIONS]: t('Transactions'),
   [DataCategory.ATTACHMENTS]: t('Attachments'),
   [DataCategory.PROFILES]: t('Profiles'),
+  [DataCategory.REPLAYS]: t('Session Replays'),
 };
 
 // Special Search characters

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -69,6 +69,7 @@ export enum DataCategory {
   TRANSACTIONS = 'transactions',
   ATTACHMENTS = 'attachments',
   PROFILES = 'profiles',
+  REPLAYS = 'replays',
 }
 
 export type EventType = 'error' | 'transaction' | 'attachment';

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -76,6 +76,7 @@ export class OrganizationStats extends Component<Props> {
       case DataCategory.TRANSACTIONS:
       case DataCategory.ATTACHMENTS:
       case DataCategory.PROFILES:
+      case DataCategory.REPLAYS:
         return dataCategory as DataCategory;
       default:
         return DataCategory.ERRORS;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -243,9 +243,17 @@ export class OrganizationStats extends Component<Props> {
   };
 
   renderProjectPageControl = () => {
+    const {organization} = this.props;
+
     if (!this.hasProjectStats) {
       return null;
     }
+
+    const hasReplay = organization.features.includes('session-replay-ui');
+    const options = hasReplay
+      ? CHART_OPTIONS_DATACATEGORY
+      : CHART_OPTIONS_DATACATEGORY.filter(opt => opt.value !== DataCategory.REPLAYS);
+
     return (
       <PageControl>
         <PageFilterBar>
@@ -253,7 +261,7 @@ export class OrganizationStats extends Component<Props> {
           <DropdownDataCategory
             triggerProps={{prefix: t('Category')}}
             value={this.dataCategory}
-            options={CHART_OPTIONS_DATACATEGORY}
+            options={options}
             onChange={opt =>
               this.setStateOnUrl({dataCategory: opt.value as DataCategory})
             }
@@ -296,12 +304,17 @@ export class OrganizationStats extends Component<Props> {
 
     const {start, end, period, utc} = this.dataDatetime;
 
+    const hasReplay = organization.features.includes('session-replay-ui');
+    const options = hasReplay
+      ? CHART_OPTIONS_DATACATEGORY
+      : CHART_OPTIONS_DATACATEGORY.filter(opt => opt.value !== DataCategory.REPLAYS);
+
     return (
       <Fragment>
         <DropdownDataCategory
           triggerProps={{prefix: t('Category')}}
           value={this.dataCategory}
-          options={CHART_OPTIONS_DATACATEGORY}
+          options={options}
           onChange={opt => this.setStateOnUrl({dataCategory: opt.value as DataCategory})}
         />
 

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -70,6 +70,12 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     disabled: false,
     yAxisMinInterval: 100,
   },
+  {
+    label: DATA_CATEGORY_NAMES[DataCategory.REPLAYS],
+    value: DataCategory.REPLAYS,
+    disabled: false,
+    yAxisMinInterval: 100,
+  },
 ];
 
 export enum ChartDataTransform {


### PR DESCRIPTION
To test I compared the Accepted rate from Jan 12 to 8 against our 'Replays Accepted by Org' chart in looker. The numbers match up.
The project table below also has correct breakdowns, for the javascript project we've got the correct totals (matching looker,  and zero's for all the others as expected.

Checked that the feature flag is working by opening a test account and verifying that the option is not shown. You can type in `replays` into the query string and see the results even if the feature is disabled... but i don't think that's a big deal for the short time between now and when we open up replays more.

Fixes #42565