### PR TITLE
feat(dynamic-sampling): Add decaying function support for latest release boost [TET-624]

### DIFF
--- a/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
@@ -23,6 +23,7 @@ class BoostLatestReleasesDataProvider(BiasDataProvider):
     def get_bias_data(self, bias_params: BiasParams) -> BiasData:
         return {
             "id": RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE],
+            "baseSampleRate": bias_params.base_sample_rate,
             "sampleRate": min(1.0, bias_params.base_sample_rate * RELEASE_BOOST_FACTOR),
             "boostedReleases": ProjectBoostedReleases(
                 bias_params.project.id
@@ -70,6 +71,12 @@ class BoostLatestReleasesRulesGenerator(BiasRulesGenerator):
                                 + boosted_release.platform.time_to_adoption
                             ).replace(tzinfo=UTC)
                         ),
+                    },
+                    # We want to use the linear decaying function for latest release boosting, with the goal
+                    # of interpolating the adoption growth with the reduction is sample rate.
+                    "decayingFn": {
+                        "function": "linear",
+                        "decayedSampleRate": bias_data["baseSampleRate"],
                     },
                 }
                 for idx, boosted_release in enumerate(boosted_releases)

--- a/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
@@ -73,7 +73,7 @@ class BoostLatestReleasesRulesGenerator(BiasRulesGenerator):
                         ),
                     },
                     # We want to use the linear decaying function for latest release boosting, with the goal
-                    # of interpolating the adoption growth with the reduction is sample rate.
+                    # of interpolating the adoption growth with the reduction in sample rate.
                     "decayingFn": {
                         "function": "linear",
                         "decayedSampleRate": bias_data["baseSampleRate"],

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_latest_releases_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_latest_releases_bias.py
@@ -24,6 +24,7 @@ MOCK_DATETIME = ONE_DAY_AGO.replace(hour=10, minute=0, second=0, microsecond=0)
 def test_generate_bias_rules(data_provider, default_project):
     now = timezone.now()
 
+    base_sample_rate = 0.2
     sample_rate = 0.7
     platform = "python"
 
@@ -50,6 +51,7 @@ def test_generate_bias_rules(data_provider, default_project):
 
     data_provider.get_bias_data.return_value = {
         "id": 1000,
+        "baseSampleRate": base_sample_rate,
         "sampleRate": sample_rate,
         "boostedReleases": boosted_releases,
     }
@@ -71,6 +73,7 @@ def test_generate_bias_rules(data_provider, default_project):
                 "end": (now + timedelta(seconds=LATEST_RELEASE_TTAS[platform])).isoformat(" "),
                 "start": now.isoformat(" "),
             },
+            "decayingFn": {"function": "linear", "decayedSampleRate": base_sample_rate},
             "type": "trace",
         },
         {
@@ -88,6 +91,7 @@ def test_generate_bias_rules(data_provider, default_project):
                 "end": (now + timedelta(seconds=LATEST_RELEASE_TTAS[platform])).isoformat(" "),
                 "start": now.isoformat(" "),
             },
+            "decayingFn": {"function": "linear", "decayedSampleRate": base_sample_rate},
             "type": "trace",
         },
     ]

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -413,6 +413,7 @@ def test_generate_rules_with_different_project_platforms(
                 "start": "2022-10-21 18:50:25+00:00",
                 "end": end,
             },
+            "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
         },
         {
             "active": True,
@@ -465,6 +466,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             },
             "id": 1500,
             "timeRange": {"start": "2022-10-21 18:50:25+00:00", "end": "2022-10-21 20:03:03+00:00"},
+            "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
         },
         {
             "sampleRate": 0.5,
@@ -479,6 +481,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             },
             "id": 1501,
             "timeRange": {"start": "2022-10-21 18:50:25+00:00", "end": "2022-10-21 20:03:03+00:00"},
+            "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
         },
         {
             "sampleRate": 0.5,
@@ -493,6 +496,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             },
             "id": 1502,
             "timeRange": {"start": "2022-10-21 18:50:25+00:00", "end": "2022-10-21 20:03:03+00:00"},
+            "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
         },
         {
             "active": True,
@@ -549,6 +553,7 @@ def test_generate_rules_does_not_return_rule_with_deleted_release(
             },
             "id": 1500,
             "timeRange": {"start": "2022-10-21 18:50:25+00:00", "end": "2022-10-21 20:03:03+00:00"},
+            "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
         },
         {
             "active": True,

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -359,6 +359,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                     "start": "2022-10-21 18:50:25+00:00",
                     "end": "2022-10-21 19:50:25+00:00",
                 },
+                "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
             },
             {
                 "sampleRate": 0.5,
@@ -380,6 +381,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                     "start": "2022-10-21 18:50:25+00:00",
                     "end": "2022-10-21 19:50:25+00:00",
                 },
+                "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
             },
             {
                 "sampleRate": 0.5,
@@ -401,6 +403,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                     "start": "2022-10-21 18:50:25+00:00",
                     "end": "2022-10-21 19:50:25+00:00",
                 },
+                "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
             },
             {
                 "sampleRate": 0.5,
@@ -422,6 +425,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                     "start": "2022-10-21 18:50:25+00:00",
                     "end": "2022-10-21 19:50:25+00:00",
                 },
+                "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
             },
             {
                 "sampleRate": 0.5,
@@ -443,6 +447,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                     "start": "2022-10-21 18:50:25+00:00",
                     "end": "2022-10-21 19:50:25+00:00",
                 },
+                "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
             },
             {
                 "sampleRate": 0.5,
@@ -464,6 +469,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                     "start": "2022-10-21 18:50:25+00:00",
                     "end": "2022-10-21 19:50:25+00:00",
                 },
+                "decayingFn": {"function": "linear", "decayedSampleRate": 0.1},
             },
             {
                 "sampleRate": 0.1,


### PR DESCRIPTION
This PR aims at implementing the `decayingFn` field to the latest release boosting rule. This PR is linked to the decaying function implementation in Relay (https://github.com/getsentry/relay/pull/1692).