### PR TITLE
ref(js): useResizableDrawer works with size

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
@@ -71,36 +71,32 @@ export function ProfileDetails(props: ProfileDetailsProps) {
   const detailsBarRef = useRef<HTMLDivElement>(null);
 
   const resizableOptions: UseResizableDrawerOptions = useMemo(() => {
-    const initialDimensions: [number, number] | [undefined, number] =
-      flamegraphPreferences.layout === 'table bottom' ? [260, 200] : [0, 200];
+    const isSidebarLayout =
+      flamegraphPreferences.layout === 'table left' ||
+      flamegraphPreferences.layout === 'table right';
 
-    const onResize = (
-      newDimensions: [number, number],
-      maybeOldDimensions?: [number, number]
-    ) => {
+    // Only used when in sidebar layout
+    const initialSize = isSidebarLayout ? 260 : 0;
+
+    const onResize = (newSize: number, maybeOldSize?: number) => {
       if (!detailsBarRef.current) {
         return;
       }
 
-      if (
-        flamegraphPreferences.layout === 'table left' ||
-        flamegraphPreferences.layout === 'table right'
-      ) {
+      if (isSidebarLayout) {
         detailsBarRef.current.style.width = `100%`;
-        detailsBarRef.current.style.height =
-          (maybeOldDimensions?.[1] ?? newDimensions[1]) + 'px';
+        detailsBarRef.current.style.height = `${maybeOldSize ?? newSize}px`;
       } else {
-        detailsBarRef.current.style.height = ``;
-        detailsBarRef.current.style.width = ``;
+        detailsBarRef.current.style.height = '';
+        detailsBarRef.current.style.width = '';
       }
     };
 
     return {
-      initialDimensions,
+      initialSize,
       onResize,
-      direction:
-        flamegraphPreferences.layout === 'table bottom' ? 'horizontal-ltr' : 'vertical',
-      min: [0, 26],
+      direction: isSidebarLayout ? 'up' : 'left',
+      min: 26,
     };
   }, [flamegraphPreferences.layout]);
 

--- a/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
@@ -17,6 +17,8 @@ import {CollapsibleTimeline} from './collapsibleTimeline';
 // 664px is approximately the width where we start to scroll inside
 // 30px is the min height to where the drawer can still be resized
 const MIN_FLAMEGRAPH_DRAWER_DIMENSIONS: [number, number] = [680, 30];
+const FLAMEGRAPH_DRAWER_INITIAL_HEIGHT = 180;
+
 interface FlamegraphLayoutProps {
   flamegraph: React.ReactElement;
   flamegraphDrawer: React.ReactElement;
@@ -31,43 +33,37 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
   const flamegraphDrawerRef = useRef<HTMLDivElement>(null);
 
   const resizableOptions: UseResizableDrawerOptions = useMemo(() => {
-    const initialDimensions: [number, number] = [
-      // Half the screen minus the ~sidebar width
-      Math.max(window.innerWidth * 0.5 - 220, MIN_FLAMEGRAPH_DRAWER_DIMENSIONS[0]),
-      180,
-    ];
+    const isSidebarLayout = layout === 'table left' || layout === 'table right';
 
-    const onResize = (
-      newDimensions: [number, number],
-      maybeOldDimensions: [number, number] | undefined
-    ) => {
+    const initialSize = isSidebarLayout
+      ? // Half the screen minus the ~sidebar width
+        Math.max(window.innerWidth * 0.5 - 220, MIN_FLAMEGRAPH_DRAWER_DIMENSIONS[0])
+      : FLAMEGRAPH_DRAWER_INITIAL_HEIGHT;
+
+    const min = isSidebarLayout
+      ? MIN_FLAMEGRAPH_DRAWER_DIMENSIONS[0]
+      : MIN_FLAMEGRAPH_DRAWER_DIMENSIONS[1];
+
+    const onResize = (newSize: number, maybeOldSize: number | undefined) => {
       if (!flamegraphDrawerRef.current) {
         return;
       }
 
-      if (layout === 'table left' || layout === 'table right') {
-        flamegraphDrawerRef.current.style.width = `${
-          maybeOldDimensions?.[0] ?? newDimensions[0]
-        }px`;
+      if (isSidebarLayout) {
+        flamegraphDrawerRef.current.style.width = `${maybeOldSize ?? newSize}px`;
         flamegraphDrawerRef.current.style.height = `100%`;
       } else {
-        flamegraphDrawerRef.current.style.height = `${
-          maybeOldDimensions?.[1] ?? newDimensions[1]
-        }px`;
+        flamegraphDrawerRef.current.style.height = `${maybeOldSize ?? newSize}px`;
         flamegraphDrawerRef.current.style.width = `100%`;
       }
     };
 
     return {
-      initialDimensions,
+      initialSize,
       onResize,
       direction:
-        layout === 'table left'
-          ? 'horizontal-ltr'
-          : layout === 'table right'
-          ? 'horizontal-rtl'
-          : 'vertical',
-      min: MIN_FLAMEGRAPH_DRAWER_DIMENSIONS,
+        layout === 'table left' ? 'left' : layout === 'table right' ? 'right' : 'up',
+      min,
     };
   }, [layout]);
 

--- a/static/app/utils/profiling/hooks/useResizableDrawer.tsx
+++ b/static/app/utils/profiling/hooks/useResizableDrawer.tsx
@@ -1,40 +1,62 @@
 import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
 export interface UseResizableDrawerOptions {
-  direction: 'horizontal-ltr' | 'horizontal-rtl' | 'vertical';
-  min: [number, number];
-  onResize: (
-    newDimensions: [number, number],
-    maybeOldDimensions?: [number, number]
-  ) => void;
-  initialDimensions?: [number, number];
+  /**
+   * When dragging, which direction should be used for the delta
+   */
+  direction: 'right' | 'left' | 'down' | 'up';
+  /**
+   * The minimum sizes the container may be dragged to
+   */
+  min: number;
+  /**
+   * Triggered while dragging
+   */
+  onResize: (newSize: number, maybeOldSize?: number) => void;
+  /**
+   * The starting size of the container. If not specified will be assumed as 0
+   */
+  initialSize?: number;
 }
 
+/**
+ * Hook to support draggable container resizing
+ *
+ * This only resizes one dimension at a time.
+ */
 export function useResizableDrawer(options: UseResizableDrawerOptions): {
-  dimensions: [number, number];
+  /**
+   * Apply to the drag handle element
+   */
   onMouseDown: React.MouseEventHandler<HTMLElement>;
+  /**
+   * The resulting size of the container axis. Updated while dragging.
+   *
+   * NOTE: Be careful using this as this as react state updates are not
+   * synchronous, you may want to update the element size using onResize instead
+   */
+  size: number;
 } {
   const rafIdRef = useRef<number | null>(null);
-  const startResizeVectorRef = useRef<[number, number] | null>(null);
-  const [dimensions, setDimensions] = useState<[number, number]>([
-    options.initialDimensions ? options.initialDimensions[0] : 0,
-    options.initialDimensions ? options.initialDimensions[1] : 0,
-  ]);
+  const currentMouseVectorRaf = useRef<[number, number] | null>(null);
+  const [size, setSize] = useState<number>(options.initialSize ?? 0);
 
   // We intentionally fire this once at mount to ensure the dimensions are set and
   // any potentional values set by CSS will be overriden. If no initialDimensions are provided,
   // invoke the onResize callback with the previously stored dimensions.
   useLayoutEffect(() => {
-    options.onResize(options.initialDimensions ?? [0, 0], dimensions);
+    options.onResize(options.initialSize ?? 0, size);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.direction]);
 
-  const dimensionsRef = useRef<[number, number]>(dimensions);
-  dimensionsRef.current = dimensions;
+  const sizeRef = useRef<number>(size);
+  sizeRef.current = size;
 
   const onMouseMove = useCallback(
     (event: MouseEvent) => {
-      document.body.style.pointerEvents = 'none';
+      const isXAxis = options.direction === 'left' || options.direction === 'right';
+      const isInverted = options.direction === 'down' || options.direction === 'left';
+
       document.body.style.userSelect = 'none';
 
       if (rafIdRef.current !== null) {
@@ -42,35 +64,27 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
       }
 
       rafIdRef.current = window.requestAnimationFrame(() => {
-        if (!startResizeVectorRef.current) {
+        if (!currentMouseVectorRaf.current) {
           return;
         }
-        const currentPositionVector: [number, number] = [event.clientX, event.clientY];
+        const newPositionVector: [number, number] = [event.clientX, event.clientY];
 
-        const distance = [
-          startResizeVectorRef.current[0] - currentPositionVector[0],
-          startResizeVectorRef.current[1] - currentPositionVector[1],
+        const positionDelta = [
+          currentMouseVectorRaf.current[0] - newPositionVector[0],
+          currentMouseVectorRaf.current[1] - newPositionVector[1],
         ];
 
-        startResizeVectorRef.current = currentPositionVector;
+        currentMouseVectorRaf.current = newPositionVector;
 
-        const newDimensions: [number, number] = [
-          // Round to 1px precision
-          Math.round(
-            Math.max(
-              options.min[0],
-              dimensionsRef.current[0] +
-                distance[0] * (options.direction === 'horizontal-ltr' ? -1 : 1)
-            )
-          ),
-          // Round to 1px precision
-          Math.round(
-            Math.max(options.min[1] ?? 0, dimensionsRef.current[1] + distance[1])
-          ),
-        ];
+        const sizeDelta = isXAxis ? positionDelta[0] : positionDelta[1];
 
-        options.onResize(newDimensions);
-        setDimensions(newDimensions);
+        // Round to 1px precision
+        const newSize = Math.round(
+          Math.max(options.min, sizeRef.current + sizeDelta * (isInverted ? -1 : 1))
+        );
+
+        options.onResize(newSize);
+        setSize(newSize);
       });
     },
     [options]
@@ -85,7 +99,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
 
   const onMouseDown = useCallback(
     (evt: React.MouseEvent<HTMLElement>) => {
-      startResizeVectorRef.current = [evt.clientX, evt.clientY];
+      currentMouseVectorRaf.current = [evt.clientX, evt.clientY];
 
       document.addEventListener('mousemove', onMouseMove, {passive: true});
       document.addEventListener('mouseup', onMouseUp);
@@ -101,5 +115,5 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
     };
   });
 
-  return {dimensions, onMouseDown};
+  return {size, onMouseDown};
 }


### PR DESCRIPTION
Instead of having the useResizableDrawer hook accept a dimension array
where the dimension that gets resized depends on the `direction` option,
the hook now only deals with a single axis and describes it as "size".

This makes the hook easier to reason about since previously the value of
the unused dimension was not important.

Additional changes include:

 - Options are now documented

 - `direction` values have changed to cardinal directions, and now
   includes `south`, which it did not support before

 - Usage in FlamegraphLayout has been updated to take into account usage
   of size and now discriminates itself which axis to apply the size to.