### PR TITLE
fix(scim): no space in transaction name

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -376,7 +376,9 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         - The API also does not support setting secondary emails.
         """
 
-        with sentry_sdk.start_transaction(name="Provision Scim Member", sampled=True) as txn:
+        with sentry_sdk.start_transaction(
+            name="scim.provision_member", op="scim", sampled=True
+        ) as txn:
             if (
                 features.has("organizations:scim-orgmember-roles", organization, actor=None)
                 and "sentryOrgRole" in request.data


### PR DESCRIPTION
I think this is preventing the transaction from showing up

