### PR TITLE
bug: Fix import of button

### DIFF
--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -10,7 +10,7 @@ import {
   SuggestedAssignee,
 } from 'sentry/components/assigneeSelectorDropdown';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
-import Button from 'sentry/components/button';
+import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {AutoCompleteRoot} from 'sentry/components/dropdownAutoComplete/menu';
 import {


### PR DESCRIPTION
Looks like these two PR's landed at about the same time:
- https://github.com/getsentry/sentry/commit/b8170ca778fdff4e507b8e248fdac2bee7270d57
- https://github.com/getsentry/sentry/commit/7c374c91fc1b45bd78663b222f8f4a1525d61513

one did an `import Button from ..`
and the other removed `export default Button;`

CI didn't test the combination until they both hit master and we tried to deploy.