### PR TITLE
Allow tests to be annotated with single-server-process mode.

### DIFF
--- a/tests/acceptance/sentry_plugins/test_amazon_sqs.py
+++ b/tests/acceptance/sentry_plugins/test_amazon_sqs.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class AmazonSQSTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_bitbucket.py
+++ b/tests/acceptance/sentry_plugins/test_bitbucket.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class BitbucketTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_github.py
+++ b/tests/acceptance/sentry_plugins/test_github.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class GitHubTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_gitlab.py
+++ b/tests/acceptance/sentry_plugins/test_gitlab.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class GitLabTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_jira.py
+++ b/tests/acceptance/sentry_plugins/test_jira.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class JIRATest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_pagerduty.py
+++ b/tests/acceptance/sentry_plugins/test_pagerduty.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class PagerDutyTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_phabricator.py
+++ b/tests/acceptance/sentry_plugins/test_phabricator.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class PhabricatorTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_pivotal.py
+++ b/tests/acceptance/sentry_plugins/test_pivotal.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class PivotalTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_pushover.py
+++ b/tests/acceptance/sentry_plugins/test_pushover.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class PushoverTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_segment.py
+++ b/tests/acceptance/sentry_plugins/test_segment.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class SegmentTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_sessionstack.py
+++ b/tests/acceptance/sentry_plugins/test_sessionstack.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class SessionStackTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_slack.py
+++ b/tests/acceptance/sentry_plugins/test_slack.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class SlackTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_splunk.py
+++ b/tests/acceptance/sentry_plugins/test_splunk.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class SplunkTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/acceptance/sentry_plugins/test_victorops.py
+++ b/tests/acceptance/sentry_plugins/test_victorops.py
@@ -2,7 +2,7 @@ from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test(stable=True, single_server_silo_mode=True)
 class VictorOpsTest(AcceptanceTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Most tests are validating code that effects one silo mode at a time -- some tests, however, validate multiple interactions between silo endpoints.  Furthermore, in the case of acceptance tests and redirects, the test doesn't have control over the current expected silo context.

single server silo mode is an option that changes the silo mode in the midst of tests in response to an endpoint being hit.  Enabling this will allow writing tests in getsentry that invoke redirects (in the `test_identity.py` and login flows, this is common).  Previously this option existed but only effected acceptance tests -- making this an explicit arguments makes it possible to run this on other types of tests.

You may ask: "Why not automatically do this for all tests anyways?"  Well, there's a problem -- some tests actually *depend* on fixing the silo context and do not want to switch it based on annotation.  For instance, our proxy tests actually want to validate the behavior of hitting an endpoint in the wrong silo mode and having the proxy pass the request through.  

In general, too, I believe having tests "automatically swap out silo modes" is actually fragile testing in some ways -- it's very lenient and could easily hide contradictions if it were the default behavior.  It is the subset of all tests that generally want this behavior.  Keeping it an "opt in behavior" ensures that we generally write tests that validate consistency of any one specific silo perspective, and only carefully understood integration tests allow this dynamic context swapping.