### PR TITLE
fix(integrations): Use services to get organization data

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -15,8 +15,10 @@ from sentry.charts.types import ChartType
 from sentry.discover.arithmetic import is_equation
 from sentry.integrations.slack.message_builder.discover import SlackDiscoverMessageBuilder
 from sentry.models import ApiKey, Integration
+from sentry.models.organization import Organization
 from sentry.models.user import User
 from sentry.search.events.filter import to_list
+from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.utils.dates import (
     get_interval_from_range,
     parse_stats_period,
@@ -105,7 +107,13 @@ def unfurl_discover(
     links: list[UnfurlableUrl],
     user: User | None,
 ) -> UnfurledUrl:
-    orgs_by_slug = {org.slug: org for org in integration.organizations.all()}
+    org_integrations = integration_service.get_organization_integrations(
+        integration_id=integration.id
+    )
+    organizations = Organization.objects.filter(
+        id__in=[oi.organization_id for oi in org_integrations]
+    )
+    orgs_by_slug = {org.slug: org for org in organizations}
     unfurls = {}
 
     for link in links:
@@ -262,11 +270,11 @@ def unfurl_discover(
             chart_url=url,
         ).build()
 
-    org_model = integration.organizations.first()
-    if org_model is not None and hasattr(org_model, "id"):
+    first_org_integration = org_integrations[0] if len(org_integrations) > 0 else None
+    if first_org_integration is not None and hasattr(first_org_integration, "id"):
         analytics.record(
             "integrations.slack.chart_unfurl",
-            organization_id=org_model.id,
+            organization_id=first_org_integration.organization_id,
             user_id=user.id if user else None,
             unfurls_count=len(unfurls),
         )

--- a/src/sentry/integrations/slack/unfurl/metric_alerts.py
+++ b/src/sentry/integrations/slack/unfurl/metric_alerts.py
@@ -14,6 +14,7 @@ from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.models import AlertRule, Incident, User
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.models import Integration, Organization
+from sentry.services.hybrid_cloud.integration import integration_service
 
 from . import Handler, UnfurlableUrl, UnfurledUrl, make_type_coercer
 
@@ -51,14 +52,19 @@ def unfurl_metric_alerts(
         else:
             alert_filter_query |= Q(id=alert_rule_id, organization__slug=org_slug)
 
-    all_integration_orgs = integration.organizations.all()
+    org_integrations = integration_service.get_organization_integrations(
+        integration_id=integration.id
+    )
+    organizations = Organization.objects.filter(
+        id__in=[oi.organization_id for oi in org_integrations]
+    )
     alert_rule_map = {
         rule.id: rule
         for rule in AlertRule.objects.filter(
             alert_filter_query,
             # Filter by integration organization here as well to make sure that
             # we have permission to access these incidents.
-            organization__in=all_integration_orgs,
+            organization_id__in=[org.id for org in organizations],
         )
     }
 
@@ -73,11 +79,11 @@ def unfurl_metric_alerts(
                 incident_filter_query,
                 # Filter by integration organization here as well to make sure that
                 # we have permission to access these incidents.
-                organization__in=all_integration_orgs,
+                organization_id__in=organizations,
             )
         }
 
-    orgs_by_slug: dict[str, Organization] = {org.slug: org for org in all_integration_orgs}
+    orgs_by_slug: dict[str, Organization] = {org.slug: org for org in organizations}
 
     result = {}
     for link in links:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -14,6 +14,7 @@ from sentry.integrations.slack.message_builder.discover import SlackDiscoverMess
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.integrations.slack.unfurl import LinkType, UnfurlableUrl, link_handlers, match_link
+from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.snuba.dataset import Dataset
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import install_slack
@@ -106,7 +107,8 @@ class UnfurlTest(TestCase):
         # We're redefining project to ensure that the individual tests have unique project ids.
         # Sharing project ids across tests could result in some race conditions
         self.project = self.create_project()
-        self.integration = install_slack(self.organization)
+        self._integration = install_slack(self.organization)
+        self.integration = integration_service._serialize_integration(self._integration)
 
         self.request = RequestFactory().get("slack/event")
         self.frozen_time = freezegun.freeze_time(datetime.now() - timedelta(days=1))


### PR DESCRIPTION
Fixes SENTRY-XTT [link](https://sentry.io/organizations/sentry/issues/3873687703/?project=1&query=is%3Aunresolved&referrer=issue-stream)

This issue came up because we were the organizations table through the Integration model. Instead we have to use services to do this request.