### PR TITLE
ref(dropdownMenuControl): Rename as DropdownMenu

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -6,8 +6,8 @@ import ButtonBar from 'sentry/components/buttonBar';
 import {openConfirmModal} from 'sentry/components/confirm';
 import CustomIgnoreCountModal from 'sentry/components/customIgnoreCountModal';
 import CustomIgnoreDurationModal from 'sentry/components/customIgnoreDurationModal';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import type {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import DropdownMenu from 'sentry/components/dropdownMenu';
 import Tooltip from 'sentry/components/tooltip';
 import {IconChevron, IconMute} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -265,7 +265,7 @@ const IgnoreActions = ({
       >
         {t('Ignore')}
       </IgnoreButton>
-      <DropdownMenuControl
+      <DropdownMenu
         size="sm"
         trigger={triggerProps => (
           <DropdownTrigger

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -7,8 +7,8 @@ import ButtonBar from 'sentry/components/buttonBar';
 import {openConfirmModal} from 'sentry/components/confirm';
 import CustomCommitsResolutionModal from 'sentry/components/customCommitsResolutionModal';
 import CustomResolutionModal from 'sentry/components/customResolutionModal';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import type {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import DropdownMenu from 'sentry/components/dropdownMenu';
 import Tooltip from 'sentry/components/tooltip';
 import {IconCheckmark, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -189,7 +189,7 @@ class ResolveActions extends Component<Props> {
     const isDisabled = !projectSlug ? disabled : disableDropdown;
 
     return (
-      <DropdownMenuControl
+      <DropdownMenu
         items={items}
         trigger={triggerProps => (
           <DropdownTrigger

--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -1,13 +1,13 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import DropdownMenuControl from './dropdownMenuControl';
+import DropdownMenu from 'sentry/components/dropdownMenu';
 
 describe('DropdownMenu', function () {
   it('renders a basic menu', function () {
     const onAction = jest.fn();
 
     render(
-      <DropdownMenuControl
+      <DropdownMenu
         items={[
           {
             key: 'item1',
@@ -55,7 +55,7 @@ describe('DropdownMenu', function () {
     const onAction = jest.fn();
 
     render(
-      <DropdownMenuControl
+      <DropdownMenu
         items={[
           {
             key: 'item1',
@@ -85,7 +85,7 @@ describe('DropdownMenu', function () {
     const onAction = jest.fn();
 
     render(
-      <DropdownMenuControl
+      <DropdownMenu
         items={[
           {
             key: 'item1',

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -12,6 +12,8 @@ import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
 import {MenuItemProps} from './item';
 import DropdownMenuList, {DropdownMenuContext, DropdownMenuListProps} from './list';
 
+export {MenuItemProps};
+
 /**
  * Recursively removes hidden items, including those nested in submenus
  */

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -6,13 +6,11 @@ import {useResizeObserver} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
 
 import DropdownButton, {DropdownButtonProps} from 'sentry/components/dropdownButton';
-import DropdownMenu, {
-  DropdownMenuContext,
-  DropdownMenuProps,
-} from 'sentry/components/dropdownMenu';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
 import {FormSize} from 'sentry/utils/theme';
 import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
+
+import {MenuItemProps} from './item';
+import DropdownMenuList, {DropdownMenuContext, DropdownMenuListProps} from './list';
 
 /**
  * Recursively removes hidden items, including those nested in submenus
@@ -45,9 +43,9 @@ function getDisabledKeys(source: MenuItemProps[]): MenuItemProps['key'][] {
   }, []);
 }
 
-interface DropdownMenuControlProps
+interface DropdownMenuProps
   extends Omit<
-      DropdownMenuProps,
+      DropdownMenuListProps,
       'overlayState' | 'overlayPositionProps' | 'items' | 'children' | 'menuTitle'
     >,
     Pick<
@@ -123,7 +121,7 @@ interface DropdownMenuControlProps
  * A menu component that renders both the trigger button and the dropdown
  * menu. See: https://react-spectrum.adobe.com/react-aria/useMenuTrigger.html
  */
-function DropdownMenuControl({
+function DropdownMenu({
   items,
   disabledKeys,
   trigger,
@@ -145,7 +143,7 @@ function DropdownMenuControl({
   shouldCloseOnInteractOutside,
   preventOverflowOptions,
   ...props
-}: DropdownMenuControlProps) {
+}: DropdownMenuProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
 
   const {rootOverlayState} = useContext(DropdownMenuContext);
@@ -237,7 +235,7 @@ function DropdownMenuControl({
     }
 
     return (
-      <DropdownMenu
+      <DropdownMenuList
         {...props}
         {...menuProps}
         size={size}
@@ -265,20 +263,20 @@ function DropdownMenuControl({
             </Item>
           );
         }}
-      </DropdownMenu>
+      </DropdownMenuList>
     );
   }
 
   return (
-    <MenuControlWrap className={className} as={renderWrapAs} role="presentation">
+    <DropdownMenuWrap className={className} as={renderWrapAs} role="presentation">
       {renderTrigger()}
       {renderMenu()}
-    </MenuControlWrap>
+    </DropdownMenuWrap>
   );
 }
 
-export default DropdownMenuControl;
+export default DropdownMenu;
 
-const MenuControlWrap = styled('div')`
+const DropdownMenuWrap = styled('div')`
   list-style-type: none;
 `;

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -6,7 +6,6 @@ import {TreeState} from '@react-stately/tree';
 import {Node} from '@react-types/shared';
 import {LocationDescriptor} from 'history';
 
-import {DropdownMenuContext} from 'sentry/components/dropdownMenu';
 import Link from 'sentry/components/links/link';
 import MenuListItem, {
   InnerWrap as MenuListItemInnerWrap,
@@ -15,6 +14,8 @@ import MenuListItem, {
 import {IconChevron} from 'sentry/icons';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import usePrevious from 'sentry/utils/usePrevious';
+
+import {DropdownMenuContext} from './list';
 
 export interface MenuItemProps extends MenuListItemProps {
   /**

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -10,12 +10,13 @@ import {TreeState, useTreeState} from '@react-stately/tree';
 import {Node} from '@react-types/shared';
 import omit from 'lodash/omit';
 
-import MenuControl from 'sentry/components/dropdownMenuControl';
-import MenuItem, {MenuItemProps} from 'sentry/components/dropdownMenuItem';
-import MenuSection from 'sentry/components/dropdownMenuSection';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import space from 'sentry/styles/space';
 import useOverlay from 'sentry/utils/useOverlay';
+
+import DropdownMenu from './index';
+import DropdownMenuItem, {MenuItemProps} from './item';
+import DropdownMenuSection from './section';
 
 type OverlayState = ReturnType<typeof useOverlay>['state'];
 
@@ -34,7 +35,7 @@ interface DropdownMenuContextValue {
 
 export const DropdownMenuContext = createContext<DropdownMenuContextValue>({});
 
-export interface DropdownMenuProps
+export interface DropdownMenuListProps
   extends Omit<
     AriaMenuOptions<MenuItemProps>,
     | 'selectionMode'
@@ -63,7 +64,7 @@ export interface DropdownMenuProps
   size?: MenuItemProps['size'];
 }
 
-function DropdownMenu({
+function DropdownMenuList({
   closeOnSelect = true,
   onClose,
   minWidth,
@@ -72,7 +73,7 @@ function DropdownMenu({
   overlayState,
   overlayPositionProps,
   ...props
-}: DropdownMenuProps) {
+}: DropdownMenuListProps) {
   const {rootOverlayState, parentMenuState} = useContext(DropdownMenuContext);
   const state = useTreeState<MenuItemProps>({...props, selectionMode: 'single'});
   const stateCollection = useMemo(() => [...state.collection], [state.collection]);
@@ -135,7 +136,7 @@ function DropdownMenu({
   // Render a single menu item
   const renderItem = (node: Node<MenuItemProps>, isLastNode: boolean) => {
     return (
-      <MenuItem
+      <DropdownMenuItem
         node={node}
         state={state}
         onClose={onClose}
@@ -152,7 +153,7 @@ function DropdownMenu({
     }
 
     const trigger = triggerProps => (
-      <MenuItem
+      <DropdownMenuItem
         renderAs="div"
         node={node}
         state={state}
@@ -171,7 +172,7 @@ function DropdownMenu({
     );
 
     return (
-      <MenuControl
+      <DropdownMenu
         isOpen={state.selectionManager.isSelected(node.key)}
         items={node.value.children}
         trigger={trigger}
@@ -202,7 +203,9 @@ function DropdownMenu({
 
       if (node.type === 'section') {
         itemToRender = (
-          <MenuSection node={node}>{renderCollection([...node.childNodes])}</MenuSection>
+          <DropdownMenuSection node={node}>
+            {renderCollection([...node.childNodes])}
+          </DropdownMenuSection>
         );
       } else {
         itemToRender = node.value.isSubmenu
@@ -232,7 +235,7 @@ function DropdownMenu({
         <DropdownMenuContext.Provider value={contextValue}>
           <StyledOverlay>
             {menuTitle && <MenuTitle>{menuTitle}</MenuTitle>}
-            <MenuWrap
+            <DropdownMenuListWrap
               ref={menuRef}
               hasTitle={!!menuTitle}
               {...mergeProps(modifiedMenuProps, keyboardProps)}
@@ -242,7 +245,7 @@ function DropdownMenu({
               }}
             >
               {renderCollection(stateCollection)}
-            </MenuWrap>
+            </DropdownMenuListWrap>
           </StyledOverlay>
         </DropdownMenuContext.Provider>
       </PositionWrapper>
@@ -250,14 +253,14 @@ function DropdownMenu({
   );
 }
 
-export default DropdownMenu;
+export default DropdownMenuList;
 
 const StyledOverlay = styled(Overlay)`
   display: flex;
   flex-direction: column;
 `;
 
-const MenuWrap = styled('ul')<{hasTitle: boolean}>`
+const DropdownMenuListWrap = styled('ul')<{hasTitle: boolean}>`
   margin: 0;
   padding: ${space(0.5)} 0;
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/components/dropdownMenu/section.tsx
+++ b/static/app/components/dropdownMenu/section.tsx
@@ -2,10 +2,11 @@ import styled from '@emotion/styled';
 import {useMenuSection} from '@react-aria/menu';
 import {Node} from '@react-types/shared';
 
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
 import space from 'sentry/styles/space';
 
-type Props = {
+import {MenuItemProps} from './item';
+
+type DropdownMenuSectionProps = {
   children: React.ReactNode;
   node: Node<MenuItemProps>;
 };
@@ -14,23 +15,23 @@ type Props = {
  * A wrapper component for menu sections. See:
  * https://react-spectrum.adobe.com/react-aria/useMenu.html
  */
-function MenuSection({node, children}: Props) {
+function DropdownMenuSection({node, children}: DropdownMenuSectionProps) {
   const {itemProps, headingProps, groupProps} = useMenuSection({
     heading: node.rendered,
     'aria-label': node['aria-label'],
   });
 
   return (
-    <MenuSectionWrap {...itemProps}>
+    <DropdownMenuSectionWrap {...itemProps}>
       {node.rendered && <Heading {...headingProps}>{node.rendered}</Heading>}
       <Group {...groupProps}>{children}</Group>
-    </MenuSectionWrap>
+    </DropdownMenuSectionWrap>
   );
 }
 
-export default MenuSection;
+export default DropdownMenuSection;
 
-const MenuSectionWrap = styled('li')`
+const DropdownMenuSectionWrap = styled('li')`
   list-style-type: none;
 `;
 
@@ -44,7 +45,7 @@ const Heading = styled('span')`
   margin: ${space(1)} ${space(1.5)} ${space(0.5)};
   padding-right: ${space(1)};
 
-  ${MenuSectionWrap}:first-of-type & {
+  ${DropdownMenuSectionWrap}:first-of-type & {
     margin-top: ${space(0.5)};
   }
 `;

--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
+import DropdownMenu from 'sentry/components/dropdownMenu';
 import {Panel} from 'sentry/components/panels';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -216,6 +216,6 @@ const Value = styled('span')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
 `;
 
-const StyledDropdownMenuControl = styled(DropdownMenuControl)`
+const StyledDropdownMenuControl = styled(DropdownMenu)`
   margin-left: auto;
 `;

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -5,7 +5,7 @@ import {Role} from 'sentry/components/acl/role';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {openConfirmModal} from 'sentry/components/confirm';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
+import DropdownMenu from 'sentry/components/dropdownMenu';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel, PanelBody, PanelFooter, PanelHeader} from 'sentry/components/panels';
 import {IconChevron, IconEllipsis} from 'sentry/icons';
@@ -115,7 +115,7 @@ function Screenshot({
               >
                 {t('View screenshot')}
               </Button>
-              <DropdownMenuControl
+              <DropdownMenu
                 position="bottom"
                 offset={4}
                 triggerProps={{

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -4,8 +4,7 @@ import styled from '@emotion/styled';
 import HighlightTopRightPattern from 'sentry-images/pattern/highlight-top-right.svg';
 
 import {Button} from 'sentry/components/button';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useOnboardingDocs from 'sentry/components/onboardingWizard/useOnboardingDocs';
@@ -148,7 +147,7 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
       <TopRightBackgroundImage src={HighlightTopRightPattern} />
       <TaskList>
         <Heading>{t('Boost Performance')}</Heading>
-        <DropdownMenuControl
+        <DropdownMenu
           items={items}
           triggerLabel={
             <StyledIdBadge

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -4,8 +4,7 @@ import styled from '@emotion/styled';
 import HighlightTopRightPattern from 'sentry-images/pattern/highlight-top-right.svg';
 
 import {Button} from 'sentry/components/button';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useOnboardingDocs from 'sentry/components/onboardingWizard/useOnboardingDocs';
@@ -70,7 +69,7 @@ function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
       <TopRightBackgroundImage src={HighlightTopRightPattern} />
       <TaskList>
         <Heading>{t('Getting Started with Session Replay')}</Heading>
-        <DropdownMenuControl
+        <DropdownMenu
           items={items}
           triggerLabel={
             <StyledIdBadge

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -48,8 +48,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 // eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 
-import DropdownMenuControl from '../dropdownMenuControl';
-import {MenuItemProps} from '../dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from '../dropdownMenu';
 
 import {ActionButton} from './actionButton';
 import SearchBarDatePicker from './searchBarDatePicker';
@@ -2036,6 +2035,6 @@ const VerticalEllipsisIcon = styled(IconEllipsis)`
   transform: rotate(90deg);
 `;
 
-const OverlowingActionsMenu = styled(DropdownMenuControl)`
+const OverlowingActionsMenu = styled(DropdownMenu)`
   display: flex;
 `;

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -6,8 +6,7 @@ import partial from 'lodash/partial';
 
 import {Button} from 'sentry/components/button';
 import Count from 'sentry/components/count';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import Duration from 'sentry/components/duration';
 import FileSize from 'sentry/components/fileSize';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
@@ -357,7 +356,7 @@ const SPECIAL_FIELDS: SpecialFields = {
 
       return (
         <RightAlignedContainer>
-          <DropdownMenuControl
+          <DropdownMenu
             position="left"
             size="xs"
             triggerProps={{

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -9,8 +9,7 @@ import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import {openConfirmModal} from 'sentry/components/confirm';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 import DropdownBubble from 'sentry/components/dropdownBubble';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Highlight from 'sentry/components/highlight';
 import IdBadge from 'sentry/components/idBadge';
@@ -388,7 +387,7 @@ function RuleListRow({
       <ActionsRow>
         <Access access={['alerts:write']}>
           {({hasAccess}) => (
-            <DropdownMenuControl
+            <DropdownMenu
               items={actions}
               position="bottom-end"
               triggerProps={{

--- a/static/app/views/dashboards/manage/dashboardList.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.tsx
@@ -12,8 +12,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {Client} from 'sentry/api';
 import {Button} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import Pagination from 'sentry/components/pagination';
 import TimeSince from 'sentry/components/timeSince';
@@ -101,7 +100,7 @@ function DashboardList({
     ];
 
     return (
-      <DropdownMenuControl
+      <DropdownMenu
         items={menuItems}
         trigger={triggerProps => (
           <DropdownTrigger

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -5,8 +5,7 @@ import {Location} from 'history';
 import {openDashboardWidgetQuerySelectorModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {isWidgetViewerPath} from 'sentry/components/modals/widgetViewerModal/utils';
 import Tag from 'sentry/components/tag';
 import {IconEllipsis, IconExpand} from 'sentry/icons';
@@ -291,7 +290,7 @@ const ContextWrapper = styled('div')`
   margin-left: ${space(1)};
 `;
 
-const StyledDropdownMenuControl = styled(DropdownMenuControl)`
+const StyledDropdownMenuControl = styled(DropdownMenu)`
   & > button {
     z-index: auto;
   }

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -8,8 +8,7 @@ import {resetPageFilters} from 'sentry/actionCreators/pageFilters';
 import {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
 import {Button} from 'sentry/components/button';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import Pagination from 'sentry/components/pagination';
 import TimeSince from 'sentry/components/timeSince';
@@ -108,7 +107,7 @@ class QueryList extends Component<Props> {
 
   renderDropdownMenu(items: MenuItemProps[]) {
     return (
-      <DropdownMenuControl
+      <DropdownMenu
         items={items}
         trigger={triggerProps => (
           <DropdownTrigger

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -15,8 +15,7 @@ import Banner from 'sentry/components/banner';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import FeatureBadge from 'sentry/components/featureBadge';
 import {Hovercard} from 'sentry/components/hovercard';
 import InputControl from 'sentry/components/input';
@@ -573,7 +572,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     }
 
     const contextMenu = (
-      <DropdownMenuControl
+      <DropdownMenu
         items={contextMenuItems}
         trigger={triggerProps => (
           <Button

--- a/static/app/views/discover/table/quickContext/actionDropdown.tsx
+++ b/static/app/views/discover/table/quickContext/actionDropdown.tsx
@@ -3,8 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Button} from 'sentry/components/button';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -146,7 +145,7 @@ function ActionDropDown(props: Props) {
   }
 
   return (
-    <DropdownMenuControl
+    <DropdownMenu
       items={menuItems}
       trigger={triggerProps => (
         <StyledTrigger

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -4,8 +4,7 @@ import {useTheme} from '@emotion/react';
 import ActionLink from 'sentry/components/actions/actionLink';
 import IgnoreActions from 'sentry/components/actions/ignore';
 import {openConfirmModal} from 'sentry/components/confirm';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
@@ -256,7 +255,7 @@ function ActionSet({
           {t('Merge')}
         </ActionLink>
       )}
-      <DropdownMenuControl
+      <DropdownMenu
         size="sm"
         items={menuItems}
         triggerProps={{

--- a/static/app/views/issueList/savedIssueSearches.tsx
+++ b/static/app/views/issueList/savedIssueSearches.tsx
@@ -6,8 +6,7 @@ import orderBy from 'lodash/orderBy';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button, ButtonLabel} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {CreateSavedSearchModal} from 'sentry/components/modals/savedSearchModal/createSavedSearchModal';
@@ -325,7 +324,7 @@ const StyledItemButton = styled(Button)`
   }
 `;
 
-const OverflowMenu = styled(DropdownMenuControl)`
+const OverflowMenu = styled(DropdownMenu)`
   position: absolute;
   top: 12px;
   right: ${space(1)};

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -18,8 +18,8 @@ import IgnoreActions, {getIgnoreActions} from 'sentry/components/actions/ignore'
 import ResolveActions from 'sentry/components/actions/resolve';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import type {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import DropdownMenu from 'sentry/components/dropdownMenu';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import {
   IconCheckmark,
@@ -386,7 +386,7 @@ class Actions extends Component<Props> {
       const {dropdownItems, onIgnore} = getIgnoreActions({onUpdate: this.onUpdate});
       return (
         <ActionWrapper>
-          <DropdownMenuControl
+          <DropdownMenu
             triggerProps={{
               'aria-label': t('More Actions'),
               icon: <IconEllipsis size="xs" />,
@@ -584,7 +584,7 @@ class Actions extends Component<Props> {
           group={group}
           onClick={this.handleClick(disabled, this.onToggleSubscribe)}
         />
-        <DropdownMenuControl
+        <DropdownMenu
           triggerProps={{
             'aria-label': t('More Actions'),
             icon: <IconEllipsis size="xs" />,

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -11,8 +11,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import {getInterval} from 'sentry/components/charts/utils';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import DatePageFilter from 'sentry/components/datePageFilter';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
+import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -147,7 +146,7 @@ function VitalDetailContent(props: Props) {
     );
 
     return (
-      <DropdownMenuControl
+      <DropdownMenu
         items={items}
         triggerLabel={vitalAbbreviations[vitalName]}
         triggerProps={{

--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -7,7 +7,7 @@ import {archiveRelease, restoreRelease} from 'sentry/actionCreators/release';
 import {Client} from 'sentry/api';
 import ButtonBar from 'sentry/components/buttonBar';
 import {openConfirmModal} from 'sentry/components/confirm';
-import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
+import DropdownMenu from 'sentry/components/dropdownMenu';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import NavigationButtonGroup from 'sentry/components/navigationButtonGroup';
 import TextOverflow from 'sentry/components/textOverflow';
@@ -204,7 +204,7 @@ function ReleaseActions({
         onNewerClick={() => handleNavigationClick('newer')}
         onNewestClick={() => handleNavigationClick('newest')}
       />
-      <DropdownMenuControl
+      <DropdownMenu
         size="sm"
         items={menuItems}
         triggerProps={{


### PR DESCRIPTION
Rather than writing
```jsx
import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
```
we can now write
```jsx
import DropdownMenu, {MenuItemProps} from 'sentry/components/dropdownMenu';
```

Luckily there's no usage in `getsentry` so no additional PR is needed.