### PR TITLE
feat(perf-issues): Change unc. assets threshold

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -263,7 +263,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         },
         DetectorType.UNCOMPRESSED_ASSETS: {
             "size_threshold_bytes": 500 * 1024,
-            "duration_threshold": 50,  # ms
+            "duration_threshold": 200,  # ms
             "allowed_span_ops": ["resource.css", "resource.script"],
         },
     }


### PR DESCRIPTION
### Summary 
Bumping to 200ms from 50ms to isolate assets that are more likely to see benefits from compression.

