### PR TITLE
feat(perf-issues): Add alpha badge for uncompressed asset perf issue

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -284,6 +284,14 @@ function GroupHeader({
             title="Large Render Blocking Asset Performance Issues are in active development and may change"
           />
         )}
+        {group.issueType === IssueType.PERFORMANCE_UNCOMPRESSED_ASSET && (
+          <FeatureBadge
+            type="alpha"
+            title={t(
+              'Uncompressed Asset Performance Issues are in active development and may change'
+            )}
+          />
+        )}
       </ShortIdBreadrcumb>
     </GuideAnchor>
   );


### PR DESCRIPTION
Alpha badge was missing for this performance issue type