### PR TITLE
fix(hybrid-cloud): Clean up single_process_silo_mode_state after tests

### DIFF
--- a/src/sentry/silo/base.py
+++ b/src/sentry/silo/base.py
@@ -51,14 +51,14 @@ class SiloMode(Enum):
         """
         if "pytest" in sys.modules:
             assert (
-                _single_process_silo_mode_state.mode is None
+                single_process_silo_mode_state.mode is None
             ), "Re-entrant invariant broken! Use exit_single_process_silo_context to explicit pass 'fake' RPC boundaries."
-        old = _single_process_silo_mode_state.mode
-        _single_process_silo_mode_state.mode = mode
+        old = single_process_silo_mode_state.mode
+        single_process_silo_mode_state.mode = mode
         try:
             yield
         finally:
-            _single_process_silo_mode_state.mode = old
+            single_process_silo_mode_state.mode = old
 
     @classmethod
     @contextlib.contextmanager
@@ -69,24 +69,24 @@ class SiloMode(Enum):
         process boundaries in play.  Call this inside of any RPC interaction to ensure that such acceptance tests
         can 'swap' the silo context on the fly.
         """
-        old = _single_process_silo_mode_state.mode
-        _single_process_silo_mode_state.mode = None
+        old = single_process_silo_mode_state.mode
+        single_process_silo_mode_state.mode = None
         try:
             yield
         finally:
-            _single_process_silo_mode_state.mode = old
+            single_process_silo_mode_state.mode = old
 
     @classmethod
     def get_current_mode(cls) -> SiloMode:
         process_level_silo_mode = cls.resolve(settings.SILO_MODE)
-        return cls.resolve(_single_process_silo_mode_state.mode, process_level_silo_mode)
+        return cls.resolve(single_process_silo_mode_state.mode, process_level_silo_mode)
 
 
 class SingleProcessSiloModeState(threading.local):
     mode: SiloMode | None = None
 
 
-_single_process_silo_mode_state = SingleProcessSiloModeState()
+single_process_silo_mode_state = SingleProcessSiloModeState()
 
 
 class SiloLimit(abc.ABC):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -122,6 +122,7 @@ from sentry.search.events.constants import (
 )
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.silo import single_process_silo_mode_state
 from sentry.snuba.metrics.datasource import get_series
 from sentry.tagstore.snuba import SnubaTagStorage
 from sentry.testutils.factories import get_fixture_path
@@ -314,6 +315,7 @@ class BaseTestCase(Fixtures):
         GroupMeta.objects.clear_local_cache()
 
     def _post_teardown(self):
+        single_process_silo_mode_state.mode = None
         super()._post_teardown()
 
     def options(self, options):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,6 @@ import os
 
 import pytest
 
-from sentry.silo import single_process_silo_mode_state
-
 pytest_plugins = ["sentry.utils.pytest"]
 
 
@@ -144,10 +142,3 @@ def setup_default_hybrid_cloud_stubs():
         for stub in stubs:
             stack.enter_context(stub)
         yield
-
-
-@pytest.fixture(autouse=True)
-def cleanup_single_process_silo_mode_state():
-    single_process_silo_mode_state.mode = None
-    yield
-    single_process_silo_mode_state.mode = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import os
 
 import pytest
 
+from sentry.silo import single_process_silo_mode_state
+
 pytest_plugins = ["sentry.utils.pytest"]
 
 
@@ -142,3 +144,10 @@ def setup_default_hybrid_cloud_stubs():
         for stub in stubs:
             stack.enter_context(stub)
         yield
+
+
+@pytest.fixture(autouse=True)
+def cleanup_single_process_silo_mode_state():
+    single_process_silo_mode_state.mode = None
+    yield
+    single_process_silo_mode_state.mode = None


### PR DESCRIPTION
Replaces https://github.com/getsentry/sentry/pull/43415. Should fix test failures such as https://sentry.io/organizations/sentry/issues/3883424913/