### PR TITLE
ref: run migrations-requiring tests in a separate suite

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -62,11 +62,6 @@ runs:
         # isn't right because job-total will be 3x larger and you'd never run 2/3 of the tests.
         # MATRIX_INSTANCE_TOTAL: ${{ strategy.job-total }}
       run: |
-        # Only set `MIGRATIONS_TEST_MIGRATE` if it is not already set (or if it's an empty string)
-        if [ -z $MIGRATIONS_TEST_MIGRATE ]; then
-          echo "MIGRATIONS_TEST_MIGRATE=0" >> $GITHUB_ENV
-        fi
-
         echo "PIP_DISABLE_PIP_VERSION_CHECK=on" >> $GITHUB_ENV
         echo "PIP_INDEX_URL=https://pypi.devinfra.sentry.io/simple" >> $GITHUB_ENV
         echo "SENTRY_SKIP_BACKEND_VALIDATION=1" >> $GITHUB_ENV

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -80,7 +80,6 @@ jobs:
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
       MATRIX_INSTANCE_TOTAL: 4
-      MIGRATIONS_TEST_MIGRATE: 1
 
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
@@ -103,6 +102,37 @@ jobs:
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           make test-python-ci
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts
+
+  backend-migration-tests:
+    if: needs.files-changed.outputs.backend == 'true'
+    needs: files-changed
+    name: backend migration tests
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        pg-version: ['9.6']
+
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          snuba: true
+          pg-version: ${{ matrix.pg-version }}
+
+      - name: run tests
+        run: |
+          MIGRATIONS_TEST_MIGRATE=1 PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations" make test-python-ci
 
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
@@ -351,7 +381,6 @@ jobs:
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
       MATRIX_INSTANCE_TOTAL: 2
-      MIGRATIONS_TEST_MIGRATE: 1
 
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
@@ -444,6 +473,7 @@ jobs:
       [
         api-docs,
         backend-test,
+        backend-migration-tests,
         cli,
         lint,
         requirements,

--- a/.github/workflows/shuffle-tests.yml
+++ b/.github/workflows/shuffle-tests.yml
@@ -31,7 +31,6 @@ jobs:
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
       MATRIX_INSTANCE_TOTAL: 4
-      MIGRATIONS_TEST_MIGRATE: 1
 
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,6 @@ addopts = "-ra --tb=short --strict-markers -p no:celery"
 # currently we have a few relative imports that don't work with that.
 markers = [
     "snuba: mark a test as requiring snuba",
-    "itunes: test requires iTunes interaction, skipped unless --itunes is provided",
-    "getsentryllc: test requires credentials for the GetSentry LLC organisation in Apple App Store Connect",
     "sentry_metrics: test requires access to sentry metrics",
 ]
 selenium_driver = "chrome"

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1911,6 +1911,7 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
         self.login_as(self.user)
 
 
+@pytest.mark.migrations
 class TestMigrations(TransactionTestCase):
     """
     From https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -39,6 +39,8 @@ def pytest_configure(config):
         category=UnsupportedBackend,
     )
 
+    config.addinivalue_line("markers", "migrations: requires MIGRATIONS_TEST_MIGRATE=1")
+
     # HACK: Only needed for testing!
     os.environ.setdefault("_SENTRY_SKIP_CONFIGURATION", "1")
 
@@ -263,6 +265,13 @@ def register_extensions():
     bindings.add(
         "integration-repository.provider", ExampleRepositoryProvider, id="integrations:example"
     )
+
+
+def pytest_runtest_setup(item):
+    if not settings.MIGRATIONS_TEST_MIGRATE and any(
+        mark for mark in item.iter_markers(name="migrations")
+    ):
+        pytest.skip("migrations are not enabled, run with MIGRATIONS_TEST_MIGRATE=1 pytest ...")
 
 
 def pytest_runtest_teardown(item):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import pytest
 import responses
-from django.conf import settings
 from django.core import mail
 from django.utils import timezone
 from freezegun import freeze_time
@@ -513,9 +512,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.include_all_projects == include_all_projects
 
     # This test will fail unless real migrations are run. Refer to migration 0061.
-    @pytest.mark.skipif(
-        not settings.MIGRATIONS_TEST_MIGRATE, reason="requires custom migration 0061"
-    )
+    @pytest.mark.migrations  # requires custom migration 0061
     def test_two_archived_with_same_name(self):
         name = "allowed"
         alert_rule_1 = create_alert_rule(


### PR DESCRIPTION
this introduces the following:
- `@pytest.mark.migrations` -- a marker for tests which need to have migrations -- they will be auto-skipped otherwise
- a new test suite specifically for running migrations tests

this also disables migrations in other test suites -- this speeds up the testsuite by 60 seconds (was previously attributed to a `setup` task for the first test in `--durations` output)