### PR TITLE
fix(ui): Prevent all events table from overflowing

### DIFF
--- a/static/app/views/organizationGroupDetails/groupEvents.tsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.tsx
@@ -108,16 +108,14 @@ class GroupEvents extends Component<Props, State> {
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          <Wrapper>
-            {this.renderSearchBar()}
-            <AllEventsTable
-              issueId={this.props.group.id}
-              location={this.props.location}
-              organization={this.props.organization}
-              group={this.props.group}
-              excludedTags={excludedTags}
-            />
-          </Wrapper>
+          <AllEventsFilters>{this.renderSearchBar()}</AllEventsFilters>
+          <AllEventsTable
+            issueId={this.props.group.id}
+            location={this.props.location}
+            organization={this.props.organization}
+            group={this.props.group}
+            excludedTags={excludedTags}
+          />
         </Layout.Main>
       </Layout.Body>
     );
@@ -130,9 +128,8 @@ const FilterSection = styled('div')`
   grid-template-columns: max-content 1fr;
 `;
 
-const Wrapper = styled('div')`
-  display: grid;
-  gap: ${space(2)};
+const AllEventsFilters = styled('div')`
+  margin-bottom: ${space(2)};
 `;
 
 export {GroupEvents};


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/42570

Before:

![CleanShot 2023-01-12 at 14 29 20](https://user-images.githubusercontent.com/10888943/212194648-1c2721f6-0362-427f-93c6-5ac9e3d6144b.png)

After:

![CleanShot 2023-01-12 at 14 28 44](https://user-images.githubusercontent.com/10888943/212195506-23602f27-2a18-4fbb-b459-df08a0df8829.png)
