### PR TITLE
Add pytest-fail-slow plugin

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -77,7 +77,7 @@ runs:
 
         ### pytest configuration ###
         echo "PY_COLORS=1" >> "$GITHUB_ENV"
-        echo "PYTEST_ADDOPTS=--reruns=5 --durations=10" >> $GITHUB_ENV
+        echo "PYTEST_ADDOPTS=--reruns=5 --durations=10 --fail-slow=60s" >> $GITHUB_ENV
 
         ### pytest-sentry configuration ###
         if [ "$GITHUB_REPOSITORY" = "getsentry/sentry" ]; then

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -129,6 +129,7 @@ pysocks==1.7.1
 pytest==7.2.0
 pytest-cov==4.0.0
 pytest-django==4.4.0
+pytest-fail-slow==0.3.0
 pytest-rerunfailures==10.2
 pytest-sentry==0.1.11
 pytest-xdist==3.0.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ openapi-core>=0.14.2
 pytest>=7.2
 pytest-cov>=4.0.0
 pytest-django>=4.4.0
+pytest-fail-slow>=0.3.0
 pytest-rerunfailures>=10
 pytest-sentry>=0.1.11
 pytest-xdist>=3


### PR DESCRIPTION
This will fail tests that take longer than 60s.

The difference between this plugin and pytest-timeout is that this won't exit the test early, meaning it avoids issues where required cleanup doesn't happen, causing test contamination.

Note: `pytest-fail-slow` will only fail if the test itself is slower than the specified the duration, the setup and teardown is not included in this time.