### PR TITLE
fix(metrics): use retention_days from org settings in indexer

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -20,6 +20,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message
 from django.conf import settings
 
+from sentry import quotas
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.consumers.indexer.common import IndexerOutputMessageBatch, MessageBatch
 from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingPayload
@@ -344,7 +345,7 @@ class IndexerBatch:
                     )
                 continue
 
-            new_payload_value["retention_days"] = 90
+            new_payload_value["retention_days"] = quotas.get_event_retention(organization=org_id)
             new_payload_value["mapping_meta"] = output_message_meta
             new_payload_value["use_case_id"] = self.use_case_id.value
 

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import MutableMapping
 from datetime import datetime, timezone
+from unittest.mock import Mock, patch
 
 import pytest
 from arroyo.backends.kafka import KafkaPayload
@@ -208,6 +209,7 @@ def test_extract_strings_with_rollout(should_index_tag_values, expected):
     assert batch.extract_strings() == expected
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_all_resolved(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -340,6 +342,7 @@ def test_all_resolved(caplog, settings):
     ]
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_all_resolved_with_routing_information(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -475,6 +478,7 @@ def test_all_resolved_with_routing_information(caplog, settings):
     ]
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_batch_resolve_with_values_not_indexed(caplog, settings):
     """
     Tests that the indexer batch skips resolving tag values for indexing and
@@ -601,6 +605,7 @@ def test_batch_resolve_with_values_not_indexed(caplog, settings):
     ]
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_metric_id_rate_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -697,6 +702,7 @@ def test_metric_id_rate_limited(caplog, settings):
     ]
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_tag_key_rate_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -775,6 +781,7 @@ def test_tag_key_rate_limited(caplog, settings):
     assert _deconstruct_messages(snuba_payloads) == []
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_tag_value_rate_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -893,6 +900,7 @@ def test_tag_value_rate_limited(caplog, settings):
     ]
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_one_org_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -997,6 +1005,7 @@ def test_one_org_limited(caplog, settings):
     ]
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_cardinality_limiter(caplog, settings):
     """
     Test functionality of the indexer batch related to cardinality-limiting. More concretely, assert that `IndexerBatch.filter_messages`:

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -3,7 +3,7 @@ import time
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Dict, List, MutableMapping, Sequence, Union
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 import pytest
 from arroyo.backends.kafka import KafkaPayload
@@ -280,6 +280,7 @@ def __translated_payload(
     return payload
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_process_messages() -> None:
     message_payloads = [counter_payload, distribution_payload, set_payload]
     message_batch = [
@@ -358,6 +359,7 @@ invalid_payloads = [
 ]
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 @pytest.mark.parametrize("invalid_payload, error_text, format_payload", invalid_payloads)
 def test_process_messages_invalid_messages(
     invalid_payload, error_text, format_payload, caplog
@@ -423,6 +425,7 @@ def test_process_messages_invalid_messages(
     assert error_text in caplog.text
 
 
+@patch("sentry.quotas.get_event_retention", Mock(return_value=90))
 def test_process_messages_rate_limited(caplog, settings) -> None:
     """
     Test handling of `None`-values coming from the indexer service, which


### PR DESCRIPTION
We were hardcoding a 90-day TTL here, but we should pull from the org settings. This brings us into line with how other datasets are handled: https://www.notion.so/sentry/Notes-on-adherence-to-retention-9b6a314bed174fed921f3c4cac8a39fe