### PR TITLE
feat: Rename "resources and whatever" to "resources"

### DIFF
--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -306,7 +306,7 @@ describe('EventEntries', function () {
       );
 
       const resourcesHeadingText = screen.getByRole('heading', {
-        name: /resources and whatever/i,
+        name: /resources/i,
       });
 
       expect(resourcesHeadingText).toBeInTheDocument();
@@ -354,7 +354,7 @@ describe('EventEntries', function () {
         name: /breadcrumbs/i,
       });
       const resourcesHeadingText = screen.getByRole('heading', {
-        name: /resources and whatever/i,
+        name: /resources/i,
       });
 
       expect(spanEvidenceHeading).toBeInTheDocument();
@@ -375,7 +375,7 @@ describe('EventEntries', function () {
 
       expect(
         within(eventEntriesContainer.children[2] as HTMLElement).getByRole('heading', {
-          name: /resources and whatever/i,
+          name: /resources/i,
         })
       ).toBeInTheDocument();
     });

--- a/static/app/components/events/interfaces/performance/resources.tsx
+++ b/static/app/components/events/interfaces/performance/resources.tsx
@@ -19,7 +19,7 @@ type Props = {
 // This section provides users with resources on how to resolve an issue
 export function Resources(props: Props) {
   return (
-    <EventDataSection type="resources-and-whatever" title={t('Resources and Whatever')}>
+    <EventDataSection type="resources" title={t('Resources')}>
       {props.description}
       <LinkSection>
         {props.links.map(({link, text}) => (


### PR DESCRIPTION
The word "resources" already covers everything included here. "And whatever" is superfluous and sounds excessively casual and non specific. Customers wrote to us asking if we left placeholder in.