### PR TITLE
fix(ui): Improve PrebuiltSwitch in DiscoverLanding

### DIFF
--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -210,7 +210,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
           onSearch={this.handleSearchQuery}
         />
         <PrebuiltSwitch>
-          <SwitchLabel>Show Prebuilt</SwitchLabel>
+          Show Prebuilt
           <Switch
             isActive={renderPrebuilt}
             isDisabled={renderPrebuilt && (savedQueries ?? []).length === 0}
@@ -351,12 +351,12 @@ const StyledHeading = styled(PageHeading)`
   line-height: 40px;
 `;
 
-const PrebuiltSwitch = styled('div')`
+const PrebuiltSwitch = styled('label')`
   display: flex;
-`;
-
-const SwitchLabel = styled('div')`
-  padding-right: 8px;
+  align-items: center;
+  gap: ${space(1.5)};
+  font-weight: normal;
+  margin: 0;
 `;
 
 const StyledSearchBar = styled(SearchBar)`


### PR DESCRIPTION
Before
<img width="534" alt="image" src="https://user-images.githubusercontent.com/1421724/211791069-f5896105-26ac-43a7-99f3-5b495e5fce8d.png">


After
<img width="510" alt="image" src="https://user-images.githubusercontent.com/1421724/211791013-4a4747f1-3ab0-4703-919c-8e7821c91f32.png">

You can now also click on the label.
