### PR TITLE
fix(domains) Fix page reload during issue tab navigation

### DIFF
--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -24,7 +24,8 @@ type NormalizeUrlOptions = {
 };
 
 /**
- * Normalize a URL for customer domains based on the current route state
+ * Normalize a URL for customer domains based on the organization that was
+ * present in the initial page load.
  */
 export function normalizeUrl(path: string, options?: NormalizeUrlOptions): string;
 export function normalizeUrl(

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -37,6 +37,7 @@ import withRouteAnalytics, {
   WithRouteAnalyticsProps,
 } from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import withApi from 'sentry/utils/withApi';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 import {ERROR_TYPES} from './constants';
 import GroupHeader from './header';
@@ -259,14 +260,16 @@ class GroupDetails extends Component<Props, State> {
   }
 
   getCurrentRouteInfo(group: Group): {baseUrl: string; currentTab: Tab} {
-    const {organization, router} = this.props;
+    const {organization, params} = this.props;
     const {event} = this.state;
 
     const currentTab = this.getCurrentTab();
 
-    const baseUrl = `/organizations/${organization.slug}/issues/${group.id}/${
-      router.params.eventId && event ? `events/${event.id}/` : ''
-    }`;
+    const baseUrl = normalizeUrl(
+      `/organizations/${organization.slug}/issues/${group.id}/${
+        params.eventId && event ? `events/${event.id}/` : ''
+      }`
+    );
 
     return {baseUrl, currentTab};
   }


### PR DESCRIPTION
When customer domains is active we don't want to reload the entire issue details page. To avoid this we need to normalize URLs before they are provided to the TabItem component because it doesn't use our Link component.
