### PR TITLE
chore: Update more emails for customer-domains

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -16,7 +16,6 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.utils import json
-from sentry.utils.http import absolute_uri
 
 from .base import DEFAULT_EXPIRATION, ExportQueryType, ExportStatus
 
@@ -93,7 +92,7 @@ class ExportedData(Model):
                 extra={"data_export_id": self.id, "organization_id": self.organization_id},
             )
             return
-        url = absolute_uri(
+        url = self.organization.absolute_url(
             reverse("sentry-data-export-details", args=[self.organization.slug, self.id])
         )
         msg = MessageBuilder(

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -186,8 +186,9 @@
     <td class="project-breakdown-graph-cell errors">
     <h4 class="total-count-title">Total Project Errors</h4>
     <h1 style="margin: 0;" class="total-count">{{ trends.total_error_count|small_count:1 }}</h1>
-    {% url 'sentry-organization-issue-list' organization.slug as issue_list%}
-    <a href="{% absolute_uri issue_list %}?referrer=weekly-email" style="font-size: 12px; margin-bottom: 16px; display: block;">View All Errors</a>
+    {% url 'sentry-organization-issue-list' organization.slug as issue_list %}
+    <a href="{% org_url organization issue_list query="referrer=weekly-email" %}"
+       style="font-size: 12px; margin-bottom: 16px; display: block;">View All Errors</a>
 
     <table class="graph">
       <tr>
@@ -221,7 +222,9 @@
     <td class="project-breakdown-graph-cell transactions">
       <h4 class="total-count-title">Total Project Transactions</h4>
       <h1 style="margin: 0;" class="total-count">{{ trends.total_transaction_count|small_count:1 }}</h1>
-      <a href="{% absolute_uri '/organizations/{}/performance/?referrer=weekly_email_view_all' organization.slug %}" style="font-size: 12px; margin-bottom: 16px; display: block;">View All Transactions</a>
+      {% url 'sentry-organization-perfomance' organization.slug as performance_landing %}
+      <a href="{% org_url organization performance_landing query='referrer=weekly_email_view_all' %}"
+         style="font-size: 12px; margin-bottom: 16px; display: block;">View All Transactions</a>
       <table class="graph">
         <tr>
           {% for timestamp, project_values in trends.series %}
@@ -255,7 +258,9 @@
           <img src="{% absolute_asset_url 'sentry' 'images/email/icon-circle-lightning.png' %}" width="32px" height="32px" alt="Sentry">
           <h1 style="font-weight: bold; font-size: 17px;">Something slow?</h1>
           <p style="font-size: 11px;">Trace those 10-second page loads to poor-performing API calls.</p>
-          <a href="{% absolute_uri '/organizations/{}/performance/?referrer=weekly_email_upsell' organization.slug %}" class="btn" style="margin-top: 8px;">Set Up Performance</a>
+          {% url 'sentry-organization-performance' organization.slug as performance_landing %}
+          <a href="{% org_url organization performance_landing query='referrer=weekly_email_upsell' %}"
+             class="btn" style="margin-top: 8px;">Set Up Performance</a>
         </div>
       </td>
     {% endif %}
@@ -329,7 +334,7 @@
 
   </div>
 
-  {%if key_errors|length > 0 %}
+  {% if key_errors|length > 0 %}
   <div id="key-errors">
     <h4>Issues with the most errors</h4>
     {% for a in key_errors %}
@@ -337,7 +342,8 @@
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
       <div style="width: 65%;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
-        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px; height: 24px;" href="{% absolute_uri issue_detail %}?referrer=weekly-email">{{a.group.message}}</a>
+        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px; height: 24px;"
+           href="{% org_url organization issue_detail query='referrer=weekly-email' %}">{{a.group.message}}</a>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
@@ -345,7 +351,7 @@
     {% endfor %}
   </div>
   {% endif %}
-  {%if key_performance_issues|length > 0 %}
+  {% if key_performance_issues|length > 0 %}
   <div id="key-performance-issues">
     <h4>Most frequent performance issues</h4>
     {% for a in key_performance_issues %}
@@ -353,7 +359,8 @@
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
       <div style="width: 65%;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
-        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px; height: 24px;" href="{% absolute_uri issue_detail %}?referrer=weekly-email">{{a.group.message}}</a>
+        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px; height: 24px;"
+           href="{% org_url organization issue_detail query="referrer=weekly-email" %}">{{a.group.message}}</a>
         <div style="font-size: 12px; color: #80708F;">{{a.group.get_type_display}}</div>
       </div>
       <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
@@ -361,14 +368,17 @@
     {% endfor %}
   </div>
   {% endif %}
-  {%if key_transactions|length > 0 %}
+  {% if key_transactions|length > 0 %}
   <div id="key-transactions">
     <h4>Most frequent transactions</h4>
     {% for a in key_transactions %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
       <div style="width: 65%;">
-        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px;" href="{% absolute_uri '/organizations/{}/performance/summary/?project={}&transaction={}&referrer=weekly_report' organization.slug a.project.id a.name %}">{{a.name}}</a>
+        {% querystring project=a.project.id transaction=a.name referrer="weekly_report" as query %}
+        {% url 'sentry-organization-performance-summary' organization.slug as performance_summary %}
+        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px;"
+           href="{% org_url organization performance_summary query=query %}">{{a.name}}</a>
         <div style="font-size: 12px; color: #80708F;">{{a.project.name}}</div>
       </div>
       <div style="font-size: 14px; margin-left: auto; display: flex;">

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -105,7 +105,7 @@ def org_url(organization, path, query=None, fragment=None) -> str:
     Generate an absolute url for an organization
     """
     if not hasattr(organization, "absolute_url"):
-        raise RuntimeError("organiation parameter is not an Organization instance")
+        raise RuntimeError("organization parameter is not an Organization instance")
     return organization.absolute_url(path, query=query, fragment=fragment)
 
 

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -3,7 +3,7 @@ import os.path
 from collections import namedtuple
 from datetime import datetime, timedelta
 from random import randint
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from django import template
 from django.template.defaultfilters import stringfilter
@@ -105,8 +105,13 @@ def org_url(organization, path, query=None, fragment=None) -> str:
     Generate an absolute url for an organization
     """
     if not hasattr(organization, "absolute_url"):
-        raise RuntimeError("organiation parameter is missing absolute_url")
+        raise RuntimeError("organiation parameter is not an Organization instance")
     return organization.absolute_url(path, query=query, fragment=fragment)
+
+
+@register.simple_tag
+def querystring(**kwargs):
+    return urlencode(kwargs, doseq=False)
 
 
 @register.simple_tag

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -100,6 +100,16 @@ def absolute_uri(parser, token):
 
 
 @register.simple_tag
+def org_url(organization, path, query=None, fragment=None) -> str:
+    """
+    Generate an absolute url for an organization
+    """
+    if not hasattr(organization, "absolute_url"):
+        raise RuntimeError("organiation parameter is missing absolute_url")
+    return organization.absolute_url(path, query=query, fragment=fragment)
+
+
+@register.simple_tag
 def system_origin():
     from sentry.utils.http import absolute_uri, origin_from_url
 

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -660,6 +660,16 @@ urlpatterns += [
                     name="sentry-organization-member-settings-old",
                 ),
                 url(
+                    r"^(?P<organization_slug>[\w_-]+)/performance/$",
+                    react_page_view,
+                    name="sentry-organization-performance",
+                ),
+                url(
+                    r"^(?P<organization_slug>[\w_-]+)/performance/summary/$",
+                    react_page_view,
+                    name="sentry-organization-performance-summary",
+                ),
+                url(
                     r"^(?P<organization_slug>[\w_-]+)/stats/$",
                     react_page_view,
                     name="sentry-organization-stats",

--- a/tests/sentry/data_export/test_models.py
+++ b/tests/sentry/data_export/test_models.py
@@ -10,6 +10,7 @@ from sentry.data_export.base import DEFAULT_EXPIRATION, ExportQueryType, ExportS
 from sentry.data_export.models import ExportedData
 from sentry.models import File
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
@@ -112,6 +113,19 @@ class ExportedDataTest(TestCase):
         with self.tasks():
             self.data_export.email_success()
         assert len(mail.outbox) == 1
+
+    @with_feature("organizations:customer-domains")
+    def test_email_success_customer_domains(self):
+        self.data_export.finalize_upload(file=self.file1)
+        with self.tasks():
+            self.data_export.email_success()
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert msg.subject == "Your data is ready."
+        assert (
+            self.organization.absolute_url(f"/organizations/{self.organization.slug}/data-export/")
+            in msg.body
+        )
 
     @patch("sentry.utils.email.MessageBuilder")
     def test_email_success_content(self, builder):

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -56,6 +56,34 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             message = mail.outbox[0]
             assert self.organization.name in message.subject
 
+    @with_feature("organizations:customer-domains")
+    @with_feature("organizations:weekly-email-refresh")
+    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
+    def test_message_links_customer_domains(self):
+        Project.objects.all().delete()
+
+        now = datetime.now().replace(tzinfo=pytz.utc)
+
+        project = self.create_project(
+            organization=self.organization, teams=[self.team], date_added=now - timedelta(days=90)
+        )
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(days=1)),
+            },
+            project_id=project.id,
+        )
+        with self.tasks():
+            schedule_organizations(timestamp=to_timestamp(now))
+            assert len(mail.outbox) == 1
+
+            message = mail.outbox[0]
+            assert self.organization.name in message.subject
+            html = message.alternatives[0][0]
+            assert (
+                f"http://{self.organization.slug}.testserver/issues/?referrer=weekly-email" in html
+            )
+
     @mock.patch("sentry.tasks.weekly_reports.send_email")
     def test_deliver_reports_respects_settings(self, mock_send_email):
         user = self.user

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -121,6 +121,15 @@ def test_org_url_customer_domains(input, output):
         assert result == output
 
 
+def test_querystring():
+    input = """
+    {% load sentry_helpers %}
+    {% querystring transaction="testing" referrer="weekly_report" space="some thing"%}
+    """
+    result = engines["django"].from_string(input).render(context={}).strip()
+    assert result == "transaction=testing&amp;referrer=weekly_report&amp;space=some+thing"
+
+
 def test_date_handle_date_and_datetime():
     result = (
         engines["django"]

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -3,6 +3,9 @@ import datetime
 import pytest
 from django.template import engines
 
+from sentry.models.organization import Organization
+from sentry.testutils.helpers.features import Feature
+
 
 def test_system_origin():
     result = (
@@ -62,6 +65,60 @@ def test_absolute_uri(input, output):
         .strip()
     )
     assert result == output
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    (
+        ("{% org_url organization '/issues/' %}", "http://testserver/issues/"),
+        (
+            "{% org_url organization '/issues/' query='referrer=alert' %}",
+            "http://testserver/issues/?referrer=alert",
+        ),
+        (
+            "{% org_url organization '/issues/' query='referrer=alert' fragment='test' %}",
+            "http://testserver/issues/?referrer=alert#test",
+        ),
+        ("{% org_url organization path %}", "http://testserver/organizations/sentry/issues/"),
+    ),
+)
+def test_org_url(input, output):
+    prefix = "{% load sentry_helpers %}"
+    org = Organization(id=1, slug="sentry", name="Sentry")
+    result = (
+        engines["django"]
+        .from_string(prefix + input)
+        .render(context={"organization": org, "path": "/organizations/sentry/issues/"})
+        .strip()
+    )
+    assert result == output
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    (
+        (
+            "{% org_url organization '/organizations/sentry/discover/' %}",
+            "http://sentry.testserver/discover/",
+        ),
+        (
+            "{% org_url organization path query='referrer=alert' %}",
+            "http://sentry.testserver/issues/?referrer=alert",
+        ),
+    ),
+)
+def test_org_url_customer_domains(input, output):
+    prefix = "{% load sentry_helpers %}"
+    org = Organization(id=1, slug="sentry", name="Sentry")
+
+    with Feature("organizations:customer-domains"):
+        result = (
+            engines["django"]
+            .from_string(prefix + input)
+            .render(context={"organization": org, "path": "/organizations/sentry/issues/"})
+            .strip()
+        )
+        assert result == output
 
 
 def test_date_handle_date_and_datetime():


### PR DESCRIPTION
Update the data export and weekly report emails to use customer-domain compatible URL generation.

This required adding a few more template tags to django templates as Django doesn't allow object methods to be called with parameters. Django also doesn't seem to include a way to convert kwargs into a querystring so I added one of those too.