### PR TITLE
chore(perf): Refactor & test accordion component

### DIFF
--- a/static/app/views/performance/landing/widgets/components/accordion.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/accordion.spec.tsx
@@ -1,0 +1,30 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import Accordion from 'sentry/views/performance/landing/widgets/components/accordion';
+
+const items = [
+  {header: () => <p>header</p>, content: () => <p>first content</p>},
+  {header: () => <p>second header</p>, content: () => <p>second content</p>},
+];
+
+describe('Accordion', function () {
+  it('renders expanded item', async function () {
+    const {container} = render(
+      <Accordion expandedIndex={0} setExpandedIndex={() => {}} items={items} />
+    );
+    expect(container).toSnapshot();
+    expect(await screen.findByText('first content')).toBeInTheDocument();
+    expect(screen.queryByText('second content')).not.toBeInTheDocument();
+  });
+
+  it('invokes callback on header click', function () {
+    const spy = jest.fn();
+    render(<Accordion expandedIndex={0} setExpandedIndex={spy} items={items} />);
+    userEvent.click(
+      screen.getByRole('button', {
+        expanded: false,
+      })
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/static/app/views/performance/landing/widgets/components/accordion.tsx
+++ b/static/app/views/performance/landing/widgets/components/accordion.tsx
@@ -4,30 +4,29 @@ import styled from '@emotion/styled';
 import DropdownButton from 'sentry/components/dropdownButton';
 import space from 'sentry/styles/space';
 
-type Props = {
-  content: ReactNode;
-  expandedIndex: number;
-  headers: (() => ReactNode)[];
-  setExpandedIndex: (index: number) => void;
-};
+interface AccordionItemContent {
+  content: () => ReactNode;
+  header: () => ReactNode;
+}
 
-export default function Accordion({
-  content,
-  headers,
-  expandedIndex,
-  setExpandedIndex,
-}: Props) {
+interface Props {
+  expandedIndex: number;
+  items: AccordionItemContent[];
+  setExpandedIndex: (index: number) => void;
+}
+
+export default function Accordion({expandedIndex, setExpandedIndex, items}: Props) {
   return (
     <AccordionContainer>
-      {headers.map((header, index) => (
+      {items.map((item, index) => (
         <AccordionItem
           isExpanded={index === expandedIndex}
           currentIndex={index}
           key={index}
-          content={content}
+          content={item.content()}
           setExpandedIndex={setExpandedIndex}
         >
-          {header()}
+          {item.header()}
         </AccordionItem>
       ))}
     </AccordionContainer>

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -215,6 +215,21 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
     chart: chartQuery,
   };
 
+  const assembleAccordionItems = provided =>
+    getItems(provided).map(item => ({header: item, content: getChart(provided)}));
+
+  const getChart = provided => () =>
+    (
+      <DurationChart
+        {...provided.widgetData.chart}
+        {...provided}
+        disableMultiAxis
+        disableXAxis
+        chartColors={props.chartColor ? [props.chartColor] : undefined}
+        isLineChart
+      />
+    );
+
   const getItems = provided =>
     provided.widgetData.list.data.map(listItem => () => {
       const transaction = (listItem.transaction as string | undefined) ?? '';
@@ -365,17 +380,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             <Accordion
               expandedIndex={selectedListIndex}
               setExpandedIndex={setSelectListIndex}
-              headers={getItems(provided)}
-              content={
-                <DurationChart
-                  {...provided.widgetData.chart}
-                  {...provided}
-                  disableMultiAxis
-                  disableXAxis
-                  chartColors={props.chartColor ? [props.chartColor] : undefined}
-                  isLineChart
-                />
-              }
+              items={assembleAccordionItems(provided)}
             />
           ),
           // accordion items height + chart height

--- a/static/app/views/performance/landing/widgets/widgets/stackedBarsChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedBarsChartListWidget.tsx
@@ -164,6 +164,41 @@ export function StackedBarsChartListWidget(props: PerformanceWidgetProps) {
     chart: chartQuery,
   };
 
+  const assembleAccordionItems = provided =>
+    getHeaders(provided).map(header => ({header, content: getChart(provided)}));
+
+  const getChart = provided => () =>
+    (
+      <BarChart
+        {...provided.widgetData.chart}
+        {...provided}
+        colors={colors}
+        series={provided.widgetData.chart.data}
+        stacked
+        animation
+        isGroupedByDate
+        showTimeInTooltip
+        xAxis={{
+          show: false,
+          axisLabel: {show: true, margin: 8},
+          axisLine: {show: false},
+        }}
+        tooltip={{
+          valueFormatter: value => tooltipFormatter(value, 'duration'),
+        }}
+        start={
+          provided.widgetData.chart.start
+            ? new Date(provided.widgetData.chart.start)
+            : undefined
+        }
+        end={
+          provided.widgetData.chart.end
+            ? new Date(provided.widgetData.chart.end)
+            : undefined
+        }
+      />
+    );
+
   const getHeaders = provided =>
     provided.widgetData.list.data.map(listItem => () => {
       const transaction = (listItem.transaction as string | undefined) ?? '';
@@ -216,45 +251,13 @@ export function StackedBarsChartListWidget(props: PerformanceWidgetProps) {
       Queries={Queries}
       Visualizations={[
         {
-          component: provided => {
-            return (
-              <Accordion
-                expandedIndex={selectedListIndex}
-                setExpandedIndex={setSelectListIndex}
-                content={
-                  <BarChart
-                    {...provided.widgetData.chart}
-                    {...provided}
-                    colors={colors}
-                    series={provided.widgetData.chart.data}
-                    stacked
-                    animation
-                    isGroupedByDate
-                    showTimeInTooltip
-                    xAxis={{
-                      show: false,
-                      axisLabel: {show: true, margin: 8},
-                      axisLine: {show: false},
-                    }}
-                    tooltip={{
-                      valueFormatter: value => tooltipFormatter(value, 'duration'),
-                    }}
-                    start={
-                      provided.widgetData.chart.start
-                        ? new Date(provided.widgetData.chart.start)
-                        : undefined
-                    }
-                    end={
-                      provided.widgetData.chart.end
-                        ? new Date(provided.widgetData.chart.end)
-                        : undefined
-                    }
-                  />
-                }
-                headers={getHeaders(provided)}
-              />
-            );
-          },
+          component: provided => (
+            <Accordion
+              expandedIndex={selectedListIndex}
+              setExpandedIndex={setSelectListIndex}
+              items={assembleAccordionItems(provided)}
+            />
+          ),
           height: 124 + props.chartHeight,
           noPadding: true,
         },

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -92,6 +92,30 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
     [props.chartSetting, trendChangeType]
   );
 
+  const assembleAccordionItems = provided =>
+    getItems(provided).map(item => ({header: item, content: getChart(provided)}));
+
+  const getChart = provided => () =>
+    (
+      <TrendsChart
+        {...provided}
+        {...rest}
+        isLoading={provided.widgetData.chart.isLoading}
+        statsData={provided.widgetData.chart.statsData}
+        query={eventView.query}
+        project={eventView.project}
+        environment={eventView.environment}
+        start={eventView.start}
+        end={eventView.end}
+        statsPeriod={eventView.statsPeriod}
+        transaction={provided.widgetData.chart.transactionsList[selectedListIndex]}
+        trendChangeType={trendChangeType}
+        trendFunctionField={trendFunctionField}
+        disableXAxis
+        disableLegend
+      />
+    );
+
   const getItems = provided =>
     provided.widgetData.chart.transactionsList.map(listItem => () => {
       const initialConditions = new MutableSearch([]);
@@ -140,28 +164,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
             <Accordion
               expandedIndex={selectedListIndex}
               setExpandedIndex={setSelectListIndex}
-              headers={getItems(provided)}
-              content={
-                <TrendsChart
-                  {...provided}
-                  {...rest}
-                  isLoading={provided.widgetData.chart.isLoading}
-                  statsData={provided.widgetData.chart.statsData}
-                  query={eventView.query}
-                  project={eventView.project}
-                  environment={eventView.environment}
-                  start={eventView.start}
-                  end={eventView.end}
-                  statsPeriod={eventView.statsPeriod}
-                  transaction={
-                    provided.widgetData.chart.transactionsList[selectedListIndex]
-                  }
-                  trendChangeType={trendChangeType}
-                  trendFunctionField={trendFunctionField}
-                  disableXAxis
-                  disableLegend
-                />
-              }
+              items={assembleAccordionItems(provided)}
             />
           ),
           // accordion items height + chart height

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -206,6 +206,20 @@ export function VitalWidget(props: PerformanceWidgetProps) {
     // TODO(k-fish): Add analytics.
   };
 
+  const assembleAccordionItems = provided =>
+    getItems(provided).map(item => ({header: item, content: getChart(provided)}));
+
+  const getChart = provided => () =>
+    (
+      <_VitalChart
+        {...provided.widgetData.chart}
+        {...provided}
+        field={field}
+        vitalFields={vitalFields}
+        grid={provided.grid}
+      />
+    );
+
   const getItems = provided =>
     provided.widgetData.list.data.slice(0, 3).map(listItem => () => {
       const transaction = (listItem?.transaction as string | undefined) ?? '';
@@ -278,16 +292,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
             <Accordion
               expandedIndex={selectedListIndex}
               setExpandedIndex={setSelectListIndex}
-              headers={getItems(provided)}
-              content={
-                <_VitalChart
-                  {...provided.widgetData.chart}
-                  {...provided}
-                  field={field}
-                  vitalFields={vitalFields}
-                  grid={provided.grid}
-                />
-              }
+              items={assembleAccordionItems(provided)}
             />
           ),
           // accordion items height + chart height


### PR DESCRIPTION
Use a more intuitive prop structure for the `Accordion` component. Pass `items` consisting of `headers` and their `content` instead of `headers` and a single `content`. Also added component tests testing basic accordion functionality.