### PR TITLE
ref(metrics): Honor max-batch-size again, set it to default disabled

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -446,7 +446,7 @@ def query_subscription_consumer(**options):
     subscriber.run()
 
 
-def batching_kafka_options(group):
+def batching_kafka_options(group, max_batch_size=None, max_batch_time_ms=1000):
     """
     Expose batching_kafka_consumer options as CLI args.
 
@@ -465,7 +465,7 @@ def batching_kafka_options(group):
         f = click.option(
             "--max-batch-size",
             "max_batch_size",
-            default=100,
+            default=max_batch_size,
             type=int,
             help="How many messages to process before committing offsets.",
         )(f)
@@ -473,7 +473,7 @@ def batching_kafka_options(group):
         f = click.option(
             "--max-batch-time-ms",
             "max_batch_time",
-            default=1000,
+            default=max_batch_time_ms,
             type=int,
             help="How long to batch for before committing offsets.",
         )(f)
@@ -523,7 +523,7 @@ def batching_kafka_options(group):
     is_flag=True,
     help="Listen to all consumer types at once.",
 )
-@batching_kafka_options("ingest-consumer")
+@batching_kafka_options("ingest-consumer", max_batch_size=100)
 @click.option(
     "--concurrency",
     type=int,
@@ -586,7 +586,7 @@ def occurrences_ingest_consumer():
     required=True,
     help="Regional name to run the consumer for",
 )
-@batching_kafka_options("region-to-control-consumer")
+@batching_kafka_options("region-to-control-consumer", max_batch_size=100)
 @configuration
 def region_to_control_consumer(region_name, **kafka_options):
     """
@@ -649,7 +649,7 @@ def metrics_parallel_consumer(**options):
 
 @run.command("billing-metrics-consumer")
 @log_options()
-@batching_kafka_options("billing-metrics-consumer")
+@batching_kafka_options("billing-metrics-consumer", max_batch_size=100)
 @configuration
 def metrics_billing_consumer(**options):
     from sentry.ingest.billing_metrics_consumer import get_metrics_billing_consumer
@@ -661,7 +661,7 @@ def metrics_billing_consumer(**options):
 @run.command("ingest-profiles")
 @log_options()
 @click.option("--topic", default="profiles", help="Topic to get profiles data from.")
-@batching_kafka_options("ingest-profiles")
+@batching_kafka_options("ingest-profiles", max_batch_size=100)
 @configuration
 def profiles_consumer(**options):
     from sentry.profiles.consumers import get_profiles_process_consumer
@@ -672,7 +672,7 @@ def profiles_consumer(**options):
 @run.command("ingest-replay-recordings")
 @log_options()
 @configuration
-@batching_kafka_options("ingest-replay-recordings")
+@batching_kafka_options("ingest-replay-recordings", max_batch_size=100)
 @click.option(
     "--topic", default="ingest-replay-recordings", help="Topic to get replay recording data from"
 )
@@ -685,7 +685,7 @@ def replays_recordings_consumer(**options):
 @run.command("indexer-last-seen-updater")
 @log_options()
 @configuration
-@batching_kafka_options("indexer-last-seen-updater-consumer")
+@batching_kafka_options("indexer-last-seen-updater-consumer", max_batch_size=100)
 @click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=25000)
 @click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=10000)
 @click.option("--topic", default="snuba-metrics", help="Topic to read indexer output from.")

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -209,7 +209,6 @@ def get_parallel_metrics_consumer(
         processing_factory,
         CommitPolicy(
             min_commit_frequency_sec=max_batch_time / 1000,
-            # TODO(markus): honor CLI params or remove them
-            min_commit_messages=None,
+            min_commit_messages=max_batch_size,
         ),
     )


### PR DESCRIPTION
IMO a default of "do not commit based on message count" while keeping
"commit based on time" to 1s is a better default for arbitrary consumers
than committing every 100 messages without considering the consumer's
throughput.

Given how arroyo's commit policies work, this new set of CLI defaults
is also more performant since there's currently some additional overhead
in there in enforcing max-batch-size.

Since we're (modestly) interested in further unifying CLI parameters,
update the default in the batching_kafka_options but also make it so
that those defaults can be overridden with different defaults on a
per-consumer basis.

The ingest-metrics consumer (metrics indexer) however does now have a
new default. See also https://github.com/getsentry/ops/pull/5880
