### PR TITLE
feat(view-hierarchy): Add depth markers

### DIFF
--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -53,17 +53,21 @@ function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
     r,
     {handleExpandTreeNode}
   ) => {
+    const key = `view-hierarchy-node-${r.key}`;
+    const depthMarkers = Array(r.item.depth)
+      .fill('')
+      .map((_, i) => <DepthMarker key={`${key}-depth-${i}`} />);
     return (
       <TreeItem
-        key={`view-hierarchy-node-${r.key}`}
+        key={key}
         ref={n => {
           r.ref = n;
         }}
         style={r.styles}
-        depth={r.item.depth}
       >
+        {depthMarkers}
         <Node
-          id={`view-hierarchy-node-${r.key}`}
+          id={key}
           label={getNodeLabel(r.item.node)}
           onExpandClick={() => handleExpandTreeNode(r.item, {expandChildren: false})}
           collapsible={!!r.item.node.children?.length}
@@ -127,7 +131,13 @@ const RenderedItemsContainer = styled('div')`
   position: relative;
 `;
 
-const TreeItem = styled('div')<{depth: number}>`
-  padding-left: ${p => p.depth * 16}px;
+const TreeItem = styled('div')`
+  display: flex;
   height: 20px;
+`;
+
+const DepthMarker = styled('div')`
+  margin-left: 5px;
+  width: ${space(2)};
+  border-left: 1px solid ${p => p.theme.gray200};
 `;


### PR DESCRIPTION
Given the depth of a node, map over that range and add div elements that indicate the depth level of the node. This helps users see the depth of the nodes and the relationships to their parents better.

Before:
<img width="624" alt="Screen Shot 2023-01-17 at 3 53 19 PM" src="https://user-images.githubusercontent.com/22846452/213010212-ffbeec08-4223-42d7-9394-5e572a85c0c0.png">

After:
<img width="596" alt="Screen Shot 2023-01-17 at 3 54 25 PM" src="https://user-images.githubusercontent.com/22846452/213010231-510fdfff-5f9c-4fd8-a251-aca7b550b8b5.png">

Closes #43321 