### PR TITLE
test(acceptance): Reduce flakiness by waiting for requests to complete

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -878,6 +878,9 @@ class AcceptanceTestCase(TransactionTestCase):
         self.browser.wait_until_not(".loading")
 
     def tearDown(self):
+        # Avoid tests finishing before their API calls have finished.
+        # NOTE: This is not fool-proof, it requires loading indicators to be
+        # used.
         self.wait_for_loading()
         super().tearDown()
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -869,12 +869,10 @@ class AcceptanceTestCase(TransactionTestCase):
             yield
 
     def wait_for_loading(self):
-        # Avoid tests finishing before their API calls have finished.
-        # NOTE: This is not fool-proof, it requires loading indicators to be
-        # used.
+        # NOTE: [data-test-id="loading-placeholder"] is not used here as
+        # some dashboards have placeholders that never complete.
         self.browser.wait_until_not('[data-test-id="events-request-loading"]')
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
-        self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
         self.browser.wait_until_not(".loading")
 
     def tearDown(self):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -869,10 +869,17 @@ class AcceptanceTestCase(TransactionTestCase):
             yield
 
     def wait_for_loading(self):
+        # Avoid tests finishing before their API calls have finished.
+        # NOTE: This is not fool-proof, it requires loading indicators to be
+        # used.
         self.browser.wait_until_not('[data-test-id="events-request-loading"]')
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
         self.browser.wait_until_not(".loading")
+
+    def tearDown(self):
+        self.wait_for_loading()
+        super().tearDown()
 
     def save_cookie(self, name, value, **params):
         self.browser.save_cookie(name=name, value=value, **params)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -878,7 +878,7 @@ class AcceptanceTestCase(TransactionTestCase):
     def tearDown(self):
         # Avoid tests finishing before their API calls have finished.
         # NOTE: This is not fool-proof, it requires loading indicators to be
-        # used.
+        # used when API requests are made.
         self.wait_for_loading()
         super().tearDown()
 


### PR DESCRIPTION
In the past few weeks I've noticed a number of flakes that originate from a race condition between API calls and Django DB cleanup.

The solution is the same in each test, wait for the API call to finish by waiting for some indicator to get removed from the DOM.

This change will wait for the common loading indicators to finish before Django performs its teardown.

NOTE: There is an argument for and against this change.
    - **For:** This helps to ensure tests that don't need to wait for API calls to finish don't accidentally cause future tests to fail.
    - **Against:** Tests should wait for their API calls to finish and adding these checks adds delays to an already slow set of tests.