### PR TITLE
ref(scim): Use transaction instead of span

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -376,7 +376,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         - The API also does not support setting secondary emails.
         """
 
-        with sentry_sdk.start_span(op="enterprise.scim-provision-user") as span:
+        with sentry_sdk.start_transaction(name="Provision Scim Member", sampled=True) as txn:
             if (
                 features.has("organizations:scim-orgmember-roles", organization, actor=None)
                 and "sentryOrgRole" in request.data
@@ -387,7 +387,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
             else:
                 role = organization.default_role
                 idp_role_restricted = False
-            span.set_tag("role_restricted", idp_role_restricted)
+            txn.set_tag("role_restricted", idp_role_restricted)
 
             # Allow any role as long as it doesn't have `org:admin` permissions
             allowed_roles = {role for role in roles.get_all() if not role.has_scope("org:admin")}
@@ -395,10 +395,10 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
             # Check for roles not found
             # TODO: move this to the serializer verification
             if role not in {role.id for role in allowed_roles}:
-                span.set_tag("invalid_role_selection", True)
-                raise SCIMApiError(detail=SCIM_400_INVALID_ORGROLE, span=span)
+                txn.set_tag("invalid_role_selection", True)
+                raise SCIMApiError(detail=SCIM_400_INVALID_ORGROLE)
 
-            span.set_tag("invalid_role_selection", False)
+            txn.set_tag("invalid_role_selection", False)
             serializer = OrganizationMemberSerializer(
                 data={
                     "email": request.data.get("userName"),
@@ -421,8 +421,8 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
                 if "role" in serializer.errors:
                     # TODO: Change this to an error pointing to a doc showing the workaround if they
                     # tried to provision an org admin
-                    raise SCIMApiError(detail=SCIM_400_INVALID_ORGROLE, span=span)
-                raise SCIMApiError(detail=json.dumps(serializer.errors), span=span)
+                    raise SCIMApiError(detail=SCIM_400_INVALID_ORGROLE)
+                raise SCIMApiError(detail=json.dumps(serializer.errors))
 
             result = serializer.validated_data
             with transaction.atomic():

--- a/src/sentry/scim/endpoints/utils.py
+++ b/src/sentry/scim/endpoints/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+import sentry_sdk
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.exceptions import APIException, ParseError
@@ -17,9 +18,10 @@ ACCEPTED_FILTERED_KEYS = ["userName", "value", "displayName"]
 
 
 class SCIMApiError(APIException):
-    def __init__(self, detail, status_code=400, span=None):
-        if span is not None:
-            span.set_tag("http.response_code", status_code)
+    def __init__(self, detail, status_code=400):
+        transaction = sentry_sdk.Hub.current.scope.transaction
+        if transaction is not None:
+            transaction.set_tag("http.status_code", status_code)
         self.status_code = status_code
         self.detail = {"schemas": [SCIM_API_ERROR], "detail": detail}
 


### PR DESCRIPTION
Trying to force sampling on scim-for-roles. explicitly using transactions instead of span

