### PR TITLE
chore(domains) Update URL generation in Group and Project models

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -33,7 +33,6 @@ from sentry.locks import locks
 from sentry.snuba.models import SnubaQuery
 from sentry.utils import metrics
 from sentry.utils.colors import get_hashed_color
-from sentry.utils.http import absolute_uri
 from sentry.utils.integrationdocs import integration_doc_exists
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import SnowflakeIdMixin
@@ -207,12 +206,13 @@ class Project(Model, PendingDeletionMixin, SnowflakeIdMixin):
         self.update_rev_for_option()
 
     def get_absolute_url(self, params=None):
-        url = f"/organizations/{self.organization.slug}/issues/"
+        path = f"/organizations/{self.organization.slug}/issues/"
         params = {} if params is None else params
         params["project"] = self.id
+        query = None
         if params:
-            url = url + "?" + urlencode(params)
-        return absolute_uri(url)
+            query = urlencode(params)
+        return self.organization.absolute_url(path, query=query)
 
     def is_internal_project(self):
         for value in (settings.SENTRY_FRONTEND_PROJECT, settings.SENTRY_PROJECT):

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -19,6 +19,7 @@ from sentry.models import (
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.snuba.models import SnubaQuery
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import ExternalProviders
 
@@ -198,6 +199,26 @@ class ProjectTest(TestCase):
         assert rule2.owner is None
         assert rule3.owner is not None
         assert rule4.owner is not None
+
+    def test_get_absolute_url(self):
+        url = self.project.get_absolute_url()
+        assert (
+            url
+            == f"http://testserver/organizations/{self.organization.slug}/issues/?project={self.project.id}"
+        )
+
+        url = self.project.get_absolute_url(params={"q": "all"})
+        assert (
+            url
+            == f"http://testserver/organizations/{self.organization.slug}/issues/?q=all&project={self.project.id}"
+        )
+
+    @with_feature("organizations:customer-domains")
+    def test_get_absolute_url_customer_domains(self):
+        url = self.project.get_absolute_url()
+        assert (
+            url == f"http://{self.organization.slug}.testserver/issues/?project={self.project.id}"
+        )
 
 
 @region_silo_test


### PR DESCRIPTION
This will spread customer domains out to all the URLs generated by these models which includes issue alerts and digest emails.