### PR TITLE
ref(flamegraphTreeTable): Use `InteractionStateLayer`

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -222,6 +223,7 @@ export function FlamegraphTreeTable({
         <FrameCallersTableHeader>
           <FrameWeightCell>
             <TableHeaderButton onClick={() => onSortChange('self weight')}>
+              <InteractionStateLayer />
               <span>
                 {t('Self Time')}{' '}
                 <QuestionTooltip
@@ -239,6 +241,7 @@ export function FlamegraphTreeTable({
           </FrameWeightCell>
           <FrameWeightCell>
             <TableHeaderButton onClick={() => onSortChange('total weight')}>
+              <InteractionStateLayer />
               <span>
                 {t('Total Time')}{' '}
                 <QuestionTooltip
@@ -256,6 +259,7 @@ export function FlamegraphTreeTable({
           </FrameWeightCell>
           <FrameNameCell>
             <TableHeaderButton onClick={() => onSortChange('name')}>
+              <InteractionStateLayer />
               {t('Frame')}{' '}
               {sort === 'name' ? (
                 <IconArrow direction={direction === 'desc' ? 'down' : 'up'} />
@@ -326,10 +330,6 @@ const TableHeaderButton = styled('button')`
   background-color: ${props => props.theme.surface100};
   transition: background-color 100ms ease-in-out;
   line-height: 24px;
-
-  &:hover {
-    background-color: ${props => props.theme.surface400};
-  }
 
   svg {
     width: 10px;


### PR DESCRIPTION
Remove `surface400` and instead use `InteractionStateLayer`, since `surface400` is being deprecated (https://github.com/getsentry/sentry/pull/43616 — only the current value and its use as a hover color will be removed, I'm adding a different color to the series soon).

**Before:**

<img width="303" alt="Screenshot 2023-01-24 at 10 11 52 AM" src="https://user-images.githubusercontent.com/44172267/214374026-a25f8325-cfaa-4e3f-9497-63f4868f017f.png">
<img width="303" alt="Screenshot 2023-01-24 at 10 12 05 AM" src="https://user-images.githubusercontent.com/44172267/214374061-30dabd5c-9ce5-4569-8c70-b127ece1aaf0.png">

**After:** the hover effect is more prominent is light mode and less contrasty in dark mode. `InteractionStateLayer` works better than `surface400` on a wider range of backgrounds.

<img width="303" alt="Screenshot 2023-01-24 at 10 11 24 AM" src="https://user-images.githubusercontent.com/44172267/214373933-b0da936a-a82c-4b0a-a679-9844019fbb47.png">
<img width="303" alt="Screenshot 2023-01-24 at 10 11 10 AM" src="https://user-images.githubusercontent.com/44172267/214373895-9cebcc12-1658-49ee-8df6-410f5661f59c.png">
