### PR TITLE
run getsentry tests on sentry backend PRs

### DIFF
--- a/.github/workflows/scripts/getsentry-dispatch.js
+++ b/.github/workflows/scripts/getsentry-dispatch.js
@@ -15,7 +15,7 @@ const DISPATCHES = [
   },
   {
     workflow: 'backend.yml',
-    pathFilterName: 'backend_dependencies',
+    pathFilterName: 'backend_src',
   },
 ];
 

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -49,7 +49,7 @@ def clean_phone(phone):
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
     # we use regex below to split the string since we allow any whitespace, comma, or combination of the two
-    # as a delimeter
+    # as a delimiter
     phone_numbers = set(re.split(r"[,\s]+", data))
     stripped_phone_numbers = {num.strip() for num in phone_numbers}
     return stripped_phone_numbers


### PR DESCRIPTION
do we want to do this?

this is a bit of a step backwards in treating sentry / getsentry as separate entities in that we're running all of the tests more often -- but it should prevent more breakages in `getsentry` in theory