### PR TITLE
feat(hybrid-cloud): internal RPC

### DIFF
--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from django.conf import settings
+from OpenSSL.crypto import X509Name
+from rest_framework import permissions
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.authentication import MutualTlsAuthentication
+from sentry.api.base import Endpoint, control_silo_endpoint, region_silo_endpoint
+from sentry.services.hybrid_cloud.rpc import ServiceEndpoint, endpoint_registry
+from sentry.services.hybrid_cloud.rpc.endpoints import MethodEndpoint
+from sentry.silo import SiloLimit, SiloMode
+
+
+class SiloPermission(permissions.BasePermission):
+    def has_permission(self, request: Request, view: RpcEndpoint):
+        auth: X509Name = request.auth
+        if not isinstance(request.auth, X509Name):
+            common_name: str = auth.commonName
+            is_control_silo = common_name == settings.CONTROL_SILO_COMMON_NAME
+
+            # Region silo RPCs cannot communicate with each other; they may only be
+            # contacted on behalf of the control silo.
+            if view.silo_mode() == SiloMode.REGION:
+                return is_control_silo
+
+            return True
+        return False
+
+
+class RpcEndpoint(Endpoint):
+    authentication_classes = (MutualTlsAuthentication,)
+    permission_classes = (SiloPermission,)
+
+    def silo_mode(self) -> SiloMode:
+        limit: SiloLimit = getattr(self, "silo_limit")
+        for mode in limit.modes:
+            if mode == SiloMode.MONOLITH:
+                continue
+            return mode
+        assert False, "RpcEndpoint.silo_limit did not contain a valid silo mode!  Major code error."
+
+    def post(self, request: Request, service_name: str, method_name: str) -> Response:
+        service_endpoint: ServiceEndpoint | None = endpoint_registry.get(service_name)
+        if service_endpoint is None:
+            raise NotFound(detail=f"Service {repr(service_name)} is not registered")
+
+        if service_endpoint.silo_mode != self.silo_mode():
+            raise NotFound(
+                detail=f"Service {repr(service_name)} is not an {self.silo_mode()} endpoint"
+            )
+
+        if method_name not in service_endpoint.published_methods:
+            raise NotFound(
+                detail=f"Service {repr(service_name)} does not have published method {repr(method_name)}"
+            )
+
+        endpoint: MethodEndpoint
+        with service_endpoint.prepare_call(method_name) as (method, endpoint):
+            kwds = endpoint.params_serializer.from_json(request.data)
+            result = method(**kwds)
+            return Response(endpoint.result_serializer.to_json(result))
+
+
+@region_silo_endpoint
+class RegionRpcEndpoint(RpcEndpoint):
+    pass
+
+
+@control_silo_endpoint
+class ControlRpcEndpoint(RpcEndpoint):
+    pass

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -211,6 +211,7 @@ from .endpoints.internal import (
     InternalStatsEndpoint,
     InternalWarningsEndpoint,
 )
+from .endpoints.internal.rpc import ControlRpcEndpoint, RegionRpcEndpoint
 from .endpoints.issue_occurrence import IssueOccurrenceEndpoint
 from .endpoints.monitor_checkin_details import MonitorCheckInDetailsEndpoint
 from .endpoints.monitor_checkins import MonitorCheckInsEndpoint
@@ -2480,6 +2481,23 @@ urlpatterns = [
                 url(r"^packages/$", InternalPackagesEndpoint.as_view()),
                 url(r"^environment/$", InternalEnvironmentEndpoint.as_view()),
                 url(r"^mail/$", InternalMailEndpoint.as_view()),
+                url(
+                    r"^rpc/",
+                    include(
+                        [
+                            url(
+                                r"^region/(?P<service_name>[^\/]+)/(?P<method_name>[^\/]+)/$",
+                                RegionRpcEndpoint.as_view(),
+                                name="sentry-rpc-region",
+                            ),
+                            url(
+                                r"^control/(?P<service_name>[^\/]+)/(?P<method_name>[^\/]+)/$",
+                                ControlRpcEndpoint.as_view(),
+                                name="sentry-rpc-control",
+                            ),
+                        ]
+                    ),
+                ),
             ]
         ),
     ),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2942,3 +2942,6 @@ SINGLE_SERVER_SILO_MODE = False
 
 # Set the URL for signup page that we redirect to for the setup wizard if signup=1 is in the query params
 SENTRY_SIGNUP_URL = None
