### PR TITLE
chore(issue-platform): Add feature flag for ingesting profile main thread blocked issues

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1016,6 +1016,8 @@ SENTRY_FEATURES = {
     "organizations:profiling-ui-frames": False,
     # Enable the profiling dashboard redesign
     "organizations:profiling-dashboard-redesign": False,
+    # Whether to enable ingest for profile blocked main thread issues
+    "organizations:profile-blocked-main-thread-ingest": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -201,6 +201,7 @@ default_manager.add("organizations:integrations-stacktrace-link", OrganizationFe
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature)
 default_manager.add("organizations:onboarding-heartbeat-footer", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
+default_manager.add("organizations:profile-blocked-main-thread-ingest", OrganizationFeature)
 default_manager.add("organizations:relay", OrganizationFeature)
 default_manager.add("organizations:sso-basic", OrganizationFeature)
 default_manager.add("organizations:sso-saml2", OrganizationFeature)


### PR DESCRIPTION
This adds a feature flag to control whether we ingest profile main thread blocked issues