### PR TITLE
ref(tsdb): port over non-outcomes tsdb models to use SnQL

### DIFF
--- a/src/sentry/issues/query.py
+++ b/src/sentry/issues/query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from snuba_sdk import Column, Function
 from snuba_sdk.query import SelectableExpression
@@ -14,8 +14,8 @@ def apply_performance_conditions(conditions: List[Any], group: Group) -> List[An
     return conditions
 
 
-def manual_group_on_time_aggregation(rollup, time_column_alias) -> SelectableExpression:
-    def rollup_agg(rollup_granularity: int, alias: str):
+def manual_group_on_time_aggregation(rollup: int, time_column_alias: str) -> SelectableExpression:
+    def rollup_agg(rollup_granularity: int, alias: str) -> Optional[SelectableExpression]:
         if rollup_granularity == 60:
             return Function(
                 "toUnixTimestamp", [Function("toStartOfMinute", [Column("timestamp")])], alias

--- a/src/sentry/issues/query.py
+++ b/src/sentry/issues/query.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List
 
+from snuba_sdk import Column, Function
+from snuba_sdk.query import SelectableExpression
+
 if TYPE_CHECKING:
     from sentry.models.group import Group
 
@@ -9,3 +12,44 @@ if TYPE_CHECKING:
 def apply_performance_conditions(conditions: List[Any], group: Group) -> List[Any]:
     conditions.append([["has", ["group_ids", group.id]], "=", 1])
     return conditions
+
+
+def manual_group_on_time_aggregation(rollup, time_column_alias) -> SelectableExpression:
+    def rollup_agg(rollup_granularity: int, alias: str):
+        if rollup_granularity == 60:
+            return Function(
+                "toUnixTimestamp", [Function("toStartOfMinute", [Column("timestamp")])], alias
+            )
+        elif rollup_granularity == 3600:
+            return Function(
+                "toUnixTimestamp", [Function("toStartOfHour", [Column("timestamp")])], alias
+            )
+        elif rollup_granularity == 3600 * 24:
+            return Function(
+                "toUnixTimestamp",
+                [Function("toDateTime", [Function("toDate", [Column("timestamp")])])],
+                alias,
+            )
+        else:
+            return None
+
+    # if we don't have an explicit function mapped to this rollup, we have to calculate it on the fly
+    # multiply(intDiv(toUInt32(toUnixTimestamp(timestamp)), granularity)))
+    synthetic_rollup = Function(
+        "multiply",
+        [
+            Function(
+                "intDiv",
+                [
+                    Function("toUInt32", [Function("toUnixTimestamp", [Column("timestamp")])]),
+                    rollup,
+                ],
+            ),
+            rollup,
+        ],
+        time_column_alias,
+    )
+
+    known_rollups = rollup_agg(rollup, time_column_alias)
+
+    return known_rollups if known_rollups else synthetic_rollup

--- a/src/sentry/search/events/builder/issue_platform.py
+++ b/src/sentry/search/events/builder/issue_platform.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 
-from snuba_sdk import Column, Function
-
+from sentry.issues.query import manual_group_on_time_aggregation
 from sentry.search.events.builder import TimeseriesQueryBuilder
 from sentry.search.events.types import ParamsType
 from sentry.utils.snuba import Dataset
@@ -34,39 +33,5 @@ class IssuePlatformTimeseriesQueryBuilder(TimeseriesQueryBuilder):
             has_metrics=has_metrics,
             skip_tag_resolution=skip_tag_resolution,
         )
-        rollup_to_start_func = {
-            60: "toStartOfMinute",
-            3600: "toStartOfHour",
-            3600 * 24: "toDate",
-        }
-        rollup_func = rollup_to_start_func.get(interval)
-        if rollup_func:
-            if rollup_func == "toDate":
-                self.time_column = Function(
-                    "toUnixTimestamp",
-                    [Function("toDateTime", [Function(rollup_func, [Column("timestamp")])])],
-                    alias="time",
-                )
-            else:
-                self.time_column = Function(
-                    "toUnixTimestamp", [Function(rollup_func, [Column("timestamp")])], alias="time"
-                )
-        else:
-            self.time_column = Function(
-                "multiply",
-                [
-                    Function(
-                        "intDiv",
-                        [
-                            Function(
-                                "toUInt32", [Function("toUnixTimestamp", [Column("timestamp")])]
-                            ),
-                            interval,
-                        ],
-                    ),
-                    interval,
-                ],
-                alias="time",
-            )
-
+        self.time_column = manual_group_on_time_aggregation(interval, "time")
         self.groupby = [self.time_column]

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -95,18 +95,15 @@ def get_project_list(project_id):
     return project_id if isinstance(project_id, Iterable) else [project_id]
 
 
-def _translate_filter_keys(project_ids, group_ids, environment_ids) -> Dict[str, Any]:
-    from sentry.utils.snuba import get_snuba_translators
+def _translate_filter_keys(f_keys, project_ids, group_ids, environment_ids) -> Dict[str, Any]:
+    f_keys["project_id"] = project_ids
 
-    filter_keys = {"project_id": project_ids}
     if environment_ids:
-        filter_keys["environment"] = environment_ids
+        f_keys["environment"] = environment_ids
     if group_ids:
-        filter_keys["group_id"] = group_ids
+        f_keys["group_id"] = group_ids
 
-    forward, reverse = get_snuba_translators(filter_keys, is_grouprelease=False)
-
-    return forward(filter_keys)
+    return f_keys
 
 
 class SnubaTagStorage(TagStorage):

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -50,6 +50,7 @@ from sentry.utils.hashlib import md5_text
 from sentry.utils.snuba import (
     _prepare_start_end,
     get_organization_id_from_project_ids,
+    get_snuba_translators,
     nest_groups,
     raw_snql_query,
 )
@@ -95,15 +96,16 @@ def get_project_list(project_id):
     return project_id if isinstance(project_id, Iterable) else [project_id]
 
 
-def _translate_filter_keys(f_keys, project_ids, group_ids, environment_ids) -> Dict[str, Any]:
-    f_keys["project_id"] = project_ids
+def _translate_filter_keys(project_ids, group_ids, environment_ids) -> Dict[str, Any]:
+    filter_keys = {"project_id": project_ids}
 
     if environment_ids:
-        f_keys["environment"] = environment_ids
+        filter_keys["environment"] = environment_ids
     if group_ids:
-        f_keys["group_id"] = group_ids
+        filter_keys["group_id"] = group_ids
 
-    return f_keys
+    forward, reverse = get_snuba_translators(filter_keys, is_grouprelease=False)
+    return forward(filter_keys)
 
 
 class SnubaTagStorage(TagStorage):

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -24,6 +24,7 @@ from snuba_sdk.query import SelectableExpression
 
 from sentry.constants import DataCategory
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
+from sentry.issues.query import manual_group_on_time_aggregation
 from sentry.tsdb.base import BaseTSDB, TSDBModel
 from sentry.utils import outcomes, snuba
 from sentry.utils.dates import to_datetime
@@ -267,48 +268,6 @@ class SnubaTSDB(BaseTSDB):
 
         return known_rollups if known_rollups else synthetic_rollup
 
-    def __manual_group_on_time_aggregation_sqnl(
-        self, rollup, time_column_alias
-    ) -> SelectableExpression:
-        def rollup_agg(rollup_granularity: int, alias: str):
-            if rollup_granularity == 60:
-                return Function(
-                    "toUnixTimestamp", [Function("toStartOfMinute", [Column("timestamp")])], alias
-                )
-            elif rollup_granularity == 3600:
-                return Function(
-                    "toUnixTimestamp", [Function("toStartOfHour", [Column("timestamp")])], alias
-                )
-            elif rollup_granularity == 3600 * 24:
-                return Function(
-                    "toUnixTimestamp",
-                    [Function("toDateTime", [Function("toDate", [Column("timestamp")])])],
-                    alias,
-                )
-            else:
-                return None
-
-        # if we don't have an explicit function mapped to this rollup, we have to calculate it on the fly
-        # multiply(intDiv(toUInt32(toUnixTimestamp(timestamp)), granularity)))
-        synthetic_rollup = Function(
-            "multiply",
-            [
-                Function(
-                    "intDiv",
-                    [
-                        Function("toUInt32", [Function("toUnixTimestamp", [Column("timestamp")])]),
-                        rollup,
-                    ],
-                ),
-                rollup,
-            ],
-            time_column_alias,
-        )
-
-        known_rollups = rollup_agg(rollup, time_column_alias)
-
-        return known_rollups if known_rollups else synthetic_rollup
-
     def get_data(
         self,
         model,
@@ -427,7 +386,7 @@ class SnubaTSDB(BaseTSDB):
         ]
 
         if group_on_time and manual_group_on_time:
-            aggregations.append(self.__manual_group_on_time_aggregation_sqnl(rollup, "time"))
+            aggregations.append(manual_group_on_time_aggregation(rollup, "time"))
 
         if keys:
             start = to_datetime(series[0])

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -84,16 +84,7 @@ class SnubaTSDB(BaseTSDB):
     # Since transactions are currently (and temporarily) written to Snuba's events storage we need to
     # include this condition to ensure they are excluded from the query. Once we switch to the
     # errors storage in Snuba, this can be omitted and transactions will be excluded by default.
-    LEGACY_events_type_condition = ["type", "!=", "transaction"]
     events_type_condition = Condition(Column("type"), Op.NEQ, "transaction")
-    # ``non_outcomes_query_settings`` are all the query settings for non outcomes based TSDB models.
-    # Single tenant reads Snuba for these models, and writes to DummyTSDB. It reads and writes to Redis for all the
-    # other models.
-    non_outcomes_query_settings = {
-        # TSDBModel.release: SnubaModelQuerySettings(
-        #     snuba.Dataset.Events, "tags[sentry:release]", None, [LEGACY_events_type_condition]
-        # ),
-    }
 
     # ``project_filter_model_query_settings`` and ``outcomes_partial_query_settings`` are all the TSDB models for
     # outcomes
@@ -171,6 +162,9 @@ class SnubaTSDB(BaseTSDB):
         ),
     }
 
