### PR TITLE
fix(ui): Consistent size for inviteRowControl remove button

### DIFF
--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -129,7 +129,6 @@ function InviteRowControl({
       <Button
         borderless
         icon={<IconClose />}
-        size="zero"
         onClick={onRemove}
         disabled={disableRemove}
         aria-label={t('Remove')}


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/211723823-c6f230a9-16f3-44d4-9ac5-f266a7e2c393.png)

After
![image](https://user-images.githubusercontent.com/1421724/211723881-6c1ba6c2-6089-431e-822a-6a76a28bfc98.png)

I'll open another PR to make the modal a bit wider too