### PR TITLE
fix(ui): Correct breadcrumb scrollbar header padding

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -167,6 +167,11 @@ const StyledPanelTable = styled(PanelTable)<{scrollbarSize: number}>`
       }
     }
 
+    /* Scroll bar header */
+    :nth-child(6) {
+      padding: 0;
+    }
+
     /* Content */
     :nth-child(n + 7) {
       grid-column: 1/-1;
@@ -196,8 +201,6 @@ const StyledPanelTable = styled(PanelTable)<{scrollbarSize: number}>`
       }
     }
   }
-
-  overflow: hidden;
 `;
 
 const Time = styled('div')`


### PR DESCRIPTION
There was some extra overflow we were hacking around. 
![image](https://user-images.githubusercontent.com/1421724/213280985-4f5cfd2a-db07-4625-9858-c987b6ef6ac0.png)

Fix here.