### PR TITLE
fix(integrations): Use organization_id for finding the integration

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -101,6 +101,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         integration_id: int | None = None,
         provider: str | None = None,
         external_id: str | None = None,
+        organization_id: id | None = None,
     ) -> APIIntegration | None:
         integration_kwargs: Dict[str, Any] = {}
         if integration_id is not None:
@@ -109,6 +110,8 @@ class DatabaseBackedIntegrationService(IntegrationService):
             integration_kwargs["provider"] = provider
         if external_id is not None:
             integration_kwargs["external_id"] = external_id
+        if organization_id is not None:
+            integration_kwargs["organizationintegration__organization_id"] = organization_id
 
         if not integration_kwargs:
             return None
@@ -174,7 +177,10 @@ class DatabaseBackedIntegrationService(IntegrationService):
         external_id: str | None = None,
     ) -> Tuple[APIIntegration | None, APIOrganizationIntegration | None]:
         integration = self.get_integration(
-            integration_id=integration_id, provider=provider, external_id=external_id
+            organization_id=organization_id,
+            integration_id=integration_id,
+            provider=provider,
+            external_id=external_id,
         )
         if not integration:
             return (None, None)

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -101,7 +101,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         integration_id: int | None = None,
         provider: str | None = None,
         external_id: str | None = None,
-        organization_id: id | None = None,
+        organization_id: int | None = None,
     ) -> APIIntegration | None:
         integration_kwargs: Dict[str, Any] = {}
         if integration_id is not None:

--- a/tests/sentry/hybrid_cloud/test_integration.py
+++ b/tests/sentry/hybrid_cloud/test_integration.py
@@ -238,6 +238,18 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
         )
         assert result is None
 
+    def test_get_organization_context(self):
+        new_org = self.create_organization()
+        with exempt_from_silo_limits():
+            org_integration = self.integration3.add_organization(new_org)
+
+        result_integration, result_org_integration = integration_service.get_organization_context(
+            organization_id=new_org.id,
+            provider="example",
+        )
+        self.verify_integration_result(result=result_integration, expected=self.integration3)
+        self.verify_org_integration_result(result=result_org_integration, expected=org_integration)
+
     @freeze_time()
     def test_update_organization_integrations(self):
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
Fixes https://sentry.io/organizations/sentry/issues/3873673216/ - SENTRY-XTS

The error came up because the organization_id wasn't being used to find the integration. The get_org_context method would find the first integration, and attempt to connect it to the organization, which would fail.
