### PR TITLE
feat(ui): Make inviteMembersModal wider

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -515,7 +515,7 @@ const StatusMessage = styled('div')<{status?: 'success' | 'error'}>`
 
 export const modalCss = css`
   width: 100%;
-  max-width: 800px;
+  max-width: 900px;
   margin: 50px auto;
 `;
 


### PR DESCRIPTION
Follow up for https://github.com/getsentry/sentry/pull/43079 since the close button used a bit more space here to be consistent

we probably want it a bit bigger anyway.