### PR TITLE
feat: add project_platform to analytics events

### DIFF
--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -10,12 +10,15 @@ export type ProfilingEventParameters = {
     action: 'done' | 'dismissed';
   };
   'profiling_views.profile_details': {
+    project_id: string | number | undefined;
     project_platform: PlatformKey | undefined;
   };
   'profiling_views.profile_flamegraph': {
+    project_id: string | number | undefined;
     project_platform: PlatformKey | undefined;
   };
   'profiling_views.profile_summary': {
+    project_id: string | number | undefined;
     project_platform: PlatformKey | undefined;
   };
   'profiling_views.visit_discord_channel': {};

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -1,4 +1,4 @@
-import {Project} from 'sentry/types';
+import {PlatformKey} from 'sentry/data/platformCategories';
 
 export type ProfilingEventParameters = {
   'profiling_views.give_feedback_action': {};
@@ -10,13 +10,13 @@ export type ProfilingEventParameters = {
     action: 'done' | 'dismissed';
   };
   'profiling_views.profile_details': {
-    project: Project | undefined;
+    project_platform: PlatformKey | undefined;
   };
   'profiling_views.profile_flamegraph': {
-    project: Project | undefined;
+    project_platform: PlatformKey | undefined;
   };
   'profiling_views.profile_summary': {
-    project: Project | undefined;
+    project_platform: PlatformKey | undefined;
   };
   'profiling_views.visit_discord_channel': {};
 };

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -1,3 +1,5 @@
+import {Project} from 'sentry/types';
+
 export type ProfilingEventParameters = {
   'profiling_views.give_feedback_action': {};
   'profiling_views.go_to_flamegraph': {source: string};
@@ -7,9 +9,15 @@ export type ProfilingEventParameters = {
   'profiling_views.onboarding_action': {
     action: 'done' | 'dismissed';
   };
-  'profiling_views.profile_details': {};
-  'profiling_views.profile_flamegraph': {};
-  'profiling_views.profile_summary': {};
+  'profiling_views.profile_details': {
+    project: Project | undefined;
+  };
+  'profiling_views.profile_flamegraph': {
+    project: Project | undefined;
+  };
+  'profiling_views.profile_summary': {
+    project: Project | undefined;
+  };
   'profiling_views.visit_discord_channel': {};
 };
 

--- a/static/app/utils/profiling/hooks/useCurrentProjectFromRouteParam.tsx
+++ b/static/app/utils/profiling/hooks/useCurrentProjectFromRouteParam.tsx
@@ -1,0 +1,12 @@
+import {useParams} from 'sentry/utils/useParams';
+import useProjects from 'sentry/utils/useProjects';
+
+export function useCurrentProjectFromRouteParam() {
+  const params = useParams();
+  const projects = useProjects({limit: 1, slugs: [params?.projectId]});
+  const currentProject = projects.projects?.[0] ?? null;
+  return {
+    currentProject,
+    ...projects,
+  };
+}

--- a/static/app/utils/profiling/hooks/useCurrentProjectFromRouteParam.tsx
+++ b/static/app/utils/profiling/hooks/useCurrentProjectFromRouteParam.tsx
@@ -4,9 +4,5 @@ import useProjects from 'sentry/utils/useProjects';
 export function useCurrentProjectFromRouteParam() {
   const params = useParams();
   const projects = useProjects({limit: 1, slugs: [params?.projectId]});
-  const currentProject = projects.projects?.[0] ?? null;
-  return {
-    currentProject,
-    ...projects,
-  };
+  return projects.projects?.[0] ?? null;
 }

--- a/static/app/views/profiling/profileDetails/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails/profileDetails.tsx
@@ -15,6 +15,7 @@ function ProfileDetails() {
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
       organization,
+      project_id: currentProject?.id,
       project_platform: currentProject?.platform,
     });
     // ignore  currentProject so we don't block the analytics event

--- a/static/app/views/profiling/profileDetails/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails/profileDetails.tsx
@@ -15,7 +15,7 @@ function ProfileDetails() {
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
       organization,
-      project: currentProject,
+      project_platform: currentProject?.platform,
     });
     // ignore  currentProject so we don't block the analytics event
     // or fire more than once unnecessarily

--- a/static/app/views/profiling/profileDetails/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails/profileDetails.tsx
@@ -4,17 +4,22 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {useCurrentProjectFromRouteParam} from 'sentry/utils/profiling/hooks/useCurrentProjectFromRouteParam';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {ProfileDetailsTable} from './components/profileDetailsTable';
 
 function ProfileDetails() {
   const organization = useOrganization();
-
+  const {currentProject} = useCurrentProjectFromRouteParam();
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
       organization,
+      project: currentProject,
     });
