### PR TITLE
feat(scim): set team idp_provisioned field via scim

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -158,7 +158,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                     team = Team.objects.create(
                         name=result.get("name") or result["slug"],
                         slug=result.get("slug"),
-                        idp_provisioned=result.get("idp_provisioned"),
+                        idp_provisioned=result.get("idp_provisioned", False),
                         organization=organization,
                     )
             except IntegrityError:

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -48,6 +48,7 @@ class TeamPostSerializer(serializers.Serializer):
             )
         },
     )
+    idp_provisioned = serializers.BooleanField(required=False, default=False)
 
     def validate(self, attrs):
         if not (attrs.get("name") or attrs.get("slug")):
@@ -157,6 +158,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                     team = Team.objects.create(
                         name=result.get("name") or result["slug"],
                         slug=result.get("slug"),
+                        idp_provisioned=result.get("idp_provisioned"),
                         organization=organization,
                     )
             except IntegrityError:

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -393,7 +393,6 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         try:
             with transaction.atomic():
                 team.idp_provisioned = True
-                team.save()
 
                 for operation in operations:
                     op = operation["op"].lower()

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -393,6 +393,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         try:
             with transaction.atomic():
                 team.idp_provisioned = True
+                team.save()
 
                 for operation in operations:
                     op = operation["op"].lower()

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -193,7 +193,11 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
         # shim displayName from SCIM api in order to work with
         # our regular team index POST
         request.data.update(
-            {"name": request.data["displayName"], "slug": slugify(request.data["displayName"])}
+            {
+                "name": request.data["displayName"],
+                "slug": slugify(request.data["displayName"]),
+                "idp_provisioned": True,
+            }
         ),
         return super().post(request, organization)
 
@@ -388,6 +392,9 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             return Response(SCIM_400_TOO_MANY_PATCH_OPS_ERROR, status=400)
         try:
             with transaction.atomic():
+                team.idp_provisioned = True
+                team.save()
+
                 for operation in operations:
                     op = operation["op"].lower()
                     if op == TeamPatchOps.ADD and operation["path"] == "members":


### PR DESCRIPTION
Sets the `idp_provisioned` field on the `Team` model when creating or patching a team through SCIM.