### PR TITLE
fix(ui): Consistently use Layout.* on detail views

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -189,6 +189,7 @@ export const Label = styled('div')<{isDisabled: boolean}>`
 const InnerLabel = styled(TextOverflow)`
   border-top: 1px solid transparent;
   border-bottom: 1px dotted ${p => p.theme.gray200};
+  line-height: 38px;
 `;
 
 const InputWrapper = styled('div')<{isEmpty: boolean}>`
@@ -204,7 +205,7 @@ const StyledInput = styled(Input)`
   border: none !important;
   background: transparent;
   height: auto;
-  min-height: 34px;
+  min-height: 40px;
   padding: 0;
   font-size: inherit;
   &,

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -1,10 +1,8 @@
 import {PlainRoute} from 'react-router';
-import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import Breadcrumbs, {Crumb, CrumbDropdown} from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 
 interface Props {
@@ -39,11 +37,7 @@ function BuilderBreadCrumbs({title, alertName, projectSlug, organization}: Props
     crumbs.push({label: alertName});
   }
 
-  return <StyledBreadcrumbs crumbs={crumbs} />;
+  return <Breadcrumbs crumbs={crumbs} />;
 }
-
-const StyledBreadcrumbs = styled(Breadcrumbs)`
-  margin-bottom: ${space(1)};
-`;
 
 export default BuilderBreadCrumbs;

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -16,6 +16,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
+import PageHeading from 'sentry/components/pageHeading';
 import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconCopy, IconEdit} from 'sentry/icons';
@@ -278,17 +279,15 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
                 },
               ]}
             />
-            <Layout.Title>
-              <RuleName>
-                <IdBadge
-                  project={project}
-                  avatarSize={28}
-                  hideName
-                  avatarProps={{hasTooltip: true, tooltip: project.slug}}
-                />
-                {rule.name}
-              </RuleName>
-            </Layout.Title>
+            <RuleName>
+              <IdBadge
+                project={project}
+                avatarSize={28}
+                hideName
+                avatarProps={{hasTooltip: true, tooltip: project.slug}}
+              />
+              {rule.name}
+            </RuleName>
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
@@ -357,10 +356,10 @@ const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
   margin-bottom: ${space(2)};
 `;
 
-const RuleName = styled('div')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  grid-column-gap: ${space(1)};
+const RuleName = styled(PageHeading)`
+  line-height: 40px;
+  display: flex;
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/alerts/rules/metric/details/header.tsx
+++ b/static/app/views/alerts/rules/metric/details/header.tsx
@@ -83,8 +83,7 @@ const RuleTitle = styled(PageHeading, {
 })<{loading: boolean}>`
   ${p => p.loading && 'opacity: 0'};
   line-height: 40px;
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  grid-column-gap: ${space(1)};
+  display: flex;
+  gap: ${space(1)};
   align-items: center;
 `;

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -10,6 +10,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
+import PageHeading from 'sentry/components/pageHeading';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
@@ -173,7 +174,7 @@ class AlertWizard extends Component<Props, State> {
               location={location}
               canChangeProject
             />
-            <Layout.Title>{t('Select Alert')}</Layout.Title>
+            <StyledHeading>{t('Select Alert')}</StyledHeading>
           </StyledHeaderContent>
         </Layout.Header>
         <Layout.Body>
@@ -232,6 +233,10 @@ class AlertWizard extends Component<Props, State> {
 
 const StyledHeaderContent = styled(Layout.HeaderContent)`
   overflow: visible;
+`;
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const CategoryTitle = styled('h2')`

