### PR TITLE
test(perf-issues): Reduce performance issue details page test flakiness

### DIFF
--- a/tests/acceptance/test_performance_issues.py
+++ b/tests/acceptance/test_performance_issues.py
@@ -66,8 +66,6 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase):
             event = self.store_event(data=event_data, project_id=self.project.id)
 
             self.page.visit_issue(self.org.slug, event.groups[0].id)
-            self.browser.click('[aria-label="Show Details"]')
-
             self.browser.snapshot("performance issue details", desktop_only=True)
 
     @patch("django.utils.timezone.now")


### PR DESCRIPTION
The after-click section of the test often fails, the element doesn't appear. Probably we need to wait for it to appear, but for now I'm removing that part altogether.
