### PR TITLE
fix(hybrid-cloud): Fix redirect for api/new-token/

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -346,7 +346,7 @@ urlpatterns += [
     ),
     url(
         r"^api/new-token/$",
-        RedirectView.as_view(pattern_name="sentry-api-new-auth-token", permanent=False),
+        RedirectView.as_view(pattern_name="sentry-account-api-new-auth-token", permanent=False),
     ),
     url(r"^api/[^0]+/", RedirectView.as_view(pattern_name="sentry-api", permanent=False)),
     url(r"^out/$", OutView.as_view()),


### PR DESCRIPTION
Fixes [SENTRY-XTK](https://sentry.sentry.io/issues/3872699413/?project=1)

This is a change to redirect I had missed in https://github.com/getsentry/sentry/pull/41959. 

`sentry-api-new-auth-token` has since been renamed to `sentry-account-api-new-auth-token`.