### PR TITLE
feat(perf-issues): Configure Slow DB Issue settings

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2312,7 +2312,6 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
 
                     new_grouphashes = new_grouphashes - groups_to_ignore
 
-                delete_slow_span_group_hashes(new_grouphashes, performance_problems)
                 new_grouphashes_count = len(new_grouphashes)
 
                 with metrics.timer("performance.performance_issue.check_write_limits"):
@@ -2422,45 +2421,28 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
 
 @metrics.wraps("performance.performance_issue.should_create_group", sample_rate=1.0)
 def should_create_group(client: Any, grouphash: str, type: GroupType) -> bool:
-    with sentry_sdk.start_span(op="event_manager.should_create_group") as span:
-        times_seen = client.incr(f"grouphash:{grouphash}")
+    times_seen = client.incr(f"grouphash:{grouphash}")
+    metrics.incr(
+        "performance.performance_issue.grouphash_counted",
+        tags={
+            "times_seen": times_seen,
+            "group_type": GROUP_TYPE_TO_TEXT.get(type, "Unknown Type"),
+        },
+        sample_rate=1.0,
+    )
+
+    if times_seen >= GROUPHASH_IGNORE_LIMIT_MAP.get(type, DEFAULT_GROUPHASH_IGNORE_LIMIT):
+        client.delete(grouphash)
         metrics.incr(
-            "performance.performance_issue.grouphash_counted",
-            tags={
-                "times_seen": times_seen,
-                "group_type": GROUP_TYPE_TO_TEXT.get(type, "Unknown Type"),
-            },
+            "performance.performance_issue.issue_will_be_created",
+            tags={"group_type": type.name},
             sample_rate=1.0,
         )
 
-        if times_seen >= GROUPHASH_IGNORE_LIMIT_MAP.get(type, DEFAULT_GROUPHASH_IGNORE_LIMIT):
-            client.delete(grouphash)
-            metrics.incr(
-                "performance.performance_issue.issue_will_be_created",
-                tags={"group_type": type.name},
-                sample_rate=1.0,
-            )
-
-            # TODO: Experimental tag to indicate when a Slow DB Issue would have been created.
-            # This is in place to confirm whether the above rate limit is effective in preventing spikes
-            # and inaccuracies.
-            if type == GroupType.PERFORMANCE_SLOW_SPAN:
-                if span.containing_transaction:
-                    span.containing_transaction.set_tag("_will_create_slow_db_issue", "true")
-                return False
-
-            return True
-        else:
-            client.expire(grouphash, 60 * 60 * 24)  # 24 hour expiration from last seen
-            return False
-
-
-def delete_slow_span_group_hashes(
-    group_hashes: set[str], performance_problems: Sequence[PerformanceProblem]
-) -> None:
-    for problem in performance_problems:
-        if problem.type == GroupType.PERFORMANCE_SLOW_SPAN and problem.fingerprint in group_hashes:
-            group_hashes.remove(problem.fingerprint)
+        return True
+    else:
+        client.expire(grouphash, 60 * 60 * 24)  # 24 hour expiration from last seen
+        return False
 
 
 @metrics.wraps("event_manager.save_transaction_events")

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -127,7 +127,7 @@ default_manager.add("organizations:performance-vitals-inp", OrganizationFeature,
 default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
 default_manager.add("organizations:performance-new-widget-designs", OrganizationFeature, True)
-default_manager.add("organizations:performance-slow-db-issue", OrganizationFeature, True)
+default_manager.add("organizations:performance-slow-db-issue", OrganizationFeature)
 default_manager.add("organizations:profiling", OrganizationFeature)
 default_manager.add("organizations:profiling-flamechart-spans", OrganizationFeature, True)
 default_manager.add("organizations:profiling-dashboard-redesign", OrganizationFeature, True)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -573,6 +573,11 @@ register("performance.issues.n_plus_one_api_calls.problem-creation", default=0.0
 register("performance.issues.n_plus_one_api_calls.la-rollout", default=0.0)
 register("performance.issues.n_plus_one_api_calls.ea-rollout", default=0.0)
 register("performance.issues.n_plus_one_api_calls.ga-rollout", default=0.0)
+register("performance.issues.slow_span.problem-creation", default=0.0)
+register("performance.issues.slow_span.la-rollout", default=0.0)
+register("performance.issues.slow_span.ea-rollout", default=0.0)
+register("performance.issues.slow_span.ga-rollout", default=0.0)
+
 
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
 register("performance.issues.n_plus_one_db.count_threshold", default=5)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -83,10 +83,6 @@ DETECTOR_TYPE_ISSUE_CREATION_TO_SYSTEM_OPTION = {
     DetectorType.N_PLUS_ONE_API_CALLS: "performance.issues.n_plus_one_api_calls.problem-creation",
     DetectorType.FILE_IO_MAIN_THREAD: "performance.issues.file_io_main_thread.problem-creation",
     DetectorType.UNCOMPRESSED_ASSETS: "performance.issues.compressed_assets.problem-creation",
-    # NOTE: Slow Span issues are not allowed for creation yet, the addition of this line is temporary so that we can
-    # record some metrics for issues of this type that *should* be created. We won't actually create any of these issues atm.
-    # This is handled within `event_manager.py` before the issue gets created.
-    # TODO: Remove this once we've verified that quality issues will be created, and not during spikes.
     DetectorType.SLOW_SPAN: "performance.issues.slow_span.problem-creation",
 }
 
@@ -547,11 +543,11 @@ class SlowSpanDetector(PerformanceDetector):
                 offender_span_ids=spans_involved,
             )
 
-    # TODO: Temporarily set to true for now, but issues will not be created.
     def is_creation_allowed_for_organization(self, organization: Optional[Organization]) -> bool:
-        return True
+        return features.has(
+            "organizations:organizations:performance-slow-db-issue", organization, actor=None
+        )
 
-    # TODO: Temporarily set to true for now, but issues will not be created.
     def is_creation_allowed_for_project(self, project: Optional[Project]) -> bool:
         return True
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -544,15 +544,9 @@ class SlowSpanDetector(PerformanceDetector):
             )
 
     def is_creation_allowed_for_organization(self, organization: Optional[Organization]) -> bool:
-        return features.has(
-            "organizations:organizations:performance-slow-db-issue", organization, actor=None
-        )
+        return features.has("organizations:performance-slow-db-issue", organization, actor=None)
 
     def is_creation_allowed_for_project(self, project: Optional[Project]) -> bool:
-        return True
-
-    # TODO: Temporarily set to true for now, but issues will not be created.
-    def is_creation_allowed_for_system(self) -> bool:
         return True
 
     @classmethod


### PR DESCRIPTION
Prepares the Slow DB Span Issue for gradual rollout by:

- Deleting the custom code paths in `event_manager` that prevent its creation
- Update the feature flag to not be a Flagr feature
- Register system settings for creation and LA, EA, GA rollout
- Add a test to confirm that the issue is created when 100 events with slow db problems are detected