### PR TITLE
feat(hybrid-cloud): Create organization mappings

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -529,6 +529,11 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     status=status.HTTP_409_CONFLICT,
                 )
 
+            # Send outbox message to clean up mappings after organization
+            # creation transaction
+            outbox = Organization.outbox_to_verify_mapping(organization.id)
+            outbox.save()
+
             if was_pending_deletion:
                 self.create_audit_entry(
                     request=request,

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -248,6 +248,15 @@ class Organization(Model, SnowflakeIdMixin):
             object_identifier=org_id,
         )
 
+    @staticmethod
+    def outbox_to_verify_mapping(org_id: int) -> RegionOutbox:
+        return RegionOutbox(
+            shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+            shard_identifier=org_id,
+            category=OutboxCategory.VERIFY_ORGANIZATION_MAPPING,
+            object_identifier=org_id,
+        )
+
     @cached_property
     def is_default(self):
         if not settings.SENTRY_SINGLE_ORGANIZATION:

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -178,6 +178,9 @@ class Organization(Model, SnowflakeIdMixin):
 
     objects = OrganizationManager(cache_fields=("pk", "slug"))
 
+    # Not persisted. Getsentry fills this in in post-save hooks and we use it for synchronizing data across silos.
+    customer_id: Optional[str] = None
+
     class Meta:
         app_label = "sentry"
         db_table = "sentry_organization"

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -44,6 +44,7 @@ class OutboxCategory(IntEnum):
     WEBHOOK_PROXY = 1
     ORGANIZATION_UPDATE = 2
     ORGANIZATION_MEMBER_UPDATE = 3
+    VERIFY_ORGANIZATION_MAPPING = 4
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/receivers/outbox.py
+++ b/src/sentry/receivers/outbox.py
@@ -65,3 +65,11 @@ def process_organization_member_updates(object_identifier: int, **kwds: Any):
     if (org_member := _maybe_process_tombstone(OrganizationMember, object_identifier)) is None:
         return
     org_member  # TODO: When we get the org member mapping table in place, here is where we'll sync it.
+
+
+@receiver(process_region_outbox, sender=OutboxCategory.VERIFY_ORGANIZATION_MAPPING)
+def process_organization_mapping_verifications(object_identifier: int, **kwds: Any):
+    if (org := _maybe_process_tombstone(Organization, object_identifier)) is None:
+        return
+
+    organization_mapping_service.verify_mappings(org.id, org.slug)

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -80,6 +80,10 @@ class OrganizationMappingService(InterfaceWithLifecycle):
     def update(self, update: ApiOrganizationMappingUpdate) -> None:
         pass
 
+    @abstractmethod
+    def verify_mappings(self, organization_id: int, slug: str) -> None:
+        pass
+
 
 def impl_with_db() -> OrganizationMappingService:
     from sentry.services.hybrid_cloud.organization_mapping.impl import (

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 class APIOrganizationMapping:
     organization_id: int = -1
     slug: str = ""
+    name: str = ""
     region_name: str = ""
     date_created: datetime = timezone.now()
     verified: bool = False
@@ -51,6 +52,7 @@ class OrganizationMappingService(InterfaceWithLifecycle):
         user: User,
         organization_id: int,
         slug: str,
+        name: str,
         region_name: str,
         idempotency_key: Optional[str] = "",
         customer_id: Optional[str],

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -19,6 +19,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
         user: User,
         organization_id: int,
         slug: str,
+        name: str,
         region_name: str,
         idempotency_key: Optional[str] = "",
         # There's only a customer_id when updating an org slug
@@ -29,16 +30,18 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
             org_mapping, _created = OrganizationMapping.objects.update_or_create(
                 slug=slug,
                 idempotency_key=idempotency_key,
+                region_name=region_name,
                 defaults={
                     "customer_id": customer_id,
                     "organization_id": organization_id,
-                    "region_name": region_name,
+                    "name": name,
                 },
             )
         else:
             org_mapping = OrganizationMapping.objects.create(
                 organization_id=organization_id,
                 slug=slug,
+                name=name,
                 idempotency_key=idempotency_key,
                 region_name=region_name,
                 customer_id=customer_id,
@@ -47,7 +50,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
         return self.serialize_organization_mapping(org_mapping)
 
     def serialize_organization_mapping(
-        cls, org_mapping: OrganizationMapping
+        self, org_mapping: OrganizationMapping
     ) -> APIOrganizationMapping:
         args = {
             field.name: getattr(org_mapping, field.name)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -263,6 +263,7 @@ class Factories:
     def create_org_mapping(org, **kwds):
         kwds.setdefault("organization_id", org.id)
         kwds.setdefault("slug", org.slug)
+        kwds.setdefault("name", org.name)
         kwds.setdefault("idempotency_key", uuid4().hex)
         kwds.setdefault("region_name", "test-region")
         return OrganizationMapping.objects.create(**kwds)


### PR DESCRIPTION
Creates an `OrganizationMapping` in the control silo during organization create and slug update to obtain a globally unique slug.

[Internal docs](https://www.notion.so/Draft-Reduce-usage-of-replication-from-Control-to-Region-Silos-7265991ff2104f1490acfded02b6a1b3#763a77050ceb4bf699995fb04f5b01aa)