### PR TITLE
fix(ui): Use plainTextLabel on rule option select

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -68,10 +68,11 @@ const createSelectOptions = (
 
     return {
       value: node,
+      plainTextLabel: node.prompt ?? node.label,
       label: (
         <Fragment>
           {isNew && <StyledFeatureBadge type="new" noTooltip />}
-          {node.prompt?.length ? node.prompt : node.label}
+          {node.prompt ?? node.label}
         </Fragment>
       ),
     };


### PR DESCRIPTION
This fixes an issue where the options could not be searched since the
labels were react elements