### PR TITLE
fix(profiling): uses projectID from an event on transactionProfileProvider

### DIFF
--- a/static/app/components/profiling/transactionProfileIdProvider.tsx
+++ b/static/app/components/profiling/transactionProfileIdProvider.tsx
@@ -10,9 +10,11 @@ interface TransactionToProfileIdProviderProps {
   children: React.ReactNode;
   timestamp: string | undefined;
   transactionId: string | undefined;
+  projectId?: string | undefined;
 }
 
 export function TransactionProfileIdProvider({
+  projectId,
   timestamp,
   transactionId,
   children,
@@ -36,6 +38,7 @@ export function TransactionProfileIdProvider({
   }, [timestamp]);
 
   const {status, data, error} = useProfileEvents({
+    projects: projectId ? [projectId] : undefined,
     fields: ['id'],
     referrer: 'transactionToProfileProvider',
     limit: 1,

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -95,7 +95,7 @@ export function useProfileEvents<F extends string>({
     refetchOnWindowFocus: false,
     refetchOnMount,
     retry: false,
-    enabled: enabled && Boolean(endpointOptions.query.project),
+    enabled,
   });
 }
 

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -95,7 +95,7 @@ export function useProfileEvents<F extends string>({
     refetchOnWindowFocus: false,
     refetchOnMount,
     retry: false,
-    enabled,
+    enabled: enabled && Boolean(endpointOptions.query.project),
   });
 }
 

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -153,6 +153,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
       metaResults?: TraceMetaQueryChildrenProps
     ) => (
       <TransactionProfileIdProvider
+        projectId={event.projectID}
         transactionId={event.type === 'transaction' ? event.id : undefined}
         timestamp={event.dateReceived}
       >

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -245,6 +245,7 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
 
     return (
       <TransactionProfileIdProvider
+        projectId={event?.projectID}
         transactionId={event?.type === 'transaction' ? event.id : undefined}
         timestamp={event?.dateReceived}
       >

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -157,6 +157,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
           <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
             {results => (
               <TransactionProfileIdProvider
+                projectId={event.projectID}
                 transactionId={event.type === 'transaction' ? event.id : undefined}
                 timestamp={event.dateReceived}
               >


### PR DESCRIPTION
## Summary

- uses `projectID` from an `event`

fixes: https://sentry.io/organizations/sentry/issues/3878681065/events/ace61b244768418691fe25a0b6de60d9/?project=11276