### PR TITLE
fix(txnames): Clear redis set after each cluster run

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -66,6 +66,13 @@ def get_transaction_names(project: Project) -> Iterator[str]:
     return client.sscan_iter(redis_key)  # type: ignore
 
 
+def clear_transaction_names(project: Project) -> None:
+    client = get_redis_client()
+    redis_key = _get_redis_key(project)
+
+    client.delete(redis_key)
+
+
 def record_transaction_name(project: Project, event_data: Mapping[str, Any], **kwargs: Any) -> None:
     transaction_info = event_data.get("transaction_info") or {}
 

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -66,3 +66,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 clusterer.add_input(redis.get_transaction_names(project))
                 new_rules = clusterer.get_rules()
                 rules.update_rules(project, new_rules)
+
+                # Clear transaction names to prevent the set from picking up
+                # noise over a long time range.
+                redis.clear_transaction_names(project)

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _store_transaction_name,
+    clear_transaction_names,
     get_transaction_names,
     record_transaction_name,
 )
@@ -70,6 +71,18 @@ def test_collection():
 
     project3 = Project(id=103, name="project3", organization_id=1)
     assert set() == set(get_transaction_names(project3))
+
+
+def test_clear_redis():
+    project = Project(id=101, name="p1", organization_id=1)
+    _store_transaction_name(project, "foo")
+    assert set(get_transaction_names(project)) == {"foo"}
+    clear_transaction_names(project)
+    assert set(get_transaction_names(project)) == set()
+
+    # Deleting for a none-existing project does not crash:
+    project2 = Project(id=666, name="project2", organization_id=1)
+    clear_transaction_names(project2)
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 100)
@@ -173,11 +186,14 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
             _store_transaction_name(project1, f"/users/trans/tx-{project1.id}-{i}")
             _store_transaction_name(project1, f"/test/path/{i}")
 
+        # Add a transaction to project2 so it runs again
+        _store_transaction_name(project2, "foo")
+
         with mock.patch("sentry.ingest.transaction_clusterer.tasks.PROJECTS_PER_TASK", 1):
             spawn_clusterers()
 
         # One project per batch now:
-        assert cluster_projects_delay.call_count == 2
+        assert cluster_projects_delay.call_count == 2, cluster_projects_delay.call_args
 
         pr_rules = _get_rules(project1)
         assert pr_rules.keys() == {


### PR DESCRIPTION
When our clustering approach is successful, it will discover all relevant rules over time, and the only new transaction names added to the set will be random noise (for example, 404 requests). To prevent that we derive rules from this noise, clear the redis set after every clusterer run.

Fixes https://github.com/getsentry/team-ingest/issues/40.