### PR TITLE
fix(txnames): Escape * in transaction name rules

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tree.py
+++ b/src/sentry/ingest/transaction_clusterer/tree.py
@@ -117,7 +117,9 @@ class TreeClusterer(Clusterer):
 
     @staticmethod
     def _build_rule(path: List["Edge"]) -> ReplacementRule:
-        path_str = SEP.join(["*" if isinstance(key, Merged) else key for key in path])
+        path_str = SEP.join(
+            ["*" if isinstance(key, Merged) else key.replace("*", r"\*") for key in path]
+        )
         path_str += "/**"
         return ReplacementRule(path_str)
 

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -50,6 +50,17 @@ def test_single_leaf():
     assert clusterer.get_rules() == ["/a/*/**"]
 
 
+def test_asterisk_in_input():
+    """Original asterisks are escaped"""
+    clusterer = TreeClusterer(merge_threshold=2)
+    transaction_names = [
+        "/a/*/c/",
+        "/a/*/d/",
+    ]
+    clusterer.add_input(transaction_names)
+    assert clusterer.get_rules() == [r"/a/\*/*/**"]
+
+
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 5)
 def test_collection():
     project1 = Project(id=101, name="p1", organization_id=1)


### PR DESCRIPTION
Literal asterisks in transaction names (such as created by https://github.com/getsentry/relay/issues/1621) should not be confused with the directive `*`, which for transaction name rules means "match and replace".

https://github.com/getsentry/team-ingest/issues/35