+    // ignore  currentProject so we don't block the analytics event
+    // or fire more than once unnecessarily
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organization]);
 
   return (

--- a/static/app/views/profiling/profileDetails/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails/profileDetails.tsx
@@ -11,7 +11,7 @@ import {ProfileDetailsTable} from './components/profileDetailsTable';
 
 function ProfileDetails() {
   const organization = useOrganization();
-  const {currentProject} = useCurrentProjectFromRouteParam();
+  const currentProject = useCurrentProjectFromRouteParam();
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
       organization,

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -60,7 +60,7 @@ function ProfileFlamegraph(): React.ReactElement {
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_flamegraph', {
       organization,
-      project: currentProject,
+      project_platform: currentProject?.platform,
     });
     // ignore  currentProject so we don't block the analytics event
     // or fire more than once unnecessarily

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -61,6 +61,7 @@ function ProfileFlamegraph(): React.ReactElement {
     trackAdvancedAnalyticsEvent('profiling_views.profile_flamegraph', {
       organization,
       project_platform: currentProject?.platform,
+      project_id: currentProject?.id,
     });
     // ignore  currentProject so we don't block the analytics event
     // or fire more than once unnecessarily

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -55,7 +55,7 @@ function ProfileFlamegraph(): React.ReactElement {
     }
   );
 
-  const {currentProject} = useCurrentProjectFromRouteParam();
+  const currentProject = useCurrentProjectFromRouteParam();
 
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_flamegraph', {

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -22,6 +22,7 @@ import {
   FlamegraphStateQueryParamSync,
 } from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphQueryParamSync';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
+import {useCurrentProjectFromRouteParam} from 'sentry/utils/profiling/hooks/useCurrentProjectFromRouteParam';
 import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -54,10 +55,16 @@ function ProfileFlamegraph(): React.ReactElement {
     }
   );
 
+  const {currentProject} = useCurrentProjectFromRouteParam();
+
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_flamegraph', {
       organization,
+      project: currentProject,
     });
+    // ignore  currentProject so we don't block the analytics event
+    // or fire more than once unnecessarily
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organization]);
 
   const onImport: ProfileDragDropImportProps['onImport'] = useCallback(

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -45,6 +45,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
       organization,
       project_platform: project?.platform,
+      project_id: project?.id,
     });
     // ignore  currentProject so we don't block the analytics event
     // or fire more than once unnecessarily

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -20,11 +20,11 @@ import {PageFilters, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {isAggregateField} from 'sentry/utils/discover/fields';
+import {useCurrentProjectFromRouteParam} from 'sentry/utils/profiling/hooks/useCurrentProjectFromRouteParam';
 import {useProfileFilters} from 'sentry/utils/profiling/hooks/useProfileFilters';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
 import {ProfileSummaryContent} from './content';
@@ -39,19 +39,17 @@ interface ProfileSummaryPageProps {
 
 function ProfileSummaryPage(props: ProfileSummaryPageProps) {
   const organization = useOrganization();
-  const {projects} = useProjects({
-    slugs: defined(props.params.projectId) ? [props.params.projectId] : [],
-  });
+  const {currentProject: project} = useCurrentProjectFromRouteParam();
 
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
       organization,
+      project,
     });
+    // ignore  currentProject so we don't block the analytics event
+    // or fire more than once unnecessarily
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organization]);
-
-  // Extract the project matching the provided project slug,
-  // if it doesn't exist, set this to null and handle it accordingly.
-  const project = projects.length === 1 ? projects[0] : null;
 
   const transaction = decodeScalar(props.location.query.transaction);
 

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -39,7 +39,7 @@ interface ProfileSummaryPageProps {
 
 function ProfileSummaryPage(props: ProfileSummaryPageProps) {
   const organization = useOrganization();
-  const {currentProject: project} = useCurrentProjectFromRouteParam();
+  const project = useCurrentProjectFromRouteParam();
 
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -44,7 +44,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
   useEffect(() => {
     trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
       organization,
-      project,
+      project_platform: project?.platform,
     });
     // ignore  currentProject so we don't block the analytics event
     // or fire more than once unnecessarily


### PR DESCRIPTION
## Summary
This change adds `project_platform` to our analytics event in order to better segment users in amplitude.

`project_platform` is an existing event property in amplitude
![image](https://user-images.githubusercontent.com/7349258/213215304-2fc943c1-7513-41d8-bac5-a3a97882cb27.png)



Originally the plan was to pass the whole project object, but that would be an excessive amount of data