### PR TITLE
feat(profiling): add p95 support to profiling hovercard

### DIFF
--- a/static/app/components/profiling/functionsMiniGrid.tsx
+++ b/static/app/components/profiling/functionsMiniGrid.tsx
@@ -42,7 +42,7 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
 
       {functions &&
         functions.map((f, idx) => {
-          const [exampleProfileIdRaw] = f.examples;
+          const exampleProfileIdRaw = f.worst;
           const exampleProfileId = exampleProfileIdRaw.replaceAll('-', '');
           return (
             <Fragment key={idx}>

--- a/static/app/components/profiling/functionsMiniGrid.tsx
+++ b/static/app/components/profiling/functionsMiniGrid.tsx
@@ -37,7 +37,7 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
   return (
     <FunctionsMiniGridContainer>
       <FunctionsMiniGridHeader>{t('Slowest app functions')}</FunctionsMiniGridHeader>
-      <FunctionsMiniGridHeader align="right">{t('P99')}</FunctionsMiniGridHeader>
+      <FunctionsMiniGridHeader align="right">{t('P95')}</FunctionsMiniGridHeader>
       <FunctionsMiniGridHeader align="right">{t('Count')}</FunctionsMiniGridHeader>
 
       {functions &&
@@ -57,7 +57,7 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
                 </FunctionNameTextTruncate>
               </FunctionsMiniGridCell>
               <FunctionsMiniGridCell align="right">
-                <PerformanceDuration nanoseconds={f.p99} abbreviation />
+                <PerformanceDuration nanoseconds={f.p95} abbreviation />
               </FunctionsMiniGridCell>
               <FunctionsMiniGridCell align="right">
                 <NumberContainer>{f.count}</NumberContainer>

--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -192,11 +192,12 @@ const COLUMN_ORDER: TableColumnKey[] = [
   'package',
   'count',
   'p75',
+  'p95',
   'p99',
   'examples',
 ];
 
-const COLUMNS: Record<TableColumnKey, TableColumn> = {
+const COLUMNS: Record<Exclude<TableColumnKey, 'p95'>, TableColumn> = {
   name: {
     key: 'name',
     name: t('Name'),

--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -192,7 +192,6 @@ const COLUMN_ORDER: TableColumnKey[] = [
   'package',
   'count',
   'p75',
-  'p95',
   'p99',
   'examples',
 ];

--- a/static/app/types/profiling/core.tsx
+++ b/static/app/types/profiling/core.tsx
@@ -48,6 +48,7 @@ export type SuspectFunction = {
   fingerprint: number;
   name: string;
   p75: number;
+  p95: number;
   p99: number;
   package: string;
   path: string;

--- a/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
+++ b/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
@@ -63,7 +63,7 @@ export function useProfilingTransactionQuickSummary(
     query: '',
     selection,
     transaction,
-    sort: '-p99',
+    sort: '-p95',
     functionType: 'application',
     enabled: !skipFunctions,
   });


### PR DESCRIPTION
### Summary
Sorts and displays the profiling hovercard suspect functions by `-p95` by default.

~~Blocked by: https://github.com/getsentry/vroom/pull/116~~