### PR TITLE
fix(hybrid-cloud): Delete organization mappings

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -8,6 +8,7 @@ from typing import FrozenSet, Optional, Sequence
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
 from django.db.models import QuerySet
+from django.db.models.signals import post_delete
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -621,3 +622,18 @@ class Organization(Model, SnowflakeIdMixin):
         if not self.get_option("sentry:alerts_member_write", ALERTS_MEMBER_WRITE_DEFAULT):
             scopes.discard("alerts:write")
         return frozenset(scopes)
+
+    # TODO(hybrid-cloud): Replace with Region tombstone when it's implemented
+    @classmethod
+    def remove_organization_mapping(cls, instance, **kwargs):
+        from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
+
+        organization_mapping_service.delete(instance.id)
+
+
+post_delete.connect(
+    Organization.remove_organization_mapping,
+    dispatch_uid="sentry.remove_organization_mapping",
+    sender=Organization,
+    weak=False,
+)

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -84,6 +84,10 @@ class OrganizationMappingService(InterfaceWithLifecycle):
     def verify_mappings(self, organization_id: int, slug: str) -> None:
         pass
 
+    @abstractmethod
+    def delete(self, organization_id: int) -> None:
+        pass
+
 
 def impl_with_db() -> OrganizationMappingService:
     from sentry.services.hybrid_cloud.organization_mapping.impl import (

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -78,3 +78,6 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
         OrganizationMapping.objects.filter(
             organization_id=organization_id, date_created__lte=mapping.date_created
         ).exclude(slug=slug).delete()
+
+    def delete(self, organization_id: int) -> None:
+        OrganizationMapping.objects.filter(organization_id=organization_id).delete()

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -23,6 +23,7 @@ from sentry.models import (
     Repository,
     ScheduledDeletion,
 )
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.snuba.models import SnubaQuery
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TransactionTestCase
@@ -33,7 +34,9 @@ from sentry.testutils.silo import region_silo_test
 class DeleteOrganizationTest(TransactionTestCase):
     def test_simple(self):
         org = self.create_organization(name="test")
+        org_mapping = self.create_organization_mapping(org)
         org2 = self.create_organization(name="test2")
+        org_mapping2 = self.create_organization_mapping(org2)
         self.create_team(organization=org, name="test1")
         self.create_team(organization=org, name="test2")
         release = Release.objects.create(version="a" * 32, organization_id=org.id)
@@ -95,8 +98,10 @@ class DeleteOrganizationTest(TransactionTestCase):
             run_deletion(deletion.id)
 
         assert Organization.objects.filter(id=org2.id).exists()
+        assert OrganizationMapping.objects.filter(id=org_mapping2.id).exists()
 
         assert not Organization.objects.filter(id=org.id).exists()
+        assert not OrganizationMapping.objects.filter(id=org_mapping.id).exists()
         assert not Environment.objects.filter(id=env.id).exists()
         assert not ReleaseEnvironment.objects.filter(id=release_env.id).exists()
         assert not Repository.objects.filter(id=repo.id).exists()


### PR DESCRIPTION
Cascade delete organization mappings when organizations are deleted. This will be replaced with region tombstones, but that work is still in progress.