### PR TITLE
fix: Remove leading slash from codecov path

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -19,6 +19,7 @@ def get_codecov_data(
         owner_username, repo_name = repo.split("/")
         if service == "github":
             service = "gh"
+        path = path.lstrip("/")
         url = CODECOV_URL.format(
             service=service, owner_username=owner_username, repo_name=repo_name
         )


### PR DESCRIPTION
The codecov coverage for [this issue](https://sentry.io/organizations/sentry/issues/3788707673/?project=1&query=transaction%3A%5Bsentry.tasks.derive_code_mappings.derive_code_mappings%2C%2Fapi%2F0%2Fprojects%2F%7Borganization_slug%7D%2F%7Bproject_slug%7D%2Fstacktrace-link%2F%5D+is%3Aunresolved&referrer=issue-stream) is failing due to the path starting with `/`. 

As shown below, the attempted codecov URL includes a leading `/` in front of path.
<img width="559" alt="Screen Shot 2023-01-24 at 3 21 29 PM" src="https://user-images.githubusercontent.com/116035587/214401880-20b367b8-b641-4775-955e-d675d1594d7f.png">
This leading slash is gotten from the stacktrace `sourceRoot` [here](https://github.com/getsentry/sentry/blob/f3fc570c21bbd1a22b09eb03552bf3271c44fe59/src/sentry/api/endpoints/project_stacktrace_link.py#L31). This does not pose an issue for stacktrace linking, as the leading `/` is removed [here](https://github.com/getsentry/sentry/blob/f3fc570c21bbd1a22b09eb03552bf3271c44fe59/src/sentry/integrations/mixins/repositories.py#L35). This PR will remove the leading `/` from the path in the same way.

Failing URL (with leading slash): https://api.codecov.io/api/v2/gh/getsentry/repos/sentry/report?branch=master&path=%2Fsrc%2Fsentry%2Fshared_integrations%2Fclient%2Fbase.py
Correct URL (w/out leading slash): https://api.codecov.io/api/v2/gh/getsentry/repos/sentry/report?branch=master&path=src%2Fsentry%2Fshared_integrations%2Fclient%2Fbase.py
