### PR TITLE
fix(integrations): Remove duplicate assignees from message assignments

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -109,7 +109,8 @@ def build_tag_fields(
 
 
 def get_option_groups(group: Group) -> Sequence[Mapping[str, Any]]:
-    members = user_service.get_from_group(group)
+    all_members = user_service.get_from_group(group)
+    members = {m.id: m for m in all_members}.values()
     teams = group.project.teams.all()
 
     option_groups = []

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -110,7 +110,7 @@ def build_tag_fields(
 
 def get_option_groups(group: Group) -> Sequence[Mapping[str, Any]]:
     all_members = user_service.get_from_group(group)
-    members = {m.id: m for m in all_members}.values()
+    members = list({m.id: m for m in all_members}.values())
     teams = group.project.teams.all()
 
     option_groups = []


### PR DESCRIPTION
This PR addresses a bug where users were appearing in duplicate on slack notifications. This occurred if they were in multiple teams that could be assigned to an issue. Now, we will ensure they're distinct before sending them in the slack message.

A test was added to prevent regression