### PR TITLE
fix(crons): Allow empty values on non-required fields

### DIFF
--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -44,8 +44,8 @@ class CronJobValidator(serializers.Serializer):
         choices=list(zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys()))
     )
     schedule = ObjectField()
-    checkin_margin = EmptyIntegerField(required=False, default=None)
-    max_runtime = EmptyIntegerField(required=False, default=None)
+    checkin_margin = EmptyIntegerField(required=False, allow_null=True, default=None)
+    max_runtime = EmptyIntegerField(required=False, allow_null=True, default=None)
 
     def validate_schedule_type(self, value):
         if value:


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/42998

Should allow None on these fields or else users who create a cron monitor can't edit it without filling in these values.