### PR TITLE
feat(issue-platform): Control shown tabs with issue capability config

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -72,7 +72,11 @@ type CapabilityInfo = {
  */
 export type IssueCategoryCapabilities = {
   /**
-   * Are codeowner features enabled for this issue
+   * Is the Attachments tab shown for this issue
+   */
+  attachments: CapabilityInfo;
+  /**
+   * Are codeowner features shown for this issue
    */
   codeowners: CapabilityInfo;
   /**
@@ -84,6 +88,10 @@ export type IssueCategoryCapabilities = {
    */
   deleteAndDiscard: CapabilityInfo;
   /**
+   * Is the Grouping tab shown for this issue
+   */
+  grouping: CapabilityInfo;
+  /**
    * Can the issue be ignored (and the dropdown options)
    */
   ignore: CapabilityInfo;
@@ -92,9 +100,25 @@ export type IssueCategoryCapabilities = {
    */
   merge: CapabilityInfo;
   /**
+   * Is the Merged Issues tab shown for this issue
+   */
+  mergedIssues: CapabilityInfo;
+  /**
+   * Is the Replays tab shown for this issue
+   */
+  replays: CapabilityInfo;
+  /**
    * Can the issue be shared
    */
   share: CapabilityInfo;
+  /**
+   * Is the Similar Issues tab shown for this issue
+   */
+  similarIssues: CapabilityInfo;
+  /**
+   * Is the User Feedback tab enabled for this issue
+   */
+  userFeedback: CapabilityInfo;
 };
 
 // endpoint: /api/0/issues/:issueId/attachments/?limit=50

--- a/static/app/utils/groupCapabilities.tsx
+++ b/static/app/utils/groupCapabilities.tsx
@@ -12,6 +12,14 @@ const ISSUE_CATEGORY_CAPABILITIES: Record<IssueCategory, IssueCategoryCapabiliti
     ignore: {enabled: true},
     share: {enabled: true},
     codeowners: {enabled: true},
+
+    // Tabs
+    userFeedback: {enabled: true},
+    attachments: {enabled: true},
+    mergedIssues: {enabled: true},
+    grouping: {enabled: true},
+    similarIssues: {enabled: true},
+    replays: {enabled: true},
   },
   [IssueCategory.PERFORMANCE]: {
     delete: {
@@ -32,6 +40,14 @@ const ISSUE_CATEGORY_CAPABILITIES: Record<IssueCategory, IssueCategoryCapabiliti
       enabled: false,
       disabledReason: t('Codeowners do not apply to performance issues'),
     },
+
+    // Tabs
+    userFeedback: {enabled: false},
+    attachments: {enabled: false},
+    mergedIssues: {enabled: false},
+    grouping: {enabled: false},
+    similarIssues: {enabled: false},
+    replays: {enabled: false},
   },
 };
 

