### PR TITLE
feat(perf-issues): Improve span evidence UI

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -95,11 +95,6 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction-name')
       ).toHaveTextContent('/');
 
-      expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
-      expect(
-        screen.getByTestId('span-evidence-key-value-list.parent-name')
-      ).toHaveTextContent('pageload');
-
       expect(screen.getByRole('cell', {name: 'Offending Span'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.offending-spans')

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -46,7 +46,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.parent-name')
       ).toHaveTextContent('http.server');
 
-      expect(screen.getByRole('cell', {name: 'Repeating Span'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.offending-spans')
       ).toHaveTextContent('db - SELECT * FROM books');
@@ -95,7 +95,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction-name')
       ).toHaveTextContent('/');
 
-      expect(screen.getByRole('cell', {name: 'Repeating Span'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.offending-spans')
       ).toHaveTextContent('GET http://service.api/book/?book_id=7');

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -95,7 +95,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction-name')
       ).toHaveTextContent('/');
 
-      expect(screen.getByRole('cell', {name: 'Offending Span'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Repeating Span'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.offending-spans')
       ).toHaveTextContent('GET http://service.api/book/?book_id=7');

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -28,22 +28,31 @@ export function SpanEvidenceKeyValueList({
       value: transactionName,
       subjectDataTestId: `${TEST_ID_NAMESPACE}.transaction-name`,
     },
-    {
+  ];
+
+  if (
+    [
+      IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+      IssueType.PERFORMANCE_FILE_IO_MAIN_THREAD,
+    ].includes(issueType)
+  ) {
+    data.push({
       key: '1',
       subject: t('Parent Span'),
       value: getSpanEvidenceValue(parentSpan),
       subjectDataTestId: `${TEST_ID_NAMESPACE}.parent-name`,
-    },
-    {
-      key: '2',
-      subject:
-        issueType === IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES
-          ? t('Repeating Span')
-          : t('Offending Span'),
-      value: getSpanEvidenceValue(offendingSpans[0]),
-      subjectDataTestId: `${TEST_ID_NAMESPACE}.offending-spans`,
-    },
-  ];
+    });
+  }
+
+  data.push({
+    key: '2',
+    subject:
+      issueType === IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES
+        ? t('Repeating Span')
+        : t('Offending Span'),
+    value: getSpanEvidenceValue(offendingSpans[0]),
+    subjectDataTestId: `${TEST_ID_NAMESPACE}.offending-spans`,
+  });
 
   let problemParameters;
   if (issueType === IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS) {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -46,10 +46,12 @@ export function SpanEvidenceKeyValueList({
 
   data.push({
     key: '2',
-    subject:
-      issueType === IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES
-        ? t('Repeating Span')
-        : t('Offending Span'),
+    subject: [
+      IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+      IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
+    ].includes(issueType)
+      ? t('Repeating Span')
+      : t('Offending Span'),
     value: getSpanEvidenceValue(offendingSpans[0]),
     subjectDataTestId: `${TEST_ID_NAMESPACE}.offending-spans`,
   });

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -50,7 +50,7 @@ export function SpanEvidenceKeyValueList({
       IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
       IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
     ].includes(issueType)
-      ? t('Repeating Span')
+      ? t('Repeating Spans (%s)', offendingSpans.length)
       : t('Offending Span'),
     value: getSpanEvidenceValue(offendingSpans[0]),
     subjectDataTestId: `${TEST_ID_NAMESPACE}.offending-spans`,

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -7,7 +7,7 @@ import {RawSpanType} from '../spans/types';
 import {TraceContextSpanProxy} from './spanEvidence';
 
 type SpanEvidenceKeyValueListProps = {
-  issueType: IssueType | undefined;
+  issueType: IssueType;
   offendingSpans: Array<RawSpanType | TraceContextSpanProxy>;
   parentSpan: RawSpanType | TraceContextSpanProxy | null;
   transactionName: string;

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -83,11 +83,11 @@ const SpanEvidencePreviewBody = ({
 
   const spanInfo = data && getSpanInfoFromTransactionEvent(data);
 
-  if (spanInfo && data) {
+  if (spanInfo && data?.perfProblem) {
     return (
       <SpanEvidencePreviewWrapper data-test-id="span-evidence-preview-body">
         <SpanEvidenceKeyValueList
-          issueType={data?.perfProblem?.issueType}
+          issueType={data.perfProblem.issueType}
           transactionName={data.title}
           parentSpan={spanInfo.parentSpan}
           offendingSpans={spanInfo.offendingSpans}

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -608,9 +608,9 @@ export type EventUser = {
 
 export type PerformanceDetectorData = {
   causeSpanIds: string[];
+  issueType: IssueType;
   offenderSpanIds: string[];
   parentSpanIds: string[];
-  issueType?: IssueType;
 };
 
 type EventEvidenceDisplay = {


### PR DESCRIPTION
A few small improvements to span evidence.

**e.g.,**

![Screen Shot 2023-01-12 at 11 22 13 AM](https://user-images.githubusercontent.com/989898/212123186-66b886d9-1b91-43c2-a057-ed2c3fa5eb8c.png)

## Changes

- Use stricter type, since issue type is always there
- Hide the parent span from N+1 API Calls evidence
- Use "Repeating Spans" for N+1 API Calls
- Show repeating span count in parens
