### PR TITLE
ref(consumers): add no-strict-offset-reset to many consumers

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 def get_metrics_billing_consumer(
     group_id: str,
     auto_offset_reset: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
     force_topic: Union[str, None],
     force_cluster: Union[str, None],
     max_batch_size: int,
@@ -37,7 +37,7 @@ def get_metrics_billing_consumer(
             build_kafka_consumer_configuration(
                 default_config={},
                 group_id=group_id,
-                strict_offset_reset=not no_strict_offset_reset,
+                strict_offset_reset=strict_offset_reset,
                 auto_offset_reset=auto_offset_reset,
                 bootstrap_servers=bootstrap_servers,
             ),

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 def get_metrics_billing_consumer(
     group_id: str,
     auto_offset_reset: str,
+    no_strict_offset_reset: bool,
     force_topic: Union[str, None],
     force_cluster: Union[str, None],
     max_batch_size: int,
@@ -36,6 +37,7 @@ def get_metrics_billing_consumer(
             build_kafka_consumer_configuration(
                 default_config={},
                 group_id=group_id,
+                strict_offset_reset=not no_strict_offset_reset,
                 auto_offset_reset=auto_offset_reset,
                 bootstrap_servers=bootstrap_servers,
             ),

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -32,12 +32,14 @@ class InvalidEventPayloadError(Exception):
 
 def get_occurrences_ingest_consumer(
     consumer_type: str,
+    no_strict_offset_reset: bool,
 ) -> StreamProcessor[KafkaPayload]:
-    return create_ingest_occurences_consumer(consumer_type)
+    return create_ingest_occurences_consumer(consumer_type, no_strict_offset_reset)
 
 
 def create_ingest_occurences_consumer(
-    topic_name: str, **options: Any
+    topic_name: str,
+    no_strict_offset_reset: bool,
 ) -> StreamProcessor[KafkaPayload]:
     kafka_cluster = settings.KAFKA_TOPICS[topic_name]["cluster"]
     create_topics(kafka_cluster, [topic_name])
@@ -47,6 +49,7 @@ def create_ingest_occurences_consumer(
             get_kafka_consumer_cluster_options(kafka_cluster),
             auto_offset_reset="latest",
             group_id="occurrence-consumer",
+            strict_offset_reset=not no_strict_offset_reset,
         )
     )
 

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -32,14 +32,14 @@ class InvalidEventPayloadError(Exception):
 
 def get_occurrences_ingest_consumer(
     consumer_type: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
 ) -> StreamProcessor[KafkaPayload]:
-    return create_ingest_occurences_consumer(consumer_type, no_strict_offset_reset)
+    return create_ingest_occurences_consumer(consumer_type, strict_offset_reset)
 
 
 def create_ingest_occurences_consumer(
     topic_name: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
 ) -> StreamProcessor[KafkaPayload]:
     kafka_cluster = settings.KAFKA_TOPICS[topic_name]["cluster"]
     create_topics(kafka_cluster, [topic_name])
@@ -49,7 +49,7 @@ def create_ingest_occurences_consumer(
             get_kafka_consumer_cluster_options(kafka_cluster),
             auto_offset_reset="latest",
             group_id="occurrence-consumer",
-            strict_offset_reset=not no_strict_offset_reset,
+            strict_offset_reset=strict_offset_reset,
         )
     )
 

--- a/src/sentry/profiles/consumers/__init__.py
+++ b/src/sentry/profiles/consumers/__init__.py
@@ -17,7 +17,7 @@ def get_profiles_process_consumer(
     topic: str,
     group_id: str,
     auto_offset_reset: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
     force_topic: str | None,
     force_cluster: str | None,
     **options: dict[str, str],
@@ -27,7 +27,7 @@ def get_profiles_process_consumer(
         topic,
         group_id,
         auto_offset_reset=auto_offset_reset,
-        no_strict_offset_reset=no_strict_offset_reset,
+        strict_offset_reset=strict_offset_reset,
         force_cluster=force_cluster,
     )
     consumer = KafkaConsumer(consumer_config)
@@ -43,7 +43,7 @@ def get_config(
     topic: str,
     group_id: str,
     auto_offset_reset: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
     force_cluster: str | None,
 ) -> MutableMapping[str, Any]:
     cluster_name: str = force_cluster or settings.KAFKA_TOPICS[topic]["cluster"]
@@ -53,5 +53,5 @@ def get_config(
         ),
         group_id=group_id,
         auto_offset_reset=auto_offset_reset,
-        strict_offset_reset=not no_strict_offset_reset,
+        strict_offset_reset=strict_offset_reset,
     )

--- a/src/sentry/profiles/consumers/__init__.py
+++ b/src/sentry/profiles/consumers/__init__.py
@@ -17,12 +17,19 @@ def get_profiles_process_consumer(
     topic: str,
     group_id: str,
     auto_offset_reset: str,
+    no_strict_offset_reset: bool,
     force_topic: str | None,
     force_cluster: str | None,
     **options: dict[str, str],
 ) -> StreamProcessor[KafkaPayload]:
     topic = force_topic or topic
-    consumer_config = get_config(topic, group_id, auto_offset_reset, force_cluster)
+    consumer_config = get_config(
+        topic,
+        group_id,
+        auto_offset_reset=auto_offset_reset,
+        no_strict_offset_reset=no_strict_offset_reset,
+        force_cluster=force_cluster,
+    )
     consumer = KafkaConsumer(consumer_config)
     return StreamProcessor(
         consumer=consumer,
@@ -33,7 +40,11 @@ def get_profiles_process_consumer(
 
 
 def get_config(
-    topic: str, group_id: str, auto_offset_reset: str, force_cluster: str | None
+    topic: str,
+    group_id: str,
+    auto_offset_reset: str,
+    no_strict_offset_reset: bool,
+    force_cluster: str | None,
 ) -> MutableMapping[str, Any]:
     cluster_name: str = force_cluster or settings.KAFKA_TOPICS[topic]["cluster"]
     return build_kafka_consumer_configuration(
@@ -42,4 +53,5 @@ def get_config(
         ),
         group_id=group_id,
         auto_offset_reset=auto_offset_reset,
+        strict_offset_reset=not no_strict_offset_reset,
     )

--- a/src/sentry/region_to_control/consumer.py
+++ b/src/sentry/region_to_control/consumer.py
@@ -21,7 +21,7 @@ from .messages import AuditLogEvent, RegionToControlMessage, UserIpEvent
 
 def get_region_to_control_consumer(
     group_id: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
     auto_offset_reset: str = "earliest",
     **opts: Any,
 ) -> StreamProcessor[KafkaPayload]:
@@ -34,7 +34,7 @@ def get_region_to_control_consumer(
                 cluster_name,
             ),
             auto_offset_reset=auto_offset_reset,
-            strict_offset_reset=not no_strict_offset_reset,
+            strict_offset_reset=strict_offset_reset,
             group_id=group_id,
         )
     )

--- a/src/sentry/region_to_control/consumer.py
+++ b/src/sentry/region_to_control/consumer.py
@@ -21,6 +21,7 @@ from .messages import AuditLogEvent, RegionToControlMessage, UserIpEvent
 
 def get_region_to_control_consumer(
     group_id: str,
+    no_strict_offset_reset: bool,
     auto_offset_reset: str = "earliest",
     **opts: Any,
 ) -> StreamProcessor[KafkaPayload]:
@@ -33,6 +34,7 @@ def get_region_to_control_consumer(
                 cluster_name,
             ),
             auto_offset_reset=auto_offset_reset,
+            strict_offset_reset=not no_strict_offset_reset,
             group_id=group_id,
         )
     )

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -53,10 +53,7 @@ _DEFAULT_DAEMONS = {
         "--no-strict-offset-reset",
     ],
     "ingest": ["sentry", "run", "ingest-consumer", "--all-consumer-types"],
