### PR TITLE
feat(dx): Avoid relative imports in ts files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,8 @@
     "**/node_modules/@storybook/addons/*",
     "**/node_modules/@testing-library/*"
   ],
+  // Avoid relative imports
+  "typescript.preferences.importModuleSpecifier": "non-relative",
 
   "[typescriptreact]": {
     "editor.formatOnSave": true,


### PR DESCRIPTION
We would prefer absolute imports starting with `sentry/`. This should
help stop vscode from using relative imports.

You can still use relative imports, the editor will just be less
aggressive about it