### PR TITLE
fix(discover): Make sure event.type filter for metric query is not negated

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -688,7 +688,8 @@ class MetricsDatasetConfig(DatasetConfig):
     def _event_type_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         """Not really a converter, check its transaction, error otherwise"""
         value = search_filter.value.value
-        if value == "transaction":
+        operator = search_filter.operator
+        if value == "transaction" and operator == "=":
             return None
 
         raise IncompatibleMetricsQuery("Can only filter event.type:transaction")

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -440,7 +440,8 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
     def _event_type_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         """Not really a converter, check its transaction, error otherwise"""
         value = search_filter.value.value
-        if value == "transaction":
+        operator = search_filter.operator
+        if value == "transaction" and operator == "=":
             return None
 
         raise IncompatibleMetricsQuery("Can only filter event.type:transaction")

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -1552,6 +1552,24 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 ],
             )
 
+    def test_event_type_query_condition(self):
+        query = MetricsQueryBuilder(
+            self.params,
+            query="event.type:transaction",
+            dataset=Dataset.PerformanceMetrics,
+            selected_columns=[],
+        )
+        self.assertCountEqual(query.where, self.default_conditions)
+
+    def test_invalid_event_type_query_condition(self):
+        with pytest.raises(IncompatibleMetricsQuery):
+            MetricsQueryBuilder(
+                self.params,
+                query="!event.type:transaction",
+                dataset=Dataset.PerformanceMetrics,
+                selected_columns=[],
+            )
+
 
 class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_get_query(self):


### PR DESCRIPTION
We only support `event.type:transaction`, so we should also check that the operator is `=`, not `!=`.