### PR TITLE
Switch to venv action

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -108,12 +108,11 @@ runs:
           echo "TOTAL_TEST_GROUPS=$MATRIX_INSTANCE_TOTAL" >> $GITHUB_ENV
         fi
 
-    - name: Setup python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+    - uses: getsentry/action-setup-venv@64876d2bb1817c9bb6f391ad765677b109704af5 # v1.0.4
       with:
         python-version: ${{ inputs.python-version }}
-        cache: pip
         cache-dependency-path: ${{ inputs.workdir }}/requirements-dev-frozen.txt
+        install-cmd: pip install -r ${{ inputs.workdir }}/requirements-dev-frozen.txt
 
     - name: Set up outputs
       id: config
@@ -134,7 +133,6 @@ runs:
         WORKDIR: ${{ inputs.workdir }}
       run: |
         cd "$WORKDIR"
-        pip install -r requirements-dev-frozen.txt
         # We need to install editable otherwise things like check migration will fail.
         SENTRY_LIGHT_BUILD=1 pip install --no-deps -e .
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -146,12 +146,13 @@ jobs:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+      - uses: getsentry/action-setup-venv@64876d2bb1817c9bb6f391ad765677b109704af5 # v1.0.4
         with:
           python-version: 3.8.13
+          cache-depedency: requirements-dev-frozen.txt
+          install-cmd: pip install -q --constraint requirements-dev-frozen.txt pip-tools
       - name: check requirements
         run: |
-          python -m pip install -q --constraint requirements-dev-frozen.txt pip-tools
           python -S -m tools.freeze_requirements
           if ! git diff --exit-code; then
             echo $'\n\nrun `make freeze-requirements` locally to update requirements'
@@ -196,13 +197,13 @@ jobs:
               - added|modified: '**/*.py'
               - added|modified: 'requirements-*.txt'
 
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+      - uses: getsentry/action-setup-venv@64876d2bb1817c9bb6f391ad765677b109704af5 # v1.0.4
         with:
           python-version: 3.8.13
-          cache: pip
           cache-dependency-path: |
             requirements-dev.txt
             requirements-dev-frozen.txt
+          install-cmd: pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
 
       - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7  # v3.0.11
         with:
@@ -215,7 +216,6 @@ jobs:
         # We don't need pre-commit install --install-hooks since we're just interested
         # in running the hooks.
         run: |
-          pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
           pre-commit install-hooks
 
       - name: Run pre-commit on changed files
@@ -422,16 +422,11 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
 
-      - name: Setup Python
-        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+      - uses: getsentry/action-setup-venv@64876d2bb1817c9bb6f391ad765677b109704af5 # v1.0.4
         with:
           python-version: 3.8.13
-          cache: pip
           cache-dependency-path: requirements-dev-frozen.txt
-
-      # We don't call setup-sentry, because we don't need devservices.
-      - name: Setup backend typing
-        run: pip install -r requirements-dev-frozen.txt
+          install-cmd: pip install -r requirements-dev-frozen.txt
 
       - name: Run backend typing (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         run: make backend-typing

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -59,11 +59,9 @@ jobs:
       - uses: getsentry/action-setup-volta@54775a59c41065f54ecc76d1dd5f2cdc7a1550cb  # v1.1.0
 
       # This handles Python's cache
-      - name: Setup Python & cache
-        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+      - uses: getsentry/action-setup-venv@64876d2bb1817c9bb6f391ad765677b109704af5 # v1.0.4
         with:
           python-version: 3.8.13
-          cache: 'pip'
           cache-dependency-path: requirements-dev-frozen.txt
 
       # This tests starting up the dev services, loading mocks and pre-commit installation
@@ -72,10 +70,7 @@ jobs:
         # GHA pythons are miscompiled and report macos 10.16
         env:
           SYSTEM_VERSION_COMPAT: 0
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          make bootstrap
+        run: make bootstrap
 
   # The pyenv set up takes long, thus, separating it into its own
   pyenv-setup:
@@ -111,15 +106,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+      - uses: getsentry/action-setup-venv@64876d2bb1817c9bb6f391ad765677b109704af5 # v1.0.4
         with:
           python-version: 3.8.13
-          cache: pip
           cache-dependency-path: |
             requirements-dev.txt
             requirements-dev-frozen.txt
-      - name: install dependencies
-        run: pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
+          install-cmd: pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
       - name: run tests
         run: make test-tools
       - name: Handle artifacts


### PR DESCRIPTION
The previous attempt to land this broke snuba.

This was due to:

```
install-cmd: pip install -r requirements-dev-frozen.txt
```

which should have been:

```
install-cmd: pip install -r ${{ inputs.workdir }}/requirements-dev-frozen.txt
```