### PR TITLE
fix(dashboards): Fixes display of dataset selector in dashboards for safari

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -68,6 +68,5 @@ export function DataSetStep({dataSet, onChange, displayType}: Props) {
 
 const DataSetChoices = styled(RadioGroup)`
   display: flex;
-  flex-wrap: wrap;
   gap: ${space(2)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -68,5 +68,7 @@ export function DataSetStep({dataSet, onChange, displayType}: Props) {
 
 const DataSetChoices = styled(RadioGroup)`
   display: flex;
+  flex-wrap: wrap;
   gap: ${space(2)};
+  flex-direction: row;
 `;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -61,6 +61,7 @@ export function DataSetStep({dataSet, onChange, displayType}: Props) {
         onChange={newDataSet => {
           onChange(newDataSet as DataSet);
         }}
+        orientInline
       />
     </BuildStep>
   );
@@ -70,5 +71,4 @@ const DataSetChoices = styled(RadioGroup)`
   display: flex;
   flex-wrap: wrap;
   gap: ${space(2)};
-  flex-direction: row;
 `;


### PR DESCRIPTION
The dataset selector was not rendering properly for safari. This fixes display issues.
before
<img width="404" alt="image" src="https://user-images.githubusercontent.com/83961295/214329945-5960e345-4d49-472a-9a98-f5d01aedb1b9.png">

after
<img width="955" alt="image" src="https://user-images.githubusercontent.com/83961295/214337195-64ad49b9-be08-4ae4-aac2-2e6fe079fac3.png">
