### PR TITLE
fix(hc): Have ApiInviteHelper work in region silo

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -234,9 +234,7 @@ class AuthIdentityHandler:
             login_redirect_url = absolute_uri(login_redirect_url, url_prefix=url_prefix)
         return login_redirect_url
 
-    def _handle_new_membership(
-        self, auth_identity: ApiAuthIdentity
-    ) -> ApiOrganizationMember | None:
+    def _handle_new_membership(self, auth_identity: ApiAuthIdentity) -> ApiOrganizationMember:
         user, om = auth_service.handle_new_membership(
             self.request, self.organization, auth_identity, self.auth_provider
         )
@@ -320,8 +318,7 @@ class AuthIdentityHandler:
 
         if member is None:
             member = self._get_organization_member(auth_identity)
-        if member is not None:
-            self._set_linked_flag(member)
+        self._set_linked_flag(member)
 
         if auth_is_new:
             audit_log_service.log_auth_identity(
@@ -364,7 +361,7 @@ class AuthIdentityHandler:
 
         return deletion_result
 
-    def _get_organization_member(self, auth_identity: AuthIdentity) -> ApiOrganizationMember | None:
+    def _get_organization_member(self, auth_identity: AuthIdentity) -> ApiOrganizationMember:
         """
         Check to see if the user has a member associated, if not, create a new membership
         based on the auth_identity email.

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -21,7 +21,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import View
 
 from sentry import audit_log, features
-from sentry.api.invite_helper import remove_invite_details_from_session
+from sentry.api.invite_helper import get_invite_details, remove_invite_details_from_session
 from sentry.api.utils import generate_organization_url
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.auth.exceptions import IdentityNotValid
@@ -229,7 +229,10 @@ class AuthIdentityHandler:
 
     def _handle_new_membership(self, auth_identity: ApiAuthIdentity) -> ApiOrganizationMember:
         user, om = auth_service.handle_new_membership(
-            self.request, self.organization, auth_identity, self.auth_provider
+            detail=get_invite_details(self.request),
+            organization=self.organization,
+            auth_identity=auth_identity,
+            auth_provider=self.auth_provider,
         )
 
         if om is not None:

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -32,14 +32,7 @@ from sentry.auth.idpmigration import (
 from sentry.auth.provider import MigratingIdentityId, Provider
 from sentry.auth.superuser import is_active_superuser
 from sentry.locks import locks
-from sentry.models import (
-    AuditLogEntry,
-    AuthIdentity,
-    AuthProvider,
-    Organization,
-    OrganizationMember,
-    User,
-)
+from sentry.models import AuditLogEntry, AuthIdentity, AuthProvider, Organization, User
 from sentry.pipeline import Pipeline, PipelineSessionStore
 from sentry.pipeline.provider import PipelineProvider
 from sentry.services.hybrid_cloud.audit import AuditLogMetadata, audit_log_service
@@ -463,10 +456,10 @@ class AuthIdentityHandler:
             # we only allow this flow to happen if the existing user has
             # membership, otherwise we short circuit because it might be
             # an attempt to hijack membership of another organization
-            has_membership = OrganizationMember.objects.filter(
-                user=self._app_user, organization=self.organization
-            ).exists()
-            if has_membership:
+            membership = organization_service.check_membership_by_id(
+                user_id=self._app_user.id, organization_id=self.organization.id
+            )
+            if membership is not None:
                 try:
                     self._login(self.user)
                 except self._NotCompletedSecurityChecks:

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -452,7 +452,7 @@ class AuthIdentityHandler:
                 is_account_verified = self.has_verified_account(verification_value)
 
         is_new_account = not self.user.is_authenticated  # stateful
-        if self._app_user and self.identity.get("email_verified") or is_account_verified:
+        if self._app_user and (self.identity.get("email_verified") or is_account_verified):
             # we only allow this flow to happen if the existing user has
             # membership, otherwise we short circuit because it might be
             # an attempt to hijack membership of another organization

--- a/src/sentry/auth/idpmigration.py
+++ b/src/sentry/auth/idpmigration.py
@@ -8,7 +8,8 @@ from django.urls import reverse
 from rb.clients import LocalClient
 
 from sentry import options
-from sentry.models import AuthProvider, Organization, OrganizationMember, User
+from sentry.models import AuthProvider, User
+from sentry.services.hybrid_cloud.organization import ApiOrganization, organization_service
 from sentry.utils import json, metrics, redis
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
@@ -21,7 +22,7 @@ SSO_VERIFICATION_KEY = "confirm_account_verification_key"
 
 def send_one_time_account_confirm_link(
     user: User,
-    org: Organization,
+    org: ApiOrganization,
     provider: AuthProvider,
     email: str,
     identity_id: str,
@@ -34,7 +35,7 @@ def send_one_time_account_confirm_link(
     in an email to the associated address.
 
     :param user: the user profile to link
-    :param organization: the organization whose SSO provider is being used
+    :param org: the organization whose SSO provider is being used
     :param provider: the SSO provider
     :param email: the email address associated with the SSO identity
     :param identity_id: the SSO identity id
@@ -52,7 +53,7 @@ def get_redis_cluster() -> LocalClient:
 @dataclass
 class AccountConfirmLink:
     user: User
-    organization: Organization
+    organization: ApiOrganization
     provider: AuthProvider
     email: str
     identity_id: str
@@ -88,17 +89,14 @@ class AccountConfirmLink:
     def store_in_redis(self) -> None:
         cluster = get_redis_cluster()
 
-        try:
-            member_id = OrganizationMember.objects.get(
-                organization=self.organization, user=self.user
-            ).id
-        except OrganizationMember.DoesNotExist:
-            member_id = None
+        member = organization_service.check_membership_by_id(
+            organization_id=self.organization.id, user_id=self.user.id
+        )
 
         verification_value = {
             "user_id": self.user.id,
             "email": self.email,
-            "member_id": member_id,
+            "member_id": member.id if member is not None else None,
             "organization_id": self.organization.id,
             "identity_id": self.identity_id,
             "provider": self.provider.provider,

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -182,6 +182,12 @@ class OrganizationMember(Model):
         self.token = None
         self.token_expires_at = None
 
+    def set_user_by_id(self, user_id: int) -> None:
+        self.user_id = user_id
+        self.email = None
+        self.token = None
+        self.token_expires_at = None
+
     def remove_user(self):
         self.email = self.get_email()
         self.user = None

--- a/src/sentry/services/hybrid_cloud/audit/__init__.py
+++ b/src/sentry/services/hybrid_cloud/audit/__init__.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
+from sentry.services.hybrid_cloud.auth import ApiAuthIdentity, ApiAuthProvider
+from sentry.services.hybrid_cloud.organization import ApiOrganization, ApiOrganizationMember
+from sentry.services.hybrid_cloud.user import APIUser
+from sentry.silo import SiloMode
+
+
+@dataclass
+class AuditLogMetadata:
+    organization: ApiOrganization
+    event: int
+    actor_label: str | None = None
+    actor: APIUser | None = None
+    ip_address: str | None = None
+    target_object: int | None = None
+    target_user: APIUser | None = None
+
+
+class AuditLogService(InterfaceWithLifecycle):
+    @abc.abstractmethod
+    def write_audit_log(
+        self,
+        *,
+        metadata: AuditLogMetadata,
+        data: Mapping[str, Any],
+    ) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def log_organization_membership(
+        self,
+        *,
+        metadata: AuditLogMetadata,
+        organization_member: ApiOrganizationMember,
+    ) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def log_auth_provider(
+        self,
+        *,
+        metadata: AuditLogMetadata,
+        provider: ApiAuthProvider,
+    ) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def log_auth_identity(
+        self,
+        *,
+        metadata: AuditLogMetadata,
+        auth_identity: ApiAuthIdentity,
+    ) -> None:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        pass
+
+
+def impl_with_db() -> AuditLogService:
+    from sentry.services.hybrid_cloud.audit.impl import DatabaseBackedAuditLogService
+
+    return DatabaseBackedAuditLogService()
+
+
+audit_log_service: AuditLogService = silo_mode_delegation(
+    {
+        SiloMode.MONOLITH: impl_with_db,
+        SiloMode.CONTROL: impl_with_db,
+        SiloMode.REGION: stubbed(impl_with_db, SiloMode.CONTROL),
+    }
+)

--- a/src/sentry/services/hybrid_cloud/audit/impl.py
+++ b/src/sentry/services/hybrid_cloud/audit/impl.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from sentry.models import AuditLogEntry, AuthIdentity, AuthProvider, Organization, Team, User
+from sentry.services.hybrid_cloud.audit import AuditLogMetadata, AuditLogService
+from sentry.services.hybrid_cloud.auth import ApiAuthIdentity, ApiAuthProvider
+from sentry.services.hybrid_cloud.organization import ApiOrganizationMember
+from sentry.services.hybrid_cloud.user import APIUser, user_service
+
+
+class DatabaseBackedAuditLogService(AuditLogService):
+    @staticmethod
+    def _resolve_user(user: APIUser | int | None) -> User | None:
+        if user is None:
+            return None
+        if isinstance(user, int):
+            user_id = user
+        else:
+            user_id = user.id
+        return User.objects.get(id=user_id)
+
+    def write_audit_log(self, *, metadata: AuditLogMetadata, data: Mapping[str, Any]) -> None:
+        organization = Organization.objects.get(id=metadata.organization.id)
+        AuditLogEntry.objects.create(
+            organization=organization,
+            event=metadata.event,
+            actor_label=metadata.actor_label,
+            actor=self._resolve_user(metadata.actor),
+            ip_address=metadata.ip_address,
+            target_object=metadata.target_object,
+            target_user=self._resolve_user(metadata.target_user),
+            data=data,
+        )
+
+    def log_organization_membership(
+        self, *, metadata: AuditLogMetadata, organization_member: ApiOrganizationMember
+    ) -> None:
+        user_id = organization_member.user_id
+        assert user_id is not None
+        user = user_service.get_user(user_id=user_id)
+        assert user is not None
+
+        team_ids = [mt.team_id for mt in organization_member.member_teams]
+        team_slugs = list(Team.objects.filter(id__in=team_ids).values_list("slug", flat=True))
+
+        data = {
+            "email": user.email,
+            "user": None,  # TODO,
+            "teams": team_ids,
+            "teams_slugs": team_slugs,
+            "has_global_access": organization_member.has_global_access,
+            "role": organization_member.role,
+            "invite_status": None,  # TODO
+        }
+        return self.write_audit_log(metadata=metadata, data=data)
+
+    def log_auth_provider(self, *, metadata: AuditLogMetadata, provider: ApiAuthProvider) -> None:
+        model = AuthProvider.objects.get(id=provider.id)
+        data = model.get_audit_log_data()
+        return self.write_audit_log(metadata=metadata, data=data)
+
+    def log_auth_identity(
+        self, *, metadata: AuditLogMetadata, auth_identity: ApiAuthIdentity
+    ) -> None:
+        model = AuthIdentity.objects.get(id=auth_identity.id)
+        data = model.get_audit_log_data()  # TODO: Adapt to Api dataclass
+        return self.write_audit_log(metadata=metadata, data=data)

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -12,6 +12,7 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.request import Request
 
 from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
+from sentry.api.invite_helper import InviteDetail
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
 from sentry.services.hybrid_cloud.organization import ApiOrganization, ApiOrganizationMember
@@ -137,7 +138,7 @@ class AuthService(InterfaceWithLifecycle):
     @abc.abstractmethod
     def handle_new_membership(
         self,
-        request: Request,
+        detail: InviteDetail,
         organization: ApiOrganization,
         auth_identity: ApiAuthIdentity,
         auth_provider: ApiAuthProvider,

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -14,7 +14,7 @@ from rest_framework.request import Request
 from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
-from sentry.services.hybrid_cloud.organization import ApiOrganizationMember
+from sentry.services.hybrid_cloud.organization import ApiOrganization, ApiOrganizationMember
 from sentry.services.hybrid_cloud.user import APIUser
 from sentry.silo import SiloMode
 from sentry.utils.linksign import find_signature
@@ -132,6 +132,16 @@ class AuthService(InterfaceWithLifecycle):
         This method returns a list of auth providers for an org
         :return:
         """
+        pass
+
+    @abc.abstractmethod
+    def handle_new_membership(
+        self,
+        request: Request,
+        organization: ApiOrganization,
+        auth_identity: ApiAuthIdentity,
+        auth_provider: ApiAuthProvider,
+    ) -> Tuple[APIUser, ApiOrganizationMember | None]:
         pass
 
 
@@ -307,6 +317,14 @@ class ApiAuthProvider:
     organization_id: int = -1
     provider: str = ""
     flags: ApiAuthProviderFlags = field(default_factory=lambda: ApiAuthProviderFlags())
+
+
+@dataclass
+class ApiAuthIdentity:
+    id: int = -1
+    user_id: int = -1
+    provider_id: int = -1
+    ident: str = ""
 
 
 @dataclass(eq=True)

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -141,7 +141,7 @@ class AuthService(InterfaceWithLifecycle):
         organization: ApiOrganization,
         auth_identity: ApiAuthIdentity,
         auth_provider: ApiAuthProvider,
-    ) -> Tuple[APIUser, ApiOrganizationMember | None]:
+    ) -> Tuple[APIUser, ApiOrganizationMember]:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -263,7 +263,7 @@ class DatabaseBackedAuthService(AuthService):
         organization: ApiOrganization,
         auth_identity: ApiAuthIdentity,
         auth_provider: ApiAuthProvider,
