### PR TITLE
ref(notifications): filter to accepting recipients helper function

### DIFF
--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -215,9 +215,12 @@ class BaseNotification(abc.ABC):
     def filter_to_accepting_recipients(
         self, recipients: Iterable[Team | APIUser]
     ) -> Mapping[ExternalProviders, Iterable[Team | APIUser]]:
-        return NotificationSetting.objects.filter_to_accepting_recipients(
+        accepting_recipients: Mapping[
+            ExternalProviders, Iterable[Team | APIUser]
+        ] = NotificationSetting.objects.filter_to_accepting_recipients(
             self.organization, recipients, self.notification_setting_type
         )
+        return accepting_recipients
 
     def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | APIUser]]:
         # need a notification_setting_type to call this function

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -212,7 +212,9 @@ class BaseNotification(abc.ABC):
 
         return notification_providers()
 
-    def filter_to_accepting_recipients(self, recipients):
+    def filter_to_accepting_recipients(
+        self, recipients: Iterable[Team | APIUser]
+    ) -> Mapping[ExternalProviders, Iterable[Team | APIUser]]:
         return NotificationSetting.objects.filter_to_accepting_recipients(
             self.organization, recipients, self.notification_setting_type
         )

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -212,6 +212,11 @@ class BaseNotification(abc.ABC):
 
         return notification_providers()
 
+    def filter_to_accepting_recipients(self, recipients):
+        return NotificationSetting.objects.filter_to_accepting_recipients(
+            self.organization, recipients, self.notification_setting_type
+        )
+
     def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | APIUser]]:
         # need a notification_setting_type to call this function
         if not self.notification_setting_type:
@@ -219,9 +224,7 @@ class BaseNotification(abc.ABC):
 
         available_providers = self.get_notification_providers()
         recipients = list(self.determine_recipients())
-        recipients_by_provider = NotificationSetting.objects.filter_to_accepting_recipients(
-            self.organization, recipients, self.notification_setting_type
-        )
+        recipients_by_provider = self.filter_to_accepting_recipients(recipients)
 
         return {
             provider: recipients_of_provider


### PR DESCRIPTION
The `filter_to_accepting_recipients` helper function that's being pulled out here is going to be overwritten for spike protection notifications. To avoid duping the entire `get_participants` function, I'm factoring out the only part that would be different in the base class from spike protection notifications.