### PR TITLE
feat(profiling): Add temp link to highlighted profile

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
+from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,6 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.utils import generate_organization_url
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.project import Project
 from sentry.models.release import Release
@@ -169,3 +171,50 @@ class ProjectProfilingFunctionsEndpoint(ProjectProfilingPaginatedBaseEndpoint):
 
     def get_on_result(self) -> Any:
         return lambda results: {"functions": results}
+
+
+class ProjectProfileEventSerializer(serializers.Serializer):
+    name = serializers.CharField(required=False)
+    package = serializers.CharField(required=False)
+
+    def validate(self, data):
+        if "name" not in data and "package" in data:
+            raise serializers.ValidationError("The package was specified with no name")
+
+        if "name" in data:
+            data["package"] = data.get("package", "")
+
+        return data
+
+
+@region_silo_endpoint
+class ProjectProfilingEventEndpoint(ProjectProfilingBaseEndpoint):
+    def convert_args(self, request: Request, *args, **kwargs):
+        # disables the auto conversion of project slug inherited from the
+        # project endpoint since this takes the project id instead of the slug
+        return (args, kwargs)
+
+    def get(self, request: Request, project_id, profile_id: str) -> HttpResponse:
+        try:
+            project = Project.objects.get_from_cache(id=project_id)
+        except Project.DoesNotExist:
+            return HttpResponse(status=404)
+
+        if not features.has("organizations:profiling", project.organization, actor=request.user):
+            return Response(status=404)
+
+        serializer = ProjectProfileEventSerializer(data=request.GET)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        data = serializer.validated_data
+
+        org_url = generate_organization_url(project.organization.slug)
+
+        redirect_url = f"{org_url}/profiling/profile/{project.slug}/{profile_id}/flamechart/"
+
+        if data:
+            name = data["name"]
+            package = data["package"]
+            redirect_url = f"{redirect_url}?frameName={name}&framePackage={package}"
+
+        return HttpResponseRedirect(redirect_url)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -408,6 +408,7 @@ from .endpoints.project_processingissues import (
     ProjectProcessingIssuesFixEndpoint,
 )
 from .endpoints.project_profiling_profile import (
+    ProjectProfilingEventEndpoint,
     ProjectProfilingFunctionsEndpoint,
     ProjectProfilingProfileEndpoint,
     ProjectProfilingRawProfileEndpoint,
@@ -2335,6 +2336,13 @@ urlpatterns = [
                 ),
             ]
         ),
+    ),
+    # Profiling - This is a temporary endpoint to easily go from a project id + profile id to a flamechart.
+    # It will be removed in the near future.
+    url(
+        r"^profiling/projects/(?P<project_id>[\w_-]+)/profile/(?P<profile_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/",
+        ProjectProfilingEventEndpoint.as_view(),
+        name="",
     ),
     # Groups
     url(r"^(?:issues|groups)/", include(GROUP_URLS)),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2342,7 +2342,7 @@ urlpatterns = [
     url(
         r"^profiling/projects/(?P<project_id>[\w_-]+)/profile/(?P<profile_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/",
         ProjectProfilingEventEndpoint.as_view(),
-        name="",
+        name="sentry-api-0-profiling-project-profile",
     ),
     # Groups
     url(r"^(?:issues|groups)/", include(GROUP_URLS)),


### PR DESCRIPTION
As part of the profiling issues initiative, we need a way to easily go to a profile with certain frames highlighted given only the project id, profile id and the frame name + package. This endpoint will be removed in the future once we no longer need it.