### PR TITLE
ref(js): Export Button as named export

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -482,4 +482,4 @@ const Icon = styled('span')<IconProps & Omit<StyledButtonProps, 'theme'>>`
 /**
  * Also export these styled components so we can use them as selectors
  */
-export {StyledButton, ButtonLabel, Icon};
+export {Button, StyledButton, ButtonLabel, Icon};


### PR DESCRIPTION
I'm going to remove the default export here and later add `LinkButton`
which will make typing on the button much better.