### PR TITLE
ref(workflow): Refactor assignee out of assignee selector

### DIFF
--- a/static/app/components/assigneeSelector.spec.jsx
+++ b/static/app/components/assigneeSelector.spec.jsx
@@ -82,6 +82,7 @@ describe('AssigneeSelector', () => {
     TeamStore.reset();
     TeamStore.setTeams([TEAM_1]);
     GroupStore.reset();
+    GroupStore.loadInitialData([GROUP_1, GROUP_2]);
 
     jest.spyOn(MemberListStore, 'getAll').mockImplementation(() => null);
     jest.spyOn(ProjectsStore, 'getAll').mockImplementation(() => [PROJECT_1]);

--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -16,11 +16,15 @@ import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
-import type {Actor, SuggestedOwnerReason} from 'sentry/types';
+import type {Actor, Group, SuggestedOwnerReason} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface AssigneeSelectorProps
-  extends Omit<AssigneeSelectorDropdownProps, 'children' | 'organization'> {
+  extends Omit<AssigneeSelectorDropdownProps, 'children' | 'organization' | 'group'> {
+  /**
+   * The group id
+   */
+  id: string;
   noDropdown?: boolean;
 }
 
@@ -121,16 +125,15 @@ function AssigneeAvatar({
 function AssigneeSelector({noDropdown, ...props}: AssigneeSelectorProps) {
   const organization = useOrganization();
   const groups = useLegacyStore(GroupStore);
-  const group = groups.find(item => item.id === props.id);
-  const assignedTo = group?.assignedTo;
+  const group = groups.find(item => item.id === props.id) as Group;
 
   return (
     <AssigneeWrapper>
-      <AssigneeSelectorDropdown organization={organization} {...props}>
+      <AssigneeSelectorDropdown organization={organization} group={group} {...props}>
         {({loading, isOpen, getActorProps, suggestedAssignees}) => {
           const avatarElement = (
             <AssigneeAvatar
-              assignedTo={assignedTo}
+              assignedTo={group.assignedTo}
               suggestedActors={suggestedAssignees}
             />
           );

--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -20,11 +20,7 @@ import type {Actor, Group, SuggestedOwnerReason} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface AssigneeSelectorProps
-  extends Omit<AssigneeSelectorDropdownProps, 'children' | 'organization' | 'group'> {
-  /**
-   * The group id
-   */
-  id: string;
+  extends Omit<AssigneeSelectorDropdownProps, 'children' | 'organization'> {
   noDropdown?: boolean;
 }
 
@@ -129,7 +125,7 @@ function AssigneeSelector({noDropdown, ...props}: AssigneeSelectorProps) {
 
   return (
     <AssigneeWrapper>
-      <AssigneeSelectorDropdown organization={organization} group={group} {...props}>
+      <AssigneeSelectorDropdown organization={organization} {...props}>
         {({loading, isOpen, getActorProps, suggestedAssignees}) => {
           const avatarElement = (
             <AssigneeAvatar

--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -43,49 +43,57 @@ function AssigneeAvatar({
   };
   const assignedToSuggestion = suggestedActors.find(actor => actor.id === assignedTo?.id);
 
-  return assignedTo ? (
-    <ActorAvatar
-      actor={assignedTo}
-      className="avatar"
-      size={24}
-      tooltip={
-        <TooltipWrapper>
-          {tct('Assigned to [name]', {
-            name: assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name,
-          })}
-          {assignedToSuggestion &&
-            suggestedReasons[assignedToSuggestion.suggestedReason] && (
-              <TooltipSubtext>
-                {suggestedReasons[assignedToSuggestion.suggestedReason]}
-              </TooltipSubtext>
-            )}
-        </TooltipWrapper>
-      }
-    />
-  ) : suggestedActors && suggestedActors.length > 0 ? (
-    <SuggestedAvatarStack
-      size={28}
-      owners={suggestedActors}
-      tooltipOptions={{isHoverable: true}}
-      tooltip={
-        <TooltipWrapper>
-          <div>
-            {tct('Suggestion: [name]', {
-              name:
-                suggestedActors[0].type === 'team'
-                  ? `#${suggestedActors[0].name}`
-                  : suggestedActors[0].name,
+  if (assignedTo) {
+    return (
+      <ActorAvatar
+        actor={assignedTo}
+        className="avatar"
+        size={24}
+        tooltip={
+          <TooltipWrapper>
+            {tct('Assigned to [name]', {
+              name: assignedTo.type === 'team' ? `#${assignedTo.name}` : assignedTo.name,
             })}
-            {suggestedActors.length > 1 &&
-              tn(' + %s other', ' + %s others', suggestedActors.length - 1)}
-          </div>
-          <TooltipSubtext>
-            {suggestedReasons[suggestedActors[0].suggestedReason]}
-          </TooltipSubtext>
-        </TooltipWrapper>
-      }
-    />
-  ) : (
+            {assignedToSuggestion &&
+              suggestedReasons[assignedToSuggestion.suggestedReason] && (
+                <TooltipSubtext>
+                  {suggestedReasons[assignedToSuggestion.suggestedReason]}
+                </TooltipSubtext>
+              )}
+          </TooltipWrapper>
+        }
+      />
+    );
+  }
+
+  if (suggestedActors.length > 0) {
+    return (
+      <SuggestedAvatarStack
+        size={28}
+        owners={suggestedActors}
+        tooltipOptions={{isHoverable: true}}
+        tooltip={
+          <TooltipWrapper>
+            <div>
+              {tct('Suggestion: [name]', {
+                name:
+                  suggestedActors[0].type === 'team'
+                    ? `#${suggestedActors[0].name}`
+                    : suggestedActors[0].name,
+              })}
+              {suggestedActors.length > 1 &&
+                tn(' + %s other', ' + %s others', suggestedActors.length - 1)}
+            </div>
+            <TooltipSubtext>
+              {suggestedReasons[suggestedActors[0].suggestedReason]}
+            </TooltipSubtext>
+          </TooltipWrapper>
+        }
+      />
+    );
+  }
+
+  return (
     <Tooltip
       isHoverable
       skipWrapper

--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -20,7 +20,10 @@ import type {Actor, Group, SuggestedOwnerReason} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface AssigneeSelectorProps
-  extends Omit<AssigneeSelectorDropdownProps, 'children' | 'organization'> {
+  extends Omit<
+    AssigneeSelectorDropdownProps,
+    'children' | 'organization' | 'assignedTo'
+  > {
   noDropdown?: boolean;
 }
 
@@ -125,7 +128,11 @@ function AssigneeSelector({noDropdown, ...props}: AssigneeSelectorProps) {
 
   return (
     <AssigneeWrapper>
-      <AssigneeSelectorDropdown organization={organization} {...props}>
+      <AssigneeSelectorDropdown
+        organization={organization}
+        assignedTo={group.assignedTo}
+        {...props}
+      >
         {({loading, isOpen, getActorProps, suggestedAssignees}) => {
           const avatarElement = (
             <AssigneeAvatar

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -20,13 +20,13 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import space from 'sentry/styles/space';
 import type {
   Actor,
+  Group,
   Organization,
-  SuggestedOwner,
   SuggestedOwnerReason,
   Team,
   User,
 } from 'sentry/types';
-import {buildTeamId, buildUserId, valueIsEqual} from 'sentry/utils';
+import {buildTeamId, buildUserId} from 'sentry/utils';
 
 export type SuggestedAssignee = Actor & {
   assignee: AssignableTeam | User;
@@ -49,7 +49,7 @@ type RenderProps = {
 
 export interface AssigneeSelectorDropdownProps {
   children: (props: RenderProps) => React.ReactNode;
-  id: string;
+  group: Group;
   organization: Organization;
   disabled?: boolean;
   memberList?: User[];
@@ -62,10 +62,7 @@ export interface AssigneeSelectorDropdownProps {
 }
 
 type State = {
-  loading: boolean;
-  assignedTo?: Actor;
   memberList?: User[];
-  suggestedOwners?: SuggestedOwner[] | null;
 };
 
 export class AssigneeSelectorDropdown extends Component<
@@ -75,57 +72,12 @@ export class AssigneeSelectorDropdown extends Component<
   state = this.getInitialState();
 
   getInitialState() {
-    const group = GroupStore.get(this.props.id);
     const memberList = MemberListStore.loaded ? MemberListStore.getAll() : undefined;
-    const loading = GroupStore.hasStatus(this.props.id, 'assignTo');
-    const suggestedOwners = group?.owners;
 
     return {
-      assignedTo: group?.assignedTo,
       memberList,
-      loading,
-      suggestedOwners,
+      loading: false,
     };
-  }
-
-  componentWillReceiveProps(nextProps: AssigneeSelectorDropdownProps) {
-    const loading = GroupStore.hasStatus(nextProps.id, 'assignTo');
-    if (nextProps.id !== this.props.id || loading !== this.state.loading) {
-      const group = GroupStore.get(this.props.id);
-      this.setState({
-        loading,
-        assignedTo: group?.assignedTo,
-        suggestedOwners: group?.owners,
-      });
-    }
-  }
-
-  shouldComponentUpdate(nextProps: AssigneeSelectorDropdownProps, nextState: State) {
-    if (nextState.loading !== this.state.loading) {
-      return true;
-    }
-
-    // If the memberList in props has changed, re-render as
-    // props have updated, and we won't use internal state anyways.
-    if (
-      nextProps.memberList &&
-      !valueIsEqual(this.props.memberList, nextProps.memberList)
-    ) {
-      return true;
-    }
-
-    if (!valueIsEqual(this.props.owners, nextProps.owners)) {
-      return true;
-    }
-
-    const currentMembers = this.memberList();
-    // XXX(billyvg): this means that once `memberList` is not-null, this component will never update due to `memberList` changes
-    // Note: this allows us to show a "loading" state for memberList, but only before `MemberListStore.loadInitialData`
-    // is called
-    if (currentMembers === undefined && nextState.memberList !== currentMembers) {
-      return true;
-    }
-    return !valueIsEqual(nextState.assignedTo, this.state.assignedTo, true);
   }
 
   componentWillUnmount() {
@@ -133,7 +85,6 @@ export class AssigneeSelectorDropdown extends Component<
   }
 
   unlisteners = [
-    GroupStore.listen(itemIds => this.onGroupChange(itemIds), undefined),
     MemberListStore.listen((users: User[]) => {
       this.handleMemberListUpdate(users);
     }, undefined),
@@ -155,23 +106,8 @@ export class AssigneeSelectorDropdown extends Component<
     return this.props.memberList ?? this.state.memberList;
   }
 
-  onGroupChange(itemIds: Set<string>) {
-    if (!itemIds.has(this.props.id)) {
-      return;
-    }
-    const group = GroupStore.get(this.props.id);
-    this.setState({
-      assignedTo: group?.assignedTo,
-      suggestedOwners: group?.owners,
-      loading: GroupStore.hasStatus(this.props.id, 'assignTo'),
-    });
-  }
-
   assignableTeams(): AssignableTeam[] {
-    const group = GroupStore.get(this.props.id);
-    if (!group) {
-      return [];
-    }
+    const {group} = this.props;
 
     const teams = ProjectsStore.getBySlug(group.project.slug)?.teams ?? [];
     return teams
@@ -185,17 +121,15 @@ export class AssigneeSelectorDropdown extends Component<
   }
 
   assignToUser(user: User | Actor) {
-    assignToUser({id: this.props.id, user, assignedBy: 'assignee_selector'});
-    this.setState({loading: true});
+    assignToUser({id: this.props.group.id, user, assignedBy: 'assignee_selector'});
   }
 
   assignToTeam(team: Team) {
     assignToActor({
       actor: {id: team.id, type: 'team'},
-      id: this.props.id,
+      id: this.props.group.id,
       assignedBy: 'assignee_selector',
     });
-    this.setState({loading: true});
   }
 
   handleAssign: React.ComponentProps<typeof DropdownAutoComplete>['onSelect'] = (
@@ -225,8 +159,7 @@ export class AssigneeSelectorDropdown extends Component<
 
   clearAssignTo = (e: React.MouseEvent<HTMLDivElement>) => {
     // clears assignment
-    clearAssignment(this.props.id, 'assignee_selector');
-    this.setState({loading: true});
+    clearAssignment(this.props.group.id, 'assignee_selector');
     e.stopPropagation();
   };
 
@@ -319,7 +252,7 @@ export class AssigneeSelectorDropdown extends Component<
   renderSuggestedAssigneeNodes(): React.ComponentProps<
     typeof DropdownAutoComplete
   >['items'] {
-    const {assignedTo} = this.state;
+    const {assignedTo} = this.props.group;
     const textReason: Record<SuggestedOwnerReason, string> = {
       suspectCommit: t('Suspect Commit'),
       releaseCommit: t('Suspect Release'),
@@ -430,7 +363,7 @@ export class AssigneeSelectorDropdown extends Component<
   }
 
   renderInviteMemberLink() {
-    const {loading} = this.state;
+    const loading = GroupStore.hasStatus(this.props.group.id, 'assignTo');
 
     return (
       <InviteMemberLink
@@ -456,7 +389,7 @@ export class AssigneeSelectorDropdown extends Component<
     const assignableTeams = this.assignableTeams();
     const memberList = this.memberList() ?? [];
 
-    const {owners} = this.props;
+    const {owners, group} = this.props;
     if (owners !== undefined) {
       // Add team or user from store
       return owners
@@ -487,12 +420,11 @@ export class AssigneeSelectorDropdown extends Component<
         .filter((owner): owner is SuggestedAssignee => !!owner);
     }
 
-    const {suggestedOwners} = this.state;
-    if (!suggestedOwners) {
+    if (!group.owners) {
       return [];
     }
 
-    const suggestedAssignees: Array<SuggestedAssignee | null> = suggestedOwners.map(
+    const suggestedAssignees: Array<SuggestedAssignee | null> = group.owners.map(
       owner => {
         // converts a backend suggested owner to a suggested assignee
         const [ownerType, id] = owner.owner.split(':');
@@ -530,9 +462,9 @@ export class AssigneeSelectorDropdown extends Component<
   }
 
   render() {
-    const {disabled, children} = this.props;
-    const {loading, assignedTo} = this.state;
+    const {disabled, children, group} = this.props;
     const memberList = this.memberList();
+    const loading = GroupStore.hasStatus(group.id, 'assignTo');
 
     const suggestedAssignees = this.getSuggestedAssignees();
 
@@ -551,7 +483,7 @@ export class AssigneeSelectorDropdown extends Component<
         itemSize="small"
         searchPlaceholder={t('Filter teams and people')}
         menuFooter={
-          assignedTo ? (
+          group.assignedTo ? (
             <div>
               <MenuItemFooterWrapper role="button" onClick={this.clearAssignTo}>
                 <IconContainer>

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -45,7 +45,6 @@ type RenderProps = {
   isOpen: boolean;
   loading: boolean;
   suggestedAssignees: SuggestedAssignee[];
-  assignedTo?: Actor;
 };
 
 export interface AssigneeSelectorDropdownProps {
@@ -535,6 +534,8 @@ export class AssigneeSelectorDropdown extends Component<
     const {loading, assignedTo} = this.state;
     const memberList = this.memberList();
 
+    const suggestedAssignees = this.getSuggestedAssignees();
+
     return (
       <DropdownAutoComplete
         disabled={disabled}
@@ -572,8 +573,7 @@ export class AssigneeSelectorDropdown extends Component<
             loading,
             isOpen,
             getActorProps,
-            assignedTo,
-            suggestedAssignees: this.getSuggestedAssignees(),
+            suggestedAssignees,
           })
         }
       </DropdownAutoComplete>

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -51,6 +51,7 @@ export interface AssigneeSelectorDropdownProps {
   children: (props: RenderProps) => React.ReactNode;
   id: string;
   organization: Organization;
+  assignedTo?: Actor;
   disabled?: boolean;
   memberList?: User[];
   onAssign?: (
@@ -63,7 +64,6 @@ export interface AssigneeSelectorDropdownProps {
 
 type State = {
   loading: boolean;
-  assignedTo?: Actor;
   memberList?: User[];
   suggestedOwners?: SuggestedOwner[] | null;
 };
@@ -94,7 +94,6 @@ export class AssigneeSelectorDropdown extends Component<
       const group = GroupStore.get(this.props.id);
       this.setState({
         loading,
-        assignedTo: group?.assignedTo,
         suggestedOwners: group?.owners,
       });
     }
@@ -125,7 +124,7 @@ export class AssigneeSelectorDropdown extends Component<
     if (currentMembers === undefined && nextState.memberList !== currentMembers) {
       return true;
     }
-    return !valueIsEqual(nextState.assignedTo, this.state.assignedTo, true);
+    return !valueIsEqual(this.props.assignedTo, nextProps.assignedTo, true);
   }
 
   componentWillUnmount() {
@@ -161,7 +160,6 @@ export class AssigneeSelectorDropdown extends Component<
     }
     const group = GroupStore.get(this.props.id);
     this.setState({
-      assignedTo: group?.assignedTo,
       suggestedOwners: group?.owners,
       loading: GroupStore.hasStatus(this.props.id, 'assignTo'),
     });
@@ -319,7 +317,7 @@ export class AssigneeSelectorDropdown extends Component<
   renderSuggestedAssigneeNodes(): React.ComponentProps<
     typeof DropdownAutoComplete
   >['items'] {
-    const {assignedTo} = this.state;
+    const {assignedTo} = this.props;
     const textReason: Record<SuggestedOwnerReason, string> = {
       suspectCommit: t('Suspect Commit'),
       releaseCommit: t('Suspect Release'),
@@ -530,8 +528,8 @@ export class AssigneeSelectorDropdown extends Component<
   }
 
   render() {
-    const {disabled, children} = this.props;
-    const {loading, assignedTo} = this.state;
+    const {disabled, children, assignedTo} = this.props;
+    const {loading} = this.state;
     const memberList = this.memberList();
 
     const suggestedAssignees = this.getSuggestedAssignees();

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -122,6 +122,7 @@ describe('Group > AssignedTo', () => {
       )
     );
 
+    // Group changes are passed down from parent component
     rerender(<AssignedTo project={project} group={assignedGroup} event={event} />);
     expect(await screen.findByText(team1slug)).toBeInTheDocument();
     // TEAM_1 initials
@@ -159,6 +160,7 @@ describe('Group > AssignedTo', () => {
       )
     );
 
+    // Group changes are passed down from parent component
     rerender(<AssignedTo project={project} group={assignedGroup} event={event} />);
     await openMenu();
     userEvent.click(screen.getByRole('button', {name: 'Clear Assignee'}));

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -92,17 +92,21 @@ describe('Group > AssignedTo', () => {
   });
 
   it('can assign team', async () => {
+    const assignedGroup: Group = {
+      ...GROUP_1,
+      assignedTo: {...TEAM_1, type: 'team'},
+    };
     const assignMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: `/issues/${GROUP_1.id}/`,
-      body: {
-        ...GROUP_1,
-        assignedTo: {...TEAM_1, type: 'team'},
-      },
+      body: assignedGroup,
     });
-    render(<AssignedTo project={project} group={GROUP_1} event={event} />, {
-      organization,
-    });
+    const {rerender} = render(
+      <AssignedTo project={project} group={GROUP_1} event={event} />,
+      {
+        organization,
+      }
+    );
     await openMenu();
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -118,24 +122,29 @@ describe('Group > AssignedTo', () => {
       )
     );
 
+    rerender(<AssignedTo project={project} group={assignedGroup} event={event} />);
     expect(await screen.findByText(team1slug)).toBeInTheDocument();
     // TEAM_1 initials
     expect(screen.getByTestId('assignee-selector')).toHaveTextContent('CT');
   });
 
   it('successfully clears assignment', async () => {
+    const assignedGroup: Group = {
+      ...GROUP_1,
+      assignedTo: {...TEAM_1, type: 'team'},
+    };
     const assignMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: `/issues/${GROUP_1.id}/`,
-      body: {
-        ...GROUP_1,
-        assignedTo: {...TEAM_1, type: 'team'},
-      },
+      body: assignedGroup,
     });
 
-    render(<AssignedTo project={project} group={GROUP_1} event={event} />, {
-      organization,
-    });
+    const {rerender} = render(
+      <AssignedTo project={project} group={GROUP_1} event={event} />,
+      {
+        organization,
+      }
+    );
     await openMenu();
 
     // Assign first item in list, which is TEAM_1
@@ -150,6 +159,7 @@ describe('Group > AssignedTo', () => {
       )
     );
 
+    rerender(<AssignedTo project={project} group={assignedGroup} event={event} />);
     await openMenu();
     userEvent.click(screen.getByRole('button', {name: 'Clear Assignee'}));
 

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -215,6 +215,7 @@ function AssignedTo({group, project, event, disableDropdown = false}: AssignedTo
           owners={owners}
           disabled={disableDropdown}
           id={group.id}
+          assignedTo={group.assignedTo}
         >
           {({loading, isOpen, getActorProps}) => (
             <DropdownButton data-test-id="assignee-selector" {...getActorProps({})}>

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -214,7 +214,7 @@ function AssignedTo({group, project, event, disableDropdown = false}: AssignedTo
           organization={organization}
           owners={owners}
           disabled={disableDropdown}
-          group={group}
+          id={group.id}
         >
           {({loading, isOpen, getActorProps}) => (
             <DropdownButton data-test-id="assignee-selector" {...getActorProps({})}>

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -127,13 +127,13 @@ function getOwnerList(
   }));
 }
 
-export function getAssignedToDisplayName(group: Group, assignedTo?: Actor) {
-  if (assignedTo?.type === 'team') {
+export function getAssignedToDisplayName(group: Group) {
+  if (group.assignedTo?.type === 'team') {
     const team = TeamStore.getById(group.assignedTo.id);
     return `#${team?.slug ?? group.assignedTo.name}`;
   }
-  if (assignedTo?.type === 'user') {
-    const user = MemberListStore.getById(assignedTo.id);
+  if (group.assignedTo?.type === 'user') {
+    const user = MemberListStore.getById(group.assignedTo.id);
     return user?.name ?? group.assignedTo.name;
   }
 
@@ -216,15 +216,15 @@ function AssignedTo({group, project, event, disableDropdown = false}: AssignedTo
           disabled={disableDropdown}
           id={group.id}
         >
-          {({loading, assignedTo, isOpen, getActorProps}) => (
+          {({loading, isOpen, getActorProps}) => (
             <DropdownButton data-test-id="assignee-selector" {...getActorProps({})}>
               <ActorWrapper>
                 {loading ? (
                   <StyledLoadingIndicator mini size={24} />
-                ) : assignedTo ? (
+                ) : group.assignedTo ? (
                   <ActorAvatar
                     data-test-id="assigned-avatar"
-                    actor={assignedTo}
+                    actor={group.assignedTo}
                     hasTooltip={false}
                     size={24}
                   />
@@ -233,7 +233,7 @@ function AssignedTo({group, project, event, disableDropdown = false}: AssignedTo
                     <IconUser size="md" />
                   </IconWrapper>
                 )}
-                <ActorName>{getAssignedToDisplayName(group, assignedTo)}</ActorName>
+                <ActorName>{getAssignedToDisplayName(group)}</ActorName>
               </ActorWrapper>
               {!disableDropdown && (
                 <IconChevron

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -214,7 +214,7 @@ function AssignedTo({group, project, event, disableDropdown = false}: AssignedTo
           organization={organization}
           owners={owners}
           disabled={disableDropdown}
-          id={group.id}
+          group={group}
         >
           {({loading, isOpen, getActorProps}) => (
             <DropdownButton data-test-id="assignee-selector" {...getActorProps({})}>

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -216,5 +216,17 @@ describe('GroupStore', function () {
         expect(GroupStore.trigger).toHaveBeenCalledWith(new Set(['1', '2', '3']));
       });
     });
+
+    describe('onAssignToSuccess()', function () {
+      it("should treat undefined itemIds argument as 'all'", function () {
+        GroupStore.items = [g('1')];
+        const assignedGroup = g('1', {assignedTo: TestStubs.User({type: 'user'})});
+        GroupStore.onAssignToSuccess('1337', '1', assignedGroup);
+
+        expect(GroupStore.trigger).toHaveBeenCalledTimes(1);
+        expect(GroupStore.trigger).toHaveBeenCalledWith(new Set(['1']));
+        expect(GroupStore.items[0]).toEqual(assignedGroup);
+      });
+    });
   });
 });

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -323,11 +323,12 @@ const storeConfig: GroupStoreDefinition = {
   },
 
   onAssignToSuccess(_changeId, itemId, response) {
-    const item = this.get(itemId);
-    if (!item) {
+    const idx = this.items.findIndex(i => i.id === itemId);
+    if (idx === -1) {
       return;
     }
-    item.assignedTo = response.assignedTo;
+
+    this.items[idx] = {...this.items[idx], assignedTo: response.assignedTo};
     this.clearStatus(itemId, 'assignTo');
     this.updateItems([itemId]);
   },

--- a/static/app/views/eventsV2/table/quickContext/issueContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext/issueContext.tsx
@@ -147,7 +147,7 @@ function IssueContext(props: BaseContextProps) {
               <IconUser size="md" />
             </StyledIconWrapper>
           )}
-          {getAssignedToDisplayName(issue, issue.assignedTo)}
+          {getAssignedToDisplayName(issue)}
         </AssignedToBody>
       </IssueContextContainer>
     );


### PR DESCRIPTION
Pulls the assignedTo out of the dropdown render props. Tried to pull the entire groupStore out of there but listening to group store for trigger changes is still needed for the loading state will have to take that out after

WOR-2557