### PR TITLE
feat(view-hierarchy): Display selected node information below tree

### DIFF
--- a/static/app/components/events/viewHierarchy/detailsPanel.spec.tsx
+++ b/static/app/components/events/viewHierarchy/detailsPanel.spec.tsx
@@ -1,0 +1,52 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DetailsPanel} from './detailsPanel';
+
+const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
+const MOCK_DATA = {
+  ...DEFAULT_VALUES,
+  id: 'parent',
+  type: 'Container',
+  x: 200,
+  y: 201,
+  width: 202,
+  height: 203,
+  children: [
+    {
+      ...DEFAULT_VALUES,
+      id: 'intermediate',
+      type: 'Nested Container',
+      children: [
+        {
+          ...DEFAULT_VALUES,
+          id: 'leaf',
+          type: 'Text',
+          children: [],
+        },
+      ],
+    },
+  ],
+};
+
+describe('View Hierarchy Details Panel', function () {
+  it('omits id and children from rendered data', function () {
+    render(<DetailsPanel data={MOCK_DATA} />);
+
+    expect(screen.getByRole('cell', {name: '200'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '201'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '202'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '203'})).toBeInTheDocument();
+    expect(screen.queryByRole('cell', {name: 'id'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('cell', {name: 'children'})).not.toBeInTheDocument();
+  });
+
+  it('accepts a custom title renderer', function () {
+    const testGetTitle = jest.fn().mockImplementation(data => {
+      return `${data.type} - ${data.id}`;
+    });
+    render(<DetailsPanel data={MOCK_DATA} getTitle={testGetTitle} />);
+
+    expect(testGetTitle).toHaveBeenCalled();
+    expect(screen.getByText('Container - parent')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/viewHierarchy/detailsPanel.tsx
+++ b/static/app/components/events/viewHierarchy/detailsPanel.tsx
@@ -9,7 +9,7 @@ import {ViewHierarchyWindow} from '.';
 
 type DetailsPanelProps = {
   data: ViewHierarchyWindow | null;
-  getTitle: any;
+  getTitle?: (data: ViewHierarchyWindow) => string;
 };
 
 function DetailsPanel({data, getTitle}: DetailsPanelProps) {
@@ -27,7 +27,7 @@ function DetailsPanel({data, getTitle}: DetailsPanelProps) {
 
   return (
     <Container>
-      <Title>{getTitle?.(data)}</Title>
+      {!!getTitle && <Title>{getTitle(data)}</Title>}
       <KeyValueList data={keyValueData} />
     </Container>
   );

--- a/static/app/components/events/viewHierarchy/detailsPanel.tsx
+++ b/static/app/components/events/viewHierarchy/detailsPanel.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+import omit from 'lodash/omit';
+
+import space from 'sentry/styles/space';
+
+import KeyValueList from '../interfaces/keyValueList';
+
+import {ViewHierarchyWindow} from '.';
+
+type DetailsPanelProps = {
+  data: ViewHierarchyWindow | null;
+  getTitle: any;
+};
+
+function DetailsPanel({data, getTitle}: DetailsPanelProps) {
+  if (!data) {
+    return null;
+  }
+
+  const keyValueData = Object.entries(omit(data, 'id', 'children')).map(
+    ([key, value]) => ({
+      key,
+      value,
+      subject: key,
+    })
+  );
+
+  return (
+    <Container>
+      <Title>{getTitle?.(data)}</Title>
+      <KeyValueList data={keyValueData} />
+    </Container>
+  );
+}
+
+export {DetailsPanel};
+
+const Title = styled('header')`
+  margin-bottom: ${space(1)};
+  font-weight: bold;
+`;
+
+const Container = styled('div')`
+  margin-top: ${space(1)};
+  border: 1px solid ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(1.5)};
+  padding-bottom: 0;
+  max-height: 400px;
+  overflow: auto;
+`;

--- a/static/app/components/events/viewHierarchy/detailsPanel.tsx
+++ b/static/app/components/events/viewHierarchy/detailsPanel.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
 import space from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 
 import KeyValueList from '../interfaces/keyValueList';
 
@@ -23,7 +24,7 @@ function DetailsPanel({data, getTitle}: DetailsPanelProps) {
 
   return (
     <Container>
-      {!!getTitle && <Title>{getTitle(data)}</Title>}
+      {defined(getTitle) && <Title>{getTitle(data)}</Title>}
       <KeyValueList data={keyValueData} />
     </Container>
   );

--- a/static/app/components/events/viewHierarchy/detailsPanel.tsx
+++ b/static/app/components/events/viewHierarchy/detailsPanel.tsx
@@ -8,15 +8,11 @@ import KeyValueList from '../interfaces/keyValueList';
 import {ViewHierarchyWindow} from '.';
 
 type DetailsPanelProps = {
-  data: ViewHierarchyWindow | null;
+  data: ViewHierarchyWindow;
   getTitle?: (data: ViewHierarchyWindow) => string;
 };
 
 function DetailsPanel({data, getTitle}: DetailsPanelProps) {
-  if (!data) {
-    return null;
-  }
-
   const keyValueData = Object.entries(omit(data, 'id', 'children')).map(
     ([key, value]) => ({
       key,

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -1,0 +1,73 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ViewHierarchy} from '.';
+
+const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
+const MOCK_DATA = {
+  rendering_system: 'test-rendering-system',
+  windows: [
+    {
+      ...DEFAULT_VALUES,
+      id: 'parent',
+      type: 'Container',
+      identifier: 'test_identifier',
+      x: 200,
+      children: [
+        {
+          ...DEFAULT_VALUES,
+          id: 'intermediate',
+          type: 'Nested Container',
+          identifier: 'nested',
+          children: [
+            {
+              ...DEFAULT_VALUES,
+              id: 'leaf',
+              type: 'Text',
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('View Hierarchy', function () {
+  it('allows selecting and deselecting through the tree to highlight node data', function () {
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
+
+    expect(screen.queryByText('200')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByText('Container - test_identifier'));
+
+    expect(screen.getByText('200')).toBeInTheDocument();
+
+    // 1 for the tree node, 1 for the details panel header
+    expect(screen.getAllByText('Container - test_identifier')).toHaveLength(2);
+    // 1 for the "identifier" value in the details panel
+    expect(screen.getByText('Container')).toBeInTheDocument();
+
+    // Click the node again
+    userEvent.click(screen.getAllByText('Container - test_identifier')[0]);
+
+    // 1 for the tree node
+    expect(screen.getByText('Container - test_identifier')).toBeInTheDocument();
+    expect(screen.queryByText('Container')).not.toBeInTheDocument();
+  });
+
+  it('can continue to make selections for inspecting data', function () {
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
+
+    userEvent.click(screen.getByText('Container - test_identifier'));
+
+    // 1 for the tree node, 1 for the details panel header
+    expect(screen.getAllByText('Container - test_identifier')).toHaveLength(2);
+
+    userEvent.click(screen.getByText('Nested Container - nested'));
+
+    // 1 for the tree node, 1 for the details panel header
+    expect(screen.getAllByText('Nested Container - nested')).toHaveLength(2);
+    // Only visible in the tree node
+    expect(screen.getByText('Container - test_identifier')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -3,8 +3,13 @@ import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
 
+import {DetailsPanel} from './detailsPanel';
 import {RenderingSystem} from './renderingSystem';
 import {Tree} from './tree';
+
+function getNodeLabel({identifier, type}: ViewHierarchyWindow) {
+  return identifier ? `${type} - ${identifier}` : type;
+}
 
 export type ViewHierarchyWindow = {
   alpha: number;
@@ -31,18 +36,26 @@ type ViewHierarchyProps = {
 
 function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
   const [selectedWindow] = useState(0);
+  const [selectedNode, setSelectedNode] = useState<null | ViewHierarchyWindow>(null);
   return (
     <Fragment>
       <RenderingSystem system={viewHierarchy.rendering_system} />
       <TreeContainer>
         <Tree<ViewHierarchyWindow>
           data={viewHierarchy.windows[selectedWindow]}
-          getNodeLabel={({identifier, type}) =>
-            identifier ? `${type} - ${identifier}` : type
-          }
+          getNodeLabel={getNodeLabel}
+          onNodeSelection={data => {
+            if (data !== selectedNode) {
+              setSelectedNode(data);
+            } else {
+              setSelectedNode(null);
+            }
+          }}
           isRoot
+          selectedNodeId={selectedNode?.id ?? ''}
         />
       </TreeContainer>
+      <DetailsPanel data={selectedNode} getTitle={getNodeLabel} />
     </Fragment>
   );
 }

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 
 import {DetailsPanel} from './detailsPanel';
 import {RenderingSystem} from './renderingSystem';
@@ -55,7 +56,9 @@ function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
           selectedNodeId={selectedNode?.id ?? ''}
         />
       </TreeContainer>
-      <DetailsPanel data={selectedNode} getTitle={getNodeLabel} />
+      {defined(selectedNode) && (
+        <DetailsPanel data={selectedNode} getTitle={getNodeLabel} />
+      )}
     </Fragment>
   );
 }

--- a/static/app/components/events/viewHierarchy/tree.tsx
+++ b/static/app/components/events/viewHierarchy/tree.tsx
@@ -52,9 +52,9 @@ type TreeData<T> = T & {id: string; children?: TreeData<T>[]};
 type TreeProps<T> = {
   data: TreeData<T>;
   getNodeLabel: (data: TreeData<T>) => string;
-  selectedNodeId: string;
   isRoot?: boolean;
   onNodeSelection?: (data: TreeData<T>) => void;
+  selectedNodeId?: string;
 };
 
 function Tree<T>({


### PR DESCRIPTION
Allows a user to click on the text for an element in the tree and if they do, a details panel appears below the tree and displays metadata for that node. I omit `id` because we generate that to help render the tree, and `children` because that's not what the user would expect as metadata here

Closes [#42947](https://github.com/getsentry/sentry/issues/42947)