### PR TITLE
feat(spans): add span search support

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -536,6 +536,8 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
   // of model to search through. This will become useful as we  build
   // differential flamecharts or start comparing different profiles/charts
   const flamegraphs = useMemo(() => [flamegraph], [flamegraph]);
+  const spans = useMemo(() => (spanChart ? [spanChart] : []), [spanChart]);
+
   return (
     <Fragment>
       <FlamegraphToolbar>
@@ -551,6 +553,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
           onViewChange={onViewChange}
         />
         <FlamegraphSearch
+          spans={spans}
           flamegraphs={flamegraphs}
           canvasPoolManager={canvasPoolManager}
         />

--- a/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpanTooltip.tsx
@@ -67,10 +67,7 @@ export function FlamegraphSpanTooltip({
           backgroundColor={formatColorForSpan(hoveredNode, spansRenderer)}
         />
         {spanChart.formatter(hoveredNode.duration)}{' '}
-        {formatWeightToTransactionDuration(hoveredNode, spanChart)}{' '}
-        {hoveredNode.node.span.op === 'missing instrumentation'
-          ? t('Missing instrumentation')
-          : hoveredNode.node.span.description}
+        {formatWeightToTransactionDuration(hoveredNode, spanChart)} {hoveredNode.text}
       </FlamegraphTooltipFrameMainInfo>
       <FlamegraphTooltipTimelineInfo>
         {hoveredNode.node.span.op ? `${t('op')}:${hoveredNode.node.span.op} ` : null}

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -15,27 +15,48 @@ import {
 } from 'sentry/utils/profiling/flamegraphFrame';
 import {fzf} from 'sentry/utils/profiling/fzf/fzf';
 import {memoizeByReference} from 'sentry/utils/profiling/profile/utils';
+import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
 import {parseRegExp} from 'sentry/utils/profiling/validators/regExp';
 
-export function searchFzf(
+export function searchFrameFzf(
   frame: FlamegraphFrame,
-  matches: FlamegraphSearchResults['results'],
+  matches: FlamegraphSearchResults['results']['frames'],
   query: string
 ) {
   const match = fzf(frame.frame.name, query, false);
 
-  if (match.score > 0) {
-    matches.set(getFlamegraphFrameSearchId(frame), {
-      frame,
-      match: match.matches[0],
-    });
+  if (match.score <= 0) {
+    return match;
   }
+
+  matches.set(getFlamegraphFrameSearchId(frame), {
+    frame,
+    match: match.matches[0],
+  });
   return match;
 }
 
-export function searchRegExp(
+export function searchSpanFzf(
+  span: SpanChartNode,
+  matches: FlamegraphSearchResults['results']['spans'],
+  query: string
+) {
+  const match = fzf(span.text ?? '', query, false);
+
+  if (match.score <= 0) {
+    return match;
+  }
+
+  matches.set(span.node.span.span_id, {
+    span,
+    match: match.matches[0],
+  });
+  return match;
+}
+
+export function searchFrameRegExp(
   frame: FlamegraphFrame,
-  matches: FlamegraphSearchResults['results'],
+  matches: FlamegraphSearchResults['results']['frames'],
   query: string,
   flags: string
 ) {
@@ -43,50 +64,91 @@ export function searchRegExp(
   const reMatches = Array.from(frame.frame.name.matchAll(regExp));
   const match = findBestMatchFromRegexpMatchArray(reMatches);
 
-  if (match) {
-    matches.set(getFlamegraphFrameSearchId(frame), {
-      frame,
-      match,
-    });
+  if (match === null) {
+    return match;
   }
+
+  matches.set(getFlamegraphFrameSearchId(frame), {
+    frame,
+    match,
+  });
+  return match;
+}
+
+export function searchSpanRegExp(
+  span: SpanChartNode,
+  matches: FlamegraphSearchResults['results']['spans'],
+  query: string,
+  flags: string
+) {
+  const regExp = new RegExp(query, flags ?? 'g');
+  const reMatches = Array.from(span.text.matchAll(regExp));
+  const match = findBestMatchFromRegexpMatchArray(reMatches);
+
+  if (match === null) {
+    return match;
+  }
+
+  matches.set(span.node.span.span_id, {
+    span,
+    match,
+  });
   return match;
 }
 
 function yieldingRafFrameSearch(
   query: string,
+  spans: ReadonlyArray<SpanChartNode>,
   frames: ReadonlyArray<FlamegraphFrame>,
   cb: (results: FlamegraphSearchResults['results']) => void
 ) {
   const raf = {id: 0};
   const budget = 12; // ms
-  const results: FlamegraphSearchResults['results'] = new Map();
+  const results: FlamegraphSearchResults['results'] = {
+    frames: new Map(),
+    spans: new Map(),
+  };
   const regexp = parseRegExp(query);
   const isRegExpSearch = regexp !== null;
+
+  let processedFrames = 0;
+  let processedSpans = 0;
+
+  const framesToProcess = frames.length;
+  const spansToProcess = spans.length;
+
   // we lowercase the query to make the search case insensitive (assumption of fzf)
-  let processed = 0;
   const lowercaseQuery = query.toLowerCase();
   const [_, lookup, flags] = isRegExpSearch ? regexp : ['', '', ''];
 
-  const searchFunction = isRegExpSearch ? searchRegExp : searchFzf;
+  const searchFramesFunction = isRegExpSearch ? searchFrameRegExp : searchFrameFzf;
+  const searchSpansFunction = isRegExpSearch ? searchSpanRegExp : searchSpanFzf;
   const searchQuery = isRegExpSearch ? lookup : lowercaseQuery;
 
-  function search() {
+  function searchFramesAndSpans() {
     const start = performance.now();
 
-    while (performance.now() - start < budget && processed < frames.length) {
-      searchFunction(frames[processed]!, results, searchQuery, flags);
-      processed++;
+    while (processedSpans < spansToProcess && performance.now() - start < budget) {
+      searchSpansFunction(spans[processedSpans]!, results.spans, searchQuery, flags);
+      processedSpans++;
     }
 
-    if (processed === frames.length) {
-      cb(results);
+    while (processedFrames < framesToProcess && performance.now() - start < budget) {
+      searchFramesFunction(frames[processedFrames]!, results.frames, searchQuery, flags);
+      processedFrames++;
     }
-    if (processed < frames.length) {
-      raf.id = requestAnimationFrame(search);
+
+    if (processedFrames === framesToProcess && processedSpans === spansToProcess) {
+      cb(results);
+      return;
+    }
+
+    if (processedFrames < framesToProcess || processedSpans < spansToProcess) {
+      raf.id = requestAnimationFrame(searchFramesAndSpans);
     }
   }
 
-  raf.id = requestAnimationFrame(search);
+  raf.id = requestAnimationFrame(searchFramesAndSpans);
   return raf;
 }
 
@@ -95,7 +157,7 @@ function sortFrameResults(
 ): Array<FlamegraphFrame> {
   // If frames have the same start times, move frames with lower stack depth first.
   // This results in top down and left to right iteration
-  return [...frames.values()]
+  return [...frames.frames.values()]
     .map(f => f.frame)
     .sort((a, b) =>
       a.start === b.start
@@ -156,17 +218,19 @@ const numericSort = (
 interface FlamegraphSearchProps {
   canvasPoolManager: CanvasPoolManager;
   flamegraphs: Flamegraph | Flamegraph[];
+  spans: SpanChart | SpanChart[];
 }
 
 function FlamegraphSearch({
   flamegraphs,
   canvasPoolManager,
+  spans,
 }: FlamegraphSearchProps): React.ReactElement | null {
   const search = useFlamegraphSearch();
   const dispatch = useDispatchFlamegraphState();
   const [didInitialSearch, setDidInitialSearch] = useState(!search.query);
 
-  const allFrames = useMemo(() => {
+  const allFlamegraphFrames = useMemo(() => {
     if (Array.isArray(flamegraphs)) {
       return flamegraphs.reduce(
         (acc: FlamegraphFrame[], graph) => acc.concat(graph.frames),
@@ -176,6 +240,14 @@ function FlamegraphSearch({
 
     return flamegraphs.frames;
   }, [flamegraphs]);
+
+  const allSpanChartNodes = useMemo(() => {
+    if (Array.isArray(spans)) {
+      return spans.reduce((acc: SpanChartNode[], span) => acc.concat(span.spans), []);
+    }
+
+    return spans.spans;
+  }, [spans]);
 
   const onZoomIntoFrame = useCallback(
     (frame: FlamegraphFrame) => {
@@ -210,26 +282,31 @@ function FlamegraphSearch({
         return;
       }
 
-      rafHandler.current = yieldingRafFrameSearch(query, allFrames, results => {
-        dispatch({
-          type: 'set results',
-          payload: {
-            results,
-            query,
-          },
-        });
-      });
+      rafHandler.current = yieldingRafFrameSearch(
+        query,
+        allSpanChartNodes,
+        allFlamegraphFrames,
+        results => {
+          dispatch({
+            type: 'set results',
+            payload: {
+              results,
+              query,
+            },
+          });
+        }
+      );
     },
-    [dispatch, allFrames]
+    [dispatch, allFlamegraphFrames, allSpanChartNodes]
   );
 
   useEffect(() => {
-    if (didInitialSearch || allFrames.length === 0) {
+    if (didInitialSearch || allFlamegraphFrames.length === 0) {
       return;
     }
     handleChange(search.query);
     setDidInitialSearch(true);
-  }, [didInitialSearch, handleChange, allFrames, search.query]);
+  }, [didInitialSearch, handleChange, allFlamegraphFrames, search.query]);
 
   const onNextSearchClick = useCallback(() => {
     const frames = memoizedSortFrameResults(search.results);
@@ -293,8 +370,10 @@ function FlamegraphSearch({
           <Fragment>
             <StyledTrailingText>
               {`${
-                search.index !== null && search.results.size > 0 ? search.index + 1 : '-'
-              }/${search.results.size}`}
+                search.index !== null && search.results.frames.size > 0
+                  ? search.index + 1
+                  : '-'
+              }/${search.results.frames.size}`}
             </StyledTrailingText>
             <SearchBarTrailingButton
               size="zero"

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -161,7 +161,7 @@ function FlamegraphZoomView({
     if (!flamegraphRenderer) {
       return;
     }
-    flamegraphRenderer.setSearchResults(flamegraphSearch.results);
+    flamegraphRenderer.setSearchResults(flamegraphSearch.results.frames);
   }, [flamegraphRenderer, flamegraphSearch.results]);
 
   useEffect(() => {
@@ -188,7 +188,7 @@ function FlamegraphZoomView({
       textRenderer.draw(
         flamegraphView.toOriginConfigView(flamegraphView.configView),
         flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace),
-        flamegraphSearch.results
+        flamegraphSearch.results.frames
       );
     };
 
@@ -243,7 +243,7 @@ function FlamegraphZoomView({
     flamegraphRenderer,
     sampleTickRenderer,
     canvasPoolManager,
-    flamegraphSearch,
+    flamegraphSearch.results.frames,
   ]);
 
   const selectedFramesRef = useRef<FlamegraphFrame[] | null>(null);

--- a/static/app/components/profiling/flamegraphSearch.spec.tsx
+++ b/static/app/components/profiling/flamegraphSearch.spec.tsx
@@ -1,6 +1,9 @@
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 
-import {searchFzf, searchRegExp} from './flamegraph/flamegraphToolbar/flamegraphSearch';
+import {
+  searchFrameFzf,
+  searchFrameRegExp,
+} from './flamegraph/flamegraphToolbar/flamegraphSearch';
 
 const f = (name: string) => {
   return {
@@ -12,7 +15,7 @@ const f = (name: string) => {
 
 describe('fzf', () => {
   it('matches only first occurence', () => {
-    expect(searchFzf(f('foofoo'), new Map(), 'foo')).toMatchObject({
+    expect(searchFrameFzf(f('foofoo'), new Map(), 'foo')).toMatchObject({
       start: 0,
       end: 3,
       matches: [[0, 3]],
@@ -20,25 +23,27 @@ describe('fzf', () => {
   });
 
   it('prefers matches at start', () => {
-    expect(searchFzf(f('f'), new Map(), 'f').score).toBeGreaterThan(
-      searchFzf(f('of'), new Map(), 'f').score
+    expect(searchFrameFzf(f('f'), new Map(), 'f').score).toBeGreaterThan(
+      searchFrameFzf(f('of'), new Map(), 'f').score
     );
   });
 
   it('penalizes gaps', () => {
-    expect(searchFzf(f('f oo'), new Map(), 'foo').score).toBeLessThan(
-      searchFzf(f('foo'), new Map(), 'foo').score
+    expect(searchFrameFzf(f('f oo'), new Map(), 'foo').score).toBeLessThan(
+      searchFrameFzf(f('foo'), new Map(), 'foo').score
     );
   });
 
   it('narrows down indices on backtracking', () => {
     // https://github.com/junegunn/fzf/blob/f81feb1e69e5cb75797d50817752ddfe4933cd68/src/algo/algo.go#L13
-    expect(searchFzf(f('a_____b___abc__'), new Map(), 'abc').matches).toEqual([[10, 13]]);
+    expect(searchFrameFzf(f('a_____b___abc__'), new Map(), 'abc').matches).toEqual([
+      [10, 13],
+    ]);
   });
 });
 
 describe('regexp', () => {
   it('finds all matches', () => {
-    expect(searchRegExp(f('foofoo'), new Map(), 'foo', 'g')).toEqual([0, 3]);
+    expect(searchFrameRegExp(f('foofoo'), new Map(), 'foo', 'g')).toEqual([0, 3]);
   });
 });

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContext.tsx
@@ -32,7 +32,10 @@ export const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
   },
   search: {
     index: null,
-    results: new Map(),
+    results: {
+      frames: new Map(),
+      spans: new Map(),
+    },
     query: '',
   },
 };

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch.tsx
@@ -1,16 +1,25 @@
 import type Fuse from 'fuse.js';
 
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {SpanChartNode} from 'sentry/utils/profiling/spanChart';
 
 export type FlamegraphSearchResult = {
   frame: FlamegraphFrame;
   match: Fuse.RangeTuple;
 };
 
+export type SpansSearchResult = {
+  match: Fuse.RangeTuple;
+  span: SpanChartNode;
+};
+
 export type FlamegraphSearch = {
   index: number | null;
   query: string;
-  results: Map<string, FlamegraphSearchResult>;
+  results: {
+    frames: Map<string, FlamegraphSearchResult>;
+    spans: Map<string, SpansSearchResult>;
+  };
 };
 
 type ClearFlamegraphSearchAction = {
@@ -45,7 +54,10 @@ export function flamegraphSearchReducer(
         ...state,
         query: '',
         index: null,
-        results: new Map(),
+        results: {
+          frames: new Map(),
+          spans: new Map(),
+        },
       };
     }
     case 'set results': {

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -50,6 +50,7 @@ export interface FlamegraphTheme {
     // Nice color picker for GLSL colors - https://keiwando.com/color-picker/
     SAMPLE_TICK_COLOR: ColorChannels;
     SEARCH_RESULT_FRAME_COLOR: string;
+    SEARCH_RESULT_SPAN_COLOR: string;
     SELECTED_FRAME_BORDER_COLOR: string;
     SPAN_COLOR_BUCKET: (t: number) => ColorChannels;
     SPAN_FALLBACK_COLOR: [number, number, number, number];
@@ -171,6 +172,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
     MINIMAP_POSITION_OVERLAY_COLOR: 'rgba(0,0,0,0.1)',
     SAMPLE_TICK_COLOR: [255, 0, 0, 0.5],
     SEARCH_RESULT_FRAME_COLOR: 'vec4(0.99, 0.70, 0.35, 1.0)',
+    SEARCH_RESULT_SPAN_COLOR: '#fdb359',
     SELECTED_FRAME_BORDER_COLOR: lightTheme.blue400,
     SPAN_FRAME_LINE_PATTERN: '#dedae3',
     SPAN_FRAME_LINE_PATTERN_BACKGROUND: '#f4f2f7',
@@ -205,6 +207,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     SPAN_FRAME_LINE_PATTERN: '#594b66',
     SPAN_FRAME_LINE_PATTERN_BACKGROUND: '#1a1724',
     SELECTED_FRAME_BORDER_COLOR: lightTheme.blue400,
+    SEARCH_RESULT_SPAN_COLOR: '#b9834a',
     SPAN_FRAME_BORDER: '#57575b',
     STACK_TO_COLOR: makeStackToColor([1, 1, 1, 0.1]),
   },

--- a/static/app/utils/profiling/renderers/flamegraphDomRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphDomRenderer.tsx
@@ -63,7 +63,10 @@ export class FlamegraphDomRenderer {
     return null;
   }
 
-  draw(configViewToPhysicalSpace: mat3, _searchResults: FlamegraphSearch['results']) {
+  draw(
+    configViewToPhysicalSpace: mat3,
+    _searchResults: FlamegraphSearch['results']['frames']
+  ) {
     if (!this.container) {
       throw new Error('No container to render into');
     }

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -229,7 +229,7 @@ describe('flamegraphRenderer', () => {
         [{name: 'f0'}, {name: 'f1'}]
       );
 
-      const results: FlamegraphSearch['results'] = new Map();
+      const results: FlamegraphSearch['results']['frames'] = new Map();
 
       const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
       const flamegraphView = new CanvasView<Flamegraph>({

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -426,7 +426,7 @@ class FlamegraphRenderer {
     return hoveredNode;
   }
 
-  setSearchResults(searchResults: FlamegraphSearch['results']) {
+  setSearchResults(searchResults: FlamegraphSearch['results']['frames']) {
     const matchedFrame = new Float32Array(6).fill(1);
     const unMatchedFrame = new Float32Array(6).fill(0);
 

--- a/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
@@ -33,7 +33,7 @@ class FlamegraphTextRenderer extends TextRenderer {
   draw(
     configView: Rect,
     configViewToPhysicalSpace: mat3,
-    flamegraphSearchResults: FlamegraphSearch['results']
+    flamegraphSearchResults: FlamegraphSearch['results']['frames']
   ): void {
     // Make sure we set font size before we measure text for the first draw
     const FONT_SIZE = this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio;

--- a/static/app/utils/profiling/renderers/spansRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansRenderer.tsx
@@ -1,5 +1,6 @@
 import {mat3, vec2} from 'gl-matrix';
 
+import {FlamegraphSearch} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch';
 import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {
   getContext,
@@ -62,6 +63,7 @@ export class SpanChartRenderer2D {
   canvas: HTMLCanvasElement | null;
   spanChart: SpanChart;
   theme: FlamegraphTheme;
+  searchResults: FlamegraphSearch['results']['spans'] = new Map();
 
   pattern: CanvasPattern;
   patternDataUrl: string;
@@ -100,6 +102,10 @@ export class SpanChartRenderer2D {
     return (
       this.colors.get(span.node.span.span_id) ?? this.theme.COLORS.FRAME_FALLBACK_COLOR
     );
+  }
+
+  setSearchResults(searchResults: FlamegraphSearch['results']['spans']) {
+    this.searchResults = searchResults;
   }
 
   findHoveredNode(configSpaceCursor: vec2): SpanChartNode | null {
@@ -196,7 +202,9 @@ export class SpanChartRenderer2D {
       } else {
         this.context.beginPath();
         this.context.setTransform(1, 0, 0, 1, 0, 0);
-        this.context.fillStyle = colorComponentsToRgba(color);
+        this.context.fillStyle = this.searchResults.has(span.node.span.span_id)
+          ? this.theme.COLORS.SEARCH_RESULT_SPAN_COLOR
+          : colorComponentsToRgba(color);
         this.context.fillRect(
           rect.x + BORDER_WIDTH / 2,
           rect.y + BORDER_WIDTH / 2,

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -16,6 +16,7 @@ export interface SpanChartNode {
   node: SpanTree['root'];
   parent: SpanChartNode | null;
   start: number;
+  text: string;
 }
 
 class SpanChart {
@@ -23,6 +24,7 @@ class SpanChart {
   root: SpanChartNode = {
     parent: null,
     node: SpanTreeNode.Root(),
+    text: 'root',
     duration: 0,
     depth: -1,
     start: 0,
@@ -102,6 +104,10 @@ class SpanChart {
           duration: this.toFinalUnit(duration),
           start: this.toFinalUnit(start),
           end: this.toFinalUnit(end),
+          text:
+            node.span.op && node.span.description
+              ? node.span.op + ': ' + node.span.description
+              : node.span.op || node.span.description || '<unknown span>',
           node,
           depth,
           parent,

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -1,6 +1,7 @@
 import {uuid4} from '@sentry/utils';
 
 import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import {t} from 'sentry/locale';
 import {EventOrGroupType, EventTransaction} from 'sentry/types';
 
 // Empty transaction to use as a default value with duration of 1 second
@@ -145,6 +146,7 @@ class SpanTree {
           parent.children.push(
             new SpanTreeNode(
               {
+                description: t('Missing instrumentation'),
                 op: 'missing instrumentation',
                 start_timestamp:
                   parent.children[parent.children.length - 1].span.timestamp,


### PR DESCRIPTION
Add support for span search. 

Because we show a computed string on each span, I made it a property on the chartnode. If we dont do that, we need to otherwise keep the property in sync and searching becomes awkward as we need to possibly offset our matches. This way we also get the benefit of being able to search in span op and name at the cost of not being able to search only in one of the properties (which we dont do anyways, least not yet)