+
+# The TLS common name for the control silo X509 name.
+CONTROL_SILO_COMMON_NAME = "control.local"

--- a/src/sentry/models/organizationmapping.py
+++ b/src/sentry/models/organizationmapping.py
@@ -34,3 +34,22 @@ class OrganizationMapping(Model):
         db_table = "sentry_organizationmapping"
 
     __repr__ = sane_repr("organization_id", "slug", "region_name", "verified")
+
+    @classmethod
+    def find_region_name_by_org_id(cls, id: int) -> str | None:
+        mapping: OrganizationMapping = OrganizationMapping.objects.filter(
+            organization_id=id, verified=True
+        ).last()
+        if mapping is None:
+            mapping = OrganizationMapping.objects.filter(organization_id=id).last()
+        if mapping is None:
+            return None
+        return mapping.region_name
+
+    @classmethod
+    def find_region_name_by_org_slug(cls, slug: str) -> str | None:
+        mapping: OrganizationMapping = OrganizationMapping.objects.filter(slug=slug).first()
+        if mapping is None:
+            return None
+
+        return mapping.region_name

--- a/src/sentry/services/hybrid_cloud/rpc/__init__.py
+++ b/src/sentry/services/hybrid_cloud/rpc/__init__.py
@@ -1,0 +1,1 @@
+from .endpoints import ServiceEndpoint, endpoint_registry  # noqa

