### PR TITLE
fix(domains) Remove more params.orgId usage

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -24,7 +24,7 @@ import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
   WithRouteAnalyticsProps &
-  RouteComponentProps<{monitorId: string; orgId: string}, {}> & {
+  RouteComponentProps<{monitorId: string}, {}> & {
     organization: Organization;
   };
 

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -10,7 +10,7 @@ import MonitorForm from './monitorForm';
 import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
-  RouteComponentProps<{monitorId: string; orgId: string}, {}> & {
+  RouteComponentProps<{monitorId: string}, {}> & {
     organization: Organization;
   };
 

--- a/static/app/views/settings/components/settingsSearch/index.spec.jsx
+++ b/static/app/views/settings/components/settingsSearch/index.spec.jsx
@@ -13,7 +13,7 @@ describe('SettingsSearch', function () {
   const routerContext = TestStubs.routerContext([
     {
       router: TestStubs.router({
-        params: {orgId: 'org-slug'},
+        params: {},
       }),
     },
   ]);
@@ -65,7 +65,7 @@ describe('SettingsSearch', function () {
   });
 
   it('renders', function () {
-    render(<SettingsSearch params={{orgId: 'org-slug'}} />);
+    render(<SettingsSearch params={{}} />);
 
     // renders input
     expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.jsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeyDetails.spec.jsx
@@ -13,13 +13,10 @@ describe('OrganizationApiKeyDetails', function () {
   });
 
   it('renders', function () {
-    const wrapper = render(
-      <OrganizationApiKeyDetails params={{apiKey: 1, orgId: 'org-slug'}} />,
-      {
-        context: TestStubs.routerContext(),
-        organization: TestStubs.Organization(),
-      }
-    );
+    const wrapper = render(<OrganizationApiKeyDetails params={{apiKey: 1}} />, {
+      context: TestStubs.routerContext(),
+      organization: TestStubs.Organization(),
+    });
 
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(wrapper.container).toSnapshot();

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -43,7 +43,6 @@ const TWO_FACTOR_REQUIRED = t(
 
 type RouteParams = {
   memberId: string;
-  orgId: string;
 };
 
 type Props = {

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
@@ -22,7 +22,7 @@ describe('OrganizationMembersWrapper', function () {
 
   const defaultProps = {
     location: {query: {}},
-    params: {orgId: organization.slug},
+    params: {},
   };
 
   beforeEach(function () {

--- a/static/app/views/settings/project/projectFilters/index.spec.jsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.jsx
@@ -18,7 +18,7 @@ describe('ProjectFilters', function () {
   function renderComponent() {
     return render(
       <ProjectFilters
-        params={{projectId: project.slug, orgId: org.slug}}
+        params={{projectId: project.slug}}
         location={{}}
         project={project}
         organization={org}

--- a/static/app/views/settings/project/projectServiceHooks.tsx
+++ b/static/app/views/settings/project/projectServiceHooks.tsx
@@ -63,12 +63,13 @@ type State = {
 
 class ProjectServiceHooks extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {orgId, projectId} = this.props.params;
-    return [['hookList', `/projects/${orgId}/${projectId}/hooks/`]];
+    const {organization, params} = this.props;
+    const projectId = params.projectId;
+    return [['hookList', `/projects/${organization.slug}/${projectId}/hooks/`]];
   }
 
   onToggleActive = (hook: ServiceHook) => {
-    const {orgId, projectId} = this.props.params;
+    const {organization, params} = this.props;
     const {hookList} = this.state;
     if (!hookList) {
       return;
@@ -76,29 +77,32 @@ class ProjectServiceHooks extends AsyncView<Props, State> {
 
     addLoadingMessage(t('Saving changes\u2026'));
 
-    this.api.request(`/projects/${orgId}/${projectId}/hooks/${hook.id}/`, {
-      method: 'PUT',
-      data: {
-        isActive: hook.status !== 'active',
-      },
-      success: data => {
-        clearIndicators();
-        this.setState({
-          hookList: hookList.map(h => {
-            if (h.id === data.id) {
-              return {
-                ...h,
-                ...data,
-              };
-            }
-            return h;
-          }),
-        });
-      },
-      error: () => {
-        addErrorMessage(t('Unable to remove application. Please try again.'));
-      },
-    });
+    this.api.request(
+      `/projects/${organization.slug}/${params.projectId}/hooks/${hook.id}/`,
+      {
+        method: 'PUT',
+        data: {
+          isActive: hook.status !== 'active',
+        },
+        success: data => {
+          clearIndicators();
+          this.setState({
+            hookList: hookList.map(h => {
+              if (h.id === data.id) {
+                return {
+                  ...h,
+                  ...data,
+                };
+              }
+              return h;
+            }),
+          });
+        },
+        error: () => {
+          addErrorMessage(t('Unable to remove application. Please try again.'));
+        },
+      }
+    );
   };
 
   renderEmpty() {
@@ -110,7 +114,7 @@ class ProjectServiceHooks extends AsyncView<Props, State> {
   }
 
   renderResults() {
-    const {orgId, projectId} = this.props.params;
+    const {organization, params} = this.props;
 
     return (
       <Fragment>
@@ -124,8 +128,8 @@ class ProjectServiceHooks extends AsyncView<Props, State> {
           {this.state.hookList?.map(hook => (
             <ServiceHookRow
               key={hook.id}
-              orgId={orgId}
-              projectId={projectId}
+              orgId={organization.slug}
+              projectId={params.projectId}
               hook={hook}
               onToggleActive={this.onToggleActive.bind(this, hook)}
             />
@@ -140,8 +144,8 @@ class ProjectServiceHooks extends AsyncView<Props, State> {
     const body =
       hookList && hookList.length > 0 ? this.renderResults() : this.renderEmpty();
 
-    const {orgId, projectId} = this.props.params;
-    const access = new Set(this.props.organization.access);
+    const {organization, params} = this.props;
+    const access = new Set(organization.access);
 
     return (
       <Fragment>
@@ -151,7 +155,7 @@ class ProjectServiceHooks extends AsyncView<Props, State> {
             access.has('project:write') ? (
               <Button
                 data-test-id="new-service-hook"
-                to={`/settings/${orgId}/projects/${projectId}/hooks/new/`}
+                to={`/settings/${organization.slug}/projects/${params.projectId}/hooks/new/`}
                 size="sm"
                 priority="primary"
                 icon={<IconAdd size="xs" isCircled />}

--- a/static/app/views/settings/projectDataForwarding.tsx
+++ b/static/app/views/settings/projectDataForwarding.tsx
@@ -19,10 +19,11 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
-type RouteParams = {orgId: string; projectId: string};
-
 type StatProps = {
-  params: RouteParams;
+  params: {
+    orgId: string;
+    projectId: string;
+  };
 };
 
 type StatState = AsyncComponent['state'] & {
@@ -81,7 +82,7 @@ class DataForwardingStats extends AsyncComponent<StatProps, StatState> {
   }
 }
 
-type Props = RouteComponentProps<RouteParams, {}> & {
+type Props = RouteComponentProps<{projectId: string}, {}> & {
   organization: Organization;
   project: Project;
 };
@@ -92,9 +93,10 @@ type State = AsyncComponent['state'] & {
 
 class ProjectDataForwarding extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {orgId, projectId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
 
-    return [['plugins', `/projects/${orgId}/${projectId}/plugins/`]];
+    return [['plugins', `/projects/${organization.slug}/${projectId}/plugins/`]];
   }
 
   get forwardingPlugins() {

--- a/static/app/views/settings/projectDebugFiles/index.spec.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.spec.tsx
@@ -14,7 +14,7 @@ describe('ProjectDebugFiles', function () {
   const props = {
     organization,
     project,
-    params: {orgId: organization.slug, projectId: project.slug},
+    params: {projectId: project.slug},
     location: {
       ...router.location,
       query: {

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -21,7 +21,7 @@ import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 import DebugFileRow from './debugFileRow';
 import Sources from './sources';
 
-type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
+type Props = RouteComponentProps<{projectId: string}, {}> & {
   organization: Organization;
   project: Project;
 };
@@ -51,13 +51,12 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {organization, params, location} = this.props;
     const {builtinSymbolSources} = this.state || {};
-    const {orgId, projectId} = params;
     const {query} = location.query;
 
     const endpoints: ReturnType<AsyncView['getEndpoints']> = [
       [
         'debugFiles',
-        `/projects/${orgId}/${projectId}/files/dsyms/`,
+        `/projects/${organization.slug}/${params.projectId}/files/dsyms/`,
         {
           query: {
             query,
@@ -87,16 +86,19 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
   }
 
   handleDelete = (id: string) => {
-    const {orgId, projectId} = this.props.params;
+    const {organization, params} = this.props;
 
     this.setState({
       loading: true,
     });
 
-    this.api.request(`/projects/${orgId}/${projectId}/files/dsyms/?id=${id}`, {
-      method: 'DELETE',
-      complete: () => this.fetchData(),
-    });
+    this.api.request(
+      `/projects/${organization.slug}/${params.projectId}/files/dsyms/?id=${id}`,
+      {
+        method: 'DELETE',
+        complete: () => this.fetchData(),
+      }
+    );
   };
 
   handleSearch = (query: string) => {
@@ -109,11 +111,10 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
   };
 
   async fetchProject() {
-    const {params} = this.props;
-    const {orgId, projectId} = params;
+    const {organization, params} = this.props;
     try {
       const updatedProject = await this.api.requestPromise(
-        `/projects/${orgId}/${projectId}/`
+        `/projects/${organization.slug}/${params.projectId}/`
       );
       ProjectsStore.onUpdateSuccess(updatedProject);
     } catch {
@@ -142,14 +143,13 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
   renderDebugFiles() {
     const {debugFiles, showDetails} = this.state;
     const {organization, params} = this.props;
-    const {orgId, projectId} = params;
 
     if (!debugFiles?.length) {
       return null;
     }
 
     return debugFiles.map(debugFile => {
-      const downloadUrl = `${this.api.baseUrl}/projects/${orgId}/${projectId}/files/dsyms/?id=${debugFile.id}`;
+      const downloadUrl = `${this.api.baseUrl}/projects/${organization.slug}/${params.projectId}/files/dsyms/?id=${debugFile.id}`;
 
       return (
         <DebugFileRow

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -25,7 +25,7 @@ type Props = {
     plugins: Plugin[];
   };
   project: Project;
-} & RouteComponentProps<{orgId: string; pluginId: string; projectId: string}, {}>;
+} & RouteComponentProps<{pluginId: string; projectId: string}, {}>;
 
 type State = {
   pluginDetails?: Plugin;
@@ -117,12 +117,14 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
   };
 
   handleEnable = () => {
-    enablePlugin(this.props.params);
+    const {organization, params} = this.props;
+    enablePlugin({...params, orgId: organization.slug});
     this.analyticsChangeEnableStatus(true);
   };
 
   handleDisable = () => {
-    disablePlugin(this.props.params);
+    const {organization, params} = this.props;
+    disablePlugin({...params, orgId: organization.slug});
     this.analyticsChangeEnableStatus(false);
   };
 

--- a/static/app/views/settings/projectPlugins/index.spec.jsx
+++ b/static/app/views/settings/projectPlugins/index.spec.jsx
@@ -10,7 +10,7 @@ jest.mock('sentry/actionCreators/plugins', () => ({
 }));
 
 describe('ProjectPluginsContainer', function () {
-  let org, project, plugins, params, organization;
+  let org, project, plugins, params;
 
   beforeEach(function () {
     org = TestStubs.Organization();
@@ -25,12 +25,7 @@ describe('ProjectPluginsContainer', function () {
       },
     ]);
     params = {
-      orgId: org.slug,
       projectId: project.slug,
-    };
-    organization = {
-      id: org.slug,
-      features: [],
     };
 
     MockApiClient.addMockResponse({
@@ -60,7 +55,8 @@ describe('ProjectPluginsContainer', function () {
       <ProjectPluginsContainer
         plugins={{plugins, loading: false}}
         params={params}
-        organization={organization}
+        organization={org}
+        project={project}
       />
     );
   });

--- a/static/app/views/settings/projectPlugins/index.tsx
+++ b/static/app/views/settings/projectPlugins/index.tsx
@@ -12,7 +12,7 @@ import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
 import ProjectPlugins from './projectPlugins';
 
-type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
+type Props = RouteComponentProps<{projectId: string}, {}> & {
   organization: Organization;
   plugins: {
     error: React.ComponentProps<typeof ProjectPlugins>['error'];
@@ -28,7 +28,9 @@ class ProjectPluginsContainer extends Component<Props> {
   }
 
   fetchData = async () => {
-    const plugins = await fetchPlugins(this.props.params);
+    const {organization, params} = this.props;
+
+    const plugins = await fetchPlugins({...params, orgId: organization.slug});
     const installCount = plugins.filter(
       plugin => plugin.hasConfiguration && plugin.enabled
     ).length;
@@ -44,20 +46,21 @@ class ProjectPluginsContainer extends Component<Props> {
   };
 
   handleChange = (pluginId: string, shouldEnable: boolean) => {
-    const {projectId, orgId} = this.props.params;
+    const {organization, params} = this.props;
+
     const actionCreator = shouldEnable ? enablePlugin : disablePlugin;
-    actionCreator({projectId, orgId, pluginId});
+    actionCreator({projectId: params.projectId, orgId: organization.slug, pluginId});
   };
 
   render() {
     const {loading, error, plugins} = this.props.plugins || {};
-    const {orgId} = this.props.params;
+    const {organization} = this.props;
 
     const title = t('Legacy Integrations');
 
     return (
       <Fragment>
-        <SentryDocumentTitle title={title} orgSlug={orgId} />
+        <SentryDocumentTitle title={title} orgSlug={organization.slug} />
         <SettingsPageHeader title={title} />
         <PermissionAlert />
 

--- a/static/app/views/settings/projectPlugins/projectPluginDetails.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginDetails.spec.tsx
@@ -50,7 +50,6 @@ describe('ProjectPluginDetails', function () {
         organization={organization}
         project={project}
         params={{
-          orgId: organization.slug,
           projectId: project.slug,
           pluginId: 'amazon-sqs',
         }}
@@ -75,7 +74,6 @@ describe('ProjectPluginDetails', function () {
         project={project}
         plugins={{plugins}}
         params={{
-          orgId: organization.slug,
           projectId: project.slug,
           pluginId: 'amazon-sqs',
         }}
@@ -103,7 +101,6 @@ describe('ProjectPluginDetails', function () {
         project={project}
         plugins={{plugins}}
         params={{
-          orgId: organization.slug,
           projectId: project.slug,
           pluginId: 'amazon-sqs',
         }}

--- a/static/app/views/settings/projectPlugins/projectPlugins.tsx
+++ b/static/app/views/settings/projectPlugins/projectPlugins.tsx
@@ -24,12 +24,11 @@ type Props = {
   organization: Organization;
   plugins: Plugin[];
   project: Project;
-} & RouteComponentProps<{orgId: string}, {}>;
+} & RouteComponentProps<{}, {}>;
 
 class ProjectPlugins extends Component<Props> {
   render() {
-    const {plugins, loading, error, onChange, routes, organization, params, project} =
-      this.props;
+    const {plugins, loading, error, onChange, routes, organization, project} = this.props;
     const hasError = error;
     const isLoading = !hasError && loading;
 
@@ -40,6 +39,7 @@ class ProjectPlugins extends Component<Props> {
     if (isLoading) {
       return <LoadingIndicator />;
     }
+    const params = {orgId: organization.slug, projectId: project.slug};
 
     return (
       <Panel>

--- a/static/app/views/settings/projectProguard/projectProguard.tsx
+++ b/static/app/views/settings/projectProguard/projectProguard.tsx
@@ -16,7 +16,7 @@ import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import ProjectProguardRow from './projectProguardRow';
 
-type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
+type Props = RouteComponentProps<{projectId: string}, {}> & {
   organization: Organization;
   project: Project;
 };
@@ -40,13 +40,13 @@ class ProjectProguard extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {params, location} = this.props;
-    const {orgId, projectId} = params;
+    const {organization, params, location} = this.props;
+    const {projectId} = params;
 
     const endpoints: ReturnType<AsyncView['getEndpoints']> = [
       [
         'mappings',
-        `/projects/${orgId}/${projectId}/files/dsyms/`,
+        `/projects/${organization.slug}/${projectId}/files/dsyms/`,
         {query: {query: location.query.query, file_formats: 'proguard'}},
       ],
     ];
@@ -55,14 +55,17 @@ class ProjectProguard extends AsyncView<Props, State> {
   }
 
   handleDelete = (id: string) => {
-    const {orgId, projectId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
 
     this.setState({
       loading: true,
     });
 
     this.api.request(
-      `/projects/${orgId}/${projectId}/files/dsyms/?id=${encodeURIComponent(id)}`,
+      `/projects/${organization.slug}/${projectId}/files/dsyms/?id=${encodeURIComponent(
+        id
+      )}`,
       {
         method: 'DELETE',
         complete: () => this.fetchData(),
@@ -100,16 +103,16 @@ class ProjectProguard extends AsyncView<Props, State> {
   renderMappings() {
     const {mappings} = this.state;
     const {organization, params} = this.props;
-    const {orgId, projectId} = params;
+    const {projectId} = params;
 
     if (!mappings?.length) {
       return null;
     }
 
     return mappings.map(mapping => {
-      const downloadUrl = `${
-        this.api.baseUrl
-      }/projects/${orgId}/${projectId}/files/dsyms/?id=${encodeURIComponent(mapping.id)}`;
+      const downloadUrl = `${this.api.baseUrl}/projects/${
+        organization.slug
+      }/${projectId}/files/dsyms/?id=${encodeURIComponent(mapping.id)}`;
 
       return (
         <ProjectProguardRow

--- a/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
@@ -33,7 +33,8 @@ describe('ProjectCspReports', function () {
         router={router}
         routes={router.routes}
         location={TestStubs.location({pathname: routeUrl})}
-        params={{orgId: organization.slug, projectId: project.slug}}
+        organization={organization}
+        params={{projectId: project.slug}}
       />
     );
     expect(container).toSnapshot();
@@ -47,7 +48,8 @@ describe('ProjectCspReports', function () {
         router={router}
         routes={router.routes}
         location={TestStubs.location({pathname: routeUrl})}
-        params={{orgId: organization.slug, projectId: project.slug}}
+        organization={organization}
+        params={{projectId: project.slug}}
       />
     );
 
@@ -82,7 +84,8 @@ describe('ProjectCspReports', function () {
         router={router}
         routes={router.routes}
         location={TestStubs.location({pathname: routeUrl})}
-        params={{orgId: organization.slug, projectId: project.slug}}
+        organization={organization}
+        params={{projectId: project.slug}}
       />
     );
 

--- a/static/app/views/settings/projectSecurityHeaders/csp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.tsx
@@ -8,7 +8,7 @@ import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import PreviewFeature from 'sentry/components/previewFeature';
 import formGroups from 'sentry/data/forms/cspReports';
 import {t, tct} from 'sentry/locale';
-import {Project, ProjectKey} from 'sentry/types';
+import {Organization, Project, ProjectKey} from 'sentry/types';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -16,7 +16,9 @@ import ReportUri, {
   getSecurityDsn,
 } from 'sentry/views/settings/projectSecurityHeaders/reportUri';
 
-type Props = RouteComponentProps<{orgId: string; projectId: string}, {}>;
+type Props = RouteComponentProps<{projectId: string}, {}> & {
+  organization: Organization;
+};
 
 type State = {
   keyList: null | ProjectKey[];
@@ -25,10 +27,11 @@ type State = {
 
 export default class ProjectCspReports extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {orgId, projectId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
     return [
-      ['keyList', `/projects/${orgId}/${projectId}/keys/`],
-      ['project', `/projects/${orgId}/${projectId}/`],
+      ['keyList', `/projects/${organization.slug}/${projectId}/keys/`],
+      ['project', `/projects/${organization.slug}/${projectId}/`],
     ];
   }
 
@@ -65,7 +68,8 @@ export default class ProjectCspReports extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {orgId, projectId} = this.props.params;
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
     const {project, keyList} = this.state;
     if (!keyList || !project) {
       return null;
@@ -77,13 +81,13 @@ export default class ProjectCspReports extends AsyncView<Props, State> {
 
         <PreviewFeature />
 
-        <ReportUri keyList={keyList} orgId={orgId} projectId={projectId} />
+        <ReportUri keyList={keyList} orgId={organization.slug} projectId={projectId} />
 
         <Form
           saveOnBlur
           apiMethod="PUT"
           initialData={project.options}
-          apiEndpoint={`/projects/${orgId}/${projectId}/`}
+          apiEndpoint={`/projects/${organization.slug}/${projectId}/`}
         >
           <Access access={['project:write']}>
             {({hasAccess}) => <JsonForm disabled={!hasAccess} forms={formGroups} />}

--- a/static/app/views/settings/projectSecurityHeaders/expectCt.spec.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/expectCt.spec.tsx
@@ -23,8 +23,9 @@ describe('ProjectExpectCtReports', function () {
         routeParams={{}}
         router={router}
         routes={router.routes}
-        params={{orgId: org.slug, projectId: project.slug}}
+        params={{projectId: project.slug}}
         location={TestStubs.location({pathname: url})}
+        organization={org}
       />
     );
 

--- a/static/app/views/settings/projectSecurityHeaders/expectCt.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/expectCt.tsx
@@ -4,24 +4,28 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import PreviewFeature from 'sentry/components/previewFeature';
 import {t, tct} from 'sentry/locale';
-import {ProjectKey} from 'sentry/types';
+import {Organization, ProjectKey} from 'sentry/types';
 import routeTitleGen from 'sentry/utils/routeTitle';
+import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import ReportUri, {
   getSecurityDsn,
 } from 'sentry/views/settings/projectSecurityHeaders/reportUri';
 
-type Props = RouteComponentProps<{orgId: string; projectId: string}, {}>;
+type Props = RouteComponentProps<{projectId: string}, {}> & {
+  organization: Organization;
+};
 
 type State = {
   keyList: null | ProjectKey[];
 } & AsyncView['state'];
 
-export default class ProjectExpectCtReports extends AsyncView<Props, State> {
+class ProjectExpectCtReports extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {orgId, projectId} = this.props.params;
-    return [['keyList', `/projects/${orgId}/${projectId}/keys/`]];
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
+    return [['keyList', `/projects/${organization.slug}/${projectId}/keys/`]];
   }
 
   getTitle() {
@@ -34,7 +38,7 @@ export default class ProjectExpectCtReports extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {params} = this.props;
+    const {organization, params} = this.props;
     const {keyList} = this.state;
     if (!keyList) {
       return null;
@@ -46,7 +50,11 @@ export default class ProjectExpectCtReports extends AsyncView<Props, State> {
 
         <PreviewFeature />
 
-        <ReportUri keyList={keyList} orgId={params.orgId} projectId={params.orgId} />
+        <ReportUri
+          keyList={keyList}
+          orgId={organization.slug}
+          projectId={params.projectId}
+        />
 
         <Panel>
           <PanelHeader>{'About'}</PanelHeader>
@@ -86,3 +94,5 @@ export default class ProjectExpectCtReports extends AsyncView<Props, State> {
     );
   }
 }
+
+export default withOrganization(ProjectExpectCtReports);

--- a/static/app/views/settings/projectSecurityHeaders/hpkp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/hpkp.tsx
@@ -4,24 +4,28 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import PreviewFeature from 'sentry/components/previewFeature';
 import {t, tct} from 'sentry/locale';
-import {ProjectKey} from 'sentry/types';
+import {Organization, ProjectKey} from 'sentry/types';
 import routeTitleGen from 'sentry/utils/routeTitle';
+import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import ReportUri, {
   getSecurityDsn,
 } from 'sentry/views/settings/projectSecurityHeaders/reportUri';
 
-type Props = RouteComponentProps<{orgId: string; projectId: string}, {}>;
+type Props = RouteComponentProps<{projectId: string}, {}> & {
+  organization: Organization;
+};
 
 type State = {
   keyList: null | ProjectKey[];
 } & AsyncView['state'];
 
-export default class ProjectHpkpReports extends AsyncView<Props, State> {
+class ProjectHpkpReports extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {orgId, projectId} = this.props.params;
-    return [['keyList', `/projects/${orgId}/${projectId}/keys/`]];
+    const {organization} = this.props;
+    const {projectId} = this.props.params;
+    return [['keyList', `/projects/${organization.slug}/${projectId}/keys/`]];
   }
 
   getTitle() {
@@ -54,7 +58,7 @@ export default class ProjectHpkpReports extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {params} = this.props;
+    const {organization, params} = this.props;
     const {keyList} = this.state;
     if (!keyList) {
       return null;
@@ -66,7 +70,11 @@ export default class ProjectHpkpReports extends AsyncView<Props, State> {
 
         <PreviewFeature />
 
-        <ReportUri keyList={keyList} orgId={params.orgId} projectId={params.projectId} />
+        <ReportUri
+          keyList={keyList}
+          orgId={organization.slug}
+          projectId={params.projectId}
+        />
 
         <Panel>
           <PanelHeader>{t('About')}</PanelHeader>
@@ -126,3 +134,5 @@ export default class ProjectHpkpReports extends AsyncView<Props, State> {
     );
   }
 }
+
+export default withOrganization(ProjectHpkpReports);

--- a/static/app/views/settings/projectSecurityHeaders/index.spec.jsx
+++ b/static/app/views/settings/projectSecurityHeaders/index.spec.jsx
@@ -22,7 +22,7 @@ describe('ProjectSecurityHeaders', function () {
         organization={org}
         project={project}
         {...TestStubs.routerProps({
-          params: {orgId: org.slug, projectId: project.slug},
+          params: {projectId: project.slug},
           location: TestStubs.location({pathname: url}),
         })}
       />


### PR DESCRIPTION
Clean up a few types I missed before. Update another block of settings views as under customer-domains `params.orgId` doesn't exist in class components.
