### PR TITLE
ref(perf-issues): Update Slow DB Span Issue fingerprinting

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -525,23 +525,20 @@ class SlowSpanDetector(PerformanceDetector):
         if not SlowSpanDetector.is_span_eligible(span):
             return
 
-        description = span.get("description", None)
-        description = description.strip()
+        query = span.get("description", None)
+        query = query.strip()
 
         if span_duration >= timedelta(
             milliseconds=duration_threshold
         ) and not self.stored_problems.get(fingerprint, False):
             spans_involved = [span_id]
-
-            hash = span.get("hash", "")
             type = DETECTOR_TYPE_TO_GROUP_TYPE[self.settings_key]
-            transaction_name = self._event.get("transaction")
 
             self.stored_problems[fingerprint] = PerformanceProblem(
                 type=type,
-                fingerprint=self._fingerprint(transaction_name, op, hash, type),
+                fingerprint=self._fingerprint(query),
                 op=op,
-                desc=description,
+                desc=query,
                 cause_span_ids=[],
                 parent_span_ids=[],
                 offender_span_ids=spans_involved,
@@ -574,10 +571,10 @@ class SlowSpanDetector(PerformanceDetector):
 
         return True
 
-    def _fingerprint(self, transaction_name, span_op, hash, problem_class):
-        signature = (str(transaction_name) + str(span_op) + str(hash)).encode("utf-8")
+    def _fingerprint(self, query):
+        signature = (str(query)).encode("utf-8")
         full_fingerprint = hashlib.sha1(signature).hexdigest()
-        return f"1-{problem_class}-{full_fingerprint}"
+        return f"1-{GroupType.PERFORMANCE_SLOW_SPAN.value}-{full_fingerprint}"
 
 
 class RenderBlockingAssetSpanDetector(PerformanceDetector):

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -525,20 +525,22 @@ class SlowSpanDetector(PerformanceDetector):
         if not SlowSpanDetector.is_span_eligible(span):
             return
 
-        query = span.get("description", None)
-        query = query.strip()
+        description = span.get("description", None)
+        description = description.strip()
 
         if span_duration >= timedelta(
             milliseconds=duration_threshold
         ) and not self.stored_problems.get(fingerprint, False):
             spans_involved = [span_id]
+
+            hash = span.get("hash", "")
             type = DETECTOR_TYPE_TO_GROUP_TYPE[self.settings_key]
 
             self.stored_problems[fingerprint] = PerformanceProblem(
                 type=type,
-                fingerprint=self._fingerprint(query),
+                fingerprint=self._fingerprint(hash),
                 op=op,
-                desc=query,
+                desc=description,
                 cause_span_ids=[],
                 parent_span_ids=[],
                 offender_span_ids=spans_involved,
@@ -571,8 +573,8 @@ class SlowSpanDetector(PerformanceDetector):
 
         return True
 
-    def _fingerprint(self, query):
-        signature = (str(query)).encode("utf-8")
+    def _fingerprint(self, hash):
+        signature = (str(hash)).encode("utf-8")
         full_fingerprint = hashlib.sha1(signature).hexdigest()
         return f"1-{GroupType.PERFORMANCE_SLOW_SPAN.value}-{full_fingerprint}"
 

--- a/tests/sentry/utils/performance_issues/test_slow_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_slow_span_detector.py
@@ -40,7 +40,7 @@ class SlowSpanDetectorTest(unittest.TestCase):
         assert self.find_problems(slow_not_allowed_op_span_event) == []
         assert self.find_problems(slow_span_event) == [
             PerformanceProblem(
-                fingerprint="1-GroupType.PERFORMANCE_SLOW_SPAN-020e34d374ab4b5cd00a6a1b4f76f325209f7263",
+                fingerprint="1-1001-ae5ce0e354aeee83e6184c77edd50dfb56244ba9",
                 op="db",
                 desc="SELECT count() FROM table WHERE id = %s",
                 type=GroupType.PERFORMANCE_SLOW_SPAN,
@@ -63,12 +63,12 @@ class SlowSpanDetectorTest(unittest.TestCase):
         assert self.find_problems(http_span_event) == []
         assert self.find_problems(db_span_event) == [
             PerformanceProblem(
-                fingerprint="1-GroupType.PERFORMANCE_SLOW_SPAN-dff8b4c2cafa12af9b5a35f3b12f9f8c2d790170",
+                fingerprint="1-1001-ae5ce0e354aeee83e6184c77edd50dfb56244ba9",
                 op="db.query",
                 desc="SELECT count() FROM table WHERE id = %s",
                 type=GroupType.PERFORMANCE_SLOW_SPAN,
-                parent_span_ids=None,
-                cause_span_ids=None,
+                parent_span_ids=[],
+                cause_span_ids=[],
                 offender_span_ids=["bbbbbbbbbbbbbbbb"],
             )
         ]
@@ -99,12 +99,12 @@ class SlowSpanDetectorTest(unittest.TestCase):
         assert self.find_problems(slow_span_event_with_truncated_query) == []
         assert self.find_problems(slow_span_event) == [
             PerformanceProblem(
-                fingerprint="1-GroupType.PERFORMANCE_SLOW_SPAN-020e34d374ab4b5cd00a6a1b4f76f325209f7263",
+                fingerprint="1-1001-f40a1ab06e0c43c7aabafb9c29c5c9a9629805ed",
                 op="db",
                 desc="SELECT `product`.`id` FROM `products`",
                 type=GroupType.PERFORMANCE_SLOW_SPAN,
-                parent_span_ids=None,
-                cause_span_ids=None,
+                parent_span_ids=[],
+                cause_span_ids=[],
                 offender_span_ids=["bbbbbbbbbbbbbbbb"],
             )
         ]

--- a/tests/sentry/utils/performance_issues/test_slow_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_slow_span_detector.py
@@ -40,7 +40,7 @@ class SlowSpanDetectorTest(unittest.TestCase):
         assert self.find_problems(slow_not_allowed_op_span_event) == []
         assert self.find_problems(slow_span_event) == [
             PerformanceProblem(
-                fingerprint="1-1001-ae5ce0e354aeee83e6184c77edd50dfb56244ba9",
+                fingerprint="1-1001-da39a3ee5e6b4b0d3255bfef95601890afd80709",
                 op="db",
                 desc="SELECT count() FROM table WHERE id = %s",
                 type=GroupType.PERFORMANCE_SLOW_SPAN,
@@ -63,7 +63,7 @@ class SlowSpanDetectorTest(unittest.TestCase):
         assert self.find_problems(http_span_event) == []
         assert self.find_problems(db_span_event) == [
             PerformanceProblem(
-                fingerprint="1-1001-ae5ce0e354aeee83e6184c77edd50dfb56244ba9",
+                fingerprint="1-1001-da39a3ee5e6b4b0d3255bfef95601890afd80709",
                 op="db.query",
                 desc="SELECT count() FROM table WHERE id = %s",
                 type=GroupType.PERFORMANCE_SLOW_SPAN,
@@ -78,7 +78,7 @@ class SlowSpanDetectorTest(unittest.TestCase):
 
         assert self.find_problems(n_plus_one_event) == [
             PerformanceProblem(
-                fingerprint="1-GroupType.PERFORMANCE_SLOW_SPAN-8dbbcc64ef67d2d9d390327411669ebe29b0ea45",
+                fingerprint="1-1001-d02c8b2fd92a2d72011671feda429fa8ce2ac00f",
                 op="db",
                 desc="\n                SELECT VERSION(),\n                       @@sql_mode,\n                       @@default_storage_engine,\n                       @@sql_auto_is_null,\n                       @@lower_case_table_names,\n                       CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL\n            ",
                 type=GroupType.PERFORMANCE_SLOW_SPAN,
@@ -99,7 +99,7 @@ class SlowSpanDetectorTest(unittest.TestCase):
         assert self.find_problems(slow_span_event_with_truncated_query) == []
         assert self.find_problems(slow_span_event) == [
             PerformanceProblem(
-                fingerprint="1-1001-f40a1ab06e0c43c7aabafb9c29c5c9a9629805ed",
+                fingerprint="1-1001-da39a3ee5e6b4b0d3255bfef95601890afd80709",
                 op="db",
                 desc="SELECT `product`.`id` FROM `products`",
                 type=GroupType.PERFORMANCE_SLOW_SPAN,


### PR DESCRIPTION
This PR corrects two things:

- Updates the fingerprint strategy to use solely the span's hash, since one slow DB query = one fix (we don't want to create multiple issues just because the transaction where the query occurred is different)
- Uses the enum value in the fingerprint instead of the name