### PR TITLE
Extend timeout for semver backfill

### DIFF
--- a/tests/sentry/migrations/test_0223_semver_backfill_2.py
+++ b/tests/sentry/migrations/test_0223_semver_backfill_2.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from psycopg2.extras import execute_values
 
 from sentry.testutils.cases import TestMigrations
@@ -103,6 +104,7 @@ class TestBackfill(TestMigrations):
         super().tearDown()
         self.execute_values_patcher.stop()
 
+    @pytest.mark.fail_slow("90s")
     def test(self):
         Release = self.apps.get_model("sentry", "Release")
         none_releases = Release.objects.filter(id__in=self.expected_none_ids)

--- a/tests/sentry/migrations/test_0289_dashboardwidgetquery_convert_orderby_to_field.py
+++ b/tests/sentry/migrations/test_0289_dashboardwidgetquery_convert_orderby_to_field.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models.dashboard_widget import (
     DashboardWidgetDisplayTypes,
     DashboardWidgetQuery,
@@ -74,6 +76,7 @@ class TestConvertDashboardWidgetQueryOrderby(TestMigrations):
     def tearDown(self):
         super().tearDown()
 
+    @pytest.mark.fail_slow("90s")
     def test(self):
         assert DashboardWidgetQuery.objects.get(id=self.simple_aggregate.id).orderby == "count()"
         assert DashboardWidgetQuery.objects.get(id=self.field.id).orderby == "-project"


### PR DESCRIPTION
This is based off of the durations from GitHub actions:

```
============================= slowest 10 durations =============================
95.07s call     tests/sentry/migrations/test_0223_semver_backfill_2.py::TestBackfill::test
88.63s setup    tests/integration/test_api.py::AuthenticationTest::test_sso_auth_required
84.30s call     tests/sentry/migrations/test_0223_semver_backfill_2.py::TestBackfill::test
84.00s call     tests/sentry/migrations/test_0223_semver_backfill_2.py::TestBackfill::test
78.15s call     tests/sentry/migrations/test_0223_semver_backfill_2.py::TestBackfill::test
71.24s call     tests/sentry/migrations/test_0223_semver_backfill_2.py::TestBackfill::test
69.88s call     tests/sentry/migrations/test_0223_semver_backfill_2.py::TestBackfill::test
59.03s call     tests/sentry/migrations/test_0289_dashboardwidgetquery_convert_orderby_to_field.py::TestConvertDashboardWidgetQueryOrderby::test
43.43s call     tests/sentry/migrations/test_0290_fix_project_has_releases.py::BackfillProjectHasReleaseTest::test
10.81s call     tests/sentry/replays/test_organization_issue_replay_count.py::OrganizationIssueReplayCountEndpointTest::test_max_51
```

Note: The setup call isn't limited by a timeout.