### PR TITLE
ref(ui): Switch projectId prop to projectSlug

### DIFF
--- a/static/app/components/events/attachmentUrl.tsx
+++ b/static/app/components/events/attachmentUrl.tsx
@@ -9,12 +9,18 @@ type Props = {
   children: (downloadUrl: string | null) => React.ReactElement | null;
   eventId: string;
   organization: Organization;
-  projectId: string;
+  projectSlug: string;
 };
 
-function AttachmentUrl({attachment, organization, eventId, projectId, children}: Props) {
+function AttachmentUrl({
+  attachment,
+  organization,
+  eventId,
+  projectSlug,
+  children,
+}: Props) {
   function getDownloadUrl() {
-    return `/api/0/projects/${organization.slug}/${projectId}/events/${eventId}/attachments/${attachment.id}/`;
+    return `/api/0/projects/${organization.slug}/${projectSlug}/events/${eventId}/attachments/${attachment.id}/`;
   }
 
   return (

--- a/static/app/components/events/attachmentViewers/utils.tsx
+++ b/static/app/components/events/attachmentViewers/utils.tsx
@@ -5,15 +5,15 @@ export type ViewerProps = {
   attachment: EventAttachment;
   eventId: Event['id'];
   orgId: string;
-  projectId: string;
+  projectSlug: string;
   className?: string;
 };
 
 export function getAttachmentUrl(props: ViewerProps, withPrefix?: boolean): string {
-  const {orgId, projectId, eventId, attachment} = props;
+  const {orgId, projectSlug, eventId, attachment} = props;
   return `${
     withPrefix ? '/api/0' : ''
-  }/projects/${orgId}/${projectId}/events/${eventId}/attachments/${
+  }/projects/${orgId}/${projectSlug}/events/${eventId}/attachments/${
     attachment.id
   }/?download`;
 }

--- a/static/app/components/events/eventAttachments.spec.tsx
+++ b/static/app/components/events/eventAttachments.spec.tsx
@@ -9,7 +9,7 @@ describe('EventAttachments', function () {
 
   const props = {
     orgId: organization.slug,
-    projectId: project.slug,
+    projectSlug: project.slug,
     location: routerContext.context.location,
     attachments: [],
     onDeleteAttachment: jest.fn(),
@@ -28,7 +28,7 @@ describe('EventAttachments', function () {
 
     expect(screen.getByRole('link', {name: 'configure limit'})).toHaveAttribute(
       'href',
-      `/settings/${props.orgId}/projects/${props.projectId}/security-and-privacy/`
+      `/settings/${props.orgId}/projects/${props.projectSlug}/security-and-privacy/`
     );
 
     expect(

--- a/static/app/components/events/eventAttachments.tsx
+++ b/static/app/components/events/eventAttachments.tsx
@@ -23,7 +23,7 @@ type Props = {
   location: Location;
   onDeleteAttachment: (attachmentId: IssueAttachment['id']) => void;
   orgId: string;
-  projectId: string;
+  projectSlug: string;
 };
 
 type State = {
@@ -74,7 +74,7 @@ export class EventAttachments extends Component<Props, State> {
       <AttachmentPreviewWrapper>
         <AttachmentComponent
           orgId={this.props.orgId}
-          projectId={this.props.projectId}
+          projectSlug={this.props.projectSlug}
           eventId={this.props.event.id}
           attachment={attachment}
         />
@@ -92,7 +92,7 @@ export class EventAttachments extends Component<Props, State> {
   }
 
   render() {
-    const {event, projectId, orgId, location, attachments, onDeleteAttachment} =
+    const {event, projectSlug, orgId, location, attachments, onDeleteAttachment} =
       this.props;
     const crashFileStripped = event.metadata.stripped_crash;
 
@@ -111,7 +111,7 @@ export class EventAttachments extends Component<Props, State> {
         {crashFileStripped && (
           <EventAttachmentsCrashReportsNotice
             orgSlug={orgId}
-            projectSlug={projectId}
+            projectSlug={projectSlug}
             groupId={event.groupID!}
             location={location}
           />
@@ -132,7 +132,7 @@ export class EventAttachments extends Component<Props, State> {
                   <FileSize bytes={attachment.size} />
                 </Size>
                 <AttachmentUrl
-                  projectId={projectId}
+                  projectSlug={projectSlug}
                   eventId={event.id}
                   attachment={attachment}
                 >

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -352,7 +352,7 @@ const EventEntries = ({
         <EventTagsAndScreenshot
           event={event}
           organization={organization as Organization}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           location={location}
           isShare={isShare}
           hasContext={hasContext}
@@ -388,7 +388,7 @@ const EventEntries = ({
         <EventAttachments
           event={event}
           orgId={orgSlug}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           location={location}
           attachments={attachments}
           onDeleteAttachment={handleDeleteAttachment}
@@ -402,7 +402,7 @@ const EventEntries = ({
       )}
       {!isShare && event.groupID && (
         <EventGroupingInfo
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           event={event}
           showGroupingConfig={
             orgFeatures.includes('set-grouping-config') && 'groupingConfig' in event
@@ -413,7 +413,7 @@ const EventEntries = ({
         <EventRRWebIntegration
           event={event}
           orgId={orgSlug}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           renderer={children => (
             <StyledReplayEventDataSection type="context-replay" title={t('Replay')}>
               {children}

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -58,7 +58,7 @@ export function EventEntry({
         <ExceptionV2
           event={event}
           data={entry.data}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
           hasHierarchicalGrouping={hasHierarchicalGrouping}
         />
@@ -66,7 +66,7 @@ export function EventEntry({
         <Exception
           event={event}
           data={entry.data}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
           hasHierarchicalGrouping={hasHierarchicalGrouping}
         />
@@ -83,7 +83,7 @@ export function EventEntry({
         <StackTraceV2
           event={event}
           data={entry.data}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
           hasHierarchicalGrouping={hasHierarchicalGrouping}
         />
@@ -91,7 +91,7 @@ export function EventEntry({
         <StackTrace
           event={event}
           data={entry.data}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
           hasHierarchicalGrouping={hasHierarchicalGrouping}
         />
@@ -129,7 +129,7 @@ export function EventEntry({
         <ThreadsV2
           event={event}
           data={entry.data}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
           hasHierarchicalGrouping={hasHierarchicalGrouping}
         />
@@ -137,7 +137,7 @@ export function EventEntry({
         <Threads
           event={event}
           data={entry.data}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           groupingCurrentLevel={groupingCurrentLevel}
           hasHierarchicalGrouping={hasHierarchicalGrouping}
         />
@@ -147,7 +147,7 @@ export function EventEntry({
       return (
         <DebugMeta
           event={event}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           groupId={group?.id}
           organization={organization as Organization}
           data={entry.data}

--- a/static/app/components/events/eventTags/eventTagsPill.tsx
+++ b/static/app/components/events/eventTags/eventTagsPill.tsx
@@ -21,7 +21,7 @@ const iconStyle = css`
 
 type Props = {
   organization: Organization;
-  projectId: string;
+  projectSlug: string;
   query: Query;
   streamPath: string;
   tag: EventTag;
@@ -32,7 +32,7 @@ const EventTagsPill = ({
   tag,
   query,
   organization,
-  projectId,
+  projectSlug,
   streamPath,
   meta,
 }: Props) => {
@@ -46,7 +46,7 @@ const EventTagsPill = ({
       {key === 'release' ? (
         <VersionHoverCard
           organization={organization}
-          projectSlug={projectId}
+          projectSlug={projectSlug}
           releaseVersion={value}
           showUnderline
           underlineColor="linkUnderline"

--- a/static/app/components/events/eventTags/index.spec.tsx
+++ b/static/app/components/events/eventTags/index.spec.tsx
@@ -25,7 +25,7 @@ describe('event tags', function () {
     render(
       <EventTags
         organization={organization}
-        projectId={project.id}
+        projectSlug={project.slug}
         location={router.location}
         event={event}
       />,
@@ -73,7 +73,7 @@ describe('event tags', function () {
     render(
       <EventTags
         organization={organization}
-        projectId={project.id}
+        projectSlug={project.slug}
         location={router.location}
         event={event}
       />,

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -15,10 +15,10 @@ type Props = {
   event: Event;
   location: Location;
   organization: Organization;
-  projectId: string;
+  projectSlug: string;
 };
 
-export function EventTags({event, organization, projectId, location}: Props) {
+export function EventTags({event, organization, projectSlug, location}: Props) {
   const meta = event._meta?.tags;
 
   if (!!meta?.[''] && !event.tags) {
@@ -39,7 +39,7 @@ export function EventTags({event, organization, projectId, location}: Props) {
           <EventTagsPill
             key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
             tag={tag}
-            projectId={projectId}
+            projectSlug={projectSlug}
             organization={organization}
             query={generateQueryWithTag({...location.query, referrer: 'event-tags'}, tag)}
             streamPath={streamPath}

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -157,7 +157,7 @@ describe('EventTagsAndScreenshot', function () {
         <EventTagsAndScreenshot
           event={{...event, tags, contexts}}
           organization={organization}
-          projectId={project.slug}
+          projectSlug={project.slug}
           location={router.location}
           attachments={[]}
           onDeleteScreenshot={() => jest.fn()}
@@ -208,7 +208,7 @@ describe('EventTagsAndScreenshot', function () {
         <EventTagsAndScreenshot
           event={{...event, tags, contexts}}
           organization={organization}
-          projectId={project.slug}
+          projectSlug={project.slug}
           location={router.location}
           attachments={[]}
           onDeleteScreenshot={() => jest.fn()}
@@ -231,7 +231,7 @@ describe('EventTagsAndScreenshot', function () {
         <EventTagsAndScreenshot
           event={{...event, tags, contexts}}
           organization={organization}
-          projectId={project.slug}
+          projectSlug={project.slug}
           location={router.location}
           attachments={attachments}
           onDeleteScreenshot={() => jest.fn()}
@@ -273,7 +273,7 @@ describe('EventTagsAndScreenshot', function () {
           <EventTagsAndScreenshot
             event={event}
             organization={organization}
-            projectId={project.slug}
+            projectSlug={project.slug}
             location={router.location}
             attachments={attachments}
             onDeleteScreenshot={() => jest.fn()}
@@ -325,7 +325,7 @@ describe('EventTagsAndScreenshot', function () {
         <EventTagsAndScreenshot
           event={{...event, tags, contexts}}
           organization={organization}
-          projectId={project.slug}
+          projectSlug={project.slug}
           location={router.location}
           attachments={attachments}
           onDeleteScreenshot={() => jest.fn()}
@@ -381,7 +381,7 @@ describe('EventTagsAndScreenshot', function () {
         <EventTagsAndScreenshot
           event={{...event, tags, contexts}}
           organization={organization}
-          projectId={project.slug}
+          projectSlug={project.slug}
           location={router.location}
           attachments={moreAttachments}
           onDeleteScreenshot={() => jest.fn()}
@@ -417,7 +417,7 @@ describe('EventTagsAndScreenshot', function () {
         <EventTagsAndScreenshot
           event={{...event, contexts}}
           organization={organization}
-          projectId={project.slug}
+          projectSlug={project.slug}
           location={router.location}
           attachments={attachments}
           onDeleteScreenshot={() => jest.fn()}
@@ -452,7 +452,7 @@ describe('EventTagsAndScreenshot', function () {
         <EventTagsAndScreenshot
           event={{...event, tags}}
           organization={organization}
-          projectId={project.slug}
+          projectSlug={project.slug}
           location={router.location}
           attachments={attachments}
           onDeleteScreenshot={() => jest.fn()}

--- a/static/app/components/events/eventTagsAndScreenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.tsx
@@ -33,13 +33,13 @@ type Props = Omit<
 > & {
   attachments: ScreenshotProps['screenshot'][];
   onDeleteScreenshot: ScreenshotProps['onDelete'];
-  projectId: string;
+  projectSlug: string;
   hasContext?: boolean;
   isShare?: boolean;
 };
 
 export function EventTagsAndScreenshot({
-  projectId: projectSlug,
+  projectSlug,
   location,
   event,
   attachments,

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -94,7 +94,7 @@ function Screenshot({
             <StyledImageVisualization
               attachment={screenshotAttachment}
               orgId={orgSlug}
-              projectId={projectSlug}
+              projectSlug={projectSlug}
               eventId={eventId}
               onLoad={() => setLoadingImage(false)}
               onError={() => setLoadingImage(false)}

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -164,7 +164,7 @@ function Modal({
         <StyledImageVisualization
           attachment={currentEventAttachment}
           orgId={orgSlug}
-          projectId={projectSlug}
+          projectSlug={projectSlug}
           eventId={currentEventAttachment.event_id}
         />
 

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -29,7 +29,7 @@ function Tags({event, organization, projectSlug, location, hasEventContext}: Pro
       <EventTags
         event={event}
         organization={organization}
-        projectId={projectSlug}
+        projectSlug={projectSlug}
         location={location}
       />
     </EventDataSection>

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -30,7 +30,7 @@ function EventViewHierarchy({projectSlug, viewHierarchies}: Props) {
         attachment: hierarchyMeta,
         eventId: hierarchyMeta.event_id,
         orgId: organization.slug,
-        projectId: projectSlug,
+        projectSlug,
       }),
     ],
     {staleTime: FIVE_SECONDS_IN_MS, refetchOnWindowFocus: false}

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -19,7 +19,7 @@ import GroupVariant from './groupingVariant';
 type Props = AsyncComponent['props'] & {
   event: Event;
   organization: Organization;
-  projectId: string;
+  projectSlug: string;
   showGroupingConfig: boolean;
 };
 
@@ -31,9 +31,9 @@ type State = AsyncComponent['state'] & {
 
 class GroupingInfo extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization, event, projectId} = this.props;
+    const {organization, event, projectSlug} = this.props;
 
-    let path = `/projects/${organization.slug}/${projectId}/events/${event.id}/grouping-info/`;
+    let path = `/projects/${organization.slug}/${projectSlug}/events/${event.id}/grouping-info/`;
     if (this.state?.configOverride) {
       path = `${path}?config=${this.state.configOverride}`;
     }

--- a/static/app/components/events/interfaces/crashContent/exception/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/index.tsx
@@ -11,7 +11,7 @@ type Props = {
   hasHierarchicalGrouping: boolean;
   newestFirst: boolean;
   platform: PlatformType;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   stackType: STACK_TYPE;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   meta?: Record<any, any>;
@@ -21,7 +21,7 @@ type Props = {
 function Exception({
   stackView,
   stackType,
-  projectId,
+  projectSlug,
   values,
   event,
   newestFirst,
@@ -35,7 +35,7 @@ function Exception({
       {stackView === STACK_VIEW.RAW ? (
         <RawContent
           eventId={event.id}
-          projectId={projectId}
+          projectSlug={projectSlug}
           type={stackType}
           values={values}
           platform={platform}

--- a/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
@@ -18,7 +18,7 @@ type Props = {
   api: Client;
   eventId: Event['id'];
   platform: PlatformType;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   type: 'original' | 'minified';
   // XXX: Organization is NOT available for Shared Issues!
   organization?: Organization;
@@ -55,10 +55,10 @@ class RawContent extends Component<Props, State> {
   }
 
   getAppleCrashReportEndpoint(organization: Organization) {
-    const {type, projectId, eventId} = this.props;
+    const {type, projectSlug, eventId} = this.props;
 
     const minified = type === 'minified';
-    return `/projects/${organization.slug}/${projectId}/events/${eventId}/apple-crash-report?minified=${minified}`;
+    return `/projects/${organization.slug}/${projectSlug}/events/${eventId}/apple-crash-report?minified=${minified}`;
   }
 
   getContent(isNative: boolean, exc: any) {

--- a/static/app/components/events/interfaces/crashContent/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/index.tsx
@@ -8,7 +8,7 @@ type Props = Pick<
   ExceptionProps,
   | 'stackType'
   | 'stackView'
-  | 'projectId'
+  | 'projectSlug'
   | 'event'
   | 'newestFirst'
   | 'groupingCurrentLevel'
@@ -23,7 +23,7 @@ function CrashContent({
   stackView,
   stackType,
   newestFirst,
-  projectId,
+  projectSlug,
   groupingCurrentLevel,
   hasHierarchicalGrouping,
   exception,
@@ -36,7 +36,7 @@ function CrashContent({
       <Exception
         stackType={stackType}
         stackView={stackView}
-        projectId={projectId}
+        projectSlug={projectSlug}
         newestFirst={newestFirst}
         event={event}
         platform={platform}

--- a/static/app/components/events/interfaces/debugMeta/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.spec.tsx
@@ -19,7 +19,7 @@ describe('DebugMeta', function () {
         <GlobalModal />
         <DebugMeta
           organization={organization}
-          projectId={project.id}
+          projectSlug={project.slug}
           event={event}
           data={eventEntryDebugMeta.data}
           {...routerProps}

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -55,7 +55,7 @@ type Props = DefaultProps &
   WithRouterProps & {
     event: Event;
     organization: Organization;
-    projectId: Project['id'];
+    projectSlug: Project['slug'];
     groupId?: Group['id'];
   };
 
@@ -223,7 +223,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
       return;
     }
 
-    const {location, organization, projectId: projSlug, groupId, event} = this.props;
+    const {location, organization, projectSlug, groupId, event} = this.props;
     const {query} = location;
 
     const {imageCodeId, imageDebugId} = query;
@@ -251,7 +251,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
           {...deps}
           image={image}
           organization={organization}
-          projSlug={projSlug}
+          projSlug={projectSlug}
           event={event}
           onReprocessEvent={
             defined(groupId) ? this.handleReprocessEvent(groupId) : undefined

--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -16,7 +16,7 @@ type Props = {
   data: ExceptionType;
   event: Event;
   hasHierarchicalGrouping: boolean;
-  projectId: string;
+  projectSlug: string;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hideGuide?: boolean;
 };
@@ -24,7 +24,7 @@ type Props = {
 export function Exception({
   event,
   data,
-  projectId,
+  projectSlug,
   hasHierarchicalGrouping,
   groupingCurrentLevel,
   hideGuide = false,
@@ -89,7 +89,7 @@ export function Exception({
       wrapTitle={false}
     >
       <CrashContent
-        projectId={projectId}
+        projectSlug={projectSlug}
         event={event}
         stackType={stackType}
         stackView={stackView}

--- a/static/app/components/events/interfaces/exceptionV2.tsx
+++ b/static/app/components/events/interfaces/exceptionV2.tsx
@@ -13,7 +13,7 @@ type Props = {
   data: ExceptionType;
   event: Event;
   hasHierarchicalGrouping: boolean;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hideGuide?: boolean;
 };
@@ -21,7 +21,7 @@ type Props = {
 export function ExceptionV2({
   event,
   data,
-  projectId,
+  projectSlug,
   hasHierarchicalGrouping,
   groupingCurrentLevel,
 }: Props) {
@@ -64,7 +64,7 @@ export function ExceptionV2({
       title={<PermalinkTitle>{t('Stack Trace')}</PermalinkTitle>}
       type={EntryType.EXCEPTION}
       stackType={STACK_TYPE.ORIGINAL}
-      projectId={projectId}
+      projectSlug={projectSlug}
       eventId={event.id}
       recentFirst={isStacktraceNewestFirst()}
       fullStackTrace={!data.hasSystemFrames}
@@ -117,7 +117,7 @@ export function ExceptionV2({
                 ? STACK_VIEW.FULL
                 : STACK_VIEW.APP
             }
-            projectId={projectId}
+            projectSlug={projectSlug}
             newestFirst={recentFirst}
             event={event}
             platform={platform}

--- a/static/app/components/events/interfaces/stackTrace.tsx
+++ b/static/app/components/events/interfaces/stackTrace.tsx
@@ -20,7 +20,7 @@ type Props = Pick<
 > & {
   data: NonNullable<CrashContentProps['stacktrace']>;
   event: Event;
-  projectSlug: Project['id'];
+  projectSlug: Project['slug'];
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hideGuide?: boolean;
 };

--- a/static/app/components/events/interfaces/stackTrace.tsx
+++ b/static/app/components/events/interfaces/stackTrace.tsx
@@ -20,14 +20,14 @@ type Props = Pick<
 > & {
   data: NonNullable<CrashContentProps['stacktrace']>;
   event: Event;
-  projectId: Project['id'];
+  projectSlug: Project['id'];
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hideGuide?: boolean;
 };
 
 export function StackTrace({
   hideGuide = false,
-  projectId,
+  projectSlug,
   event,
   data,
   hasHierarchicalGrouping,
@@ -70,7 +70,7 @@ export function StackTrace({
         <NoStackTraceMessage />
       ) : (
         <CrashContent
-          projectId={projectId}
+          projectSlug={projectSlug}
           event={event}
           stackView={stackView}
           newestFirst={newestFirst}

--- a/static/app/components/events/interfaces/stackTraceV2.tsx
+++ b/static/app/components/events/interfaces/stackTraceV2.tsx
@@ -18,13 +18,13 @@ type Props = Pick<
 > & {
   data: NonNullable<CrashContentProps['stacktrace']>;
   event: Event;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hideGuide?: boolean;
 };
 
 export function StackTraceV2({
-  projectId,
+  projectSlug,
   event,
   data,
   hasHierarchicalGrouping,
@@ -48,7 +48,7 @@ export function StackTraceV2({
     <TraceEventDataSection
       type={EntryType.STACKTRACE}
       stackType={STACK_TYPE.ORIGINAL}
-      projectId={projectId}
+      projectSlug={projectSlug}
       eventId={event.id}
       platform={platform}
       stackTraceNotFound={stackTraceNotFound}

--- a/static/app/components/events/interfaces/threads/content.tsx
+++ b/static/app/components/events/interfaces/threads/content.tsx
@@ -13,7 +13,7 @@ type CrashContentProps = React.ComponentProps<typeof CrashContent>;
 type Props = {
   event: Event;
   newestFirst: boolean;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   stackTraceNotFound: boolean;
   stackType: STACK_TYPE;
   data?: Thread;
@@ -25,7 +25,7 @@ type Props = {
 
 const Content = ({
   event,
-  projectId,
+  projectSlug,
   data,
   stackView,
   groupingCurrentLevel,
@@ -56,7 +56,7 @@ const Content = ({
         stackType={stackType}
         stackView={stackView}
         newestFirst={newestFirst}
-        projectId={projectId}
+        projectSlug={projectSlug}
         exception={exception}
         stacktrace={stacktrace}
         groupingCurrentLevel={groupingCurrentLevel}

--- a/static/app/components/events/interfaces/threads/index.spec.tsx
+++ b/static/app/components/events/interfaces/threads/index.spec.tsx
@@ -51,7 +51,7 @@ describe('Threads', () => {
       <Threads
         data={data}
         hasHierarchicalGrouping={false}
-        projectId="project-id"
+        projectSlug="project-id"
         event={newEvent}
       />
     );
@@ -69,7 +69,7 @@ describe('Threads', () => {
       <Threads
         data={{...data, values: [{...data.values[0], stacktrace: null}]}}
         hasHierarchicalGrouping={false}
-        projectId="project-id"
+        projectSlug="project-id"
         event={{
           ...event,
           entries: [
@@ -97,7 +97,7 @@ describe('Threads', () => {
       render(
         <Threads
           data={threadsEntry.data}
-          projectId="project-id"
+          projectSlug="project-id"
           event={event}
           hasHierarchicalGrouping={false}
         />
@@ -112,7 +112,7 @@ describe('Threads', () => {
         <Threads
           data={threadsEntry.data}
           hasHierarchicalGrouping={false}
-          projectId="project-id"
+          projectSlug="project-id"
           event={{
             ...event,
             entries: [

--- a/static/app/components/events/interfaces/threads/index.tsx
+++ b/static/app/components/events/interfaces/threads/index.tsx
@@ -24,7 +24,7 @@ type Props = Pick<
     values?: Array<Thread>;
   };
   event: Event;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   hideGuide?: boolean;
 };
 
@@ -51,7 +51,7 @@ function getIntendedStackView(thread: Thread, event: Event) {
 export function Threads({
   data,
   event,
-  projectId,
+  projectSlug,
   hasHierarchicalGrouping,
   groupingCurrentLevel,
   hideGuide = false,
@@ -166,7 +166,7 @@ export function Threads({
         stacktrace={stacktrace}
         event={event}
         newestFirst={newestFirst}
-        projectId={projectId}
+        projectSlug={projectSlug}
         groupingCurrentLevel={groupingCurrentLevel}
         stackTraceNotFound={stackTraceNotFound}
         hasHierarchicalGrouping={hasHierarchicalGrouping}

--- a/static/app/components/events/interfaces/threadsV2.spec.tsx
+++ b/static/app/components/events/interfaces/threadsV2.spec.tsx
@@ -200,7 +200,7 @@ describe('ThreadsV2', function () {
         event,
         groupingCurrentLevel: 0,
         hasHierarchicalGrouping: true,
-        projectId: project.id,
+        projectSlug: project.slug,
       };
 
       it('renders', function () {
@@ -861,7 +861,7 @@ describe('ThreadsV2', function () {
         event,
         groupingCurrentLevel: 0,
         hasHierarchicalGrouping: true,
-        projectId: project.id,
+        projectSlug: project.slug,
       };
 
       it('renders', function () {
@@ -1012,7 +1012,7 @@ describe('ThreadsV2', function () {
         ).toBeInTheDocument();
 
         MockApiClient.addMockResponse({
-          url: `/projects/${organization.slug}/2/events/${event.id}/apple-crash-report?minified=false`,
+          url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/apple-crash-report?minified=false`,
           body: '',
         });
 

--- a/static/app/components/events/interfaces/threadsV2.tsx
+++ b/static/app/components/events/interfaces/threadsV2.tsx
@@ -33,7 +33,7 @@ type Props = Pick<ExceptionProps, 'groupingCurrentLevel' | 'hasHierarchicalGroup
     values?: Array<Thread>;
   };
   event: Event;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
 };
 
 type State = {
@@ -58,7 +58,7 @@ function getIntendedStackView(
 export function ThreadsV2({
   data,
   event,
-  projectId,
+  projectSlug,
   hasHierarchicalGrouping,
   groupingCurrentLevel,
 }: Props) {
@@ -152,7 +152,7 @@ export function ThreadsV2({
               ? STACK_VIEW.FULL
               : STACK_VIEW.APP
           }
-          projectId={projectId}
+          projectSlug={projectSlug}
           newestFirst={recentFirst}
           event={event}
           platform={platform}
@@ -204,7 +204,7 @@ export function ThreadsV2({
     <TraceEventDataSection
       type={EntryType.THREADS}
       stackType={STACK_TYPE.ORIGINAL}
-      projectId={projectId}
+      projectSlug={projectSlug}
       eventId={event.id}
       recentFirst={isStacktraceNewestFirst()}
       fullStackTrace={stackView === STACK_VIEW.FULL}

--- a/static/app/components/events/rrwebIntegration.tsx
+++ b/static/app/components/events/rrwebIntegration.tsx
@@ -6,7 +6,7 @@ import {Event} from 'sentry/types/event';
 type Props = {
   event: Event;
   orgId: Organization['id'];
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   renderer?: Function;
 } & AsyncComponent['props'];
 
@@ -16,11 +16,11 @@ type State = {
 
 export class EventRRWebIntegration extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {orgId, projectId, event} = this.props;
+    const {orgId, projectSlug, event} = this.props;
     return [
       [
         'attachmentList',
-        `/projects/${orgId}/${projectId}/events/${event.id}/attachments/`,
+        `/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/`,
 
         // This was changed from `rrweb.json`, so that we can instead
         // support incremental rrweb events as attachments. This is to avoid
@@ -50,10 +50,10 @@ export class EventRRWebIntegration extends AsyncComponent<Props, State> {
       return null;
     }
 
-    const {orgId, projectId, event} = this.props;
+    const {orgId, projectSlug, event} = this.props;
 
     function createAttachmentUrl(attachment: IssueAttachment) {
-      return `/api/0/projects/${orgId}/${projectId}/events/${event.id}/attachments/${attachment.id}/?download`;
+      return `/api/0/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/${attachment.id}/?download`;
     }
 
     return renderer(

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -50,7 +50,7 @@ type Props = {
   hasNewestFirst: boolean;
   hasVerboseFunctionNames: boolean;
   platform: PlatformType;
-  projectId: Project['id'];
+  projectSlug: Project['slug'];
   recentFirst: boolean;
   stackTraceNotFound: boolean;
   stackType: STACK_TYPE;
@@ -73,7 +73,7 @@ export function TraceEventDataSection({
   children,
   platform,
   stackType,
-  projectId,
+  projectSlug,
   eventId,
   hasNewestFirst,
   hasMinified,
@@ -169,7 +169,7 @@ export function TraceEventDataSection({
   const minified = stackType === STACK_TYPE.MINIFIED;
 
   // Apple crash report endpoint
-  const appleCrashEndpoint = `/projects/${organization.slug}/${projectId}/events/${eventId}/apple-crash-report?minified=${minified}`;
+  const appleCrashEndpoint = `/projects/${organization.slug}/${projectSlug}/events/${eventId}/apple-crash-report?minified=${minified}`;
   const rawStackTraceDownloadLink = `${api.baseUrl}${appleCrashEndpoint}&download=1`;
 
   const sortByTooltip = !hasNewestFirst

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -166,7 +166,7 @@ class GroupEventAttachments extends AsyncComponent<Props, State> {
         <GroupEventAttachmentsTable
           attachments={eventAttachments}
           orgId={params.orgId}
-          projectId={project.slug}
+          projectSlug={project.slug}
           groupId={params.groupId}
           onDelete={this.handleDelete}
           deletedAttachments={deletedAttachments}

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsTable.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsTable.tsx
@@ -8,13 +8,13 @@ type Props = {
   groupId: string;
   onDelete: (attachmentId: string) => void;
   orgId: string;
-  projectId: string;
+  projectSlug: string;
 };
 
 const GroupEventAttachmentsTable = ({
   attachments,
   orgId,
-  projectId,
+  projectSlug,
   groupId,
   onDelete,
   deletedAttachments,
@@ -36,7 +36,7 @@ const GroupEventAttachmentsTable = ({
             key={attachment.id}
             attachment={attachment}
             orgId={orgId}
-            projectId={projectId}
+            projectSlug={projectSlug}
             groupId={groupId}
             onDelete={onDelete}
             isDeleted={deletedAttachments.some(id => attachment.id === id)}

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsTableRow.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsTableRow.tsx
@@ -15,12 +15,12 @@ type Props = {
   isDeleted: boolean;
   onDelete: (attachmentId: string) => void;
   orgId: string;
-  projectId: string;
+  projectSlug: string;
 };
 
 const GroupEventAttachmentsTableRow = ({
   attachment,
-  projectId,
+  projectSlug,
   onDelete,
   isDeleted,
   orgId,
@@ -51,7 +51,7 @@ const GroupEventAttachmentsTableRow = ({
     <td>
       <ActionsWrapper>
         <AttachmentUrl
-          projectId={projectId}
+          projectSlug={projectSlug}
           eventId={attachment.event_id}
           attachment={attachment}
         >

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/screenshotCard.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/screenshotCard.tsx
@@ -119,7 +119,7 @@ export function ScreenshotCard({
             <StyledImageVisualization
               attachment={eventAttachment}
               orgId={organization.slug}
-              projectId={projectSlug}
+              projectSlug={projectSlug}
               eventId={eventId}
               onLoad={() => setLoadingImage(false)}
               onError={() => setLoadingImage(false)}

--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -111,7 +111,7 @@ export function Tags({
               <EventTagsPill
                 key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
                 tag={tag}
-                projectId={transaction.project_slug}
+                projectSlug={transaction.project_slug}
                 organization={organization}
                 query={query}
                 streamPath={streamPath}

--- a/static/app/views/projectDetail/projectLatestAlerts.spec.jsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.spec.jsx
@@ -135,7 +135,6 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         location={{
           query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
         }}
-        projectId={project.slug}
         isProjectStabilized
       />
     );


### PR DESCRIPTION
projectSlug being called projectId is confusing
![image](https://user-images.githubusercontent.com/1400464/214229285-a756f6d2-3ab4-476b-8769-0e2757670c34.png)