--- a/src/sentry/services/hybrid_cloud/rpc/endpoints.py
+++ b/src/sentry/services/hybrid_cloud/rpc/endpoints.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import abc
+import contextlib
+import dataclasses
+import inspect
+from functools import cached_property
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Generic,
+    Mapping,
+    MutableMapping,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    get_type_hints,
+)
+
+from sentry.models import OrganizationMapping
+from sentry.services.hybrid_cloud import InterfaceWithLifecycle, ServiceInterface
+from sentry.services.hybrid_cloud.rpc.serialization import (
+    JsonSerializer,
+    TypeSerializationError,
+    get_serializer_from_annotation,
+    get_serializer_from_args,
+)
+from sentry.silo import SiloMode
+from sentry.silo.client import BaseSiloClient, RegionSiloClient
+from sentry.types.region import RegionResolutionError, get_region_by_name
+
+_T = TypeVar("_T")
+_S = TypeVar("_S")
+
+
+class RpcError(Exception):
+    pass
+
+
+class NoMethodError(RpcError):
+    pass
+
+
+class NoRouteError(RpcError):
+    pass
+
+
+class MissingOrgError(RpcError):
+    pass
+
+
+class MissingRegionError(RegionResolutionError, RpcError):
+    pass
+
+
+@dataclasses.dataclass
+class ServiceEndpoint:
+    service_name: str
+    factory: Callable[[], InterfaceWithLifecycle]
+    silo_mode: SiloMode
+
+    def __post_init__(self):
+        assert (
+            self.service_base
+        ), "Service factory functions must annotate a InterfaceWithLifecycle service base"
+        self.published_methods  # Prevalidate method signatures are serializable.
+
+    @cached_property
+    def service_base(self) -> Type[InterfaceWithLifecycle] | None:
+        annotations: Mapping[str, Any] = get_type_hints(self.factory)
+        return_annotation: Any = annotations.get("return", None)
+        if issubclass(return_annotation, InterfaceWithLifecycle) and inspect.isabstract(
+            return_annotation
+        ):
+            return return_annotation
+        return None
+
+    @contextlib.contextmanager
+    def prepare_call(
+        self, method_name: str
+    ) -> ContextManager[Tuple[Callable[..., Any], MethodEndpoint]]:
+        service = self.factory()
+        try:
+            yield getattr(service, method_name), self.published_methods[method_name]
+        finally:
+            service.close()
+
+    @cached_property
+    def published_methods(self) -> Mapping[str, MethodEndpoint]:
+        result: MutableMapping[str, MethodEndpoint] = {}
+        for k in dir(self.service_base):
+            method = getattr(self.service_base, k)
+            if not self._is_published_method(method):
+                continue
+
+            try:
+                args_serializer = get_serializer_from_args(method)
+                return_annotation = get_type_hints(self.factory).get("return", None)
+                return_serializer = get_serializer_from_annotation(return_annotation)
+                result[method] = MethodEndpoint(args_serializer, return_serializer, k)
+            except TypeSerializationError as e:
+                raise TypeSerializationError(
+                    f"Service {self.service_name!r} has invalid published method {k!r}: {e}"
+                )
+
+        return result
+
+    def _is_published_method(self, v: Any):
+        if not inspect.ismethod(v):
+            return False
+        if not getattr(v, "__isabstractmethod__"):
+            return False
+        return True
+
+
+@dataclasses.dataclass
+class MethodEndpoint:
+    params_serializer: JsonSerializer
+    result_serializer: JsonSerializer
+    method_name: str
+
+
+endpoint_registry: MutableMapping[str, ServiceEndpoint] = {}
+
+
+def expose_as_region_silo_rpc(
+    service_name: str, f: Callable[[], ServiceInterface]
+) -> Callable[[], ServiceInterface]:
+    if service_name in endpoint_registry:
+        raise ValueError(f"Service {service_name} registered twice!")
+
+    endpoint_registry[service_name] = ServiceEndpoint(
+        factory=f, service_name=service_name, silo_mode=SiloMode.REGION
+    )
+    return f
+
+
+def impl_with_region_silo_client(
+    service_name: str, service_base: Type[ServiceInterface]
+) -> Callable[[], ServiceInterface]:
+    pass
+
+
+class RpcClient(abc.ABC):
+    @abc.abstractmethod
+    def route(self, method_name: str, parameters: Mapping[str, Any]) -> BaseSiloClient:
+        pass
+
+    def invoke(
+        self, method_name: str, parameters: Mapping[str, Any], result_dataclass: Type[_T]
+    ) -> _T:
+        pass
+
+
+class RegionRpcClient(Generic[ServiceInterface], RpcClient):
+    service_name: str
+    service_base: ServiceInterface
+
+    def __init__(self, service_name: str, service_base: ServiceInterface):
+        self.service_name = service_name
+        self.service_base = service_base
+
+    def route(self, method_name: str, parameters: Mapping[str, Any]) -> BaseSiloClient:
+        if not hasattr(self.service_base, method_name):
+            raise NoMethodError(f"No method for rpc {self.service_name} {repr(method_name)}")
+
+        method = getattr(self.service_base, method_name)
+        org_routing: Callable[..., str | int] | None = getattr(method, "__org_routing")
+
+        org: str | int = org_routing(**parameters)
+        region_name: str | None
+        if isinstance(org, str):
+            region_name = OrganizationMapping.find_region_name_by_org_slug(org)
+        else:
+            region_name = OrganizationMapping.find_region_name_by_org_id(org)
+
+        if region_name is None:
+            raise MissingOrgError(
+                f"Organization {repr(org)} does not exist in OrganizationMapping."
+            )
+
+        try:
+            region = get_region_by_name(region_name)
+        except RegionResolutionError as e:
+            raise MissingRegionError(str(e))
+
+        return RegionSiloClient(region)
+
+
+class HasOrganizationId(Protocol):
+    organization_id: int
+
+
+class HasOrganizationSlug(Protocol):
+    organization_slug: str
+
+
+class HasRegionName(Protocol):
+    region_name: str
+
+
+_HasOrganizationId = TypeVar("_HasOrganizationId", bound=HasOrganizationId)
+_HasOrganizationSlug = TypeVar("_HasOrganizationSlug", bound=HasOrganizationSlug)
+_HasRegionName = TypeVar("_HasRegionName", bound=HasRegionName)
+
+
+def routes_region_by_org_id(
+    method: Callable[[_S, _HasOrganizationId], _T]
+) -> Callable[[_S, _HasOrganizationId], _T]:
+    def route_by_org_id(m: HasOrganizationId) -> str:
+        return OrganizationMapping.find_region_name_by_org_id(m.organization_id)
+
+    setattr(method, "__org_routing", route_by_org_id)
+    return method
+
+
+def routes_region_by_region_name(
+    method: Callable[[_S, _HasRegionName], _T]
+) -> Callable[[_S, _HasRegionName], _T]:
+    def route_by_region_name(m: HasRegionName) -> str:
+        return m.region_name
+
+    setattr(method, "__org_routing", route_by_region_name)
+    return method
+
+
+def routes_region_by_org_slug(
+    method: Callable[[_S, _HasOrganizationSlug], _T]
+) -> Callable[[_S, _HasOrganizationSlug], _T]:
+    def route_by_org_slug(m: HasOrganizationSlug) -> str:
+        return OrganizationMapping.find_region_name_by_org_slug(m.organization_slug)
+
+    setattr(method, "__org_routing", route_by_org_slug)
+    return method

