### PR TITLE
fix(derived_code_mappings): Revert the logic for derived tagging

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -122,9 +122,6 @@ def set_tags(scope: Scope, result: JSONData) -> None:
     scope.set_tag("stacktrace_link.tried_url", result.get("attemptedUrl"))
     if result["config"]:
         scope.set_tag("stacktrace_link.empty_root", result["config"]["stackRoot"] == "")
-        scope.set_tag(
-            "stacktrace_link.auto_derived", result["config"]["automaticallyGenerated"] is True
-        )
 
 
 @region_silo_endpoint
@@ -208,6 +205,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
         except Exception:
             logger.exception("There was a failure sorting the code mappings")
 
+        derived = False
         current_config = None
         with configure_scope() as scope:
             set_top_tags(scope, project, ctx, len(configs) > 0)
@@ -217,6 +215,11 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
                     # Later on, if there are matching code mappings this will be overwritten
                     result["error"] = "stack_root_mismatch"
                     continue
+                if (
+                    filepath.startswith(config.stack_root)
+                    and config.automatically_generated is True
+                ):
+                    derived = True
 
                 outcome = {}
                 munging_outcome = {}
@@ -259,6 +262,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
                     if current_config["outcome"].get("attemptedUrl"):
                         result["attemptedUrl"] = current_config["outcome"]["attemptedUrl"]
             try:
+                scope.set_tag("stacktrace_link.auto_derived", derived)
                 set_tags(scope, result)
             except Exception:
                 logger.exception("Failed to set tags.")


### PR DESCRIPTION
This lines up with some drop in success rate for derived code mappings.

Partially reverts 78f53abf41d6e47c1a4af0b9d238e3067aedfd95 (#43104)