### PR TITLE
fix(view-hierarchy): Node title contents wrapping

### DIFF
--- a/static/app/components/events/viewHierarchy/tree.tsx
+++ b/static/app/components/events/viewHierarchy/tree.tsx
@@ -116,6 +116,7 @@ const ChildList = styled('ul')`
 const NodeContents = styled('li')`
   padding-left: 0;
   display: block;
+  white-space: nowrap;
 `;
 
 const NodeTitle = styled('span')<{selected?: boolean}>`


### PR DESCRIPTION
Deeply nested view hierarchies were having their contents wrap which isn't desirable/necessary. The text will currently go all the way up to the right border in these cases, but I will fix this in the future for usability improvements.

Before:
![Screen Shot 2023-01-13 at 10 58 28 AM](https://user-images.githubusercontent.com/22846452/212364175-9afc08c5-cade-4bef-bd0a-e39ec7dd12e2.png)

After:
![Screen Shot 2023-01-13 at 10 58 18 AM](https://user-images.githubusercontent.com/22846452/212364206-b88659b4-ba3b-449f-823d-2b3a388cb3b5.png)

