### PR TITLE
fix(view-hierarchy): Tree collapsing all nodes on re-render

### DIFF
--- a/static/app/components/events/eventViewHierarchy.spec.tsx
+++ b/static/app/components/events/eventViewHierarchy.spec.tsx
@@ -1,0 +1,68 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {EventViewHierarchy} from './eventViewHierarchy';
+
+// Mocks for useVirtualizedTree hook
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+window.ResizeObserver = ResizeObserver;
+window.Element.prototype.scrollTo = jest.fn();
+
+const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
+const MOCK_DATA = JSON.stringify({
+  rendering_system: 'test-rendering-system',
+  windows: [
+    {
+      ...DEFAULT_VALUES,
+      id: 'parent',
+      type: 'Container',
+      identifier: 'test_identifier',
+      x: 200,
+      children: [
+        {
+          ...DEFAULT_VALUES,
+          id: 'intermediate',
+          type: 'Nested Container',
+          identifier: 'nested',
+          children: [
+            {
+              ...DEFAULT_VALUES,
+              id: 'leaf',
+              type: 'Text',
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+describe('Event View Hierarchy', function () {
+  let mockAttachment;
+  beforeEach(function () {
+    mockAttachment = TestStubs.EventAttachment();
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/mock/events/${mockAttachment.event_id}/attachments/${mockAttachment.id}/?download`,
+      body: MOCK_DATA,
+    });
+  });
+
+  it('does not collapse all nodes when update triggers re-render', async function () {
+    const {rerender} = render(
+      <EventViewHierarchy projectSlug="mock" viewHierarchies={[mockAttachment]} />
+    );
+
+    expect(await screen.findByText('Nested Container - nested')).toBeInTheDocument();
+
+    rerender(
+      <EventViewHierarchy projectSlug="mock" viewHierarchies={[mockAttachment]} />
+    );
+
+    expect(await screen.findByText('Nested Container - nested')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -36,6 +36,8 @@ function EventViewHierarchy({projectSlug, viewHierarchies}: Props) {
     {staleTime: FIVE_SECONDS_IN_MS, refetchOnWindowFocus: false}
   );
 
+  // Memoize the JSON parsing because downstream hooks depend on
+  // referential equality of objects in the data
   const hierarchy = useMemo<ViewHierarchyData>(() => {
     if (!data) {
       return null;

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -10,7 +10,7 @@ import {useQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {EventDataSection} from './eventDataSection';
-import {ViewHierarchy} from './viewHierarchy';
+import {ViewHierarchy, ViewHierarchyData} from './viewHierarchy';
 
 const FIVE_SECONDS_IN_MS = 5 * 1000;
 
@@ -36,17 +36,22 @@ function EventViewHierarchy({projectSlug, viewHierarchies}: Props) {
     {staleTime: FIVE_SECONDS_IN_MS, refetchOnWindowFocus: false}
   );
 
+  const hierarchy = useMemo<ViewHierarchyData>(() => {
+    if (!data) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(data);
+    } catch (err) {
+      Sentry.captureException(err);
+      return null;
+    }
+  }, [data]);
+
   // TODO(nar): This loading behaviour is subject to change
   if (isLoading || !data) {
     return <LoadingIndicator />;
-  }
-
-  let parsedViewHierarchy;
-  try {
-    parsedViewHierarchy = JSON.parse(data);
-  } catch (err) {
-    Sentry.captureException(err);
-    return null;
   }
 
   return (
@@ -54,8 +59,8 @@ function EventViewHierarchy({projectSlug, viewHierarchies}: Props) {
       type="view_hierarchy"
       title={tn('View Hierarchy', 'View Hierarchies', viewHierarchies.length)}
     >
-      <ErrorBoundary>
-        <ViewHierarchy viewHierarchy={parsedViewHierarchy} />
+      <ErrorBoundary mini>
+        <ViewHierarchy viewHierarchy={hierarchy} />
       </ErrorBoundary>
     </EventDataSection>
   );


### PR DESCRIPTION
When clicking the event title on an issue, or clicking the anchor for one of the sections in the issue details page, the tree would go from fully expanded to fully collapsed.

This is because the `useVirtualizedTree` hook internally maintains a Set of expanded nodes and uses referential checks to see if a node is expanded. If we don't memoize, then the references change and the nodes collapse.

I also changed the way we were rendering the error boundary with the `mini` flag because it fits the page a lot nicer in the case of an error.

<img width="1020" alt="Screen Shot 2023-01-17 at 3 25 06 PM" src="https://user-images.githubusercontent.com/22846452/213005352-bd880d1b-b981-465f-af88-90b506b367c0.png">
