### PR TITLE
perf(codecov): Add caching for projects without Codecov integrations

### DIFF
--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping
 from unittest import mock
 
 import pytest
+import requests
 
 from sentry.api.endpoints.project_stacktrace_link import ProjectStacktraceLinkEndpoint
 from sentry.integrations.example.integration import ExampleIntegration
@@ -10,6 +11,7 @@ from sentry.models import Integration, OrganizationIntegration
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.cache import cache
 
 example_base_url = "https://example.com/getsentry/sentry/blob/master"
 
@@ -314,6 +316,8 @@ class ProjectStracktraceLinkTestCodecov(BaseProjectStacktraceLink):
             source_root="",
         )
         self.filepath = "src/path/to/file.py"
+        self.organization.flags.codecov_access = True
+        self.organization.save()
 
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):
@@ -323,9 +327,6 @@ class ProjectStracktraceLinkTestCodecov(BaseProjectStacktraceLink):
     @mock.patch("sentry.api.endpoints.project_stacktrace_link.get_codecov_data")
     @mock.patch.object(ExampleIntegration, "get_stacktrace_link")
     def test_codecov_line_coverage_success(self, mock_integration, mock_get_codecov_data):
-        self.organization.flags.codecov_access = True
-        self.organization.save()
-
         expected_line_coverage = [[1, 0], [3, 1], [4, 0]]
         expected_codecov_url = "https://app.codecov.io/gh/getsentry/sentry/commit/a67ea84967ed1ec42844720d9daf77be36ff73b0/blob/src/path/to/file.py"
         expected_status_code = 200
@@ -344,13 +345,14 @@ class ProjectStracktraceLinkTestCodecov(BaseProjectStacktraceLink):
         assert response.data["codecov"]["lineCoverage"] == expected_line_coverage
         assert response.data["codecov"]["status"] == expected_status_code
 
+        cache_val = cache.get(f"codecov_integration_exists:{self.project.id}")
+        assert cache_val is True
+
     @with_feature("organizations:codecov-stacktrace-integration")
     @mock.patch("sentry.api.endpoints.project_stacktrace_link.get_codecov_data")
     @mock.patch.object(ExampleIntegration, "get_stacktrace_link")
     def test_codecov_line_coverage_exception(self, mock_integration, mock_get_codecov_data):
         self._caplog.set_level(logging.ERROR, logger="sentry")
-        self.organization.flags.codecov_access = True
-        self.organization.save()
 
         mock_integration.return_value = "https://github.com/repo/blob/master/src/path/to/file.py"
         mock_get_codecov_data.side_effect = Exception
@@ -373,6 +375,50 @@ class ProjectStracktraceLinkTestCodecov(BaseProjectStacktraceLink):
                 "Something unexpected happen. Continuing execution.",
             )
         ]
+
+        # Don't set the cache in the error case
+        cache_val = cache.get(f"codecov_integration_exists:{self.project.id}")
+        assert cache_val is None
+
+    @with_feature("organizations:codecov-stacktrace-integration")
+    @mock.patch("sentry.api.endpoints.project_stacktrace_link.get_codecov_data")
+    @mock.patch.object(ExampleIntegration, "get_stacktrace_link")
+    def test_codecov_line_coverage_cached(self, mock_integration, mock_get_codecov_data):
+        mock_integration.return_value = "https://github.com/repo/blob/master/src/path/to/file.py"
+        mock_response = requests.Response()
+        mock_response.status_code = 404
+        mock_response.url = "https://codecov.io/"
+        mock_get_codecov_data.side_effect = requests.exceptions.HTTPError(response=mock_response)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={
+                "file": self.filepath,
+                "absPath": "abs_path",
+                "module": "module",
+                "package": "package",
+            },
+        )
+        assert response.data["codecov"]["status"] == 404
+        cache_val = cache.get(f"codecov_integration_exists:{self.project.id}")
+        assert cache_val is False
+
+        # Make sure we don't make the request again
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={
+                "file": self.filepath,
+                "absPath": "abs_path",
+                "module": "module",
+                "package": "package",
+            },
+        )
+        assert response.data["codecov"]["status"] == 404
+        assert mock_get_codecov_data.call_count == 1
+        cache_val = cache.get(f"codecov_integration_exists:{self.project.id}")
+        assert cache_val is False
 
 
 class ProjectStacktraceLinkTestMultipleMatches(BaseProjectStacktraceLink):


### PR DESCRIPTION
Add a project-level cache to improve stacktrace-link load times for issues/projects that have no Codecov integration. We cache the existence of the integration with a 1-hour expiration to prevent querying Codecov too frequently. 

WOR-2629