### PR TITLE
fix(perf-issues): make consecutive db fingerprinting more aggressive

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1019,7 +1019,10 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         return is_db_op and is_query
 
     def _fingerprint(self) -> str:
-        hashed_spans = fingerprint_spans(self.consecutive_db_spans)
+        prior_span_index = self.consecutive_db_spans.index(self.independent_db_spans[0]) - 1
+        hashed_spans = fingerprint_spans(
+            [self.consecutive_db_spans[prior_span_index]] + self.independent_db_spans
+        )
         return f"1-{GroupType.PERFORMANCE_CONSECUTIVE_DB_QUERIES.value}-{hashed_spans}"
 
     def on_complete(self) -> None:

--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -145,7 +145,7 @@ class ConsecutiveDbDetectorTest(unittest.TestCase):
 
         assert problems == [
             PerformanceProblem(
-                fingerprint="1-1007-0700523cc3ca755e447329779e50aeb19549e74f",
+                fingerprint="1-1007-12c8e51ada0049de34d58cd14d13f073b8638259",
                 op="db",
                 desc="SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` ORDER BY `books_book`.`id` ASC LIMIT 1",
                 type=GroupType.PERFORMANCE_CONSECUTIVE_DB_QUERIES,
@@ -201,7 +201,7 @@ class ConsecutiveDbDetectorTest(unittest.TestCase):
 
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1007-e6a9fc04320a924f46c7c737432bb0389d9dd095",
+                fingerprint="1-1007-3bc15c8aae3e4124dd409035f32ea2fd6835efc9",
                 op="db",
                 desc="SELECT COUNT(*) FROM `products`",
                 type=GroupType.PERFORMANCE_CONSECUTIVE_DB_QUERIES,
@@ -210,3 +210,45 @@ class ConsecutiveDbDetectorTest(unittest.TestCase):
                 offender_span_ids=["bbbbbbbbbbbbbbbb"],
             )
         ]
+
+    def test_fingerprint_of_autogroups_match(self):
+        span_duration = 50
+        spans_1 = [
+            create_span(
+                "db",
+                span_duration,
+                "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
+            ),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
+        ]
+        spans_1 = [
+            modify_span_start(span, span_duration * spans_1.index(span)) for span in spans_1
+        ]  # ensure spans don't overlap
+
+        spans_2 = [
+            create_span(
+                "db",
+                span_duration,
+                "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
+            ),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
+        ]
+        spans_2 = [
+            modify_span_start(span, span_duration * spans_2.index(span)) for span in spans_2
+        ]  # ensure spans don't overlap
+
+        event_1 = create_event(spans_1)
+        event_2 = create_event(spans_2)
+
+        fingerprint_1 = self.find_problems(event_1)[0].fingerprint
+        fingerprint_2 = self.find_problems(event_2)[0].fingerprint
+
+        assert fingerprint_1 == fingerprint_2


### PR DESCRIPTION
I recently noticed a scenario where events weren't grouped due a mismatch in the number of autogrouped spans within the events. As the previous fingerprint algorithm took in consideration all consecutive db queries. This PR makes the grouping more aggressive, which will result in less groups and limit any risks of fingerprint explosion. 
- We now only fingerprint on the parallelizable queries, plus one query before the first one.
- The one query before it is in order to provide some info around the parallelizable ones (one issue = 1 fix), this works well in most cases, and if there are cases that are too aggressive that is something that we can iterate on. The goal here was to limit the chance of fingerprint explosion.