### PR TITLE
fix(ui): Consistently use Layout.* on main views

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -51,6 +51,7 @@ export const HeaderActions = styled('div')`
   flex-direction: column;
   justify-content: normal;
   min-width: max-content;
+  margin-top: ${space(0.25)};
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     width: max-content;

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PageHeading from 'sentry/components/pageHeading';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {Member, Organization, Project} from 'sentry/types';
@@ -118,9 +119,8 @@ class Create extends Component<Props, State> {
     return (
       <Fragment>
         <SentryDocumentTitle title={title} projectSlug={project.slug} />
-
         <Layout.Header>
-          <StyledHeaderContent>
+          <Layout.HeaderContent>
             <BuilderBreadCrumbs
               organization={organization}
               alertName={t('Set Conditions')}
@@ -131,12 +131,12 @@ class Create extends Component<Props, State> {
               location={location}
               canChangeProject
             />
-            <Layout.Title>
+            <StyledHeading>
               {wizardAlertType
                 ? `${t('Set Conditions for')} ${AlertWizardAlertNames[wizardAlertType]}`
                 : title}
-            </Layout.Title>
-          </StyledHeaderContent>
+            </StyledHeading>
+          </Layout.HeaderContent>
         </Layout.Header>
         <Body>
           <Teams provideUserTeams>
@@ -185,8 +185,8 @@ class Create extends Component<Props, State> {
   }
 }
 
-const StyledHeaderContent = styled(Layout.HeaderContent)`
-  overflow: visible;
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const Body = styled(Layout.Body)`

--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PageHeading from 'sentry/components/pageHeading';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {Member, Organization, Project} from 'sentry/types';
@@ -80,7 +81,7 @@ class ProjectAlertsEditor extends Component<Props, State> {
               routes={routes}
               location={location}
             />
-            <Layout.Title>{this.getTitle()}</Layout.Title>
+            <StyledHeading>{this.getTitle()}</StyledHeading>
           </Layout.HeaderContent>
         </Layout.Header>
         <EditConditionsBody>
@@ -121,6 +122,10 @@ const EditConditionsBody = styled(Layout.Body)`
   *:not(img) {
     max-width: 1000px;
   }
+`;
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 export default ProjectAlertsEditor;

--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -8,11 +8,11 @@ import CreateAlertButton from 'sentry/components/createAlertButton';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
+import PageHeading from 'sentry/components/pageHeading';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import space from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -44,7 +44,7 @@ const AlertHeader = ({router, activeTab}: Props) => {
   return (
     <Layout.Header>
       <Layout.HeaderContent>
-        <StyledLayoutTitle>
+        <StyledHeading>
           {t('Alerts')}
           <PageHeadingQuestionTooltip
             title={tct(
@@ -52,10 +52,10 @@ const AlertHeader = ({router, activeTab}: Props) => {
               {link: <ExternalLink href="https://docs.sentry.io/product/alerts/" />}
             )}
           />
-        </StyledLayoutTitle>
+        </StyledHeading>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
-        <Actions gap={1}>
+        <ButtonBar gap={1}>
           <CreateAlertButton
             organization={organization}
             iconProps={{size: 'sm'}}
@@ -78,7 +78,7 @@ const AlertHeader = ({router, activeTab}: Props) => {
             icon={<IconSettings size="sm" />}
             aria-label={t('Settings')}
           />
-        </Actions>
+        </ButtonBar>
       </Layout.HeaderActions>
       <Layout.HeaderNavTabs underlined>
         {alertRulesLink}
@@ -94,10 +94,6 @@ const AlertHeader = ({router, activeTab}: Props) => {
 
 export default AlertHeader;
 
-const StyledLayoutTitle = styled(Layout.Title)`
-  margin-top: ${space(0.5)};
-`;
-
-const Actions = styled(ButtonBar)`
-  height: 32px;
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;

