### PR TITLE
feat(view-hierarchy): Add hover and select in virtualized tree

### DIFF
--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {ViewHierarchy} from '.';
 
@@ -44,7 +44,7 @@ const MOCK_DATA = {
 };
 
 describe('View Hierarchy', function () {
-  it('can continue to make selections for inspecting data', function () {
+  it('can continue make selections for inspecting data', function () {
     render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
 
     // 1 for the tree node, 1 for the details panel header
@@ -65,6 +65,24 @@ describe('View Hierarchy', function () {
     expect(screen.getByText('Nested Container - nested')).toBeInTheDocument();
   });
 
+  it('can expand and collapse by clicking the icon', function () {
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
+
+    expect(screen.queryByText('Text')).toBeInTheDocument();
+
+    userEvent.click(
+      within(screen.getByLabelText('Nested Container - nested')).getByRole('button', {
+        name: 'Collapse',
+      })
+    );
+
+    expect(screen.queryByText('Text')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByRole('button', {name: 'Expand'}));
+
+    expect(screen.queryByText('Text')).toBeInTheDocument();
+  });
+
   it('can navigate with keyboard shortcuts after a selection', function () {
     render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
 
@@ -74,5 +92,19 @@ describe('View Hierarchy', function () {
 
     // 1 for the tree node, 1 for the details panel header
     expect(screen.getAllByText('Nested Container - nested')).toHaveLength(2);
+  });
+
+  it('can expand/collapse with the keyboard', function () {
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
+
+    userEvent.click(screen.getAllByText('Nested Container - nested')[0]);
+
+    userEvent.keyboard('{Enter}');
+
+    expect(screen.queryByText('Text')).not.toBeInTheDocument();
+
+    userEvent.keyboard('{Enter}');
+
+    expect(screen.getByText('Text')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -11,6 +11,7 @@ class ResizeObserver {
 
 window.ResizeObserver = ResizeObserver;
 window.Element.prototype.scrollTo = jest.fn();
+window.Element.prototype.scrollIntoView = jest.fn();
 
 const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
 const MOCK_DATA = {
@@ -43,32 +44,8 @@ const MOCK_DATA = {
 };
 
 describe('View Hierarchy', function () {
-  it('allows selecting and deselecting through the tree to highlight node data', function () {
-    render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
-
-    expect(screen.queryByText('200')).not.toBeInTheDocument();
-
-    userEvent.click(screen.getByText('Container - test_identifier'));
-
-    expect(screen.getByText('200')).toBeInTheDocument();
-
-    // 1 for the tree node, 1 for the details panel header
-    expect(screen.getAllByText('Container - test_identifier')).toHaveLength(2);
-    // 1 for the "identifier" value in the details panel
-    expect(screen.getByText('Container')).toBeInTheDocument();
-
-    // Click the node again
-    userEvent.click(screen.getAllByText('Container - test_identifier')[0]);
-
-    // 1 for the tree node
-    expect(screen.getByText('Container - test_identifier')).toBeInTheDocument();
-    expect(screen.queryByText('Container')).not.toBeInTheDocument();
-  });
-
   it('can continue to make selections for inspecting data', function () {
     render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
-
-    userEvent.click(screen.getByText('Container - test_identifier'));
 
     // 1 for the tree node, 1 for the details panel header
     expect(screen.getAllByText('Container - test_identifier')).toHaveLength(2);
@@ -79,5 +56,23 @@ describe('View Hierarchy', function () {
     expect(screen.getAllByText('Nested Container - nested')).toHaveLength(2);
     // Only visible in the tree node
     expect(screen.getByText('Container - test_identifier')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('Text'));
+
+    // 1 for the tree node, 1 for the details panel header, 1 for the details value
+    expect(screen.getAllByText('Text')).toHaveLength(3);
+    // Only visible in the tree node
+    expect(screen.getByText('Nested Container - nested')).toBeInTheDocument();
+  });
+
+  it('can navigate with keyboard shortcuts after a selection', function () {
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
+
+    userEvent.click(screen.getAllByText('Container - test_identifier')[0]);
+
+    userEvent.keyboard('{ArrowDown}');
+
+    // 1 for the tree node, 1 for the details panel header
+    expect(screen.getAllByText('Nested Container - nested')).toHaveLength(2);
   });
 });

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -44,7 +44,9 @@ function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
     null
   );
   const [selectedWindow] = useState(0);
-  const [selectedNode, setSelectedNode] = useState<ViewHierarchyWindow | null>(null);
+  const [selectedNode, setSelectedNode] = useState<ViewHierarchyWindow | undefined>(
+    viewHierarchy.windows[0]
+  );
   const hierarchy = useMemo(() => {
     return [viewHierarchy.windows[selectedWindow]];
   }, [selectedWindow, viewHierarchy.windows]);
@@ -73,14 +75,10 @@ function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
         tabIndex={selectedNodeIndex === r.key ? 0 : 1}
         onMouseEnter={handleRowMouseEnter}
         onKeyDown={handleRowKeyDown}
-        onClick={e => {
-          handleRowClick(e, selectedNode === r.item.node);
-          if (r.item.node !== selectedNode) {
-            setSelectedNode(r.item.node);
-          } else {
-            setSelectedNode(null);
-          }
+        onFocus={() => {
+          setSelectedNode(r.item.node);
         }}
+        onClick={handleRowClick}
       >
         {depthMarkers}
         <Node
@@ -89,7 +87,6 @@ function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
           onExpandClick={() => handleExpandTreeNode(r.item, {expandChildren: false})}
           collapsible={!!r.item.node.children?.length}
           isExpanded={r.item.expanded}
-          isSelected={selectedNode === r.item.node}
           isFocused={selectedNodeIndex === r.key}
         />
       </TreeItem>
@@ -109,6 +106,7 @@ function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
     tree: hierarchy,
     expanded: true,
     overscroll: 10,
+    initialSelectedNodeIndex: 0,
   });
 
   return (

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -162,7 +162,7 @@ const TreeItem = styled('div')`
 
 const DepthMarker = styled('div')`
   margin-left: 5px;
-  width: ${space(2)};
+  min-width: ${space(2)};
   border-left: 1px solid ${p => p.theme.gray200};
 `;
 

--- a/static/app/components/events/viewHierarchy/node.tsx
+++ b/static/app/components/events/viewHierarchy/node.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 
 type NodeProps = {
   id: string;
@@ -10,15 +9,15 @@ type NodeProps = {
   label: string;
   onExpandClick: () => void;
   collapsible?: boolean;
+  isFocused?: boolean;
   isSelected?: boolean;
-  onSelection?: () => void;
 };
 
 function Node({
   label,
   id,
-  onSelection,
   isExpanded,
+  isFocused,
   isSelected,
   onExpandClick,
   collapsible = false,
@@ -39,7 +38,7 @@ function Node({
           <IconAdd legacySize="9px" color="white" />
         )}
       </IconWrapper>
-      <NodeTitle id={`${id}-title`} onClick={onSelection} selected={isSelected}>
+      <NodeTitle id={`${id}-title`} selected={isSelected} focused={isFocused}>
         {label}
       </NodeTitle>
     </NodeContents>
@@ -54,14 +53,17 @@ const NodeContents = styled('div')`
   white-space: nowrap;
 `;
 
-const NodeTitle = styled('span')<{selected?: boolean}>`
+const NodeTitle = styled('span')<{focused?: boolean; selected?: boolean}>`
   cursor: pointer;
-  ${({selected, theme}) =>
+  ${({focused, theme}) =>
+    focused &&
+    `
+    color: ${theme.white};
+  `}
+  ${({selected}) =>
     selected &&
     `
-    background-color: ${theme.purple200};
-    padding: 0 ${space(0.5)};
-    border-radius: ${theme.borderRadius}
+    font-weight: bold;
   `}
 `;
 

--- a/static/app/components/events/viewHierarchy/node.tsx
+++ b/static/app/components/events/viewHierarchy/node.tsx
@@ -18,7 +18,6 @@ function Node({
   id,
   isExpanded,
   isFocused,
-  isSelected,
   onExpandClick,
   collapsible = false,
 }: NodeProps) {
@@ -38,7 +37,7 @@ function Node({
           <IconAdd legacySize="9px" color="white" />
         )}
       </IconWrapper>
-      <NodeTitle id={`${id}-title`} selected={isSelected} focused={isFocused}>
+      <NodeTitle id={`${id}-title`} focused={isFocused}>
         {label}
       </NodeTitle>
     </NodeContents>
@@ -53,17 +52,12 @@ const NodeContents = styled('div')`
   white-space: nowrap;
 `;
 
-const NodeTitle = styled('span')<{focused?: boolean; selected?: boolean}>`
+const NodeTitle = styled('span')<{focused?: boolean}>`
   cursor: pointer;
   ${({focused, theme}) =>
     focused &&
     `
     color: ${theme.white};
-  `}
-  ${({selected}) =>
-    selected &&
-    `
-    font-weight: bold;
   `}
 `;
 

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -31,7 +31,7 @@ export interface UseVirtualizedListProps<T extends TreeLike> {
         node: VirtualizedTreeNode<T>,
         opts?: {expandChildren: boolean}
       ) => void;
-      handleRowClick: (evt: React.MouseEvent<HTMLElement>) => void;
+      handleRowClick: (evt: React.MouseEvent<HTMLElement>, toggle?: boolean) => void;
       handleRowKeyDown: (event: React.KeyboardEvent) => void;
       handleRowMouseEnter: (event: React.MouseEvent<HTMLElement>) => void;
       selectedNodeIndex: number | null;
@@ -315,9 +315,14 @@ export function useVirtualizedTree<T extends TreeLike>(
   // When a row is clicked, we update the selected node
   const handleRowClick = useCallback(
     (selectedNodeIndex: number) => {
-      return (_evt: React.MouseEvent<HTMLElement>) => {
-        dispatch({type: 'set selected node index', payload: selectedNodeIndex});
-        markRowAsClicked(selectedNodeIndex, latestItemsRef.current, {
+      return (_evt: React.MouseEvent<HTMLElement>, toggleSelection?: boolean) => {
+        let selectedNode: number | null = selectedNodeIndex;
+        if (toggleSelection && selectedNodeIndex === state.selectedNodeIndex) {
+          selectedNode = null;
+        }
+
+        dispatch({type: 'set selected node index', payload: selectedNode});
+        markRowAsClicked(selectedNode, latestItemsRef.current, {
           ghostRowRef: clickedGhostRowRef.current,
           rowHeight: props.rowHeight,
           scrollTop: latestStateRef.current.scrollTop,
@@ -325,7 +330,7 @@ export function useVirtualizedTree<T extends TreeLike>(
         });
       };
     },
-    [props.rowHeight, theme]
+    [props.rowHeight, theme, state.selectedNodeIndex]
   );
 
   // When a node is expanded, the underlying tree is recomputed (the flattened tree is updated)

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -31,7 +31,7 @@ export interface UseVirtualizedListProps<T extends TreeLike> {
         node: VirtualizedTreeNode<T>,
         opts?: {expandChildren: boolean}
       ) => void;
-      handleRowClick: (evt: React.MouseEvent<HTMLElement>, toggle?: boolean) => void;
+      handleRowClick: (evt: React.MouseEvent<HTMLElement>) => void;
       handleRowKeyDown: (event: React.KeyboardEvent) => void;
       handleRowMouseEnter: (event: React.MouseEvent<HTMLElement>) => void;
       selectedNodeIndex: number | null;
@@ -41,6 +41,7 @@ export interface UseVirtualizedListProps<T extends TreeLike> {
   scrollContainer: HTMLElement | null;
   tree: T[];
   expanded?: boolean;
+  initialSelectedNodeIndex?: number;
   overscroll?: number;
   skipFunction?: (node: VirtualizedTreeNode<T>) => boolean;
   sortFunction?: (a: VirtualizedTreeNode<T>, b: VirtualizedTreeNode<T>) => number;
@@ -55,7 +56,7 @@ export function useVirtualizedTree<T extends TreeLike>(
 
   const [state, dispatch] = useReducer(VirtualizedTreeReducer, {
     roots: props.tree,
-    selectedNodeIndex: null,
+    selectedNodeIndex: props.initialSelectedNodeIndex ?? null,
     scrollTop: 0,
     overscroll: props.overscroll ?? DEFAULT_OVERSCROLL_ITEMS,
     scrollHeight: props.scrollContainer?.getBoundingClientRect()?.height ?? 0,
@@ -315,14 +316,9 @@ export function useVirtualizedTree<T extends TreeLike>(
   // When a row is clicked, we update the selected node
   const handleRowClick = useCallback(
     (selectedNodeIndex: number) => {
-      return (_evt: React.MouseEvent<HTMLElement>, toggleSelection?: boolean) => {
-        let selectedNode: number | null = selectedNodeIndex;
-        if (toggleSelection && selectedNodeIndex === state.selectedNodeIndex) {
-          selectedNode = null;
-        }
-
-        dispatch({type: 'set selected node index', payload: selectedNode});
-        markRowAsClicked(selectedNode, latestItemsRef.current, {
+      return (_evt: React.MouseEvent<HTMLElement>) => {
+        dispatch({type: 'set selected node index', payload: selectedNodeIndex});
+        markRowAsClicked(selectedNodeIndex, latestItemsRef.current, {
           ghostRowRef: clickedGhostRowRef.current,
           rowHeight: props.rowHeight,
           scrollTop: latestStateRef.current.scrollTop,
@@ -330,7 +326,7 @@ export function useVirtualizedTree<T extends TreeLike>(
         });
       };
     },
-    [props.rowHeight, theme, state.selectedNodeIndex]
+    [props.rowHeight, theme]
   );
 
   // When a node is expanded, the underlying tree is recomputed (the flattened tree is updated)


### PR DESCRIPTION
We can get some nice functionality from the hook such as a bar that shows on hover and a bar that highlights which node is selected. There are also some handlers we were missing to get key bindings like arrow key navigation or expand/collapse on Enter after making a selection.

When navigating through the tree using arrow keys, the selected node will automatically change to reflect what's in focus. There's currently a bug where if your node overflows horizontally and you press arrow up/down then the horizontal scrolling will be reset to the left. I was planning to tackle this separately because it also affects the tree in profiling.

I spoke to Olivier and we decided to leave the first node selected by default and remove the ability to deselect. This is more aligned with the experience in devtools.