### PR TITLE
feat(replays): Check if replays exist before linking to the Replay Details page from Discover/Issues/Performance

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -7,6 +7,7 @@ import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelTable from 'sentry/components/panels/panelTable';
 import QuestionTooltip from 'sentry/components/questionTooltip';
+import ReplayIdCountProvider from 'sentry/components/replays/replayIdCountProvider';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -19,6 +20,7 @@ import {
   fieldAlignment,
   getAggregateAlias,
 } from 'sentry/utils/discover/fields';
+import ViewReplayLink from 'sentry/utils/discover/viewReplayLink';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import CellAction, {Actions} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
@@ -143,11 +145,19 @@ class TransactionsTable extends PureComponent<Props> {
       const target = generateLink?.[field]?.(organization, row, location.query);
 
       if (target && !objectIsEmpty(target)) {
-        rendered = (
-          <Link data-test-id={`view-${fields[index]}`} to={target}>
-            {rendered}
-          </Link>
-        );
+        if (fields[index] === 'replayId') {
+          rendered = (
+            <ViewReplayLink replayId={row.replayId} to={target}>
+              {rendered}
+            </ViewReplayLink>
+          );
+        } else {
+          rendered = (
+            <Link data-test-id={`view-${fields[index]}`} to={target}>
+              {rendered}
+            </Link>
+          );
+        }
       }
 
       const isNumeric = ['integer', 'number', 'duration'].includes(fieldType);
@@ -198,28 +208,31 @@ class TransactionsTable extends PureComponent<Props> {
   }
 
   render() {
-    const {isLoading, tableData} = this.props;
+    const {isLoading, organization, tableData} = this.props;
 
     const hasResults =
       tableData && tableData.data && tableData.meta && tableData.data.length > 0;
+    const replayIds = tableData?.data?.map(row => row.replayId);
 
     // Custom set the height so we don't have layout shift when results are loaded.
     const loader = <LoadingIndicator style={{margin: '70px auto'}} />;
 
     return (
-      <VisuallyCompleteWithData id="TransactionsTable" hasData={hasResults}>
-        <PanelTable
-          data-test-id="transactions-table"
-          isEmpty={!hasResults}
-          emptyMessage={t('No transactions found')}
-          headers={this.renderHeader()}
-          isLoading={isLoading}
-          disablePadding
-          loader={loader}
-        >
-          {this.renderResults()}
-        </PanelTable>
-      </VisuallyCompleteWithData>
+      <ReplayIdCountProvider organization={organization} replayIds={replayIds}>
+        <VisuallyCompleteWithData id="TransactionsTable" hasData={hasResults}>
+          <PanelTable
+            data-test-id="transactions-table"
+            isEmpty={!hasResults}
+            emptyMessage={t('No transactions found')}
+            headers={this.renderHeader()}
+            isLoading={isLoading}
+            disablePadding
+            loader={loader}
+          >
+            {this.renderResults()}
+          </PanelTable>
+        </VisuallyCompleteWithData>
+      </ReplayIdCountProvider>
     );
   }
 }

--- a/static/app/components/replays/replayIdCountProvider.tsx
+++ b/static/app/components/replays/replayIdCountProvider.tsx
@@ -1,0 +1,30 @@
+import {ReactNode, ReactText} from 'react';
+
+import ReplayCountContext from 'sentry/components/replays/replayCountContext';
+import useReplaysCount from 'sentry/components/replays/useReplaysCount';
+import {Organization} from 'sentry/types';
+
+type Props = {
+  children: ReactNode;
+  organization: Organization;
+  replayIds: ReactText[] | string[] | undefined;
+};
+
+function unique<T>(arr: T[]) {
+  return Array.from(new Set(arr));
+}
+
+function ReplayIdCountProvider({children, organization, replayIds}: Props) {
+  const ids = replayIds?.map(String)?.filter(Boolean) || [];
+  const counts = useReplaysCount({
+    replayIds: unique(ids),
+    organization,
+    projectIds: [],
+  });
+
+  return (
+    <ReplayCountContext.Provider value={counts}>{children}</ReplayCountContext.Provider>
+  );
+}
+
+export default ReplayIdCountProvider;

