### PR TITLE
ref(profiling): fix timeline message sizes

### DIFF
--- a/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
+++ b/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -59,8 +60,25 @@ const StyledButton = styled(Button)`
   }
 `;
 
+export function CollapsibleTimelineLoadingIndicator({size}: {size?: number}) {
+  return (
+    <CollapsibleTimelineLoadingIndicatorContainer>
+      <LoadingIndicator size={size ?? 32} />
+    </CollapsibleTimelineLoadingIndicatorContainer>
+  );
+}
+
 const CollapsibleTimelineContainer = styled('div')`
   position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const CollapsibleTimelineLoadingIndicatorContainer = styled('div')`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   width: 100%;
   height: 100%;
 `;
@@ -78,4 +96,16 @@ const CollapsibleTimelineHeader = styled('div')<{border: string}>`
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 
+export const CollapsibleTimelineMessage = styled('p')`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  color: ${p => p.theme.subText};
+  padding-bottom: ${space(4)};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
 export {CollapsibleTimeline};

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -11,7 +11,6 @@ import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 import * as qs from 'query-string';
 
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {
   CanvasPoolManager,
@@ -38,6 +37,10 @@ import {useDrawHoveredBorderEffect} from './interactions/useDrawHoveredBorderEff
 import {useDrawSelectedBorderEffect} from './interactions/useDrawSelectedBorderEffect';
 import {useInteractionViewCheckPoint} from './interactions/useInteractionViewCheckPoint';
 import {useWheelCenterZoom} from './interactions/useWheelCenterZoom';
+import {
+  CollapsibleTimelineLoadingIndicator,
+  CollapsibleTimelineMessage,
+} from './collapsibleTimeline';
 import {FlamegraphSpanTooltip} from './flamegraphSpanTooltip';
 
 interface FlamegraphSpansProps {
@@ -375,13 +378,15 @@ export function FlamegraphSpans({
       {/* transaction loads after profile, so we want to show loading even if it's in initial state */}
       {profiledTransaction.type === 'loading' ||
       profiledTransaction.type === 'initial' ? (
-        <LoadingIndicatorContainer>
-          <LoadingIndicator size={42} />
-        </LoadingIndicatorContainer>
+        <CollapsibleTimelineLoadingIndicator />
       ) : profiledTransaction.type === 'errored' ? (
-        <MessageContainer>{t('No associated transaction found')}</MessageContainer>
+        <CollapsibleTimelineMessage>
+          {t('No associated transaction found')}
+        </CollapsibleTimelineMessage>
       ) : profiledTransaction.type === 'resolved' && spanChart.spans.length <= 1 ? (
-        <MessageContainer>{t('Transaction has no spans')}</MessageContainer>
+        <CollapsibleTimelineMessage>
+          {t('Transaction has no spans')}
+        </CollapsibleTimelineMessage>
       ) : null}
       {hoveredNode && spansRenderer && configSpaceCursor && spansCanvas && spansView ? (
         <FlamegraphSpanTooltip
@@ -397,26 +402,6 @@ export function FlamegraphSpans({
     </Fragment>
   );
 }
-
-const MessageContainer = styled('p')`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  color: ${p => p.theme.subText};
-`;
-
-const LoadingIndicatorContainer = styled('div')`
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-`;
 
 const Canvas = styled('canvas')<{cursor?: CSSProperties['cursor']}>`
   width: 100%;

--- a/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
@@ -10,7 +10,6 @@ import {
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {
   CanvasPoolManager,
@@ -34,6 +33,10 @@ import {useCanvasScroll} from './interactions/useCanvasScroll';
 import {useCanvasZoomOrScroll} from './interactions/useCanvasZoomOrScroll';
 import {useInteractionViewCheckPoint} from './interactions/useInteractionViewCheckPoint';
 import {useWheelCenterZoom} from './interactions/useWheelCenterZoom';
+import {
+  CollapsibleTimelineLoadingIndicator,
+  CollapsibleTimelineMessage,
+} from './collapsibleTimeline';
 
 interface FlamegraphUIFramesProps {
   canvasBounds: Rect;
@@ -285,35 +288,15 @@ export function FlamegraphUIFrames({
       />
       {/* transaction loads after profile, so we want to show loading even if it's in initial state */}
       {profileGroup.type === 'loading' || profileGroup.type === 'initial' ? (
-        <LoadingIndicatorContainer>
-          <LoadingIndicator size={42} />
-        </LoadingIndicatorContainer>
+        <CollapsibleTimelineLoadingIndicator />
       ) : profileGroup.type === 'resolved' && uiFrames.frames.length <= 1 ? (
-        <MessageContainer>{t('Profile has no dropped or slow frames')}</MessageContainer>
+        <CollapsibleTimelineMessage>
+          {t('Profile has no dropped or slow frames')}
+        </CollapsibleTimelineMessage>
       ) : null}
     </Fragment>
   );
 }
-
-const MessageContainer = styled('p')`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  color: ${p => p.theme.subText};
-`;
-
-const LoadingIndicatorContainer = styled('div')`
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-`;
 
 const Canvas = styled('canvas')<{cursor?: CSSProperties['cursor']}>`
   width: 100%;


### PR DESCRIPTION
Reduce font size on the timeline messaging and center it (also no more copy paste components)

<img width="1081" alt="CleanShot 2023-01-25 at 12 05 34@2x" src="https://user-images.githubusercontent.com/9317857/214631349-fa789102-e222-4387-945a-f16a1221f1b7.png">
