### PR TITLE
ref(ui): Improve interactive widget header

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -249,12 +249,13 @@ export const WidgetInteractiveTitle = ({
 };
 
 const StyledCompactSelect = styled(CompactSelect)`
+  /* Reset font-weight set by HeaderTitleLegend, buttons are already bold and
+   * setting this higher up causes it to trickle into the menues */
+  font-weight: normal;
+  margin: 0 -${space(0.5)};
   min-width: 0;
-  font-weight: 400;
-  margin: -${space(0.5)} -${space(0.75)} 0;
 
   button {
-    padding: ${space(0.5)} ${space(0.75)};
     font-size: ${p => p.theme.fontSizeLarge};
   }
 `;

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -42,6 +42,7 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
 const StyledHeaderTitleLegend = styled(HeaderTitleLegend)`
   position: relative;
   z-index: initial;
+  top: -${space(0.5)};
 `;
 
 const TitleContainer = styled('div')`


### PR DESCRIPTION
* Removes bolding of menu items
* Better alignment of the header visually

before
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/1421724/211950275-ed317de9-0b30-42bb-9812-2b61d0aad559.png">

after
<img width="1481" alt="image" src="https://user-images.githubusercontent.com/1421724/211950082-c6dec306-4353-463d-b13a-a507da81287d.png">
