### PR TITLE
chore(types): Use constant for data category on FE

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -1,7 +1,14 @@
 /* global process */
 
 import {t} from 'sentry/locale';
-import {DataCategory, OrgRole, PermissionResource, Scope} from 'sentry/types';
+import {
+  DataCategory,
+  DataCategoryExact,
+  DataCategoryInfo,
+  OrgRole,
+  PermissionResource,
+  Scope,
+} from 'sentry/types';
 
 /**
  * Common constants here
@@ -228,6 +235,66 @@ export const DATA_CATEGORY_NAMES = {
   [DataCategory.ATTACHMENTS]: t('Attachments'),
   [DataCategory.PROFILES]: t('Profiles'),
   [DataCategory.REPLAYS]: t('Session Replays'),
+};
+
+// https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
+export const DATA_CATEGORY_INFO: Record<DataCategoryExact, DataCategoryInfo> = {
+  [DataCategoryExact.ERROR]: {
+    name: 'error',
+    apiName: 'error',
+    plural: 'errors',
+    displayName: 'error',
+    titleName: t('Errors'),
+    uid: 1,
+  },
+  [DataCategoryExact.TRANSACTION]: {
+    name: 'transaction',
+    apiName: 'transaction',
+    plural: 'transactions',
+    displayName: 'transaction',
+    titleName: t('Transactions'),
+    uid: 2,
+  },
+  [DataCategoryExact.ATTACHMENT]: {
+    name: 'attachment',
+    apiName: 'attachment',
+    plural: 'attachments',
+    displayName: 'attachment',
+    titleName: t('Attachments'),
+    uid: 4,
+  },
+  [DataCategoryExact.PROFILE]: {
+    name: 'profile',
+    apiName: 'profile',
+    plural: 'profiles',
+    displayName: 'profile',
+    titleName: t('Profiles'),
+    uid: 6,
+  },
+  [DataCategoryExact.REPLAY]: {
+    name: 'replay',
+    apiName: 'replay',
+    plural: 'replays',
+    displayName: 'replay',
+    titleName: t('Session Replays'),
+    uid: 7,
+  },
+  [DataCategoryExact.TRANSACTION_PROCESSED]: {
+    name: 'transaction_processed',
+    apiName: 'transactions',
+    plural: 'transactions',
+    displayName: 'transaction',
+    titleName: t('Transactions'),
+    uid: 8,
+  },
+  [DataCategoryExact.TRANSACTION_INDEXED]: {
+    name: 'transaction_indexed',
+    apiName: 'transactionIndexed',
+    plural: 'indexed transactions',
+    displayName: 'indexed transaction',
+    titleName: t('Indexed Transactions'),
+    uid: 9,
+  },
 };
 
 // Special Search characters

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -78,6 +78,27 @@ export enum DataCategory {
   REPLAYS = 'replays',
 }
 
+// https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
+// Should be used in conjuction with DATA_CATEGORY_INFO rather than manipulating the string
+export enum DataCategoryExact {
+  ERROR = 'error',
+  TRANSACTION = 'transaction',
+  ATTACHMENT = 'attachment',
+  PROFILE = 'profile',
+  REPLAY = 'replay',
+  TRANSACTION_PROCESSED = 'transaction_processed',
+  TRANSACTION_INDEXED = 'transaction_indexed',
+}
+
+export interface DataCategoryInfo {
+  apiName: string;
+  displayName: string;
+  name: string;
+  plural: string;
+  titleName: React.ReactNode;
+  uid: number;
+}
+
 export type EventType = 'error' | 'transaction' | 'attachment';
 
 export enum Outcome {


### PR DESCRIPTION
This PR offers a replacement for the existing datacategory type on the frontend without enforcing it. There is a comment on the DataCategory type which outlines that the frontend is pluralized while the backend isn't but this gets messy when trying to manipulate the string to display to the user, especially now that indexed transactions and processed transactions will be valid.
