### PR TITLE
bug(perf-issues): improve Render Blocking Asset detector fingerprint

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -657,7 +657,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
 
         if self._is_blocking_render(span):
             span_id = span.get("span_id", None)
-            fingerprint = fingerprint_span(span)
+            fingerprint = self._fingerprint(span)
             if span_id and fingerprint:
                 self.stored_problems[fingerprint] = PerformanceProblem(
                     fingerprint=fingerprint,
@@ -686,6 +686,10 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         span_duration = get_span_duration(span)
         fcp_ratio_threshold = self.settings.get("fcp_ratio_threshold")
         return span_duration / self.fcp > fcp_ratio_threshold
+
+    def _fingerprint(self, span):
+        hashed_spans = fingerprint_spans([span])
+        return f"1-{GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN.value}-{hashed_spans}"
 
 
 class NPlusOneAPICallsDetector(PerformanceDetector):

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -48,7 +48,7 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
 
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="6060649d4f8435d88735",
+                fingerprint="1-1004-da39a3ee5e6b4b0d3255bfef95601890afd80709",
                 op="resource.script",
                 desc="SELECT count() FROM table WHERE id = %s",
                 type=GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN,


### PR DESCRIPTION
Include the `GroupType` value and fingerprint version number in the fingerprint, to match our other detectors. This detector has not been released yet so there won't be any issues with mismatched fingerprints leading to new issues.