--- a/src/sentry/services/hybrid_cloud/rpc/serialization.py
+++ b/src/sentry/services/hybrid_cloud/rpc/serialization.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import abc
+import collections.abc
+import dataclasses
+import datetime
+from inspect import FullArgSpec, getfullargspec
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
+
+from django.utils.dateparse import parse_datetime
+
+from sentry.services.hybrid_cloud import Unset
+
+_T = TypeVar("_T")
+
+
+class JsonSerializer(abc.ABC):
+    @abc.abstractmethod
+    def schema_type(self) -> Mapping[str, Any]:
+        pass
+
+    @abc.abstractmethod
+    def to_json(self, value: Any) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def from_json(self, value: Any) -> Any:
+        pass
+
+
+class ScalarSerializer(JsonSerializer):
+    t: Any
+    inner: Callable[[Any], Any]
+    outer: Callable[[Any], Any]
+
+    def __init__(self, t: Any, outer: Callable[[Any], Any], inner: Callable[[Any], Any]):
+        self.t = t
+        self.outer = outer
+        self.inner = inner
+
+    def schema_type(self) -> Mapping[str, Any]:
+        return self.t
+
+    def to_json(self, value: Any) -> Any:
+        return self.inner(value)
+
+    def from_json(self, value: Any) -> Any:
+        return self.outer(value)
+
+
+class ListSerializer(JsonSerializer):
+    inner: JsonSerializer
+    outer: Callable[[Iterable[Any]], Any]
+
+    def __init__(self, outer: Callable[[Iterable[Any]], Any], inner: JsonSerializer):
+        self.outer = outer
+        self.inner = inner
+
+    def schema_type(self) -> Mapping[str, Any]:
+        return dict(type="array", items=self.inner.schema_type())
+
+    def to_json(self, value: Any) -> Any:
+        return [self.inner.to_json(i) for i in value]
+
+    def from_json(self, value: Any) -> Any:
+        return self.outer(self.inner.from_json(i) for i in value)
+
+
+class DataClassSerializer(JsonSerializer):
+    fields: Mapping[str, JsonSerializer]
+    constructor: Any
+
+    def __init__(self, fields: Mapping[str, JsonSerializer], constructor: Any):
+        self.fields = fields
+        self.constructor = constructor
+
+    def schema_type(self) -> Mapping[str, Any]:
+        return dict(type="object", properties={k: v.schema_type() for k, v in self.fields.items()})
+
+    def to_json(self, value: Any) -> Any:
+        result: Any = getattr(value, "__extra_fields__", None) or {}
+        for k, s in self.fields.items():
+            v = getattr(value, k)
+            if v is Unset:
+                continue
+            result[k] = s.to_json(v)
+        return result
+
+    def from_json(self, value: Any) -> Any:
+        kwds: MutableMapping[str, Any] = {}
+        extra_fields: MutableMapping[str, Any] = {}
+        for k, v in value.items():
+            if k in self.fields:
+                kwds[k] = self.fields[k].from_json(v)
+            else:
+                extra_fields[k] = v
+        result = self.constructor(**kwds)
+        setattr(result, "__extra_fields__", extra_fields)
+        return result
+
+
+@dataclasses.dataclass
+class Entry:
+    k: str
+    v: object
+
+
+class EntrySerializer(DataClassSerializer):
+    inner: JsonSerializer
+
+    def __init__(self, inner: JsonSerializer):
+        self.inner = inner
+        super().__init__({"k": str_serializer, "v": inner}, Entry)
+
+    def schema_type(self) -> Mapping[str, Any]:
+        return dict(
+            type="object",
+            properties=dict(
+                k=str_serializer.schema_type(),
+                v=self.inner.schema_type(),
+            ),
+            required=["k", "v"],
+        )
+
+
+class NullableSerializer(JsonSerializer):
+    inner: JsonSerializer
+
+    def __init__(self, inner: JsonSerializer):
+        self.inner = inner
+
+    def schema_type(self) -> Mapping[str, Any]:
+        return dict(nullable=True, **self.inner.schema_type())
+
+    def to_json(self, value: Any) -> Any:
+        if value is None:
+            return None
+        return self.inner.to_json(value)
+
+    def from_json(self, value: Any) -> Any:
+        if value is None:
+            return None
+        return self.inner.from_json(value)
+
+
+class MapSerializer(ListSerializer):
+    def __init__(self, inner: JsonSerializer):
+        super().__init__(lambda values: {e.k: e.v for e in values}, EntrySerializer(inner))
+
+    def to_json(self, value: Any) -> Any:
+        return super().to_json(Entry(k=k, v=v) for k, v in value.items())
+
+
+_id = lambda i: i
+
+int_serializer = ScalarSerializer(dict(type="integer", format="int64"), _id, _id)
+str_serializer = ScalarSerializer(dict(type="string"), _id, _id)
+float_serializer = ScalarSerializer(dict(type="number"), _id, _id)
+bool_serializer = ScalarSerializer(dict(type="boolean"), _id, _id)
+opaque_serializer = ScalarSerializer(dict(type="object"), _id, _id)
+datetime_serializer = ScalarSerializer(
+    dict(type="string", format="date-time"),
+    lambda s: parse_datetime(s),
+    lambda o: o.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+)
+
+
+class TypeSerializationError(TypeError):
+    def __init__(self, parent: object, t: object, message: str):
+        if t is parent:
+            t_msg = ""
+        else:
+            t_msg = f"{t} "
+        super().__init__(f"{parent} is not serializable: {t_msg}{message}")
+
+
+def _from_entries() -> Any:
+    pass
+
+
+def get_serializer_from_args(f: Callable[..., Any]) -> JsonSerializer:
+    argspec: FullArgSpec = getfullargspec(f)
+    try:
+        assert len(argspec.args) == 2
+        assert not argspec.kwonlyargs
+        assert argspec.args[0] == "self"
+        assert argspec.args[1] in argspec.annotations
+    except AssertionError:
+        raise TypeSerializationError(
+            f,
+            f,
+            "RPC service methods must have exactly only non self argument, which must be annotated",
+        )
+
+    return get_serializer_from_annotation(argspec.annotations[argspec.args[1]])
+
+
+# This, alternative, attempts to create a serializer from a full argspec.  It works but it has some problems:
+# 1. Error messages are kinda, not great.  It's hard to report on issues with function arguments as opposed to issues with dataclasses.
+# 2. It doesn't, yet, handle the case where we receive "extra fields" as a result of version drift.  We need to not return a dict
+# that would compromise a callsite of an older version unaware of a new keyword.
+# 3. It makes the routes_by_org_id family of functions more tricky to implement correctly.
+# def get_serializer_from_args(f: function) -> JsonSerializer:
+#     if f in serializers_cache:
+#         return serializers_cache[f]
+#
+#     argspec: FullArgSpec = getfullargspec(f)
+#     try:
+#         assert argspec.args == ['self']
+#         assert not argspec.defaults
+#     except AssertionError:
+#         raise RpcSerializationError(None, argspec, "has positional args other than 'self'.  All RPC calls must be kwds only (ie method(self, *, arg1=1, arg2=2))")
+#     fields: MutableMapping[str, JsonSerializer] = {}
+#     for argname in argspec.kwonlyargs:
+#         if not argspec.kwonlydefaults or argname not in argspec.kwonlydefaults:
+#             raise RpcSerializationError(None, argspec, f"has argument {repr(argname)} without a default.  Please provide a default.")
+#         if not argspec.annotations or argname not in argspec.annotations:
+#             raise RpcSerializationError(None, argspec, f"has argument {repr(argname)} without a type annotation.  Please provide one.")
+#         fields[argname] = get_serializer(argspec.annotations[argname], None)
+#
+#     result = StructSerializer(fields, lambda keys: keys)
+#     serializers_cache[f] = result
+#     return result
+
+
+def get_serializer_from_annotation(
+    t: object, parent: object | None = None, parameters: MutableMapping[Any, Any] | None = None
+) -> JsonSerializer:
+    if parent is None:
+        parent = t
+    if t is type(None):  # noqa
+        raise TypeSerializationError(parent, t, "fields cannot be serialized")
+    if t is int:
+        return int_serializer
+    if t is str:
+        return str_serializer
+    if t is float:
+        return float_serializer
+    if t is bool:
+        return bool_serializer
+    if t is object:
+        return opaque_serializer
+    if t is datetime.datetime:
+        return datetime_serializer
+
+    origin = get_origin(t)
+    args: Sequence[object] = get_args(t)
+
+    if parameters is None:
+        parameters = {}
+
+    for i, p in enumerate(getattr(origin, "__parameters__", [])):
+        if i > len(args):
+            break
+        parameters[p] = args[i]
+
+    def resolve_inner_type(t: object) -> object:
+        try:
+            return parameters[t]
+        except KeyError:
+            return t
+
+    if origin is Union:
+        if len(args) == 2 and type(None) in args:
+            for arg in args:
+                if arg is type(None):  # noqa
+                    continue
+                inner = get_serializer_from_annotation(resolve_inner_type(arg), parent, parameters)
+                return NullableSerializer(inner)
+        else:
+            raise TypeSerializationError(parent, t, "is not supported, only Optional")
+
+    if origin is frozenset:
+        if len(args) != 1:
+            raise TypeSerializationError(parent, t, "is not supported without type parameters")
+        inner = get_serializer_from_annotation(resolve_inner_type(args[0]), parent, parameters)
+        return ListSerializer(frozenset, inner)
+    if origin is list:
+        if len(args) != 1:
+            raise TypeSerializationError(parent, t, "is not supported without type parameters")
+        inner = get_serializer_from_annotation(resolve_inner_type(args[0]), parent, parameters)
+        return ListSerializer(list, inner)
+    if origin is set:
+        if len(args) != 1:
+            raise TypeSerializationError(parent, t, "is not supported without type parameters")
+        inner = get_serializer_from_annotation(resolve_inner_type(args[0]), parent, parameters)
+        return ListSerializer(set, inner)
+    if (
+        origin is dict
+        or origin is collections.abc.Mapping
+        or origin is collections.abc.MutableMapping
+    ):
+        if len(args) != 2:
+            raise TypeSerializationError(parent, t, "is not supported without type parameters")
+        if args[0] != str:
+            raise TypeSerializationError(parent, t, "keys are not supported, only strings allowed")
+        return MapSerializer(
+            get_serializer_from_annotation(resolve_inner_type(args[1]), parent, parameters)
+        )
+    if dataclasses.is_dataclass(origin):
+        fields: MutableMapping[str, JsonSerializer] = {}
+        field: dataclasses.Field
+        for field in dataclasses.fields(origin):
+            if field.default is dataclasses.MISSING:
+                raise TypeSerializationError(
+                    parent,
+                    t,
+                    f"has field {repr(field.name)} without a default.  Please provide a default or default_factory",
+                )
+
+            fields[field.name] = get_serializer_from_annotation(
+                resolve_inner_type(field.type), parent, parameters
+            )
+        return DataClassSerializer(fields, origin)
+
+    if isinstance(t, str):
+        raise TypeSerializationError(
+            parent, t, "is a forward ref string, try replacing it with a concrete type."
+        )
+
+    raise TypeSerializationError(
+        parent,
+        t,
+        "is not supported for rpc serialization. See sentry.services.hybrid_cloud.rpc.serialization for supported types",
+    )

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -7,11 +7,13 @@ from typing import Any, Callable, Generator, Iterable, Tuple, cast
 from unittest import TestCase
 
 import pytest
