### PR TITLE
fix(dashboards): Assign where in widget serializer for validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -197,7 +197,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
 
             builder.resolve_time_conditions()
             builder.resolve_conditions(conditions, use_aggregate_conditions=True)
-            builder.resolve_params()
+            builder.where = builder.resolve_params()
         except InvalidSearchQuery as err:
             data["discover_query_error"] = {"conditions": [f"Invalid conditions: {err}"]}
             return data

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -197,6 +197,8 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
 
             builder.resolve_time_conditions()
             builder.resolve_conditions(conditions, use_aggregate_conditions=True)
+            # We need to resolve params to set time range params here since some
+            # field aliases might those params to be resolved (total.count)
             builder.where = builder.resolve_params()
         except InvalidSearchQuery as err:
             data["discover_query_error"] = {"conditions": [f"Invalid conditions: {err}"]}

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1357,6 +1357,31 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 200, response.data
 
+    def test_add_discover_widget_using_total_count(self):
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {"id": str(self.widget_1.id)},
+                {
+                    "title": "Issues",
+                    "displayType": "table",
+                    "widgetType": "discover",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": ["count()", "total.count"],
+                            "columns": ["total.count"],
+                            "aggregates": ["count()"],
+                            "conditions": "",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
     def test_update_dashboard_with_filters(self):
         project1 = self.create_project(name="foo", organization=self.organization)
         project2 = self.create_project(name="bar", organization=self.organization)

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -577,3 +577,26 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
+
+    def test_save_with_total_count(self):
+        data = {
+            "title": "Test Query",
+            "displayType": "table",
+            "widgetType": "discover",
+            "limit": 5,
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": [],
+                    "columns": ["total.count"],
+                    "aggregates": ["count()"],
+                }
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data


### PR DESCRIPTION
total.count requires a timerange. When validating widgets for dashboard saves we use an UnresolvedQuery for validation. Since UnresolvedQuery overrides resolve_query, we don't assign the where clause and that's why there is no timestamp information for validation