--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -3,11 +3,12 @@ import styled from '@emotion/styled';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import IdBadge from 'sentry/components/idBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
 import PageHeading from 'sentry/components/pageHeading';
 import {IconCopy, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {MetricRule} from 'sentry/views/alerts/rules/metric/types';
@@ -41,24 +42,14 @@ function DetailsHeader({hasMetricRuleDetailsError, rule, organization, project}:
   };
 
   return (
-    <Header>
-      <BreadCrumbBar>
-        <AlertBreadcrumbs
+    <Layout.Header>
+      <Layout.HeaderContent>
+        <Breadcrumbs
           crumbs={[
             {label: t('Alerts'), to: `/organizations/${organization.slug}/alerts/rules/`},
             {label: ruleTitle},
           ]}
         />
-        <Controls>
-          <Button size="sm" icon={<IconCopy />} to={duplicateLink}>
-            {t('Duplicate')}
-          </Button>
-          <Button size="sm" icon={<IconEdit />} to={settingsLink}>
-            {t('Edit Rule')}
-          </Button>
-        </Controls>
-      </BreadCrumbBar>
-      <Details>
         <RuleTitle data-test-id="incident-rule-title" loading={!isRuleReady}>
           {project && (
             <IdBadge
@@ -70,56 +61,28 @@ function DetailsHeader({hasMetricRuleDetailsError, rule, organization, project}:
           )}
           {ruleTitle}
         </RuleTitle>
-      </Details>
-    </Header>
+      </Layout.HeaderContent>
+      <Layout.HeaderActions>
+        <ButtonBar gap={1}>
+          <Button size="sm" icon={<IconCopy />} to={duplicateLink}>
+            {t('Duplicate')}
+          </Button>
+          <Button size="sm" icon={<IconEdit />} to={settingsLink}>
+            {t('Edit Rule')}
+          </Button>
+        </ButtonBar>
+      </Layout.HeaderActions>
+    </Layout.Header>
   );
 }
 
 export default DetailsHeader;
 
-const Header = styled('div')`
-  background-color: ${p => p.theme.backgroundSecondary};
-  border-bottom: 1px solid ${p => p.theme.border};
-`;
-
-const BreadCrumbBar = styled('div')`
-  display: flex;
-  margin-bottom: 0;
-  padding: ${space(2)} ${space(4)} ${space(1)};
-`;
-
-const AlertBreadcrumbs = styled(Breadcrumbs)`
-  flex-grow: 1;
-  font-size: ${p => p.theme.fontSizeExtraLarge};
-  padding: 0;
-`;
-
-const Controls = styled('div')`
-  display: grid;
-  grid-auto-flow: column;
-  gap: ${space(1)};
-`;
-
-const Details = styled(PageHeader)`
-  margin-bottom: 0;
-  padding: ${space(1.5)} ${space(4)} ${space(2)};
-
-  grid-template-columns: max-content auto;
-  display: grid;
-  gap: ${space(3)};
-  grid-auto-flow: column;
-
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    grid-template-columns: auto;
-    grid-auto-flow: row;
-  }
-`;
-
 const RuleTitle = styled(PageHeading, {
   shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'loading',
 })<{loading: boolean}>`
   ${p => p.loading && 'opacity: 0'};
-  line-height: 1.5;
+  line-height: 40px;
   display: grid;
   grid-template-columns: max-content 1fr;
   grid-column-gap: ${space(1)};

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -10,10 +10,11 @@ import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import CompactSelect from 'sentry/components/compactSelect';
-import {Title} from 'sentry/components/layouts/thirds';
+import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageHeading from 'sentry/components/pageHeading';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -276,9 +277,9 @@ class ManageDashboards extends AsyncView<Props, State> {
         <SentryDocumentTitle title={t('Dashboards')} orgSlug={organization.slug}>
           <StyledPageContent>
             <NoProjectMessage organization={organization}>
-              <PageContent>
-                <StyledPageHeader>
-                  <StyledTitle>
+              <Layout.Header>
+                <Layout.HeaderContent>
+                  <StyledHeading>
                     {t('Dashboards')}
                     <PageHeadingQuestionTooltip
                       title={tct(
@@ -290,7 +291,9 @@ class ManageDashboards extends AsyncView<Props, State> {
                         }
                       )}
                     />
-                  </StyledTitle>
+                  </StyledHeading>
+                </Layout.HeaderContent>
+                <Layout.HeaderActions>
                   <ButtonBar gap={1.5}>
                     <TemplateSwitch>
                       {t('Show Templates')}
@@ -313,11 +316,15 @@ class ManageDashboards extends AsyncView<Props, State> {
                       {t('Create Dashboard')}
                     </Button>
                   </ButtonBar>
-                </StyledPageHeader>
-                {showTemplates && this.renderTemplates()}
-                {this.renderActions()}
-                {this.renderDashboards()}
-              </PageContent>
+                </Layout.HeaderActions>
+              </Layout.Header>
+              <Layout.Body>
+                <Layout.Main fullWidth>
+                  {showTemplates && this.renderTemplates()}
+                  {this.renderActions()}
+                  {this.renderDashboards()}
+                </Layout.Main>
+              </Layout.Body>
             </NoProjectMessage>
           </StyledPageContent>
         </SentryDocumentTitle>
@@ -326,19 +333,12 @@ class ManageDashboards extends AsyncView<Props, State> {
   }
 }
 
-const StyledTitle = styled(Title)`
-  width: auto;
-`;
-
 const StyledPageContent = styled(PageContent)`
   padding: 0;
 `;
 
-const StyledPageHeader = styled('div')`
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  margin-bottom: ${space(2)};
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const StyledActions = styled('div')`
@@ -365,7 +365,7 @@ const TemplateSwitch = styled('label')`
 const TemplateContainer = styled('div')`
   display: grid;
   gap: ${space(2)};
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(0.5)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: repeat(2, minmax(200px, 1fr));

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -11,6 +11,7 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Button from 'sentry/components/button';
 import CompactSelect from 'sentry/components/compactSelect';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {Title} from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SearchBar from 'sentry/components/searchBar';
@@ -297,8 +298,8 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         <SentryDocumentTitle title={t('Discover')} orgSlug={organization.slug}>
           <StyledPageContent>
             <NoProjectMessage organization={organization}>
-              <PageContent>
-                <StyledPageHeader>
+              <Layout.Header>
+                <Layout.HeaderContent>
                   {organization.features.includes(
                     'discover-query-builder-as-landing-page'
                   ) ? (
@@ -310,7 +311,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
                       </GuideAnchor>
                     </Title>
                   )}
-                  <StyledButton
+                </Layout.HeaderContent>
+                <Layout.HeaderActions>
+                  <Button
                     data-test-id="build-new-query"
                     to={to}
                     size="sm"
@@ -322,12 +325,16 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
                     }}
                   >
                     {t('Build a new query')}
-                  </StyledButton>
-                </StyledPageHeader>
-                {this.renderBanner()}
-                {this.renderActions()}
-                {this.renderComponent()}
-              </PageContent>
+                  </Button>
+                </Layout.HeaderActions>
+              </Layout.Header>
+              <Layout.Body>
+                <Layout.Main fullWidth>
+                  {this.renderBanner()}
+                  {this.renderActions()}
+                  {this.renderComponent()}
+                </Layout.Main>
+              </Layout.Body>
             </NoProjectMessage>
           </StyledPageContent>
         </SentryDocumentTitle>
@@ -348,15 +355,6 @@ const SwitchLabel = styled('div')`
   padding-right: 8px;
 `;
 
-const StyledPageHeader = styled('div')`
-  display: flex;
-  align-items: flex-end;
-  font-size: ${p => p.theme.headerFontSize};
-  color: ${p => p.theme.textColor};
-  justify-content: space-between;
-  margin-bottom: ${space(2)};
-`;
-
 const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
 `;
@@ -371,10 +369,6 @@ const StyledActions = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: auto;
   }
