### PR TITLE
ref(checkbox): Use variable-weight icons

### DIFF
--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -3,7 +3,6 @@ import {css, Theme} from '@emotion/react';
 import styled, {Interpolation} from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import {IconCheckmark, IconSubtract} from 'sentry/icons';
 import {FormSize} from 'sentry/utils/theme';
 
 type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
@@ -26,15 +25,13 @@ interface Props extends Omit<CheckboxProps, 'checked' | 'size'> {
 type CheckboxConfig = {
   borderRadius: string;
   box: string;
-  // TODO: We should use IconSize here, but the `xs` checkmark needs the
-  // smaller icon size right now, so we use legacySize
   icon: string;
 };
 
 const checkboxSizeMap: Record<FormSize, CheckboxConfig> = {
   xs: {box: '12px', borderRadius: '2px', icon: '10px'},
-  sm: {box: '16px', borderRadius: '4px', icon: '12px'},
-  md: {box: '22px', borderRadius: '6px', icon: '16px'},
+  sm: {box: '16px', borderRadius: '4px', icon: '13px'},
+  md: {box: '22px', borderRadius: '6px', icon: '18px'},
 };
 
 const Checkbox = ({
@@ -63,10 +60,17 @@ const Checkbox = ({
         type="checkbox"
         {...props}
       />
+
       <StyledCheckbox aria-hidden checked={checked} size={size}>
-        {checked === true && <IconCheckmark legacySize={checkboxSizeMap[size].icon} />}
+        {checked === true && (
+          <VariableWeightIcon viewBox="0 0 16 16" size={checkboxSizeMap[size].icon}>
+            <path d="M2.86 9.14C4.42 10.7 6.9 13.14 6.86 13.14L12.57 3.43" />
+          </VariableWeightIcon>
+        )}
         {checked === 'indeterminate' && (
-          <IconSubtract legacySize={checkboxSizeMap[size].icon} />
+          <VariableWeightIcon viewBox="0 0 16 16" size={checkboxSizeMap[size].icon}>
+            <path d="M3 8H13" />
+          </VariableWeightIcon>
         )}
       </StyledCheckbox>
       {!props.disabled && (
@@ -140,6 +144,17 @@ const StyledCheckbox = styled('div')<{
           background: ${p.theme.background};
           border: 1px solid ${p.theme.gray200};
         `}
+`;
+
+const VariableWeightIcon = styled('svg')<{size: string}>`
+  width: ${p => p.size};
+  height: ${p => p.size};
+
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke: ${p => p.theme.white};
+  stroke-width: calc((0.7px + ${p => p.size} * 0.035) * 1.4);
 `;
 
 export default Checkbox;

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -154,7 +154,7 @@ const VariableWeightIcon = styled('svg')<{size: string}>`
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke: ${p => p.theme.white};
-  stroke-width: calc((0.7px + ${p => p.size} * 0.035) * 1.4);
+  stroke-width: calc(1px + ${p => p.size} * 0.05);
 `;
 
 export default Checkbox;

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -30,7 +30,7 @@ type CheckboxConfig = {
 
 const checkboxSizeMap: Record<FormSize, CheckboxConfig> = {
   xs: {box: '12px', borderRadius: '2px', icon: '10px'},
-  sm: {box: '16px', borderRadius: '4px', icon: '13px'},
+  sm: {box: '16px', borderRadius: '4px', icon: '12px'},
   md: {box: '22px', borderRadius: '6px', icon: '18px'},
 };
 
@@ -154,7 +154,7 @@ const VariableWeightIcon = styled('svg')<{size: string}>`
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke: ${p => p.theme.white};
-  stroke-width: calc(1px + ${p => p.size} * 0.05);
+  stroke-width: calc(1.4px + ${p => p.size} * 0.04);
 `;
 
 export default Checkbox;


### PR DESCRIPTION
Use special variable-weight versions of the checkmark and subtract icon for `Checkbox`.

**Before:**
<img width="424" alt="Screenshot 2023-01-25 at 10 01 04 AM" src="https://user-images.githubusercontent.com/44172267/214645225-215efecf-e6aa-4f57-b36f-298ce7b08954.png">
<img width="122" alt="Screenshot 2023-01-25 at 9 59 02 AM" src="https://user-images.githubusercontent.com/44172267/214644820-39170ea2-aab2-456c-a6d1-04779fa6946e.png">

**After:**
<img width="424" alt="Screenshot 2023-01-25 at 10 21 39 AM" src="https://user-images.githubusercontent.com/44172267/214649541-561ad430-add7-4cd1-8c32-5f626cb7a4d3.png">
<img width="122" alt="Screenshot 2023-01-25 at 9 59 12 AM" src="https://user-images.githubusercontent.com/44172267/214644875-82741643-f12c-433d-9420-85a4aa0b37d0.png">
