### PR TITLE
ref(profiling): move hovercard queries to useProfilingTransactionQuickSummary

### DIFF
--- a/static/app/components/profiling/profilingTransactionHovercard.tsx
+++ b/static/app/components/profiling/profilingTransactionHovercard.tsx
@@ -5,18 +5,14 @@ import {Hovercard} from 'sentry/components/hovercard';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
-import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import {getShortEventId} from 'sentry/utils/events';
-import {useFunctions} from 'sentry/utils/profiling/hooks/useFunctions';
-import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import {useProfilingTransactionQuickSummary} from 'sentry/utils/profiling/hooks/useProfilingTransactionQuickSummary';
 import {
   generateProfileFlamechartRouteWithQuery,
   generateProfileSummaryRouteWithQuery,
 } from 'sentry/utils/profiling/routes';
 import {useLocation} from 'sentry/utils/useLocation';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {ContextTitle} from 'sentry/views/discover/table/quickContext/styles';
-import {getProfilesTableFields} from 'sentry/views/profiling/profileSummary/content';
 
 import {Button} from '../button';
 import Link from '../links/link';
@@ -76,48 +72,19 @@ function ProfilingTransactionHovercardBody({
   project,
   organization,
 }: ProfilingTransactionHovercardProps) {
-  const {selection} = usePageFilters();
-
-  const baseQueryOptions = {
-    query: `transaction:"${transaction}"`,
-    fields: getProfilesTableFields(project.platform),
-    enabled: Boolean(transaction),
-    limit: 1,
-    referrer: 'api.profiling.profiling-transaction-hovercard',
-    refetchOnMount: false,
-    projects: [project.id],
-  };
-
-  const slowestProfileQuery = useProfileEvents({
-    ...baseQueryOptions,
-    sort: {
-      key: 'profile.duration',
-      order: 'desc',
-    },
-  });
-
-  const latestProfileQuery = useProfileEvents({
-    ...baseQueryOptions,
-    sort: {
-      key: 'timestamp',
-      order: 'desc',
-    },
-  });
-
-  const functions = useFunctions({
-    project,
-    query: '',
-    selection,
+  const {
+    slowestProfile,
+    slowestProfileQuery,
+    slowestProfileDurationMultiplier,
+    latestProfileQuery,
+    latestProfile,
+    functionsQuery,
+    functions,
+  } = useProfilingTransactionQuickSummary({
     transaction,
-    sort: '-p99',
-    functionType: 'application',
+    project,
+    referrer: 'api.profiling.profiling-transaction-hovercard',
   });
-
-  const slowestProfile = slowestProfileQuery?.data?.[0].data[0] ?? null;
-  const durationUnits = slowestProfileQuery.data?.[0].meta.units['profile.duration'];
-  const multiplier = durationUnits ? DURATION_UNITS[durationUnits] ?? 1 : 1;
-
-  const latestProfile = latestProfileQuery?.data?.[0].data[0] ?? null;
 
   const linkToFlamechartRoute = (
     profileId: string,
@@ -154,7 +121,10 @@ function ProfilingTransactionHovercardBody({
           {slowestProfile ? (
             <Flex gap={space(1)}>
               <PerformanceDuration
-                milliseconds={multiplier * (slowestProfile['profile.duration'] as number)}
+                milliseconds={
+                  slowestProfileDurationMultiplier *
+                  (slowestProfile['profile.duration'] as number)
+                }
                 abbreviation
               />
               <Link to={linkToFlamechartRoute(String(slowestProfile.id))}>
@@ -173,8 +143,8 @@ function ProfilingTransactionHovercardBody({
           <FunctionsMiniGridHeader align="right">{t('P99')}</FunctionsMiniGridHeader>
           <FunctionsMiniGridHeader align="right">{t('Count')}</FunctionsMiniGridHeader>
 
-          {functions.type === 'resolved' &&
-            functions.data.functions.map(f => {
+          {functionsQuery.type === 'resolved' &&
+            functions?.map(f => {
               const [exampleProfileIdRaw] = f.examples;
               const exampleProfileId = exampleProfileIdRaw.replaceAll('-', '');
               return (
@@ -201,7 +171,7 @@ function ProfilingTransactionHovercardBody({
               );
             })}
         </FunctionsMiniGrid>
-        {functions.type === 'loading' && (
+        {functionsQuery.type === 'loading' && (
           <Flex align="stretch" justify="center" column h="100%">
             <Flex align="center" justify="center">
               <LoadingIndicator mini />
@@ -209,7 +179,7 @@ function ProfilingTransactionHovercardBody({
           </Flex>
         )}
 
-        {functions.type === 'resolved' && functions.data.functions.length === 0 && (
+        {functionsQuery.type === 'resolved' && functions?.length === 0 && (
           <Flex align="stretch" justify="center" column h="100%">
             <Flex align="center" justify="center">
               {t('No functions data')}

--- a/static/app/utils/profiling/hooks/useFunctions.tsx
+++ b/static/app/utils/profiling/hooks/useFunctions.tsx
@@ -21,6 +21,7 @@ interface UseFunctionsOptions {
   sort: string;
   transaction: string | null;
   cursor?: string;
+  enabled?: boolean;
   functionType?: 'application' | 'system' | 'all';
   selection?: PageFilters;
 }
@@ -34,6 +35,7 @@ function useFunctions({
   sort,
   cursor,
   selection,
+  enabled = true,
 }: UseFunctionsOptions): RequestState<FunctionsResult> {
   const api = useApi();
   const organization = useOrganization();
@@ -43,7 +45,7 @@ function useFunctions({
   });
 
   useEffect(() => {
-    if (selection === undefined || transaction === null) {
+    if (selection === undefined || transaction === null || !enabled) {
       return undefined;
     }
 
@@ -83,6 +85,7 @@ function useFunctions({
     selection,
     sort,
     transaction,
+    enabled,
   ]);
 
   return requestState;

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -11,13 +11,14 @@ import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {ProfilingFieldType} from 'sentry/views/profiling/profileSummary/content';
 
 type Sort<F> = {
   key: F;
   order: 'asc' | 'desc';
 };
 
-interface UseProfileEventsOptions<F> {
+export interface UseProfileEventsOptions<F = ProfilingFieldType> {
   fields: readonly F[];
   referrer: string;
   sort: Sort<F>;

--- a/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
+++ b/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
@@ -46,7 +46,7 @@ export function useProfilingTransactionQuickSummary(
       key: 'profile.duration',
       order: 'desc',
     },
-    enabled: skipSlowestProfile,
+    enabled: !skipSlowestProfile,
   });
 
   const latestProfileQuery = useProfileEvents({
@@ -55,7 +55,7 @@ export function useProfilingTransactionQuickSummary(
       key: 'timestamp',
       order: 'desc',
     },
-    enabled: skipLatestProfile,
+    enabled: !skipLatestProfile,
   });
 
   const functionsQuery = useFunctions({
@@ -65,7 +65,7 @@ export function useProfilingTransactionQuickSummary(
     transaction,
     sort: '-p99',
     functionType: 'application',
-    enabled: skipFunctions,
+    enabled: !skipFunctions,
   });
 
   const slowestProfile = slowestProfileQuery?.data?.[0].data[0] ?? null;

--- a/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
+++ b/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
@@ -1,0 +1,99 @@
+import {Project} from 'sentry/types';
+import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
+import {useFunctions} from 'sentry/utils/profiling/hooks/useFunctions';
+import {
+  useProfileEvents,
+  UseProfileEventsOptions,
+} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {getProfilesTableFields} from 'sentry/views/profiling/profileSummary/content';
+
+interface UseProfilingTransactionQuickSummaryOptions {
+  project: Project;
+  referrer: string;
+  transaction: string;
+  skipFunctions?: boolean;
+  skipLatestProfile?: boolean;
+  skipSlowestProfile?: boolean;
+}
+
+export function useProfilingTransactionQuickSummary(
+  options: UseProfilingTransactionQuickSummaryOptions
+) {
+  const {
+    transaction,
+    project,
+    referrer,
+    skipFunctions = false,
+    skipLatestProfile = false,
+    skipSlowestProfile = false,
+  } = options;
+  const {selection} = usePageFilters();
+
+  const baseQueryOptions: Omit<UseProfileEventsOptions, 'sort'> = {
+    query: `transaction:"${transaction}"`,
+    fields: getProfilesTableFields(project.platform),
+    enabled: Boolean(transaction),
+    limit: 1,
+    referrer,
+    refetchOnMount: false,
+    projects: [project.id],
+  };
+
+  const slowestProfileQuery = useProfileEvents({
+    ...baseQueryOptions,
+    sort: {
+      key: 'profile.duration',
+      order: 'desc',
+    },
+    enabled: skipSlowestProfile,
+  });
+
+  const latestProfileQuery = useProfileEvents({
+    ...baseQueryOptions,
+    sort: {
+      key: 'timestamp',
+      order: 'desc',
+    },
+    enabled: skipLatestProfile,
+  });
+
+  const functionsQuery = useFunctions({
+    project,
+    query: '',
+    selection,
+    transaction,
+    sort: '-p99',
+    functionType: 'application',
+    enabled: skipFunctions,
+  });
+
+  const slowestProfile = slowestProfileQuery?.data?.[0].data[0] ?? null;
+  const durationUnits = slowestProfileQuery.data?.[0].meta.units['profile.duration'];
+  const slowestProfileDurationMultiplier = durationUnits
+    ? DURATION_UNITS[durationUnits] ?? 1
+    : 1;
+
+  const latestProfile = latestProfileQuery?.data?.[0].data[0] ?? null;
+
+  const functions =
+    functionsQuery.type === 'resolved' ? functionsQuery.data.functions : null;
+
+  return {
+    // slowest
+    slowestProfileQuery,
+    slowestProfile,
+    slowestProfileDurationMultiplier,
+    // latest
+    latestProfileQuery,
+    latestProfile,
+    // function
+    functionsQuery,
+    functions,
+    // general
+    isLoading:
+      slowestProfileQuery.isLoading ||
+      latestProfileQuery.isLoading ||
+      functionsQuery.type === 'loading',
+  };
+}


### PR DESCRIPTION
## Summary
Moving the queries we use for the transaction hover card into their own hook so we can re-use it within the dashboard. More specifically we're planning on presenting similar info to replace the `count()` chart.

Possible variants: 
![image](https://user-images.githubusercontent.com/7349258/214602349-01da523f-3ff6-4954-9db9-a9aa8b0ab9be.png)