-    # TODO: we would want to pass auto-offset-reset=latest and
-    # no-strict-offset-reset here but this consumer takes no
-    # arguments.
-    "occurrences": ["sentry", "run", "occurrences-ingest-consumer"],
+    "occurrences": ["sentry", "run", "occurrences-ingest-consumer", "--no-strict-offset-reset"],
     # TODO: this consumer does not take no-strict-offset-reset
     "region_to_control": ["sentry", "run", "region-to-control-consumer", "--region-name", "_local"],
     "server": ["sentry", "run", "web"],

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -87,7 +87,7 @@ _DEFAULT_DAEMONS = {
         *_DEV_METRICS_INDEXER_ARGS,
     ],
     # TODO: we want to pass no-strict-offset-reset here
-    "metrics-billing": ["sentry", "run", "billing-metrics-consumer"],
+    "metrics-billing": ["sentry", "run", "billing-metrics-consumer", "--no-strict-offset-reset"],
     # TODO: we want to pass no-strict-offset-reset here
     "profiles": ["sentry", "run", "ingest-profiles"],
 }

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -86,10 +86,8 @@ _DEFAULT_DAEMONS = {
         "performance",
         *_DEV_METRICS_INDEXER_ARGS,
     ],
-    # TODO: we want to pass no-strict-offset-reset here
     "metrics-billing": ["sentry", "run", "billing-metrics-consumer", "--no-strict-offset-reset"],
