### PR TITLE
feat(profiling): default sort by p99()

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -54,7 +54,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
   const query = decodeScalar(location.query.query, '');
 
   const sort = formatSort<FieldType>(decodeScalar(location.query.sort), FIELDS, {
-    key: 'count()',
+    key: 'p99()',
     order: 'desc',
   });
 


### PR DESCRIPTION
## Summary
We're changing the profiling transactions table by `-p99()` in an effort to reduce clicks into profiles that potentially highlight problem areas.

In future our sort should also take in consideration of `count()` similar to `user misery` since.

See also; https://github.com/getsentry/team-profiling/issues/138