### PR TITLE
feat(replays): Remove search/filtering from Transaction Summary > Replay tab

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionReplays/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/content.tsx
@@ -1,22 +1,10 @@
-import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 import {Location} from 'history';
 import first from 'lodash/first';
-import omit from 'lodash/omit';
 
-import CompactSelect from 'sentry/components/compactSelect';
-import DatePageFilter from 'sentry/components/datePageFilter';
-import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
-import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Pagination from 'sentry/components/pagination';
-import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
-import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import useMedia from 'sentry/utils/useMedia';
 import ReplayTable from 'sentry/views/replays/replayTable';
@@ -24,11 +12,7 @@ import {ReplayColumns} from 'sentry/views/replays/replayTable/types';
 import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
 import type {SpanOperationBreakdownFilter} from '../filter';
-import {
-  EventsDisplayFilterName,
-  getEventsFilterOptions,
-  PercentileValues,
-} from '../transactionEvents/utils';
+import {EventsDisplayFilterName, PercentileValues} from '../transactionEvents/utils';
 
 import type {ReplayListRecordWithTx} from './useReplaysFromTransaction';
 
@@ -44,88 +28,12 @@ type Props = {
   percentileValues?: PercentileValues;
 };
 
-function ReplaysContent({
-  eventView,
-  eventsDisplayFilterName,
-  isFetching,
-  location,
-  organization,
-  pageLinks,
-  replays,
-  spanOperationBreakdownFilter,
-  percentileValues,
-}: Props) {
-  const query = location.query;
-
+function ReplaysContent({eventView, isFetching, pageLinks, replays}: Props) {
   const theme = useTheme();
   const hasRoomForColumns = useMedia(`(min-width: ${theme.breakpoints.small})`);
 
-  const eventsFilterOptions = getEventsFilterOptions(
-    spanOperationBreakdownFilter,
-    percentileValues
-  );
-
-  function handleChange(key: string) {
-    return function (value: string | undefined) {
-      const queryParams = normalizeDateTimeParams({
-        ...(location.query || {}),
-        [key]: value,
-      });
-
-      // do not propagate pagination when making a new search
-      const toOmit = ['cursor'];
-      if (!defined(value)) {
-        toOmit.push(key);
-      }
-      const searchQueryParams = omit(queryParams, toOmit);
-
-      browserHistory.push({
-        ...location,
-        query: searchQueryParams,
-      });
-    };
-  }
-
-  const handleEventDisplayFilterChange = (newFilterName: EventsDisplayFilterName) => {
-    const nextQuery: Location['query'] = {
-      ...location.query,
-      showTransactions: newFilterName,
-    };
-
-    if (newFilterName === EventsDisplayFilterName.p100) {
-      delete nextQuery.showTransaction;
-    }
-
-    browserHistory.push({
-      pathname: location.pathname,
-      query: nextQuery,
-    });
-  };
-
   return (
     <Layout.Main fullWidth>
-      <FilterActions>
-        <PageFilterBar condensed>
-          <EnvironmentPageFilter />
-          <DatePageFilter alignDropdown="left" />
-        </PageFilterBar>
-        <StyledSearchBar
-          organization={organization}
-          projectIds={eventView.project}
-          query={query.query}
-          fields={eventView.fields}
-          onSearch={handleChange('query')}
-        />
-        <PercentileSelect
-          triggerProps={{prefix: t('Percentile')}}
-          value={eventsDisplayFilterName}
-          onChange={opt => handleEventDisplayFilterChange(opt.value)}
-          options={Object.entries(eventsFilterOptions).map(([name, filter]) => ({
-            value: name as EventsDisplayFilterName,
-            label: filter.label,
-          }))}
-        />
-      </FilterActions>
       <ReplayTable
         fetchError={undefined}
         isFetching={isFetching}
@@ -145,35 +53,5 @@ function ReplaysContent({
     </Layout.Main>
   );
 }
-
-const FilterActions = styled('div')`
-  display: grid;
-  gap: ${space(2)};
-  margin-bottom: ${space(2)};
-  grid-template-columns: repeat(2, 1fr);
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: auto 1fr auto;
-  }
-`;
-
-const PercentileSelect = styled(CompactSelect)`
-  order: 2;
-  justify-self: flex-end;
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    order: 3;
-  }
-`;
-
-const StyledSearchBar = styled(SearchBar)`
-  order: 3;
-  grid-column: span 2;
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    order: 2;
-    grid-column: span 1;
-  }
-`;
 
 export default ReplaysContent;


### PR DESCRIPTION
The search+filters on this page don't make sense. The tab has a count, "50+" replays, but once you start filtering or narrowing the time range less than 50 will appear.

Also, you're searching through _transactions_ not replays. So it's really a copy of the existing "All Events" tab which is further to the left. The only difference is that on the "All Events" tab you see the transaction info, and a button to View Replay. Here you see the replay info, but can't search by it. Also sorting on this table only applies to the current page of data.

The Issues>Replays tab does not have search/filter widgets for the same reason.

It'd be more useful if you could search for replays here, like "gimme a replay that's at least 1minute long and includes a slow http span" but that's not possible at least until we revisit how data is fetched. For now lets simplify. 

| Before | After |
| --- | --- |
| <img width="1362" alt="SCR-20230112-kp0" src="https://user-images.githubusercontent.com/187460/212199321-7dc329f4-a684-4084-848a-e2eef1ed7469.png"> | <img width="1362" alt="SCR-20230112-kon" src="https://user-images.githubusercontent.com/187460/212199342-eb9751d9-a81a-4d86-9762-e6036ffc221a.png"> |



Fixes #42818