### PR TITLE
fix(deps): remove trailing .0 in requirements for pyuwsgi

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -70,7 +70,7 @@ urllib3[brotli]>=1.26.9
 brotli>=1.0.9
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
-pyuwsgi==2.0.20.0
+pyuwsgi==2.0.20
 zstandard>=0.18.0
 
 msgpack>=1.0.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -141,7 +141,7 @@ python-utils==3.3.3
 python3-saml==1.14.0
 pytz==2018.9
 pyupgrade==3.2.3
-pyuwsgi==2.0.20.0
+pyuwsgi==2.0.20
 pyvat==1.3.15
 pyyaml==5.4
 rb==1.9.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -95,7 +95,7 @@ python-u2flib-server==5.0.0
 python-utils==3.3.3
 python3-saml==1.14.0
 pytz==2018.9
-pyuwsgi==2.0.20.0
+pyuwsgi==2.0.20
 pyvat==1.3.15
 pyyaml==5.4
 rb==1.9.0


### PR DESCRIPTION
Potential fix for https://github.com/getsentry/sentry/issues/43171.

Poetry appears to not honor version semantics.
