### PR TITLE
feat(ui): Add plainTextLabel for select items

### DIFF
--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -1,6 +1,7 @@
 import {forwardRef, useCallback, useMemo} from 'react';
 import ReactSelect, {
   components as selectComponents,
+  createFilter,
   GroupedOptionsType,
   mergeStyles,
   OptionsType,
@@ -512,8 +513,14 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
     Option,
   };
 
+  const filterOptions = createFilter({
+    // Use plainTextLabel if available
+    stringify: option => option.data.plainTextLabel ?? `${option.label} ${option.value}`,
+  });
+
   return (
     <SelectPicker<OptionType>
+      filterOption={filterOptions}
       styles={mappedStyles}
       components={{...replacedComponents, ...components}}
       async={async}

--- a/static/app/components/group/externalIssueForm.spec.jsx
+++ b/static/app/components/group/externalIssueForm.spec.jsx
@@ -182,12 +182,12 @@ describe('ExternalIssueForm', () => {
         renderComponent('Link');
         jest.useFakeTimers();
         userEvent.click(screen.getAllByText('Issue').at(1));
-        userEvent.type(screen.getByRole('textbox', {name: 'Issue'}), 'doOT');
+        userEvent.type(screen.getByRole('textbox', {name: 'Issue'}), 'faster');
         expect(window.fetch).toHaveBeenCalledTimes(0);
         jest.advanceTimersByTime(300);
         expect(window.fetch).toHaveBeenCalledTimes(1);
         expect(window.fetch).toHaveBeenCalledWith(
-          '/search?field=externalIssue&query=doOT&repo=scefali%2Ftest'
+          '/search?field=externalIssue&query=faster&repo=scefali%2Ftest'
         );
         expect(await screen.findByText('#2345 perf: Make it faster')).toBeInTheDocument();
       });

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -48,6 +48,12 @@ export type Writable<T> = {-readonly [K in keyof T]: T[K]};
 export interface SelectValue<T> extends MenuListItemProps {
   label: string | number | React.ReactElement;
   value: T;
+  /**
+   * In scenarios where you're using a react element as the label react-select
+   * will be unable to filter to that label. Use this to specify the plain text of
+   * the label.
+   */
+  plainTextLabel?: string;
 }
 
 /**


### PR DESCRIPTION
This allows us to specify the text to be filtered on for select items
when we're using a custom react node label (with react-select can't use
to filter from)