### PR TITLE
test(acceptance): Fix flakes in issue details workflow

### DIFF
--- a/fixtures/page_objects/issue_details.py
+++ b/fixtures/page_objects/issue_details.py
@@ -1,4 +1,6 @@
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.ui import WebDriverWait
 
 from .base import BasePage
 from .global_selection import GlobalSelectionPage
@@ -76,6 +78,11 @@ class IssueDetailsPage(BasePage):
         assignee.find_element(
             by=By.CSS_SELECTOR, value='[data-test-id="assignee-selector"]'
         ).click()
+
+        # Wait for the input to be loaded
+        wait = WebDriverWait(assignee, 10)
+        wait.until(expected_conditions.presence_of_element_located((By.TAG_NAME, "input")))
+
         assignee.find_element(by=By.TAG_NAME, value="input").send_keys(user)
 
         # Click the member/team

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -870,6 +870,12 @@ class AcceptanceTestCase(TransactionTestCase):
         ):
             yield
 
+    def wait_for_loading(self):
+        self.browser.wait_until_not('[data-test-id="events-request-loading"]')
+        self.browser.wait_until_not('[data-test-id="loading-indicator"]')
+        self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
+        self.browser.wait_until_not(".loading")
+
     def save_cookie(self, name, value, **params):
         self.browser.save_cookie(name=name, value=value, **params)
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -484,12 +484,10 @@ def browser(request, live_server):
 
         driver = start_chrome(**chrome_args)
         if slow_network:
-            # https://github.com/ChromeDevTools/devtools-frontend/blob/80c102878fd97a7a696572054007d40560dcdd21/front_end/sdk/NetworkManager.js#L252-L274
             driver.set_network_conditions(
                 offline=False,
-                latency=400 * 5,
-                download_throughput=500 * 1024 / 8 * 0.8,
-                upload_throughput=500 * 1024 / 8 * 0.8,
+                latency=400 * 2,  # additional latency (ms)
+                throughput=500 * 1024,  # maximal throughput
             )
     elif driver_type == "firefox":
         driver = webdriver.Firefox()

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -40,6 +40,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(platform="python")
         self.page.visit_issue(self.org.slug, event.group.id)
         self.page.resolve_issue()
+        self.wait_for_loading()
 
         res = self.page.api_issue_get(event.group.id)
         assert res.status_code == 200, res
@@ -49,6 +50,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(platform="python")
         self.page.visit_issue(self.org.slug, event.group.id)
         self.page.ignore_issue()
+        self.wait_for_loading()
 
         res = self.page.api_issue_get(event.group.id)
         assert res.status_code == 200, res
@@ -58,6 +60,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(platform="python")
         self.page.visit_issue(self.org.slug, event.group.id)
         self.page.bookmark_issue()
+        self.wait_for_loading()
 
         res = self.page.api_issue_get(event.group.id)
         assert res.status_code == 200, res


### PR DESCRIPTION
This change waits for loading to complete in a number of checks. This is intermittent when running locally but is reliable when running with --slow-network=true

NOTE: The changes to the network configuration is to make the browser slow enough to more easily show issues while avoiding timeouts on selenium waits.