### PR TITLE
style(js): Remove spaces between types in PanelTableProps

### DIFF
--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -13,20 +13,16 @@ export type PanelTableProps = {
    * Headers of the table.
    */
   headers: React.ReactNode[];
-
   /**
    * The body of the table. Make sure the number of children elements are
    * multiples of the length of headers.
    */
   children?: React.ReactNode | (() => React.ReactNode);
-
   className?: string;
-
   /**
    * Renders without predefined padding on the header and body cells
    */
   disablePadding?: boolean;
-
   /**
    * Action to display when isEmpty is true
    */
@@ -35,22 +31,18 @@ export type PanelTableProps = {
    * Message to use for `<EmptyStateWarning>`
    */
   emptyMessage?: React.ReactNode;
-
   /**
    * Displays an `<EmptyStateWarning>` if true
    */
   isEmpty?: boolean;
-
   /**
    * If this is true, then display a loading indicator
    */
   isLoading?: boolean;
-
   /**
    * A custom loading indicator.
    */
   loader?: React.ReactNode;
-
   /**
    * If true, scrolling headers out of view will pin to the top of container.
    */


### PR DESCRIPTION
This is how we usually do it

We should write a lint with fixer for it probably