### PR TITLE
feat(perf-issues): Add Slow DB Span Admin Options

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -34,6 +34,10 @@ const optionsAvailable = [
   'performance.issues.compressed_assets.ea-rollout',
   'performance.issues.compressed_assets.ga-rollout',
   'performance.issues.file_io_main_thread.problem-creation',
+  'performance.issues.slow_span.problem-creation',
+  'performance.issues.slow_span.la-rollout',
+  'performance.issues.slow_span.ea-rollout',
+  'performance.issues.slow_span.ga-rollout',
 ];
 
 type Field = ReturnType<typeof getOption>;
@@ -138,6 +142,13 @@ export default class AdminSettings extends AsyncView<{}, State> {
             <Panel>
               <PanelHeader>Performance Issues - File IO on Main Thread</PanelHeader>
               {fields['performance.issues.file_io_main_thread.problem-creation']}
+            </Panel>
+            <Panel>
+              <PanelHeader>Performance Issues - Slow DB Span Detector</PanelHeader>
+              {fields['performance.issues.slow_span.problem-creation']}
+              {fields['performance.issues.slow_span.la-rollout']}
+              {fields['performance.issues.slow_span.ea-rollout']}
+              {fields['performance.issues.slow_span.ga-rollout']}
             </Panel>
           </Feature>
         </Form>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -279,6 +279,38 @@ const performanceOptionDefinitions: Field[] = [
     ),
     ...HIGH_THROUGHPUT_RATE_OPTION,
   },
+  {
+    key: 'performance.issues.slow_span.problem-creation',
+    label: t('Problem Creation Rate'),
+    help: t(
+      'Controls the overall rate at which performance problems are detected by the slow DB span detector.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.slow_span.la-rollout',
+    label: t('Limited Availability Detection Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the slow DB span detector for LA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.slow_span.ea-rollout',
+    label: t('Early Adopter Detection Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the slow DB span detector for EA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.slow_span.ga-rollout',
+    label: t('General Availability Detection Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the slow DB span detector for GA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
 ];
 
 // This are ordered based on their display order visually


### PR DESCRIPTION
Adds options to control the rollout and creation of Slow DB Span Issues for the admin UI