### PR TITLE
feat(replays): Enable the filters on Replay Details if there is an item selected

### DIFF
--- a/static/app/views/replays/detail/console/consoleFilters.tsx
+++ b/static/app/views/replays/detail/console/consoleFilters.tsx
@@ -17,17 +17,18 @@ function Filters({
   setLogLevel,
   setSearchTerm,
 }: Props) {
+  const logLevels = getLogLevels();
   return (
     <FiltersGrid>
       <CompactSelect
         triggerProps={{prefix: t('Log Level')}}
         triggerLabel={logLevel.length === 0 ? t('Any') : null}
         multiple
-        options={getLogLevels()}
+        options={logLevels}
         onChange={selected => setLogLevel(selected.map(_ => _.value))}
         size="sm"
         value={logLevel}
-        isDisabled={!breadcrumbs || !breadcrumbs.length}
+        isDisabled={!logLevels.length}
       />
       <SearchBar
         onChange={setSearchTerm}

--- a/static/app/views/replays/detail/domMutations/domFilters.tsx
+++ b/static/app/views/replays/detail/domMutations/domFilters.tsx
@@ -15,17 +15,18 @@ function DomFilters({
   setType,
   type,
 }: Props) {
+  const mutationTypes = getMutationsTypes();
   return (
     <FiltersGrid>
       <CompactSelect
         triggerProps={{prefix: t('Event Type')}}
         triggerLabel={type.length === 0 ? t('Any') : null}
         multiple
-        options={getMutationsTypes()}
+        options={mutationTypes}
         size="sm"
         onChange={selected => setType(selected.map(_ => _.value))}
         value={type}
-        isDisabled={!actions || !actions.length}
+        isDisabled={!mutationTypes.length}
       />
       <SearchBar
         size="sm"

--- a/static/app/views/replays/detail/network/networkFilters.tsx
+++ b/static/app/views/replays/detail/network/networkFilters.tsx
@@ -20,27 +20,29 @@ function NetworkFilters({
   status,
   type,
 }: Props) {
+  const statusTypes = getStatusTypes();
+  const resourceTypes = getResourceTypes();
   return (
     <FiltersGrid>
       <CompactSelect
         triggerProps={{prefix: t('Status')}}
         triggerLabel={status.length === 0 ? t('Any') : null}
         multiple
-        options={getStatusTypes()}
+        options={statusTypes}
         size="sm"
         onChange={selected => setStatus(selected.map(_ => _.value))}
         value={status}
-        isDisabled={!networkSpans || !networkSpans.length}
+        isDisabled={!statusTypes.length}
       />
       <CompactSelect
         triggerProps={{prefix: t('Type')}}
         triggerLabel={type.length === 0 ? t('Any') : null}
         multiple
-        options={getResourceTypes()}
+        options={resourceTypes}
         size="sm"
         onChange={selected => setType(selected.map(_ => _.value))}
         value={type}
-        isDisabled={!networkSpans || !networkSpans.length}
+        isDisabled={!resourceTypes.length}
       />
       <SearchBar
         size="sm"


### PR DESCRIPTION
Before we'd disable the replay details filter dropdowns if there were no rows to search through.
The problem is that if you have a filter in your query params, the label would not say 'any' and it could be confusing:
![image (1)](https://user-images.githubusercontent.com/187460/211405947-4ffcb086-0a07-4150-b4ef-a721e79ebe66.png)

In the above screen shot it says we're looking at 'sentry errors' but there are no results. No way to clear that 'sentry errors' either.


Now we allow the 'sentry errors' to be cleared, but once there is nothin in the list the dropdown will revert to being disabled (it does this on it's own, regardless of the props).