### PR TITLE
feat(n1-api-call): Split up parameters into rows

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -194,9 +194,13 @@ describe('SpanEvidenceKeyValueList', () => {
       ).toHaveTextContent('/book/');
 
       expect(screen.queryByRole('cell', {name: 'Parameters'})).toBeInTheDocument();
-      expect(
-        screen.getByTestId('span-evidence-key-value-list.parameters')
-      ).toHaveTextContent('book_id:{7,8} sort:{up,down}');
+
+      const parametersKeyValue = screen.getByTestId(
+        'span-evidence-key-value-list.parameters'
+      );
+
+      expect(parametersKeyValue).toHaveTextContent('book_id:{7,8}');
+      expect(parametersKeyValue).toHaveTextContent('sort:{up,down}');
     });
 
     describe('extractQueryParameters', () => {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -305,7 +305,7 @@ type ParameterLookup = Record<string, string[]>;
   * @returns A condensed string describing the query parameters changing
   * between the URLs of the given span. e.g., "id:{1,2,3}"
  */
-function formatChangingQueryParameters(spans: Span[], baseURL?: string): string {
+function formatChangingQueryParameters(spans: Span[], baseURL?: string): string[] {
   const URLs = spans
     .map(span => extractSpanURLString(span, baseURL))
     .filter((url): url is URL => url instanceof URL);
@@ -323,7 +323,7 @@ function formatChangingQueryParameters(spans: Span[], baseURL?: string): string 
     }
   }
 
-  return pairs.join(' ');
+  return pairs;
 }
 
 const extractSpanURLString = (span: Span, baseURL?: string): URL | null => {


### PR DESCRIPTION
Much easier to read! Maybe more improvements to follow?
