### PR TITLE
feat(perf-issues): Partially parameterize N+1 API Calls span URLs

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -821,15 +821,15 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         )
 
     def _fingerprint(self) -> str:
-        urls = [urlparse(get_url_from_span(span)) for span in self.spans]
+        parameterized_first_url = self.parameterize_url(get_url_from_span(self.spans[0]))
 
-        all_query_params: set[str] = set()
-        for url in urls:
-            all_query_params.update(parse_qs(url.query).keys())
+        parts = parameterized_first_url.split("?")
+        if len(parts) > 1:
+            [path, _query] = parts
+        else:
+            path = parts[0]
 
-        first_url = urls[0]
-        raw_fingerprint = f"{first_url.netloc}{first_url.path}?{'&'.join(sorted(all_query_params))}"
-        fingerprint = hashlib.sha1(raw_fingerprint.encode("utf8")).hexdigest()
+        fingerprint = hashlib.sha1(path.encode("utf8")).hexdigest()
 
         return f"1-{GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS.value}-{fingerprint}"
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -813,6 +813,8 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if parsed_url.netloc in cls.HOST_DENYLIST:
             return False
 
+        # Ignore anything that looks like an asset. Some frameworks (and apps)
+        # fetch assets via XHR, which is not our concern
         _pathname, extension = os.path.splitext(parsed_url.path)
         if extension and extension in [".js", ".css", ".svg", ".png", ".mp3"]:
             return False

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -727,7 +727,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         for fragment in parsed_url.path.split("/"):
             try:
                 int(fragment)
-                path_fragments.append("%d")
+                path_fragments.append("*")
             except ValueError:  # Not an integer parameter
                 path_fragments.append(str(fragment))
 
@@ -739,7 +739,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
                 ".".join(host_fragments),
                 "/".join(path_fragments),
                 "?",
-                "&".join(sorted([f"{key}=%s" for key in query.keys()])),
+                "&".join(sorted([f"{key}=*" for key in query.keys()])),
             ]
         ).rstrip("?")
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -711,7 +711,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         return self.settings["detection_rate"] > random.random()
 
     @staticmethod
-    def condense_url(url: str) -> str:
+    def parameterize_url(url: str) -> str:
         parsed_url = urlparse(str(url))
 
         protocol_fragments = []
@@ -728,7 +728,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             try:
                 int(fragment)
                 path_fragments.append("%d")
-            except ValueError:  # Not an integer
+            except ValueError:  # Not an integer parameter
                 path_fragments.append(str(fragment))
 
         query = parse_qs(parsed_url.query)
@@ -739,7 +739,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
                 ".".join(host_fragments),
                 "/".join(path_fragments),
                 "?",
-                "&".join(sorted(query.keys())),
+                "&".join(sorted([f"{key}=%s" for key in query.keys()])),
             ]
         ).rstrip("?")
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -50,6 +50,30 @@ CONTAINS_PARAMETER_REGEX = re.compile(
     )
 )
 
+URL_PARAMETER_REGEX = re.compile(
+    r"""(?x)
+    (?P<uuid>
+        \b
+            [0-9a-fA-F]{8}-
+            [0-9a-fA-F]{4}-
+            [0-9a-fA-F]{4}-
+            [0-9a-fA-F]{4}-
+            [0-9a-fA-F]{12}
+        \b
+    ) |
+    (?P<sha1>
+        \b[0-9a-fA-F]{40}\b
+    ) |
+    (?P<md5>
+        \b[0-9a-fA-F]{32}\b
+    ) |
+    (?P<int>
+        -\d+\b |
+        \b\d+\b
+    )
+"""
+)  # From message.py
+
 
 class DetectorType(Enum):
     SLOW_DB_QUERY = "slow_db_query"
@@ -725,10 +749,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
         path_fragments = []
         for fragment in parsed_url.path.split("/"):
-            try:
-                int(fragment)
+            if URL_PARAMETER_REGEX.search(fragment):
                 path_fragments.append("*")
-            except ValueError:  # Not an integer parameter
+            else:
                 path_fragments.append(str(fragment))
 
         query = parse_qs(parsed_url.query)

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -109,6 +109,48 @@ class NPlusOneAPICallsDetectorTest(TestCase):
 
 
 @pytest.mark.parametrize(
+    "url,condensed_url",
+    [
+        (
+            "",
+            "",
+        ),
+        (
+            "http://service.io",
+            "http://service.io",
+        ),
+        (
+            "https://www.service.io/resources/11",
+            "https://www.service.io/resources/%d",
+        ),
+        (
+            "https://www.service.io/resources/11/details",
+            "https://www.service.io/resources/%d/details",
+        ),
+        (
+            "https://www.service.io/resources/11/details?id=1&sort=down",
+            "https://www.service.io/resources/%d/details?id&sort",
+        ),
+        (
+            "https://www.service.io/resources/11/details?sort=down&id=1",
+            "https://www.service.io/resources/%d/details?id&sort",
+        ),
+        (
+            "https://service.io/clients/somecord/details?id=17",
+            "https://service.io/clients/somecord/details?id",
+        ),
+        (
+            "/clients/11/project/1343",
+            "/clients/%d/project/%d",
+        ),
+    ],
+)
+def test_condenses_url(url, condensed_url):
+    r = NPlusOneAPICallsDetector.condense_url(url)
+    assert r == condensed_url
+
+
+@pytest.mark.parametrize(
     "span",
     [
         {

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -145,7 +145,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         ),
     ],
 )
