### PR TITLE
ref(issue-platform): port over tagstore queries targetting search_issues to SnQL

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -3,7 +3,6 @@ import os
 import re
 from collections import defaultdict
 from collections.abc import Iterable
-from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Sequence
 
 from dateutil.parser import parse as parse_datetime
@@ -535,8 +534,8 @@ class SnubaTagStorage(TagStorage):
         translated_params = self._translate_filter_keys(project_ids, group_id_list, environment_ids)
         organization_id = get_organization_id_from_project_ids(project_ids)
         start, end = _prepare_start_end(
-            datetime(2008, 5, 8),
-            datetime.utcnow() + timedelta(seconds=1),
+            None,
+            None,
             organization_id,
             group_id_list,
         )
@@ -903,11 +902,6 @@ class SnubaTagStorage(TagStorage):
     ):
         translated_params = self._translate_filter_keys(project_ids, group_ids, environment_ids)
         organization_id = get_organization_id_from_project_ids(project_ids)
-        if not start:
-            start = datetime(2008, 5, 8)
-        if not end:
-            end = datetime.utcnow() + timedelta(seconds=1)
-
         start, end = _prepare_start_end(
             start,
             end,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -446,6 +446,21 @@ def get_arrayjoin(column):
         return match.groups()[0]
 
 
+def get_organization_id_from_project_ids(project_ids: Sequence[int]) -> int:
+    # any project will do, as they should all be from the same organization
+    try:
+        # Most of the time the project should exist, so get from cache to keep it fast
+        organization_id = Project.objects.get_from_cache(pk=project_ids[0]).organization_id
+    except Project.DoesNotExist:
+        # But in the case the first project doesn't exist, grab the first non deleted project
+        project = Project.objects.filter(pk__in=project_ids).values("organization_id").first()
+        if project is None:
+            raise UnqualifiedQueryError("All project_ids from the filter no longer exist")
+        organization_id = project.get("organization_id")
+
+    return organization_id
+
+
 def get_query_params_to_update_for_projects(query_params, with_org=False):
     """
     Get the project ID and query params that need to be updated for project
@@ -475,16 +490,7 @@ def get_query_params_to_update_for_projects(query_params, with_org=False):
             "No project_id filter, or none could be inferred from other filters."
         )
 
-    # any project will do, as they should all be from the same organization
-    try:
-        # Most of the time the project should exist, so get from cache to keep it fast
-        organization_id = Project.objects.get_from_cache(pk=project_ids[0]).organization_id
-    except Project.DoesNotExist:
-        # But in the case the first project doesn't exist, grab the first non deleted project
-        project = Project.objects.filter(pk__in=project_ids).values("organization_id").first()
-        if project is None:
-            raise UnqualifiedQueryError("All project_ids from the filter no longer exist")
-        organization_id = project.get("organization_id")
+    organization_id = get_organization_id_from_project_ids(project_ids)
 
     params = {"project": project_ids}
     if with_org:
@@ -520,14 +526,42 @@ def get_query_params_to_update_for_organizations(query_params):
     return organization_id, {"organization": organization_id}
 
 
+def _prepare_start_end(
+    start: datetime, end: datetime, organization_id: int, group_ids: Optional[Sequence[int]]
+) -> Tuple[datetime, datetime]:
+    # convert to naive UTC datetimes, as Snuba only deals in UTC
+    # and this avoids offset-naive and offset-aware issues
+    start = naiveify_datetime(start)
+    end = naiveify_datetime(end)
+
+    expired, start = outside_retention_with_modified_start(
+        start, end, Organization(organization_id)
+    )
+    if expired:
+        raise QueryOutsideRetentionError("Invalid date range. Please try a more recent date range.")
+
+    # if `shrink_time_window` pushed `start` after `end` it means the user queried
+    # a Group for T1 to T2 when the group was only active for T3 to T4, so the query
+    # wouldn't return any results anyway
+    new_start = shrink_time_window(group_ids, start)
+
+    # TODO (alexh) this is a quick emergency fix for an occasion where a search
+    # results in only 1 django candidate, which is then passed to snuba to
+    # check and we raised because of it. Remove this once we figure out why the
+    # candidate was returned from django at all if it existed only outside the
+    # time range of the query
+    if new_start <= end:
+        start = new_start
+
+    if start > end:
+        raise QueryOutsideGroupActivityError
+
+    return start, end
+
+
 def _prepare_query_params(query_params):
     kwargs = deepcopy(query_params.kwargs)
     query_params_conditions = deepcopy(query_params.conditions)
-
-    # convert to naive UTC datetimes, as Snuba only deals in UTC
-    # and this avoids offset-naive and offset-aware issues
-    start = naiveify_datetime(query_params.start)
-    end = naiveify_datetime(query_params.end)
 
     with timer("get_snuba_map"):
         forward, reverse = get_snuba_translators(
@@ -563,27 +597,12 @@ def _prepare_query_params(query_params):
             else:
                 query_params_conditions.append((col, "IN", keys))
 
-    expired, start = outside_retention_with_modified_start(
-        start, end, Organization(organization_id)
+    start, end = _prepare_start_end(
+        query_params.start,
+        query_params.end,
+        organization_id,
+        query_params.filter_keys.get("group_id"),
     )
-    if expired:
-        raise QueryOutsideRetentionError("Invalid date range. Please try a more recent date range.")
-
-    # if `shrink_time_window` pushed `start` after `end` it means the user queried
-    # a Group for T1 to T2 when the group was only active for T3 to T4, so the query
-    # wouldn't return any results anyway
-    new_start = shrink_time_window(query_params.filter_keys.get("group_id"), start)
-
-    # TODO (alexh) this is a quick emergency fix for an occasion where a search
-    # results in only 1 django candidate, which is then passed to snuba to
-    # check and we raised because of it. Remove this once we figure out why the
-    # candidate was returned from django at all if it existed only outside the
-    # time range of the query
-    if new_start <= end:
-        start = new_start
-
-    if start > end:
-        raise QueryOutsideGroupActivityError
 
     kwargs.update(
         {

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -527,8 +527,16 @@ def get_query_params_to_update_for_organizations(query_params):
 
 
 def _prepare_start_end(
-    start: datetime, end: datetime, organization_id: int, group_ids: Optional[Sequence[int]]
+    start: Optional[datetime],
+    end: Optional[datetime],
+    organization_id: int,
+    group_ids: Optional[Sequence[int]],
 ) -> Tuple[datetime, datetime]:
+    if not start:
+        start = datetime(2008, 5, 8)
+    if not end:
+        end = datetime.utcnow() + timedelta(seconds=1)
+
     # convert to naive UTC datetimes, as Snuba only deals in UTC
     # and this avoids offset-naive and offset-aware issues
     start = naiveify_datetime(start)


### PR DESCRIPTION
Had to extract some logic to its own functions within `utils/snuba.py` to be able to replicate the same functionality baked into `sentry.utils.snuba.query`

```
get_generic_groups_user_counts before
==========
 SELECT (group_id AS _snuba_group_id), (uniq((user AS `_snuba_tags[sentry:user]`)) AS _snuba_count)
  FROM search_issues_local
 WHERE greaterOrEquals((client_timestamp AS _snuba_timestamp), toDateTime('2008-05-08T00:00:00', 'Universal'))
   AND less(_snuba_timestamp, toDateTime('2023-01-18T23:48:13', 'Universal'))
   AND in((project_id AS _snuba_project_id), tuple(4551276234473474))
   AND in(_snuba_project_id, tuple(4551276234473474))
   AND in(_snuba_group_id, (2, 3))
 GROUP BY _snuba_group_id
 ORDER BY _snuba_count DESC
 LIMIT 1000
OFFSET 0

get_generic_groups_user_counts after
==========
  SELECT (group_id AS _snuba_group_id), _snuba_group_id, (uniq((user AS `_snuba_tags[sentry:user]`)) AS _snuba_count)
  FROM search_issues_local
 WHERE in((project_id AS _snuba_project_id), [4551276257345538])
   AND in(_snuba_group_id, [2, 3])
   AND less((client_timestamp AS _snuba_timestamp), toDateTime('2023-01-18T23:54:02', 'Universal'))
   AND greaterOrEquals(_snuba_timestamp, toDateTime('2008-05-08T00:00:00', 'Universal'))
 GROUP BY _snuba_group_id
 ORDER BY _snuba_count DESC
 LIMIT 1000
OFFSET 0
```

```
get_generic_group_list_tag_value before
 SELECT (group_id AS _snuba_group_id), (count() AS _snuba_times_seen), (min((client_timestamp AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen)
  FROM search_issues_local
 WHERE greaterOrEquals(_snuba_timestamp, toDateTime('2023-01-19T17:29:14', 'Universal'))
   AND less(_snuba_timestamp, toDateTime('2023-01-19T18:33:16', 'Universal'))
   AND in((project_id AS _snuba_project_id), tuple(4551280658350082))
   AND has(_tags_hash_map, cityHash64('environment=development'))
   AND in(_snuba_project_id, tuple(4551280658350082))
   AND in(_snuba_group_id, tuple(2))
   AND in((environment AS _snuba_environment), tuple('development'))
 GROUP BY _snuba_group_id
 LIMIT 1000
OFFSET 0

get_generic_group_list_tag_value after
 SELECT (group_id AS _snuba_group_id), _snuba_group_id, (count() AS _snuba_times_seen), (min((client_timestamp AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen)
  FROM search_issues_local
 WHERE in((project_id AS _snuba_project_id), [4551280646946818])
   AND in(_snuba_group_id, [2])
   AND less(_snuba_timestamp, toDateTime('2023-01-19T18:30:22', 'Universal'))
   AND greaterOrEquals(_snuba_timestamp, toDateTime('2023-01-19T17:26:20', 'Universal'))
   AND has(_tags_hash_map, cityHash64('environment=development'))
 GROUP BY _snuba_group_id
 LIMIT 1000
OFFSET 0

```


Resolves sentry#43031