### PR TITLE
feat(profiling): Add more metrics to the profiling pipeline

### DIFF
--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -18,6 +18,20 @@ def process_message(message: Message[KafkaPayload]) -> None:
         metrics.timing("profiles.consumer.profile.size", len(message_dict["payload"]))
         profile = json.loads(message_dict["payload"], use_rapid_json=True)
 
+    tags = {"platform": profile["platform"]}
+
+    if "version" in profile and profile["version"]:
+        tags["version"] = profile["version"]
+        tags["format"] = "sample"
+    else:
+        tags["format"] = "legacy"
+
+    metrics.incr(
+        "process_profile.profile.format",
+        tags=tags,
+        sample_rate=1.0,
+    )
+
     profile.update(
         {
             "organization_id": message_dict["organization_id"],

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -162,13 +162,13 @@ def process_profile_task(
         )
         return
 
+    _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
+
     metrics.gauge(
         "process_profile.kafka_producer.queue.size",
-        len(_profiles_kafka_producer._KafkaProducer__producer),
+        len(_profiles_kafka_producer._KafkaProducer__producer),  # type: ignore
         sample_rate=1.0,
     )
-
-    _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
 
 
 SHOULD_SYMBOLICATE = frozenset(["cocoa", "rust"])

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -162,6 +162,12 @@ def process_profile_task(
         )
         return
 
+    metrics.gauge(
+        "process_profile.kafka_producer.queue.size",
+        len(_profiles_kafka_producer.__producer),
+        sample_rate=1.0,
+    )
+
     _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
 
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -164,7 +164,7 @@ def process_profile_task(
 
     metrics.gauge(
         "process_profile.kafka_producer.queue.size",
-        len(_profiles_kafka_producer.__producer),
+        len(_profiles_kafka_producer._KafkaProducer__producer),
         sample_rate=1.0,
     )
 


### PR DESCRIPTION
We're adding 2 metrics to get more insights into the profiling pipeline:
- one metric to count the different format currently used by different SDKs so we can tell when we can drop support for one given format
- one metric to count the number of messages in-flight in our Celery workers to help track down a memory leak