### PR TITLE
feat(perf-issues): Improve `sentry performance` CLI command

### DIFF
--- a/src/sentry/runner/commands/performance.py
+++ b/src/sentry/runner/commands/performance.py
@@ -18,9 +18,12 @@ def performance() -> None:
 
 @performance.command()
 @click.argument("filename", type=click.Path(exists=True))
+@click.option(
+    "-d", "--detector", "detector_class", help="Limit detection to only one detector class"
+)
 @click.option("-v", "--verbose", count=True)
 @configuration
-def detect(filename, verbose):
+def detect(filename, detector_class, verbose):
     """
     Runs performance problem detection on event data in the supplied filename
     using default detector settings with every detector. Filename should be a
@@ -28,13 +31,16 @@ def detect(filename, verbose):
     """
     from sentry.utils.performance_issues import performance_detection
 
-    detector_classes = [
-        cls
-        for _, cls in performance_detection.__dict__.items()
-        if isclass(cls)
-        and issubclass(cls, performance_detection.PerformanceDetector)
-        and cls != performance_detection.PerformanceDetector
-    ]
+    if detector_class:
+        detector_classes = [performance_detection.__dict__[detector_class]]
+    else:
+        detector_classes = [
+            cls
+            for _, cls in performance_detection.__dict__.items()
+            if isclass(cls)
+            and issubclass(cls, performance_detection.PerformanceDetector)
+            and cls != performance_detection.PerformanceDetector
+        ]
 
     settings = performance_detection.get_detection_settings()
 

--- a/src/sentry/runner/commands/performance.py
+++ b/src/sentry/runner/commands/performance.py
@@ -46,26 +46,29 @@ def detect(filename, detector_class, verbose):
 
     with open(filename) as file:
         data = json.loads(file.read())
-        click.echo(f"Event ID: {data['event_id']}")
+        if verbose > 1:
+            click.echo(f"Event ID: {data['event_id']}")
 
         detectors = [cls(settings, data) for cls in detector_classes]
 
         for detector in detectors:
-            click.echo(f"Detecting using {detector.__class__.__name__}")
+            if verbose > 0:
+                click.echo(f"Detecting using {detector.__class__.__name__}")
+
             performance_detection.run_detector_on_data(detector, data)
 
-            if len(detector.stored_problems) == 0:
-                click.echo("No problems detected")
-            else:
-                click.echo(
-                    f"Found {len(detector.stored_problems)} {pluralize(len(detector.stored_problems), 'problem,problems')}"
-                )
+            if verbose > 1:
+                if len(detector.stored_problems) == 0:
+                    click.echo("No problems detected")
+                else:
+                    click.echo(
+                        f"Found {len(detector.stored_problems)} {pluralize(len(detector.stored_problems), 'problem,problems')}"
+                    )
 
-            if verbose > 0:
-                for problem in detector.stored_problems.values():
-                    try:
-                        click.echo(problem.to_dict())
-                    except AttributeError:
-                        click.echo(problem)
+            for problem in detector.stored_problems.values():
+                try:
+                    click.echo(problem.to_dict())
+                except AttributeError:
+                    click.echo(problem)
 
             click.echo("\n")


### PR DESCRIPTION
- Allow specifying detector for detector CLI
- Add granular verbosity to detect command

**e.g.,**

```bash
sentry performance detect -vv -d NPlusOneAPICallsDetector fixtures/events/performance_problems/n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream.json
```
