### PR TITLE
feat(profiling): add Slowest Transactions panel on profiling landing

### DIFF
--- a/static/app/components/profiling/flex.tsx
+++ b/static/app/components/profiling/flex.tsx
@@ -1,0 +1,84 @@
+import {CSSProperties} from 'react';
+import styled from '@emotion/styled';
+
+const px = (val: string | number | undefined) =>
+  typeof val === 'string' ? val : typeof val === 'number' ? val + 'px' : undefined;
+
+interface FlexProps {
+  align?: CSSProperties['alignItems'];
+  column?: boolean;
+  gap?: number | string;
+  h?: number | string;
+  justify?: CSSProperties['justifyContent'];
+  m?: number | string;
+  maxH?: number | string;
+  mb?: number | string;
+  minH?: number | string;
+  ml?: number | string;
+  mr?: number | string;
+  mt?: number | string;
+  mx?: number | string;
+  my?: number | string;
+  p?: number | string;
+  pb?: number | string;
+  pl?: number | string;
+  pr?: number | string;
+  pt?: number | string;
+  px?: number | string;
+  py?: number | string;
+  w?: number | string;
+  wrap?: CSSProperties['flexWrap'];
+}
+
+// TODO(@eliashussary): move to common folder / bring up in fe-tsc
+const FlexContainer = styled('div')<FlexProps>`
+  /* these can all come from a better base primitive */
+  display: flex;
+  height: ${p => px(p.h)};
+  width: ${p => px(p.w)};
+  min-height: ${p => px(p.minH)};
+  max-height: ${p => px(p.maxH)};
+  /* padding */
+  padding: ${p => px(p.p)};
+  padding-left: ${p => px(p.pl || p.px)};
+  padding-right: ${p => px(p.pr || p.px)};
+  padding-top: ${p => px(p.pt || p.py)};
+  padding-bottom: ${p => px(p.pb || p.py)};
+  /* margin */
+  margin: ${p => px(p.m)};
+  margin-left: ${p => px(p.ml || p.mx)};
+  margin-right: ${p => px(p.mr || p.mx)};
+  margin-top: ${p => px(p.mt || p.my)};
+  margin-bottom: ${p => px(p.mb || p.my)};
+  /* flex specific */
+  flex-direction: ${p => (p.column ? 'column' : 'row')};
+  justify-content: ${p => p.justify};
+  align-items: ${p => p.align};
+  gap: ${p => px(p.gap)};
+  flex-wrap: ${p => p.wrap};
+`;
+
+interface FlexItemProps {
+  basis?: CSSProperties['flexBasis'];
+  grow?: CSSProperties['flexGrow'];
+  shrink?: CSSProperties['flexShrink'];
+}
+
+const FlexItem = styled('div')<FlexItemProps>`
+  /* // TODO: determine sane defaults for these */
+  flex-grow: ${p => p.grow};
+  flex-shrink: ${p => p.shrink};
+  flex-basis: ${p => p.basis};
+  overflow: hidden;
+`;
+
+type FlexNamespace = typeof FlexContainer & {
+  Container: typeof FlexContainer;
+  Item: typeof FlexItem;
+};
+
+export const Flex = FlexContainer as FlexNamespace;
+Object.assign(FlexContainer, {
+  Container: FlexContainer,
+  Item: FlexItem,
+});

--- a/static/app/components/profiling/flex.tsx
+++ b/static/app/components/profiling/flex.tsx
@@ -72,13 +72,8 @@ const FlexItem = styled('div')<FlexItemProps>`
   overflow: hidden;
 `;
 
