### PR TITLE
fix(span-grouping): add db.redis to redis grouping strategy

### DIFF
--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -224,7 +224,7 @@ def remove_http_client_query_string_strategy(span: Span) -> Optional[Sequence[st
     return [method, url.scheme, url.netloc, url.path]
 
 
-@span_op("redis")
+@span_op(["redis", "db.redis"])
 def remove_redis_command_arguments_strategy(span: Span) -> Optional[Sequence[str]]:
     """For a `redis` span, the fingerprint to use is simply the redis command name.
     The arguments to the redis command is highly variable and therefore not used as

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -277,6 +277,7 @@ def test_remove_http_client_query_string_strategy(
         # op is not `redis`
         (SpanBuilder().with_description("INCRBY 'key' 1").build(), None),
         (SpanBuilder().with_op("redis").with_description("INCRBY 'key' 1").build(), ["INCRBY"]),
+        (SpanBuilder().with_op("db.redis").with_description("INCRBY 'key' 1").build(), ["INCRBY"]),
     ],
 )
 def test_remove_redis_command_arguments_strategy(


### PR DESCRIPTION
right now redis span names aren't parameterized, as the op has been changed to `db.redis`. this PR should fix it.