### PR TITLE
fix(checkbox): Fix hitbox size in Firefox

### DIFF
--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -92,9 +92,10 @@ const HiddenInput = styled('input')`
   opacity: 0;
   top: 0;
   left: 0;
-  right: 0;
-  bottom: 0;
+  height: 100%;
+  width: 100%;
   margin: 0;
+  padding: 0;
   cursor: pointer;
 
   &.focus-visible + * {


### PR DESCRIPTION
Firefox seems to have a set width/height that will override the inset (unlike Chrome), so this makes ensures the sizing is consistent between browsers.