-    # TODO: we want to pass no-strict-offset-reset here
-    "profiles": ["sentry", "run", "ingest-profiles"],
+    "profiles": ["sentry", "run", "ingest-profiles", "--no-strict-offset-reset"],
 }
 
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -54,8 +54,14 @@ _DEFAULT_DAEMONS = {
     ],
     "ingest": ["sentry", "run", "ingest-consumer", "--all-consumer-types"],
     "occurrences": ["sentry", "run", "occurrences-ingest-consumer", "--no-strict-offset-reset"],
-    # TODO: this consumer does not take no-strict-offset-reset
-    "region_to_control": ["sentry", "run", "region-to-control-consumer", "--region-name", "_local"],
+    "region_to_control": [
+        "sentry",
+        "run",
+        "region-to-control-consumer",
+        "--region-name",
+        "_local",
+        "--no-strict-offset-reset",
+    ],
     "server": ["sentry", "run", "web"],
     "storybook": ["yarn", "storybook"],
     "subscription-consumer": [

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -24,7 +24,7 @@ _DEV_METRICS_INDEXER_ARGS = [
     # Avoid Offset out of range errors.
     "--auto-offset-reset",
     "latest",
-    # TODO: we want to pass no-strict-offset-reset here
+    "--no-strict-offset-reset",
 ]
 
 _DEFAULT_DAEMONS = {

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -24,6 +24,7 @@ _DEV_METRICS_INDEXER_ARGS = [
     # Avoid Offset out of range errors.
     "--auto-offset-reset",
     "latest",
+    # TODO: we want to pass no-strict-offset-reset here
 ]
 
 _DEFAULT_DAEMONS = {
@@ -37,6 +38,7 @@ _DEFAULT_DAEMONS = {
         "--loglevel=debug",
         "--commit-batch-size=100",
         "--commit-batch-timeout-ms=1000",
+        "--no-strict-offset-reset",
     ],
     "post-process-forwarder-transactions": [
         "sentry",
@@ -48,9 +50,14 @@ _DEFAULT_DAEMONS = {
         "--commit-batch-timeout-ms=1000",
         "--commit-log-topic=snuba-transactions-commit-log",
         "--synchronize-commit-group=transactions_group",
+        "--no-strict-offset-reset",
     ],
     "ingest": ["sentry", "run", "ingest-consumer", "--all-consumer-types"],
+    # TODO: we would want to pass auto-offset-reset=latest and
+    # no-strict-offset-reset here but this consumer takes no
+    # arguments.
     "occurrences": ["sentry", "run", "occurrences-ingest-consumer"],
+    # TODO: this consumer does not take no-strict-offset-reset
     "region_to_control": ["sentry", "run", "region-to-control-consumer", "--region-name", "_local"],
     "server": ["sentry", "run", "web"],
     "storybook": ["yarn", "storybook"],
@@ -79,7 +86,9 @@ _DEFAULT_DAEMONS = {
         "performance",
         *_DEV_METRICS_INDEXER_ARGS,
     ],
+    # TODO: we want to pass no-strict-offset-reset here
     "metrics-billing": ["sentry", "run", "billing-metrics-consumer"],
+    # TODO: we want to pass no-strict-offset-reset here
     "profiles": ["sentry", "run", "ingest-profiles"],
 }
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -72,7 +72,7 @@ def strict_offset_reset_option():
         default=True,
         help=(
             "--strict-offset-reset, the default, means that the kafka consumer "
-            "still errors in case the offset has expired.\n\n"
+            "still errors in case the offset is out of range.\n\n"
             "--no-strict-offset-reset will use the auto offset reset even in that case. "
             "This is useful in development, but not desirable in production since expired "
             "offsets mean data-loss.\n\n"

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -66,10 +66,10 @@ class QueueSetType(click.ParamType):
 QueueSet = QueueSetType()
 
 
-def no_strict_offset_reset_option():
+def strict_offset_reset_option():
     return click.option(
-        "--no-strict-offset-reset",
-        is_flag=True,
+        "--strict-offset-reset/--no-strict-offset-reset",
+        default=True,
         help="Forces the kafka consumer auto offset reset.",
     )
 
@@ -356,7 +356,7 @@ def cron(**options):
     type=click.Choice(["earliest", "latest"]),
     help="Position in the commit log topic to begin reading from when no prior offset has been recorded.",
 )
-@no_strict_offset_reset_option()
+@strict_offset_reset_option()
 # TODO: Remove this option once we have fully cut over to the streaming consumer
 @click.option(
     "--use-streaming-consumer",
@@ -386,7 +386,7 @@ def post_process_forwarder(**options):
             commit_batch_timeout_ms=options["commit_batch_timeout_ms"],
             concurrency=options["concurrency"],
             initial_offset_reset=options["initial_offset_reset"],
-            strict_offset_reset=not options["no_strict_offset_reset"],
+            strict_offset_reset=options["strict_offset_reset"],
             use_streaming_consumer=bool(options["use_streaming_consumer"]),
         )
     except ForwarderNotRequired:
@@ -565,7 +565,7 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 
 
 @run.command("occurrences-ingest-consumer")
-@no_strict_offset_reset_option()
+@strict_offset_reset_option()
 @configuration
 def occurrences_ingest_consumer(**options):
     from django.conf import settings
@@ -589,7 +589,7 @@ def occurrences_ingest_consumer(**options):
     help="Regional name to run the consumer for",
 )
 @batching_kafka_options("region-to-control-consumer", max_batch_size=100)
-@no_strict_offset_reset_option()
+@strict_offset_reset_option()
 @configuration
 def region_to_control_consumer(region_name, **kafka_options):
     """
@@ -610,7 +610,7 @@ def region_to_control_consumer(region_name, **kafka_options):
 @run.command("ingest-metrics-parallel-consumer")
 @log_options()
 @batching_kafka_options("ingest-metrics-consumer")
-@no_strict_offset_reset_option()
+@strict_offset_reset_option()
 @configuration
 @click.option(
     "--processes",
@@ -650,7 +650,7 @@ def metrics_parallel_consumer(**options):
 @run.command("billing-metrics-consumer")
 @log_options()
 @batching_kafka_options("billing-metrics-consumer", max_batch_size=100)
-@no_strict_offset_reset_option()
+@strict_offset_reset_option()
 @configuration
 def metrics_billing_consumer(**options):
     from sentry.ingest.billing_metrics_consumer import get_metrics_billing_consumer
@@ -663,7 +663,7 @@ def metrics_billing_consumer(**options):
 @log_options()
 @click.option("--topic", default="profiles", help="Topic to get profiles data from.")
 @batching_kafka_options("ingest-profiles", max_batch_size=100)
-@no_strict_offset_reset_option()
+@strict_offset_reset_option()
 @configuration
 def profiles_consumer(**options):
     from sentry.profiles.consumers import get_profiles_process_consumer
@@ -690,7 +690,7 @@ def replays_recordings_consumer(**options):
 @log_options()
 @configuration
 @batching_kafka_options("indexer-last-seen-updater-consumer", max_batch_size=100)
-@no_strict_offset_reset_option()
+@strict_offset_reset_option()
 @click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=25000)
 @click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=10000)
 @click.option("--topic", default="snuba-metrics", help="Topic to read indexer output from.")

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -565,8 +565,9 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 
 
 @run.command("occurrences-ingest-consumer")
+@no_strict_offset_reset_option()
 @configuration
-def occurrences_ingest_consumer():
+def occurrences_ingest_consumer(**options):
     from django.conf import settings
 
     from sentry.issues.occurrence_consumer import get_occurrences_ingest_consumer
@@ -575,7 +576,7 @@ def occurrences_ingest_consumer():
     consumer_type = settings.KAFKA_INGEST_OCCURRENCES
 
     with metrics.global_tags(ingest_consumer_types=consumer_type, _all_threads=True):
-        consumer = get_occurrences_ingest_consumer(consumer_type)
+        consumer = get_occurrences_ingest_consumer(consumer_type, **options)
         run_processor_with_signals(consumer)
 
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -66,6 +66,14 @@ class QueueSetType(click.ParamType):
 QueueSet = QueueSetType()
 
 
+def no_strict_offset_reset_option():
+    return click.option(
+        "--no-strict-offset-reset",
+        is_flag=True,
+        help="Forces the kafka consumer auto offset reset.",
+    )
+
+
 @click.group()
 def run():
     "Run a service."
@@ -348,11 +356,7 @@ def cron(**options):
     type=click.Choice(["earliest", "latest"]),
     help="Position in the commit log topic to begin reading from when no prior offset has been recorded.",
 )
-@click.option(
-    "--no-strict-offset-reset",
-    is_flag=True,
-    help="Forces the kafka consumer auto offset reset.",
-)
+@no_strict_offset_reset_option()
 # TODO: Remove this option once we have fully cut over to the streaming consumer
 @click.option(
     "--use-streaming-consumer",
@@ -604,6 +608,7 @@ def region_to_control_consumer(region_name, **kafka_options):
 @run.command("ingest-metrics-parallel-consumer")
 @log_options()
 @batching_kafka_options("ingest-metrics-consumer")
+@no_strict_offset_reset_option()
 @configuration
 @click.option(
     "--processes",
@@ -681,6 +686,7 @@ def replays_recordings_consumer(**options):
 @log_options()
 @configuration
 @batching_kafka_options("indexer-last-seen-updater-consumer", max_batch_size=100)
+@no_strict_offset_reset_option()
 @click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=25000)
 @click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=10000)
 @click.option("--topic", default="snuba-metrics", help="Topic to read indexer output from.")

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -589,6 +589,7 @@ def occurrences_ingest_consumer(**options):
     help="Regional name to run the consumer for",
 )
 @batching_kafka_options("region-to-control-consumer", max_batch_size=100)
+@no_strict_offset_reset_option()
 @configuration
 def region_to_control_consumer(region_name, **kafka_options):
     """

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -70,7 +70,14 @@ def strict_offset_reset_option():
     return click.option(
         "--strict-offset-reset/--no-strict-offset-reset",
         default=True,
-        help="Forces the kafka consumer auto offset reset.",
+        help=(
+            "--strict-offset-reset, the default, means that the kafka consumer "
+            "still errors in case the offset has expired.\n\n"
+            "--no-strict-offset-reset will use the auto offset reset even in that case. "
+            "This is useful in development, but not desirable in production since expired "
+            "offsets mean data-loss.\n\n"
+            "Most consumers that do not have this option at all default to 'Not Strict'."
+        ),
     )
 
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -661,6 +661,7 @@ def metrics_billing_consumer(**options):
 @log_options()
 @click.option("--topic", default="profiles", help="Topic to get profiles data from.")
 @batching_kafka_options("ingest-profiles", max_batch_size=100)
+@no_strict_offset_reset_option()
 @configuration
 def profiles_consumer(**options):
     from sentry.profiles.consumers import get_profiles_process_consumer

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -648,6 +648,7 @@ def metrics_parallel_consumer(**options):
 @run.command("billing-metrics-consumer")
 @log_options()
 @batching_kafka_options("billing-metrics-consumer", max_batch_size=100)
+@no_strict_offset_reset_option()
 @configuration
 def metrics_billing_consumer(**options):
     from sentry.ingest.billing_metrics_consumer import get_metrics_billing_consumer

--- a/src/sentry/sentry_metrics/consumers/indexer/common.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/common.py
@@ -22,7 +22,9 @@ DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
 DEFAULT_QUEUED_MIN_MESSAGES = 100000
 
 
-def get_config(topic: str, group_id: str, auto_offset_reset: str) -> MutableMapping[Any, Any]:
+def get_config(
+    topic: str, group_id: str, auto_offset_reset: str, no_strict_offset_reset: bool
+) -> MutableMapping[Any, Any]:
     cluster_name: str = settings.KAFKA_TOPICS[topic]["cluster"]
     consumer_config: MutableMapping[str, Any] = build_kafka_consumer_configuration(
         kafka_config.get_kafka_consumer_cluster_options(
@@ -30,6 +32,7 @@ def get_config(topic: str, group_id: str, auto_offset_reset: str) -> MutableMapp
         ),
         group_id=group_id,
         auto_offset_reset=auto_offset_reset,
+        strict_offset_reset=not no_strict_offset_reset,
         queued_max_messages_kbytes=DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
         queued_min_messages=DEFAULT_QUEUED_MIN_MESSAGES,
     )

--- a/src/sentry/sentry_metrics/consumers/indexer/common.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/common.py
@@ -23,7 +23,7 @@ DEFAULT_QUEUED_MIN_MESSAGES = 100000
 
 
 def get_config(
-    topic: str, group_id: str, auto_offset_reset: str, no_strict_offset_reset: bool
+    topic: str, group_id: str, auto_offset_reset: str, strict_offset_reset: bool
 ) -> MutableMapping[Any, Any]:
     cluster_name: str = settings.KAFKA_TOPICS[topic]["cluster"]
     consumer_config: MutableMapping[str, Any] = build_kafka_consumer_configuration(
@@ -32,7 +32,7 @@ def get_config(
         ),
         group_id=group_id,
         auto_offset_reset=auto_offset_reset,
-        strict_offset_reset=not no_strict_offset_reset,
+        strict_offset_reset=strict_offset_reset,
         queued_max_messages_kbytes=DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
         queued_min_messages=DEFAULT_QUEUED_MIN_MESSAGES,
     )

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -184,7 +184,7 @@ def get_parallel_metrics_consumer(
     output_block_size: int,
     group_id: str,
     auto_offset_reset: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
     indexer_profile: MetricsIngestConfiguration,
     slicing_router: Optional[SlicingRouter],
     # TODO: those options are discarded, try removing this?
@@ -211,7 +211,7 @@ def get_parallel_metrics_consumer(
                 indexer_profile.input_topic,
                 group_id,
                 auto_offset_reset=auto_offset_reset,
-                no_strict_offset_reset=no_strict_offset_reset,
+                strict_offset_reset=strict_offset_reset,
             )
         ),
         Topic(indexer_profile.input_topic),

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -184,8 +184,10 @@ def get_parallel_metrics_consumer(
     output_block_size: int,
     group_id: str,
     auto_offset_reset: str,
+    no_strict_offset_reset: bool,
     indexer_profile: MetricsIngestConfiguration,
     slicing_router: Optional[SlicingRouter],
+    # TODO: those options are discarded, try removing this?
     **options: Mapping[str, Union[str, int]],
 ) -> StreamProcessor[KafkaPayload]:
     processing_factory = MetricsConsumerStrategyFactory(
@@ -204,7 +206,14 @@ def get_parallel_metrics_consumer(
     create_topics(cluster_name, [indexer_profile.input_topic])
 
     return StreamProcessor(
-        KafkaConsumer(get_config(indexer_profile.input_topic, group_id, auto_offset_reset)),
+        KafkaConsumer(
+            get_config(
+                indexer_profile.input_topic,
+                group_id,
+                auto_offset_reset=auto_offset_reset,
+                no_strict_offset_reset=no_strict_offset_reset,
+            )
+        ),
         Topic(indexer_profile.input_topic),
         processing_factory,
         CommitPolicy(

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -187,8 +187,6 @@ def get_parallel_metrics_consumer(
     strict_offset_reset: bool,
     indexer_profile: MetricsIngestConfiguration,
     slicing_router: Optional[SlicingRouter],
-    # TODO: those options are discarded, try removing this?
-    **options: Mapping[str, Union[str, int]],
 ) -> StreamProcessor[KafkaPayload]:
     processing_factory = MetricsConsumerStrategyFactory(
         max_msg_batch_size=max_msg_batch_size,

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -2,7 +2,7 @@ import datetime
 import functools
 from abc import abstractmethod
 from datetime import timedelta
-from typing import Any, Callable, Mapping, Optional, Set, Union
+from typing import Any, Callable, Mapping, Optional, Set
 
 import rapidjson
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
@@ -198,8 +198,6 @@ def get_last_seen_updater(
     auto_offset_reset: str,
     strict_offset_reset: bool,
     ingest_config: MetricsIngestConfiguration,
-    # TODO: remove ignored parameter?
-    **options: Mapping[str, Union[str, int]],
 ) -> StreamProcessor[KafkaPayload]:
     """
     The last_seen updater uses output from the metrics indexer to update the

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -196,7 +196,7 @@ def get_last_seen_updater(
     max_batch_size: int,
     max_batch_time: float,
     auto_offset_reset: str,
-    no_strict_offset_reset: bool,
+    strict_offset_reset: bool,
     ingest_config: MetricsIngestConfiguration,
     # TODO: remove ignored parameter?
     **options: Mapping[str, Union[str, int]],
@@ -219,7 +219,7 @@ def get_last_seen_updater(
                 ingest_config.output_topic,
                 group_id,
                 auto_offset_reset=auto_offset_reset,
-                no_strict_offset_reset=no_strict_offset_reset,
+                strict_offset_reset=strict_offset_reset,
             )
         ),
         Topic(ingest_config.output_topic),

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -196,7 +196,9 @@ def get_last_seen_updater(
     max_batch_size: int,
     max_batch_time: float,
     auto_offset_reset: str,
+    no_strict_offset_reset: bool,
     ingest_config: MetricsIngestConfiguration,
+    # TODO: remove ignored parameter?
     **options: Mapping[str, Union[str, int]],
 ) -> StreamProcessor[KafkaPayload]:
     """
@@ -212,7 +214,14 @@ def get_last_seen_updater(
     )
 
     return StreamProcessor(
-        KafkaConsumer(get_config(ingest_config.output_topic, group_id, auto_offset_reset)),
+        KafkaConsumer(
+            get_config(
+                ingest_config.output_topic,
+                group_id,
+                auto_offset_reset=auto_offset_reset,
+                no_strict_offset_reset=no_strict_offset_reset,
+            )
+        ),
         Topic(ingest_config.output_topic),
         processing_factory,
         IMMEDIATE,

--- a/tests/sentry/region_to_control/test_region_to_control_kafka.py
+++ b/tests/sentry/region_to_control/test_region_to_control_kafka.py
@@ -44,7 +44,9 @@ def region_to_control_consumer(random_group_id):
 
     with override_settings(SILO_MODE=SiloMode.CONTROL):
         consumer = get_region_to_control_consumer(
-            group_id=random_group_id, auto_offset_reset="earliest"
+            group_id=random_group_id,
+            auto_offset_reset="earliest",
+            strict_offset_reset=False,
         )
 
         consumer._run_once()


### PR DESCRIPTION
`--auto-offset-reset` as defined by confluent kafka automatically resets offsets in two scenarios:
* when the offset does not exist (fresh topic)
* when the offset is out of range (kafka messages have passed retention period and the offset is pointing nowhere)

in production, we want to automatically reset offsets when the offset is not there, but still error when the offset points to garbage.

for this purpose arroyo overrides the behavior of auto-offset-reset to still error on the second scenario, and introduces a new optional flag called `strict-offset-reset` that, when setting it to false, restores the default behavior of confluent kafka.

many newer consumers using newer arroyo features are therefore erroring in dev because data there passes the retention period all the time while the garbage offsets remain.

introduce `--no-strict-offset-reset` to most important consumers and pass it by default in devserver.

also, remove some unused parameters in the last-seen-updater, there's an ops PR for that at https://github.com/getsentry/ops/pull/5908