### PR TITLE
fix(domains) Fix URL generation in organization team settings

### DIFF
--- a/static/app/views/settings/organizationTeams/index.tsx
+++ b/static/app/views/settings/organizationTeams/index.tsx
@@ -14,7 +14,7 @@ type Props = {
   api: Client;
   organization: Organization;
   teams: Team[];
-} & RouteComponentProps<{orgId: string}, {}>;
+} & RouteComponentProps<{}, {}>;
 
 type State = AsyncView['state'] & {
   requestList: AccessRequest[];
@@ -22,9 +22,9 @@ type State = AsyncView['state'] & {
 
 class OrganizationTeamsContainer extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {orgId} = this.props.params;
+    const {organization} = this.props;
 
-    return [['requestList', `/organizations/${orgId}/access-requests/`]];
+    return [['requestList', `/organizations/${organization.slug}/access-requests/`]];
   }
 
   componentDidMount() {
@@ -32,8 +32,9 @@ class OrganizationTeamsContainer extends AsyncView<Props, State> {
   }
 
   fetchStats() {
+    const {organization} = this.props;
     loadStats(this.props.api, {
-      orgId: this.props.params.orgId,
+      orgId: organization.slug,
       query: {
         since: (new Date().getTime() / 1000 - 3600 * 24).toString(),
         stat: 'generated',

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
@@ -23,7 +23,7 @@ describe('OrganizationTeams', function () {
     const createWrapper = props =>
       render(
         <OrganizationTeams
-          params={{orgId: organization.slug, projectId: project.slug}}
+          params={{projectId: project.slug}}
           routes={[]}
           features={new Set(['open-membership'])}
           access={new Set(['project:admin'])}
@@ -122,7 +122,7 @@ describe('OrganizationTeams', function () {
     const createWrapper = props =>
       render(
         <OrganizationTeams
-          params={{orgId: organization.slug, projectId: project.slug}}
+          params={{projectId: project.slug}}
           routes={[]}
           features={new Set([])}
           access={new Set([])}
@@ -190,12 +190,12 @@ describe('OrganizationTeams', function () {
   });
 
   describe('Team Requests', function () {
-    const orgId = 'org-slug';
     const {organization, project} = initializeOrg({
       organization: {
         openMembership: false,
       },
     });
+    const orgId = organization.slug;
     const accessRequest = TestStubs.AccessRequest();
     const requester = TestStubs.User({
       id: '9',
@@ -208,7 +208,7 @@ describe('OrganizationTeams', function () {
     const createWrapper = props =>
       render(
         <OrganizationTeams
-          params={{orgId: organization.slug, projectId: project.slug}}
+          params={{projectId: project.slug}}
           routes={[]}
           features={new Set([])}
           access={new Set([])}
@@ -290,7 +290,7 @@ describe('OrganizationTeams', function () {
       const {organization, project} = initializeOrg({organization: {orgRole: 'admin'}});
       render(
         <OrganizationTeams
-          params={{orgId: organization.slug, projectId: project.slug}}
+          params={{projectId: project.slug}}
           routes={[]}
           features={new Set()}
           access={access}
@@ -305,7 +305,7 @@ describe('OrganizationTeams', function () {
       const {organization, project} = initializeOrg({organization: {orgRole: 'admin'}});
       render(
         <OrganizationTeams
-          params={{orgId: organization.slug, projectId: project.slug}}
+          params={{projectId: project.slug}}
           routes={[]}
           features={features}
           access={access}
@@ -320,7 +320,7 @@ describe('OrganizationTeams', function () {
       const {organization, project} = initializeOrg({organization: {orgRole: 'member'}});
       render(
         <OrganizationTeams
-          params={{orgId: organization.slug, projectId: project.slug}}
+          params={{projectId: project.slug}}
           routes={[]}
           features={features}
           access={access}

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -28,13 +28,12 @@ type Props = {
   onRemoveAccessRequest: (id: string, isApproved: boolean) => void;
   organization: Organization;
   requestList: AccessRequest[];
-} & RouteComponentProps<{orgId: string}, {}>;
+} & RouteComponentProps<{}, {}>;
 
 function OrganizationTeams({
   organization,
   access,
   features,
-  params,
   requestList,
   onRemoveAccessRequest,
 }: Props) {
@@ -86,7 +85,7 @@ function OrganizationTeams({
       <SettingsPageHeader title={title} action={action} />
 
       <OrganizationAccessRequests
-        orgId={params.orgId}
+        orgId={organization.slug}
         requestList={requestList}
         onRemoveAccessRequest={onRemoveAccessRequest}
       />


### PR DESCRIPTION
I missed this earlier but found requests in logs going to undefined org slug.