### PR TITLE
ref(ui): Replace `&` with `and` in project setup step

### DIFF
--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -151,7 +151,7 @@ class CreateProject extends Component<Props, State> {
     return (
       <Fragment>
         <PageHeading withMargins>
-          {t('3. Name your project & assign it a team')}
+          {t('3. Name your project and assign it a team')}
         </PageHeading>
         {createProjectForm}
       </Fragment>


### PR DESCRIPTION
Before
<img width="776" alt="image" src="https://user-images.githubusercontent.com/1421724/212008401-d44db44c-f7f3-4e6e-90b9-2f1a4ffdb04b.png">


After
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1421724/212008431-fb77a649-0592-48fe-801d-ee11386214d0.png">
