### PR TITLE
fix(derived-code-mappings): Do not complain if there's no Github installation

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -146,7 +146,6 @@ def get_installation(
     )
 
     if not integration or not organization_integration:
-        logger.exception(f"Github integration not found for {organization.id}")
         return None, None
 
     installation = integration_service.get_installation(


### PR DESCRIPTION
This was not being triggered before until #43183 was merged.

Fixes SENTRY-XTS