### PR TITLE
fix(domains) Fix router.push() with string URLs

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -21,6 +21,7 @@ import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import useApi from 'sentry/utils/useApi';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {
   DashboardDetails,
   DashboardListItem,
@@ -130,13 +131,15 @@ function AddToDashboardModal({
         ? `/organizations/${organization.slug}/dashboards/new/widget/new/`
         : `/organizations/${organization.slug}/dashboard/${selectedDashboardId}/widget/new/`;
 
-    router.push({
-      pathname,
-      query: {
-        ...widgetAsQueryParams,
-        ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
-      },
-    });
+    router.push(
+      normalizeUrl({
+        pathname,
+        query: {
+          ...widgetAsQueryParams,
+          ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
+        },
+      })
+    );
     closeModal();
   }
 

--- a/static/app/views/acceptProjectTransfer.tsx
+++ b/static/app/views/acceptProjectTransfer.tsx
@@ -6,6 +6,7 @@ import Form from 'sentry/components/forms/form';
 import NarrowLayout from 'sentry/components/narrowLayout';
 import {t, tct} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
@@ -42,7 +43,7 @@ class AcceptProjectTransfer extends AsyncView<Props, State> {
       success: () => {
         const orgSlug = formData.organization;
 
-        this.props.router.push(`/${orgSlug}`);
+        this.props.router.push(normalizeUrl(`/organizations/${orgSlug}/projects/`));
         addSuccessMessage(t('Project successfully transferred'));
       },
       error: error => {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -63,6 +63,7 @@ import {getDisplayName} from 'sentry/utils/environment';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import routeTitleGen from 'sentry/utils/routeTitle';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
 import PreviewTable from 'sentry/views/alerts/rules/issue/previewTable';
@@ -535,9 +536,11 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
     metric.endTransaction({name: 'saveAlertRule'});
 
-    router.push({
-      pathname: `/organizations/${organization.slug}/alerts/rules/${project.slug}/${rule.id}/details/`,
-    });
+    router.push(
+      normalizeUrl({
+        pathname: `/organizations/${organization.slug}/alerts/rules/${project.slug}/${rule.id}/details/`,
+      })
+    );
     addSuccessMessage(isNew ? t('Created alert rule') : t('Updated alert rule'));
   };
 
@@ -641,7 +644,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   handleCancel = () => {
     const {organization, router} = this.props;
 
-    router.push(`/organizations/${organization.slug}/alerts/rules/`);
+    router.push(normalizeUrl(`/organizations/${organization.slug}/alerts/rules/`));
   };
 
   hasError = (field: string) => {

--- a/static/app/views/alerts/rules/metric/create.tsx
+++ b/static/app/views/alerts/rules/metric/create.tsx
@@ -3,6 +3,7 @@ import {RouteComponentProps} from 'react-router';
 import {Organization, Project} from 'sentry/types';
 import {metric} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {
   createDefaultRule,
   createRuleFromEventView,
@@ -37,16 +38,15 @@ function MetricRulesCreate(props: Props) {
       : undefined;
 
     metric.endTransaction({name: 'saveAlertRule'});
-    router.push(
-      alertRuleId
-        ? {
-            pathname: `/organizations/${organization.slug}/alerts/rules/details/${alertRuleId}/`,
-          }
-        : {
-            pathname: `/organizations/${organization.slug}/alerts/rules/`,
-            query: {project: project.id},
-          }
-    );
+    const target = alertRuleId
+      ? {
+          pathname: `/organizations/${organization.slug}/alerts/rules/details/${alertRuleId}/`,
+        }
+      : {
+          pathname: `/organizations/${organization.slug}/alerts/rules/`,
+          query: {project: project.id},
+        };
+    router.push(normalizeUrl(target));
   }
 
   const {project, eventView, wizardTemplate, sessionId, userTeamIds, ...otherProps} =

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -44,6 +44,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {MINUTES_THRESHOLD_TO_DISPLAY_SECONDS} from 'sentry/utils/sessions';
 import theme from 'sentry/utils/theme';
 import toArray from 'sentry/utils/toArray';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 // eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
@@ -263,10 +264,12 @@ class MetricChart extends PureComponent<Props, State> {
     }
 
     const handleIncidentClick = (incident: Incident) => {
-      router.push({
-        pathname: alertDetailsLink(organization, incident),
-        query: {alert: incident.identifier},
-      });
+      router.push(
+        normalizeUrl({
+          pathname: alertDetailsLink(organization, incident),
+          query: {alert: incident.identifier},
+        })
+      );
     };
 
     const {criticalDuration, warningDuration, totalDuration, chartOption} =

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -23,6 +23,7 @@ import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
 import theme from 'sentry/utils/theme';
 import withApi from 'sentry/utils/withApi';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
 import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
@@ -206,23 +207,27 @@ class Dashboard extends Component<Props, State> {
     const {organization, router, location, paramDashboardId} = this.props;
 
     if (paramDashboardId) {
-      router.push({
-        pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/new/`,
+      router.push(
+        normalizeUrl({
+          pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/new/`,
+          query: {
+            ...location.query,
+            source: DashboardWidgetSource.DASHBOARDS,
+          },
+        })
+      );
+      return;
+    }
+
+    router.push(
+      normalizeUrl({
+        pathname: `/organizations/${organization.slug}/dashboards/new/widget/new/`,
         query: {
           ...location.query,
           source: DashboardWidgetSource.DASHBOARDS,
         },
-      });
-      return;
-    }
-
-    router.push({
-      pathname: `/organizations/${organization.slug}/dashboards/new/widget/new/`,
-      query: {
-        ...location.query,
-        source: DashboardWidgetSource.DASHBOARDS,
-      },
-    });
+      })
+    );
 
     return;
   };
@@ -288,23 +293,27 @@ class Dashboard extends Component<Props, State> {
     const {organization, router, location, paramDashboardId} = this.props;
 
     if (paramDashboardId) {
-      router.push({
-        pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/${index}/edit/`,
+      router.push(
+        normalizeUrl({
+          pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/${index}/edit/`,
+          query: {
+            ...location.query,
+            source: DashboardWidgetSource.DASHBOARDS,
+          },
+        })
+      );
+      return;
+    }
+
+    router.push(
+      normalizeUrl({
+        pathname: `/organizations/${organization.slug}/dashboards/new/widget/${index}/edit/`,
         query: {
           ...location.query,
           source: DashboardWidgetSource.DASHBOARDS,
         },
-      });
-      return;
-    }
-
-    router.push({
-      pathname: `/organizations/${organization.slug}/dashboards/new/widget/${index}/edit/`,
-      query: {
-        ...location.query,
-        source: DashboardWidgetSource.DASHBOARDS,
-      },
-    });
+      })
+    );
 
     return;
   };

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -33,6 +33,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import withApi from 'sentry/utils/withApi';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
 import {
@@ -174,13 +175,15 @@ class DashboardDetail extends Component<Props, State> {
           onEdit: () => {
             const widgetIndex = dashboard.widgets.indexOf(widget);
             if (dashboardId) {
-              router.push({
-                pathname: `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
-                query: {
-                  ...location.query,
-                  source: DashboardWidgetSource.DASHBOARDS,
-                },
-              });
+              router.push(
+                normalizeUrl({
+                  pathname: `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
+                  query: {
+                    ...location.query,
+                    source: DashboardWidgetSource.DASHBOARDS,
+                  },
+                })
+              );
               return;
             }
           },
@@ -464,13 +467,15 @@ class DashboardDetail extends Component<Props, State> {
     });
 
     if (dashboardId) {
-      router.push({
-        pathname: `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/new/`,
-        query: {
-          ...location.query,
-          source: DashboardWidgetSource.DASHBOARDS,
-        },
-      });
+      router.push(
+        normalizeUrl({
+          pathname: `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/new/`,
+          query: {
+            ...location.query,
+            source: DashboardWidgetSource.DASHBOARDS,
+          },
+        })
+      );
       return;
     }
   };

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -34,6 +34,7 @@ import {
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import useApi from 'sentry/utils/useApi';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withTags from 'sentry/utils/withTags';
 import {
@@ -730,7 +731,7 @@ function WidgetBuilder({
     nextWidgetList = generateWidgetsAfterCompaction(nextWidgetList);
 
     onSave(nextWidgetList);
-    router.push(previousLocation);
+    router.push(normalizeUrl(previousLocation));
   }
 
   async function handleSave() {
@@ -861,17 +862,21 @@ function WidgetBuilder({
         : undefined;
 
     if (id === NEW_DASHBOARD_ID) {
-      router.push({
-        pathname: `/organizations/${organization.slug}/dashboards/new/`,
-        query: pathQuery,
-      });
+      router.push(
+        normalizeUrl({
+          pathname: `/organizations/${organization.slug}/dashboards/new/`,
+          query: pathQuery,
+        })
+      );
       return;
     }
 
-    router.push({
-      pathname: `/organizations/${organization.slug}/dashboard/${id}/`,
-      query: pathQuery,
-    });
+    router.push(
+      normalizeUrl({
+        pathname: `/organizations/${organization.slug}/dashboard/${id}/`,
+        query: pathQuery,
+      })
+    );
   }
 
   function isFormInvalid() {

--- a/static/app/views/integrationOrganizationLink.tsx
+++ b/static/app/views/integrationOrganizationLink.tsx
@@ -20,6 +20,7 @@ import {
   trackIntegrationAnalytics,
 } from 'sentry/utils/integrationUtil';
 import {singleLineRenderer} from 'sentry/utils/marked';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import AsyncView from 'sentry/views/asyncView';
 import AddIntegration from 'sentry/views/organizationIntegrations/addIntegration';
 
@@ -132,7 +133,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
     const {organization} = this.state;
     const orgId = organization && organization.slug;
     this.props.router.push(
-      `/settings/${orgId}/integrations/${data.provider.key}/${data.id}/`
+      normalizeUrl(`/settings/${orgId}/integrations/${data.provider.key}/${data.id}/`)
     );
   };
 

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -37,6 +37,7 @@ import withRouteAnalytics, {
   WithRouteAnalyticsProps,
 } from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import withApi from 'sentry/utils/withApi';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 import {ERROR_TYPES} from './constants';
 import GroupHeader from './header';
@@ -623,7 +624,7 @@ class GroupDetails extends Component<Props, State> {
       if (group.id !== event?.groupID && !eventError) {
         // if user pastes only the event id into the url, but it's from another group, redirect to correct group/event
         const redirectUrl = `/organizations/${organization.slug}/issues/${event?.groupID}/events/${event?.id}/`;
-        router.push(redirectUrl);
+        router.push(normalizeUrl(redirectUrl));
       } else {
         childProps = {
           ...childProps,

--- a/static/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -12,6 +12,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Integration, IntegrationProvider, ObjectStatus} from 'sentry/types';
 import {getAlertText} from 'sentry/utils/integrationUtil';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
@@ -126,7 +127,9 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     // send the user to the configure integration view for that integration
     const {orgId} = this.props.params;
     this.props.router.push(
-      `/settings/${orgId}/integrations/${integration.provider.key}/${integration.id}/`
+      normalizeUrl(
+        `/settings/${orgId}/integrations/${integration.provider.key}/${integration.id}/`
+      )
     );
   };
 

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -8,6 +8,7 @@ import ContextPickerModal from 'sentry/components/contextPickerModal';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {PluginProjectItem, PluginWithProjectList} from 'sentry/types';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
@@ -115,7 +116,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
           needOrg={false}
           onFinish={path => {
             modalProps.closeModal();
-            router.push(path);
+            router.push(normalizeUrl(path));
           }}
         />
       ),

--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -41,6 +41,7 @@ import {formatVersion} from 'sentry/utils/formatters';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {getAdoptionSeries, getCount} from 'sentry/utils/sessions';
 import withApi from 'sentry/utils/withApi';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {sessionDisplayToField} from 'sentry/views/releases/list/releasesRequest';
 
 import {ReleasesDisplayOption} from './releasesDisplayOptions';
@@ -120,12 +121,14 @@ class ReleasesAdoptionChart extends Component<Props> {
 
     const project = selection.projects[0];
 
-    router.push({
-      pathname: `/organizations/${organization?.slug}/releases/${encodeURIComponent(
-        params.seriesId
-      )}/`,
-      query: {project, environment: location.query.environment},
-    });
+    router.push(
+      normalizeUrl({
+        pathname: `/organizations/${organization?.slug}/releases/${encodeURIComponent(
+          params.seriesId
+        )}/`,
+        query: {project, environment: location.query.environment},
+      })
+    );
   };
 
   renderEmpty() {

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -27,6 +27,7 @@ import {Member, Organization, Team} from 'sentry/types';
 import isMemberDisabledFromLimit from 'sentry/utils/isMemberDisabledFromLimit';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import Teams from 'sentry/utils/teams';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -169,7 +170,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
 
     try {
       await Promise.all(requests);
-      router.push(`/settings/${organization.slug}/members/`);
+      router.push(normalizeUrl(`/settings/${organization.slug}/members/`));
       addSuccessMessage(t('All authenticators have been removed'));
     } catch (err) {
       addErrorMessage(t('Error removing authenticators'));


### PR DESCRIPTION
When pushing onto history with string URLs we need to call normalizeUrl() so that URLs are correct for customers with customer-domains active.

Spread operations using `location` don't need to be updated as we can assume that the current URL pathname is correct.