### PR TITLE
fix(useOverlay): Fix overlay flicker on touch devices

### DIFF
--- a/static/app/components/dropdownMenuControl.tsx
+++ b/static/app/components/dropdownMenuControl.tsx
@@ -157,11 +157,7 @@ function DropdownMenuControl({
     position,
     isDismissable: !isSubmenu && isDismissable,
     shouldCloseOnBlur: !isSubmenu && shouldCloseOnBlur,
-    shouldCloseOnInteractOutside: target =>
-      !isSubmenu &&
-      target &&
-      triggerRef.current !== target &&
-      !triggerRef.current?.contains(target),
+    shouldCloseOnInteractOutside: () => !isSubmenu,
     // Necessary for submenus to be correctly positioned
     ...(isSubmenu && {preventOverflowOptions: {boundary: document.body, altAxis: true}}),
   });

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -173,7 +173,7 @@ function useOverlay({
       open && popperUpdate?.();
     },
   });
-  const {buttonProps} = useButton({onPress: openState.open}, triggerRef);
+  const {buttonProps} = useButton({onPress: openState.toggle}, triggerRef);
   const {triggerProps, overlayProps: overlayTriggerProps} = useOverlayTrigger(
     {type},
     openState,
@@ -191,7 +191,11 @@ function useOverlay({
       isDismissable,
       shouldCloseOnBlur,
       isKeyboardDismissDisabled,
-      shouldCloseOnInteractOutside,
+      shouldCloseOnInteractOutside: target =>
+        target &&
+        triggerRef.current !== target &&
+        !triggerRef.current?.contains(target) &&
+        (shouldCloseOnInteractOutside?.(target) ?? true),
     },
     overlayRef
   );


### PR DESCRIPTION
When not configured properly, overlays implemented with `useOverlay` will flicker and not close when pressing on the trigger button on touch devices:
https://user-images.githubusercontent.com/44172267/211688000-b05839bc-d38c-4319-a584-b49b4cc7b32e.mov

So far this problem only affects `DropdownMenuControl`, for which I've implemented a fix. This PR applies that same fix to `useOverlay`, so in the future all components that use `useOverlay` will work as expected, not just `DropdownMenuControl`:
https://user-images.githubusercontent.com/44172267/211689057-7886ed8f-6042-4050-972f-4906ccb109e2.mov