--- a/static/app/views/dashboardsV2/controls.tsx
+++ b/static/app/views/dashboardsV2/controls.tsx
@@ -46,6 +46,7 @@ function Controls({
     return (
       <Button
         data-test-id="dashboard-cancel"
+        size="sm"
         onClick={e => {
           e.preventDefault();
           onCancel();
@@ -66,12 +67,13 @@ function Controls({
           onConfirm={onDelete}
           disabled={dashboards.length <= 1}
         >
-          <Button data-test-id="dashboard-delete" priority="danger">
+          <Button size="sm" data-test-id="dashboard-delete" priority="danger">
             {t('Delete')}
           </Button>
         </Confirm>
         <Button
           data-test-id="dashboard-commit"
+          size="sm"
           onClick={e => {
             e.preventDefault();
             onCommit();
@@ -90,6 +92,7 @@ function Controls({
         {renderCancelButton()}
         <Button
           data-test-id="dashboard-commit"
+          size="sm"
           onClick={e => {
             e.preventDefault();
             onCommit();
@@ -108,6 +111,7 @@ function Controls({
         {renderCancelButton(t('Go Back'))}
         <Button
           data-test-id="dashboard-commit"
+          size="sm"
           onClick={e => {
             e.preventDefault();
             onCommit();

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -21,6 +21,7 @@ import {
 } from 'sentry/components/modals/widgetViewerModal/utils';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import PageHeading from 'sentry/components/pageHeading';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {usingCustomerDomain} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -631,13 +632,13 @@ class DashboardDetail extends Component<Props, State> {
         <PageContent>
           <NoProjectMessage organization={organization}>
             <StyledPageHeader>
-              <StyledTitle>
+              <StyledHeading>
                 <DashboardTitle
                   dashboard={modifiedDashboard ?? dashboard}
                   onUpdate={this.setModifiedDashboard}
                   isEditing={this.isEditing}
                 />
-              </StyledTitle>
+              </StyledHeading>
               <Controls
                 organization={organization}
                 dashboards={dashboards}
@@ -764,13 +765,13 @@ class DashboardDetail extends Component<Props, State> {
                       },
                     ]}
                   />
-                  <Layout.Title>
+                  <StyledHeading>
                     <DashboardTitle
                       dashboard={modifiedDashboard ?? dashboard}
                       onUpdate={this.setModifiedDashboard}
                       isEditing={this.isEditing}
                     />
-                  </Layout.Title>
+                  </StyledHeading>
                 </Layout.HeaderContent>
                 <Layout.HeaderActions>
                   <Controls
@@ -926,8 +927,8 @@ const StyledPageHeader = styled('div')`
   }
 `;
 
-const StyledTitle = styled(Layout.Title)`
-  margin-top: 0;
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const StyledPageContent = styled(PageContent)`

--- a/static/app/views/dashboardsV2/title.tsx
+++ b/static/app/views/dashboardsV2/title.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import EditableText from 'sentry/components/editableText';
 import {t} from 'sentry/locale';
 
@@ -11,7 +13,7 @@ type Props = {
 
 function DashboardTitle({dashboard, isEditing, onUpdate}: Props) {
   return (
-    <div>
+    <Fragment>
       {!dashboard ? (
         t('Dashboards')
       ) : (
@@ -23,7 +25,7 @@ function DashboardTitle({dashboard, isEditing, onUpdate}: Props) {
           autoSelect
         />
       )}
-    </div>
+    </Fragment>
   );
 }
 

--- a/static/app/views/dashboardsV2/widgetBuilder/header.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/header.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -5,6 +7,7 @@ import EditableText from 'sentry/components/editableText';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {LinkProps} from 'sentry/components/links/link';
+import PageHeading from 'sentry/components/pageHeading';
 import {t} from 'sentry/locale';
 
 import {DashboardDetails} from '../types';
@@ -40,7 +43,7 @@ export function Header({
             {label: t('Widget Builder')},
           ]}
         />
-        <Layout.Title>
+        <StyledHeading>
           <EditableText
             aria-label={t('Widget title')}
             value={title}
@@ -48,7 +51,7 @@ export function Header({
             errorMessage={t('Widget title is required')}
             maxLength={255}
           />
-        </Layout.Title>
+        </StyledHeading>
       </Layout.HeaderContent>
 
       <Layout.HeaderActions>
@@ -66,3 +69,7 @@ export function Header({
     </Layout.Header>
   );
 }
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;

--- a/static/app/views/eventsV2/eventInputName.tsx
+++ b/static/app/views/eventsV2/eventInputName.tsx
@@ -2,7 +2,7 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
 import EditableText from 'sentry/components/editableText';
-import {Title} from 'sentry/components/layouts/thirds';
+import PageHeading from 'sentry/components/pageHeading';
 import {t} from 'sentry/locale';
 import {Organization, SavedQuery} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
@@ -57,19 +57,19 @@ function EventInputName({organization, eventView, savedQuery, isHomepage}: Props
   const value = isHomepage ? HOMEPAGE_DEFAULT : eventView.name || NAME_DEFAULT;
 
   return (
-    <StyledTitle data-test-id={`discover2-query-name-${value}`}>
+    <StyledHeading data-test-id={`discover2-query-name-${value}`}>
       <EditableText
         value={value}
         onChange={handleChange}
         isDisabled={!eventView.id || isHomepage}
         errorMessage={t('Please set a name for this query')}
       />
-    </StyledTitle>
+    </StyledHeading>
   );
 }
 
-const StyledTitle = styled(Title)`
-  overflow: unset;
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 export default EventInputName;

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -12,8 +12,8 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Button from 'sentry/components/button';
 import CompactSelect from 'sentry/components/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {Title} from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import PageHeading from 'sentry/components/pageHeading';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Switch from 'sentry/components/switchButton';
@@ -305,11 +305,11 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
                   ) ? (
                     this.renderBreadcrumbs()
                   ) : (
-                    <Title>
+                    <StyledHeading>
                       <GuideAnchor target="discover_landing_header">
                         {t('Discover')}
                       </GuideAnchor>
-                    </Title>
+                    </StyledHeading>
                   )}
                 </Layout.HeaderContent>
                 <Layout.HeaderActions>
@@ -345,6 +345,10 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
 
 const StyledPageContent = styled(PageContent)`
   padding: 0;
+`;
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
 `;
 
 const PrebuiltSwitch = styled('div')`

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -7,6 +7,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
+import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import withRouteAnalytics, {
@@ -76,7 +77,7 @@ class MonitorDetails extends AsyncView<Props, State> {
     }
 
     return (
-      <Fragment>
+      <StyledPageContent>
         <MonitorHeader monitor={monitor} orgId={this.orgSlug} onUpdate={this.onUpdate} />
         <Layout.Body>
           <Layout.Main fullWidth>
@@ -101,10 +102,14 @@ class MonitorDetails extends AsyncView<Props, State> {
             )}
           </Layout.Main>
         </Layout.Body>
-      </Fragment>
+      </StyledPageContent>
     );
   }
 }
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;
 
 const StyledPageFilterBar = styled(PageFilterBar)`
   margin-bottom: ${space(2)};

--- a/static/app/views/monitors/monitorHeader.tsx
+++ b/static/app/views/monitors/monitorHeader.tsx
@@ -5,6 +5,7 @@ import {SectionHeading} from 'sentry/components/charts/styles';
 import Clipboard from 'sentry/components/clipboard';
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageHeading from 'sentry/components/pageHeading';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -39,17 +40,15 @@ const MonitorHeader = ({monitor, orgId, onUpdate}: Props) => {
     <Layout.Header>
       <Layout.HeaderContent>
         <Breadcrumbs crumbs={crumbs} />
-        <Layout.Title>
-          <MonitorName>
-            <IdBadge
-              project={monitor.project}
-              avatarSize={28}
-              hideName
-              avatarProps={{hasTooltip: true, tooltip: monitor.project.slug}}
-            />
-            {monitor.name}
-          </MonitorName>
-        </Layout.Title>
+        <MonitorName>
+          <IdBadge
+            project={monitor.project}
+            avatarSize={28}
+            hideName
+            avatarProps={{hasTooltip: true, tooltip: monitor.project.slug}}
+          />
+          {monitor.name}
+        </MonitorName>
         <Clipboard value={monitor.id}>
           <MonitorId>
             {monitor.id} <IconCopy size="xs" />
@@ -74,10 +73,10 @@ const MonitorHeader = ({monitor, orgId, onUpdate}: Props) => {
   );
 };
 
-const MonitorName = styled('div')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  grid-column-gap: ${space(1)};
+const MonitorName = styled(PageHeading)`
+  line-height: 40px;
+  display: flex;
+  gap: ${space(1)};
   align-items: center;
 `;
 
@@ -94,6 +93,7 @@ const MonitorStats = styled('div')`
   grid-column-gap: ${space(4)};
   grid-row-gap: ${space(0.5)};
   margin-bottom: ${space(2)};
+  margin-top: ${space(1)};
 `;
 
 const MonitorStatLabel = styled(SectionHeading)`

--- a/static/app/views/monitors/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/monitorHeaderActions.tsx
@@ -1,5 +1,4 @@
 import {browserHistory} from 'react-router';
-import styled from '@emotion/styled';
 
 import {
   addErrorMessage,
@@ -11,7 +10,6 @@ import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
 import {IconDelete, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {logException} from 'sentry/utils/logging';
 import useApi from 'sentry/utils/useApi';
 
@@ -66,37 +64,28 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
     });
 
   return (
-    <ButtonContainer>
-      <ButtonBar gap={1}>
-        <Button
-          size="sm"
-          icon={<IconEdit size="xs" />}
-          to={`/organizations/${orgId}/crons/${monitor.id}/edit/`}
-        >
-          {t('Edit')}
+    <ButtonBar gap={1}>
+      <Button
+        size="sm"
+        icon={<IconEdit size="xs" />}
+        to={`/organizations/${orgId}/crons/${monitor.id}/edit/`}
+      >
+        {t('Edit')}
+      </Button>
+      <Button size="sm" onClick={toggleStatus}>
+        {monitor.status !== 'disabled' ? t('Pause') : t('Enable')}
+      </Button>
+      <Confirm
+        onConfirm={handleDelete}
+        message={t('Are you sure you want to permanently delete this cron monitor?')}
+      >
+        <Button size="sm" icon={<IconDelete size="xs" />}>
+          {t('Delete')}
         </Button>
-        <Button size="sm" onClick={toggleStatus}>
-          {monitor.status !== 'disabled' ? t('Pause') : t('Enable')}
-        </Button>
-        <Confirm
-          onConfirm={handleDelete}
-          message={t('Are you sure you want to permanently delete this cron monitor?')}
-        >
-          <Button size="sm" icon={<IconDelete size="xs" />}>
-            {t('Delete')}
-          </Button>
-        </Confirm>
-        <CronsFeedbackButton />
-      </ButtonBar>
-    </ButtonContainer>
+      </Confirm>
+      <CronsFeedbackButton />
+    </ButtonBar>
   );
 };
-
-const ButtonContainer = styled('div')`
-  margin-bottom: ${space(3)};
-  display: flex;
-  flex-shrink: 1;
-  align-self: flex-end;
-`;
 
 export default MonitorHeaderActions;

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -10,6 +10,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PageHeading from 'sentry/components/pageHeading';
 import TimeSince from 'sentry/components/timeSince';
 import {t, tct, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -330,9 +331,9 @@ class TraceDetailsContent extends Component<Props, State> {
               location={location}
               traceSlug={traceSlug}
             />
-            <Layout.Title data-test-id="trace-header">
+            <StyledHeading data-test-id="trace-header">
               {t('Trace ID: %s', traceSlug)}
-            </Layout.Title>
+            </StyledHeading>
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
@@ -360,6 +361,10 @@ class TraceDetailsContent extends Component<Props, State> {
     );
   }
 }
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
 
 const Margin = styled('div')`
   margin-top: ${space(2)};

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
@@ -16,6 +17,7 @@ import RootSpanStatus from 'sentry/components/events/rootSpanStatus';
 import FileSize from 'sentry/components/fileSize';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
+import PageHeading from 'sentry/components/pageHeading';
 import {TransactionProfileIdProvider} from 'sentry/components/profiling/transactionProfileIdProvider';
 import {TransactionToProfileButton} from 'sentry/components/profiling/transactionToProfileButton';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -171,7 +173,9 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                       }}
                       eventSlug={eventSlug}
                     />
-                    <Layout.Title data-test-id="event-header">{event.title}</Layout.Title>
+                    <StyledHeading data-test-id="event-header">
+                      {event.title}
+                    </StyledHeading>
                   </Layout.HeaderContent>
                   <Layout.HeaderActions>
                     <ButtonBar gap={1}>
@@ -309,5 +313,9 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     );
   }
 }
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
 
 export default EventDetailsContent;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -9,6 +9,7 @@ import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import FeatureBadge from 'sentry/components/featureBadge';
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageHeading from 'sentry/components/pageHeading';
 import {isProfilingSupportedOrProjectHasProfiles} from 'sentry/components/profiling/ProfilingOnboarding/util';
 import ReplayCountBadge from 'sentry/components/replays/replayCountBadge';
 import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
@@ -123,19 +124,17 @@ function TransactionHeader({
           }}
           tab={currentTab}
         />
-        <Layout.Title>
-          <TransactionName>
-            {project && (
-              <IdBadge
-                project={project}
-                avatarSize={28}
-                hideName
-                avatarProps={{hasTooltip: true, tooltip: project.slug}}
-              />
-            )}
-            {transactionName}
-          </TransactionName>
-        </Layout.Title>
+        <TransactionName>
+          {project && (
+            <IdBadge
+              project={project}
+              avatarSize={28}
+              hideName
+              avatarProps={{hasTooltip: true, tooltip: project.slug}}
+            />
+          )}
+          {transactionName}
+        </TransactionName>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         <ButtonBar gap={1}>
@@ -226,10 +225,10 @@ function TransactionHeader({
   );
 }
 
-const TransactionName = styled('div')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  grid-column-gap: ${space(1)};
+const TransactionName = styled(PageHeading)`
+  line-height: 40px;
+  display: flex;
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import Feature from 'sentry/components/acl/feature';
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageHeading from 'sentry/components/pageHeading';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
@@ -70,19 +71,17 @@ export default function SpanDetailsContentWrapper(props: Props) {
             tab={Tab.Spans}
             spanSlug={spanSlug}
           />
-          <Layout.Title>
-            <TransactionName>
-              {project && (
-                <IdBadge
-                  project={project}
-                  avatarSize={28}
-                  hideName
-                  avatarProps={{hasTooltip: true, tooltip: project.slug}}
-                />
-              )}
-              {transactionName}
-            </TransactionName>
-          </Layout.Title>
+          <TransactionName>
+            {project && (
+              <IdBadge
+                project={project}
+                avatarSize={28}
+                hideName
+                avatarProps={{hasTooltip: true, tooltip: project.slug}}
+              />
+            )}
+            {transactionName}
+          </TransactionName>
         </Layout.HeaderContent>
       </Layout.Header>
       <Layout.Body>
@@ -155,10 +154,10 @@ export default function SpanDetailsContentWrapper(props: Props) {
   );
 }
 
-const TransactionName = styled('div')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  grid-column-gap: ${space(1)};
+const TransactionName = styled(PageHeading)`
+  line-height: 40px;
+  display: flex;
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -12,6 +12,7 @@ import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import PageHeading from 'sentry/components/pageHeading';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -229,7 +230,7 @@ class TrendsContent extends Component<Props, State> {
                 },
               ]}
             />
-            <Layout.Title>{t('Trends')}</Layout.Title>
+            <StyledHeading>{t('Trends')}</StyledHeading>
           </Layout.HeaderContent>
         </Layout.Header>
         <Layout.Body>
@@ -336,6 +337,10 @@ class DefaultTrends extends Component<DefaultTrendsProps> {
     return null;
   }
 }
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
 
 const FilterActions = styled('div')`
   display: grid;

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -19,6 +19,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import PageHeading from 'sentry/components/pageHeading';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {IconCheckmark, IconClose} from 'sentry/icons';
@@ -263,7 +264,7 @@ function VitalDetailContent(props: Props) {
       <Layout.Header>
         <Layout.HeaderContent>
           <Breadcrumb organization={organization} location={location} vitalName={vital} />
-          <Layout.Title>{vitalMap[vital]}</Layout.Title>
+          <StyledHeading>{vitalMap[vital]}</StyledHeading>
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <ButtonBar gap={1}>
@@ -298,6 +299,10 @@ function VitalDetailContent(props: Props) {
 }
 
 export default withProjects(VitalDetailContent);
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
 
 const StyledDescription = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -10,11 +10,13 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import PageHeading from 'sentry/components/pageHeading';
 import {Breadcrumb} from 'sentry/components/profiling/breadcrumb';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import SmartSearchBar, {SmartSearchBarProps} from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
+import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {PageFilters, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -120,31 +122,31 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
         specificProjectSlugs={defined(project) ? [project.slug] : []}
       >
         <NoProjectMessage organization={organization}>
-          {project && transaction && (
-            <Fragment>
-              <Layout.Header>
-                <Layout.HeaderContent>
-                  <Breadcrumb
-                    organization={organization}
-                    trails={[
-                      {
-                        type: 'landing',
-                        payload: {
-                          query: props.location.query,
+          <StyledPageContent>
+            {project && transaction && (
+              <Fragment>
+                <Layout.Header>
+                  <Layout.HeaderContent>
+                    <Breadcrumb
+                      organization={organization}
+                      trails={[
+                        {
+                          type: 'landing',
+                          payload: {
+                            query: props.location.query,
+                          },
                         },
-                      },
-                      {
-                        type: 'profile summary',
-                        payload: {
-                          projectSlug: project.slug,
-                          query: props.location.query,
-                          transaction,
+                        {
+                          type: 'profile summary',
+                          payload: {
+                            projectSlug: project.slug,
+                            query: props.location.query,
+                            transaction,
+                          },
                         },
-                      },
-                    ]}
-                  />
-                  <Layout.Title>
-                    <Title>
+                      ]}
+                    />
+                    <ProfileTitle>
                       {project ? (
                         <IdBadge
                           project={project}
@@ -154,47 +156,53 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                         />
                       ) : null}
                       {transaction}
-                    </Title>
-                  </Layout.Title>
-                </Layout.HeaderContent>
-              </Layout.Header>
-              <Layout.Body>
-                <Layout.Main fullWidth>
-                  <ActionBar>
-                    <PageFilterBar condensed>
-                      <EnvironmentPageFilter />
-                      <DatePageFilter alignDropdown="left" />
-                    </PageFilterBar>
-                    <SmartSearchBar
-                      organization={organization}
-                      hasRecentSearches
-                      searchSource="profile_summary"
-                      supportedTags={profileFilters}
-                      query={rawQuery}
-                      onSearch={handleSearch}
-                      maxQueryLength={MAX_QUERY_LENGTH}
+                    </ProfileTitle>
+                  </Layout.HeaderContent>
+                </Layout.Header>
+                <Layout.Body>
+                  <Layout.Main fullWidth>
+                    <ActionBar>
+                      <PageFilterBar condensed>
+                        <EnvironmentPageFilter />
+                        <DatePageFilter alignDropdown="left" />
+                      </PageFilterBar>
+                      <SmartSearchBar
+                        organization={organization}
+                        hasRecentSearches
+                        searchSource="profile_summary"
+                        supportedTags={profileFilters}
+                        query={rawQuery}
+                        onSearch={handleSearch}
+                        maxQueryLength={MAX_QUERY_LENGTH}
+                      />
+                    </ActionBar>
+                    <ProfileSummaryContent
+                      location={props.location}
+                      project={project}
+                      selection={props.selection}
+                      transaction={transaction}
+                      query={query}
                     />
-                  </ActionBar>
-                  <ProfileSummaryContent
-                    location={props.location}
-                    project={project}
-                    selection={props.selection}
-                    transaction={transaction}
-                    query={query}
-                  />
-                </Layout.Main>
-              </Layout.Body>
-            </Fragment>
-          )}
+                  </Layout.Main>
+                </Layout.Body>
+              </Fragment>
+            )}
+          </StyledPageContent>
         </NoProjectMessage>
       </PageFiltersContainer>
     </SentryDocumentTitle>
   );
 }
 
-const Title = styled('div')`
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;
+
+const ProfileTitle = styled(PageHeading)`
+  line-height: 40px;
   display: flex;
   gap: ${space(1)};
+  align-items: center;
 `;
 
 const ActionBar = styled('div')`

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -19,6 +19,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import PageHeading from 'sentry/components/pageHeading';
 import MissingProjectMembership from 'sentry/components/projects/missingProjectMembership';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
@@ -211,16 +212,18 @@ class ProjectDetail extends AsyncView<Props, State> {
                     {label: t('Project Details')},
                   ]}
                 />
-                <Layout.Title>
-                  {project && (
+                <ProjectTitle>
+                  {project ? (
                     <IdBadge
                       project={project}
                       avatarSize={28}
                       hideOverflow="100%"
                       disableLink
+                      hideName
                     />
-                  )}
-                </Layout.Title>
+                  ) : null}
+                  {project?.slug}
+                </ProjectTitle>
               </Layout.HeaderContent>
 
               <Layout.HeaderActions>
@@ -345,6 +348,13 @@ class ProjectDetail extends AsyncView<Props, State> {
 
 const StyledPageContent = styled(PageContent)`
   padding: 0;
+`;
+
+const ProjectTitle = styled(PageHeading)`
+  line-height: 40px;
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
 `;
 
 const ProjectFiltersWrapper = styled('div')`

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -11,6 +11,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
+import PageHeading from 'sentry/components/pageHeading';
 import Tooltip from 'sentry/components/tooltip';
 import Version from 'sentry/components/version';
 import {URL_PARAM} from 'sentry/constants/pageFilters';
@@ -97,28 +98,26 @@ const ReleaseHeader = ({
             {label: t('Release Details')},
           ]}
         />
-        <Layout.Title>
-          <ReleaseName>
-            <IdBadge project={project} avatarSize={28} hideName />
-            <StyledVersion version={version} anchor={false} truncate />
+        <StyledHeading>
+          <IdBadge project={project} avatarSize={28} hideName />
+          <StyledVersion version={version} anchor={false} truncate />
+          <IconWrapper>
+            <Tooltip title={version} containerDisplayMode="flex">
+              <Clipboard value={version}>
+                <IconCopy />
+              </Clipboard>
+            </Tooltip>
+          </IconWrapper>
+          {!!url && (
             <IconWrapper>
-              <Tooltip title={version} containerDisplayMode="flex">
-                <Clipboard value={version}>
-                  <IconCopy />
-                </Clipboard>
+              <Tooltip title={url}>
+                <ExternalLink href={url}>
+                  <IconOpen />
+                </ExternalLink>
               </Tooltip>
             </IconWrapper>
-            {!!url && (
-              <IconWrapper>
-                <Tooltip title={url}>
-                  <ExternalLink href={url}>
-                    <IconOpen />
-                  </ExternalLink>
-                </Tooltip>
-              </IconWrapper>
-            )}
-          </ReleaseName>
-        </Layout.Title>
+          )}
+        </StyledHeading>
       </Layout.HeaderContent>
 
       <Layout.HeaderActions>
@@ -149,7 +148,8 @@ const ReleaseHeader = ({
   );
 };
 
-const ReleaseName = styled('div')`
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
   display: flex;
   align-items: center;
 `;


### PR DESCRIPTION
Follow up after #43081.

This is most of the details views that were inconsistently using the layout components

[Screenshots here](https://github.com/getsentry/team-coreui/issues/46#issuecomment-1379418089)