### PR TITLE
chore(crons): Remove unused generate_secret

### DIFF
--- a/src/sentry/models/monitor.py
+++ b/src/sentry/models/monitor.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from uuid import uuid4
 
 import pytz
 from croniter import croniter
@@ -27,10 +26,6 @@ SCHEDULE_INTERVAL_MAP = {
     "hour": rrule.HOURLY,
     "minute": rrule.MINUTELY,
 }
-
-
-def generate_secret():
-    return uuid4().hex + uuid4().hex
 
 
 def get_next_schedule(base_datetime, schedule_type, schedule):


### PR DESCRIPTION
This appears to be carry over from the service_hook model

https://github.com/getsentry/sentry/blob/30d05c4c34d1706e0b9d9e46d3176a4475047415/src/sentry/models/servicehook.py#L42-L43