### PR TITLE
fix(perf-issues): Change tooltip for consecutive db query alpha badge

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -275,7 +275,7 @@ function GroupHeader({
         {group.issueType === IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES && (
           <FeatureBadge
             type="alpha"
-            title="Slow DB Span Performance Issues are in active development and may change"
+            title="Consecutive DB Query Performance Issues are in active development and may change"
           />
         )}
       </ShortIdBreadrcumb>


### PR DESCRIPTION
Tooltip text was set to slow DB span instead of consecutive db query