### PR TITLE
ref(ui): Use IconChevron for PlatformHeaderButtonBar

### DIFF
--- a/static/app/views/projectInstall/components/platformHeaderButtonBar.tsx
+++ b/static/app/views/projectInstall/components/platformHeaderButtonBar.tsx
@@ -1,16 +1,22 @@
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 type Props = {
   docsLink: string;
   gettingStartedLink: string;
 };
+
 export default function PlatformHeaderButtonBar({gettingStartedLink, docsLink}: Props) {
   return (
     <ButtonBar gap={1}>
-      <Button size="sm" to={gettingStartedLink}>
-        {t('< Back')}
+      <Button
+        size="sm"
+        icon={<IconChevron size="xs" direction="left" />}
+        to={gettingStartedLink}
+      >
+        {t('Back')}
       </Button>
       <Button size="sm" href={docsLink} external>
         {t('Full Documentation')}


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/211724874-77912698-7668-499b-8c94-220fe430e4b4.png)


After
![image](https://user-images.githubusercontent.com/1421724/211724826-a2f5b565-b330-4729-89d6-075220ff0c08.png)

It looks slightly less nice, but is consistent IMO