### PR TITLE
ref(perf-issues): Improve N+1 API Calls fingerprinting

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -791,10 +791,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
     def _fingerprint(self) -> str:
         offender_hash = self.spans[-1]["hash"]
-        problem_class = GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS
         fingerprint = hashlib.sha1(offender_hash.encode("utf8")).hexdigest()
 
-        return f"1-{problem_class}-{fingerprint}"
+        return f"1-{GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS.value}-{fingerprint}"
 
     def _spans_are_concurrent(self, span_a: Span, span_b: Span) -> bool:
         span_a_start: int = span_a.get("start_timestamp", 0) or 0

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -793,7 +793,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         offender_hash = self.spans[-1]["hash"]
         fingerprint = hashlib.sha1(offender_hash.encode("utf8")).hexdigest()
 
-        return f"1-{GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS.value}-{fingerprint}"
+        return f"1-{GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS.value}-{fingerprint}"
 
     def _spans_are_concurrent(self, span_a: Span, span_b: Span) -> bool:
         span_a_start: int = span_a.get("start_timestamp", 0) or 0

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -34,7 +34,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         problems = self.find_problems(event)
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1012-3b2ee4021cd4e24acd32179932e10553e312786b",
+                fingerprint="1-1010-3b2ee4021cd4e24acd32179932e10553e312786b",
                 op="http.client",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
                 desc="GET /api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A",

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -34,7 +34,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         problems = self.find_problems(event)
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS-3b2ee4021cd4e24acd32179932e10553e312786b",
+                fingerprint="1-1012-3b2ee4021cd4e24acd32179932e10553e312786b",
                 op="http.client",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
                 desc="GET /api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A",


### PR DESCRIPTION
The enum's value is much more resilient than its name, we should have done this from the get-go.
