### PR TITLE
feat(crons): Remove sampling on check monitors task

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -113,6 +113,7 @@ SAMPLED_TASKS = {
     "sentry.profiles.task.process_profile": 0.01,
     "sentry.tasks.derive_code_mappings.process_organizations": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.derive_code_mappings.derive_code_mappings": settings.SAMPLED_DEFAULT_RATE,
+    "sentry.tasks.check_monitors": 1.0,
 }
 
 if settings.ADDITIONAL_SAMPLED_TASKS:


### PR DESCRIPTION
Task only runs once a minute so this should be fine, and will give us observability into how monitors is performing as more users are onboarded