### PR TITLE
feat(crons): Use SentryProjectSelectorField for icons

### DIFF
--- a/static/app/components/forms/fields/sentryProjectSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.tsx
@@ -16,12 +16,16 @@ const defaultProps = {
 
 // projects can be passed as a direct prop as well
 export interface RenderFieldProps extends InputFieldProps {
+  avatarSize?: number;
   projects?: Project[];
+  /**
+   * Use the slug as the select field value. Without setting this the numeric id
+   * of the project will be used.
+   */
+  valueIsSlug?: boolean;
 }
 
-interface RenderProps
-  extends Omit<Partial<Readonly<typeof defaultProps>>, 'placeholder'>,
-    RenderFieldProps {
+interface RenderProps extends RenderFieldProps {
   projects: Project[]; // can't use AvatarProject since we need the ID
 }
 
@@ -51,7 +55,7 @@ class RenderField extends Component<RenderProps> {
     } = this.props;
 
     const projectOptions = projects.map(project => ({
-      value: project.id,
+      value: project[this.props.valueIsSlug ? 'slug' : 'id'],
       label: project.slug,
       leadingItems: (
         <IdBadge

--- a/static/app/views/monitors/monitorForm.tsx
+++ b/static/app/views/monitors/monitorForm.tsx
@@ -5,6 +5,7 @@ import {Observer} from 'mobx-react';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SelectField from 'sentry/components/forms/fields/selectField';
+import SentryProjectSelectorField from 'sentry/components/forms/fields/sentryProjectSelectorField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form, {FormProps} from 'sentry/components/forms/form';
 import FormModel from 'sentry/components/forms/model';
@@ -142,12 +143,11 @@ class MonitorForm extends Component<Props> {
                 </div>
               </FieldGroup>
             )}
-            <SelectField
+            <SentryProjectSelectorField
               name="project"
               label={t('Project')}
-              options={this.props.projects
-                .filter(p => p.isMember)
-                .map(p => ({value: p.slug, label: p.slug}))}
+              projects={this.props.projects.filter(project => project.isMember)}
+              valueIsSlug
               help={t(
                 "Select the project which contains the recurring job you'd like to monitor."
               )}


### PR DESCRIPTION
Adds the icons to the project dropdown.

I had to modify the SentryProjectSelectorField slightly since it usually
uses the `project.id` as the resulting value, but in this case we want
the slug. So it's learned a new `valueIsSlug`