### PR TITLE
feat(issue-platform): Add feature flag to gate whether we ingest profile blocked thread issues

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -13,8 +13,7 @@ from arroyo.types import Commit, Message, Partition
 from django.conf import settings
 from django.utils import timezone
 
-from sentry import nodestore
-from sentry import features
+from sentry import features, nodestore
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import ProfileBlockedThreadGroupType

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 from copy import deepcopy
 from typing import Any, Dict, Optional, Sequence
+from unittest import mock
 
 import pytest
 
@@ -96,7 +97,8 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
     @pytest.mark.django_db
     def test_process_profiling_occurrence(self) -> None:
         event_data = load_data("generic-event-profiling")
-        result = _process_message(event_data)
+        with self.feature("organizations:profile-blocked-main-thread-ingest"):
+            result = _process_message(event_data)
         assert result is not None
         project_id = event_data["event"]["project_id"]
         occurrence = result[0]
@@ -114,26 +116,33 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
     def test_invalid_event_payload(self) -> None:
         message = get_test_message(self.project.id, event={"title": "no project id"})
         with pytest.raises(InvalidEventPayloadError):
-            _process_message(message)
+            with self.feature("organizations:profile-blocked-main-thread-ingest"):
+                _process_message(message)
 
     def test_invalid_occurrence_payload(self) -> None:
         message = get_test_message(self.project.id, type=300)
         with pytest.raises(InvalidEventPayloadError):
-            _process_message(message)
+            with self.feature("organizations:profile-blocked-main-thread-ingest"), mock.patch(
+                "sentry.issues.occurrence_consumer.INGEST_ALLOWED_ISSUE_TYPES",
+                {300},
+            ):
+                _process_message(message)
 
     def test_mismatch_event_ids(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
         message["event_id"] = "id1"
         message["event"]["event_id"] = "id2"
         with pytest.raises(InvalidEventPayloadError):
-            _process_message(message)
+            with self.feature("organizations:profile-blocked-main-thread-ingest"):
+                _process_message(message)
 
 
 class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):
     def test_lookup_event_doesnt_exist(self) -> None:
         message = get_test_message(self.project.id, include_event=False)
         with pytest.raises(EventLookupError):
-            _process_message(message)
+            with self.feature("organizations:profile-blocked-main-thread-ingest"):
+                _process_message(message)
 
     @pytest.mark.django_db
     def test_transaction_lookup(self) -> None:
@@ -155,7 +164,11 @@ class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):
             event_id=event1.event_id,
             type=PerformanceSlowDBQueryGroupType.type_id,
         )
-        processed = _process_message(message)
+        with self.feature("organizations:profile-blocked-main-thread-ingest"), mock.patch(
+            "sentry.issues.occurrence_consumer.INGEST_ALLOWED_ISSUE_TYPES",
+            {PerformanceSlowDBQueryGroupType.type_id},
+        ):
+            processed = _process_message(message)
         assert processed is not None
         occurrence, _ = processed[0], processed[1]
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -76,7 +76,8 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
     @pytest.mark.django_db
     def test_occurrence_consumer_with_event(self) -> None:
         message = get_test_message(self.project.id)
-        result = _process_message(message)
+        with self.feature("organizations:profile-blocked-main-thread-ingest"):
+            result = _process_message(message)
         assert result is not None
         occurrence = result[0]
 


### PR DESCRIPTION
Adds gating in so that we only ingest profiling blocked thread issues when this feature flag is enabled.

For now we're just hardcoding to this one type, we'll expand more later as part of https://github.com/getsentry/sentry/issues/43488