### PR TITLE
Fix flake in test_adapter.py

### DIFF
--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1192,12 +1192,13 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest):
             project=self.project, key="mail:subject_prefix", value="[Example prefix] "
         )
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
+        timestamp = iso_format(before_now(minutes=1))
         event = self.store_event(
-            data={"timestamp": iso_format(before_now(minutes=1)), "fingerprint": ["group-1"]},
+            data={"timestamp": timestamp, "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
         event2 = self.store_event(
-            data={"timestamp": iso_format(before_now(minutes=1)), "fingerprint": ["group-2"]},
+            data={"timestamp": timestamp, "fingerprint": ["group-2"]},
             project_id=self.project.id,
         )
 


### PR DESCRIPTION
Resolves: https://sentry.io/organizations/sentry/issues/3623439373

Before this fix, you can end in a situation where [the start and end times](https://github.com/getsentry/sentry/blob/e466da5b1b7ec69b42cdf2b9c1ea4da349f6faa7/src/sentry/digests/notifications.py#L75-L76) are different and start comes *after* end.

Start => 2023-01-11 22:48:34+00:00
End => 2023-01-11 22:48:33+00:00

Cause of `before_now` with the modulo:

```
def before_now(**kwargs):
    date = datetime.utcnow() - timedelta(**kwargs)
    return date - timedelta(microseconds=date.microsecond % 1000)
```

Running this test without the change will typically exhibit the failing behavior 1 in 10 - 15 runs.

I ran with this change 50x and the issue did no reoccur.