### PR TITLE
Revert "fix(txnames): Escape * in transaction name rules"

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tree.py
+++ b/src/sentry/ingest/transaction_clusterer/tree.py
@@ -117,9 +117,7 @@ class TreeClusterer(Clusterer):
 
     @staticmethod
     def _build_rule(path: List["Edge"]) -> ReplacementRule:
-        path_str = SEP.join(
-            ["*" if isinstance(key, Merged) else key.replace("*", r"\*") for key in path]
-        )
+        path_str = SEP.join(["*" if isinstance(key, Merged) else key for key in path])
         path_str += "/**"
         return ReplacementRule(path_str)
 

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -50,17 +50,6 @@ def test_single_leaf():
     assert clusterer.get_rules() == ["/a/*/**"]
 
 
-def test_asterisk_in_input():
-    """Original asterisks are escaped"""
-    clusterer = TreeClusterer(merge_threshold=2)
-    transaction_names = [
-        "/a/*/c/",
-        "/a/*/d/",
-    ]
-    clusterer.add_input(transaction_names)
-    assert clusterer.get_rules() == [r"/a/\*/*/**"]
-
-
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 5)
 def test_collection():
     project1 = Project(id=101, name="p1", organization_id=1)


### PR DESCRIPTION
Reverts getsentry/sentry#43426

The concern of the PR was legitimate, but we overlooked the fact that as of https://github.com/getsentry/sentry/pull/43332, we feed the output of the normalization mechanism (i.e. transactions names with source `sanitized`) back into the clusterer as input, with the intention of creating more specific rules.

For example, a first run

```
/orgs/
    /foo/
    /bar/
    /baz/
```

might result in a rule `/orgs/*/**` which would be immediately enforced. A second run

```
/orgs/
    /*/
        /p1/
        /p2/
        /p3/   
```

should then result in the more specific rule `/orgs/*/*/**`. But with the current change it would become `/orgs/\*/*/**`, which would never match anything.