### PR TITLE
feat(perf-issues): Add UI to control render blocking asset rollout

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -38,6 +38,10 @@ const optionsAvailable = [
   'performance.issues.slow_db_query.la-rollout',
   'performance.issues.slow_db_query.ea-rollout',
   'performance.issues.slow_db_query.ga-rollout',
+  'performance.issues.render_blocking_assets.problem-creation',
+  'performance.issues.render_blocking_assets.la-rollout',
+  'performance.issues.render_blocking_assets.ea-rollout',
+  'performance.issues.render_blocking_assets.ga-rollout',
 ];
 
 type Field = ReturnType<typeof getOption>;
@@ -149,6 +153,15 @@ export default class AdminSettings extends AsyncView<{}, State> {
               {fields['performance.issues.slow_db_query.la-rollout']}
               {fields['performance.issues.slow_db_query.ea-rollout']}
               {fields['performance.issues.slow_db_query.ga-rollout']}
+            </Panel>
+            <Panel>
+              <PanelHeader>
+                Performance Issues - Large Render Blocking Asset Detector
+              </PanelHeader>
+              {fields['performance.issues.render_blocking_assets.problem-creation']}
+              {fields['performance.issues.render_blocking_assets.la-rollout']}
+              {fields['performance.issues.render_blocking_assets.ea-rollout']}
+              {fields['performance.issues.render_blocking_assets.ga-rollout']}
             </Panel>
           </Feature>
         </Form>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -311,6 +311,34 @@ const performanceOptionDefinitions: Field[] = [
     ),
     ...HIGH_THROUGHPUT_RATE_OPTION,
   },
+  {
+    key: 'performance.issues.render_blocking_assets.problem-creation',
+    label: t('Problem Creation Rate'),
+    help: t(
+      'Controls the overall rate at which performance problems are detected by the large render blocking asset detector.'
+    ),
+  },
+  {
+    key: 'performance.issues.render_blocking_assets.la-rollout',
+    label: t('Problem Creation Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the large render blocking asset detector for LA organizations.'
+    ),
+  },
+  {
+    key: 'performance.issues.render_blocking_assets.ea-rollout',
+    label: t('Problem Creation Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the large render blocking asset detector for EA organizations.'
+    ),
+  },
+  {
+    key: 'performance.issues.render_blocking_assets.ga-rollout',
+    label: t('Problem Creation Rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected by the large render blocking asset detector for GA organizations.'
+    ),
+  },
 ];
 
 // This are ordered based on their display order visually

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -320,21 +320,21 @@ const performanceOptionDefinitions: Field[] = [
   },
   {
     key: 'performance.issues.render_blocking_assets.la-rollout',
-    label: t('Problem Creation Rate'),
+    label: t('Limited Availability Detection Rate'),
     help: t(
       'Controls the rate at which performance problems are detected by the large render blocking asset detector for LA organizations.'
     ),
   },
   {
     key: 'performance.issues.render_blocking_assets.ea-rollout',
-    label: t('Problem Creation Rate'),
+    label: t('Early Adopter Detection Rate'),
     help: t(
       'Controls the rate at which performance problems are detected by the large render blocking asset detector for EA organizations.'
     ),
   },
   {
     key: 'performance.issues.render_blocking_assets.ga-rollout',
-    label: t('Problem Creation Rate'),
+    label: t('General Availability Detection Rate'),
     help: t(
       'Controls the rate at which performance problems are detected by the large render blocking asset detector for GA organizations.'
     ),


### PR DESCRIPTION
Lets us control the Large Render Blocking Asset issue detector rollout via admin settings.