### PR TITLE
fix(flamegraph): clear state when clicking between views

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
@@ -68,7 +68,9 @@ export function FlamegraphSpanTooltip({
         />
         {spanChart.formatter(hoveredNode.duration)}{' '}
         {formatWeightToTransactionDuration(hoveredNode, spanChart)}{' '}
-        {hoveredNode.node.span.description}
+        {hoveredNode.node.span.op === 'missing instrumentation'
+          ? t('Missing instrumentation')
+          : hoveredNode.node.span.description}
       </FlamegraphTooltipFrameMainInfo>
       <FlamegraphTooltipTimelineInfo>
         {hoveredNode.node.span.op ? `${t('op')}:${hoveredNode.node.span.op} ` : null}

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -333,6 +333,23 @@ export function FlamegraphSpans({
     [configSpaceCursor, hoveredNode, spansView, canvasPoolManager, lastInteraction]
   );
 
+  // When a user click anywhere outside the spans, clear cursor and selected node
+  useEffect(() => {
+    const onClickOutside = (evt: MouseEvent) => {
+      if (!spansCanvasRef || spansCanvasRef.contains(evt.target as Node)) {
+        return;
+      }
+      canvasPoolManager.dispatch('highlight span', [null, 'selected']);
+      setConfigSpaceCursor(null);
+    };
+
+    document.addEventListener('click', onClickOutside);
+
+    return () => {
+      document.removeEventListener('click', onClickOutside);
+    };
+  });
+
   return (
     <Fragment>
       <Canvas

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -109,15 +109,15 @@ export const LCH_DARK = {
 };
 
 const SPAN_LCH_LIGHT = {
-  C_0: 0.25,
-  C_d: 0.2,
-  L_0: 0.7,
-  L_d: 0.25,
+  C_0: 0.3,
+  C_d: 0.25,
+  L_0: 0.8,
+  L_d: 0.15,
 };
 
 const SPANS_LCH_DARK = {
-  C_0: 0.2,
-  C_d: 0.1,
+  C_0: 0.3,
+  C_d: 0.15,
   L_0: 0.2,
   L_d: 0.1,
 };
@@ -138,7 +138,7 @@ const SIZES: FlamegraphTheme['SIZES'] = {
   MINIMAP_HEIGHT: 100,
   MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: 2,
   SPANS_HEIGHT: 160,
-  SPANS_BAR_HEIGHT: 16,
+  SPANS_BAR_HEIGHT: 20,
   SPANS_FONT_SIZE: 11,
   TIMELINE_HEIGHT: 20,
   TOOLTIP_FONT_SIZE: 12,


### PR DESCRIPTION
Clear any state when user clicks outside of the container