### PR TITLE
fix(source-maps): Look up release by organization and add try block 

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -88,7 +88,20 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
                 }
             )
 
-        release = Release.objects.get(project_id=project.id, version=release_version)
+        try:
+            release = Release.objects.get(
+                organization=project.organization, version=release_version
+            )
+        except Release.DoesNotExist:
+            return Response(
+                {
+                    "errors": [
+                        SourceMapProcessingIssue(
+                            SourceMapProcessingIssue.MISSING_RELEASE
+                        ).get_api_context()
+                    ],
+                }
+            )
         user_agent = release.user_agent
 
         if not user_agent:

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -81,8 +81,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             },
             project_id=self.project.id,
         )
-        release = Release.objects.get(version=event.release)
-        release.update(user_agent="test_user_agent", project_id=self.project.id)
+        release = Release.objects.get(organization=self.organization, version=event.release)
+        release.update(user_agent="test_user_agent")
 
         ReleaseFile.objects.create(
             organization_id=self.project.organization_id,
@@ -123,8 +123,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         event = self.store_event(
             data={"event_id": "a" * 32, "release": "my-release"}, project_id=self.project.id
         )
-        release = Release.objects.get(version=event.release)
-        release.update(project_id=self.project.id)
+        Release.objects.get(organization=self.organization, version=event.release)
 
         resp = self.get_success_response(
             self.organization.slug,
@@ -143,8 +142,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         event = self.store_event(
             data={"event_id": "a" * 32, "release": "my-release"}, project_id=self.project.id
         )
-        release = Release.objects.get(version=event.release)
-        release.update(user_agent="test_user_agent", project_id=self.project.id)
+        release = Release.objects.get(organization=self.organization, version=event.release)
+        release.update(user_agent="test_user_agent")
         resp = self.get_success_response(
             self.organization.slug,
             self.project.slug,
@@ -194,8 +193,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             },
             project_id=self.project.id,
         )
-        release = Release.objects.get(version=event.release)
-        release.update(user_agent="test_user_agent", project_id=self.project.id)
+        release = Release.objects.get(organization=self.organization, version=event.release)
+        release.update(user_agent="test_user_agent")
 
         ReleaseFile.objects.create(
             organization_id=self.project.organization_id,


### PR DESCRIPTION
this pr moves the look up for release objects to use organization instead of project id (releases are unique on organization + version) and adds a try block to catch if the release does not exist. 