### PR TITLE
feat(perf-issues): Extract common base path of N+1 API Calls repeated spans

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -152,7 +152,7 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
         screen.getByTestId(/span-evidence-key-value-list.repeating-spans/)
-      ).toHaveTextContent('GET http://service.api/book/?book_id=7');
+      ).toHaveTextContent('/book/');
 
       expect(screen.queryByRole('cell', {name: 'Parameters'})).toBeInTheDocument();
       expect(

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -83,16 +83,16 @@ const NPlusOneAPICallsSpanEvidence = ({
   offendingSpans,
 }: SpanEvidenceKeyValueListProps) => {
   const problemParameters = formatChangingQueryParameters(offendingSpans);
+  const basePath = formatBasePath(offendingSpans[0]);
 
   return (
     <PresortedKeyValueList
       data={
         [
           makeTransactionNameRow(transactionName),
-          makeRow(
-            t('Repeating Spans (%s)', offendingSpans.length),
-            getSpanEvidenceValue(offendingSpans[0])
-          ),
+          basePath
+            ? makeRow(t('Repeating Spans (%s)', offendingSpans.length), basePath)
+            : null,
           problemParameters.length > 0
             ? makeRow(t('Parameters'), problemParameters)
             : null,
@@ -223,4 +223,10 @@ export function extractQueryParameters(URLs: URL[]): ParameterLookup {
   return mapValues(parameterValuesByKey, parameterList => {
     return Array.from(new Set(parameterList));
   });
+}
+
+function formatBasePath(span: Span): string {
+  const spanURL = extractSpanURLString(span);
+
+  return spanURL?.pathname ?? '';
 }


### PR DESCRIPTION
**Before:**
![Screen Shot 2023-01-16 at 4 22 23 PM](https://user-images.githubusercontent.com/989898/212769124-29349c0d-a9f1-495c-96eb-24238aa48fc7.png)

**After:**
![Screen Shot 2023-01-16 at 4 22 50 PM](https://user-images.githubusercontent.com/989898/212769130-bad179ef-cc62-4a50-86d7-2735a0cc3ad9.png)

I think the copy here could use work, but we'll come back to that in the near future.