### PR TITLE
feat(profiling): add profiles by percentile chart to profile summary

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useCallback, useEffect, useMemo} from 'react';
-import {browserHistory, InjectedRouter} from 'react-router';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -41,10 +41,9 @@ import {ProfilingOnboardingPanel} from './profilingOnboardingPanel';
 
 interface ProfilingContentProps {
   location: Location;
-  router: InjectedRouter;
 }
 
-function ProfilingContent({location, router}: ProfilingContentProps) {
+function ProfilingContent({location}: ProfilingContentProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const cursor = decodeScalar(location.query.cursor);
@@ -192,7 +191,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                   </ProfilingOnboardingPanel>
                 ) : (
                   <Fragment>
-                    <ProfileCharts router={router} query={query} selection={selection} />
+                    <ProfileCharts query={query} selection={selection} />
                     <ProfileEventsTable
                       columns={FIELDS.slice()}
                       data={

--- a/static/app/views/profiling/landing/profileCharts.tsx
+++ b/static/app/views/profiling/landing/profileCharts.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import {InjectedRouter} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -14,10 +13,10 @@ import {Series} from 'sentry/types/echarts';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEventsStats';
+import useRouter from 'sentry/utils/useRouter';
 
 interface ProfileChartsProps {
   query: string;
-  router: InjectedRouter;
   hideCount?: boolean;
   selection?: PageFilters;
 }
@@ -27,7 +26,8 @@ interface ProfileChartsProps {
 // cover it up.
 const SERIES_ORDER = ['count()', 'p99()', 'p95()', 'p75()'] as const;
 
-export function ProfileCharts({query, router, selection, hideCount}: ProfileChartsProps) {
+export function ProfileCharts({query, selection, hideCount}: ProfileChartsProps) {
+  const router = useRouter();
   const theme = useTheme();
 
   const seriesOrder = useMemo(() => {

--- a/static/app/views/profiling/landing/profileCharts.tsx
+++ b/static/app/views/profiling/landing/profileCharts.tsx
@@ -18,6 +18,7 @@ import {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEven
 interface ProfileChartsProps {
   query: string;
   router: InjectedRouter;
+  hideCount?: boolean;
   selection?: PageFilters;
 }
 
@@ -26,13 +27,20 @@ interface ProfileChartsProps {
 // cover it up.
 const SERIES_ORDER = ['count()', 'p99()', 'p95()', 'p75()'] as const;
 
-export function ProfileCharts({query, router, selection}: ProfileChartsProps) {
+export function ProfileCharts({query, router, selection, hideCount}: ProfileChartsProps) {
   const theme = useTheme();
+
+  const seriesOrder = useMemo(() => {
+    if (hideCount) {
+      return SERIES_ORDER.filter(s => s !== 'count()');
+    }
+    return SERIES_ORDER;
+  }, [hideCount]);
 
   const profileStats = useProfileEventsStats({
     query,
     referrer: 'api.profiling.landing-chart',
-    yAxes: SERIES_ORDER,
+    yAxes: seriesOrder,
   });
 
   const series: Series[] = useMemo(() => {
@@ -45,7 +53,7 @@ export function ProfileCharts({query, router, selection}: ProfileChartsProps) {
     const timestamps = profileStats.data[0].timestamps.map(ts => ts * 1e3);
 
     const allSeries = profileStats.data[0].data
-      .filter(rawData => SERIES_ORDER.indexOf(rawData.axis) > -1)
+      .filter(rawData => seriesOrder.includes(rawData.axis))
       .map(rawData => {
         if (timestamps.length !== rawData.values.length) {
           throw new Error('Invalid stats response');
@@ -79,21 +87,23 @@ export function ProfileCharts({query, router, selection}: ProfileChartsProps) {
       });
 
     allSeries.sort((a, b) => {
-      const idxA = SERIES_ORDER.indexOf(a.seriesName as any);
-      const idxB = SERIES_ORDER.indexOf(b.seriesName as any);
+      const idxA = seriesOrder.indexOf(a.seriesName as any);
+      const idxB = seriesOrder.indexOf(b.seriesName as any);
 
       return idxA - idxB;
     });
 
     return allSeries;
-  }, [profileStats]);
+  }, [profileStats, seriesOrder]);
 
   return (
     <ChartZoom router={router} {...selection?.datetime}>
       {zoomRenderProps => (
         <StyledPanel>
           <TitleContainer>
-            <StyledHeaderTitle>{t('Profiles by Count')}</StyledHeaderTitle>
+            {!hideCount && (
+              <StyledHeaderTitle>{t('Profiles by Count')}</StyledHeaderTitle>
+            )}
             <StyledHeaderTitle>{t('Profiles by Percentiles')}</StyledHeaderTitle>
           </TitleContainer>
           <AreaChart
@@ -108,7 +118,7 @@ export function ProfileCharts({query, router, selection}: ProfileChartsProps) {
               },
               {
                 top: '32px',
-                left: '52%',
+                left: hideCount ? '24px' : '52%',
                 right: '24px',
                 bottom: '16px',
               },
@@ -116,13 +126,18 @@ export function ProfileCharts({query, router, selection}: ProfileChartsProps) {
             legend={{
               right: 16,
               top: 12,
-              data: SERIES_ORDER.slice(),
+              data: seriesOrder.slice(),
             }}
             axisPointer={{
-              link: [{xAxisIndex: [0, 1]}],
+              link: [
+                {
+                  xAxisIndex: [0, 1],
+                },
+              ],
             }}
             xAxes={[
               {
+                show: !hideCount,
                 gridIndex: 0,
                 type: 'time' as const,
               },

--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -18,7 +18,6 @@ import {
   useProfileEvents,
 } from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {decodeScalar} from 'sentry/utils/queryString';
-import useRouter from 'sentry/utils/useRouter';
 import {ProfileCharts} from 'sentry/views/profiling/landing/profileCharts';
 
 const FUNCTIONS_CURSOR_NAME = 'functionsCursor';
@@ -32,7 +31,6 @@ interface ProfileSummaryContentProps {
 }
 
 function ProfileSummaryContent(props: ProfileSummaryContentProps) {
-  const router = useRouter();
   const fields = useMemo(
     () => getProfilesTableFields(props.project.platform),
     [props.project]
@@ -104,7 +102,7 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
 
   return (
     <Layout.Main fullWidth>
-      <ProfileCharts query={props.query} router={router} hideCount />
+      <ProfileCharts query={props.query} hideCount />
       <TableHeader>
         <CompactSelect
           triggerProps={{prefix: t('Filter'), size: 'xs'}}

--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -18,6 +18,8 @@ import {
   useProfileEvents,
 } from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {decodeScalar} from 'sentry/utils/queryString';
+import useRouter from 'sentry/utils/useRouter';
+import {ProfileCharts} from 'sentry/views/profiling/landing/profileCharts';
 
 const FUNCTIONS_CURSOR_NAME = 'functionsCursor';
 
@@ -30,6 +32,7 @@ interface ProfileSummaryContentProps {
 }
 
 function ProfileSummaryContent(props: ProfileSummaryContentProps) {
+  const router = useRouter();
   const fields = useMemo(
     () => getProfilesTableFields(props.project.platform),
     [props.project]
@@ -101,6 +104,7 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
 
   return (
     <Layout.Main fullWidth>
+      <ProfileCharts query={props.query} router={router} hideCount />
       <TableHeader>
         <CompactSelect
           triggerProps={{prefix: t('Filter'), size: 'xs'}}


### PR DESCRIPTION
## Summary
Adds `<ProfileCharts/>` to the Profile Summary page; more specifically we show "Profiles by Percentile".

![image](https://user-images.githubusercontent.com/7349258/212970349-c6aad337-7f3a-47f6-97c2-71d91d81cf81.png)
 