### PR TITLE
feat(profiling): improve color coding

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -30,7 +30,8 @@ import useProjects from 'sentry/utils/useProjects';
 
 const FLAMEGRAPH_COLOR_CODINGS: FlamegraphColorCodings = [
   'by symbol name',
-  'by system / application',
+  'by system frame',
+  'by application frame',
   'by library',
   'by recursion',
   'by frequency',

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
@@ -81,7 +81,8 @@ const X_AXIS: Record<FlamegraphPreferences['xAxis'], string> = {
 const COLOR_CODINGS: Record<FlamegraphPreferences['colorCoding'], string> = {
   'by symbol name': t('By Symbol Name'),
   'by library': t('By Package'),
-  'by system / application': t('By System / Application'),
+  'by system frame': t('By System Frame'),
+  'by application frame': t('By Application Frame'),
   'by recursion': t('By Recursion'),
   'by frequency': t('By Frequency'),
 };

--- a/static/app/utils/profiling/colors/utils.spec.tsx
+++ b/static/app/utils/profiling/colors/utils.spec.tsx
@@ -2,7 +2,7 @@ import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {
   makeColorBucketTheme,
   makeColorMap,
-  makeColorMapByImage,
+  makeColorMapByLibrary,
   makeColorMapByRecursion,
   makeStackToColor,
 } from 'sentry/utils/profiling/colors/utils';
@@ -100,9 +100,8 @@ describe('makeColorMap', () => {
     const b = f(1, 'b');
 
     b.frame = a.frame;
-    const frames = [a, b];
 
-    const map = makeColorMap(frames, makeColorBucketTheme(LCH_LIGHT));
+    const map = makeColorMap([a, b], makeColorBucketTheme(LCH_LIGHT));
     expect(map.get(a.key)).toEqual(map.get(b.key));
   });
   it('default colors by frame name', () => {
@@ -116,19 +115,6 @@ describe('makeColorMap', () => {
     expect(getDominantColor(map.get(1))).toBe('blue');
   });
 
-  it('colors by custom sort', () => {
-    // Reverse order to ensure we actually sort
-    const frames = [f(1, 'c'), f(2, 'b'), f(3, 'a')];
-
-    const map = makeColorMap(frames, makeColorBucketTheme(LCH_LIGHT), (a, b) =>
-      b.frame.name > a.frame.name ? 1 : -1
-    );
-
-    expect(getDominantColor(map.get(3))).toBe('blue');
-    expect(getDominantColor(map.get(2))).toBe('green');
-    expect(getDominantColor(map.get(1))).toBe('red');
-  });
-
   it('colors by image', () => {
     // Reverse order to ensure we actually sort
     const frames = [
@@ -137,7 +123,7 @@ describe('makeColorMap', () => {
       f(3, 'a', undefined, 'a'),
     ];
 
-    const map = makeColorMapByImage(frames, makeColorBucketTheme(LCH_LIGHT));
+    const map = makeColorMapByLibrary(frames, makeColorBucketTheme(LCH_LIGHT));
 
     expect(getDominantColor(map.get(3))).toBe('red');
     expect(getDominantColor(map.get(2))).toBe('green');

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -223,8 +223,7 @@ export function makeColorMapByImage(
     if (!reverseFrameToImageIndex[key]) {
       reverseFrameToImageIndex[key] = [];
     }
-    // we initialize an empty array above, so this is safe
-    reverseFrameToImageIndex[key]!.push(frame);
+    reverseFrameToImageIndex[key].push(frame);
   }
 
   for (let i = 0; i < sortedFrames.length; i++) {
@@ -245,7 +244,40 @@ export function makeColorMapByImage(
   return colors;
 }
 
-export function makeColorMapBySystemVsApplication(
+export function makeColorMapBySystemFrame(
+  frames: ReadonlyArray<FlamegraphFrame>,
+  colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
+): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
+  const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
+
+  const uniqueSystemFrames: Record<string, FlamegraphFrame[]> = {};
+
+  for (let i = 0; i < frames.length; i++) {
+    if (frames[i].frame.is_application) {
+      continue;
+    }
+
+    const uniqueByProperty = frames[i].frame.name + frames[i].frame.image;
+    if (!uniqueSystemFrames[uniqueByProperty]) {
+      uniqueSystemFrames[uniqueByProperty] = [];
+    }
+
+    uniqueSystemFrames[uniqueByProperty].push(frames[i]);
+  }
+
+  const uniqueSystemFramesArray = Array.from(uniqueSystemFrames);
+
+  for (let i = 0; i < uniqueSystemFramesArray.length; i++) {
+    colors.set(
+      uniqueSystemFramesArray[i].key,
+      colorBucket(i / uniqueSystemFramesArray.length)
+    );
+  }
+
+  return colors;
+}
+
+export function makeColorMapByApplicationFrame(
   frames: ReadonlyArray<FlamegraphFrame>,
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
 ): Map<FlamegraphFrame['frame']['key'], ColorChannels> {

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphQueryParamSync.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphQueryParamSync.tsx
@@ -26,7 +26,8 @@ function isColorCoding(
 
   return (
     value === 'by symbol name' ||
-    value === 'by system / application' ||
+    value === 'by system frame' ||
+    value === 'by application frame' ||
     value === 'by library' ||
     value === 'by recursion' ||
     value === 'by frequency'

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences.tsx
@@ -1,6 +1,7 @@
 export type FlamegraphColorCodings = [
   'by symbol name',
-  'by system / application',
+  'by system frame',
+  'by application frame',
   'by library',
   'by recursion',
   'by frequency'

--- a/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
@@ -3,10 +3,11 @@ import {createContext, useMemo} from 'react';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {
+  makeColorMapByApplicationFrame,
   makeColorMapByFrequency,
   makeColorMapByImage,
   makeColorMapByRecursion,
-  makeColorMapBySystemVsApplication,
+  makeColorMapBySystemFrame,
 } from 'sentry/utils/profiling/colors/utils';
 import {
   DarkFlamegraphTheme,
@@ -40,10 +41,16 @@ function FlamegraphThemeProvider(
       case 'by library': {
         return {...base, COLORS: {...base.COLORS, COLOR_MAP: makeColorMapByImage}};
       }
-      case 'by system / application': {
+      case 'by system frame': {
         return {
           ...base,
-          COLORS: {...base.COLORS, COLOR_MAP: makeColorMapBySystemVsApplication},
+          COLORS: {...base.COLORS, COLOR_MAP: makeColorMapBySystemFrame},
+        };
+      }
+      case 'by application frame': {
+        return {
+          ...base,
+          COLORS: {...base.COLORS, COLOR_MAP: makeColorMapByApplicationFrame},
         };
       }
       case 'by frequency': {

--- a/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
@@ -5,7 +5,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {
   makeColorMapByApplicationFrame,
   makeColorMapByFrequency,
-  makeColorMapByImage,
+  makeColorMapByLibrary,
   makeColorMapByRecursion,
   makeColorMapBySystemFrame,
 } from 'sentry/utils/profiling/colors/utils';
@@ -39,7 +39,7 @@ function FlamegraphThemeProvider(
         return {...base, COLORS: {...base.COLORS, COLOR_MAP: makeColorMapByRecursion}};
       }
       case 'by library': {
-        return {...base, COLORS: {...base.COLORS, COLOR_MAP: makeColorMapByImage}};
+        return {...base, COLORS: {...base.COLORS, COLOR_MAP: makeColorMapByLibrary}};
       }
       case 'by system frame': {
         return {

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -168,6 +168,7 @@ function importSentrySampledProfile(
         samples: samplesByThread[key],
       },
     };
+
     profiles.push(
       wrapWithSpan(
         options.transaction,


### PR DESCRIPTION
Splits the by system / application into two options. Instead of showing orange for system and blue for application we now 
still color encode by name and image + is_application frame so that users can distinguish between different application and system frame calls