-`;
-
-const StyledButton = styled(Button)`
-  white-space: nowrap;
 `;
 
 export default withOrganization(DiscoverLanding);

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -32,7 +32,6 @@ import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters, SavedQuery} from 'sentry/types';
 import {defined, generateQueryWithTag} from 'sentry/utils';
@@ -585,118 +584,109 @@ export class Results extends Component<Props, State> {
 
     return (
       <SentryDocumentTitle title={title} orgSlug={organization.slug}>
-        <StyledPageContent>
-          <NoProjectMessage organization={organization}>
-            <ResultsHeader
-              setSavedQuery={setSavedQuery}
-              errorCode={errorCode}
-              organization={organization}
-              location={location}
-              eventView={eventView}
-              yAxis={yAxisArray}
-              router={router}
-              isHomepage={isHomepage}
-            />
-            <Layout.Body>
-              <CustomMeasurementsProvider
-                organization={organization}
-                selection={selection}
-              >
-                <Top fullWidth>
-                  {this.renderMetricsFallbackBanner()}
-                  {this.renderError(error)}
-                  {this.renderTips()}
-                  <StyledPageFilterBar condensed>
-                    <ProjectPageFilter />
-                    <EnvironmentPageFilter />
-                    <DatePageFilter alignDropdown="left" />
-                  </StyledPageFilterBar>
-                  <CustomMeasurementsContext.Consumer>
-                    {contextValue => (
-                      <StyledSearchBar
-                        searchSource="eventsv2"
-                        organization={organization}
-                        projectIds={eventView.project}
-                        query={query}
-                        fields={fields}
-                        onSearch={this.handleSearch}
-                        maxQueryLength={MAX_QUERY_LENGTH}
-                        customMeasurements={contextValue?.customMeasurements ?? undefined}
-                      />
-                    )}
-                  </CustomMeasurementsContext.Consumer>
-                  <MetricsCardinalityProvider
-                    organization={organization}
-                    location={location}
-                  >
-                    <ResultsChart
-                      api={api}
-                      router={router}
+        <NoProjectMessage organization={organization}>
+          <ResultsHeader
+            setSavedQuery={setSavedQuery}
+            errorCode={errorCode}
+            organization={organization}
+            location={location}
+            eventView={eventView}
+            yAxis={yAxisArray}
+            router={router}
+            isHomepage={isHomepage}
+          />
+          <Layout.Body>
+            <CustomMeasurementsProvider organization={organization} selection={selection}>
+              <Top fullWidth>
+                {this.renderMetricsFallbackBanner()}
+                {this.renderError(error)}
+                {this.renderTips()}
+                <StyledPageFilterBar condensed>
+                  <ProjectPageFilter />
+                  <EnvironmentPageFilter />
+                  <DatePageFilter alignDropdown="left" />
+                </StyledPageFilterBar>
+                <CustomMeasurementsContext.Consumer>
+                  {contextValue => (
+                    <StyledSearchBar
+                      searchSource="eventsv2"
                       organization={organization}
-                      eventView={eventView}
-                      location={location}
-                      onAxisChange={this.handleYAxisChange}
-                      onDisplayChange={this.handleDisplayChange}
-                      onTopEventsChange={this.handleTopEventsChange}
-                      onIntervalChange={this.handleIntervalChange}
-                      total={totalValues}
-                      confirmedQuery={confirmedQuery}
-                      yAxis={yAxisArray}
+                      projectIds={eventView.project}
+                      query={query}
+                      fields={fields}
+                      onSearch={this.handleSearch}
+                      maxQueryLength={MAX_QUERY_LENGTH}
+                      customMeasurements={contextValue?.customMeasurements ?? undefined}
                     />
-                  </MetricsCardinalityProvider>
-                </Top>
-                <Layout.Main fullWidth={!showTags}>
-                  <Table
+                  )}
+                </CustomMeasurementsContext.Consumer>
+                <MetricsCardinalityProvider
+                  organization={organization}
+                  location={location}
+                >
+                  <ResultsChart
+                    api={api}
+                    router={router}
                     organization={organization}
                     eventView={eventView}
                     location={location}
-                    title={title}
-                    setError={this.setError}
-                    onChangeShowTags={this.handleChangeShowTags}
-                    showTags={showTags}
+                    onAxisChange={this.handleYAxisChange}
+                    onDisplayChange={this.handleDisplayChange}
+                    onTopEventsChange={this.handleTopEventsChange}
+                    onIntervalChange={this.handleIntervalChange}
+                    total={totalValues}
                     confirmedQuery={confirmedQuery}
-                    onCursor={this.handleCursor}
-                    isHomepage={isHomepage}
-                    setTips={(tips: string[]) => this.setState({tips})}
+                    yAxis={yAxisArray}
                   />
-                </Layout.Main>
-                {showTags ? this.renderTagsTable() : null}
-                <Confirm
-                  priority="primary"
-                  header={<strong>{t('May lead to thumb twiddling')}</strong>}
-                  confirmText={t('Do it')}
-                  cancelText={t('Nevermind')}
-                  onConfirm={this.handleConfirmed}
-                  onCancel={this.handleCancelled}
-                  message={
-                    <p>
-                      {tct(
-                        `You've created a query that will search for events made
+                </MetricsCardinalityProvider>
+              </Top>
+              <Layout.Main fullWidth={!showTags}>
+                <Table
+                  organization={organization}
+                  eventView={eventView}
+                  location={location}
+                  title={title}
+                  setError={this.setError}
+                  onChangeShowTags={this.handleChangeShowTags}
+                  showTags={showTags}
+                  confirmedQuery={confirmedQuery}
+                  onCursor={this.handleCursor}
+                  isHomepage={isHomepage}
+                  setTips={(tips: string[]) => this.setState({tips})}
+                />
+              </Layout.Main>
+              {showTags ? this.renderTagsTable() : null}
+              <Confirm
+                priority="primary"
+                header={<strong>{t('May lead to thumb twiddling')}</strong>}
+                confirmText={t('Do it')}
+                cancelText={t('Nevermind')}
+                onConfirm={this.handleConfirmed}
+                onCancel={this.handleCancelled}
+                message={
+                  <p>
+                    {tct(
+                      `You've created a query that will search for events made
                       [dayLimit:over more than 30 days] for [projectLimit:more than 10 projects].
                       A lot has happened during that time, so this might take awhile.
                       Are you sure you want to do this?`,
-                        {
-                          dayLimit: <strong />,
-                          projectLimit: <strong />,
-                        }
-                      )}
-                    </p>
-                  }
-                >
-                  {this.setOpenFunction}
-                </Confirm>
-              </CustomMeasurementsProvider>
-            </Layout.Body>
-          </NoProjectMessage>
-        </StyledPageContent>
+                      {
+                        dayLimit: <strong />,
+                        projectLimit: <strong />,
+                      }
+                    )}
+                  </p>
+                }
+              >
+                {this.setOpenFunction}
+              </Confirm>
+            </CustomMeasurementsProvider>
+          </Layout.Body>
+        </NoProjectMessage>
       </SentryDocumentTitle>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledPageFilterBar = styled(PageFilterBar)`
   margin-bottom: ${space(1)};

--- a/static/app/views/eventsV2/resultsHeader.tsx
+++ b/static/app/views/eventsV2/resultsHeader.tsx
@@ -9,9 +9,9 @@ import {fetchSavedQuery} from 'sentry/actionCreators/discoverSavedQueries';
 import {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
-import {Title} from 'sentry/components/layouts/thirds';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
+import PageHeading from 'sentry/components/pageHeading';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import TimeSince from 'sentry/components/timeSince';
 import {t, tct} from 'sentry/locale';
@@ -145,9 +145,9 @@ class ResultsHeader extends Component<Props, State> {
 
     return (
       <Layout.Header>
-        <StyledHeaderContent>
+        <Layout.HeaderContent>
           {isHomepage ? (
-            <StyledTitle>
+            <StyledHeading>
               <GuideAnchor target="discover_landing_header">
                 {t('Discover')}
                 <PageHeadingQuestionTooltip
@@ -161,7 +161,7 @@ class ResultsHeader extends Component<Props, State> {
                   )}
                 />
               </GuideAnchor>
-            </StyledTitle>
+            </StyledHeading>
           ) : (
             <Fragment>
               <DiscoverBreadcrumb
@@ -179,7 +179,7 @@ class ResultsHeader extends Component<Props, State> {
             </Fragment>
           )}
           {this.renderAuthor()}
-        </StyledHeaderContent>
+        </Layout.HeaderContent>
         <Layout.HeaderActions>
           <SavedQueryButtonGroup
             setSavedQuery={setSavedQuery}
@@ -222,17 +222,12 @@ const Subtitle = styled('h4')`
   margin: ${space(0.5)} 0 0 0;
 `;
 
-const StyledHeaderContent = styled(Layout.HeaderContent)`
-  overflow: unset;
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const BannerWrapper = styled('div')`
   grid-column: 1 / -1;
-`;
-
-const StyledTitle = styled(Title)`
-  overflow: unset;
-  margin-top: 0;
 `;
 
 export default withApi(ResultsHeader);

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -13,6 +13,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
@@ -107,9 +108,9 @@ class Monitors extends AsyncView<Props, State> {
       <StyledPageContent>
         <Layout.Header>
           <Layout.HeaderContent>
-            <HeaderTitle>
+            <StyledHeading>
               {t('Cron Monitors')} <FeatureBadge type="beta" />
-            </HeaderTitle>
+            </StyledHeading>
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
@@ -187,8 +188,8 @@ const StyledPageContent = styled(PageContent)`
   padding: 0;
 `;
 
-const HeaderTitle = styled(Layout.Title)`
-  margin-top: 0;
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const StyledLink = styled(Link)`

--- a/static/app/views/organizationActivity/index.tsx
+++ b/static/app/views/organizationActivity/index.tsx
@@ -1,7 +1,9 @@
 import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
@@ -60,31 +62,50 @@ class OrganizationActivity extends AsyncView<Props, State> {
     const {loading, activity, activityPageLinks} = this.state;
 
     return (
-      <PageContent>
-        <PageHeading withMargins>{t('Activity')}</PageHeading>
-        <Panel>
-          {loading && <LoadingIndicator />}
-          {!loading && !activity?.length && this.renderEmpty()}
-          {!loading && activity?.length > 0 && (
-            <div data-test-id="activity-feed-list">
-              {activity.map(item => (
-                <ErrorBoundary
-                  mini
-                  css={{marginBottom: space(1), borderRadius: 0}}
-                  key={item.id}
-                >
-                  <ActivityFeedItem organization={this.props.organization} item={item} />
-                </ErrorBoundary>
-              ))}
-            </div>
-          )}
-        </Panel>
-        {activityPageLinks && (
-          <Pagination pageLinks={activityPageLinks} {...this.props} />
-        )}
-      </PageContent>
+      <StyledPageContent>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <StyledHeading>{t('Activity')}</StyledHeading>
+          </Layout.HeaderContent>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <Panel>
+              {loading && <LoadingIndicator />}
+              {!loading && !activity?.length && this.renderEmpty()}
+              {!loading && activity?.length > 0 && (
+                <div data-test-id="activity-feed-list">
+                  {activity.map(item => (
+                    <ErrorBoundary
+                      mini
+                      css={{marginBottom: space(1), borderRadius: 0}}
+                      key={item.id}
+                    >
+                      <ActivityFeedItem
+                        organization={this.props.organization}
+                        item={item}
+                      />
+                    </ErrorBoundary>
+                  ))}
+                </div>
+              )}
+            </Panel>
+            {activityPageLinks && (
+              <Pagination pageLinks={activityPageLinks} {...this.props} />
+            )}
+          </Layout.Main>
+        </Layout.Body>
+      </StyledPageContent>
     );
   }
 }
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
 
 export default withOrganization(OrganizationActivity);

