### PR TITLE
ci: Update self-hosted e2e action to add sentry-cli

### DIFF
--- a/.github/workflows/self-hosted-e2e-tests.yml
+++ b/.github/workflows/self-hosted-e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
           filters: .github/file-filters.yml
       - name: Run Sentry self-hosted e2e CI
         if: steps.changes.outputs.backend_all == 'true'
-        uses: getsentry/action-self-hosted-e2e-tests@ade3e646ffc3b6a765cfa18ec4ca720f710cb53d
+        uses: getsentry/action-self-hosted-e2e-tests@20b5170d3b59d8b44ee5327d64b31d6b6b5aa34f
         with:
           project_name: sentry
           image_url: us.gcr.io/sentryio/sentry:${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
This bumps the action ref to https://github.com/getsentry/action-self-hosted-e2e-tests/commit/20b5170d3b59d8b44ee5327d64b31d6b6b5aa34f, which introduces sentry-cli, a new dependency of our integration tests.