### PR TITLE
fix(commit-context): Move debounce caching to tasks and set on success only.

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -34,7 +34,14 @@ logger = logging.getLogger(__name__)
     retry_jitter=False,
 )
 def process_commit_context(
-    event_id, event_platform, event_frames, group_id, project_id, cache_key, sdk_name=None, **kwargs
+    event_id,
+    event_platform,
+    event_frames,
+    group_id,
+    project_id,
+    cache_key=None,
+    sdk_name=None,
+    **kwargs,
 ):
     """
     For a given event, look at the first in_app frame, and if we can find who modified the line, we can then update who is assigned to the issue.
@@ -48,6 +55,9 @@ def process_commit_context(
                 "sentry.tasks.process_commit_context.start",
                 tags={"event": event_id, "group": group_id, "project": project_id},
             )
+            if not cache_key:
+                cache_key = f"process-commit-context-{group_id}"
+
             set_current_event_project(project_id)
 
             project = Project.objects.get_from_cache(id=project_id)

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -44,12 +44,13 @@ def process_commit_context(
     )
     try:
         with lock.acquire():
-            group_cache_key = f"w-o-i:g-{group_id}"
+            group_cache_key = f"w-o-i:g-{group_id}-2"
             if cache.get(group_cache_key):
                 metrics.incr(
                     "sentry.tasks.process_commit_context.debounce",
-                    tags={"detail": "w-o-i:g debounce"},
+                    tags={"event": event_id, "group": group_id, "project": project_id},
                 )
+                return
 
             metrics.incr(
                 "sentry.tasks.process_commit_context.start",

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -119,13 +119,23 @@ def _process_suspect_commits(
     max_retries=5,
 )
 def process_suspect_commits(
-    event_id, event_platform, event_frames, group_id, project_id, cache_key, sdk_name=None, **kwargs
+    event_id,
+    event_platform,
+    event_frames,
+    group_id,
+    project_id,
+    cache_key=None,
+    sdk_name=None,
+    **kwargs,
 ):
     lock = locks.get(
         f"process-suspect-commits:{group_id}", duration=10, name="process_suspect_commits"
     )
     try:
         with lock.acquire():
+            if not cache_key:
+                cache_key = f"process-suspect-commits-{group_id}"
+
             _process_suspect_commits(
                 event_id,
                 event_platform,

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -23,11 +23,11 @@ logger = logging.getLogger(__name__)
 def _process_suspect_commits(
     event_id, event_platform, event_frames, group_id, project_id, sdk_name=None, **kwargs
 ):
-    group_cache_key = f"w-o-i:g-{group_id}"
+    group_cache_key = f"w-o-i:g-{group_id}-2"
     if cache.get(group_cache_key):
         metrics.incr(
             "sentry.tasks.process_suspect_commits.debounce",
-            tags={"detail": "w-o-i:g debounce"},
+            tags={"event": event_id, "group": group_id, "project": project_id},
         )
         return
 

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -102,7 +102,9 @@ def _process_suspect_commits(
                             organization_id=project.organization_id,
                         )[0].delete()
 
-                cache.set(group_cache_key, True, 604800)  # 1 week in seconds
+                cache.set(
+                    group_cache_key, True, PREFERRED_GROUP_OWNER_AGE.total_seconds()
+                )  # 1 week in seconds
         except Commit.DoesNotExist:
             logger.info(
                 "process_suspect_commits.skipped",

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1038,8 +1038,7 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
             integration_id=self.integration.id,
         )
         self.code_mapping = self.create_code_mapping(
-            repo=self.repo,
-            project=self.project,
+            repo=self.repo, project=self.project, stack_root="src/"
         )
         self.commit_author = self.create_commit_author(project=self.project, user=self.user)
         self.commit = self.create_commit(

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -993,6 +993,86 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         )
 
 
+class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
+    github_blame_return_value = {
+        "commitId": "asdfwreqr",
+        "committedDate": "",
+        "commitMessage": "placeholder commit message",
+        "commitAuthorName": "",
+        "commitAuthorEmail": "admin@localhost",
+    }
+
+    def setUp(self):
+        self.created_event = self.create_event(
+            data={
+                "message": "Kaboom!",
+                "platform": "python",
+                "timestamp": iso_format(before_now(seconds=10)),
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "function": "handle_set_commits",
+                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
+                            "module": "sentry.tasks",
+                            "in_app": False,
+                            "lineno": 30,
+                            "filename": "sentry/tasks.py",
+                        },
+                        {
+                            "function": "set_commits",
+                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
+                            "module": "sentry.models.release",
+                            "in_app": True,
+                            "lineno": 39,
+                            "filename": "sentry/models/release.py",
+                        },
+                    ]
+                },
+                "fingerprint": ["put-me-in-the-control-group"],
+            },
+            project_id=self.project.id,
+        )
+        self.cache_key = write_event_to_cache(self.created_event)
+        self.repo = self.create_repo(
+            name="example",
+            integration_id=self.integration.id,
+        )
+        self.code_mapping = self.create_code_mapping(
+            repo=self.repo,
+            project=self.project,
+        )
+        self.commit_author = self.create_commit_author(project=self.project, user=self.user)
+        self.commit = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=self.commit_author,
+            key="asdfwreqr",
+            message="placeholder commit message",
+        )
+
+    @with_feature("organizations:commit-context")
+    @patch(
+        "sentry.integrations.github.GitHubIntegration.get_commit_context",
+        return_value=github_blame_return_value,
+    )
+    def test_debounce_cache_is_set(self, mock_get_commit_context):
+        with self.tasks():
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                cache_key=self.cache_key,
+                group_id=self.created_event.group_id,
+            )
+        assert GroupOwner.objects.get(
+            group=self.created_event.group,
+            project=self.created_event.project,
+            organization=self.created_event.project.organization,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+        )
+        assert cache.has_key(f"process-commit-context-{self.created_event.group_id}")
+
+
 class SnoozeTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.signals.issue_unignored.send_robust")
     @patch("sentry.rules.processor.RuleProcessor")
@@ -1104,6 +1184,7 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
 class PostProcessGroupErrorTest(
     TestCase,
     AssignmentTestMixin,
+    ProcessCommitsTestMixin,
     CorePostProcessGroupTestMixin,
     DeriveCodeMappingsProcessGroupTestMixin,
     InboxTestMixin,


### PR DESCRIPTION
## Objective:

The original cache placement causes the process_commit_context to be only run once every 7 days for a group, regardless of whether the task was able to successfully find a Suspect Committer for that group. I have moved the debounce cache to the individual tasks and set to True only when a Suspect Committer has been found.