--- a/static/app/views/organizationStats/header.tsx
+++ b/static/app/views/organizationStats/header.tsx
@@ -4,9 +4,9 @@ import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
+import PageHeading from 'sentry/components/pageHeading';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {t, tct} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 
 type Props = {
@@ -18,7 +18,7 @@ function StatsHeader({organization, activeTab}: Props) {
   return (
     <Layout.Header>
       <Layout.HeaderContent>
-        <StyledLayoutTitle>
+        <StyledHeading>
           {t('Stats')}
           <PageHeadingQuestionTooltip
             title={tct(
@@ -26,7 +26,7 @@ function StatsHeader({organization, activeTab}: Props) {
               {link: <ExternalLink href="https://docs.sentry.io/product/stats/" />}
             )}
           />
-        </StyledLayoutTitle>
+        </StyledHeading>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         {activeTab !== 'stats' && (
@@ -54,6 +54,6 @@ function StatsHeader({organization, activeTab}: Props) {
 
 export default StatsHeader;
 
-const StyledLayoutTitle = styled(Layout.Title)`
-  margin-top: ${space(0.5)};
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -28,7 +28,6 @@ import {
 } from 'sentry/constants';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t, tct} from 'sentry/locale';
-import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {DataCategory, DateString, Organization, PageFilters, Project} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -344,28 +343,25 @@ export class OrganizationStats extends Component<Props> {
     return (
       <SentryDocumentTitle title="Usage Stats">
         <PageFiltersContainer>
-          {hasTeamInsights && (
+          {hasTeamInsights ? (
             <HeaderTabs organization={organization} activeTab="stats" />
+          ) : (
+            <Layout.Header>
+              <Layout.HeaderContent>
+                <StyledHeading>{t('Organization Usage Stats')}</StyledHeading>
+                <HeadingSubtitle>
+                  {tct(
+                    'A view of the usage data that Sentry has received across your entire organization. [link: Read the docs].',
+                    {
+                      link: <ExternalLink href="https://docs.sentry.io/product/stats/" />,
+                    }
+                  )}
+                </HeadingSubtitle>
+              </Layout.HeaderContent>
+            </Layout.Header>
           )}
           <Body>
             <Layout.Main fullWidth>
-              {!hasTeamInsights && (
-                <Fragment>
-                  <PageHeader>
-                    <PageHeading>{t('Organization Usage Stats')}</PageHeading>
-                  </PageHeader>
-                  <p>
-                    {tct(
-                      'A view of the usage data that Sentry has received across your entire organization. [link: Read the docs].',
-                      {
-                        link: (
-                          <ExternalLink href="https://docs.sentry.io/product/stats/" />
-                        ),
-                      }
-                    )}
-                  </p>
-                </Fragment>
-              )}
               <HookHeader organization={organization} />
               {this.renderProjectPageControl()}
               <PageGrid>
@@ -407,6 +403,10 @@ export class OrganizationStats extends Component<Props> {
 }
 
 export default withPageFilters(withOrganization(OrganizationStats));
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
 
 const PageGrid = styled('div')`
   display: grid;
@@ -451,6 +451,11 @@ const Body = styled(Layout.Body)`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     display: block;
   }
+`;
+
+const HeadingSubtitle = styled('p')`
+  margin-top: ${space(0.5)};
+  margin-bottom: 0;
 `;
 
 const PageControl = styled('div')`

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -125,7 +126,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
         <NoProjectMessage organization={organization}>
           <StyledPageContent>
             <Layout.Header>
-              <StyledLayoutHeaderContent>
+              <Layout.HeaderContent>
                 <StyledHeading>
                   {t('Profiling')}
                   <PageHeadingQuestionTooltip
@@ -139,7 +140,9 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                     )}
                   />
                 </StyledHeading>
-                <HeadingActions>
+              </Layout.HeaderContent>
+              <Layout.HeaderActions>
+                <ButtonBar gap={1}>
                   <Button size="sm" onClick={onSetupProfilingClick}>
                     {t('Set Up Profiling')}
                   </Button>
@@ -159,8 +162,8 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                   >
                     {t('Join Discord')}
                   </Button>
-                </HeadingActions>
-              </StyledLayoutHeaderContent>
+                </ButtonBar>
+              </Layout.HeaderActions>
             </Layout.Header>
             <Layout.Body>
               <Layout.Main fullWidth>
@@ -243,21 +246,6 @@ type FieldType = typeof FIELDS[number];
 
 const StyledPageContent = styled(PageContent)`
   padding: 0;
-`;
-
-const StyledLayoutHeaderContent = styled(Layout.HeaderContent)`
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-`;
-
-const HeadingActions = styled('div')`
-  display: flex;
-  align-items: center;
-
-  button:not(:last-child) {
-    margin-right: ${space(1)};
-  }
 `;
 
 const StyledHeading = styled(PageHeading)`

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -20,7 +20,6 @@ import {
 } from 'sentry/data/platformCategories';
 import platforms from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
-import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import Projects from 'sentry/utils/projects';
@@ -260,7 +259,9 @@ const StyledButtonBar = styled(ButtonBar)`
   }
 `;
 
-const StyledPageHeader = styled(PageHeader)`
+const StyledPageHeader = styled('div')`
+  display: flex;
+  justify-content: space-between;
   margin-bottom: ${space(3)};
 
   h2 {

--- a/static/app/views/projectInstall/platformIntegrationSetup.tsx
+++ b/static/app/views/projectInstall/platformIntegrationSetup.tsx
@@ -9,7 +9,6 @@ import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import platforms from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
-import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {IntegrationProvider, Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -121,16 +120,16 @@ class PlatformIntegrationSetup extends AsyncComponent<Props, State> {
 
     return (
       <OuterWrapper>
-        <StyledPageHeader>
+        <InnerWrapper>
           <StyledTitle>
             {t('Automatically instrument %s', platformIntegration.name)}
           </StyledTitle>
-          <PlatformHeaderButtonBar
-            gettingStartedLink={gettingStartedLink}
-            docsLink={docsLink}
-          />
-        </StyledPageHeader>
-        <InnerWrapper>
+          <HeaderButtons>
+            <PlatformHeaderButtonBar
+              gettingStartedLink={gettingStartedLink}
+              docsLink={docsLink}
+            />
+          </HeaderButtons>
           {!installed ? (
             <Fragment>
               <AddInstallationInstructions />
@@ -186,7 +185,7 @@ const StyledButtonBar = styled(ButtonBar)`
 `;
 
 const InnerWrapper = styled('div')`
-  width: 850px;
+  max-width: 850px;
 `;
 
 const OuterWrapper = styled('div')`
@@ -196,12 +195,14 @@ const OuterWrapper = styled('div')`
   margin-top: 50px;
 `;
 
-const StyledPageHeader = styled(PageHeader)`
+const HeaderButtons = styled('div')`
+  width: min-content;
   margin-bottom: ${space(3)};
 `;
 
 const StyledTitle = styled('h2')`
-  margin: 0 ${space(3)} 0 0;
+  margin: 0;
+  margin-bottom: ${space(2)};
 `;
 
 export default withOrganization(PlatformIntegrationSetup);

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -9,6 +9,7 @@ import uniqBy from 'lodash/uniqBy';
 
 import {Client} from 'sentry/api';
 import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
@@ -141,9 +142,9 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
       <SentryDocumentTitle title={t('Projects Dashboard')} orgSlug={organization.slug} />
       {projects.length > 0 && (
         <Fragment>
-          <ProjectsHeader>
-            <Title>
-              <PageHeading>
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <StyledHeading>
                 {t('Projects')}
                 <PageHeadingQuestionTooltip
                   title={tct(
@@ -155,10 +156,10 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
                     }
                   )}
                 />
-              </PageHeading>
-            </Title>
+              </StyledHeading>
+            </Layout.HeaderContent>
             <Layout.HeaderActions>
-              <ButtonContainer>
+              <ButtonBar gap={1}>
                 <Button
                   size="sm"
                   icon={<IconUser size="xs" />}
@@ -188,10 +189,10 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
                 >
                   {t('Create Project')}
                 </Button>
-              </ButtonContainer>
+              </ButtonBar>
             </Layout.HeaderActions>
-          </ProjectsHeader>
-          <Body>
+          </Layout.Header>
+          <Layout.Body>
             <Layout.Main fullWidth>
               <SearchAndSelectorWrapper>
                 <TeamFilter
@@ -210,7 +211,7 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
               </SearchAndSelectorWrapper>
               <ProjectCardList projects={filteredProjects} />
             </Layout.Main>
-          </Body>
+          </Layout.Body>
           {showResources && <Resources organization={organization} />}
         </Fragment>
       )}
@@ -224,22 +225,8 @@ const OrganizationDashboard = (props: Props) => (
   </OrganizationDashboardWrapper>
 );
 
-const ProjectsHeader = styled(Layout.Header)`
-  border-bottom: none;
-  align-items: end;
-
-  @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    padding: 26px ${space(4)} 0 ${space(4)};
-  }
-`;
-
-const Title = styled(Layout.HeaderContent)`
-  margin-bottom: 0;
-`;
-
-const ButtonContainer = styled('div')`
-  display: inline-flex;
-  gap: ${space(1)};
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const SearchAndSelectorWrapper = styled('div')`
@@ -264,11 +251,6 @@ const StyledSearchBar = styled(SearchBar)`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     margin-top: ${space(1)};
   }
-`;
-
-const Body = styled(Layout.Body)`
-  padding-top: ${space(2)} !important;
-  background-color: ${p => p.theme.surface100};
 `;
 
 const ProjectCards = styled('div')`

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -10,6 +10,7 @@ import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
+import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
@@ -29,7 +30,6 @@ import {releaseHealth} from 'sentry/data/platformCategories';
 import {IconSearch} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {PageContent, PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {
   Organization,
@@ -522,10 +522,10 @@ class ReleasesList extends AsyncView<Props, State> {
 
     return (
       <PageFiltersContainer showAbsolute={false}>
-        <PageContent>
-          <NoProjectMessage organization={organization}>
-            <PageHeader>
-              <PageHeading>
+        <NoProjectMessage organization={organization}>
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <StyledHeading>
                 {t('Releases')}
                 <PageHeadingQuestionTooltip
                   title={tct(
@@ -537,78 +537,88 @@ class ReleasesList extends AsyncView<Props, State> {
                     }
                   )}
                 />
-              </PageHeading>
-            </PageHeader>
+              </StyledHeading>
+            </Layout.HeaderContent>
+          </Layout.Header>
 
-            {this.renderHealthCta()}
+          <Layout.Body>
+            <Layout.Main fullWidth>
+              {this.renderHealthCta()}
 
-            <ReleasesPageFilterBar condensed>
-              <GuideAnchor target="release_projects">
-                <ProjectPageFilter />
-              </GuideAnchor>
-              <EnvironmentPageFilter />
-              <DatePageFilter
-                alignDropdown="left"
-                disallowArbitraryRelativeRanges
-                hint={t('Changing this date range will recalculate the release metrics.')}
-              />
-            </ReleasesPageFilterBar>
-
-            {this.shouldShowQuickstart ? null : (
-              <SortAndFilterWrapper>
-                <GuideAnchor
-                  target="releases_search"
-                  position="bottom"
-                  disabled={!hasReleasesSetup}
-                >
-                  <StyledSmartSearchBar
-                    searchSource="releases"
-                    query={this.getQuery()}
-                    placeholder={t('Search by version, build, package, or stage')}
-                    hasRecentSearches={false}
-                    supportedTags={{
-                      ...SEMVER_TAGS,
-                      release: {
-                        key: 'release',
-                        name: 'release',
-                      },
-                    }}
-                    maxMenuHeight={500}
-                    supportedTagType={ItemType.PROPERTY}
-                    onSearch={this.handleSearch}
-                    onGetTagValues={this.getTagValues}
-                  />
+              <ReleasesPageFilterBar condensed>
+                <GuideAnchor target="release_projects">
+                  <ProjectPageFilter />
                 </GuideAnchor>
-                <ReleasesStatusOptions
-                  selected={activeStatus}
-                  onSelect={this.handleStatus}
+                <EnvironmentPageFilter />
+                <DatePageFilter
+                  alignDropdown="left"
+                  disallowArbitraryRelativeRanges
+                  hint={t(
+                    'Changing this date range will recalculate the release metrics.'
+                  )}
                 />
-                <ReleasesSortOptions
-                  selected={activeSort}
-                  selectedDisplay={activeDisplay}
-                  onSelect={this.handleSortBy}
-                  environments={selection.environments}
-                />
-                <ReleasesDisplayOptions
-                  selected={activeDisplay}
-                  onSelect={this.handleDisplay}
-                />
-              </SortAndFilterWrapper>
-            )}
+              </ReleasesPageFilterBar>
 
-            {!reloading &&
-              activeStatus === ReleasesStatusOption.ARCHIVED &&
-              !!releases?.length && <ReleaseArchivedNotice multi />}
+              {this.shouldShowQuickstart ? null : (
+                <SortAndFilterWrapper>
+                  <GuideAnchor
+                    target="releases_search"
+                    position="bottom"
+                    disabled={!hasReleasesSetup}
+                  >
+                    <StyledSmartSearchBar
+                      searchSource="releases"
+                      query={this.getQuery()}
+                      placeholder={t('Search by version, build, package, or stage')}
+                      hasRecentSearches={false}
+                      supportedTags={{
+                        ...SEMVER_TAGS,
+                        release: {
+                          key: 'release',
+                          name: 'release',
+                        },
+                      }}
+                      maxMenuHeight={500}
+                      supportedTagType={ItemType.PROPERTY}
+                      onSearch={this.handleSearch}
+                      onGetTagValues={this.getTagValues}
+                    />
+                  </GuideAnchor>
+                  <ReleasesStatusOptions
+                    selected={activeStatus}
+                    onSelect={this.handleStatus}
+                  />
+                  <ReleasesSortOptions
+                    selected={activeSort}
+                    selectedDisplay={activeDisplay}
+                    onSelect={this.handleSortBy}
+                    environments={selection.environments}
+                  />
+                  <ReleasesDisplayOptions
+                    selected={activeDisplay}
+                    onSelect={this.handleDisplay}
+                  />
+                </SortAndFilterWrapper>
+              )}
 
-            {error
-              ? super.renderError(new Error('Unable to load all required endpoints'))
-              : this.renderInnerBody(activeDisplay, showReleaseAdoptionStages)}
-          </NoProjectMessage>
-        </PageContent>
+              {!reloading &&
+                activeStatus === ReleasesStatusOption.ARCHIVED &&
+                !!releases?.length && <ReleaseArchivedNotice multi />}
+
+              {error
+                ? super.renderError(new Error('Unable to load all required endpoints'))
+                : this.renderInnerBody(activeDisplay, showReleaseAdoptionStages)}
+            </Layout.Main>
+          </Layout.Body>
+        </NoProjectMessage>
       </PageFiltersContainer>
     );
   }
 }
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
 
 const AlertText = styled('div')`
   display: flex;

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -197,6 +197,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
       ),
     };
   };
+
   return renderComponent(
     <Panel>
       <Container>

--- a/static/app/views/replays/list/container.tsx
+++ b/static/app/views/replays/list/container.tsx
@@ -14,11 +14,11 @@ function ReplaysListContainer() {
   return (
     <Fragment>
       <Layout.Header>
-        <StyledLayoutHeaderContent>
+        <Layout.HeaderContent>
           <StyledHeading>
             {t('Replays')} <ReplaysFeatureBadge space={1} />
           </StyledHeading>
-        </StyledLayoutHeaderContent>
+        </Layout.HeaderContent>
       </Layout.Header>
       <PageFiltersContainer>
         <ReplaysList />
@@ -27,15 +27,8 @@ function ReplaysListContainer() {
   );
 }
 
-const StyledLayoutHeaderContent = styled(Layout.HeaderContent)`
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-`;
-
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;
-  display: flex;
 `;
 
 export default ReplaysListContainer;

--- a/static/app/views/replays/list/replays.tsx
+++ b/static/app/views/replays/list/replays.tsx
@@ -1,12 +1,11 @@
 import {Fragment, useMemo} from 'react';
 import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
+import * as Layout from 'sentry/components/layouts/thirds';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -56,59 +55,56 @@ function ReplaysList() {
   const {hasSentOneReplay, activateSidebar} = useReplayOnboardingSidebarPanel();
 
   return (
-    <StyledPageContent>
-      <ReplaysFilters />
-      {hasSentOneReplay ? (
-        <Fragment>
-          <ReplayTable
-            fetchError={fetchError}
-            isFetching={isFetching}
-            replays={replays}
-            sort={eventView.sorts[0]}
-            visibleColumns={[
-              ReplayColumns.session,
-              ...(hasRoomForColumns
-                ? [ReplayColumns.projectId, ReplayColumns.startedAt]
-                : []),
-              ReplayColumns.duration,
-              ReplayColumns.countErrors,
-              ReplayColumns.activity,
-            ]}
-          />
-          <Pagination
-            pageLinks={pageLinks}
-            onCursor={(cursor, path, searchQuery) => {
-              trackAdvancedAnalyticsEvent('replay.list-paginated', {
-                organization,
-                direction: cursor?.endsWith(':1') ? 'prev' : 'next',
-              });
-              browserHistory.push({
-                pathname: path,
-                query: {...searchQuery, cursor},
-              });
-            }}
-          />
-        </Fragment>
-      ) : (
-        <ReplayOnboardingPanel>
-          <Button onClick={activateSidebar} priority="primary">
-            {t('Get Started')}
-          </Button>
-          <Button
-            href="https://docs.sentry.io/platforms/javascript/session-replay/"
-            external
-          >
-            {t('Read Docs')}
-          </Button>
-        </ReplayOnboardingPanel>
-      )}
-    </StyledPageContent>
+    <Layout.Body>
+      <Layout.Main fullWidth>
+        <ReplaysFilters />
+        {hasSentOneReplay ? (
+          <Fragment>
+            <ReplayTable
+              fetchError={fetchError}
+              isFetching={isFetching}
+              replays={replays}
+              sort={eventView.sorts[0]}
+              visibleColumns={[
+                ReplayColumns.session,
+                ...(hasRoomForColumns
+                  ? [ReplayColumns.projectId, ReplayColumns.startedAt]
+                  : []),
+                ReplayColumns.duration,
+                ReplayColumns.countErrors,
+                ReplayColumns.activity,
+              ]}
+            />
+            <Pagination
+              pageLinks={pageLinks}
+              onCursor={(cursor, path, searchQuery) => {
+                trackAdvancedAnalyticsEvent('replay.list-paginated', {
+                  organization,
+                  direction: cursor?.endsWith(':1') ? 'prev' : 'next',
+                });
+                browserHistory.push({
+                  pathname: path,
+                  query: {...searchQuery, cursor},
+                });
+              }}
+            />
+          </Fragment>
+        ) : (
+          <ReplayOnboardingPanel>
+            <Button onClick={activateSidebar} priority="primary">
+              {t('Get Started')}
+            </Button>
+            <Button
+              href="https://docs.sentry.io/platforms/javascript/session-replay/"
+              external
+            >
+              {t('Read Docs')}
+            </Button>
+          </ReplayOnboardingPanel>
+        )}
+      </Layout.Main>
+    </Layout.Body>
   );
 }
-
-const StyledPageContent = styled(PageContent)`
-  box-shadow: 0px 0px 1px ${p => p.theme.gray200};
-  background-color: ${p => p.theme.background};
-`;
 
 export default ReplaysList;

--- a/static/app/views/userFeedback/index.tsx
+++ b/static/app/views/userFeedback/index.tsx
@@ -9,6 +9,7 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import EventUserFeedback from 'sentry/components/events/userFeedback';
 import CompactIssue from 'sentry/components/issues/compactIssue';
+import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
@@ -20,7 +21,6 @@ import Pagination from 'sentry/components/pagination';
 import {Panel} from 'sentry/components/panels';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {t, tct} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, UserReport} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -124,24 +124,26 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
 
     return (
       <PageFiltersContainer>
-        <PageContent>
-          <NoProjectMessage organization={organization}>
-            <div data-test-id="user-feedback">
-              <Header>
-                <PageHeading>
-                  {t('User Feedback')}
-                  <PageHeadingQuestionTooltip
-                    title={tct(
-                      'Feedback submitted by users who experienced an error while using your application, including their name, email address, and any additional comments. [link: Read the docs].',
-                      {
-                        link: (
-                          <ExternalLink href="https://docs.sentry.io/product/user-feedback/" />
-                        ),
-                      }
-                    )}
-                  />
-                </PageHeading>
-              </Header>
+        <NoProjectMessage organization={organization}>
+          <Layout.Header>
+            <Layout.HeaderContent>
+              <StyledHeading>
+                {t('User Feedback')}
+                <PageHeadingQuestionTooltip
+                  title={tct(
+                    'Feedback submitted by users who experienced an error while using your application, including their name, email address, and any additional comments. [link: Read the docs].',
+                    {
+                      link: (
+                        <ExternalLink href="https://docs.sentry.io/product/user-feedback/" />
+                      ),
+                    }
+                  )}
+                />
+              </StyledHeading>
+            </Layout.HeaderContent>
+          </Layout.Header>
+          <Layout.Body data-test-id="user-feedback">
+            <Layout.Main fullWidth>
               <Filters>
                 <PageFilterBar>
                   <ProjectPageFilter />
@@ -159,9 +161,9 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
               </Filters>
               {this.renderStreamBody()}
               <Pagination pageLinks={reportListPageLinks} />
-            </div>
-          </NoProjectMessage>
-        </PageContent>
+            </Layout.Main>
+          </Layout.Body>
+        </NoProjectMessage>
       </PageFiltersContainer>
     );
   }
@@ -169,11 +171,8 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
 
 export default withOrganization(withProfiler(OrganizationUserFeedback));
 
-const Header = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: ${space(2)};
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const Filters = styled('div')`


### PR DESCRIPTION
Primarily fixes Headers.

This includes a few sub pages (not direct links of the main nav).

**Best viewed with whitespace diff off**

[Screenshots here](https://github.com/getsentry/team-coreui/issues/46)

**Follow ups**

1. I will follow up with the rest of the detail pages.
2. `PageContent` will be made a bit more generic so we don't have to restyle it
3. `PageContent` will move to `Layout.Page` (or similar)
4. `PageHeading` will be made more generic so it doesn't always need to be restyled
5. `PageHeading` will replace `Layout.Title`

Those steps should make everything FAR more consistent and intuitive.