+    # ``non_outcomes_query_settings`` are all the query settings for non outcomes based TSDB models.
+    # Single tenant reads Snuba for these models, and writes to DummyTSDB. It reads and writes to Redis for all the
+    # other models.
     # these query settings should use SnQL style parameters instead of the legacy format
     non_outcomes_snql_query_settings = {
         TSDBModel.project: SnubaModelQuerySettings(
@@ -233,7 +227,6 @@ class SnubaTSDB(BaseTSDB):
         itertools.chain(
             project_filter_model_query_settings.items(),
             outcomes_partial_query_settings.items(),
-            non_outcomes_query_settings.items(),
             non_outcomes_snql_query_settings.items(),
         )
     )

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -81,11 +81,6 @@ class SnubaTSDB(BaseTSDB):
     will return empty results for unsupported models.
     """
 
-    # Since transactions are currently (and temporarily) written to Snuba's events storage we need to
-    # include this condition to ensure they are excluded from the query. Once we switch to the
-    # errors storage in Snuba, this can be omitted and transactions will be excluded by default.
-    events_type_condition = Condition(Column("type"), Op.NEQ, "transaction")
-
     # ``project_filter_model_query_settings`` and ``outcomes_partial_query_settings`` are all the TSDB models for
     # outcomes
     project_filter_model_query_settings = {
@@ -167,12 +162,8 @@ class SnubaTSDB(BaseTSDB):
     # other models.
     # these query settings should use SnQL style parameters instead of the legacy format
     non_outcomes_snql_query_settings = {
-        TSDBModel.project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", None, [events_type_condition]
-        ),
-        TSDBModel.group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", None, [events_type_condition]
-        ),
+        TSDBModel.project: SnubaModelQuerySettings(snuba.Dataset.Events, "project_id", None, []),
+        TSDBModel.group: SnubaModelQuerySettings(snuba.Dataset.Events, "group_id", None, []),
         TSDBModel.group_performance: SnubaModelQuerySettings(
             snuba.Dataset.Transactions,
             "group_id",
@@ -182,10 +173,10 @@ class SnubaTSDB(BaseTSDB):
             [Function("arrayJoin", [Column("group_ids")], "group_id")],
         ),
         TSDBModel.release: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "tags[sentry:release]", None, [events_type_condition]
+            snuba.Dataset.Events, "tags[sentry:release]", None, []
         ),
         TSDBModel.users_affected_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "tags[sentry:user]", [events_type_condition]
+            snuba.Dataset.Events, "group_id", "tags[sentry:user]", []
         ),
         TSDBModel.users_affected_by_perf_group: SnubaModelQuerySettings(
             snuba.Dataset.Transactions,
@@ -195,16 +186,16 @@ class SnubaTSDB(BaseTSDB):
             [Function("arrayJoin", [Column("group_ids")], "group_id")],
         ),
         TSDBModel.users_affected_by_project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", "tags[sentry:user]", [events_type_condition]
+            snuba.Dataset.Events, "project_id", "tags[sentry:user]", []
         ),
         TSDBModel.frequent_environments_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "environment", [events_type_condition]
+            snuba.Dataset.Events, "group_id", "environment", []
         ),
         TSDBModel.frequent_releases_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "tags[sentry:release]", [events_type_condition]
+            snuba.Dataset.Events, "group_id", "tags[sentry:release]", []
         ),
         TSDBModel.frequent_issues_by_project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", "group_id", [events_type_condition]
+            snuba.Dataset.Events, "project_id", "group_id", []
         ),
         TSDBModel.group_generic: SnubaModelQuerySettings(
             snuba.Dataset.IssuePlatform,

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -255,7 +255,6 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
         }
 
         # No events submitted for env2
-        assert self.env2.name == "dev"
         assert self.db.get_range(
             TSDBModel.project,
             [self.proj1.id],

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -427,12 +427,12 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             ],
         }
 
-        # assert (
-        #     self.db.get_frequency_series(
-        #         TSDBModel.frequent_releases_by_group, {}, dts[0], dts[-1], rollup=3600
-        #     )
-        #     == {}
-        # )
+        assert (
+            self.db.get_frequency_series(
+                TSDBModel.frequent_releases_by_group, {}, dts[0], dts[-1], rollup=3600
+            )
+            == {}
+        )
 
     def test_result_shape(self):
         """


### PR DESCRIPTION
Move over non-outcomes tsdb models to use SnQL querying instead of the legacy format.
