### PR TITLE
ref(perf): Add padding to `WidgetInteractiveTitle`'s control button

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -8,7 +8,6 @@ import * as qs from 'query-string';
 import CompactSelect from 'sentry/components/compactSelect';
 import CompositeSelect from 'sentry/components/compositeSelect';
 import DropdownButton from 'sentry/components/dropdownButton';
-import TextOverflow from 'sentry/components/textOverflow';
 import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -244,15 +243,18 @@ export const WidgetInteractiveTitle = ({
       options={menuOptions}
       value={chartSetting}
       onChange={handleChange}
-      renderWrapAs={TextOverflow}
       triggerProps={{borderless: true, size: 'zero'}}
     />
   );
 };
 
 const StyledCompactSelect = styled(CompactSelect)`
+  min-width: 0;
+  font-weight: 400;
+  margin: -${space(0.5)} -${space(0.75)} 0;
+
   button {
-    padding: ${space(0)};
+    padding: ${space(0.5)} ${space(0.75)};
     font-size: ${p => p.theme.fontSizeLarge};
   }
 `;


### PR DESCRIPTION
Add some padding to `WidgetInteractiveTitle`'s control button, but still maintain vertical text alignment.

**Before:**
<img width="580" alt="Screenshot 2023-01-11 at 3 04 30 PM" src="https://user-images.githubusercontent.com/44172267/211937034-cfeea533-3621-4dd5-ad86-f48968eb8b0e.png">

**After:**
<img width="580" alt="Screenshot 2023-01-11 at 3 04 19 PM" src="https://user-images.githubusercontent.com/44172267/211937007-5f8add2a-7915-47b8-a681-2365e9ae4b18.png">
