### PR TITLE
feat(perf-issues): Add load-mocks for unc. assets

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -901,14 +901,6 @@ def create_mock_transactions(
 
     if load_performance_issues:
 
-        def load_performance_issues():
-            print(f"    > Loading performance issues data")  # NOQA
-            print(f"    > Loading n plus one issue")  # NOQA
-            load_n_plus_one_issue()
-            time.sleep(1.0)
-            print(f"    > Loading consecutive db issue")  # NOQA
-            load_consecutive_db_issue()
-
         def load_n_plus_one_issue():
             trace_id = uuid4().hex
             transaction_user = generate_user()
@@ -1030,7 +1022,54 @@ def create_mock_transactions(
                 ],
             )
 
+        def load_uncompressed_asset_issue():
+            time.sleep(1.0)
+            transaction_user = generate_user()
+            trace_id = uuid4().hex
+            parent_span_id = uuid4().hex[:16]
+
+            parent_span = {
+                "timestamp": (timestamp + timedelta(milliseconds=300)).timestamp(),
+                "start_timestamp": timestamp.timestamp(),
+                "description": "new",
+                "op": "pageload",
+                "parent_span_id": uuid4().hex[:16],
+                "span_id": parent_span_id,
+                "hash": "0f43fb6f6e01ca52",
+            }
+
+            spans = [
+                {
+                    "timestamp": (timestamp + timedelta(milliseconds=1000)).timestamp(),
+                    "start_timestamp": (timestamp + timedelta(milliseconds=300)).timestamp(),
+                    "description": "https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+                    "op": "resource.script",
+                    "parent_span_id": parent_span_id,
+                    "span_id": uuid4().hex[:16],
+                    "hash": "858fea692d4d93e9",
+                    "data": {
+                        "Transfer Size": 1_000_000,
+                        "Encoded Body Size": 1_000_000,
+                        "Decoded Body Size": 1_000_000,
+                    },
+                },
+            ]
+
+            create_sample_event(
+                project=backend_project,
+                platform="transaction",
+                transaction="/uncompressed-asset/",
+                event_id=uuid4().hex,
+                user=transaction_user,
+                timestamp=timestamp + timedelta(milliseconds=300),
+                start_timestamp=timestamp,
+                trace=trace_id,
+                parent_span_id=parent_span_id,
+                spans=[parent_span] + spans,
+            )
+
         def load_consecutive_db_issue():
+            time.sleep(1.0)
             transaction_user = generate_user()
             trace_id = uuid4().hex
             parent_span_id = uuid4().hex[:16]
@@ -1087,6 +1126,15 @@ def create_mock_transactions(
                 parent_span_id=parent_span_id,
                 spans=[parent_span] + spans,
             )
+
+        def load_performance_issues():
+            print(f"    > Loading performance issues data")  # NOQA
+            print(f"    > Loading n plus one issue")  # NOQA
+            load_n_plus_one_issue()
+            print(f"    > Loading consecutive db issue")  # NOQA
+            load_consecutive_db_issue()
+            print(f"    > Loading uncompressed asset issue")  # NOQA
+            load_uncompressed_asset_issue()
 
         load_performance_issues()
 


### PR DESCRIPTION
### Summary
This adds a load-mocks event for the uncompressed assets detector for UI and backend simulation.


#### Other
- Needs other backend change https://github.com/getsentry/sentry/pull/43337 and the flag to be set, alternatively the `is_creation_allowed_for_organization` can be hardcoded to `True` which is probably faster.
- Needs UI change https://github.com/getsentry/sentry/pull/43339

