### PR TITLE
fix(hybrid-cloud): Fix customer domain redirects for superusers

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -78,17 +78,17 @@ class ReactMixin:
                 )
                 if redirect_url:
                     return HttpResponseRedirect(redirect_url)
-
-            user = getattr(request, "user", None) or None
-            if user is not None and not isinstance(user, AnonymousUser):
-                session = getattr(request, "session", None)
-                last_active_org = (session.get("activeorg", None) or None) if session else None
-                if last_active_org:
-                    redirect_url = resolve_redirect_url(
-                        request=request, org_slug=last_active_org, user_id=user.id
-                    )
-                    if redirect_url:
-                        return HttpResponseRedirect(redirect_url)
+            else:
+                user = getattr(request, "user", None) or None
+                if user is not None and not isinstance(user, AnonymousUser):
+                    session = getattr(request, "session", None)
+                    last_active_org = (session.get("activeorg", None) or None) if session else None
+                    if last_active_org:
+                        redirect_url = resolve_redirect_url(
+                            request=request, org_slug=last_active_org, user_id=user.id
+                        )
+                        if redirect_url:
+                            return HttpResponseRedirect(redirect_url)
 
         return render_to_response("sentry/base-react.html", context=context, request=request)
 

--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -36,3 +36,25 @@ class TestTestUtilsFeatureHelper(TestCase):
             assert isinstance(org_context.organization, ApiOrganization)
 
             assert features.has("organizations:customer-domains", org_context.organization)
+
+        other_org = self.create_organization()
+        with self.feature({"organizations:customer-domains": [other_org.slug]}):
+            # Feature not enabled for self.org
+            org_context = organization_service.get_organization_by_slug(
+                slug=self.org.slug, only_visible=False, user_id=None
+            )
+            assert org_context
+            assert org_context.organization
+            assert isinstance(org_context.organization, ApiOrganization)
+
+            assert features.has("organizations:customer-domains", org_context.organization) is False
+
+            # Feature enabled for other_org
+            org_context = organization_service.get_organization_by_slug(
+                slug=other_org.slug, only_visible=False, user_id=None
+            )
+            assert org_context
+            assert org_context.organization
+            assert isinstance(org_context.organization, ApiOrganization)
+
+            assert features.has("organizations:customer-domains", org_context.organization)

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -244,7 +244,7 @@ class ReactPageViewTest(TestCase):
         org = self.create_organization(owner=self.user)
         other_org = self.create_organization()
 
-        self.login_as(self.user)
+        self.login_as(self.user, superuser=True)
 
         with self.feature({"organizations:customer-domains": [org.slug]}):
             # Induce activeorg

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -239,3 +239,28 @@ class ReactPageViewTest(TestCase):
         response = self.client.get(f"/settings/{org.slug}/projects/albertos-apples/keys/")
         assert response.status_code == 200
         self.assertTemplateUsed(response, "sentry/base-react.html")
+
+    def test_customer_domain_superuser(self):
+        org = self.create_organization(owner=self.user)
+        other_org = self.create_organization()
+
+        self.login_as(self.user)
+
+        with self.feature({"organizations:customer-domains": [org.slug]}):
+            # Induce activeorg
+            response = self.client.get(
+                "/",
+                HTTP_HOST=f"{org.slug}.testserver",
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == [(f"http://{org.slug}.testserver/issues/", 302)]
+            assert self.client.session["activeorg"] == org.slug
+
+            # Access another org as superuser
+            response = self.client.get(
+                reverse("sentry-organization-issue-list", args=[other_org.slug]),
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == []


### PR DESCRIPTION
This pull request fixes a redirect edge case whereby a superuser may be unable to access an organization in the following conditions:

1. user is a superuser
2. organization being accessed does not have customer domain enabled
3. the user's last active org has customer domain enabled


I've also enhanced the `self.feature()` such that we can enable features for specific organizations:

```python
with self.feature({'feature-1': ['org-slug', 'albertos-apples']}):
    pass
```