### PR TITLE
CI(dispatch): Switch to merge commit sha where possible

### DIFF
--- a/.github/workflows/scripts/getsentry-dispatch.js
+++ b/.github/workflows/scripts/getsentry-dispatch.js
@@ -26,6 +26,12 @@ module.exports = {
       backend_dependencies: fileChanges.backend_dependencies !== 'true',
     };
 
+    const pr = context.payload.pull_request;
+    // sentrySHA is the sha getsentry should run against.
+    const sentrySHA = pr.merge_commit_sha || pr.head.sha;
+    // prSHA is the sha actions should post commit statuses too.
+    const prSHA = pr.head.sha;
+
     await Promise.all(
       DISPATCHES.map(({workflow, pathFilterName}) => {
         return github.rest.actions.createWorkflowDispatch({
@@ -36,7 +42,8 @@ module.exports = {
           inputs: {
             pull_request_number: `${context.payload.pull_request.number}`, // needs to be string
             skip: `${shouldSkip[pathFilterName]}`, // even though this is a boolean, it must be cast to a string
-            'sentry-sha': context.payload.pull_request.head.sha,
+            'sentry-sha': sentrySHA,
+            'sentry-pr-sha': prSHA,
           },
         });
       })

--- a/.github/workflows/scripts/getsentry-dispatch.js
+++ b/.github/workflows/scripts/getsentry-dispatch.js
@@ -28,7 +28,7 @@ module.exports = {
 
     const pr = context.payload.pull_request;
     // sentrySHA is the sha getsentry should run against.
-    const sentrySHA = pr.merge_commit_sha || pr.head.sha;
+    const sentrySHA = pr.merge_commit_sha;
     // prSHA is the sha actions should post commit statuses too.
     const prSHA = pr.head.sha;
 

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -56,7 +56,7 @@ jobs:
               workflow_id: 'acceptance.yml',
               ref: 'master',
               inputs: {
-                'sentry-sha': '${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}',
+                'sentry-sha': '${{ github.event.pull_request.merge_commit_sha }}',
                 'sentry-pr-sha': '${{ github.event.pull_request.head.sha }}',
               }
             })

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -56,6 +56,7 @@ jobs:
               workflow_id: 'acceptance.yml',
               ref: 'master',
               inputs: {
-                'sentry-sha': '${{ github.event.pull_request.head.sha }}',
+                'sentry-sha': '${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}',
+                'sentry-pr-sha': '${{ github.event.pull_request.head.sha }}',
               }
             })


### PR DESCRIPTION
I've tried testing this PR by changing the getsentry-dispatch action to run on pull_request and it seems to have kicked off the getsentry actions on the merge commit while posting a status on this PR, so I believe this is working as intended.