### PR TITLE
bug(replays): Remove deferred measurement cache from Replay Network table

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -126,7 +126,6 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
                 cellRenderer={cellRenderer}
                 columnCount={COLUMN_COUNT}
                 columnWidth={getColumnWidth(width)}
-                deferredMeasurementCache={cache}
                 estimatedColumnSize={width}
                 estimatedRowSize={HEADER_HEIGHT + items.length * BODY_HEIGHT}
                 fixedRowCount={1}


### PR DESCRIPTION
Hard to repro this issue on dev, but this was a fix I discovered while building the 'other sessions' pr (see #42864)

Hoping to merge this in and get the network tab unblocked.

Related to #43043