### PR TITLE
ref(issue-platform): port over issue platform tsdb queries from legacy to SnQL

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -95,6 +95,20 @@ def get_project_list(project_id):
     return project_id if isinstance(project_id, Iterable) else [project_id]
 
 
+def _translate_filter_keys(project_ids, group_ids, environment_ids) -> Dict[str, Any]:
+    from sentry.utils.snuba import get_snuba_translators
+
+    filter_keys = {"project_id": project_ids}
+    if environment_ids:
+        filter_keys["environment"] = environment_ids
+    if group_ids:
+        filter_keys["group_id"] = group_ids
+
+    forward, reverse = get_snuba_translators(filter_keys, is_grouprelease=False)
+
+    return forward(filter_keys)
+
+
 class SnubaTagStorage(TagStorage):
     def __get_tag_key(self, project_id, group_id, environment_id, key):
         tag = f"tags[{key}]"
@@ -531,7 +545,7 @@ class SnubaTagStorage(TagStorage):
     def get_generic_group_list_tag_value(
         self, project_ids, group_id_list, environment_ids, key, value
     ):
-        translated_params = self._translate_filter_keys(project_ids, group_id_list, environment_ids)
+        translated_params = _translate_filter_keys(project_ids, group_id_list, environment_ids)
         organization_id = get_organization_id_from_project_ids(project_ids)
         start, end = _prepare_start_end(
             None,
@@ -579,19 +593,6 @@ class SnubaTagStorage(TagStorage):
             )
             for group_id, data in nested_groups.items()
         }
