### PR TITLE
ref(ui): Rename confusing `isSorted` prop of `KeyValueList`

### DIFF
--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -41,7 +41,7 @@ export function TraceEventContext({event, data}: Props) {
           ...v,
           subjectDataTestId: `trace-context-${v.key.toLowerCase()}-value`,
         }))}
-        isSorted={false}
+        shouldSort={false}
         raw={false}
         isContextData
       />
@@ -52,7 +52,7 @@ export function TraceEventContext({event, data}: Props) {
           knownKeys: [...traceKnownDataValues, ...traceIgnoredDataValues],
           meta,
         })}
-        isSorted={false}
+        shouldSort={false}
         raw={false}
         isContextData
       />

--- a/static/app/components/events/device.tsx
+++ b/static/app/components/events/device.tsx
@@ -20,7 +20,7 @@ export function EventDevice({event}: Props) {
   return (
     <EventDataSection type="device" title={t('Device')} wrapTitle>
       <KeyValueList
-        isSorted={false}
+        shouldSort={false}
         data={[
           {
             key: 'name',

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -266,7 +266,7 @@ class GroupVariant extends Component<Props, State> {
             value: d[1],
           }))}
           isContextData
-          isSorted={false}
+          shouldSort={false}
         />
       </VariantWrapper>
     );

--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -10,15 +10,15 @@ import {Value, ValueProps} from './value';
 
 interface Props extends Pick<ValueProps, 'raw' | 'isContextData'> {
   data?: KeyValueListData;
-  isSorted?: boolean;
   longKeys?: boolean;
   onClick?: () => void;
+  shouldSort?: boolean;
 }
 
 function KeyValueList({
   data,
   isContextData = false,
-  isSorted = true,
+  shouldSort = true,
   raw = false,
   longKeys = false,
   onClick,
@@ -28,7 +28,7 @@ function KeyValueList({
     return null;
   }
 
-  const keyValueData = isSorted ? sortBy(data, [({key}) => key.toLowerCase()]) : data;
+  const keyValueData = shouldSort ? sortBy(data, [({key}) => key.toLowerCase()]) : data;
 
   return (
     <Table className="table key-value" onClick={onClick} {...props}>

--- a/static/app/components/events/interfaces/message.tsx
+++ b/static/app/components/events/interfaces/message.tsx
@@ -34,7 +34,7 @@ function renderParams(params: Props['data']['params'], meta: any) {
       };
     });
 
-    return <KeyValueList data={arrayData} isSorted={false} isContextData />;
+    return <KeyValueList data={arrayData} shouldSort={false} isContextData />;
   }
 
   const objectData = Object.entries(params).map(([key, value]) => ({
@@ -44,7 +44,7 @@ function renderParams(params: Props['data']['params'], meta: any) {
     meta: meta?.data?.params?.[key]?.[''],
   }));
 
-  return <KeyValueList data={objectData} isSorted={false} isContextData />;
+  return <KeyValueList data={objectData} shouldSort={false} isContextData />;
 }
 
 export function Message({data, event}: Props) {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -151,7 +151,7 @@ const DefaultSpanEvidence = ({event, offendingSpans}: SpanEvidenceKeyValueListPr
 );
 
 const PresortedKeyValueList = ({data}: {data: KeyValueListData}) => (
-  <KeyValueList isSorted={false} data={data} />
+  <KeyValueList shouldSort={false} data={data} />
 );
 
 const makeTransactionNameRow = (event: Event) => makeRow(t('Transaction'), event.title);


### PR DESCRIPTION
`isSorted` is a little confusing. It's referring to the component itself, as in `isSorted={true}` means you're creating a sorted Key Value List, so it sorts the data. This is a bit ambiguous because it could also apply to the data, i.e., the data is sorted, so don't sort it again.

`shouldSort` is clearer. `shouldSort={true}` (the default) means the component should sort the data. Matches a pattern we use elsewhere in the codebase.
