### PR TITLE
feat(codecov): Refactor stacktrace-link to support codecov query

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -33,7 +33,7 @@ import useProjects from 'sentry/utils/useProjects';
 
 import {OpenInContainer} from './openInContextLine';
 import StacktraceLinkModal from './stacktraceLinkModal';
-import UseStacktraceLink from './useStacktraceLink';
+import useStacktraceLink from './useStacktraceLink';
 
 const supportedStacktracePlatforms: PlatformKey[] = [
   'go',
@@ -144,7 +144,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     data: match,
     isLoading,
     refetch,
-  } = UseStacktraceLink({
+  } = useStacktraceLink({
     event,
     frame,
     orgSlug: organization.slug,

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -17,13 +17,7 @@ import type {PlatformKey} from 'sentry/data/platformCategories';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import type {
-  Event,
-  Frame,
-  Organization,
-  Project,
-  StacktraceLinkResult,
-} from 'sentry/types';
+import type {Event, Frame, Organization, Project} from 'sentry/types';
 import {StacktraceLinkEvents} from 'sentry/utils/analytics/integrations/stacktraceLinkAnalyticsEvents';
 import {getAnalyicsDataForEvent} from 'sentry/utils/events';
 import {
@@ -32,13 +26,14 @@ import {
 } from 'sentry/utils/integrationUtil';
 import {isMobilePlatform} from 'sentry/utils/platform';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
-import {useQuery, useQueryClient} from 'sentry/utils/queryClient';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
 import {OpenInContainer} from './openInContextLine';
 import StacktraceLinkModal from './stacktraceLinkModal';
+import UseStacktraceLink from './useStacktraceLink';
 
 const supportedStacktracePlatforms: PlatformKey[] = [
   'go',
@@ -145,25 +140,17 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
 
   const isMobile = isMobileLanguage(event);
 
-  const query = {
-    file: frame.filename,
-    platform: event.platform,
-    commitId: event.release?.lastCommit?.id,
-    ...(event.sdk?.name && {sdkName: event.sdk.name}),
-    ...(frame.absPath && {absPath: frame.absPath}),
-    ...(frame.module && {module: frame.module}),
-    ...(frame.package && {package: frame.package}),
-  };
   const {
     data: match,
     isLoading,
     refetch,
-  } = useQuery<StacktraceLinkResult>(
-    [`/projects/${organization.slug}/${project?.slug}/stacktrace-link/`, {query}],
-    {staleTime: Infinity, retry: false}
-  );
+  } = UseStacktraceLink({
+    event,
+    frame,
+    orgSlug: organization.slug,
+    projectSlug: project?.slug,
+  });
 
-  // Track stacktrace analytics after loaded
   useEffect(() => {
     if (isLoading || prompt.isLoading || !match) {
       return;

--- a/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
@@ -1,0 +1,36 @@
+import type {Event, Frame, StacktraceLinkResult} from 'sentry/types';
+import {QueryKey, useQuery} from 'sentry/utils/queryClient';
+
+interface UseStacktraceLinkProps {
+  event: Event;
+  frame: Frame;
+  orgSlug: string;
+  projectSlug: string | undefined;
+}
+
+const stacktraceLinkQueryKey = (
+  orgSlug: string,
+  projectSlug: string | undefined,
+  query: any
+): QueryKey => [`/projects/${orgSlug}/${projectSlug}/stacktrace-link/`, {query}];
+
+function UseStacktraceLink({event, frame, orgSlug, projectSlug}: UseStacktraceLinkProps) {
+  const query = {
+    file: frame.filename,
+    platform: event.platform,
+    commitId: event.release?.lastCommit?.id,
+    ...(event.sdk?.name && {sdkName: event.sdk.name}),
+    ...(frame.absPath && {absPath: frame.absPath}),
+    ...(frame.module && {module: frame.module}),
+    ...(frame.package && {package: frame.package}),
+  };
+
+  return useQuery<StacktraceLinkResult>(
+    stacktraceLinkQueryKey(orgSlug, projectSlug, query),
+    {
+      staleTime: Infinity,
+      retry: false,
+    }
+  );
+}
+export default UseStacktraceLink;

--- a/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
@@ -14,7 +14,7 @@ const stacktraceLinkQueryKey = (
   query: any
 ): QueryKey => [`/projects/${orgSlug}/${projectSlug}/stacktrace-link/`, {query}];
 
-function UseStacktraceLink({event, frame, orgSlug, projectSlug}: UseStacktraceLinkProps) {
+function useStacktraceLink({event, frame, orgSlug, projectSlug}: UseStacktraceLinkProps) {
   const query = {
     file: frame.filename,
     platform: event.platform,
@@ -33,4 +33,4 @@ function UseStacktraceLink({event, frame, orgSlug, projectSlug}: UseStacktraceLi
     }
   );
 }
-export default UseStacktraceLink;
+export default useStacktraceLink;


### PR DESCRIPTION
Pulling out the query for stacktrace-link to allow reusign the query.

WOR-2594