-def test_condenses_url(url, parameterized_url):
+def test_parameterizes_url(url, parameterized_url):
     r = NPlusOneAPICallsDetector.parameterize_url(url)
     assert r == parameterized_url
 

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -34,7 +34,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         problems = self.find_problems(event)
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1010-69d860e29da221dccf046e1cceea31eaf6eae1b4",
+                fingerprint="1-1010-7b6c834c090baf47f5d5ff177b8285c91b899dd3",
                 op="http.client",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
                 desc="GET /api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A",

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -109,7 +109,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
 
 
 @pytest.mark.parametrize(
-    "url,condensed_url",
+    "url,parameterized_url",
     [
         (
             "",
@@ -129,15 +129,15 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         ),
         (
             "https://www.service.io/resources/11/details?id=1&sort=down",
-            "https://www.service.io/resources/%d/details?id&sort",
+            "https://www.service.io/resources/%d/details?id=%s&sort=%s",
         ),
         (
             "https://www.service.io/resources/11/details?sort=down&id=1",
-            "https://www.service.io/resources/%d/details?id&sort",
+            "https://www.service.io/resources/%d/details?id=%s&sort=%s",
         ),
         (
             "https://service.io/clients/somecord/details?id=17",
-            "https://service.io/clients/somecord/details?id",
+            "https://service.io/clients/somecord/details?id=%s",
         ),
         (
             "/clients/11/project/1343",
@@ -145,9 +145,9 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         ),
     ],
 )
-def test_condenses_url(url, condensed_url):
-    r = NPlusOneAPICallsDetector.condense_url(url)
-    assert r == condensed_url
+def test_condenses_url(url, parameterized_url):
+    r = NPlusOneAPICallsDetector.parameterize_url(url)
+    assert r == parameterized_url
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -34,7 +34,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         problems = self.find_problems(event)
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1010-3b2ee4021cd4e24acd32179932e10553e312786b",
+                fingerprint="1-1010-69d860e29da221dccf046e1cceea31eaf6eae1b4",
                 op="http.client",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
                 desc="GET /api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A",

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -34,7 +34,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         problems = self.find_problems(event)
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1010-7b6c834c090baf47f5d5ff177b8285c91b899dd3",
+                fingerprint="1-1010-d750ce46bb1b13dd5780aac48098d5e20eea682c",
                 op="http.client",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
                 desc="GET /api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A",
@@ -121,27 +121,27 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         ),
         (
             "https://www.service.io/resources/11",
-            "https://www.service.io/resources/%d",
+            "https://www.service.io/resources/*",
         ),
         (
             "https://www.service.io/resources/11/details",
-            "https://www.service.io/resources/%d/details",
+            "https://www.service.io/resources/*/details",
         ),
         (
             "https://www.service.io/resources/11/details?id=1&sort=down",
-            "https://www.service.io/resources/%d/details?id=%s&sort=%s",
+            "https://www.service.io/resources/*/details?id=*&sort=*",
         ),
         (
             "https://www.service.io/resources/11/details?sort=down&id=1",
-            "https://www.service.io/resources/%d/details?id=%s&sort=%s",
+            "https://www.service.io/resources/*/details?id=*&sort=*",
         ),
         (
             "https://service.io/clients/somecord/details?id=17",
-            "https://service.io/clients/somecord/details?id=%s",
+            "https://service.io/clients/somecord/details?id=*",
         ),
         (
             "/clients/11/project/1343",
-            "/clients/%d/project/%d",
+            "/clients/*/project/*",
         ),
     ],
 )

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -143,6 +143,34 @@ class NPlusOneAPICallsDetectorTest(TestCase):
             "/clients/11/project/1343",
             "/clients/*/project/*",
         ),
+        (
+            "/clients/11/project/1343-turtles",
+            "/clients/*/project/*",
+        ),
+        (
+            "/clients/11/project/1343turtles",
+            "/clients/*/project/1343turtles",
+        ),
+        (
+            "/clients/563712f9722fb0996ac8f3905b40786f/project/1343",  # md5
+            "/clients/*/project/*",
+        ),
+        (
+            "/clients/563712f9722fb0996z/project/",  # md5-like
+            "/clients/563712f9722fb0996z/project/",
+        ),
+        (
+            "/clients/403926033d001b5279df37cbbe5287b7c7c267fa/project/1343",  # sha1
+            "/clients/*/project/*",
+        ),
+        (
+            "/clients/8ff81d74-606d-4c75-ac5e-cee65cbbc866/project/1343",  # uuid
+            "/clients/*/project/*",
+        ),
+        (
+            "/clients/hello-123s/project/1343",  # uuid-like
+            "/clients/hello-123s/project/*",
+        ),
     ],
 )
 def test_parameterizes_url(url, parameterized_url):


### PR DESCRIPTION
Closes PERF-1929. The background information is [in Notion](https://www.notion.so/sentry/Fingerprinting-660a11203fa444c1aa1787437bb8b299), but in short, without parameterizing URLs in spans we will not be able to fingerprint URLs correctly, and this creates issue explosions for some clients.

`NPlusOneAPICallsDetector` now parameterizes URLs before creating a fingerprint by replacing anything that looks like an integer, an MD5 hash, a SHA1 hash, or a UUID with `"*"`. Asterisk because that's what we expect `TreeClusterer` to return, and we're hoping to use that in the future.

Somewhat surprisingly, this is enough to cover all current known clients except Sentry itself, but EA will reveal how well this works in more detail.
