### PR TITLE
fix: Check length of latestItemsRef to determine last element

### DIFF
--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -439,7 +439,7 @@ export function useVirtualizedTree<T extends TreeLike>(
           const nextIndex = indexInVisibleItems + 1;
 
           // Bounds check if we are at end of list
-          if (nextIndex > latestTreeRef.current.flattened.length - 1) {
+          if (nextIndex > latestItemsRef.current.length - 1) {
             return;
           }
 


### PR DESCRIPTION
Key down on the last node of a tree causes an error
because it was looking at `latestTreeRef`. But determining
the `indexInVisibleItems` and subsequent dispatch
uses `latestItemsRef` so I think that's probably what
we need to check the next index against to see if we
are at the end of the list.

Hit the bug when testing https://github.com/getsentry/sentry/pull/43409
key down on the last node