### PR TITLE
feat(analytics): add project_age and issue_id to analytics

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -319,7 +319,6 @@ export function getAnalyicsDataForGroup(group: Group | null) {
     error_count: Number(group?.count || -1),
     group_has_replay: Boolean(group?.tags?.find(({key}) => key === 'replayId')),
     num_comments: group ? group.numComments : -1,
-    project_platform: group?.project.platform,
     has_external_issue: group?.annotations ? group?.annotations.length > 0 : false,
     has_owner: group?.owners ? group?.owners.length > 0 : false,
     integration_assignment_source: group ? getAssignmentIntegration(group) : '',

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -4,11 +4,15 @@ import {
   EntryThreads,
   EventMetadata,
   EventOrGroupType,
+  Group,
+  GroupActivityAssigned,
+  GroupActivityType,
   GroupTombstone,
   IssueCategory,
   TreeLabelPart,
 } from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
+import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
 
 function isTombstone(maybe: BaseGroup | Event | GroupTombstone): maybe is GroupTombstone {
@@ -263,6 +267,22 @@ function getNumberOfThreadsWithNames(event: Event) {
   return Math.max(...threadLengths);
 }
 
+/**
+ * Return the integration type for the first assignment via integration
+ */
+function getAssignmentIntegration(group: Group) {
+  if (!group.activity) {
+    return '';
+  }
+  const assignmentAcitivies = group.activity.filter(
+    activity => activity.type === GroupActivityType.ASSIGNED
+  ) as GroupActivityAssigned[];
+  const integrationAssignments = assignmentAcitivies.find(
+    activity => !!activity.data.integration
+  );
+  return integrationAssignments?.data.integration || '';
+}
+
 export function getAnalyicsDataForEvent(event?: Event) {
   return {
     event_id: event?.eventID || '-1',
@@ -280,5 +300,28 @@ export function getAnalyicsDataForEvent(event?: Event) {
     sdk_name: event?.sdk?.name,
     sdk_version: event?.sdk?.version,
     release_user_agent: event?.release?.userAgent,
+    error_has_replay: Boolean(event?.tags?.find(({key}) => key === 'replayId')),
+    has_otel: event?.contexts?.otel !== undefined,
+  };
+}
+
+export function getAnalyicsDataForGroup(group: Group | null) {
+  const groupId = group ? parseInt(group.id, 10) : -1;
+  return {
+    group_id: groupId,
+    // overload group_id with the issue_id
+    issue_id: groupId,
+    issue_category: group?.issueCategory ?? IssueCategory.ERROR,
+    issue_status: group?.status,
+    issue_age: group?.firstSeen ? getDaysSinceDate(group.firstSeen) : -1,
+    issue_level: group?.level,
+    is_assigned: !!group?.assignedTo,
+    error_count: Number(group?.count || -1),
+    group_has_replay: Boolean(group?.tags?.find(({key}) => key === 'replayId')),
+    num_comments: group ? group.numComments : -1,
+    project_platform: group?.project.platform,
+    has_external_issue: group?.annotations ? group?.annotations.length > 0 : false,
+    has_owner: group?.owners ? group?.owners.length > 0 : false,
+    integration_assignment_source: group ? getAssignmentIntegration(group) : '',
   };
 }

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -7,6 +7,7 @@ import {Client} from 'sentry/api';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {AvatarProject, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import RequestError from 'sentry/utils/requestError/requestError';
 import withApi from 'sentry/utils/withApi';
@@ -533,5 +534,14 @@ async function fetchProjects(
     results: data,
     hasMore,
     nextCursor,
+  };
+}
+
+export function getAnalyicsDataForProject(project: Project) {
+  return {
+    project_has_replay: project.hasReplays,
+    project_has_minified_stack_trace: project.hasMinifiedStackTrace,
+    project_age: getDaysSinceDate(project.dateCreated),
+    project_id: parseInt(project.id, 10),
   };
 }

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -543,5 +543,6 @@ export function getAnalyicsDataForProject(project: Project) {
     project_has_minified_stack_trace: project.hasMinifiedStackTrace,
     project_age: getDaysSinceDate(project.dateCreated),
     project_id: parseInt(project.id, 10),
+    project_platform: project.platform,
   };
 }

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -17,21 +17,17 @@ import {t} from 'sentry/locale';
 import SentryTypes from 'sentry/sentryTypes';
 import GroupStore from 'sentry/stores/groupStore';
 import space from 'sentry/styles/space';
-import {
-  AvatarProject,
-  Group,
-  GroupActivityAssigned,
-  GroupActivityType,
-  IssueCategory,
-  Organization,
-  Project,
-} from 'sentry/types';
+import {AvatarProject, Group, IssueCategory, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {getAnalyicsDataForEvent, getMessage, getTitle} from 'sentry/utils/events';
-import getDaysSinceDate from 'sentry/utils/getDaysSinceDate';
-import Projects from 'sentry/utils/projects';
+import {
+  getAnalyicsDataForEvent,
+  getAnalyicsDataForGroup,
+  getMessage,
+  getTitle,
+} from 'sentry/utils/events';
+import Projects, {getAnalyicsDataForProject} from 'sentry/utils/projects';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import withRouteAnalytics, {
   WithRouteAnalyticsProps,
@@ -49,22 +45,6 @@ import {
   markEventSeen,
   ReprocessingStatus,
 } from './utils';
-
-/**
- * Return the integration type for the first assignment via integration
- */
-function getAssignmentIntegration(group: Group) {
-  if (!group.activity) {
-    return '';
-  }
-  const assignmentAcitivies = group.activity.filter(
-    activity => activity.type === GroupActivityType.ASSIGNED
-  ) as GroupActivityAssigned[];
-  const integrationAssignments = assignmentAcitivies.find(
-    activity => !!activity.data.integration
-  );
-  return integrationAssignments?.data.integration || '';
-}
 
 type Error = typeof ERROR_TYPES[keyof typeof ERROR_TYPES] | null;
 
@@ -168,37 +148,19 @@ class GroupDetails extends Component<Props, State> {
 
   trackView(project: Project) {
     const {group, event} = this.state;
-    const {params, location, organization, router} = this.props;
+    const {location, organization, router} = this.props;
     const {alert_date, alert_rule_id, alert_type} = location.query;
 
     this.props.setEventNames('issue_details.viewed', 'Issue Details: Viewed');
     this.props.setRouteAnalyticsParams({
-      project_id: parseInt(project.id, 10),
-      group_id: parseInt(params.groupId, 10),
-      // group properties
-      issue_category: group?.issueCategory ?? IssueCategory.ERROR,
-      issue_status: group?.status,
-      issue_age: group?.firstSeen ? getDaysSinceDate(group.firstSeen) : -1,
-      issue_level: group?.level,
-      is_assigned: !!group?.assignedTo,
-      error_count: Number(group?.count || -1),
-      error_has_replay: Boolean(event?.tags?.find(({key}) => key === 'replayId')),
-      group_has_replay: Boolean(group?.tags?.find(({key}) => key === 'replayId')),
-      num_comments: group ? group.numComments : -1,
-      project_has_replay: project.hasReplays,
-      project_has_minified_stack_trace: project.hasMinifiedStackTrace,
-      project_platform: group?.project.platform,
-      has_external_issue: group?.annotations ? group?.annotations.length > 0 : false,
-      has_owner: group?.owners ? group?.owners.length > 0 : false,
-      integration_assignment_source: group ? getAssignmentIntegration(group) : '',
-      // event properties
+      ...getAnalyicsDataForGroup(group),
       ...getAnalyicsDataForEvent(event),
+      ...getAnalyicsDataForProject(project),
       // Alert properties track if the user came from email/slack alerts
       alert_date:
         typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,
       alert_rule_id: typeof alert_rule_id === 'string' ? alert_rule_id : undefined,
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
-      has_otel: event?.contexts?.otel !== undefined,
       has_setup_source_maps_alert: shouldDisplaySetupSourceMapsAlert(
         organization,
         router.location.query.project,


### PR DESCRIPTION
This PR does some refactoring of the `issue_details.viewed` analytics and adds the `project_age` field which is the number of days since the project was created. I also added `issue_id` which is the same as `group_id` since we sometimes use that nomenclature.