### PR TITLE
test(acceptance): Prevent flake in test_emails due to sequence

### DIFF
--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -47,6 +47,11 @@ def build_url(path: str, format: str = "html") -> str:
 
 
 class EmailTestCase(AcceptanceTestCase):
+    # This test requires ID's for issues to start from 1, so reset sequences
+    # to avoid the test failing if the order of tests mean issues are made
+    # before this test is run.
+    reset_sequences = True
+
     def setUp(self):
         super().setUp()
         # This email address is required to match FIXTURES.


### PR DESCRIPTION
If you run `pytest tests/acceptance/test_issue_details.py tests/acceptance/test_emails.py` you can cause test_emails to fail because the issue IDs do not start from 1, this change fixes that.

NOTE: While it would be preferable to make the test not care about the sequence, this test compares file contents with the output, and it feels reasonable to keep this behavior.