### PR TITLE
chore(hybrid-cloud): Update SSO login page copy

### DIFF
--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -131,7 +131,7 @@
               <div class="controls">
                 <label class="control-label">{% trans "Organization ID" %}</label>
                 <input type="text" class="form-control" name="organization" placeholder="acme" required>
-                <p class="help-block">Your ID is the slug after the hostname. e.g. <code>{{ server_hostname }}/<strong>acme</strong>/</code> is <code>acme</code>.</p>
+                <p class="help-block">Your ID is the slug either before or after the hostname. For example, <code><strong>acme</strong></code> is the slug in either <code>{{ server_hostname }}/<strong>acme</strong>/</code> or <code><strong>acme</strong>.{{ server_hostname }}/</code>.</p>
               </div>
             </div>
             <div class="auth-footer m-t-1">


### PR DESCRIPTION
Updating this copy in anticipation of the customer domain roll out to organizations with SSO enabled.

Preview of the new copy:

<img width="707" alt="Screen Shot 2023-01-24 at 4 53 55 PM" src="https://user-images.githubusercontent.com/139499/214429967-4c38a79d-953f-4a0c-8f1a-0b50904dde31.png">
