### PR TITLE
fix(js): Use named export for charts tooltip

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -46,7 +46,7 @@ import {defined} from 'sentry/utils';
 
 import Grid from './components/grid';
 import Legend from './components/legend';
-import Tooltip, {TooltipSubLabel} from './components/tooltip';
+import {ChartTooltip, TooltipSubLabel} from './components/tooltip';
 import XAxis from './components/xAxis';
 import YAxis from './components/yAxis';
 import LineSeries from './series/lineSeries';
@@ -476,7 +476,7 @@ function BaseChartUnwrapped({
 
   const tooltipOrNone =
     tooltip !== null
-      ? Tooltip({
+      ? ChartTooltip({
           showTimeInTooltip,
           isGroupedByDate,
           addSecondsToTimeFormat,

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -295,7 +295,7 @@ type Props = ChartProps['tooltip'] &
     chartId?: string;
   };
 
-export default function Tooltip({
+export function ChartTooltip({
   filter,
   isGroupedByDate,
   showTimeInTooltip,
@@ -402,3 +402,6 @@ export default function Tooltip({
     ...props,
   };
 }
+
+const DoNotUseChartTooltip = ChartTooltip;
+export default DoNotUseChartTooltip;

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 import {AreaChart, AreaChartProps} from 'sentry/components/charts/areaChart';
 import Grid from 'sentry/components/charts/components/grid';
-import Tooltip from 'sentry/components/charts/components/tooltip';
+import {ChartTooltip} from 'sentry/components/charts/components/tooltip';
 import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import EmptyMessage from 'sentry/components/emptyMessage';
@@ -68,7 +68,7 @@ function MemoryChart({
       left: space(1),
       right: space(1),
     }),
-    tooltip: Tooltip({
+    tooltip: ChartTooltip({
       appendToBody: true,
       trigger: 'axis',
       renderMode: 'html',


### PR DESCRIPTION
Because it was a default export it was taking precedence over the other
component tooltip in imports

Also going to rename to `ChartTooltip`