--- a/static/app/utils/discover/viewReplayLink.tsx
+++ b/static/app/utils/discover/viewReplayLink.tsx
@@ -1,0 +1,46 @@
+import {ComponentProps, ReactNode, ReactText, useContext} from 'react';
+import styled from '@emotion/styled';
+
+import Link from 'sentry/components/links/link';
+import ReplayCountContext from 'sentry/components/replays/replayCountContext';
+import Tooltip from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+
+function ViewReplayLink({
+  children,
+  replayId,
+  to,
+}: {
+  children: ReactNode;
+  replayId: ReactText | string;
+  to: ComponentProps<typeof Link>['to'];
+}) {
+  const count = useContext(ReplayCountContext)[replayId] || 0;
+
+  if (count < 1) {
+    return (
+      <Tooltip title={t('This replay may have been rate limited or deleted.')}>
+        <EmptyValueContainer>{t('(missing)')}</EmptyValueContainer>
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip title={t('View Replay')}>
+      <StyledLink data-test-id="view-replay" to={to}>
+        {children}
+      </StyledLink>
+    </Tooltip>
+  );
+}
+
+const StyledLink = styled(Link)`
+  & div {
+    display: inline;
+  }
+`;
+
+const EmptyValueContainer = styled('span')`
+  color: ${p => p.theme.gray300};
+`;
+
+export default ViewReplayLink;

--- a/static/app/utils/discover/viewReplayLink.tsx
+++ b/static/app/utils/discover/viewReplayLink.tsx
@@ -26,9 +26,7 @@ function ViewReplayLink({
   }
   return (
     <Tooltip title={t('View Replay')}>
-      <StyledLink data-test-id="view-replay" to={to}>
-        {children}
-      </StyledLink>
+      <StyledLink to={to}>{children}</StyledLink>
     </Tooltip>
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Component} from 'react';
 import {browserHistory, RouteContextInterface} from 'react-router';
 import styled from '@emotion/styled';
 import {Location, LocationDescriptor, LocationDescriptorObject} from 'history';
@@ -13,6 +13,7 @@ import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import QuestionTooltip from 'sentry/components/questionTooltip';
+import ReplayIdCountProvider from 'sentry/components/replays/replayIdCountProvider';
 import Tooltip from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {IssueAttachment, Organization, Project} from 'sentry/types';
@@ -30,6 +31,7 @@ import {
   isSpanOperationBreakdownField,
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'sentry/utils/discover/fields';
+import ViewReplayLink from 'sentry/utils/discover/viewReplayLink';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import CellAction, {Actions, updateQuery} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
@@ -209,7 +211,13 @@ class EventsTable extends Component<Props, State> {
           handleCellAction={this.handleCellAction(column)}
           allowActions={allowActions}
         >
-          {target ? <Link to={target}>{rendered}</Link> : rendered}
+          {target ? (
+            <ViewReplayLink replayId={dataRow.replayId} to={target}>
+              {rendered}
+            </ViewReplayLink>
+          ) : (
+            rendered
+          )}
         </CellAction>
       );
     }
@@ -470,8 +478,12 @@ class EventsTable extends Component<Props, State> {
                     fetchAttachments(tableData, cursor);
                   }
                   joinCustomData(tableData);
+                  const replayIds = tableData.data.map(row => row.replayId);
                   return (
-                    <Fragment>
+                    <ReplayIdCountProvider
+                      organization={organization}
+                      replayIds={replayIds}
+                    >
                       <GridEditable
                         isLoading={
                           isTotalEventsLoading ||
@@ -495,7 +507,7 @@ class EventsTable extends Component<Props, State> {
                         caption={paginationCaption}
                         pageLinks={pageLinks}
                       />
-                    </Fragment>
+                    </ReplayIdCountProvider>
                   );
                 }}
               </DiscoverQuery>

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -146,6 +146,8 @@ export function generateTransactionLink(transactionName: string) {
 }
 
 export function generateReplayLink(routes: PlainRoute<any>[]) {
+  const referrer = getRouteStringFromRoutes(routes);
+
   return (
     organization: Organization,
     tableRow: TableDataRow,
@@ -157,7 +159,6 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
     }
 
     const replaySlug = `${tableRow['project.name']}:${replayId}`;
-    const referrer = getRouteStringFromRoutes(routes);
 
     if (!tableRow.timestamp) {
       return {


### PR DESCRIPTION
Before when you were looking at any of these pages it was possible to get a link/button to a replay (see screen shot) but the replay wasn't available. It could be missing because of sampling, or because that individual replay is deleted by a user.

### Discover Table:
<img width="1114" alt="SCR-20230113-nvt" src="https://user-images.githubusercontent.com/187460/212443663-c308eb93-c18d-4836-a9e9-67eb2ba8cfe4.png">

Now when we go to render the button, we check the count first. If the count is zero, render the `missing` text instead and a tooltip.

This applies to:
- Discover `/organizations/:org/discover/homepage/`
- Issue > All Events `/organizations/:org/issues/:groupId/events/`
- Performance > Transaction Summary > Overview (events mini table, with "View All Events" button on top of it) `/organizations/:org/performance/?transaction=FOO`
- Performance > Transaction Summary > All Events `/organizations/:org/performance/summary/events/?transaction=FOO`

### What's the count?
We send a request with a list of `replayIds`, the response is an object like `{"rid1": 0, "rid2": 1}` where each key is the replayId, and the value is the number of replays found. This is an extension of the existing api endpoint that counts how many replays are available for a list of `groupIds`.

To make pageload better we do one query which inclused every row in the data table. This means we have to query after the table data is returned, so it's a sequential request. The returned counts are put into react context and are available to the  `ViewReplayLink` component.

Depends on https://github.com/getsentry/sentry/pull/43188
Fixes https://github.com/getsentry/sentry/issues/40896