### PR TITLE
feat(perf-issues): Limit uncompressed asset detector

### DIFF
--- a/fixtures/events/performance_problems/uncompressed-assets/uncompressed-script-asset.json
+++ b/fixtures/events/performance_problems/uncompressed-assets/uncompressed-script-asset.json
@@ -48,6 +48,22 @@
       "timestamp": 1667330086.5292,
       "start_timestamp": 1667330086.2861,
       "exclusive_time": 243.100167,
+      "description": "https://someother.site.com/asset.js",
+      "op": "resource.script",
+      "span_id": "b66a5642da1edb52",
+      "parent_span_id": "a0c39078d1570b00",
+      "trace_id": "0102834d0bf74d388ce0b1e15329f731",
+      "data": {
+        "Decoded Body Size": 3,
+        "Encoded Body Size": 2,
+        "Transfer Size": 3
+      },
+      "hash": "b2978b51d54d9078"
+    },
+    {
+      "timestamp": 1667330086.5292,
+      "start_timestamp": 1667330086.2861,
+      "exclusive_time": 243.100167,
       "description": "https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_components_charts_utils_tsx-app_utils_performance_quickTrace_utils_tsx-app_utils_withPage-3926ec.bc434924850c44d4057f.js",
       "op": "resource.script",
       "span_id": "b66a5642da1edb52",

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1604,13 +1604,14 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
     Checks for large assets that are affecting load time.
     """
 
-    __slots__ = "stored_problems"
+    __slots__ = ("stored_problems", "any_compression")
 
     settings_key = DetectorType.UNCOMPRESSED_ASSETS
     type: DetectorType = DetectorType.UNCOMPRESSED_ASSETS
 
     def init(self):
         self.stored_problems = {}
+        self.any_compression = False
 
     def visit_span(self, span: Span) -> None:
         op = span.get("op", None)
@@ -1635,6 +1636,8 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
 
         # Ignore assets that are already compressed.
         if encoded_body_size != decoded_body_size:
+            # Met criteria for a compressed span somewhere in the event.
+            self.any_compression = True
             return
 
         # Ignore assets that aren't big enough to worry about.
@@ -1689,6 +1692,11 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
             # This can be extended later.
             return True
         return False
+
+    def on_complete(self) -> None:
+        if not self.any_compression:
+            # Must have a compressed asset in the event to emit this perf problem.
+            self.stored_problems = {}
 
 
 # Reports metrics and creates spans for detection

--- a/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
@@ -25,6 +25,18 @@ def create_asset_span(
     return create_span("resource.script", desc=desc, duration=duration, data=data)
 
 
+def create_compressed_asset_span():
+    return create_asset_span(
+        desc="https://someothersite.example.com/app.js",
+        duration=1.0,
+        data={
+            "Transfer Size": 5,
+            "Encoded Body Size": 4,
+            "Decoded Body Size": 5,
+        },
+    )
+
+
 @region_silo_test
 @pytest.mark.django_db
 class UncompressedAssetsDetectorTest(TestCase):
@@ -50,7 +62,8 @@ class UncompressedAssetsDetectorTest(TestCase):
                         "Encoded Body Size": 1_000_000,
                         "Decoded Body Size": 1_000_000,
                     },
-                )
+                ),
+                create_compressed_asset_span(),
             ],
         }
 
@@ -81,7 +94,8 @@ class UncompressedAssetsDetectorTest(TestCase):
                         "Encoded Body Size": 1_000_000,
                         "Decoded Body Size": 1_000_000,
                     },
-                )
+                ),
+                create_compressed_asset_span(),
             ],
         }
 
@@ -110,7 +124,8 @@ class UncompressedAssetsDetectorTest(TestCase):
                         "Encoded Body Size": 1_000_000,
                         "Decoded Body Size": 1_000_000,
                     },
-                )
+                ),
+                create_compressed_asset_span(),
             ],
         }
 
@@ -128,7 +143,8 @@ class UncompressedAssetsDetectorTest(TestCase):
                         "Encoded Body Size": 99_999,
                         "Decoded Body Size": 99_999,
                     },
-                )
+                ),
+                create_compressed_asset_span(),
             ],
         }
 
@@ -146,7 +162,8 @@ class UncompressedAssetsDetectorTest(TestCase):
                         "Encoded Body Size": 101_000,
                         "Decoded Body Size": 100_999,
                     },
-                )
+                ),
+                create_compressed_asset_span(),
             ],
         }
 
@@ -164,7 +181,8 @@ class UncompressedAssetsDetectorTest(TestCase):
                         "Encoded Body Size": 101_000,
                         "Decoded Body Size": 101_000,
                     },
-                )
+                ),
+                create_compressed_asset_span(),
             ],
         }
 


### PR DESCRIPTION
### Summary
We have to limit the uncompressed asset detector performance problems because of noise caused by one-off clients/users without accept-encoding headers that will cause noisy issues on launch.

This changes the detector to only create performance problems if another span with compression was detected.

It will severely limit the number of detected issues, but we can expand the criteria later. Will check how this affects detection for now.

