### PR TITLE
feat(profiling): allow minWidth override

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -263,7 +263,10 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
         !position.view.isEmpty() &&
         previousView?.model === FALLBACK_FLAMEGRAPH
       ) {
-        newView.setConfigView(position.view);
+        // We allow min width to be initialize to lower than view.minWidth because
+        // there is a chance that user zoomed into a span duration which may have been updated
+        // after the model was loaded (see L320)
+        newView.setConfigView(position.view, {width: {min: 0}});
       }
 
       return newView;
@@ -297,7 +300,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       });
 
       // Initialize configView to whatever the flamegraph configView is
-      newView.setConfigView(flamegraphView?.configView);
+      newView.setConfigView(flamegraphView.configView, {width: {min: 0}});
 
       return newView;
     },

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -98,15 +98,23 @@ export class CanvasView<T extends {configSpace: Rect}> {
     this._initConfigView(canvas, this.configSpace);
   }
 
-  setConfigView(configView: Rect) {
+  setConfigView(
+    configView: Rect,
+    overrides?: {
+      width: {max?: number; min?: number};
+      height?: {max?: number; min?: number};
+    }
+  ) {
     this.configView = computeClampedConfigView(configView, {
       width: {
         min: this.minWidth,
         max: this.configSpace.width,
+        ...(overrides?.width ?? {}),
       },
       height: {
         min: 0,
         max: this.configSpace.height,
+        ...(overrides?.height ?? {}),
       },
     });
   }


### PR DESCRIPTION
There is a chance users may zoom into deeper than min width of a frame (after spans have rendered and minWidth was updated) so we need to allow an override.