-
-    def _translate_filter_keys(self, project_ids, group_ids, environment_ids) -> Dict[str, Any]:
-        from sentry.utils.snuba import get_snuba_translators
-
-        filter_keys = {"project_id": project_ids}
-        if environment_ids:
-            filter_keys["environment"] = environment_ids
-        if group_ids:
-            filter_keys["group_id"] = group_ids
-
-        forward, reverse = get_snuba_translators(filter_keys, is_grouprelease=False)
-
-        return forward(filter_keys)
 
     def get_group_seen_values_for_environments(
         self, project_ids, group_id_list, environment_ids, start=None, end=None
@@ -900,7 +901,7 @@ class SnubaTagStorage(TagStorage):
     def get_generic_groups_user_counts(
         self, project_ids, group_ids, environment_ids, start=None, end=None
     ):
-        translated_params = self._translate_filter_keys(project_ids, group_ids, environment_ids)
+        translated_params = _translate_filter_keys(project_ids, group_ids, environment_ids)
         organization_id = get_organization_id_from_project_ids(project_ids)
         start, end = _prepare_start_end(
             start,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -902,7 +902,6 @@ class SnubaTagStorage(TagStorage):
     ):
         translated_params = self._translate_filter_keys(project_ids, group_ids, environment_ids)
         organization_id = get_organization_id_from_project_ids(project_ids)
-
         start, end = _prepare_start_end(
             start,
             end,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -902,6 +902,7 @@ class SnubaTagStorage(TagStorage):
     ):
         translated_params = self._translate_filter_keys(project_ids, group_ids, environment_ids)
         organization_id = get_organization_id_from_project_ids(project_ids)
+
         start, end = _prepare_start_end(
             start,
             end,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -267,32 +267,6 @@ class SnubaTSDB(BaseTSDB):
 
         return known_rollups if known_rollups else synthetic_rollup
 
-    def get_sums_snql(
-        self,
-        model,
-        keys,
-        start,
-        end,
-        rollup=None,
-        environment_id=None,
-        use_cache=False,
-        jitter_value=None,
-    ):
-        pass
-
-    def get_distinct_counts_totals_snql(
-        self,
-        model,
-        keys,
-        start,
-        end=None,
-        rollup=None,
-        environment_id=None,
-        use_cache=False,
-        jitter_value=None,
-    ):
-        pass
-
     def get_data(
         self,
         model,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -393,8 +393,7 @@ class SnubaTSDB(BaseTSDB):
         # build up where conditions
         conditions = conditions if conditions is not None else []
         if model_query_settings.conditions is not None:
-            conditions += deepcopy(model_query_settings.conditions)
-            # copy because we modify the conditions in snuba.query
+            conditions += model_query_settings.conditions
 
         # build up order by
         orderby = []
@@ -409,10 +408,11 @@ class SnubaTSDB(BaseTSDB):
         if keys:
 
             def _build_select_exp(
+                selected_columns: Sequence[str],
                 aggs: Sequence[Sequence[Any]],
             ) -> Optional[Sequence[SelectableExpression]]:
                 selects = []
-                for s in model_query_settings.selected_columns or ():
+                for s in selected_columns or ():
                     selects.append(Column(s))
                 # combination of aggregations
                 for agg in aggs:
@@ -461,7 +461,7 @@ class SnubaTSDB(BaseTSDB):
 
                 return None
 
-            selected = _build_select_exp(aggregations)
+            selected = _build_select_exp(model_query_settings.selected_columns, aggregations)
             where_conds = _build_where_exp(conditions, keys_map, start, end)
 
             # snql style using Reqest

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -283,7 +283,7 @@ class SnubaTSDB(BaseTSDB):
         jitter_value=None,
     ):
         if model in self.non_outcomes_snql_query_settings:
-            return self.get_data_snql(
+            return self.__get_data_snql(
                 model,
                 keys,
                 start,
@@ -298,7 +298,7 @@ class SnubaTSDB(BaseTSDB):
                 jitter_value,
             )
         else:
-            return self.get_data_legacy(
+            return self.__get_data_legacy(
                 model,
                 keys,
                 start,
@@ -313,7 +313,7 @@ class SnubaTSDB(BaseTSDB):
                 jitter_value,
             )
 
-    def get_data_snql(
+    def __get_data_snql(
         self,
         model,
         keys,
@@ -328,6 +328,10 @@ class SnubaTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
     ):
+        """
+        Similar to __get_data_legacy but uses the SnQL format. For future additions, prefer using this impl over
+        the legacy format.
+        """
         model_requires_manual_group_on_time = model in (
             TSDBModel.group_generic,
             TSDBModel.users_affected_by_generic_group,
@@ -499,7 +503,7 @@ class SnubaTSDB(BaseTSDB):
         else:
             return result
 
-    def get_data_legacy(
+    def __get_data_legacy(
         self,
         model,
         keys,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -461,6 +461,11 @@ def get_organization_id_from_project_ids(project_ids: Sequence[int]) -> int:
     return organization_id
 
 
+def infer_project_ids_from_related_models(filter_keys: Mapping[str, Sequence[int]]) -> List[int]:
+    ids = [set(get_related_project_ids(k, filter_keys[k])) for k in filter_keys]
+    return list(set.union(*ids))
+
+
 def get_query_params_to_update_for_projects(query_params, with_org=False):
     """
     Get the project ID and query params that need to be updated for project
@@ -472,11 +477,7 @@ def get_query_params_to_update_for_projects(query_params, with_org=False):
     elif query_params.filter_keys:
         # Otherwise infer the project_ids from any related models
         with timer("get_related_project_ids"):
-            ids = [
-                set(get_related_project_ids(k, query_params.filter_keys[k]))
-                for k in query_params.filter_keys
-            ]
-            project_ids = list(set.union(*ids))
+            project_ids = infer_project_ids_from_related_models(query_params.filter_keys)
     elif query_params.conditions:
         project_ids = []
         for cond in query_params.conditions:


### PR DESCRIPTION
This PR adds a separate code path for querying the `search_issues` dataset within SnubaTSDB using the SnQL format, as opposed to the legacy format.

The end result should be functionally equivalent to what we had before. 
