### PR TITLE
feat(hybrid-cloud): Add customer domain support to slack unfurls

### DIFF
--- a/src/sentry/integrations/slack/unfurl/__init__.py
+++ b/src/sentry/integrations/slack/unfurl/__init__.py
@@ -23,7 +23,7 @@ class UnfurlableUrl(NamedTuple):
 
 
 class Handler(NamedTuple):
-    matcher: Pattern[Any]
+    matcher: Pattern[Any] | list[Pattern[Any]]
     arg_mapper: ArgsMapper
     fn: Callable[[HttpRequest, Integration, list[UnfurlableUrl], User | None], UnfurledUrl]
 
@@ -53,7 +53,14 @@ link_handlers = {
 
 def match_link(link: str) -> tuple[LinkType | None, Mapping[str, Any] | None]:
     for link_type, handler in link_handlers.items():
-        match = handler.matcher.match(link)
+        match = False
+        if isinstance(handler.matcher, Pattern):
+            match = handler.matcher.match(link)
+        else:
+            match = next(
+                filter(bool, map(lambda matcher: matcher.match(link), handler.matcher)), None
+            )
+
         if not match:
             continue
 

--- a/src/sentry/integrations/slack/unfurl/__init__.py
+++ b/src/sentry/integrations/slack/unfurl/__init__.py
@@ -23,7 +23,7 @@ class UnfurlableUrl(NamedTuple):
 
 
 class Handler(NamedTuple):
-    matcher: Pattern[Any] | list[Pattern[Any]]
+    matcher: list[Pattern[Any]]
     arg_mapper: ArgsMapper
     fn: Callable[[HttpRequest, Integration, list[UnfurlableUrl], User | None], UnfurledUrl]
 
@@ -53,13 +53,7 @@ link_handlers = {
 
 def match_link(link: str) -> tuple[LinkType | None, Mapping[str, Any] | None]:
     for link_type, handler in link_handlers.items():
-        match = False
-        if isinstance(handler.matcher, Pattern):
-            match = handler.matcher.match(link)
-        else:
-            match = next(
-                filter(bool, map(lambda matcher: matcher.match(link), handler.matcher)), None
-            )
+        match = next(filter(bool, map(lambda matcher: matcher.match(link), handler.matcher)), None)
 
         if not match:
             continue

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -298,10 +298,16 @@ def map_discover_query_args(url: str, args: Mapping[str, str | None]) -> Mapping
     return dict(**args, query=query)
 
 
+discover_link_regex = re.compile(
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/discover/(results|homepage)"
+)
+
+customer_domain_discover_link_regex = re.compile(
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/discover/(results|homepage)"
+)
+
 handler: Handler = Handler(
     fn=unfurl_discover,
-    matcher=re.compile(
-        r"^https?\://[^/]+/organizations/(?P<org_slug>[^/]+)/discover/(results|homepage)"
-    ),
+    matcher=[discover_link_regex, customer_domain_discover_link_regex],
     arg_mapper=map_discover_query_args,
 )

--- a/src/sentry/integrations/slack/unfurl/issues.py
+++ b/src/sentry/integrations/slack/unfurl/issues.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import List, Optional
 
@@ -22,7 +24,7 @@ def unfurl_issues(
     request: HttpRequest,
     integration: APIIntegration,
     links: List[UnfurlableUrl],
-    user: Optional["User"] = None,
+    user: Optional[User] = None,
 ) -> UnfurledUrl:
     """
     Returns a map of the attachments used in the response we send to Slack
@@ -63,10 +65,16 @@ def unfurl_issues(
     return out
 
 
+issue_link_regex = re.compile(
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?#organization_slug)[^/]+/issues/(?P<issue_id>\d+)(?:/events/(?P<event_id>\w+))?"
+)
+
+customer_domain_issue_link_regex = re.compile(
+    r"^https?\://(?#url_prefix)[^/]+/issues/(?P<issue_id>\d+)(?:/events/(?P<event_id>\w+))?"
+)
+
 handler: Handler = Handler(
     fn=unfurl_issues,
-    matcher=re.compile(
-        r"^https?\://[^/]+/[^/]+/[^/]+/issues/(?P<issue_id>\d+)(?:/events/(?P<event_id>\w+))?"
-    ),
+    matcher=[issue_link_regex, customer_domain_issue_link_regex],
     arg_mapper=map_issue_args,
 )

--- a/src/sentry/integrations/slack/unfurl/metric_alerts.py
+++ b/src/sentry/integrations/slack/unfurl/metric_alerts.py
@@ -137,10 +137,16 @@ def map_metric_alert_query_args(url: str, args: Mapping[str, str | None]) -> Map
     return map_incident_args(url, data)
 
 
+metric_alerts_link_regex = re.compile(
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/alerts/rules/details/(?P<alert_rule_id>\d+)"
+)
+
+customer_domain_metric_alerts_link_regex = re.compile(
+    r"^https?\://(?P<org_slug>[^/]+?)\.(?#url_prefix)[^/]+/alerts/rules/details/(?P<alert_rule_id>\d+)"
+)
+
 handler: Handler = Handler(
     fn=unfurl_metric_alerts,
-    matcher=re.compile(
-        r"^https?\://[^/]+/organizations/(?P<org_slug>[^/]+)/alerts/rules/details/(?P<alert_rule_id>\d+)"
-    ),
+    matcher=[metric_alerts_link_regex, customer_domain_metric_alerts_link_regex],
     arg_mapper=map_metric_alert_query_args,
 )

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -33,7 +33,25 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
             (LinkType.ISSUES, {"issue_id": 12345, "event_id": None}),
         ),
         (
+            "https://org1.sentry.io/issues/12345/",
+            (LinkType.ISSUES, {"issue_id": 12345, "event_id": None}),
+        ),
+        (
             "https://sentry.io/organizations/org1/alerts/rules/details/12345/",
+            (
+                LinkType.METRIC_ALERT,
+                {
+                    "alert_rule_id": 12345,
+                    "incident_id": None,
+                    "org_slug": "org1",
+                    "period": None,
+                    "start": None,
+                    "end": None,
+                },
+            ),
+        ),
+        (
+            "https://org1.sentry.io/alerts/rules/details/12345/",
             (
                 LinkType.METRIC_ALERT,
                 {
@@ -61,7 +79,35 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
             ),
         ),
         (
+            "https://org1.sentry.io/alerts/rules/details/12345/?alert=1337",
+            (
+                LinkType.METRIC_ALERT,
+                {
+                    "alert_rule_id": 12345,
+                    "incident_id": 1337,
+                    "org_slug": "org1",
+                    "period": None,
+                    "start": None,
+                    "end": None,
+                },
+            ),
+        ),
+        (
             "https://sentry.io/organizations/org1/alerts/rules/details/12345/?period=14d",
+            (
+                LinkType.METRIC_ALERT,
+                {
+                    "alert_rule_id": 12345,
+                    "incident_id": None,
+                    "org_slug": "org1",
+                    "period": "14d",
+                    "start": None,
+                    "end": None,
+                },
+            ),
+        ),
+        (
+            "https://org1.sentry.io/alerts/rules/details/12345/?period=14d",
             (
                 LinkType.METRIC_ALERT,
                 {
@@ -89,7 +135,28 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
             ),
         ),
         (
+            "https://org1.sentry.io/alerts/rules/details/12345/?end=2022-05-05T06%3A05%3A52&start=2022-05-04T00%3A46%3A19",
+            (
+                LinkType.METRIC_ALERT,
+                {
+                    "alert_rule_id": 12345,
+                    "incident_id": None,
+                    "org_slug": "org1",
+                    "period": None,
+                    "start": "2022-05-04T00:46:19",
+                    "end": "2022-05-05T06:05:52",
+                },
+            ),
+        ),
+        (
             "https://sentry.io/organizations/org1/discover/results/?project=1&yAxis=count()",
+            (
+                LinkType.DISCOVER,
+                {"org_slug": "org1", "query": QueryDict("project=1&yAxis=count()")},
+            ),
+        ),
+        (
+            "https://org1.sentry.io/discover/results/?project=1&yAxis=count()",
             (
                 LinkType.DISCOVER,
                 {"org_slug": "org1", "query": QueryDict("project=1&yAxis=count()")},


### PR DESCRIPTION
Add customer domain support to Slack unfurls. For example, https://org1.sentry.io/issues/12345/ should unfurl in Slack.