+from django.db import connections, router
 from django.test import override_settings
 
 from sentry.silo import SiloMode
 from sentry.testutils.region import override_regions
 from sentry.types.region import Region, RegionCategory
+from tests.sentry.hybrid_cloud import iter_models
 
 TestMethod = Callable[..., None]
 
@@ -164,3 +166,69 @@ def exempt_from_silo_limits() -> Generator[None, None, None]:
     """
     with override_settings(SILO_MODE=SiloMode.MONOLITH):
         yield
+
+
+def psql_function(
+    name: str,
+    body: str,
+    params: Iterable[Tuple[str, str]] = tuple(),
+    pg_locals: Iterable[Tuple[str, str]] = tuple(),
+    return_type="text",
+) -> str:
+    params_encoded = ", ".join(" ".join(t) for t in params)
+    pg_locals_encoded = "; ".join(" ".join(t) for t in pg_locals)
+    return f"create or replace function {name}({params_encoded}) returns text as $$ declare {pg_locals_encoded} begin {body} end $$ language 'plpsql'"
+
+
+duplicate_role_body = """
+EXECUTE 'CREATE ROLE ' || to_name;
+FOR info IN
+    select * from information_schema.table_privileges where table_schema='public' and grantee = 'A'
+LOOP
+    /*this is the main statement to grant any privilege*/
+    execute 'GRANT '|| info.privilege_type ||' on table public.'|| info.table_name || ' to ' || from_name;
+END LOOP;
+return '';
+"""
+
+
+# Only use this is in tests -- it's not safe to allow in any production use case.
+def duplicate_user(from_user: str, to_user: str, connection: Any):
+    connection.execute(
+        psql_function(
+            "duplicate_role", duplicate_role_body, (("from_name", "text"), ("to_name", "text"))
+        ),
+        (("info", "record")),
+    )
+    connection.execute(
+        psql_function(
+            "SELECT duplicate_role(%s, %s)",
+            [
+                from_user,
+                to_user,
+            ],
+        )
+    )
+
+
+def reset_test_role(role: str, from_role: str | None = None):
+    for name, config in connections.databases.items():
+        with connections[name].cursor() as connection:
+            connection.execute(f"DROP ROLE IF EXISTS {role}")
+            connection.execute(f"CREATE ROLE {role}")
+            duplicate_user(from_role or config["user"], role, connection)
+
+
+def restrict_role_by_silo(mode: SiloMode, role: str):
+    for model in iter_models():
+        silo_limit = getattr(model._meta, "silo_limit", None)
+        if silo_limit is None or mode not in silo_limit.modes:
+            restrict_role(role, model, "ALL PRIVILEGES")
+
+
+def restrict_role(role: str, model: Any, revocation_type: str):
+    using = router.db_for_write(model)
+    with connections[using].cursor() as connection:
+        connection.execute(
+            f"REVOKE {revocation_type} ON public.{model._meta.table_name} FROM {role}"
+        )

--- a/tests/sentry/hybrid_cloud/__init__.py
+++ b/tests/sentry/hybrid_cloud/__init__.py
@@ -7,7 +7,7 @@ from sentry.db.models.base import ModelSiloLimit
 from sentry.silo import SiloMode
 
 
-def _iter_models():
+def iter_models():
     from django.apps import apps
 
     for app, app_models in apps.all_models.items():
@@ -22,7 +22,7 @@ def _iter_models():
 
 
 def validate_models_have_silos(exemptions: Set[Type[Model]]):
-    for model in _iter_models():
+    for model in iter_models():
         if model in exemptions:
             continue
         if not isinstance(getattr(model._meta, "silo_limit", None), ModelSiloLimit):
@@ -39,7 +39,7 @@ def validate_models_have_silos(exemptions: Set[Type[Model]]):
 
 
 def validate_no_cross_silo_foreign_keys(exemptions: Set[Tuple[Type[Model], Type[Model]]]):
-    for model in _iter_models():
+    for model in iter_models():
         validate_model_no_cross_silo_foreign_keys(model, exemptions)
 
 

--- a/tests/sentry/hybrid_cloud/rpc/test_serialization.py
+++ b/tests/sentry/hybrid_cloud/rpc/test_serialization.py
@@ -1,0 +1,62 @@
+import dataclasses
+from datetime import datetime
+from typing import Dict, FrozenSet, Generic, List, Mapping, MutableMapping, Optional, Set, TypeVar
+
+import openapi_schema_validator
+from django.utils import timezone
+
+from sentry.services.hybrid_cloud.rpc.serialization import get_serializer_from_annotation
+from sentry.utils import json
+
+
+def test_serialization_errors():
+    pass
+
+
+def _test_serializer(t: object, example: object):
+    serializer = get_serializer_from_annotation(t)
+    parsed = json.loads(json.dumps(serializer.to_json(example)))
+    openapi_schema_validator.validate(parsed, serializer.schema_type())
+    loaded = serializer.from_json(parsed)
+    assert loaded == example
+
+    serializer = get_serializer_from_annotation(Optional[t])
+    parsed = json.loads(json.dumps(serializer.to_json(None)))
+    openapi_schema_validator.validate(parsed, serializer.schema_type())
+    loaded = serializer.from_json(parsed)
+    assert loaded is None
+
+
+A = TypeVar("A")
+B = TypeVar("B")
+
+
+@dataclasses.dataclass
+class TestDataClass(Generic[A, B]):
+    a: Optional[A] = None
+    b: Optional[B] = None
+    c: int = -1
+
+
+def test_serializations():
+    for t, example in [
+        (int, 1000),
+        (int, -11),
+        (float, -0),
+        (float, 1),
+        (float, 102.3),
+        (str, ""),
+        (str, "absdf"),
+        (bool, False),
+        (object, dict(a=2, b=[1, 2, 3])),
+        (datetime, timezone.now()),
+        (TestDataClass[str, List[int]], TestDataClass(a="", b=[1], c=4)),
+    ]:
+        _test_serializer(t, example)
+        _test_serializer(List[t], [example, example])
+        if not isinstance(example, dict) and not isinstance(example, TestDataClass):
+            _test_serializer(Set[t], {example})
+            _test_serializer(FrozenSet[t], frozenset([example]))
+        _test_serializer(Mapping[str, t], {"a": example, "b": example})
+        _test_serializer(Dict[str, t], {"a": example, "b": example})
+        _test_serializer(MutableMapping[str, t], {"a": example, "b": example})

--- a/tests/snuba/api/endpoints/test_rpc.py
+++ b/tests/snuba/api/endpoints/test_rpc.py
@@ -1,0 +1,54 @@
+import abc
+import dataclasses
+
+from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation
+from sentry.services.hybrid_cloud.rpc.endpoints import (
+    expose_as_region_silo_rpc,
+    impl_with_region_silo_client,
+    routes_region_by_org_id,
+)
+from sentry.silo import SiloMode
+
+
+@dataclasses.dataclass
+class CoolRequestParams:
+    a: int = -1
+    b: str = ""
+    organization_id: int = -1
+
+
+class MyCoolService(InterfaceWithLifecycle):
+    @abc.abstractmethod
+    def close(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def cool_callsite(self, params: CoolRequestParams) -> str:
+        pass
+
+
+class TestMyCoolService(MyCoolService):
+    def close(self) -> None:
+        pass
+
+    @routes_region_by_org_id
+    def cool_callsite(self, params: CoolRequestParams) -> str:
+        return f"{params.a}{params.b}"
+
+
+def impl_my_cool_service() -> MyCoolService:
+    return TestMyCoolService()
+
+
+my_cool_service = silo_mode_delegation(
+    {
+        SiloMode.REGION: expose_as_region_silo_rpc("my_cool_service", impl_my_cool_service),
+        SiloMode.CONTROL: impl_with_region_silo_client("my_cool_service", MyCoolService),
+        SiloMode.MONOLITH: impl_my_cool_service,
+    }
+)
+
+
+def test_rpc_e2e():
+    # Try validating that calling my_cool_service from all the modes works correctly.
+    pass


### PR DESCRIPTION
First pass at theoritical RPC implementation over hybrid cloud services.  I'm trying to achieve a few specific goals, which I've enumerated here:

1.  Preparing for mutual TLS as as the RPC authentication mechanism.  I'm working on a notion doc, which I'll link here later, describing how and why.  Will get ops approval.  Good news is that in practice, the only sentry changes will be 1. region specific private keys authenticating themselves  and 2.  MutualTls as a new authentication type, which checks a special header for precense of a client subject name and compares that against a known identity configuration.  Validation of certificates should be performed on the nginx / kubernates layer.
2.  Preparing for automatic serialization / endpoints for any service that is registered as a remote RPC service.  Basically, no one should be writing endpoints or serializers -- you register a service as RPC, and a singular RPC endpoint handles routing internally for you.  Serialization is also inferred from type annotations.
3.  Produce openapi specification for all routes, automagically.  The JsonSerializers correctly produce openapi specs for all inferred request and response objects.  The value of this is *schema evolution tracking* which ensures that fields don't change types or break backwards / forwards compatibility.

There's a lot of the finer details + testing that need to be straightened out.  I'm passing this work off to @RyanSkonnord but will keep a close eye on helping get this done right and over the line.