### PR TITLE
feat(perf-issues): Add settings to control problem detection back

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -17,6 +17,7 @@ const optionsAvailable = [
   'auth.user-rate-limit',
   'api.rate-limit.org-create',
   'beacon.anonymous',
+  'performance.issues.all.problem-detection',
   'performance.issues.n_plus_one_db.problem-creation',
   'performance.issues.n_plus_one_db_ext.problem-creation',
   'performance.issues.n_plus_one_db.count_threshold',
@@ -111,6 +112,10 @@ export default class AdminSettings extends AsyncView<{}, State> {
           </Panel>
 
           <Feature features={['organizations:performance-issues-dev']}>
+            <Panel>
+              <PanelHeader>Performance Issues - All</PanelHeader>
+              {fields['performance.issues.all.problem-detection']}
+            </Panel>
             <Panel>
               <PanelHeader>Performance Issues - Detectors</PanelHeader>
               {fields['performance.issues.n_plus_one_db.problem-creation']}


### PR DESCRIPTION
I'm adding back the ability to set problem detection rate in the admin settings. This is meant to be merged after https://github.com/getsentry/sentry/pull/43618 so that the detection rate can be set to 1.0. And lastly I'll be adding the option check in ingest.