### PR TITLE
ref(ui): Convert PageContent to Layout.Page

### DIFF
--- a/docs-ui/stories/views/layout-thirds.stories.js
+++ b/docs-ui/stories/views/layout-thirds.stories.js
@@ -28,20 +28,22 @@ export default {
 
 export const _6633Layout = () => (
   <Container>
-    <Layout.Header>
-      <Layout.HeaderContent>
-        <Layout.Title>Some heading content</Layout.Title>
-      </Layout.HeaderContent>
-    </Layout.Header>
-    <Layout.Body>
-      <Layout.Main>
-        <h1>Content Region</h1>
-        <p>Some text here</p>
-      </Layout.Main>
-      <Layout.Side>
-        <h3>Sidebar content</h3>
-      </Layout.Side>
-    </Layout.Body>
+    <Layout.Page>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Layout.Title>Some heading content</Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main>
+          <h1>Content Region</h1>
+          <p>Some text here</p>
+        </Layout.Main>
+        <Layout.Side>
+          <h3>Sidebar content</h3>
+        </Layout.Side>
+      </Layout.Body>
+    </Layout.Page>
   </Container>
 );
 
@@ -56,28 +58,30 @@ _6633Layout.parameters = {
 
 export const _6633WithHeaderControls = () => (
   <Container>
-    <Layout.Header>
-      <Layout.HeaderContent>
-        <Breadcrumbs crumbs={crumbs} />
-        <Layout.Title>Some heading content</Layout.Title>
-      </Layout.HeaderContent>
-      <Layout.HeaderActions>
-        <ButtonBar gap={1}>
-          <Button>Save</Button>
-          <Button>Delete</Button>
-          <Button>Update</Button>
-        </ButtonBar>
-      </Layout.HeaderActions>
-    </Layout.Header>
-    <Layout.Body>
-      <Layout.Main>
-        <h1>Content Region</h1>
-        <p>Some text here</p>
-      </Layout.Main>
-      <Layout.Side>
-        <h3>Sidebar content</h3>
-      </Layout.Side>
-    </Layout.Body>
+    <Layout.Page>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumbs crumbs={crumbs} />
+          <Layout.Title>Some heading content</Layout.Title>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <ButtonBar gap={1}>
+            <Button>Save</Button>
+            <Button>Delete</Button>
+            <Button>Update</Button>
+          </ButtonBar>
+        </Layout.HeaderActions>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main>
+          <h1>Content Region</h1>
+          <p>Some text here</p>
+        </Layout.Main>
+        <Layout.Side>
+          <h3>Sidebar content</h3>
+        </Layout.Side>
+      </Layout.Body>
+    </Layout.Page>
   </Container>
 );
 
@@ -92,34 +96,36 @@ _6633WithHeaderControls.parameters = {
 
 export const _6633WithManyHeaderControls = () => (
   <Container>
-    <Layout.Header>
-      <Layout.HeaderContent>
-        <Breadcrumbs crumbs={crumbs} />
-        <Layout.Title>Heading text</Layout.Title>
-      </Layout.HeaderContent>
-      <Layout.HeaderActions>
-        <MarginedButtonBar gap={1}>
-          <Button size="sm">Save</Button>
-          <Button size="sm">Update</Button>
-        </MarginedButtonBar>
-        <ButtonBar gap={1}>
-          <Button size="sm">rollup</Button>
-          <Button size="sm">modify</Button>
-          <Button size="sm">create</Button>
-          <Button size="sm">update</Button>
-          <Button size="sm">delete</Button>
-        </ButtonBar>
-      </Layout.HeaderActions>
-    </Layout.Header>
-    <Layout.Body>
-      <Layout.Main>
-        <h1>Content Region</h1>
-        <p>Some text here</p>
-      </Layout.Main>
-      <Layout.Side>
-        <h3>Sidebar content</h3>
-      </Layout.Side>
-    </Layout.Body>
+    <Layout.Page>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumbs crumbs={crumbs} />
+          <Layout.Title>Heading text</Layout.Title>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <MarginedButtonBar gap={1}>
+            <Button size="sm">Save</Button>
+            <Button size="sm">Update</Button>
+          </MarginedButtonBar>
+          <ButtonBar gap={1}>
+            <Button size="sm">rollup</Button>
+            <Button size="sm">modify</Button>
+            <Button size="sm">create</Button>
+            <Button size="sm">update</Button>
+            <Button size="sm">delete</Button>
+          </ButtonBar>
+        </Layout.HeaderActions>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main>
+          <h1>Content Region</h1>
+          <p>Some text here</p>
+        </Layout.Main>
+        <Layout.Side>
+          <h3>Sidebar content</h3>
+        </Layout.Side>
+      </Layout.Body>
+    </Layout.Page>
   </Container>
 );
 
@@ -134,27 +140,29 @@ _6633WithManyHeaderControls.parameters = {
 
 export const SingleColumnMode = () => (
   <Container>
-    <Layout.Header>
-      <Layout.HeaderContent>
-        <Breadcrumbs crumbs={crumbs} />
-        <Layout.Title>Some heading content</Layout.Title>
-      </Layout.HeaderContent>
-      <Layout.HeaderActions>
-        <ButtonBar gap={1}>
-          <Button size="sm">clicker</Button>
-          <Button size="sm">clicker</Button>
-        </ButtonBar>
-      </Layout.HeaderActions>
-    </Layout.Header>
-    <Layout.Body>
-      <Layout.Main fullWidth>
-        <h1>Content Region</h1>
-        <p>
-          Some text here, that goes on and on. It should strecth the full width of the
-          container, and have no space on the right.
-        </p>
-      </Layout.Main>
-    </Layout.Body>
+    <Layout.Page>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumbs crumbs={crumbs} />
+          <Layout.Title>Some heading content</Layout.Title>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <ButtonBar gap={1}>
+            <Button size="sm">clicker</Button>
+            <Button size="sm">clicker</Button>
+          </ButtonBar>
+        </Layout.HeaderActions>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <h1>Content Region</h1>
+          <p>
+            Some text here, that goes on and on. It should strecth the full width of the
+            container, and have no space on the right.
+          </p>
+        </Layout.Main>
+      </Layout.Body>
+    </Layout.Page>
   </Container>
 );
 
@@ -169,36 +177,38 @@ SingleColumnMode.parameters = {
 
 export const _6633WithTabNavigation = () => (
   <Container>
-    <BorderlessHeader>
-      <Layout.HeaderContent>
-        <StyledLayoutTitle>Alerts</StyledLayoutTitle>
-      </Layout.HeaderContent>
-      <Layout.HeaderActions>
-        <ButtonBar gap={1}>
-          <Button size="sm">clicker</Button>
-          <Button size="sm">clicker</Button>
-        </ButtonBar>
-      </Layout.HeaderActions>
-    </BorderlessHeader>
-    <TabLayoutHeader>
-      <Layout.HeaderNavTabs underlined>
-        <li className="active">
-          <Link to="#">Active</Link>
-        </li>
-        <li>
-          <Link to="#">Inactive</Link>
-        </li>
-      </Layout.HeaderNavTabs>
-    </TabLayoutHeader>
-    <Layout.Body>
-      <Layout.Main>
-        <h1>Content Region</h1>
-        <p>Some text here</p>
-      </Layout.Main>
-      <Layout.Side>
-        <h3>Sidebar content</h3>
-      </Layout.Side>
-    </Layout.Body>
+    <Layout.Page>
+      <BorderlessHeader>
+        <Layout.HeaderContent>
+          <StyledLayoutTitle>Alerts</StyledLayoutTitle>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <ButtonBar gap={1}>
+            <Button size="sm">clicker</Button>
+            <Button size="sm">clicker</Button>
+          </ButtonBar>
+        </Layout.HeaderActions>
+      </BorderlessHeader>
+      <TabLayoutHeader>
+        <Layout.HeaderNavTabs underlined>
+          <li className="active">
+            <Link to="#">Active</Link>
+          </li>
+          <li>
+            <Link to="#">Inactive</Link>
+          </li>
+        </Layout.HeaderNavTabs>
+      </TabLayoutHeader>
+      <Layout.Body>
+        <Layout.Main>
+          <h1>Content Region</h1>
+          <p>Some text here</p>
+        </Layout.Main>
+        <Layout.Side>
+          <h3>Sidebar content</h3>
+        </Layout.Side>
+      </Layout.Body>
+    </Layout.Page>
   </Container>
 );
 

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -4,24 +4,36 @@ import NavTabs from 'sentry/components/navTabs';
 import space from 'sentry/styles/space';
 
 /**
- * Base container for 66/33 containers.
+ * Main container for a page.
  */
-export const Body = styled('div')<{noRowGap?: boolean}>`
-  padding: ${space(2)};
-  margin: 0;
-  background-color: ${p => p.theme.background};
-  flex-grow: 1;
+export const Page = styled('main')<{withPadding?: boolean}>`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  ${p => p.withPadding && `padding: ${space(3)} ${space(4)}`};
+`;
+
+/**
+ * Header container for header content and header actions.
+ *
+ * Uses a horizontal layout in wide viewports to put space between
+ * the headings and the actions container. In narrow viewports these elements
+ * are stacked vertically.
+ *
+ * Use `noActionWrap` to disable wrapping if there are minimal actions.
+ */
+export const Header = styled('header')<{noActionWrap?: boolean}>`
+  display: grid;
+  grid-template-columns: ${p =>
+    !p.noActionWrap ? 'minmax(0, 1fr)' : 'minmax(0, 1fr) auto'};
+
+  padding: ${space(2)} ${space(2)} 0 ${space(2)};
+  background-color: transparent;
+  border-bottom: 1px solid ${p => p.theme.border};
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    padding: ${p =>
-      !p.noRowGap ? `${space(3)} ${space(4)}` : `${space(2)} ${space(4)}`};
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
-    display: grid;
-    grid-template-columns: minmax(100px, auto) 325px;
-    align-content: start;
-    gap: ${p => (!p.noRowGap ? `${space(3)}` : `0 ${space(3)}`)};
+    padding: ${space(2)} ${space(4)} 0 ${space(4)};
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 `;
 
@@ -78,30 +90,6 @@ export const Title = styled('h1')`
 `;
 
 /**
- * Header container for header content and header actions.
- *
- * Uses a horizontal layout in wide viewports to put space between
- * the headings and the actions container. In narrow viewports these elements
- * are stacked vertically.
- *
- * Use `noActionWrap` to disable wrapping if there are minimal actions.
- */
-export const Header = styled('header')<{noActionWrap?: boolean}>`
-  display: grid;
-  grid-template-columns: ${p =>
-    !p.noActionWrap ? 'minmax(0, 1fr)' : 'minmax(0, 1fr) auto'};
-
-  padding: ${space(2)} ${space(2)} 0 ${space(2)};
-  background-color: transparent;
-  border-bottom: 1px solid ${p => p.theme.border};
-
-  @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    padding: ${space(2)} ${space(4)} 0 ${space(4)};
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
-`;
-
-/**
  * Styled Nav Tabs for use inside a Layout.Header component
  */
 export const HeaderNavTabs = styled(NavTabs)`
@@ -125,13 +113,38 @@ export const HeaderNavTabs = styled(NavTabs)`
 `;
 
 /**
- * Containers for two column 66/33 layout.
+ * Base container for 66/33 containers.
+ */
+export const Body = styled('div')<{noRowGap?: boolean}>`
+  padding: ${space(2)};
+  margin: 0;
+  background-color: ${p => p.theme.background};
+  flex-grow: 1;
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${p =>
+      !p.noRowGap ? `${space(3)} ${space(4)}` : `${space(2)} ${space(4)}`};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    display: grid;
+    grid-template-columns: minmax(100px, auto) 325px;
+    align-content: start;
+    gap: ${p => (!p.noRowGap ? `${space(3)}` : `0 ${space(3)}`)};
+  }
+`;
+
+/**
+ * Containers for left column of the 66/33 layout.
  */
 export const Main = styled('section')<{fullWidth?: boolean}>`
   grid-column: ${p => (p.fullWidth ? '1/3' : '1/2')};
   max-width: 100%;
 `;
 
+/**
+ * Container for the right column the 66/33 layout
+ */
 export const Side = styled('aside')`
   grid-column: 2/3;
 `;

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -9,9 +9,9 @@ import {
   updateEnvironments,
   updateProjects,
 } from 'sentry/actionCreators/pageFilters';
+import * as Layout from 'sentry/components/layouts/thirds';
 import DesyncedFilterAlert from 'sentry/components/organizations/pageFilters/desyncedFiltersAlert';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import {PageContent} from 'sentry/styles/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -167,7 +167,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
 
   // Wait for global selection to be ready before rendering children
   if (!isReady) {
-    return <PageContent />;
+    return <Layout.Page withPadding />;
   }
 
   return (

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -7,10 +7,10 @@ import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {Client, ResponseMeta} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import DateTime from 'sentry/components/dateTime';
+import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
@@ -192,13 +192,13 @@ class MetricAlertDetails extends Component<Props, State> {
     const {error} = this.state;
 
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <Alert type="error" showIcon>
           {error?.status === 404
             ? t('This alert rule could not be found.')
             : t('An error occurred while fetching the alert rule.')}
         </Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 

--- a/static/app/views/dashboardsV2/create.tsx
+++ b/static/app/views/dashboardsV2/create.tsx
@@ -4,8 +4,8 @@ import {browserHistory, RouteComponentProps} from 'react-router';
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -25,9 +25,9 @@ function CreateDashboard(props: Props) {
   const [newWidget, setNewWidget] = useState<Widget | undefined>();
   function renderDisabled() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -25,7 +25,6 @@ import PageHeading from 'sentry/components/pageHeading';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {usingCustomerDomain} from 'sentry/constants';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -629,7 +628,7 @@ class DashboardDetail extends Component<Props, State> {
           },
         }}
       >
-        <PageContent>
+        <Layout.Page withPadding>
           <NoProjectMessage organization={organization}>
             <StyledPageHeader>
               <StyledHeading>
@@ -690,7 +689,7 @@ class DashboardDetail extends Component<Props, State> {
               </MetricsDataSwitcher>
             </MetricsCardinalityProvider>
           </NoProjectMessage>
-        </PageContent>
+        </Layout.Page>
       </PageFiltersContainer>
     );
   }
@@ -750,7 +749,7 @@ class DashboardDetail extends Component<Props, State> {
             },
           }}
         >
-          <StyledPageContent>
+          <Layout.Page>
             <NoProjectMessage organization={organization}>
               <Layout.Header>
                 <Layout.HeaderContent>
@@ -892,7 +891,7 @@ class DashboardDetail extends Component<Props, State> {
                 </Layout.Main>
               </Layout.Body>
             </NoProjectMessage>
-          </StyledPageContent>
+          </Layout.Page>
         </PageFiltersContainer>
       </SentryDocumentTitle>
     );
@@ -929,10 +928,6 @@ const StyledPageHeader = styled('div')`
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;
-`;
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
 `;
 
 export default withProjects(withApi(withOrganization(DashboardDetail)));

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -21,7 +21,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Switch from 'sentry/components/switchButton';
 import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, SelectValue} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -184,9 +183,9 @@ class ManageDashboards extends AsyncView<Props, State> {
 
   renderNoAccess() {
     return (
-      <PageContent>
+      <Layout.Page>
         <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 
@@ -258,9 +257,9 @@ class ManageDashboards extends AsyncView<Props, State> {
 
   renderLoading() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <LoadingIndicator />
-      </PageContent>
+      </Layout.Page>
     );
   }
 
@@ -275,7 +274,7 @@ class ManageDashboards extends AsyncView<Props, State> {
         renderDisabled={this.renderNoAccess}
       >
         <SentryDocumentTitle title={t('Dashboards')} orgSlug={organization.slug}>
-          <StyledPageContent>
+          <Layout.Page>
             <NoProjectMessage organization={organization}>
               <Layout.Header>
                 <Layout.HeaderContent>
@@ -326,16 +325,12 @@ class ManageDashboards extends AsyncView<Props, State> {
                 </Layout.Main>
               </Layout.Body>
             </NoProjectMessage>
-          </StyledPageContent>
+          </Layout.Page>
         </SentryDocumentTitle>
       </Feature>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -6,10 +6,10 @@ import isEqual from 'lodash/isEqual';
 import {Client} from 'sentry/api';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import NotFound from 'sentry/components/errors/notFound';
+import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import withRouteAnalytics, {
   WithRouteAnalyticsProps,
@@ -141,9 +141,9 @@ class OrgDashboards extends AsyncComponent<Props, State> {
 
   renderLoading() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <LoadingIndicator />
-      </PageContent>
+      </Layout.Page>
     );
   }
 

--- a/static/app/views/dashboardsV2/view.tsx
+++ b/static/app/views/dashboardsV2/view.tsx
@@ -7,9 +7,9 @@ import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import NotFound from 'sentry/components/errors/notFound';
+import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import useApi from 'sentry/utils/useApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -106,9 +106,9 @@ type FeatureProps = {
 
 export const DashboardBasicFeature = ({organization, children}: FeatureProps) => {
   const renderDisabled = () => (
-    <PageContent>
+    <Layout.Page withPadding>
       <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-    </PageContent>
+    </Layout.Page>
   );
 
   return (

--- a/static/app/views/dashboardsV2/widgetBuilder/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/index.tsx
@@ -1,7 +1,7 @@
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import WidgetBuilder from './widgetBuilder';
@@ -17,9 +17,9 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
       features={['dashboards-edit']}
       organization={organization}
       renderDisabled={() => (
-        <PageContent>
+        <Layout.Page withPadding>
           <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-        </PageContent>
+        </Layout.Page>
       )}
     >
       <WidgetBuilder {...props} organization={organization} />

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -17,7 +17,6 @@ import LoadingError from 'sentry/components/loadingError';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {DateString, Organization, PageFilters, TagCollection} from 'sentry/types';
 import {defined, objectIsEmpty} from 'sentry/utils';
@@ -936,9 +935,9 @@ function WidgetBuilder({
   if (isEditing && !isValidWidgetIndex) {
     return (
       <SentryDocumentTitle title={dashboard.title} orgSlug={orgSlug}>
-        <PageContent>
+        <Layout.Page withPadding>
           <LoadingError message={t('The widget you want to edit was not found.')} />
-        </PageContent>
+        </Layout.Page>
       </SentryDocumentTitle>
     );
   }
@@ -964,7 +963,7 @@ function WidgetBuilder({
                     location={location}
                     forceTransactions={metricsDataSide.forceTransactionsOnly}
                   >
-                    <PageContentWithoutPadding>
+                    <Layout.Page>
                       <Header
                         orgSlug={orgSlug}
                         title={state.title}
@@ -1114,7 +1113,7 @@ function WidgetBuilder({
                           />
                         </Side>
                       </Body>
-                    </PageContentWithoutPadding>
+                    </Layout.Page>
                   </MEPSettingProvider>
                 )}
               </MetricsDataSwitcher>
@@ -1127,10 +1126,6 @@ function WidgetBuilder({
 }
 
 export default withPageFilters(withTags(WidgetBuilder));
-
-const PageContentWithoutPadding = styled(PageContent)`
-  padding: 0;
-`;
 
 const BuildSteps = styled(List)`
   gap: ${space(4)};

--- a/static/app/views/eventsV2/eventDetails/index.tsx
+++ b/static/app/views/eventsV2/eventDetails/index.tsx
@@ -1,11 +1,10 @@
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -38,7 +37,7 @@ function EventDetails({organization, location, params}: Props) {
       orgSlug={organization.slug}
       projectSlug={projectSlug}
     >
-      <StyledPageContent>
+      <Layout.Page>
         <NoProjectMessage organization={organization}>
           <EventDetailsContent
             organization={organization}
@@ -49,13 +48,9 @@ function EventDetails({organization, location, params}: Props) {
             isHomepage={isHomepage}
           />
         </NoProjectMessage>
-      </StyledPageContent>
+      </Layout.Page>
     </SentryDocumentTitle>
   );
 }
 
 export default withOrganization(EventDetails);
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;

--- a/static/app/views/eventsV2/index.tsx
+++ b/static/app/views/eventsV2/index.tsx
@@ -1,7 +1,7 @@
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -13,9 +13,9 @@ type Props = {
 function DiscoverContainer({organization, children}: Props) {
   function renderNoAccess() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -18,7 +18,6 @@ import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Switch from 'sentry/components/switchButton';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, SavedQuery, SelectValue} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -240,9 +239,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
 
   renderNoAccess() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 
@@ -296,7 +295,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         renderDisabled={this.renderNoAccess}
       >
         <SentryDocumentTitle title={t('Discover')} orgSlug={organization.slug}>
-          <StyledPageContent>
+          <Layout.Page>
             <NoProjectMessage organization={organization}>
               <Layout.Header>
                 <Layout.HeaderContent>
@@ -336,16 +335,12 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
                 </Layout.Main>
               </Layout.Body>
             </NoProjectMessage>
-          </StyledPageContent>
+          </Layout.Page>
         </SentryDocumentTitle>
       </Feature>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -15,6 +15,7 @@ import {addMessage} from 'sentry/actionCreators/indicator';
 import {fetchOrgMembers, indexMembersByProject} from 'sentry/actionCreators/members';
 import {fetchTagValues, loadOrganizationTags} from 'sentry/actionCreators/tags';
 import {Client} from 'sentry/api';
+import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
 import Pagination, {CursorHandler} from 'sentry/components/pagination';
@@ -24,7 +25,6 @@ import ProcessingIssueList from 'sentry/components/stream/processingIssueList';
 import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {
   BaseGroup,
@@ -955,9 +955,9 @@ class IssueListOverview extends Component<Props, State> {
 
   renderLoading(): React.ReactNode {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <LoadingIndicator />
-      </PageContent>
+      </Layout.Page>
     );
   }
 
@@ -1175,7 +1175,7 @@ class IssueListOverview extends Component<Props, State> {
     );
 
     return (
-      <StyledPageContent>
+      <Layout.Page>
         <IssueListHeader
           organization={organization}
           query={query}
@@ -1254,7 +1254,7 @@ class IssueListOverview extends Component<Props, State> {
             sort={this.getSort()}
           />
         </StyledBody>
-      </StyledPageContent>
+      </Layout.Page>
     );
   }
 }
@@ -1305,8 +1305,4 @@ const StyledPagination = styled(Pagination)`
 
 const StyledQueryCount = styled(QueryCount)`
   margin-left: 0;
-`;
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
 `;

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -7,7 +7,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import withRouteAnalytics, {
@@ -77,7 +76,7 @@ class MonitorDetails extends AsyncView<Props, State> {
     }
 
     return (
-      <StyledPageContent>
+      <Layout.Page>
         <MonitorHeader monitor={monitor} orgId={this.orgSlug} onUpdate={this.onUpdate} />
         <Layout.Body>
           <Layout.Main fullWidth>
@@ -102,14 +101,10 @@ class MonitorDetails extends AsyncView<Props, State> {
             )}
           </Layout.Main>
         </Layout.Body>
-      </StyledPageContent>
+      </Layout.Page>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledPageFilterBar = styled(PageFilterBar)`
   margin-bottom: ${space(2)};

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -5,7 +5,6 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageHeading from 'sentry/components/pageHeading';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
@@ -53,7 +52,7 @@ class EditMonitor extends AsyncView<Props, State> {
     }
 
     return (
-      <StyledPageContent>
+      <Layout.Page>
         <Layout.Header>
           <Layout.HeaderContent>
             <Breadcrumbs
@@ -80,14 +79,10 @@ class EditMonitor extends AsyncView<Props, State> {
             />
           </Layout.Main>
         </Layout.Body>
-      </StyledPageContent>
+      </Layout.Page>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -20,7 +20,6 @@ import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SearchBar from 'sentry/components/searchBar';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -105,7 +104,7 @@ class Monitors extends AsyncView<Props, State> {
     const {organization} = this.props;
 
     return (
-      <StyledPageContent>
+      <Layout.Page>
         <Layout.Header>
           <Layout.HeaderContent>
             <StyledHeading>
@@ -170,23 +169,19 @@ class Monitors extends AsyncView<Props, State> {
                   )}
                 </p>
                 <ButtonList gap={1}>
-                  <Button href="https://docs.sentry.io/product/crons" external>
-                    {t('Read Docs')}
-                  </Button>
                   <NewMonitorButton>{t('Set up first cron monitor')}</NewMonitorButton>
+                  <Button href="https://docs.sentry.io/product/crons" external>
+                    {t('Read docs')}
+                  </Button>
                 </ButtonList>
               </OnboardingPanel>
             )}
           </Layout.Main>
         </Layout.Body>
-      </StyledPageContent>
+      </Layout.Page>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/organizationActivity/index.tsx
+++ b/static/app/views/organizationActivity/index.tsx
@@ -9,7 +9,6 @@ import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import {Panel} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Activity, Organization} from 'sentry/types';
 import routeTitle from 'sentry/utils/routeTitle';
@@ -62,7 +61,7 @@ class OrganizationActivity extends AsyncView<Props, State> {
     const {loading, activity, activityPageLinks} = this.state;
 
     return (
-      <StyledPageContent>
+      <Layout.Page>
         <Layout.Header>
           <Layout.HeaderContent>
             <StyledHeading>{t('Activity')}</StyledHeading>
@@ -95,14 +94,10 @@ class OrganizationActivity extends AsyncView<Props, State> {
             )}
           </Layout.Main>
         </Layout.Body>
-      </StyledPageContent>
+      </Layout.Page>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
@@ -5,8 +5,8 @@ import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 import first from 'lodash/first';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import Pagination from 'sentry/components/pagination';
-import {PageContent} from 'sentry/styles/organization';
 import type {Group, Organization} from 'sentry/types';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -93,7 +93,7 @@ function GroupReplays({group}: Props) {
 
   if (!eventView) {
     return (
-      <StyledPageContent>
+      <StyledLayoutPage withPadding>
         <ReplayTable
           fetchError={fetchError}
           isFetching
@@ -108,7 +108,7 @@ function GroupReplays({group}: Props) {
           ]}
         />
         <Pagination pageLinks={null} />
-      </StyledPageContent>
+      </StyledLayoutPage>
     );
   }
   return (
@@ -140,7 +140,7 @@ const GroupReplaysTable = ({
   });
 
   return (
-    <StyledPageContent>
+    <StyledLayoutPage withPadding>
       <ReplayTable
         fetchError={fetchError}
         isFetching={isFetching}
@@ -155,11 +155,11 @@ const GroupReplaysTable = ({
         ]}
       />
       <Pagination pageLinks={pageLinks} />
-    </StyledPageContent>
+    </StyledLayoutPage>
   );
 };
 
-const StyledPageContent = styled(PageContent)`
+const StyledLayoutPage = styled(Layout.Page)`
   box-shadow: 0px 0px 1px ${p => p.theme.gray200};
   background-color: ${p => p.theme.background};
 `;

--- a/static/app/views/organizationGroupDetails/groupReplays/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/index.tsx
@@ -1,7 +1,7 @@
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import type {Group} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -15,9 +15,9 @@ const GroupReplaysContainer = (props: Props) => {
   const organization = useOrganization();
   function renderNoAccess() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 

--- a/static/app/views/organizationGroupDetails/grouping/index.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/index.tsx
@@ -2,8 +2,8 @@ import {RouteComponentProps} from 'react-router';
 
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Group, Organization, Project} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -21,9 +21,9 @@ function GroupingContainer({organization, location, group, router, project}: Pro
       features={['grouping-tree-ui']}
       organization={organization}
       renderDisabled={() => (
-        <PageContent>
+        <Layout.Page withPadding>
           <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-        </PageContent>
+        </Layout.Page>
       )}
     >
       <Grouping

--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -3,8 +3,8 @@ import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -21,9 +21,9 @@ const queryClient = new QueryClient();
 function PerformanceContainer({organization, location, children}: Props) {
   function renderNoAccess() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -20,7 +20,6 @@ import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {Item, TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
@@ -155,7 +154,7 @@ export function PerformanceLanding(props: Props) {
   );
 
   return (
-    <StyledPageContent data-test-id="performance-landing-v3">
+    <Layout.Page data-test-id="performance-landing-v3">
       <PageErrorProvider>
         <Tabs
           value={landingDisplay.field}
@@ -312,13 +311,9 @@ export function PerformanceLanding(props: Props) {
           </Layout.Body>
         </Tabs>
       </PageErrorProvider>
-    </StyledPageContent>
+    </Layout.Page>
   );
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/performance/traceDetails/index.tsx
+++ b/static/app/views/performance/traceDetails/index.tsx
@@ -1,14 +1,13 @@
 import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
 import {Client} from 'sentry/api';
+import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
@@ -142,18 +141,14 @@ class TraceSummary extends Component<Props> {
 
     return (
       <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
-        <StyledPageContent>
+        <Layout.Page>
           <NoProjectMessage organization={organization}>
             {this.renderContent()}
           </NoProjectMessage>
-        </StyledPageContent>
+        </Layout.Page>
       </SentryDocumentTitle>
     );
   }
 }
 
 export default withOrganization(withApi(TraceSummary));
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;

--- a/static/app/views/performance/transactionDetails/index.tsx
+++ b/static/app/views/performance/transactionDetails/index.tsx
@@ -1,10 +1,9 @@
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import useProjects from 'sentry/utils/useProjects';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -34,7 +33,7 @@ function EventDetails(props: Props) {
       orgSlug={organization.slug}
       projectSlug={projectSlug}
     >
-      <StyledPageContent>
+      <Layout.Page>
         <NoProjectMessage organization={organization}>
           <EventDetailsContent
             organization={organization}
@@ -44,13 +43,9 @@ function EventDetails(props: Props) {
             projects={projects}
           />
         </NoProjectMessage>
-      </StyledPageContent>
+      </Layout.Page>
     </SentryDocumentTitle>
   );
 }
 
 export default withOrganization(EventDetails);
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -11,7 +11,6 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -187,7 +186,7 @@ function PageLayout(props: Props) {
             specificProjectSlugs={defined(project) ? [project.slug] : []}
           >
             <Tabs value={tab} onChange={onTabChange}>
-              <StyledPageContent>
+              <Layout.Page>
                 <NoProjectMessage organization={organization}>
                   <TransactionHeader
                     eventView={eventView}
@@ -223,7 +222,7 @@ function PageLayout(props: Props) {
                     />
                   </Layout.Body>
                 </NoProjectMessage>
-              </StyledPageContent>
+              </Layout.Page>
             </Tabs>
           </PageFiltersContainer>
         </PerformanceEventViewProvider>
@@ -235,10 +234,6 @@ function PageLayout(props: Props) {
 export function NoAccess() {
   return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledAlert = styled(Alert)`
   grid-column: 1/3;

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
@@ -6,7 +6,6 @@ import Alert from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import type {Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {
@@ -35,9 +34,9 @@ type Props = {
 
 function renderNoAccess() {
   return (
-    <PageContent>
+    <Layout.Page withPadding>
       <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-    </PageContent>
+    </Layout.Page>
   );
 }
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
@@ -1,12 +1,11 @@
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
+import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {defined} from 'sentry/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -56,7 +55,7 @@ export default function SpanDetails(props: Props) {
           forceProject={project}
           specificProjectSlugs={defined(project) ? [project.slug] : []}
         >
-          <StyledPageContent>
+          <Layout.Page>
             <NoProjectMessage organization={organization}>
               <SpanDetailsContent
                 location={location}
@@ -67,7 +66,7 @@ export default function SpanDetails(props: Props) {
                 spanSlug={spanSlug}
               />
             </NoProjectMessage>
-          </StyledPageContent>
+          </Layout.Page>
         </PageFiltersContainer>
       </Feature>
     </SentryDocumentTitle>
@@ -84,7 +83,3 @@ function getDocumentTitle(transactionName: string): string {
 
   return [t('Summary'), t('Performance')].join(' - ');
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;

--- a/static/app/views/performance/trends/index.tsx
+++ b/static/app/views/performance/trends/index.tsx
@@ -1,12 +1,11 @@
 import {Component} from 'react';
-import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Client} from 'sentry/api';
+import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import withApi from 'sentry/utils/withApi';
@@ -74,18 +73,14 @@ class TrendsSummary extends Component<Props, State> {
 
     return (
       <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
-        <StyledPageContent>
+        <Layout.Page>
           <NoProjectMessage organization={organization}>
             {this.renderContent()}
           </NoProjectMessage>
-        </StyledPageContent>
+        </Layout.Page>
       </SentryDocumentTitle>
     );
   }
 }
 
 export default withOrganization(withProjects(withPageFilters(withApi(TrendsSummary))));
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -1,15 +1,14 @@
 import {Component} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
 import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import {Client} from 'sentry/api';
+import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
@@ -112,7 +111,7 @@ class VitalDetail extends Component<Props, State> {
       <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
         <PerformanceEventViewProvider value={{eventView: this.state.eventView}}>
           <PageFiltersContainer>
-            <StyledPageContent>
+            <Layout.Page>
               <NoProjectMessage organization={organization}>
                 <VitalDetailContent
                   location={location}
@@ -123,16 +122,12 @@ class VitalDetail extends Component<Props, State> {
                   api={api}
                 />
               </NoProjectMessage>
-            </StyledPageContent>
+            </Layout.Page>
           </PageFiltersContainer>
         </PerformanceEventViewProvider>
       </SentryDocumentTitle>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 export default withApi(withPageFilters(withProjects(withOrganization(VitalDetail))));

--- a/static/app/views/permissionDenied.tsx
+++ b/static/app/views/permissionDenied.tsx
@@ -1,11 +1,11 @@
 import {useEffect} from 'react';
 import * as Sentry from '@sentry/react';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization, Project} from 'sentry/types';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {useRoutes} from 'sentry/utils/useRoutes';
@@ -37,7 +37,7 @@ function PermissionDenied(props: Props) {
 
   return (
     <SentryDocumentTitle title={t('Permission Denied')}>
-      <PageContent>
+      <Layout.Page withPadding>
         <LoadingError
           message={tct(
             `Your role does not have the necessary permissions to access this
@@ -49,7 +49,7 @@ function PermissionDenied(props: Props) {
             }
           )}
         />
-      </PageContent>
+      </Layout.Page>
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -25,7 +25,6 @@ import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t, tct} from 'sentry/locale';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {
@@ -124,7 +123,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
     <SentryDocumentTitle title={t('Profiling')} orgSlug={organization.slug}>
       <PageFiltersContainer>
         <NoProjectMessage organization={organization}>
-          <StyledPageContent>
+          <Layout.Page>
             <Layout.Header>
               <Layout.HeaderContent>
                 <StyledHeading>
@@ -225,7 +224,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                 )}
               </Layout.Main>
             </Layout.Body>
-          </StyledPageContent>
+          </Layout.Page>
         </NoProjectMessage>
       </PageFiltersContainer>
     </SentryDocumentTitle>
@@ -243,10 +242,6 @@ const FIELDS = [
 ] as const;
 
 type FieldType = typeof FIELDS[number];
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const StyledHeading = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/profiling/index.tsx
+++ b/static/app/views/profiling/index.tsx
@@ -1,7 +1,7 @@
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -17,9 +17,9 @@ function ProfilingContainer({organization, children}: Props) {
       features={['profiling']}
       organization={organization}
       renderDisabled={() => (
-        <PageContent>
+        <Layout.Page withPadding>
           <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-        </PageContent>
+        </Layout.Page>
       )}
     >
       {children}

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -16,7 +16,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import SmartSearchBar, {SmartSearchBarProps} from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {PageFilters, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -122,7 +121,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
         specificProjectSlugs={defined(project) ? [project.slug] : []}
       >
         <NoProjectMessage organization={organization}>
-          <StyledPageContent>
+          <Layout.Page>
             {project && transaction && (
               <Fragment>
                 <Layout.Header>
@@ -187,16 +186,12 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                 </Layout.Body>
               </Fragment>
             )}
-          </StyledPageContent>
+          </Layout.Page>
         </NoProjectMessage>
       </PageFiltersContainer>
     </SentryDocumentTitle>
   );
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const ProfileTitle = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -24,7 +24,6 @@ import MissingProjectMembership from 'sentry/components/projects/missingProjectM
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -155,20 +154,20 @@ class ProjectDetail extends AsyncView<Props, State> {
     const {organization} = this.props;
 
     return (
-      <PageContent>
+      <Layout.Page>
         <MissingProjectMembership organization={organization} project={project} />
-      </PageContent>
+      </Layout.Page>
     );
   }
 
   renderProjectNotFound() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <LoadingError
           message={t('This project could not be found.')}
           onRetry={this.onRetryProjects}
         />
-      </PageContent>
+      </Layout.Page>
     );
   }
 
@@ -200,7 +199,7 @@ class ProjectDetail extends AsyncView<Props, State> {
     return (
       <PageFiltersContainer skipLoadLastUsed showAbsolute={!hasOnlyBasicChart}>
         <NoProjectMessage organization={organization}>
-          <StyledPageContent>
+          <Layout.Page>
             <Layout.Header>
               <Layout.HeaderContent>
                 <Breadcrumbs
@@ -339,16 +338,12 @@ class ProjectDetail extends AsyncView<Props, State> {
                 />
               </Layout.Side>
             </Layout.Body>
-          </StyledPageContent>
+          </Layout.Page>
         </NoProjectMessage>
       </PageFiltersContainer>
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const ProjectTitle = styled(PageHeading)`
   line-height: 40px;

--- a/static/app/views/projectEventRedirect.tsx
+++ b/static/app/views/projectEventRedirect.tsx
@@ -2,8 +2,8 @@ import {useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import DetailedError from 'sentry/components/errors/detailedError';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 
 type Props = RouteComponentProps<{}, {}>;
 
@@ -60,7 +60,7 @@ function ProjectEventRedirect({router}: Props) {
   return error ? (
     <DetailedError heading={t('Not found')} message={error} hideSupportLinks />
   ) : (
-    <PageContent />
+    <Layout.Page withPadding />
   );
 }
 

--- a/static/app/views/projectInstall/gettingStarted.tsx
+++ b/static/app/views/projectInstall/gettingStarted.tsx
@@ -1,11 +1,15 @@
 import styled from '@emotion/styled';
 
-import {PageContent} from 'sentry/styles/organization';
+import * as Layout from 'sentry/components/layouts/thirds';
 import space from 'sentry/styles/space';
 
-const GettingStarted = styled(PageContent)`
+const GettingStarted = styled(Layout.Page)`
   background: ${p => p.theme.background};
   padding-top: ${space(3)};
 `;
+
+GettingStarted.defaultProps = {
+  withPadding: true,
+};
 
 export default GettingStarted;

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -7,6 +7,7 @@ import pick from 'lodash/pick';
 
 import Alert from 'sentry/components/alert';
 import AsyncComponent from 'sentry/components/asyncComponent';
+import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -15,7 +16,6 @@ import PickProjectToContinue from 'sentry/components/pickProjectToContinue';
 import {PAGE_URL_PARAM, URL_PARAM} from 'sentry/constants/pageFilters';
 import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {
   Deploy,
@@ -171,11 +171,11 @@ class ReleasesDetail extends AsyncView<Props, State> {
 
     if (possiblyWrongProject) {
       return (
-        <PageContent>
+        <Layout.Page>
           <Alert type="error" showIcon>
             {t('This release may not be in your selected project.')}
           </Alert>
-        </PageContent>
+        </Layout.Page>
       );
     }
 
@@ -184,9 +184,9 @@ class ReleasesDetail extends AsyncView<Props, State> {
 
   renderLoading() {
     return (
-      <PageContent>
+      <Layout.Page>
         <LoadingIndicator />
-      </PageContent>
+      </Layout.Page>
     );
   }
 
@@ -206,7 +206,7 @@ class ReleasesDetail extends AsyncView<Props, State> {
 
     return (
       <NoProjectMessage organization={organization}>
-        <StyledPageContent>
+        <Layout.Page>
           <ReleaseHeader
             location={location}
             organization={organization}
@@ -229,7 +229,7 @@ class ReleasesDetail extends AsyncView<Props, State> {
           >
             {this.props.children}
           </ReleaseContext.Provider>
-        </StyledPageContent>
+        </Layout.Page>
       </NoProjectMessage>
     );
   }
@@ -297,11 +297,11 @@ class ReleasesDetailContainer extends AsyncComponent<
     if (has404Errors) {
       // This catches a 404 coming from the release endpoint and displays a custom error message.
       return (
-        <PageContent>
+        <Layout.Page withPadding>
           <Alert type="error" showIcon>
             {t('This release could not be found.')}
           </Alert>
-        </PageContent>
+        </Layout.Page>
       );
     }
 
@@ -316,9 +316,9 @@ class ReleasesDetailContainer extends AsyncComponent<
 
   renderLoading() {
     return (
-      <PageContent>
+      <Layout.Page>
         <LoadingIndicator />
-      </PageContent>
+      </Layout.Page>
     );
   }
 
@@ -371,10 +371,6 @@ class ReleasesDetailContainer extends AsyncComponent<
     );
   }
 }
-
-const StyledPageContent = styled(PageContent)`
-  padding: 0;
-`;
 
 const ProjectsFooterMessage = styled('div')`
   display: grid;

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -3,6 +3,7 @@ import type {RouteComponentProps} from 'react-router';
 
 import DetailedError from 'sentry/components/errors/detailedError';
 import NotFound from 'sentry/components/errors/notFound';
+import * as Layout from 'sentry/components/layouts/thirds';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {
@@ -10,12 +11,11 @@ import {
   useReplayContext,
 } from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
 import useReplayLayout from 'sentry/utils/replays/hooks/useReplayLayout';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
 import useOrganization from 'sentry/utils/useOrganization';
-import Layout from 'sentry/views/replays/detail/layout';
+import ReplaysLayout from 'sentry/views/replays/detail/layout';
 import Page from 'sentry/views/replays/detail/page';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 import {getInitialTimeOffset} from 'sentry/views/replays/utils';
@@ -50,9 +50,9 @@ function ReplayDetails({
     if (fetchError.statusText === 'Not Found') {
       return (
         <Page orgSlug={orgSlug} replayRecord={replayRecord}>
-          <PageContent>
+          <Layout.Page withPadding>
             <NotFound />
-          </PageContent>
+          </Layout.Page>
         </Page>
       );
     }
@@ -63,7 +63,7 @@ function ReplayDetails({
     ];
     return (
       <Page orgSlug={orgSlug} replayRecord={replayRecord}>
-        <PageContent>
+        <Layout.Page>
           <DetailedError
             onRetry={onRetry}
             hideSupportLinks
@@ -79,7 +79,7 @@ function ReplayDetails({
               </Fragment>
             }
           />
-        </PageContent>
+        </Layout.Page>
       </Page>
     );
   }
@@ -131,7 +131,7 @@ function LoadedDetails({
 
   return (
     <Page orgSlug={orgSlug} crumbs={replay?.getRawCrumbs()} replayRecord={replayRecord}>
-      <Layout layout={getLayout()} />
+      <ReplaysLayout layout={getLayout()} />
     </Page>
   );
 }

--- a/static/app/views/replays/index.tsx
+++ b/static/app/views/replays/index.tsx
@@ -2,8 +2,8 @@ import {RouteComponentProps} from 'react-router';
 
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -15,9 +15,9 @@ type Props = RouteComponentProps<{}, {}> & {
 function ReplaysContainer({organization, children}: Props) {
   function renderNoAccess() {
     return (
-      <PageContent>
+      <Layout.Page withPadding>
         <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-      </PageContent>
+      </Layout.Page>
     );
   }
 

--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -3,10 +3,10 @@ import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
+import * as Layout from 'sentry/components/layouts/thirds';
 import {IconClose, IconMenu} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {fadeIn, slideInLeft} from 'sentry/styles/animations';
-import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 
 import SettingsBreadcrumb from './settingsBreadcrumb';
@@ -178,10 +178,10 @@ const Content = styled('div')`
   }
 
   /**
-   * PageContent is not normally used in settings but <PermissionDenied /> uses it under the hood.
-   * This prevents double padding.
+   * Layout.Page is not normally used in settings but <PermissionDenied /> uses
+   * it under the hood. This prevents double padding.
    */
-  ${PageContent} {
+  ${Layout.Page} {
     padding: 0;
   }
 `;


### PR DESCRIPTION
Cleanup to reduce lots of extra styled components.

Visually nothing should have changed, the change here is maintainability and clarity on usage of our layout components.

`PageContent` has been removed.

A new `Layout.Page` has been added that is recommended to use to wrap all other `Layout.*` components
