### PR TITLE
fix(ci): Correct files-changed variable name 

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -31,7 +31,8 @@ jobs:
     # Map a step output to a job output
     outputs:
       acceptance: ${{ steps.changes.outputs.acceptance }}
-      backend: ${{ steps.changes.outputs.backend_all }}
+      backend_all: ${{ steps.changes.outputs.backend_all }}
+      frontend_all: ${{ steps.changes.outputs.frontend_all }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
 
@@ -211,7 +212,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: needs.files-changed.outputs.backend_always
+        if: needs.files-changed.outputs.backend_always == 'true'
 
   chartcuterie:
     if: needs.files-changed.outputs.acceptance == 'true'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -122,7 +122,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: ${{ always() && needs.files-changed.outputs.frontend_all == 'true' }}
+        if: needs.files-changed.outputs.frontend_all == 'true'
         with:
           files: .artifacts/coverage/*
           type: frontend
@@ -211,7 +211,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: ${{ always() && needs.files-changed.outputs.backend_all == 'true' }}
+        if: needs.files-changed.outputs.backend_always
 
   chartcuterie:
     if: needs.files-changed.outputs.acceptance == 'true'
@@ -285,7 +285,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: ${{ always() && needs.files-changed.outputs.backend_all == 'true' }}
+        if: needs.files-changed.outputs.backend_all == 'true'
 
   visual-diff:
     if: always()

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -123,7 +123,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: needs.files-changed.outputs.frontend_all == 'true'
+        if: ${{ always() && needs.files-changed.outputs.frontend_all == 'true' }}
         with:
           files: .artifacts/coverage/*
           type: frontend
@@ -212,7 +212,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: needs.files-changed.outputs.backend_all == 'true'
+        if: ${{ always() && needs.files-changed.outputs.backend_all == 'true' }}
 
   chartcuterie:
     if: needs.files-changed.outputs.acceptance == 'true'
@@ -286,7 +286,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: needs.files-changed.outputs.backend_all == 'true'
+        if: ${{ always() && needs.files-changed.outputs.backend_all == 'true' }}
 
   visual-diff:
     if: always()

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -212,7 +212,7 @@ jobs:
       # it reduces large coverage fluctuations
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: needs.files-changed.outputs.backend_always == 'true'
+        if: needs.files-changed.outputs.backend_all == 'true'
 
   chartcuterie:
     if: needs.files-changed.outputs.acceptance == 'true'


### PR DESCRIPTION
This is very easy to regress.
This happened in https://github.com/getsentry/sentry/pull/38881
This means that we have been carrying forward old coverage data from four months ago for the acceptance and charcuterie jobs.