### PR TITLE
test(acceptance): Fix a flake in the test_edit_integration_schema test

### DIFF
--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -90,6 +90,8 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
         self.browser.wait_until(".ref-success")
 
+        self.browser.wait_until('[data-test-id="tesla-app"]')
+
         link = self.browser.find_element(by=By.LINK_TEXT, value="Tesla App")
         link.click()
 


### PR DESCRIPTION
This waits for the table to be loaded before looking for the element. This test fails if you run the test with `--slow-network=true`