### PR TITLE
ref(replays): Set estimatedRowSize and use registerChild when rendering virtual grid

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -10,9 +10,7 @@ import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import NetworkFilters from 'sentry/views/replays/detail/network/networkFilters';
 import NetworkHeaderCell, {
-  BODY_HEIGHT,
   COLUMN_COUNT,
-  HEADER_HEIGHT,
 } from 'sentry/views/replays/detail/network/networkHeaderCell';
 import NetworkTableCell from 'sentry/views/replays/detail/network/networkTableCell';
 import useNetworkFilters from 'sentry/views/replays/detail/network/useNetworkFilters';
@@ -20,6 +18,9 @@ import useSortNetwork from 'sentry/views/replays/detail/network/useSortNetwork';
 import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import useVirtualizedGrid from 'sentry/views/replays/detail/useVirtualizedGrid';
 import type {NetworkSpan} from 'sentry/views/replays/types';
+
+const HEADER_HEIGHT = 25;
+const BODY_HEIGHT = 28;
 
 type Props = {
   networkSpans: undefined | NetworkSpan[];

--- a/static/app/views/replays/detail/network/networkHeaderCell.tsx
+++ b/static/app/views/replays/detail/network/networkHeaderCell.tsx
@@ -14,9 +14,6 @@ type Props = {
   style: CSSProperties;
 };
 
-export const HEADER_HEIGHT = 25;
-export const BODY_HEIGHT = 28;
-
 const COLUMNS: {
   field: SortConfig['by'];
   label: string;

--- a/static/app/views/replays/detail/network/networkHeaderCell.tsx
+++ b/static/app/views/replays/detail/network/networkHeaderCell.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties} from 'react';
+import {CSSProperties, forwardRef} from 'react';
 import styled from '@emotion/styled';
 
 import {IconArrow} from 'sentry/icons';
@@ -15,6 +15,7 @@ type Props = {
 };
 
 export const HEADER_HEIGHT = 25;
+export const BODY_HEIGHT = 28;
 
 const COLUMNS: {
   field: SortConfig['by'];
@@ -68,4 +69,4 @@ const HeaderButton = styled('button')`
   }
 `;
 
-export default NetworkHeaderCell;
+export default forwardRef<HTMLButtonElement, Props>(NetworkHeaderCell);

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties} from 'react';
+import {CSSProperties, forwardRef} from 'react';
 import styled from '@emotion/styled';
 
 import FileSize from 'sentry/components/fileSize';
@@ -176,4 +176,4 @@ const Text = styled('div')`
   overflow: hidden;
 `;
 
-export default NetworkTableCell;
+export default forwardRef<HTMLDivElement, Props>(NetworkTableCell);


### PR DESCRIPTION
I'm not sure if this really fixes things or not. In prod the virtual grid has trouble rendering many items, but in dev it's more reliable.

This adds some props to the virtual MultiGrid to try to help it out. 
See: https://github.com/bvaughn/react-virtualized/blob/master/docs/CellMeasurer.md#render-props
https://github.com/bvaughn/react-virtualized/blob/master/docs/MultiGrid.md

Related to #[#43043](https://github.com/getsentry/sentry/issues/43043)

