### PR TITLE
ref: Pass in a full Project object to trackView inside OrgGroupDetails

### DIFF
--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -186,7 +186,7 @@ class GroupDetails extends Component<Props, State> {
       group_has_replay: Boolean(group?.tags?.find(({key}) => key === 'replayId')),
       num_comments: group ? group.numComments : -1,
       project_has_replay: project.hasReplays,
-      project_has_minified_stack_trace: group?.project.hasMinifiedStackTrace,
+      project_has_minified_stack_trace: project.hasMinifiedStackTrace,
       project_platform: group?.project.platform,
       has_external_issue: group?.annotations ? group?.annotations.length > 0 : false,
       has_owner: group?.owners ? group?.owners.length > 0 : false,


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/41027 I was trying to add some logging for whether an project has replays or not, but the `project` vars inside `traceView()` all come from the Groups endpoint: they're not fully hydrated projects, instead they only have these 4 fields `{id, name, platform, slug}`.


So in order to fix the logging, and make typescript a little happier, i've passed in a fully hydrated Project object that we can get from `this.props.projects`. Before typescript was picking up the `any` type from `data.project`, so a lot of downstream code wasn't doing any typechecks at all.