### PR TITLE
feat(crons): Add first_cron_monitor.created and first_cron_checkin.sent analytic event

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -7,6 +7,8 @@ from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403
 from .codeowners_updated import *  # noqa: F401,F403
 from .comment_webhooks import *  # noqa: F401,F403
+from .first_cron_checkin_sent import *  # noqa: F401,F403
+from .first_cron_monitor_created import *  # noqa: F401,F403
 from .first_event_sent import *  # noqa: F401,F403
 from .first_profile_sent import *  # noqa: F401,F403
 from .first_release_tag_sent import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/first_cron_checkin_sent.py
+++ b/src/sentry/analytics/events/first_cron_checkin_sent.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class FirstCronCheckinSent(analytics.Event):
+    type = "first_cron_checkin.sent"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("monitor_id"),
+        analytics.Attribute("user_id", required=False),
+    )
+
+
+analytics.register(FirstCronCheckinSent)

--- a/src/sentry/analytics/events/first_cron_monitor_created.py
+++ b/src/sentry/analytics/events/first_cron_monitor_created.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+class FirstCronMonitorCreated(analytics.Event):
+    type = "first_cron_monitor.created"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("user_id", required=False),
+    )
+
+
+analytics.register(FirstCronMonitorCreated)

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -9,8 +9,9 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.validators import MonitorValidator
 from sentry.db.models.query import in_iexact
-from sentry.models import Monitor, MonitorStatus, MonitorType
+from sentry.models import Monitor, MonitorStatus, MonitorType, Project
 from sentry.search.utils import tokenize_query
+from sentry.signals import first_cron_monitor_created
 
 
 def map_value_to_constant(constant, value):
@@ -117,5 +118,11 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
             event=audit_log.get_event_id("MONITOR_ADD"),
             data=monitor.get_audit_log_data(),
         )
+
+        project = result["project"]
+        if not project.flags.has_cron_monitors:
+            first_cron_monitor_created.send_robust(
+                project=project, user=request.user, sender=Project
+            )
 
         return self.respond(serialize(monitor, request.user), status=201)

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -122,6 +122,8 @@ first_event_with_minified_stack_trace_received = BetterSignal(providing_args=["p
 first_transaction_received = BetterSignal(providing_args=["project", "event"])
 first_profile_received = BetterSignal(providing_args=["project"])
 first_replay_received = BetterSignal(providing_args=["project"])
+first_cron_monitor_created = BetterSignal(providing_args=["project", "user"])
+first_cron_checkin_received = BetterSignal(providing_args=["project", "monitor_id"])
 member_invited = BetterSignal(providing_args=["member", "user"])
 member_joined = BetterSignal(providing_args=["member", "organization"])
 issue_tracker_used = BetterSignal(providing_args=["plugin", "project", "user"])


### PR DESCRIPTION
Adds signals for sending analytic events for when a user first creates a cron monitor, and first creates a check-in.

Uses the flag from https://github.com/getsentry/sentry/pull/43122

Resolves https://github.com/getsentry/team-crons/issues/13