-    ) -> Tuple[APIUser, ApiOrganizationMember | None]:
+    ) -> Tuple[APIUser, ApiOrganizationMember]:
         # TODO: Might be able to keep hold of the APIUser object whose ID was
         #  originally passed to construct the ApiAuthIdentity object
         user = User.objects.get(id=auth_identity.user_id)

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -2,18 +2,29 @@ from __future__ import annotations
 
 import base64
 import dataclasses
-from typing import List, Mapping
+from typing import List, Mapping, Tuple
 
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Count, F
+from rest_framework.request import Request
 
-from sentry import roles
+from sentry import features, roles
+from sentry.api.invite_helper import ApiInviteHelper
 from sentry.auth.access import get_permissions_for_user
 from sentry.auth.system import SystemToken
 from sentry.middleware.auth import RequestAuthenticationMiddleware
-from sentry.models import ApiKey, ApiToken, AuthIdentity, AuthProvider, OrganizationMember, User
+from sentry.models import (
+    ApiKey,
+    ApiToken,
+    AuthIdentity,
+    AuthProvider,
+    Organization,
+    OrganizationMember,
+    User,
+)
 from sentry.services.hybrid_cloud.auth import (
     ApiAuthenticatorType,
+    ApiAuthIdentity,
     ApiAuthProvider,
     ApiAuthProviderFlags,
     ApiAuthState,
@@ -25,8 +36,14 @@ from sentry.services.hybrid_cloud.auth import (
     AuthService,
     MiddlewareAuthenticationResponse,
 )
-from sentry.services.hybrid_cloud.organization import ApiOrganizationMember
-from sentry.services.hybrid_cloud.user import user_service
+from sentry.services.hybrid_cloud.organization import (
+    ApiOrganization,
+    ApiOrganizationMember,
+    ApiOrganizationMemberFlags,
+    organization_service,
+)
+from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
+from sentry.services.hybrid_cloud.user import APIUser, user_service
 from sentry.silo import SiloMode
 from sentry.utils.auth import AuthUserPasswordExpired
 from sentry.utils.types import Any
@@ -239,6 +256,64 @@ class DatabaseBackedAuthService(AuthService):
 
     def get_auth_providers(self, organization_id: int) -> List[ApiAuthProvider]:
         return list(AuthProvider.objects.filter(organization_id=organization_id))
+
+    def handle_new_membership(
+        self,
+        request: Request,
+        organization: ApiOrganization,
+        auth_identity: ApiAuthIdentity,
+        auth_provider: ApiAuthProvider,
+    ) -> Tuple[APIUser, ApiOrganizationMember | None]:
+        # TODO: Might be able to keep hold of the APIUser object whose ID was
+        #  originally passed to construct the ApiAuthIdentity object
+        user = User.objects.get(id=auth_identity.user_id)
+        serial_user = user_service.serialize_user(user)
+
+        # This raises an AvailabilityError
+        # TODO: Extract ApiInviteHelper methods into new service methods
+        orm_org = Organization.objects.get(id=organization.id)
+
+        # If the user is either currently *pending* invite acceptance (as indicated
+        # from the invite token and member id in the session) OR an existing invite exists on this
+        # organization for the email provided by the identity provider.
+        invite_helper = ApiInviteHelper.from_session_or_email(
+            request=request, organization=orm_org, email=user.email
+        )
+
+        # If we are able to accept an existing invite for the user for this
+        # organization, do so, otherwise handle new membership
+        if invite_helper:
+            if invite_helper.invite_approved:
+                om = invite_helper.accept_invite(user)
+                return serial_user, DatabaseBackedOrganizationService.serialize_member(om)
+
+            # It's possible the user has an _invite request_ that hasn't been approved yet,
+            # and is able to join the organization without an invite through the SSO flow.
+            # In that case, delete the invite request and create a new membership.
+            invite_helper.handle_invite_not_approved()
+
+        flags = ApiOrganizationMemberFlags(sso__linked=True)
+        # if the org doesn't have the ability to add members then anyone who got added
+        # this way should be disabled until the org upgrades
+        if not features.has("organizations:invite-members", orm_org):
+            flags.member_limit__restricted = True
+
+        # Otherwise create a new membership
+        om = organization_service.add_organization_member(
+            organization=organization,
+            role=organization.default_role,
+            user=serial_user,
+            flags=flags,
+        )
+
+        # TODO: Combine into one query
+        provider_model = AuthProvider.objects.get(id=auth_provider.id)
+        default_team_ids = provider_model.default_teams.values_list("id", flat=True)
+
+        for team_id in default_team_ids:
+            organization_service.add_team_member(team_id=team_id, organization_member=om)
+
+        return serial_user, om
 
 
 class FakeRequestDict:

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from sentry.models.organization import OrganizationStatus
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
+from sentry.services.hybrid_cloud.user import APIUser
 from sentry.silo import SiloMode
 
 if TYPE_CHECKING:
@@ -84,6 +85,27 @@ class OrganizationService(InterfaceWithLifecycle):
             return None
 
         return self.get_organization_by_id(id=org_id, user_id=user_id)
+
+    @abstractmethod
+    def add_organization_member(
+        self,
+        *,
+        organization: ApiOrganization,
+        user: APIUser,
+        flags: ApiOrganizationMemberFlags | None,
+        role: str | None,
+    ) -> ApiOrganizationMember:
+        pass
+
+    @abstractmethod
+    def add_team_member(
+        self, *, team_id: int, organization_member: ApiOrganizationMember
+    ) -> ApiTeamMember:
+        pass
+
+    @abstractmethod
+    def update_membership_flags(self, *, organization_member: ApiOrganizationMember) -> None:
+        pass
 
 
 def impl_with_db() -> OrganizationService:
@@ -168,6 +190,7 @@ class ApiOrganizationMember:
     user_id: Optional[int] = None
     member_teams: List[ApiTeamMember] = field(default_factory=list)
     role: str = ""
+    has_global_access: bool = False
     project_ids: List[int] = field(default_factory=list)
     scopes: List[str] = field(default_factory=list)
     flags: ApiOrganizationMemberFlags = field(default_factory=lambda: ApiOrganizationMemberFlags())
@@ -182,6 +205,13 @@ class ApiOrganizationFlags:
     require_2fa: bool = False
     disable_new_visibility_features: bool = False
     require_email_verification: bool = False
+
+
+@dataclass
+class ApiOrganizationInvite:
+    id: int = -1
+    token: str = ""
+    email: str = ""
 
 
 @dataclass
@@ -204,6 +234,8 @@ class ApiOrganization(ApiOrganizationSummary):
 
     flags: ApiOrganizationFlags = field(default_factory=lambda: ApiOrganizationFlags())
     status: OrganizationStatus = OrganizationStatus.VISIBLE
+
+    default_role: str = ""
 
 
 @dataclass

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
 
+from sentry.api.invite_helper import InviteDetail
 from sentry.models.organization import OrganizationStatus
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
 from sentry.services.hybrid_cloud.user import APIUser
@@ -105,6 +106,12 @@ class OrganizationService(InterfaceWithLifecycle):
 
     @abstractmethod
     def update_membership_flags(self, *, organization_member: ApiOrganizationMember) -> None:
+        pass
+
+    @abstractmethod
+    def handle_invite(
+        self, detail: InviteDetail, organization: ApiOrganization, user: APIUser
+    ) -> ApiOrganizationMember | None:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import dataclasses
 from collections import defaultdict
-from typing import Iterable, List, MutableMapping, Optional, Set, cast
+from typing import TYPE_CHECKING, Iterable, List, MutableMapping, Optional, Set, cast
 
 from sentry.models import (
     Organization,
@@ -17,6 +19,7 @@ from sentry.services.hybrid_cloud import logger
 from sentry.services.hybrid_cloud.organization import (
     ApiOrganization,
     ApiOrganizationFlags,
+    ApiOrganizationInvite,
     ApiOrganizationMember,
     ApiOrganizationMemberFlags,
     ApiOrganizationSummary,
@@ -26,6 +29,10 @@ from sentry.services.hybrid_cloud.organization import (
     ApiUserOrganizationContext,
     OrganizationService,
 )
+from sentry.services.hybrid_cloud.util import flags_to_bits
+
+if TYPE_CHECKING:
+    from sentry.services.hybrid_cloud.user import APIUser
 
 
 def escape_flag_name(flag_name: str) -> str:
@@ -37,23 +44,26 @@ def unescape_flag_name(flag_name: str) -> str:
 
 
 class DatabaseBackedOrganizationService(OrganizationService):
-    def _serialize_member_flags(self, member: "OrganizationMember") -> "ApiOrganizationMemberFlags":
+    @classmethod
+    def _serialize_member_flags(cls, member: OrganizationMember) -> ApiOrganizationMemberFlags:
         result = ApiOrganizationMemberFlags()
         for f in dataclasses.fields(ApiOrganizationMemberFlags):
             setattr(result, f.name, bool(getattr(member.flags, unescape_flag_name(f.name))))
         return result
 
-    def _serialize_member(
-        self,
-        member: "OrganizationMember",
-    ) -> "ApiOrganizationMember":
+    @classmethod
+    def serialize_member(
+        cls,
+        member: OrganizationMember,
+    ) -> ApiOrganizationMember:
         api_member = ApiOrganizationMember(
             id=member.id,
             organization_id=member.organization_id,
             user_id=member.user.id if member.user is not None else None,
             role=member.role,
+            has_global_access=member.has_global_access,
             scopes=list(member.get_scopes()),
-            flags=self._serialize_member_flags(member),
+            flags=cls._serialize_member_flags(member),
         )
 
         omts = OrganizationMemberTeam.objects.filter(
@@ -71,19 +81,21 @@ class DatabaseBackedOrganizationService(OrganizationService):
         for omt in omts:
             omt.organizationmember = member
             api_member.member_teams.append(
-                self._serialize_team_member(omt, project_ids_by_team_id[omt.team_id])
+                cls._serialize_team_member(omt, project_ids_by_team_id[omt.team_id])
             )
         api_member.project_ids = list(all_project_ids)
 
         return api_member
 
-    def _serialize_flags(self, org: "Organization") -> "ApiOrganizationFlags":
+    @classmethod
+    def _serialize_flags(cls, org: Organization) -> ApiOrganizationFlags:
         result = ApiOrganizationFlags()
         for f in dataclasses.fields(result):
             setattr(result, f.name, getattr(org.flags, f.name))
         return result
 
-    def _serialize_team(self, team: Team) -> "ApiTeam":
+    @classmethod
+    def _serialize_team(cls, team: Team) -> ApiTeam:
         return ApiTeam(
             id=team.id,
             status=team.status,
@@ -91,9 +103,10 @@ class DatabaseBackedOrganizationService(OrganizationService):
             slug=team.slug,
         )
 
+    @classmethod
     def _serialize_team_member(
-        self, team_member: OrganizationMemberTeam, project_ids: Iterable[int]
-    ) -> "ApiTeamMember":
+        cls, team_member: OrganizationMemberTeam, project_ids: Iterable[int]
+    ) -> ApiTeamMember:
         result = ApiTeamMember(
             id=team_member.id,
             is_active=team_member.is_active,
@@ -105,7 +118,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
         return result
 
-    def _serialize_project(self, project: Project) -> "ApiProject":
+    @classmethod
+    def _serialize_project(cls, project: Project) -> ApiProject:
         return ApiProject(
             id=project.id,
             slug=project.slug,
@@ -114,26 +128,28 @@ class DatabaseBackedOrganizationService(OrganizationService):
             status=project.status,
         )
 
-    def _serialize_organization_summary(self, org: "Organization") -> "ApiOrganizationSummary":
+    def _serialize_organization_summary(self, org: Organization) -> ApiOrganizationSummary:
         return ApiOrganizationSummary(
             slug=org.slug,
             id=org.id,
             name=org.name,
         )
 
-    def _serialize_organization(self, org: "Organization") -> "ApiOrganization":
+    @classmethod
+    def serialize_organization(cls, org: Organization) -> ApiOrganization:
         api_org: ApiOrganization = ApiOrganization(
             slug=org.slug,
             id=org.id,
-            flags=self._serialize_flags(org),
+            flags=cls._serialize_flags(org),
             name=org.name,
             status=org.status,
+            default_role=org.default_role,
         )
 
         projects: List[Project] = Project.objects.filter(organization=org)
         teams: List[Team] = Team.objects.filter(organization=org)
-        api_org.projects.extend(self._serialize_project(project) for project in projects)
-        api_org.teams.extend(self._serialize_team(team) for team in teams)
+        api_org.projects.extend(cls._serialize_project(project) for project in projects)
+        api_org.teams.extend(cls._serialize_team(team) for team in teams)
         return api_org
 
     def check_membership_by_id(
@@ -146,7 +162,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         except OrganizationMember.DoesNotExist:
             return None
 
-        return self._serialize_member(member)
+        return self.serialize_member(member)
 
     def get_organization_by_id(
         self, *, id: int, user_id: Optional[int]
@@ -155,7 +171,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         if user_id is not None:
             try:
                 om = OrganizationMember.objects.get(organization_id=id, user_id=user_id)
-                membership = self._serialize_member(om)
+                membership = self.serialize_member(om)
             except OrganizationMember.DoesNotExist:
                 pass
 
@@ -165,7 +181,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             return None
 
         return ApiUserOrganizationContext(
-            user_id=user_id, organization=self._serialize_organization(org), member=membership
+            user_id=user_id, organization=self.serialize_organization(org), member=membership
         )
 
     def check_membership_by_email(
@@ -176,7 +192,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         except OrganizationMember.DoesNotExist:
             return None
 
-        return self._serialize_member(member)
+        return self.serialize_member(member)
 
     def check_organization_by_slug(self, *, slug: str, only_visible: bool) -> Optional[int]:
         try:
@@ -235,3 +251,41 @@ class DatabaseBackedOrganizationService(OrganizationService):
             return [r.organization for r in results if scope in r.get_scopes()]
 
         return [r.organization for r in results]
+
+    @staticmethod
+    def _deserialize_member_flags(flags: ApiOrganizationMemberFlags) -> int:
+        return flags_to_bits(flags.sso__linked, flags.sso__invalid, flags.member_limit__restricted)
+
+    def add_organization_member(
+        self,
+        *,
+        organization: ApiOrganization,
+        user: APIUser,
+        flags: ApiOrganizationMemberFlags | None,
+        role: str | None,
+    ) -> ApiOrganizationMember:
+        member = OrganizationMember.objects.create(
+            organization_id=organization.id,
+            user_id=user.id,
+            flags=self._deserialize_member_flags(flags) if flags else 0,
+            role=role or organization.default_role,
+        )
+        return self.serialize_member(member)
+
+    def add_team_member(
+        self, *, team_id: int, organization_member: ApiOrganizationMember
+    ) -> ApiTeamMember:
+        omt = OrganizationMemberTeam.objects.create(
+            team_id=team_id, organizationmember_id=organization_member.id
+        )
+        project_ids = ()  # TODO?
+        return self._serialize_team_member(omt, project_ids)
+
+    def update_membership_flags(self, *, organization_member: ApiOrganizationMember) -> None:
+        model = OrganizationMember.objects.get(id=organization_member.id)
+        model.flags = self._deserialize_member_flags(organization_member.flags)
+        model.save()
+
+    @classmethod
+    def _serialize_invite(cls, om: OrganizationMember) -> ApiOrganizationInvite:
+        return ApiOrganizationInvite(om.id, om.token, om.email)

--- a/src/sentry/services/hybrid_cloud/util.py
+++ b/src/sentry/services/hybrid_cloud/util.py
@@ -1,0 +1,6 @@
+def flags_to_bits(*flag_values: bool) -> int:
+    bits = 0
+    for (index, value) in enumerate(flag_values):
+        if value:
+            bits |= 1 << index
+    return bits

--- a/src/sentry/web/frontend/idp_email_verification.py
+++ b/src/sentry/web/frontend/idp_email_verification.py
@@ -2,7 +2,7 @@ from django.http.response import HttpResponse
 from rest_framework.request import Request
 
 from sentry.auth.idpmigration import SSO_VERIFICATION_KEY, get_verification_value_from_key
-from sentry.models import Organization
+from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
@@ -32,8 +32,5 @@ class AccountConfirmationView(BaseView):
         organization_id = verification_value.get("organization_id")
         if organization_id is None:
             return None
-        try:
-            org = Organization.objects.get(id=organization_id)
-        except Organization.DoesNotExist:
-            return None
-        return org.slug
+        org_context = organization_service.get_organization_by_id(id=organization_id, user_id=None)
+        return org_context.organization.slug if org_context is not None else None

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -20,8 +20,9 @@ from sentry.models import (
     OrganizationMemberTeam,
     UserEmail,
 )
+from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
 from sentry.utils import json
 from sentry.utils.redis import clusters
 
@@ -33,6 +34,7 @@ def _set_up_request():
     return request
 
 
+@control_silo_test
 class AuthIdentityHandlerTest(TestCase):
     def setUp(self):
         self.provider = "dummy"
@@ -56,10 +58,14 @@ class AuthIdentityHandlerTest(TestCase):
         return self._handler_with(self.identity)
 
     def _handler_with(self, identity):
+        with exempt_from_silo_limits():
+            api_organization = DatabaseBackedOrganizationService.serialize_organization(
+                self.organization
+            )
         return AuthIdentityHandler(
             self.auth_provider,
             DummyProvider(self.provider),
-            self.organization,
+            api_organization,
             self.request,
             identity,
         )
@@ -107,7 +113,10 @@ class HandleNewUserTest(AuthIdentityHandlerTest):
         ]
 
     def test_associated_existing_member_invite_by_email(self):
-        member = OrganizationMember.objects.create(organization=self.organization, email=self.email)
+        with exempt_from_silo_limits():
+            member = OrganizationMember.objects.create(
+                organization=self.organization, email=self.email
+            )
 
         auth_identity = self.handler.handle_new_user()
 
@@ -137,9 +146,10 @@ class HandleNewUserTest(AuthIdentityHandlerTest):
     def test_associate_pending_invite(self):
         # The org member invite should have a non matching email, but the
         # member id and token will match from the session, allowing association
-        member = OrganizationMember.objects.create(
-            organization=self.organization, email="different.email@example.com", token="abc"
-        )
+        with exempt_from_silo_limits():
+            member = OrganizationMember.objects.create(
+                organization=self.organization, email="different.email@example.com", token="abc"
+            )
 
         self.request.session["invite_member_id"] = member.id
         self.request.session["invite_token"] = member.token
@@ -233,15 +243,19 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest):
     @mock.patch("sentry.auth.helper.messages")
     def test_new_identity_with_existing_om(self, mock_messages):
         user = self.set_up_user()
-        existing_om = OrganizationMember.objects.create(user=user, organization=self.organization)
+        with exempt_from_silo_limits():
+            existing_om = OrganizationMember.objects.create(
+                user=user, organization=self.organization
+            )
 
         auth_identity = self.handler.handle_attach_identity()
         assert auth_identity.ident == self.identity["id"]
         assert auth_identity.data == self.identity["data"]
 
-        persisted_om = OrganizationMember.objects.get(id=existing_om.id)
-        assert getattr(persisted_om.flags, "sso:linked")
-        assert not getattr(persisted_om.flags, "sso:invalid")
+        with exempt_from_silo_limits():
+            persisted_om = OrganizationMember.objects.get(id=existing_om.id)
+            assert getattr(persisted_om.flags, "sso:linked")
+            assert not getattr(persisted_om.flags, "sso:invalid")
 
         mock_messages.add_message.assert_called_with(
             self.request, mock_messages.SUCCESS, OK_LINK_IDENTITY
@@ -262,7 +276,8 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest):
         AuthIdentity.objects.create(
             user=other_user, auth_provider=self.auth_provider, ident=self.identity["id"]
         )
-        OrganizationMember.objects.create(user=other_user, organization=self.organization)
+        with exempt_from_silo_limits():
+            OrganizationMember.objects.create(user=other_user, organization=self.organization)
 
         returned_identity = self.handler.handle_attach_identity()
         assert returned_identity.user == request_user
@@ -298,7 +313,9 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
         assert request is self.request
         assert status == 200
 
-        assert context["organization"] is self.organization
+        expected_org = DatabaseBackedOrganizationService.serialize_organization(self.organization)
+
+        assert context["organization"] == expected_org
         assert context["identity"] == self.identity
         assert context["provider"] == self.auth_provider.get_provider().name
         assert context["identity_display_name"] == self.identity["name"]
@@ -334,10 +351,15 @@ class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
         existing_user.update(password="")
 
         context = self._test_simple(mock_render, "sentry/auth-confirm-account.html")
-        mock_create_key.assert_called_with(
-            existing_user, self.organization, self.auth_provider, self.email, "1234"
-        )
-        assert context["existing_user"] == existing_user
+        assert mock_create_key.call_count == 1
+        (user, org, provider, email, identity_id) = mock_create_key.call_args.args
+        assert user.id == existing_user.id
+        assert org.id == self.organization.id
+        assert provider.id == self.auth_provider.id
+        assert email == self.email
+        assert identity_id == self.identity["id"]
+
+        assert context["existing_user"].id == existing_user.id
         assert "login_form" in context
 
     @mock.patch("sentry.auth.helper.render_to_response")

--- a/tests/sentry/auth/test_idpmigration.py
+++ b/tests/sentry/auth/test_idpmigration.py
@@ -5,9 +5,11 @@ from django.urls import reverse
 import sentry.auth.idpmigration as idpmigration
 from sentry.models import AuthProvider, OrganizationMember
 from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
 from sentry.utils import json
 
 
+@control_silo_test(stable=True)
 class IDPMigrationTests(TestCase):
     def setUp(self):
         super().setUp()
@@ -20,7 +22,8 @@ class IDPMigrationTests(TestCase):
     IDENTITY_ID = "drgUQCLzOyfHxmTyVs0G"
 
     def test_send_one_time_account_confirm_link(self):
-        om = OrganizationMember.objects.create(organization=self.org, user=self.user)
+        with exempt_from_silo_limits():
+            om = OrganizationMember.objects.create(organization=self.org, user=self.user)
         link = idpmigration.send_one_time_account_confirm_link(
             self.user, self.org, self.provider, self.email, self.IDENTITY_ID
         )


### PR DESCRIPTION
Extract organization_service.handle_invite from auth_service.handle_new_membership to run on the region silo. Replace ApiInviteHelper's request attribute with a new InviteDetail dataclass that can be sent as an RPC parameter.