### PR TITLE
feat(customer-domains): Update /api/0/organizations/orgslug/auth-provider/ for customer domains

### DIFF
--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -6,7 +6,6 @@ from django.db.models import F
 
 from sentry.api.serializers import Serializer, register
 from sentry.models import AuthProvider, Organization, OrganizationMember
-from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
     from sentry.services.hybrid_cloud.auth import ApiAuthProvider
@@ -33,7 +32,7 @@ class AuthProviderSerializer(Serializer):
             "id": str(obj.id),
             "provider_name": obj.provider,
             "pending_links_count": pending_links_count,
-            "login_url": absolute_uri(login_url),
+            "login_url": organization.absolute_url(login_url),
             "default_role": organization.default_role,
             "require_link": not obj.flags.allow_unlinked,
             "scim_enabled": bool(obj.flags.scim_enabled),

--- a/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from sentry.testutils import PermissionTestCase
+from sentry.testutils import APITestCase, PermissionTestCase, SCIMTestCase
 from sentry.testutils.silo import region_silo_test
 
 
@@ -15,3 +15,53 @@ class OrganizationAuthProviderPermissionTest(PermissionTestCase):
     def test_member_can_get(self):
         with self.feature("organizations:sso-basic"):
             self.assert_member_can_access(self.path)
+
+
+@region_silo_test
+class OrganizationAuthProviderTest(SCIMTestCase, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.path = reverse(
+            "sentry-api-0-organization-auth-provider", args=[self.organization.slug]
+        )
+
+    def test_no_auth_provider(self):
+        with self.feature("organizations:sso-basic"):
+            user = self.create_user()
+            organization = self.create_organization(owner=user)
+            self.login_as(user)
+
+            response = self.client.get(
+                reverse("sentry-api-0-organization-auth-provider", args=[organization.slug])
+            )
+            assert response.status_code == 204
+            assert response.data is None
+
+    def test_with_auth_provider(self):
+        with self.feature("organizations:sso-basic"):
+            response = self.client.get(self.path)
+            assert response.status_code == 200
+            assert response.data == {
+                "id": str(self.auth_provider.id),
+                "provider_name": "dummy",
+                "pending_links_count": 1,
+                "login_url": f"http://testserver/organizations/{self.organization.slug}/issues/",
+                "default_role": "member",
+                "require_link": True,
+                "scim_enabled": True,
+            }
+
+    def test_with_auth_provider_and_customer_domain(self):
+        with self.feature(["organizations:sso-basic", "organizations:customer-domains"]):
+            response = self.client.get(self.path)
+            assert response.status_code == 200
+            assert response.data == {
+                "id": str(self.auth_provider.id),
+                "provider_name": "dummy",
+                "pending_links_count": 1,
+                "login_url": f"http://{self.organization.slug}.testserver/issues/",
+                "default_role": "member",
+                "require_link": True,
+                "scim_enabled": True,
+            }


### PR DESCRIPTION
Update `/api/0/organizations/orgslug/auth-provider/` for customer domains. Notably, the `login_url` attribute.

I've also added tests for this endpoint as it didn't previously exist when the endpoint was initially createed.