### PR TITLE
fix(perf-issues): Limit browser names on detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1665,13 +1665,13 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
     def is_event_eligible(cls, event):
         tags = event.get("tags", [])
         browser_name = next(
-            (tag[1] for tag in tags if tag[0] == "browser.name" and len(tag) == 2), None
+            (tag[1] for tag in tags if tag[0] == "browser.name" and len(tag) == 2), ""
         )
-        if browser_name in [
-            "Chrome",
-            "Firefox",
-            "Safari",
-            "Edge",
+        if browser_name.lower() in [
+            "chrome",
+            "firefox",
+            "safari",
+            "edge",
         ]:
             # Only use major browsers as some mobile browser may be responsible for not sending accept-content header,
             # which isn't fixable since you can't control what headers your users are sending.

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1662,6 +1662,23 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
     def is_creation_allowed_for_project(self, project: Project) -> bool:
         return True  # Detection always allowed by project for now
 
+    def is_event_eligible(cls, event):
+        tags = event.get("tags", [])
+        browser_name = next(
+            (tag[1] for tag in tags if tag[0] == "browser.name" and len(tag) == 2), None
+        )
+        if browser_name in [
+            "Chrome",
+            "Firefox",
+            "Safari",
+            "Edge",
+        ]:
+            # Only use major browsers as some mobile browser may be responsible for not sending accept-content header,
+            # which isn't fixable since you can't control what headers your users are sending.
+            # This can be extended later.
+            return True
+        return False
+
 
 # Reports metrics and creates spans for detection
 def report_metrics_for_detectors(

--- a/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
@@ -41,6 +41,7 @@ class UncompressedAssetsDetectorTest(TestCase):
         event = {
             "event_id": "a" * 16,
             "project": PROJECT_ID,
+            "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
                     duration=1000.0,
@@ -69,6 +70,7 @@ class UncompressedAssetsDetectorTest(TestCase):
         event = {
             "event_id": "a" * 16,
             "project": PROJECT_ID,
+            "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
                     op="resource.link",
@@ -94,6 +96,25 @@ class UncompressedAssetsDetectorTest(TestCase):
                 offender_span_ids=["bbbbbbbbbbbbbbbb"],
             )
         ]
+
+    def test_does_not_detect_mobile_uncompressed_asset(self):
+        event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "tags": [["browser.name", "firefox_mobile"]],
+            "spans": [
+                create_asset_span(
+                    duration=1000.0,
+                    data={
+                        "Transfer Size": 1_000_000,
+                        "Encoded Body Size": 1_000_000,
+                        "Decoded Body Size": 1_000_000,
+                    },
+                )
+            ],
+        }
+
+        assert len(self.find_problems(event)) == 0
 
     def test_ignores_assets_under_size(self):
         event = {


### PR DESCRIPTION
### Summary
This limits the uncompressed assets detectors to major browser for now, because sometimes the asset is uncompressed due to browser limitations. We can introduce it later, but it's a source of noise that's easy to eliminate and only removes a fraction of overall detectable issues.

