### PR TITLE
fix(alerts): Adjust slack warning message alignment

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -645,7 +645,6 @@ const MarginlessAlert = styled(Alert)`
   border-top: 1px ${p => p.theme.innerBorder} solid;
   margin: 0;
   padding: ${space(1)} ${space(1)};
-  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const StyledFeatureBadge = styled(FeatureBadge)`


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/1400464/212216915-51be74a2-8dfa-4657-b3d9-f8c435114e36.png)

after
![image](https://user-images.githubusercontent.com/1400464/212216938-6ea610de-5e27-4219-825e-13baa22d7335.png)
