### PR TITLE
fix: Resolve invalid host name for incident chart generation

### DIFF
--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -1,5 +1,6 @@
 __all__ = ("ApiClient",)
 
+from django.conf import settings
 from django.urls import resolve
 from rest_framework.test import APIRequestFactory, force_authenticate
 
@@ -78,6 +79,8 @@ class ApiClient:
             mock_request.session = {}
             mock_request.superuser = Superuser(mock_request)
 
+        if "*" not in settings.ALLOWED_HOSTS:
+            mock_request.META["HTTP_HOST"] = settings.ALLOWED_HOSTS[0]
         mock_request.is_superuser = lambda: mock_request.superuser.is_active
 
         if request:

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -99,8 +99,8 @@ def send_incident_alert_notification(action, incident, metric_value, new_status:
     client = MsTeamsClient(integration)
     try:
         client.send_card(channel, attachment)
-    except ApiError as e:
-        logger.info("rule.fail.msteams_post", extra={"error": str(e)})
+    except ApiError:
+        logger.info("rule.fail.msteams_post", exc_info=True)
 
 
 def get_preinstall_client(service_url):

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -66,8 +66,8 @@ def send_incident_alert_notification(
     client = SlackClient()
     try:
         client.post("/chat.postMessage", data=payload, timeout=5)
-    except ApiError as e:
-        logger.info("rule.fail.slack_post", extra={"error": str(e)})
+    except ApiError:
+        logger.info("rule.fail.slack_post", exc_info=True)
 
 
 def send_slack_response(

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -87,6 +87,7 @@ def send_incident_alert_notification(
                 "organization": organization.slug,
                 "sentry_app_id": sentry_app.id,
             },
+            exc_info=True,
         )
         return None
 


### PR DESCRIPTION
This ensures HTTP_HOST is mocked within api.client in order to resolve calls to request.build_absolute_uri.

Additionally improves several log statements to ensure exceptions are not lost.

Fixes SENTRY-XS9