### PR TITLE
feat(profiling): add array upper and lower bound utils

### DIFF
--- a/static/app/utils/profiling/gl/utils.spec.tsx
+++ b/static/app/utils/profiling/gl/utils.spec.tsx
@@ -50,6 +50,7 @@ describe('getContext', () => {
 
 describe('upperBound', () => {
   it.each([
+    [[], 5, 0],
     [[1, 2, 3], 2, 1],
     [[-3, -2, -1], -2, 1],
     [[1, 2, 3], 10, 3],
@@ -74,6 +75,7 @@ describe('upperBound', () => {
 
 describe('lowerBound', () => {
   it.each([
+    [[], 5, 0],
     [[1, 2, 3], 1, 0],
     [[-3, -2, -1], -1, 1],
     [[1, 2, 3], 10, 3],

--- a/static/app/utils/profiling/gl/utils.spec.tsx
+++ b/static/app/utils/profiling/gl/utils.spec.tsx
@@ -9,9 +9,11 @@ import {
   ELLIPSIS,
   findRangeBinarySearch,
   getContext,
+  lowerBound,
   makeProjectionMatrix,
   Rect,
   trimTextCenter,
+  upperBound,
 } from 'sentry/utils/profiling/gl/utils';
 
 describe('makeProjectionMatrix', () => {
@@ -43,6 +45,54 @@ describe('getContext', () => {
       // @ts-ignore partial canvas mock
       getContext({getContext: jest.fn().mockImplementationOnce(() => ctx)}, 'webgl')
     ).toBe(ctx);
+  });
+});
+
+describe('upperBound', () => {
+  it.each([
+    [[1, 2, 3], 2, 1],
+    [[-3, -2, -1], -2, 1],
+    [[1, 2, 3], 10, 3],
+  ])(`inserts`, (args, target, insert) => {
+    expect(
+      upperBound(
+        target,
+        args.map(x => ({start: x, end: x + 1}))
+      )
+    ).toBe(insert);
+  });
+
+  it('finds the upper bound frame outside of view', () => {
+    const frames = new Array(10).fill(1).map((_, i) => ({start: i, end: i + 1}));
+    const view = new Rect(4, 0, 2, 0);
+
+    expect(upperBound(view.right, frames)).toBe(6);
+    expect(frames[6].start).toBeGreaterThanOrEqual(view.right);
+    expect(frames[6].end).toBeGreaterThanOrEqual(view.right);
+  });
+});
+
+describe('lowerBound', () => {
+  it.each([
+    [[1, 2, 3], 1, 0],
+    [[-3, -2, -1], -1, 1],
+    [[1, 2, 3], 10, 3],
+  ])(`inserts`, (args, target, insert) => {
+    expect(
+      lowerBound(
+        target,
+        args.map(x => ({start: x, end: x + 1}))
+      )
+    ).toBe(insert);
+  });
+
+  it('finds the lower bound frame outside of view', () => {
+    const frames = new Array(10).fill(1).map((_, i) => ({start: i, end: i + 1}));
+    const view = new Rect(4, 0, 2, 0);
+
+    expect(lowerBound(view.left, frames)).toBe(3);
+    expect(frames[3].start).toBeLessThanOrEqual(view.left);
+    expect(frames[3].end).toBeLessThanOrEqual(view.left);
   });
 });
 

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -498,6 +498,46 @@ export function findRangeBinarySearch(
   }
 }
 
+export function upperBound<T extends {end: number; start: number}>(
+  target: number,
+  values: T[]
+) {
+  let low = 0;
+  let high = values.length;
+
+  while (low !== high) {
+    const mid = low + Math.floor((high - low) / 2);
+
+    if (values[mid].start < target) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return low;
+}
+
+export function lowerBound<T extends {end: number; start: number}>(
+  target: number,
+  values: T[]
+) {
+  let low = 0;
+  let high = values.length;
+
+  while (low !== high) {
+    const mid = low + Math.floor((high - low) / 2);
+
+    if (values[mid].end < target) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return low;
+}
+
 export function formatColorForSpan(
   frame: SpanChartNode,
   renderer: SpanChartRenderer2D

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -505,6 +505,14 @@ export function upperBound<T extends {end: number; start: number}>(
   let low = 0;
   let high = values.length;
 
+  if (high === 0) {
+    return 0;
+  }
+
+  if (high === 1) {
+    return values[0].start < target ? 1 : 0;
+  }
+
   while (low !== high) {
     const mid = low + Math.floor((high - low) / 2);
 
@@ -524,6 +532,14 @@ export function lowerBound<T extends {end: number; start: number}>(
 ) {
   let low = 0;
   let high = values.length;
+
+  if (high === 0) {
+    return 0;
+  }
+
+  if (high === 1) {
+    return values[0].end < target ? 1 : 0;
+  }
 
   while (low !== high) {
     const mid = low + Math.floor((high - low) / 2);

--- a/static/app/utils/profiling/profile/formats/android/trace.json
+++ b/static/app/utils/profiling/profile/formats/android/trace.json
@@ -1,6 +1,8 @@
 {
   "exporter": "specto.dev",
   "name": "6191083-1.1.0-2-android-MainActivity-d09a42287b9e45a49d127ba0a1dbbb4b",
+  "metadata":{},
+  "measures":{},
   "profiles": [
     {
       "endValue": 123546000,

--- a/static/app/utils/profiling/profile/formats/ios/trace.json
+++ b/static/app/utils/profiling/profile/formats/ios/trace.json
@@ -1,6 +1,8 @@
 {
   "exporter": "specto.dev",
   "name": "6191080-0.1-177-cocoa-example_ios_movies_sources.MoviesViewController-f342b6b400cd405cb32a0a4c31014f25",
+  "metadata":{},
+  "measures":{},
   "profiles": [
     {
       "endValue": 11799843291,

--- a/static/app/utils/profiling/renderers/flamegraphTextRenderer.benchmark.ts
+++ b/static/app/utils/profiling/renderers/flamegraphTextRenderer.benchmark.ts
@@ -12,7 +12,6 @@ import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
 import {Rect, transformMatrixBetweenRect} from '../gl/utils';
 import androidTrace from '../profile/formats/android/trace.json';
 import ios from '../profile/formats/ios/trace.json';
-import typescriptTrace from '../profile/formats/typescript/trace.json';
 import {importProfile} from '../profile/importProfile';
 
 import {FlamegraphTextRenderer} from './flamegraphTextRenderer';
@@ -89,12 +88,6 @@ const makeDrawRightSideOfScreen = (
     renderer.draw(configView, transform, searchResults);
   };
 };
-
-const tsProfile = importProfile(typescriptTrace as any, '');
-const tsFlamegraph = new Flamegraph(tsProfile.profiles[0], 0, {
-  inverted: false,
-  leftHeavy: false,
-});
 
 const androidProfile = importProfile(androidTrace as any, '');
 const androidFlamegraph = new Flamegraph(
@@ -193,21 +186,20 @@ const suite = (
     makeDrawRightSideOfScreen(textRenderer, flamegraph)(new Map())
   );
 
-  benchmark(
-    `${name} (full profile, w/ search matching ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
-    () => makeDrawFullScreen(textRenderer, flamegraph)(results)
-  );
+  // benchmark(
+  //   `${name} (full profile, w/ search matching ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
+  //   () => makeDrawFullScreen(textRenderer, flamegraph)(results)
+  // );
 
-  benchmark(
-    `${name} (center half, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
-    () => makeDrawCenterScreen(textRenderer, flamegraph)(results)
-  );
-  benchmark(
-    `${name} (right quarter, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
-    () => makeDrawRightSideOfScreen(textRenderer, flamegraph)(results)
-  );
+  // benchmark(
+  //   `${name} (center half, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
+  //   () => makeDrawCenterScreen(textRenderer, flamegraph)(results)
+  // );
+  // benchmark(
+  //   `${name} (right quarter, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
+  //   () => makeDrawRightSideOfScreen(textRenderer, flamegraph)(results)
+  // );
 };
 
-suite('typescript', makeTextRenderer(tsFlamegraph), tsFlamegraph);
 suite('android', makeTextRenderer(androidFlamegraph), androidFlamegraph);
 suite('ios', makeTextRenderer(iosFlamegraph), iosFlamegraph);

--- a/static/app/utils/profiling/renderers/flamegraphTextRenderer.benchmark.ts
+++ b/static/app/utils/profiling/renderers/flamegraphTextRenderer.benchmark.ts
@@ -186,19 +186,19 @@ const suite = (
     makeDrawRightSideOfScreen(textRenderer, flamegraph)(new Map())
   );
 
-  // benchmark(
-  //   `${name} (full profile, w/ search matching ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
-  //   () => makeDrawFullScreen(textRenderer, flamegraph)(results)
-  // );
+  benchmark(
+    `${name} (full profile, w/ search matching ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
+    () => makeDrawFullScreen(textRenderer, flamegraph)(results)
+  );
 
-  // benchmark(
-  //   `${name} (center half, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
-  //   () => makeDrawCenterScreen(textRenderer, flamegraph)(results)
-  // );
-  // benchmark(
-  //   `${name} (right quarter, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
-  //   () => makeDrawRightSideOfScreen(textRenderer, flamegraph)(results)
-  // );
+  benchmark(
+    `${name} (center half, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
+    () => makeDrawCenterScreen(textRenderer, flamegraph)(results)
+  );
+  benchmark(
+    `${name} (right quarter, w/ search ${flamegraph.frames.length} of ${flamegraph.frames.length})`,
+    () => makeDrawRightSideOfScreen(textRenderer, flamegraph)(results)
+  );
 };
 
 suite('android', makeTextRenderer(androidFlamegraph), androidFlamegraph);

--- a/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
@@ -71,18 +71,10 @@ class FlamegraphTextRenderer extends TextRenderer {
     const end = upperBound(configView.right, this.flamegraph.root.children);
 
     // Populate the initial set of frames to draw
-    const frames: FlamegraphFrame[] = new Array(end - start);
-    for (let i = start; i < end; i++) {
-      frames[i - start] = this.flamegraph.root.children[i];
-    }
+    const frames: FlamegraphFrame[] = this.flamegraph.root.children.slice(start, end);
 
     while (frames.length > 0) {
       const frame = frames.pop()!;
-
-      // Check if our rect overlaps with the current viewport and skip rendering if it does not.
-      if (frame.end < configView.left || frame.start > configView.right) {
-        continue;
-      }
 
       if (frame.depth > BOTTOM_BOUNDARY) {
         continue;
@@ -107,7 +99,8 @@ class FlamegraphTextRenderer extends TextRenderer {
         continue;
       }
 
-      for (let i = 0; i < frame.children.length; i++) {
+      const endChild = upperBound(configView.right, frame.children);
+      for (let i = lowerBound(configView.left, frame.children); i < endChild; i++) {
         frames.push(frame.children[i]);
       }
 

--- a/static/app/utils/profiling/renderers/spansTextRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansTextRenderer.tsx
@@ -68,18 +68,10 @@ class SpansTextRenderer extends TextRenderer {
     const end = upperBound(configView.right, this.spanChart.root.children);
 
     // Populate the initial set of frames to draw
-    const spans: SpanChartNode[] = new Array(end - start);
-    for (let i = start; i < end; i++) {
-      spans[i - start] = this.spanChart.root.children[i];
-    }
+    const spans: SpanChartNode[] = this.spanChart.root.children.slice(start, end);
 
     while (spans.length > 0) {
       const span = spans.pop()!;
-
-      // Check if our rect overlaps with the current viewport and skip rendering if it does not.
-      if (span.end < configView.left || span.start > configView.right) {
-        continue;
-      }
 
       if (span.depth > BOTTOM_BOUNDARY) {
         continue;
@@ -104,7 +96,8 @@ class SpansTextRenderer extends TextRenderer {
         continue;
       }
 
-      for (let i = 0; i < span.children.length; i++) {
+      const endChild = upperBound(configView.right, span.children);
+      for (let i = lowerBound(configView.left, span.children); i < endChild; i++) {
         spans.push(span.children[i]);
       }
 


### PR DESCRIPTION
Add new utils for finding upper and lower bounds in sorted arrays. Helps us avoid a massive root.children copy operation when view is zoomed in. This helps with text renderer performance for large js profiles where root may contain many frames

https://user-images.githubusercontent.com/9317857/213006889-41de75dd-2dea-400b-8324-c37c86620a91.mp4

