### PR TITLE
ref(dropdownMenu): Clean up prop types

### DIFF
--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {useKeyboard} from '@react-aria/interactions';
 import {AriaMenuOptions, useMenu} from '@react-aria/menu';
-import {AriaPositionProps, OverlayProps} from '@react-aria/overlays';
 import {useSeparator} from '@react-aria/separator';
 import {mergeProps} from '@react-aria/utils';
 import {useTreeState} from '@react-stately/tree';
@@ -16,7 +15,7 @@ import MenuSection from 'sentry/components/dropdownMenuSection';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import space from 'sentry/styles/space';
 
-type Props = {
+export interface DropdownMenuProps extends AriaMenuOptions<MenuItemProps> {
   /**
    * If this is a submenu, it will in some cases need to close the root menu
    * (e.g. when a submenu item is clicked).
@@ -46,9 +45,7 @@ type Props = {
   minWidth?: number;
   onClose?: () => void;
   size?: MenuItemProps['size'];
-} & AriaMenuOptions<MenuItemProps> &
-  Partial<OverlayProps> &
-  Partial<AriaPositionProps>;
+}
 
 function DropdownMenu({
   closeOnSelect = true,
@@ -60,7 +57,7 @@ function DropdownMenu({
   closeCurrentSubmenu,
   overlayPositionProps,
   ...props
-}: Props) {
+}: DropdownMenuProps) {
   const state = useTreeState<MenuItemProps>({...props, selectionMode: 'single'});
   const stateCollection = useMemo(() => [...state.collection], [state.collection]);
 

--- a/static/app/components/dropdownMenuControl.tsx
+++ b/static/app/components/dropdownMenuControl.tsx
@@ -1,13 +1,12 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
-import {AriaMenuOptions, useMenuTrigger} from '@react-aria/menu';
+import {useMenuTrigger} from '@react-aria/menu';
 import {useResizeObserver} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
-import {MenuTriggerProps} from '@react-types/menu';
 
 import DropdownButton, {DropdownButtonProps} from 'sentry/components/dropdownButton';
-import DropdownMenu from 'sentry/components/dropdownMenu';
+import DropdownMenu, {DropdownMenuProps} from 'sentry/components/dropdownMenu';
 import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
 import {FormSize} from 'sentry/utils/theme';
 import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
@@ -43,10 +42,12 @@ function getDisabledKeys(source: MenuItemProps[]): MenuItemProps['key'][] {
   }, []);
 }
 
-interface Props
-  extends Omit<Partial<MenuTriggerProps>, 'trigger'>,
-    Partial<AriaMenuOptions<MenuItemProps>>,
-    UseOverlayProps {
+interface DropdownMenuControlProps
+  extends Partial<DropdownMenuProps>,
+    Pick<
+      UseOverlayProps,
+      'isOpen' | 'offset' | 'position' | 'isDismissable' | 'shouldCloseOnBlur'
+    > {
   /**
    * Items to display inside the dropdown menu. If the item has a `children`
    * prop, it will be rendered as a menu section. If it has a `children` prop
@@ -141,7 +142,7 @@ function DropdownMenuControl({
   isDismissable = true,
   shouldCloseOnBlur = true,
   ...props
-}: Props) {
+}: DropdownMenuControlProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
 
   const {

--- a/static/app/components/dropdownMenuItem.tsx
+++ b/static/app/components/dropdownMenuItem.tsx
@@ -15,7 +15,7 @@ import {IconChevron} from 'sentry/icons';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import usePrevious from 'sentry/utils/usePrevious';
 
-export type MenuItemProps = MenuListItemProps & {
+export interface MenuItemProps extends MenuListItemProps {
   /**
    * Item key. Must be unique across the entire menu, including sub-menus.
    */
@@ -54,9 +54,9 @@ export type MenuItemProps = MenuListItemProps & {
    * Destination if this menu item is a link. See also: `isExternalLink`.
    */
   to?: LocationDescriptor;
-};
+}
 
-type Props = {
+interface DropdownMenuItemProps {
   /**
    * Whether to close the menu when an item has been clicked/selected
    */
@@ -87,14 +87,17 @@ type Props = {
    * Whether to show a divider below this item
    */
   showDivider?: boolean;
-};
+}
 
 /**
  * A menu item with a label, optional details, leading and trailing elements.
  * Can also be used as a trigger button for a submenu. See:
  * https://react-spectrum.adobe.com/react-aria/useMenu.html
  */
-const BaseDropdownMenuItem: React.ForwardRefRenderFunction<HTMLLIElement, Props> = (
+const BaseDropdownMenuItem: React.ForwardRefRenderFunction<
+  HTMLLIElement,
+  DropdownMenuItemProps
+> = (
   {
     node,
     state,
@@ -102,7 +105,7 @@ const BaseDropdownMenuItem: React.ForwardRefRenderFunction<HTMLLIElement, Props>
     closeOnSelect,
     showDivider,
     isSubmenuTrigger = false,
-    renderAs = 'li' as React.ElementType,
+    renderAs = 'li',
     ...submenuTriggerProps
   },
   forwardedRef


### PR DESCRIPTION
Remove unused prop types, including `align` and `direction`, from `DropdownMenuControl`.

**Before:** `direction` prop can be defined but doesn't do anything
<img width="1087" alt="Screenshot 2023-01-19 at 5 27 31 PM" src="https://user-images.githubusercontent.com/44172267/213598464-80533bb3-5786-4fe0-941c-4de55c740b3d.png">

**After:**
<img width="1087" alt="Screenshot 2023-01-19 at 5 26 58 PM" src="https://user-images.githubusercontent.com/44172267/213598408-2ae77bc6-98b9-4cb0-a6e8-30c594ccdf5b.png">
