### PR TITLE
feat(perf-issues): Fix N+1 API Calls issue details with relative URLs in spans

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -162,7 +162,6 @@ export function EventEntry({
       if (group?.issueCategory === IssueCategory.PERFORMANCE) {
         return (
           <SpanEvidenceSection
-            issueType={group?.issueType}
             event={event as EventTransaction}
             organization={organization as Organization}
           />

--- a/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
@@ -6,8 +6,6 @@ import {
 } from 'sentry-test/performance/utils';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {IssueType} from 'sentry/types';
-
 import {SpanEvidenceSection} from './spanEvidence';
 
 const {organization} = initializeData();
@@ -72,11 +70,7 @@ describe('spanEvidence', () => {
     builder.addSpan(parentProblemSpan);
 
     render(
-      <SpanEvidenceSection
-        event={builder.getEvent()}
-        organization={organization}
-        issueType={IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES}
-      />,
+      <SpanEvidenceSection event={builder.getEvent()} organization={organization} />,
       {organization}
     );
 

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -38,8 +38,8 @@ export function SpanEvidenceSection({event, issueType, organization}: Props) {
       )}
     >
       <SpanEvidenceKeyValueList
+        event={event}
         issueType={issueType}
-        transactionName={event.title}
         parentSpan={parentSpan}
         offendingSpans={offendingSpans}
         causeSpans={causeSpans}

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -9,11 +9,9 @@ import {TraceContextType} from '../spans/types';
 import WaterfallModel from '../spans/waterfallModel';
 
 import {SpanEvidenceKeyValueList} from './spanEvidenceKeyValueList';
-import {getSpanInfoFromTransactionEvent} from './utils';
 
 interface Props {
   event: EventTransaction;
-  issueType: IssueType;
   organization: Organization;
 }
 
@@ -21,14 +19,18 @@ export type TraceContextSpanProxy = Omit<TraceContextType, 'span_id'> & {
   span_id: string; // TODO: Remove this temporary type.
 };
 
-export function SpanEvidenceSection({event, issueType, organization}: Props) {
-  const spanInfo = getSpanInfoFromTransactionEvent(event);
-
-  if (!spanInfo) {
+export function SpanEvidenceSection({event, organization}: Props) {
+  if (!event) {
     return null;
   }
 
-  const {causeSpans, parentSpan, offendingSpans, affectedSpanIds} = spanInfo;
+  const parentSpanIDs = event?.perfProblem?.parentSpanIds ?? [];
+  const offendingSpanIDs = event?.perfProblem?.offenderSpanIds ?? [];
+
+  const affectedSpanIds = [...offendingSpanIDs];
+  if (event?.perfProblem?.issueType !== IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS) {
+    affectedSpanIds.push(...parentSpanIDs);
+  }
 
   return (
     <DataSection
@@ -37,13 +39,7 @@ export function SpanEvidenceSection({event, issueType, organization}: Props) {
         'Span Evidence identifies the root cause of this issue, found in other similar events within the same issue.'
       )}
     >
-      <SpanEvidenceKeyValueList
-        event={event}
-        issueType={issueType}
-        parentSpan={parentSpan}
-        offendingSpans={offendingSpans}
-        causeSpans={causeSpans}
-      />
+      <SpanEvidenceKeyValueList event={event} />
 
       <TraceViewWrapper>
         <TraceView

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -1,7 +1,7 @@
 import {EXAMPLE_TRANSACTION_TITLE, MockSpan} from 'sentry-test/performance/utils';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {IssueType} from 'sentry/types';
+import {EntryType, IssueType} from 'sentry/types';
 
 import {
   extractQueryParameters,
@@ -9,14 +9,11 @@ import {
 } from './spanEvidenceKeyValueList';
 
 describe('SpanEvidenceKeyValueList', () => {
-  const event = TestStubs.Event({
-    transaction: EXAMPLE_TRANSACTION_TITLE,
-    request: {
-      url: 'https://service.io/resource',
-    },
-  });
-
   describe('N+1 Database Queries', () => {
+    const event = TestStubs.Event({
+      title: EXAMPLE_TRANSACTION_TITLE,
+    });
+
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList
@@ -70,6 +67,10 @@ describe('SpanEvidenceKeyValueList', () => {
   });
 
   describe('Consecutive DB Queries', () => {
+    const event = TestStubs.Event({
+      title: EXAMPLE_TRANSACTION_TITLE,
+    });
+
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList
@@ -121,6 +122,18 @@ describe('SpanEvidenceKeyValueList', () => {
   });
 
   describe('N+1 API Calls', () => {
+    const event = TestStubs.Event({
+      title: '/',
+      entries: [
+        TestStubs.EventEntry({
+          type: EntryType.REQUEST,
+          data: {
+            url: 'http://some.service.io',
+          },
+        }),
+      ],
+    });
+
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList
@@ -139,13 +152,13 @@ describe('SpanEvidenceKeyValueList', () => {
               startTimestamp: 10,
               endTimestamp: 2100,
               op: 'http.client',
-              description: 'GET http://service.api/book/?book_id=7&sort=up',
+              description: 'GET /book/?book_id=7&sort=up',
             }).span,
             new MockSpan({
               startTimestamp: 10,
               endTimestamp: 2100,
               op: 'http.client',
-              description: 'GET http://service.api/book/?book_id=8&sort=down',
+              description: 'GET /book/?book_id=8&sort=down',
             }).span,
           ]}
         />
@@ -206,6 +219,10 @@ describe('SpanEvidenceKeyValueList', () => {
   });
 
   describe('Slow DB Span', () => {
+    const event = TestStubs.Event({
+      title: EXAMPLE_TRANSACTION_TITLE,
+    });
+
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -9,12 +9,19 @@ import {
 } from './spanEvidenceKeyValueList';
 
 describe('SpanEvidenceKeyValueList', () => {
+  const event = TestStubs.Event({
+    transaction: EXAMPLE_TRANSACTION_TITLE,
+    request: {
+      url: 'https://service.io/resource',
+    },
+  });
+
   describe('N+1 Database Queries', () => {
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList
           issueType={IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES}
-          transactionName={EXAMPLE_TRANSACTION_TITLE}
+          event={event}
           parentSpan={
             new MockSpan({
               startTimestamp: 0,
@@ -66,8 +73,8 @@ describe('SpanEvidenceKeyValueList', () => {
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList
+          event={event}
           issueType={IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES}
-          transactionName="/"
           parentSpan={
             new MockSpan({
               startTimestamp: 0,
@@ -117,8 +124,8 @@ describe('SpanEvidenceKeyValueList', () => {
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList
+          event={event}
           issueType={IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS}
-          transactionName="/"
           parentSpan={
             new MockSpan({
               startTimestamp: 0,
@@ -202,8 +209,8 @@ describe('SpanEvidenceKeyValueList', () => {
     it('Renders relevant fields', () => {
       render(
         <SpanEvidenceKeyValueList
+          event={event}
           issueType={IssueType.PERFORMANCE_SLOW_SPAN}
-          transactionName="/"
           parentSpan={
             new MockSpan({
               startTimestamp: 0,

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -140,15 +140,9 @@ export function getSpanInfoFromTransactionEvent(
   const offendingSpanIDs = event?.perfProblem?.offenderSpanIds ?? [];
   const causeSpanIDs = event?.perfProblem?.causeSpanIds ?? [];
 
-  const affectedSpanIds = [...offendingSpanIDs];
-  if (event?.perfProblem?.issueType !== IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS) {
-    affectedSpanIds.push(...parentSpanIDs);
-  }
-
   return {
     parentSpan: spansById[parentSpanIDs[0]],
     offendingSpans: offendingSpanIDs.map(spanID => spansById[spanID]),
     causeSpans: causeSpanIDs.map(spanID => spansById[spanID]),
-    affectedSpanIds,
   };
 }

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -13,7 +13,7 @@ import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {EntrySpans, EntryType, Event, EventTransaction} from 'sentry/types/event';
+import {Entry, EntrySpans, EntryType, Event, EventTransaction} from 'sentry/types/event';
 
 type StartTimestamp = number;
 type EndTimestamp = number;
@@ -81,11 +81,9 @@ class OpsBreakdown extends Component<Props> {
       return [];
     }
 
-    const spanEntry = event.entries.find(
-      (entry: EntrySpans | any): entry is EntrySpans => {
-        return entry.type === EntryType.SPANS;
-      }
-    );
+    const spanEntry = event.entries.find((entry: Entry): entry is EntrySpans => {
+      return entry.type === EntryType.SPANS;
+    });
 
     let spans: RawSpanType[] = spanEntry?.data ?? [];
 

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -13,7 +13,7 @@ import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Entry, EntrySpans, EntryType, Event, EventTransaction} from 'sentry/types/event';
+import {EntrySpans, EntryType, Event, EventTransaction} from 'sentry/types/event';
 
 type StartTimestamp = number;
 type EndTimestamp = number;
@@ -81,9 +81,11 @@ class OpsBreakdown extends Component<Props> {
       return [];
     }
 
-    const spanEntry = event.entries.find((entry: Entry): entry is EntrySpans => {
-      return entry.type === EntryType.SPANS;
-    });
+    const spanEntry = event.entries.find(
+      (entry: EntrySpans | any): entry is EntrySpans => {
+        return entry.type === EntryType.SPANS;
+      }
+    );
 
     let spans: RawSpanType[] = spanEntry?.data ?? [];
 

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -88,7 +88,7 @@ const SpanEvidencePreviewBody = ({
       <SpanEvidencePreviewWrapper data-test-id="span-evidence-preview-body">
         <SpanEvidenceKeyValueList
           issueType={data?.perfProblem?.issueType}
-          transactionName={data.title}
+          event={data}
           parentSpan={spanInfo.parentSpan}
           offendingSpans={spanInfo.offendingSpans}
           causeSpans={spanInfo.causeSpans}

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -2,7 +2,6 @@ import {Fragment, ReactChild, useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {SpanEvidenceKeyValueList} from 'sentry/components/events/interfaces/performance/spanEvidenceKeyValueList';
-import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import {GroupPreviewHovercard} from 'sentry/components/groupPreviewTooltip/groupPreviewHovercard';
 import {useDelayedLoadingState} from 'sentry/components/groupPreviewTooltip/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -81,18 +80,10 @@ const SpanEvidencePreviewBody = ({
     return <EmptyWrapper>{t('Failed to load preview')}</EmptyWrapper>;
   }
 
-  const spanInfo = data && getSpanInfoFromTransactionEvent(data);
-
-  if (spanInfo && data) {
+  if (data) {
     return (
       <SpanEvidencePreviewWrapper data-test-id="span-evidence-preview-body">
-        <SpanEvidenceKeyValueList
-          issueType={data?.perfProblem?.issueType}
-          event={data}
-          parentSpan={spanInfo.parentSpan}
-          offendingSpans={spanInfo.offendingSpans}
-          causeSpans={spanInfo.causeSpans}
-        />
+        <SpanEvidenceKeyValueList event={data} />
       </SpanEvidencePreviewWrapper>
     );
   }

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -93,6 +93,10 @@ export class TransactionEventBuilder {
     return (this.#spans.length + 1).toString(16).padStart(16, '0');
   }
 
+  addEntry(entry: EventTransaction['entries'][number]) {
+    this.#event.entries.push(entry);
+  }
+
   addSpan(mockSpan: MockSpan, numSpans = 1, parentSpanId?: string) {
     for (let i = 0; i < numSpans; i++) {
       const spanId = this.generateSpanId();

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -4,6 +4,7 @@ import {EntryType, EventOrGroupType, EventTransaction, IssueType} from 'sentry/t
 export enum ProblemSpan {
   PARENT = 'parent',
   OFFENDER = 'offender',
+  CAUSE = 'cause',
 }
 
 export const EXAMPLE_TRANSACTION_TITLE = '/api/0/transaction-test-endpoint/';
@@ -110,6 +111,9 @@ export class TransactionEventBuilder {
           break;
         case ProblemSpan.OFFENDER:
           this.#event.perfProblem?.offenderSpanIds.push(spanId);
+          break;
+        case ProblemSpan.CAUSE:
+          this.#event.perfProblem?.causeSpanIds.push(spanId);
           break;
         default:
           break;

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -24,7 +24,7 @@ export class TransactionEventBuilder {
   #event: EventTransaction;
   #spans: RawSpanType[] = [];
 
-  constructor(id?: string, title?: string) {
+  constructor(id?: string, title?: string, problemType?: IssueType) {
     this.#event = {
       id: id ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       eventID: id ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -51,7 +51,7 @@ export class TransactionEventBuilder {
         causeSpanIds: [],
         offenderSpanIds: [],
         parentSpanIds: [],
-        issueType: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+        issueType: problemType ?? IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
       },
       // For the purpose of mock data, we don't care as much about the properties below.
       // They're here to satisfy the type constraints, but in the future if we need actual values here


### PR DESCRIPTION
The page doesn't work nicely if the transaction has spans with relative URLs because JavaScript's `new URL()` doesn't work for relative URLs! It only works if a `base` is provided. Rather than faking a base URL, I'm opting to find the base URL from `event.request` which is hiding in the `entries` array.

This requires passing the entire `event` object through to the component (which I kind of prefer, to be honest), and also requires mocking a full `event` in the specs (which I kind of prefer, and would like to move in that direction). Since the entire event is getting passed through, there's no need to compute span information and pass it to the key value list, the list can parse the event inside itself.