--- a/static/app/views/organizationGroupDetails/header.spec.tsx
+++ b/static/app/views/organizationGroupDetails/header.spec.tsx
@@ -1,0 +1,120 @@
+import {browserHistory} from 'react-router';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {IssueCategory} from 'sentry/types';
+import GroupHeader from 'sentry/views/organizationGroupDetails/header';
+import {ReprocessingStatus} from 'sentry/views/organizationGroupDetails/utils';
+
+describe('groupDetails', () => {
+  const baseUrl = 'BASE_URL/';
+  const organization = TestStubs.Organization();
+  const project = TestStubs.Project({teams: [TestStubs.Team()]});
+
+  describe('issue category: error', () => {
+    const defaultProps = {
+      organization,
+      baseUrl,
+      group: TestStubs.Group({issueCategory: IssueCategory.ERROR}),
+      groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
+      project,
+    };
+
+    it('displays the correct tabs with all features enabled', () => {
+      const orgWithFeatures = TestStubs.Organization({
+        features: ['grouping-tree-ui', 'similarity-view', 'event-attachments'],
+      });
+      const projectWithSimilarityView = TestStubs.Project({
+        features: ['similarity-view'],
+      });
+
+      render(
+        <GroupHeader
+          {...defaultProps}
+          organization={orgWithFeatures}
+          project={projectWithSimilarityView}
+        />,
+        {organization: orgWithFeatures}
+      );
+
+      userEvent.click(screen.getByRole('tab', {name: /details/i}));
+      expect(browserHistory.push).toHaveBeenLastCalledWith('BASE_URL/');
+
+      userEvent.click(screen.getByRole('tab', {name: /activity/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/activity/');
+
+      userEvent.click(screen.getByRole('tab', {name: /user feedback/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/feedback/');
+
+      userEvent.click(screen.getByRole('tab', {name: /attachments/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/attachments/');
+
+      userEvent.click(screen.getByRole('tab', {name: /tags/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/tags/');
+
+      userEvent.click(screen.getByRole('tab', {name: /all events/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/events/',
+        query: {},
+      });
+
+      userEvent.click(screen.getByRole('tab', {name: /merged issues/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/merged/');
+
+      userEvent.click(screen.getByRole('tab', {name: /grouping/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/grouping/');
+
+      userEvent.click(screen.getByRole('tab', {name: /similar issues/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/similar/');
+    });
+  });
+
+  describe('issue category: performance', () => {
+    const defaultProps = {
+      organization,
+      baseUrl,
+      group: TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE}),
+      groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
+      project,
+    };
+
+    it('displays the correct tabs with all features enabled', () => {
+      const orgWithFeatures = TestStubs.Organization({
+        features: ['grouping-tree-ui', 'similarity-view', 'event-attachments'],
+      });
+
+      const projectWithSimilarityView = TestStubs.Project({
+        features: ['similarity-view'],
+      });
+
+      render(
+        <GroupHeader
+          {...defaultProps}
+          organization={orgWithFeatures}
+          project={projectWithSimilarityView}
+        />,
+        {organization: orgWithFeatures}
+      );
+
+      userEvent.click(screen.getByRole('tab', {name: /details/i}));
+      expect(browserHistory.push).toHaveBeenLastCalledWith('BASE_URL/');
+
+      userEvent.click(screen.getByRole('tab', {name: /tags/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith('BASE_URL/tags/');
+
+      userEvent.click(screen.getByRole('tab', {name: /all events/i}));
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: 'BASE_URL/events/',
+        query: {},
+      });
+
+      expect(screen.queryByRole('tab', {name: /user feedback/i})).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', {name: /attachments/i})).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', {name: /merged issues/i})).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', {name: /grouping/i})).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('tab', {name: /similar issues/i})
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
+import {LocationDescriptor} from 'history';
 import omit from 'lodash/omit';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -26,17 +27,12 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconChat} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {
-  Event,
-  Group,
-  IssueCategory,
-  IssueType,
-  Organization,
-  Project,
-} from 'sentry/types';
+import {Event, Group, IssueType, Organization, Project} from 'sentry/types';
 import {getMessage} from 'sentry/utils/events';
+import {getIssueCapability} from 'sentry/utils/groupCapabilities';
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import GroupActions from './actions';
 import {Tab} from './types';
@@ -52,6 +48,130 @@ type Props = {
   event?: Event;
 };
 
+interface GroupHeaderTabsProps extends Pick<Props, 'baseUrl' | 'group' | 'project'> {
+  disabledTabs: Tab[];
+  eventRoute: LocationDescriptor;
+}
+
+function GroupHeaderTabs({
+  baseUrl,
+  disabledTabs,
+  eventRoute,
+  group,
+  project,
+}: GroupHeaderTabsProps) {
+  const organization = useOrganization();
+  const replaysCount = useReplaysCount({
+    groupIds: group.id,
+    organization,
+    projectIds: [Number(project.id)],
+  })[group.id];
+  const projectFeatures = new Set(project ? project.features : []);
+  const organizationFeatures = new Set(organization ? organization.features : []);
+
+  const hasGroupingTreeUI = organizationFeatures.has('grouping-tree-ui');
+  const hasSimilarView = projectFeatures.has('similarity-view');
+  const hasEventAttachments = organizationFeatures.has('event-attachments');
+  const hasSessionReplay =
+    organizationFeatures.has('session-replay-ui') && projectSupportsReplay(project);
+
+  return (
+    <StyledTabList hideBorder>
+      <Item
+        key={Tab.DETAILS}
+        disabled={disabledTabs.includes(Tab.DETAILS)}
+        to={`${baseUrl}${location.search}`}
+      >
+        {t('Details')}
+      </Item>
+      <Item
+        key={Tab.ACTIVITY}
+        textValue={t('Activity')}
+        disabled={disabledTabs.includes(Tab.ACTIVITY)}
+        to={`${baseUrl}activity/${location.search}`}
+      >
+        {t('Activity')}
+        <IconBadge>
+          {group.numComments}
+          <IconChat size="xs" />
+        </IconBadge>
+      </Item>
+      <Item
+        key={Tab.USER_FEEDBACK}
+        textValue={t('User Feedback')}
+        hidden={!getIssueCapability(group.issueCategory, 'userFeedback').enabled}
+        disabled={disabledTabs.includes(Tab.USER_FEEDBACK)}
+        to={`${baseUrl}feedback/${location.search}`}
+      >
+        {t('User Feedback')} <Badge text={group.userReportCount} />
+      </Item>
+      <Item
+        key={Tab.ATTACHMENTS}
+        hidden={
+          !hasEventAttachments ||
+          !getIssueCapability(group.issueCategory, 'attachments').enabled
+        }
+        disabled={disabledTabs.includes(Tab.ATTACHMENTS)}
+        to={`${baseUrl}attachments/${location.search}`}
+      >
+        {t('Attachments')}
+      </Item>
+      <Item
+        key={Tab.TAGS}
+        disabled={disabledTabs.includes(Tab.TAGS)}
+        to={`${baseUrl}tags/${location.search}`}
+      >
+        {t('Tags')}
+      </Item>
+      <Item key={Tab.EVENTS} disabled={disabledTabs.includes(Tab.EVENTS)} to={eventRoute}>
+        {t('All Events')}
+      </Item>
+      <Item
+        key={Tab.MERGED}
+        hidden={!getIssueCapability(group.issueCategory, 'mergedIssues').enabled}
+        disabled={disabledTabs.includes(Tab.MERGED)}
+        to={`${baseUrl}merged/${location.search}`}
+      >
+        {t('Merged Issues')}
+      </Item>
+      <Item
+        key={Tab.GROUPING}
+        hidden={
+          !hasGroupingTreeUI ||
+          !getIssueCapability(group.issueCategory, 'grouping').enabled
+        }
+        disabled={disabledTabs.includes(Tab.GROUPING)}
+        to={`${baseUrl}grouping/${location.search}`}
+      >
+        {t('Grouping')}
+      </Item>
+      <Item
+        key={Tab.SIMILAR_ISSUES}
+        hidden={
+          !hasSimilarView ||
+          !getIssueCapability(group.issueCategory, 'similarIssues').enabled
+        }
+        disabled={disabledTabs.includes(Tab.SIMILAR_ISSUES)}
+        to={`${baseUrl}similar/${location.search}`}
+      >
+        {t('Similar Issues')}
+      </Item>
+      <Item
+        key={Tab.REPLAYS}
+        textValue={t('Replays')}
+        hidden={
+          !hasSessionReplay || !getIssueCapability(group.issueCategory, 'replays').enabled
+        }
+        to={`${baseUrl}replays/${location.search}`}
+      >
+        {t('Replays')}
+        <ReplayCountBadge count={replaysCount} />
+        <ReplaysFeatureBadge noTooltip />
+      </Item>
+    </StyledTabList>
+  );
+}
+
 function GroupHeader({
   baseUrl,
   group,
@@ -61,12 +181,6 @@ function GroupHeader({
   project,
 }: Props) {
   const location = useLocation();
-
-  const replaysCount = useReplaysCount({
-    groupIds: group.id,
-    organization,
-    projectIds: [Number(project.id)],
-  })[group.id];
 
   const disabledTabs = useMemo(() => {
     const hasReprocessingV2Feature = organization.features.includes('reprocessing-v2');
@@ -104,161 +218,13 @@ function GroupHeader({
     return [];
   }, [organization, groupReprocessingStatus]);
 
-  const eventRouteToObject = useMemo(() => {
+  const eventRoute = useMemo(() => {
     const searchTermWithoutQuery = omit(location.query, 'query');
     return {
       pathname: `${baseUrl}events/`,
       query: searchTermWithoutQuery,
     };
   }, [location, baseUrl]);
-
-  const errorIssueTabs = useMemo(() => {
-    const projectFeatures = new Set(project ? project.features : []);
-    const organizationFeatures = new Set(organization ? organization.features : []);
-
-    const hasGroupingTreeUI = organizationFeatures.has('grouping-tree-ui');
-    const hasSimilarView = projectFeatures.has('similarity-view');
-    const hasEventAttachments = organizationFeatures.has('event-attachments');
-    const hasSessionReplay =
-      organizationFeatures.has('session-replay-ui') && projectSupportsReplay(project);
-
-    return (
-      <StyledTabList hideBorder>
-        <Item
-          key={Tab.DETAILS}
-          disabled={disabledTabs.includes(Tab.DETAILS)}
-          to={`${baseUrl}${location.search}`}
-        >
-          {t('Details')}
-        </Item>
-        <Item
-          key={Tab.ACTIVITY}
-          textValue={t('Activity')}
-          disabled={disabledTabs.includes(Tab.ACTIVITY)}
-          to={`${baseUrl}activity/${location.search}`}
-        >
-          {t('Activity')}
-          <IconBadge>
-            {group.numComments}
-            <IconChat size="xs" />
-          </IconBadge>
-        </Item>
-        <Item
-          key={Tab.USER_FEEDBACK}
-          textValue={t('User Feedback')}
-          disabled={disabledTabs.includes(Tab.USER_FEEDBACK)}
-          to={`${baseUrl}feedback/${location.search}`}
-        >
-          {t('User Feedback')} <Badge text={group.userReportCount} />
-        </Item>
-        <Item
-          key={Tab.ATTACHMENTS}
-          hidden={!hasEventAttachments}
-          disabled={disabledTabs.includes(Tab.ATTACHMENTS)}
-          to={`${baseUrl}attachments/${location.search}`}
-        >
-          {t('Attachments')}
-        </Item>
-        <Item
-          key={Tab.TAGS}
-          disabled={disabledTabs.includes(Tab.TAGS)}
-          to={`${baseUrl}tags/${location.search}`}
-        >
-          {t('Tags')}
-        </Item>
-        <Item
-          key={Tab.EVENTS}
-          disabled={disabledTabs.includes(Tab.EVENTS)}
-          to={eventRouteToObject}
-        >
-          {t('All Events')}
-        </Item>
-        <Item
-          key={Tab.MERGED}
-          disabled={disabledTabs.includes(Tab.MERGED)}
-          to={`${baseUrl}merged/${location.search}`}
-        >
-          {t('Merged Issues')}
-        </Item>
-        <Item
-          key={Tab.GROUPING}
-          hidden={!hasGroupingTreeUI}
-          disabled={disabledTabs.includes(Tab.GROUPING)}
-          to={`${baseUrl}grouping/${location.search}`}
-        >
-          {t('Grouping')}
-        </Item>
-        <Item
-          key={Tab.SIMILAR_ISSUES}
-          hidden={!hasSimilarView}
-          disabled={disabledTabs.includes(Tab.SIMILAR_ISSUES)}
-          to={`${baseUrl}similar/${location.search}`}
-        >
-          {t('Similar Issues')}
-        </Item>
-        <Item
-          key={Tab.REPLAYS}
-          textValue={t('Replays')}
-          hidden={!hasSessionReplay}
-          to={`${baseUrl}replays/${location.search}`}
-        >
-          {t('Replays')}
-          <ReplayCountBadge count={replaysCount} />
-          <ReplaysFeatureBadge noTooltip />
-        </Item>
-      </StyledTabList>
-    );
-  }, [
-    baseUrl,
-    location,
-    disabledTabs,
-    group.numComments,
-    group.userReportCount,
-    organization,
-    project,
-    replaysCount,
-    eventRouteToObject,
-  ]);
-
-  const performanceIssueTabs = useMemo(() => {
-    return (
-      <StyledTabList hideBorder>
-        <Item
-          key={Tab.DETAILS}
-          disabled={disabledTabs.includes(Tab.DETAILS)}
-          to={`${baseUrl}${location.search}`}
-        >
-          {t('Details')}
-        </Item>
-        <Item
-          key={Tab.ACTIVITY}
-          textValue={t('Activity')}
-          disabled={disabledTabs.includes(Tab.ACTIVITY)}
-          to={`${baseUrl}activity/${location.search}`}
-        >
-          {t('Activity')}
-          <IconBadge>
-            {group.numComments}
-            <IconChat size="xs" />
-          </IconBadge>
-        </Item>
-        <Item
-          key={Tab.TAGS}
-          disabled={disabledTabs.includes(Tab.TAGS)}
-          to={`${baseUrl}tags/${location.search}`}
-        >
-          {t('Tags')}
-        </Item>
-        <Item
-          key={Tab.EVENTS}
-          disabled={disabledTabs.includes(Tab.EVENTS)}
-          to={eventRouteToObject}
-        >
-          {t('Events')}
-        </Item>
-      </StyledTabList>
-    );
-  }, [disabledTabs, group.numComments, baseUrl, location, eventRouteToObject]);
 
   const {userCount} = group;
 
@@ -346,7 +312,7 @@ function GroupHeader({
           <StatsWrapper>
             <div className="count">
               <h6 className="nav-header">{t('Events')}</h6>
-              <Link disabled={disableActions} to={eventRouteToObject}>
+              <Link disabled={disableActions} to={eventRoute}>
                 <Count className="count" value={group.count} />
               </Link>
             </div>
@@ -385,9 +351,7 @@ function GroupHeader({
             />
           </HeaderRow>
         )}
-        {group.issueCategory === IssueCategory.PERFORMANCE
-          ? performanceIssueTabs
-          : errorIssueTabs}
+        <GroupHeaderTabs {...{baseUrl, disabledTabs, eventRoute, group, project}} />
       </div>
     </Layout.Header>
   );


### PR DESCRIPTION
Instead of having to define a separate array for each issue category, adds them to the `groupCapabilities` config. Makes for one fewer place you need to make changes when adding a new issue type.