### PR TITLE
fix(alerts): Hide slack tags when empty on alert details

### DIFF
--- a/static/app/views/alerts/rules/issue/details/textRule.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.spec.tsx
@@ -1,6 +1,9 @@
 import {render} from 'sentry-test/reactTestingLibrary';
 
-import {TextCondition} from 'sentry/views/alerts/rules/issue/details/textRule';
+import {
+  TextAction,
+  TextCondition,
+} from 'sentry/views/alerts/rules/issue/details/textRule';
 
 describe('AlertRuleDetails', () => {
   it('displays EventFrequencyCondition percentage', () => {
@@ -64,6 +67,44 @@ describe('AlertRuleDetails', () => {
     );
     expect(wrapper.container).toHaveTextContent(
       'Percent of sessions affected by an issue is 150% higher in 1h compared to 1h ago'
+    );
+  });
+  it('hides slack id and empty tags', () => {
+    const wrapper = render(
+      <TextAction
+        action={{
+          id: 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction',
+          name: 'Send a notification to the Sentry Slack workspace to #my-channel (optionally, an ID: ) and show tags [] in notification',
+
+          // TODO(scttcper): label and prompt only exist in the type definition
+          label: '',
+          prompt: '',
+        }}
+        memberList={[]}
+        teams={[]}
+      />
+    );
+    expect(wrapper.container).toHaveTextContent(
+      'Send a notification to the Sentry Slack workspace to #my-channel'
+    );
+  });
+  it('shows slack tags', () => {
+    const wrapper = render(
+      <TextAction
+        action={{
+          id: 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction',
+          name: 'Send a notification to the Sentry Slack workspace to #my-channel (optionally, an ID: ) and show tags [tag1, tag2] in notification',
+
+          // TODO(scttcper): label and prompt only exist in the type definition
+          label: '',
+          prompt: '',
+        }}
+        memberList={[]}
+        teams={[]}
+      />
+    );
+    expect(wrapper.container).toHaveTextContent(
+      'Send a notification to the Sentry Slack workspace to #my-channel and show tags [tag1, tag2] in notification'
     );
   });
 });

--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -81,8 +81,12 @@ export function TextAction({
   }
 
   if (action.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction') {
-    // Remove (optionally, an ID: XXX) from slack action
-    return <Fragment>{action.name.replace(/\(optionally.*\)/, '')}</Fragment>;
+    const name = action.name
+      // Hide the id "(optionally, an ID: XXX)"
+      .replace(/\(optionally.*\)/, '')
+      // Hide empty tags
+      .replace('and show tags [] in notification', '');
+    return <Fragment>{name}</Fragment>;
   }
 
   return <Fragment>{action.name}</Fragment>;


### PR DESCRIPTION
On the issue alert details sidebar, hides the slack tags when there aren't any tags.  

Related to #43490
[WOR-2598](https://getsentry.atlassian.net/browse/WOR-2598)

[WOR-2598]: https://getsentry.atlassian.net/browse/WOR-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