### PR TITLE
ref(dropdownMenu): Use React context to manage submenus

### DIFF
--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef} from 'react';
+import {createContext, Fragment, useContext, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
@@ -6,31 +6,48 @@ import {useKeyboard} from '@react-aria/interactions';
 import {AriaMenuOptions, useMenu} from '@react-aria/menu';
 import {useSeparator} from '@react-aria/separator';
 import {mergeProps} from '@react-aria/utils';
-import {useTreeState} from '@react-stately/tree';
+import {TreeState, useTreeState} from '@react-stately/tree';
 import {Node} from '@react-types/shared';
+import omit from 'lodash/omit';
 
 import MenuControl from 'sentry/components/dropdownMenuControl';
 import MenuItem, {MenuItemProps} from 'sentry/components/dropdownMenuItem';
 import MenuSection from 'sentry/components/dropdownMenuSection';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import space from 'sentry/styles/space';
+import useOverlay from 'sentry/utils/useOverlay';
 
-export interface DropdownMenuProps extends AriaMenuOptions<MenuItemProps> {
+type OverlayState = ReturnType<typeof useOverlay>['state'];
+
+interface DropdownMenuContextValue {
   /**
-   * If this is a submenu, it will in some cases need to close the root menu
-   * (e.g. when a submenu item is clicked).
+   * Menu state (from @react-aria's useTreeState) of the parent menu. To be used to
+   * close the current submenu.
    */
-  closeRootMenu: () => void;
+  parentMenuState?: TreeState<MenuItemProps>;
   /**
-   * Whether this is a submenu
+   * Overlay state manager (from useOverlay) for the root (top-most) menu. To be used to
+   * close the entire menu system.
    */
-  isSubmenu: boolean;
+  rootOverlayState?: OverlayState;
+}
+
+export const DropdownMenuContext = createContext<DropdownMenuContextValue>({});
+
+export interface DropdownMenuProps
+  extends Omit<
+    AriaMenuOptions<MenuItemProps>,
+    | 'selectionMode'
+    | 'selectedKeys'
+    | 'defaultSelectedKeys'
+    | 'onSelectionChange'
+    | 'disallowEmptySelection'
+  > {
   overlayPositionProps: React.HTMLAttributes<HTMLDivElement>;
   /**
-   * If this is a submenu, it will in some cases need to close itself (e.g.
-   * when the user presses the arrow left key)
+   * The open state of the current overlay that contains this menu
    */
-  closeCurrentSubmenu?: () => void;
+  overlayState: OverlayState;
   /**
    * Whether the menu should close when an item has been clicked/selected
    */
@@ -43,21 +60,20 @@ export interface DropdownMenuProps extends AriaMenuOptions<MenuItemProps> {
    * Minimum menu width
    */
   minWidth?: number;
-  onClose?: () => void;
   size?: MenuItemProps['size'];
 }
 
 function DropdownMenu({
   closeOnSelect = true,
+  onClose,
   minWidth,
   size,
-  isSubmenu,
   menuTitle,
-  closeRootMenu,
-  closeCurrentSubmenu,
+  overlayState,
   overlayPositionProps,
   ...props
 }: DropdownMenuProps) {
+  const {rootOverlayState, parentMenuState} = useContext(DropdownMenuContext);
   const state = useTreeState<MenuItemProps>({...props, selectionMode: 'single'});
   const stateCollection = useMemo(() => [...state.collection], [state.collection]);
 
@@ -70,8 +86,8 @@ function DropdownMenu({
   // root menu).
   const {keyboardProps} = useKeyboard({
     onKeyDown: e => {
-      if (isSubmenu && e.key === 'ArrowLeft') {
-        closeCurrentSubmenu?.();
+      if (e.key === 'ArrowLeft' && parentMenuState) {
+        parentMenuState.selectionManager.clearSelection();
         return;
       }
       e.continuePropagation();
@@ -122,7 +138,7 @@ function DropdownMenu({
       <MenuItem
         node={node}
         state={state}
-        onClose={closeRootMenu}
+        onClose={onClose}
         closeOnSelect={closeOnSelect}
         showDivider={showDividers && !isLastNode}
       />
@@ -131,31 +147,46 @@ function DropdownMenu({
 
   // Render a submenu whose trigger button is a menu item
   const renderItemWithSubmenu = (node: Node<MenuItemProps>, isLastNode: boolean) => {
-    const trigger = submenuTriggerProps => (
+    if (!node.value.children) {
+      return null;
+    }
+
+    const trigger = triggerProps => (
       <MenuItem
         renderAs="div"
         node={node}
         state={state}
-        isSubmenuTrigger
         showDivider={showDividers && !isLastNode}
-        {...submenuTriggerProps}
+        closeOnSelect={false}
+        {...omit(triggerProps, [
+          'onClick',
+          'onDragStart',
+          'onKeyDown',
+          'onKeyUp',
+          'onMouseDown',
+          'onPointerDown',
+          'onPointerUp',
+        ])}
       />
     );
 
     return (
       <MenuControl
-        items={node.value.children as MenuItemProps[]}
+        isOpen={state.selectionManager.isSelected(node.key)}
+        items={node.value.children}
         trigger={trigger}
+        onClose={onClose}
+        closeOnSelect={closeOnSelect}
         menuTitle={node.value.submenuTitle}
+        menuWiderThanTrigger={false}
+        isDismissable={false}
+        shouldCloseOnBlur={false}
+        shouldCloseOnInteractOutside={() => false}
+        preventOverflowOptions={{boundary: document.body, altAxis: true}}
+        renderWrapAs="li"
         position="right-start"
         offset={-4}
-        closeOnSelect={closeOnSelect}
-        isOpen={state.selectionManager.isSelected(node.key)}
         size={size}
-        isSubmenu
-        closeRootMenu={closeRootMenu}
-        closeCurrentSubmenu={() => state.selectionManager.clearSelection()}
-        renderWrapAs="li"
       />
     );
   };
@@ -188,23 +219,32 @@ function DropdownMenu({
     });
 
   const theme = useTheme();
+  const contextValue = useMemo(
+    () => ({
+      rootOverlayState: rootOverlayState ?? overlayState,
+      parentMenuState: state,
+    }),
+    [rootOverlayState, overlayState, state]
+  );
   return (
     <FocusScope restoreFocus autoFocus>
       <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayPositionProps}>
-        <StyledOverlay>
-          {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}
-          <MenuWrap
-            ref={menuRef}
-            hasTitle={!!menuTitle}
-            {...mergeProps(modifiedMenuProps, keyboardProps)}
-            style={{
-              maxHeight: overlayPositionProps.style?.maxHeight,
-              minWidth,
-            }}
-          >
-            {renderCollection(stateCollection)}
-          </MenuWrap>
-        </StyledOverlay>
+        <DropdownMenuContext.Provider value={contextValue}>
+          <StyledOverlay>
+            {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}
+            <MenuWrap
+              ref={menuRef}
+              hasTitle={!!menuTitle}
+              {...mergeProps(modifiedMenuProps, keyboardProps)}
+              style={{
+                maxHeight: overlayPositionProps.style?.maxHeight,
+                minWidth,
+              }}
+            >
+              {renderCollection(stateCollection)}
+            </MenuWrap>
+          </StyledOverlay>
+        </DropdownMenuContext.Provider>
       </PositionWrapper>
     </FocusScope>
   );

--- a/static/app/components/dropdownMenuControl.spec.tsx
+++ b/static/app/components/dropdownMenuControl.spec.tsx
@@ -81,7 +81,7 @@ describe('DropdownMenu', function () {
     expect(onAction).not.toHaveBeenCalled();
   });
 
-  it('renders submenues', function () {
+  it('renders submenus', function () {
     const onAction = jest.fn();
 
     render(
@@ -140,5 +140,31 @@ describe('DropdownMenu', function () {
     userEvent.hover(parentItem);
     userEvent.click(screen.getByRole('menuitemradio', {name: 'Sub Item'}));
     expect(onAction).toHaveBeenCalled();
+
+    // Entire menu system is closed
+    expect(screen.getByRole('button', {name: 'Menu'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    // Pressing Esc closes the entire menu system
+    userEvent.click(screen.getByRole('button', {name: 'Menu'}));
+    userEvent.hover(screen.getByRole('menuitemradio', {name: 'Item'}));
+    userEvent.hover(screen.getByRole('menuitemradio', {name: 'Sub Item'}));
+    userEvent.keyboard('{Esc}');
+    expect(screen.getByRole('button', {name: 'Menu'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    // Clicking outside closes the entire menu system
+    userEvent.click(screen.getByRole('button', {name: 'Menu'}));
+    userEvent.hover(screen.getByRole('menuitemradio', {name: 'Item'}));
+    userEvent.hover(screen.getByRole('menuitemradio', {name: 'Sub Item'}));
+    userEvent.click(document.body);
+    expect(screen.getByRole('button', {name: 'Menu'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
   });
 });

--- a/static/app/components/dropdownMenuControl.tsx
+++ b/static/app/components/dropdownMenuControl.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
 import {useMenuTrigger} from '@react-aria/menu';
@@ -6,7 +6,10 @@ import {useResizeObserver} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
 
 import DropdownButton, {DropdownButtonProps} from 'sentry/components/dropdownButton';
-import DropdownMenu, {DropdownMenuProps} from 'sentry/components/dropdownMenu';
+import DropdownMenu, {
+  DropdownMenuContext,
+  DropdownMenuProps,
+} from 'sentry/components/dropdownMenu';
 import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
 import {FormSize} from 'sentry/utils/theme';
 import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
@@ -43,10 +46,19 @@ function getDisabledKeys(source: MenuItemProps[]): MenuItemProps['key'][] {
 }
 
 interface DropdownMenuControlProps
-  extends Partial<DropdownMenuProps>,
+  extends Omit<
+      DropdownMenuProps,
+      'overlayState' | 'overlayPositionProps' | 'items' | 'children' | 'menuTitle'
+    >,
     Pick<
       UseOverlayProps,
-      'isOpen' | 'offset' | 'position' | 'isDismissable' | 'shouldCloseOnBlur'
+      | 'isOpen'
+      | 'offset'
+      | 'position'
+      | 'isDismissable'
+      | 'shouldCloseOnBlur'
+      | 'shouldCloseOnInteractOutside'
+      | 'preventOverflowOptions'
     > {
   /**
    * Items to display inside the dropdown menu. If the item has a `children`
@@ -59,27 +71,18 @@ interface DropdownMenuControlProps
    */
   className?: string;
   /**
-   * If this is a submenu, it will in some cases need to close itself (e.g.
-   * when the user presses the arrow left key)
-   */
-  closeCurrentSubmenu?: () => void;
-  /**
-   * If this is a submenu, it will in some cases need to close the root menu
-   * (e.g. when a submenu item is clicked).
-   */
-  closeRootMenu?: () => void;
-  /**
    * Whether the trigger is disabled.
    */
   isDisabled?: boolean;
   /**
-   * Whether this is a submenu.
-   */
-  isSubmenu?: boolean;
-  /**
    * Title for the current menu.
    */
   menuTitle?: string;
+  /**
+   * Whether the menu should always be wider than the trigger. If true (default), then
+   * the menu will have a min width equal to the trigger's width.
+   */
+  menuWiderThanTrigger?: boolean;
   /**
    * Minimum menu width, in pixels
    */
@@ -129,9 +132,7 @@ function DropdownMenuControl({
   isDisabled: disabledProp,
   isOpen: isOpenProp,
   minMenuWidth,
-  isSubmenu = false,
-  closeRootMenu,
-  closeCurrentSubmenu,
+  menuWiderThanTrigger = true,
   renderWrapAs = 'div',
   size = 'md',
   className,
@@ -141,31 +142,33 @@ function DropdownMenuControl({
   position = 'bottom-start',
   isDismissable = true,
   shouldCloseOnBlur = true,
+  shouldCloseOnInteractOutside,
+  preventOverflowOptions,
   ...props
 }: DropdownMenuControlProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
 
+  const {rootOverlayState} = useContext(DropdownMenuContext);
   const {
     isOpen,
-    state,
+    state: overlayState,
     triggerRef,
     triggerProps: overlayTriggerProps,
     overlayProps,
   } = useOverlay({
-    onClose: closeRootMenu,
     isOpen: isOpenProp,
+    onClose: rootOverlayState?.close,
     offset,
     position,
-    isDismissable: !isSubmenu && isDismissable,
-    shouldCloseOnBlur: !isSubmenu && shouldCloseOnBlur,
-    shouldCloseOnInteractOutside: () => !isSubmenu,
-    // Necessary for submenus to be correctly positioned
-    ...(isSubmenu && {preventOverflowOptions: {boundary: document.body, altAxis: true}}),
+    isDismissable,
+    shouldCloseOnBlur,
+    shouldCloseOnInteractOutside,
+    preventOverflowOptions,
   });
 
   const {menuTriggerProps, menuProps} = useMenuTrigger(
     {type: 'menu', isDisabled},
-    {...state, focusStrategy: 'first'},
+    {...overlayState, focusStrategy: 'first'},
     triggerRef
   );
 
@@ -173,13 +176,6 @@ function DropdownMenuControl({
     {
       isDisabled,
       ...menuTriggerProps,
-      ...(isSubmenu && {
-        onKeyUp: e => e.continuePropagation(),
-        onKeyDown: e => e.continuePropagation(),
-        onPress: () => null,
-        onPressStart: () => null,
-        onPressEnd: () => null,
-      }),
     },
     triggerRef
   );
@@ -189,13 +185,15 @@ function DropdownMenuControl({
   const [triggerWidth, setTriggerWidth] = useState<number>();
   // Update triggerWidth when its size changes using useResizeObserver
   const updateTriggerWidth = useCallback(async () => {
+    if (!menuWiderThanTrigger) {
+      return;
+    }
+
     // Wait until the trigger element finishes rendering, otherwise
     // ResizeObserver might throw an infinite loop error.
     await new Promise(resolve => window.setTimeout(resolve));
-
-    const newTriggerWidth = triggerRef.current?.offsetWidth;
-    !isSubmenu && newTriggerWidth && setTriggerWidth(newTriggerWidth);
-  }, [isSubmenu, triggerRef]);
+    setTriggerWidth(triggerRef.current?.offsetWidth ?? 0);
+  }, [menuWiderThanTrigger, triggerRef]);
 
   useResizeObserver({ref: triggerRef, onResize: updateTriggerWidth});
   // If ResizeObserver is not available, manually update the width
@@ -243,12 +241,10 @@ function DropdownMenuControl({
         {...props}
         {...menuProps}
         size={size}
-        isSubmenu={isSubmenu}
         minWidth={Math.max(minMenuWidth ?? 0, triggerWidth ?? 0)}
-        closeRootMenu={closeRootMenu ?? state.close}
-        closeCurrentSubmenu={closeCurrentSubmenu}
         disabledKeys={disabledKeys ?? defaultDisabledKeys}
         overlayPositionProps={overlayProps}
+        overlayState={overlayState}
         items={activeItems}
       >
         {(item: MenuItemProps) => {


### PR DESCRIPTION
Use a React context rather than simple prop inheritance to mange submenus. This way we can eliminate special submenu-related props on `DropdownMenuControl`, including `isSubmenu`, `closeRootMenu`, and `closeCurrentSubmenu`, removing confusion when using the component.

**Before:** `isSubmenu` appears as a valid prop type on `DropdownMenuControl` when it shouldn't
<img width="1062" alt="Screenshot 2023-01-23 at 2 28 30 PM" src="https://user-images.githubusercontent.com/44172267/214164341-dc1169b0-0209-4390-bbf4-39d4e733e475.png">

**After:** `isSubmenu` and other submenu-related props are no longer valid
<img width="1062" alt="Screenshot 2023-01-23 at 2 28 13 PM" src="https://user-images.githubusercontent.com/44172267/214164339-d5821635-c0dd-47c0-bfe8-de94c9536315.png">