-type FlexNamespace = typeof FlexContainer & {
-  Container: typeof FlexContainer;
-  Item: typeof FlexItem;
-};
-
-export const Flex = FlexContainer as FlexNamespace;
-Object.assign(FlexContainer, {
+export const Flex = Object.assign(FlexContainer, {
+  ...FlexContainer,
   Container: FlexContainer,
   Item: FlexItem,
 });

--- a/static/app/components/profiling/functionsMiniGrid.tsx
+++ b/static/app/components/profiling/functionsMiniGrid.tsx
@@ -9,7 +9,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {SuspectFunction} from 'sentry/types/profiling/core';
-import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {generateProfileFlamechartRouteWithHighlightFrame} from 'sentry/utils/profiling/routes';
 
 interface FunctionsMiniGridProps {
   functions: SuspectFunction[] | null;
@@ -22,13 +22,15 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
 
   const linkToFlamechartRoute = (
     profileId: string,
-    query?: {frameName: string; framePackage: string}
+    frameName: string,
+    framePackage: string
   ) => {
-    return generateProfileFlamechartRouteWithQuery({
+    return generateProfileFlamechartRouteWithHighlightFrame({
       orgSlug: organization.slug,
       projectSlug: project.slug,
       profileId,
-      query,
+      frameName,
+      framePackage,
     });
   };
   return (
@@ -45,12 +47,7 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
             <Fragment key={idx}>
               <FunctionsMiniGridCell title={f.name}>
                 <FunctionNameTextTruncate>
-                  <Link
-                    to={linkToFlamechartRoute(exampleProfileId, {
-                      frameName: f.name,
-                      framePackage: f.package,
-                    })}
-                  >
+                  <Link to={linkToFlamechartRoute(exampleProfileId, f.name, f.package)}>
                     {f.name}
                   </Link>
                 </FunctionNameTextTruncate>

--- a/static/app/components/profiling/functionsMiniGrid.tsx
+++ b/static/app/components/profiling/functionsMiniGrid.tsx
@@ -1,0 +1,121 @@
+import {CSSProperties, Fragment} from 'react';
+import {Link} from 'react-router';
+import styled from '@emotion/styled';
+
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PerformanceDuration from 'sentry/components/performanceDuration';
+import {Flex} from 'sentry/components/profiling/flex';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Organization, Project} from 'sentry/types';
+import {SuspectFunction} from 'sentry/types/profiling/core';
+import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
+
+interface FunctionsMiniGridProps {
+  functions: SuspectFunction[] | null;
+  organization: Organization;
+  project: Project;
+}
+
+export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
+  const {organization, project, functions} = props;
+
+  const linkToFlamechartRoute = (
+    profileId: string,
+    query?: {frameName: string; framePackage: string}
+  ) => {
+    return generateProfileFlamechartRouteWithQuery({
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+      profileId,
+      query,
+    });
+  };
+  return (
+    <FunctionsMiniGridContainer>
+      <FunctionsMiniGridHeader>{t('Slowest app functions')}</FunctionsMiniGridHeader>
+      <FunctionsMiniGridHeader align="right">{t('P99')}</FunctionsMiniGridHeader>
+      <FunctionsMiniGridHeader align="right">{t('Count')}</FunctionsMiniGridHeader>
+
+      {functions &&
+        functions.map((f, idx) => {
+          const [exampleProfileIdRaw] = f.examples;
+          const exampleProfileId = exampleProfileIdRaw.replaceAll('-', '');
+          return (
+            <Fragment key={idx}>
+              <FunctionsMiniGridCell title={f.name}>
+                <FunctionNameTextTruncate>
+                  <Link
+                    to={linkToFlamechartRoute(exampleProfileId, {
+                      frameName: f.name,
+                      framePackage: f.package,
+                    })}
+                  >
+                    {f.name}
+                  </Link>
+                </FunctionNameTextTruncate>
+              </FunctionsMiniGridCell>
+              <FunctionsMiniGridCell align="right">
+                <PerformanceDuration nanoseconds={f.p99} abbreviation />
+              </FunctionsMiniGridCell>
+              <FunctionsMiniGridCell align="right">
+                <NumberContainer>{f.count}</NumberContainer>
+              </FunctionsMiniGridCell>
+            </Fragment>
+          );
+        })}
+    </FunctionsMiniGridContainer>
+  );
+}
+
+export function FunctionsMiniGridLoading() {
+  return (
+    <Flex align="stretch" justify="center" column h="100%">
+      <Flex align="center" justify="center">
+        <LoadingIndicator mini />
+      </Flex>
+    </Flex>
+  );
+}
+
+export function FunctionsMiniGridEmptyState() {
+  return (
+    <Flex align="stretch" justify="center" column h="100%">
+      <Flex align="center" justify="center">
+        {t('No functions data')}
+      </Flex>
+    </Flex>
+  );
+}
+
+export const FunctionsMiniGridContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 60% 20% 20%;
+`;
+
+export const FunctionsMiniGridHeader = styled('span')<{
+  align?: CSSProperties['textAlign'];
+}>`
+  text-transform: uppercase;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  font-weight: 600;
+  color: ${p => p.theme.subText};
+  text-align: ${p => p.align};
+`;
+
+export const FunctionsMiniGridCell = styled('div')<{align?: CSSProperties['textAlign']}>`
+  font-size: ${p => p.theme.fontSizeSmall};
+  text-align: ${p => p.align};
+  padding: ${space(0.5)} 0px;
+`;
+
+const NumberContainer = styled(`div`)`
+  text-align: right;
+`;
+
+const FunctionNameTextTruncate = styled('div')`
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;

--- a/static/app/components/profiling/textTruncateOverflow.tsx
+++ b/static/app/components/profiling/textTruncateOverflow.tsx
@@ -1,0 +1,24 @@
+import {ElementType} from 'react';
+import styled from '@emotion/styled';
+
+import space from 'sentry/styles/space';
+
+interface TextTruncateOverflowProps {
+  children: string;
+  as?: ElementType<any>;
+}
+
+// TextTruncateOverflow is strictly a css based text truncate component
+export const TextTruncateOverflow = styled(
+  ({children, as: Element = 'div', ...props}: TextTruncateOverflowProps) => (
+    <Element {...props} title={children}>
+      {children}
+    </Element>
+  )
+)`
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  margin-right: ${space(1)};
+`;

--- a/static/app/components/profiling/textTruncateOverflow.tsx
+++ b/static/app/components/profiling/textTruncateOverflow.tsx
@@ -1,24 +1,27 @@
-import {ElementType} from 'react';
+import {ComponentProps, ElementType} from 'react';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
 
-interface TextTruncateOverflowProps {
+type TextOverflowProps<T extends ElementType> = ComponentProps<T> & {
   children: string;
-  as?: ElementType<any>;
+  as?: T;
+};
+
+function TextOverflow<T extends ElementType>(props: TextOverflowProps<T>) {
+  const {children, as: Element = 'div', ...rest} = props;
+  return (
+    <Element {...rest} title={children}>
+      {children}
+    </Element>
+  );
 }
 
 // TextTruncateOverflow is strictly a css based text truncate component
-export const TextTruncateOverflow = styled(
-  ({children, as: Element = 'div', ...props}: TextTruncateOverflowProps) => (
-    <Element {...props} title={children}>
-      {children}
-    </Element>
-  )
-)`
+export const TextTruncateOverflow = styled(TextOverflow)`
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   margin-right: ${space(1)};
-`;
+` as typeof TextOverflow; // styled wasn't inferring the passed component properly this assertion is sufficient for now

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -18,7 +18,7 @@ type Sort<F> = {
   order: 'asc' | 'desc';
 };
 
-export interface UseProfileEventsOptions<F = ProfilingFieldType> {
+export interface UseProfileEventsOptions<F extends string = ProfilingFieldType> {
   fields: readonly F[];
   referrer: string;
   sort: Sort<F>;
@@ -33,7 +33,7 @@ export interface UseProfileEventsOptions<F = ProfilingFieldType> {
 
 type Unit = keyof typeof DURATION_UNITS | keyof typeof SIZE_UNITS | null;
 
-type EventsResultsDataRow<F extends string> = {
+export type EventsResultsDataRow<F extends string = ProfilingFieldType> = {
   [K in F]: string | number | null;
 };
 

--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -102,6 +102,33 @@ export function generateProfileFlamechartRouteWithQuery({
   };
 }
 
+export function generateProfileFlamechartRouteWithHighlightFrame({
+  orgSlug,
+  projectSlug,
+  profileId,
+  frameName,
+  framePackage,
+  query,
+}: {
+  frameName: string;
+  framePackage: string;
+  orgSlug: Organization['slug'];
+  profileId: Trace['id'];
+  projectSlug: Project['slug'];
+  query?: Location['query'];
+}): LocationDescriptor {
+  return generateProfileFlamechartRouteWithQuery({
+    orgSlug,
+    projectSlug,
+    profileId,
+    query: {
+      ...query,
+      frameName,
+      framePackage,
+    },
+  });
+}
+
 export function generateProfileDetailsRouteWithQuery({
   orgSlug,
   projectSlug,

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -37,6 +37,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 
 import {ProfileCharts} from './landing/profileCharts';
+import {ProfilingSlowestTransactionsPanel} from './landing/profilingSlowestTransactionsPanel';
 import {ProfilingOnboardingPanel} from './profilingOnboardingPanel';
 
 interface ProfilingContentProps {
@@ -116,6 +117,12 @@ function ProfilingContent({location}: ProfilingContentProps) {
     );
   }, [selection.projects, projects]);
 
+  const isNewProfilingDashboardEnabled = organization.features.includes(
+    'profiling-dashboard-redesign'
+  );
+
+  // isNewProfilingDashboardEnabled = false;
+
   return (
     <SentryDocumentTitle title={t('Profiling')} orgSlug={organization.slug}>
       <PageFiltersContainer>
@@ -191,7 +198,22 @@ function ProfilingContent({location}: ProfilingContentProps) {
                   </ProfilingOnboardingPanel>
                 ) : (
                   <Fragment>
-                    <ProfileCharts query={query} selection={selection} />
+                    {isNewProfilingDashboardEnabled ? (
+                      <PanelsGrid>
+                        <ProfilingSlowestTransactionsPanel />
+                        <ProfileCharts
+                          query={query}
+                          selection={selection}
+                          hideCount={isNewProfilingDashboardEnabled}
+                        />
+                      </PanelsGrid>
+                    ) : (
+                      <ProfileCharts
+                        query={query}
+                        selection={selection}
+                        hideCount={isNewProfilingDashboardEnabled}
+                      />
+                    )}
                     <ProfileEventsTable
                       columns={FIELDS.slice()}
                       data={
@@ -241,6 +263,17 @@ const ActionBar = styled('div')`
   gap: ${space(2)};
   grid-template-columns: min-content auto;
   margin-bottom: ${space(2)};
+`;
+
+// TODO: another simple primitive that can easily be <Grid columns={2} />
+const PanelsGrid = styled('div')`
+  display: grid;
+  grid-template-columns: 50% 50%;
+  gap: ${space(2)};
+
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-columns: 100%;
+  }
 `;
 
 export default ProfilingContent;

--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from 'sentry/components/button';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels';
@@ -79,7 +80,16 @@ export function ProfilingSlowestTransactionsPanel() {
               <LoadingIndicator />
             ) : (
               !hasProfilingTransactions && (
-                <Flex.Item>{t('No results found for your query')}</Flex.Item>
+                <Flex.Item>
+                  <EmptyStateWarning>
+                    <p>{t('No results found')}</p>
+                    <EmptyStateDescription>
+                      {t(
+                        'Transactions may not be listed due to the filters above or a low number of profiles.'
+                      )}
+                    </EmptyStateDescription>
+                  </EmptyStateWarning>
+                </Flex.Item>
               )
             )}
           </Flex>
@@ -223,4 +233,8 @@ const PanelItemBody = styled('div')`
 // TODO: simple layout stuff like this should come from a primitive component and we should really stop this `styled` nonsense
 const PanelItemBodyInner = styled('div')`
   padding-top: ${space(1.5)};
+`;
+
+const EmptyStateDescription = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
 `;

--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -123,8 +123,9 @@ function SlowestTransactionPanelItem({
   const organization = useOrganization();
   const projects = useProjects();
 
-  const transactionProject = projects.projects.find(
-    p => p.id === String(transaction['project.id'])
+  const transactionProject = useMemo(
+    () => projects.projects.find(p => p.id === String(transaction['project.id'])),
+    [projects.projects, transaction]
   );
 
   if (!transactionProject) {
@@ -149,7 +150,7 @@ function SlowestTransactionPanelItem({
         </Flex.Item>
 
         <PerformanceDuration nanoseconds={transaction['p95()'] as number} abbreviation />
-        <Button borderless size="zero" onClick={() => onOpen()}>
+        <Button borderless size="zero" onClick={onOpen}>
           <IconChevron direction={open ? 'up' : 'down'} size="xs" />
         </Button>
       </Flex>

--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -24,7 +24,7 @@ import {
   useProfileEvents,
 } from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {useProfilingTransactionQuickSummary} from 'sentry/utils/profiling/hooks/useProfilingTransactionQuickSummary';
-import {generateProfileSummaryRoute} from 'sentry/utils/profiling/routes';
+import {generateProfileSummaryRouteWithQuery} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
@@ -138,9 +138,10 @@ function SlowestTransactionPanelItem({
         <PlatformIcon platform={transactionProject?.platform} />
         <Flex.Item grow={1}>
           <Link
-            to={generateProfileSummaryRoute({
+            to={generateProfileSummaryRouteWithQuery({
               orgSlug: organization.slug,
               projectSlug: transactionProject?.slug!,
+              transaction: transaction.transaction as string,
             })}
           >
             <TextTruncateOverflow>

--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -1,0 +1,226 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
+
+import {Button} from 'sentry/components/button';
+import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {Panel} from 'sentry/components/panels';
+import PerformanceDuration from 'sentry/components/performanceDuration';
+import {Flex} from 'sentry/components/profiling/flex';
+import {
+  FunctionsMiniGrid,
+  FunctionsMiniGridEmptyState,
+  FunctionsMiniGridLoading,
+} from 'sentry/components/profiling/functionsMiniGrid';
+import {TextTruncateOverflow} from 'sentry/components/profiling/textTruncateOverflow';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Organization, Project} from 'sentry/types';
+import {
+  EventsResultsDataRow,
+  useProfileEvents,
+} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import {useProfilingTransactionQuickSummary} from 'sentry/utils/profiling/hooks/useProfilingTransactionQuickSummary';
+import {generateProfileSummaryRoute} from 'sentry/utils/profiling/routes';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+
+const fields = ['transaction', 'project.id', 'last_seen()', 'p95()', 'count()'] as const;
+type SlowestTransactionsFields = typeof fields[number];
+
+export function ProfilingSlowestTransactionsPanel() {
+  const profilingTransactionsQuery = useProfileEvents({
+    fields,
+    sort: {
+      key: 'p95()',
+      order: 'desc',
+    },
+    limit: 3,
+    query: 'count():>3',
+    referrer: 'api.profiling.landing-slowest-transaction-panel',
+  });
+
+  const [openPanel, setOpenPanel] = useState<null | string>(null);
+
+  const profilingTransactions = useMemo(
+    () => profilingTransactionsQuery.data?.[0].data ?? [],
+    [profilingTransactionsQuery.data]
+  );
+
+  const transactionNames = useMemo(
+    () => profilingTransactions.map(txn => txn.transaction),
+    [profilingTransactions]
+  );
+
+  if (transactionNames.length > 0 && !transactionNames.includes(openPanel)) {
+    const firstTransaction = transactionNames[0];
+    setOpenPanel(firstTransaction as string);
+  }
+
+  const {isLoading} = profilingTransactionsQuery;
+  const hasProfilingTransactions =
+    !isLoading && profilingTransactions && profilingTransactions.length > 0;
+
+  return (
+    <FlexPanel>
+      <Flex column h="100%">
+        <Flex column p={space(1.5)}>
+          <PanelHeading>{t('Slowest Transactions')}</PanelHeading>
+          <PanelSubheading>
+            {t('Slowest transactions that could use some optimization.')}
+          </PanelSubheading>
+        </Flex>
+
+        {(isLoading || !hasProfilingTransactions) && (
+          <Flex column align="center" justify="center" h="100%">
+            {isLoading ? (
+              <LoadingIndicator />
+            ) : (
+              !hasProfilingTransactions && (
+                <Flex.Item>{t('No results found for your query')}</Flex.Item>
+              )
+            )}
+          </Flex>
+        )}
+
+        {profilingTransactions?.map(transaction => {
+          return (
+            <SlowestTransactionPanelItem
+              key={transaction.transaction}
+              transaction={transaction}
+              open={transaction.transaction === openPanel}
+              onOpen={() => setOpenPanel(transaction.transaction as string)}
+            />
+          );
+        })}
+      </Flex>
+    </FlexPanel>
+  );
+}
+interface SlowestTransactionPanelItemProps {
+  onOpen: () => void;
+  open: boolean;
+  transaction: EventsResultsDataRow<SlowestTransactionsFields>;
+}
+
+function SlowestTransactionPanelItem({
+  transaction,
+  open,
+  onOpen,
+}: SlowestTransactionPanelItemProps) {
+  const organization = useOrganization();
+  const projects = useProjects();
+
+  const transactionProject = projects.projects.find(
+    p => p.id === String(transaction['project.id'])
+  );
+
+  if (!transactionProject) {
+    throw Error('Cannot find project for slowest transaction');
+  }
+
+  return (
+    <PanelItem key={transaction.transaction}>
+      <Flex justify="space-between" gap={space(1)}>
+        <PlatformIcon platform={transactionProject?.platform} />
+        <Flex.Item grow={1}>
+          <Link
+            to={generateProfileSummaryRoute({
+              orgSlug: organization.slug,
+              projectSlug: transactionProject?.slug!,
+            })}
+          >
+            <TextTruncateOverflow>
+              {transaction.transaction as string}
+            </TextTruncateOverflow>
+          </Link>
+        </Flex.Item>
+
+        <PerformanceDuration nanoseconds={transaction['p95()'] as number} abbreviation />
+        <Button borderless size="zero" onClick={() => onOpen()}>
+          <IconChevron direction={open ? 'up' : 'down'} size="xs" />
+        </Button>
+      </Flex>
+      <PanelItemBody
+        style={{
+          height: open ? 160 : 0,
+        }}
+      >
+        {open && transactionProject && (
+          <PanelItemFunctionsMiniGrid
+            transaction={String(transaction.transaction)}
+            organization={organization}
+            project={transactionProject}
+          />
+        )}
+      </PanelItemBody>
+    </PanelItem>
+  );
+}
+
+interface PanelItemFunctionsMiniGridProps {
+  organization: Organization;
+  project: Project;
+  transaction: string;
+}
+
+function PanelItemFunctionsMiniGrid(props: PanelItemFunctionsMiniGridProps) {
+  const {transaction, project, organization} = props;
+  const {functionsQuery, functions} = useProfilingTransactionQuickSummary({
+    transaction,
+    project,
+    referrer: 'api.profiling.landing-slowest-transaction-panel',
+    skipLatestProfile: true,
+    skipSlowestProfile: true,
+  });
+
+  if (functionsQuery.type === 'loading') {
+    return <FunctionsMiniGridLoading />;
+  }
+
+  if (functionsQuery.type === 'resolved' && functions && functions.length === 0) {
+    return <FunctionsMiniGridEmptyState />;
+  }
+
+  return (
+    <PanelItemBodyInner>
+      <FunctionsMiniGrid
+        functions={functions}
+        organization={organization}
+        project={project}
+      />
+    </PanelItemBodyInner>
+  );
+}
+
+const FlexPanel = styled(Panel)`
+  display: flex;
+  flex-direction: column;
+`;
+
+const PanelHeading = styled('span')`
+  font-size: ${p => p.theme.text.cardTitle.fontSize};
+  font-weight: ${p => p.theme.text.cardTitle.fontWeight};
+  line-height: ${p => p.theme.text.cardTitle.lineHeight};
+`;
+
+const PanelSubheading = styled('span')`
+  color: ${p => p.theme.subText};
+`;
+
+const PanelItem = styled('div')`
+  padding: ${space(1)} ${space(1.5)};
+  border-top: 1px solid ${p => p.theme.border};
+`;
+const PanelItemBody = styled('div')`
+  transition: height 0.1s ease;
+  width: 100%;
+  overflow: hidden;
+`;
+
+// TODO: simple layout stuff like this should come from a primitive component and we should really stop this `styled` nonsense
+const PanelItemBodyInner = styled('div')`
+  padding-top: ${space(1.5)};
+`;


### PR DESCRIPTION
## Summary

Relates to: https://github.com/getsentry/team-profiling/issues/138

Adds a `profilingSlowestTransactionsPanel` to the `profiling` landing page. There was some refactoring included in this PR moving components to a more logical space for us to work with it within profiling, namely `Flex`.

![image](https://user-images.githubusercontent.com/7349258/214942891-0ac320cd-9d6c-4767-a136-3b3c337600e0.png)

https://user-images.githubusercontent.com/7349258/214942920-186fe1cd-765e-4ac5-ac8c-713fbb8e1816.mov



