### PR TITLE
feat(codecov): Highlight stacktrace lines per codecov data

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -113,17 +113,15 @@ const Context = ({
     }
   }
 
-  const shouldShowCodecovData =
-    organization?.features.includes('codecov-stacktrace-integration') &&
-    organization?.codecovAccess;
-
-  if (shouldShowCodecovData && (isLoading || !data)) {
-    return null;
-  }
-
   const getLineCoverageColor = (line: [number, string]): string => {
+    const shouldShowCodecovData =
+      organization?.features.includes('codecov-stacktrace-integration') &&
+      organization?.codecovAccess;
+    const missingData = isLoading || !data;
+
     if (
       !shouldShowCodecovData ||
+      missingData ||
       data?.codecovStatusCode !== CodecovStatusCode.COVERAGE_EXISTS
     ) {
       return 'transparent';

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -113,7 +113,7 @@ const Context = ({
     }
   }
 
-  const getLineCoverageColor = (line: [number, string]): string => {
+  const getLineCoverageColor = (line: [number, string], isActive): string => {
     const shouldShowCodecovData =
       organization?.features.includes('codecov-stacktrace-integration') &&
       organization?.codecovAccess;
@@ -124,6 +124,10 @@ const Context = ({
       missingData ||
       data?.codecovStatusCode !== CodecovStatusCode.COVERAGE_EXISTS
     ) {
+      return 'transparent';
+    }
+
+    if (isActive) {
       return 'transparent';
     }
 
@@ -182,7 +186,7 @@ const Context = ({
               key={index}
               line={line}
               isActive={isActive}
-              color={getLineCoverageColor(line)}
+              color={getLineCoverageColor(line, isActive)}
             >
               {hasComponents && (
                 <ErrorBoundary mini>

--- a/static/app/components/events/interfaces/frame/contextLine.tsx
+++ b/static/app/components/events/interfaces/frame/contextLine.tsx
@@ -1,23 +1,30 @@
 import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
 interface Props {
+  color: string;
   isActive: boolean;
   line: [number, string];
   children?: React.ReactNode;
   className?: string;
 }
 
-const ContextLine = function ({line, isActive, children, className}: Props) {
+const ContextLine = function ({line, isActive, children, className, color}: Props) {
   let lineWs = '';
   let lineCode = '';
   if (typeof line[1] === 'string') {
     [, lineWs, lineCode] = line[1].match(/^(\s*)(.*?)$/m)!;
   }
   const Component = !children ? Fragment : Context;
+  const theme = useTheme();
   return (
-    <li className={classNames(className, 'expandable', {active: isActive})} key={line[0]}>
+    <li
+      className={classNames(className, 'expandable', {active: isActive})}
+      key={line[0]}
+      style={{backgroundColor: theme[color]}}
+    >
       <Component>
         <span className="ws">{lineWs}</span>
         <span className="contextline">{lineCode}</span>

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -145,6 +145,7 @@ export type SentryAppSchemaStacktraceLink = {
 };
 
 export enum Coverage {
+  NOT_APPLICABLE = -1,
   NOT_COVERED = 0,
   COVERED = 1,
   PARTIAL = 2,


### PR DESCRIPTION
Add line highlighting based on the coverage data returned from the Codecov API.

![image](https://user-images.githubusercontent.com/16563948/212977422-d6104260-bae0-4788-8315-7a2566f75f79.png)
