### PR TITLE
fix(codecov): Change API path and header

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -19,6 +19,7 @@ def get_codecov_data(
         owner_username, repo_name = repo.split("/")
         if service == "github":
             service = "gh"
+        path = path.lstrip("/")
         url = CODECOV_URL.format(
             service=service, owner_username=owner_username, repo_name=repo_name
         )

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -26,7 +26,7 @@ def get_codecov_data(
         with configure_scope() as scope:
             params = {"branch": branch, "path": path}
             response = requests.get(
-                url, params=params, headers={"Authorization": f"tokenAuth {codecov_token}"}
+                url, params=params, headers={"Authorization": f"Bearer {codecov_token}"}
             )
             scope.set_tag("codecov.http_code", response.status_code)
 


### PR DESCRIPTION
This PR addresses the [issues](https://sentry.io/organizations/sentry/discover/homepage/?field=codecov.http_code&field=http.referer&field=stacktrace_link.abs_path&field=codecov.attempted_url&name=All+Events&project=1&query=transaction%3A%2Fapi%2F0%2Fprojects%2F%7Borganization_slug%7D%2F%7Bproject_slug%7D%2Fstacktrace-link%2F++codecov.enabled%3ATrue+%21codecov.coverage_found%3ATrue&sort=-codecov.http_code&statsPeriod=24h&yAxis=count%28%29) that did not have codecov coverage, but should have.

There were two cases that needed to be addressed:
1. The codecov path started with a `/` that needs to be removed.
- Ex. [Issue on Sentry](https://sentry.io/organizations/sentry/issues/2509765626/?end=2023-01-24T20%3A24%3A03&project=1&referrer=performance-related-issues-issue-stream&start=2023-01-24T20%3A19%3A43)
- The following image shows the extra `/`. The URL should be: https://api.codecov.io/api/v2/gh/getsentry/repos/sentry/report?branch=master&path=src%2Fsentry%2Fsilo%2Fbase.py
<img width="559" alt="Screen Shot 2023-01-24 at 3 21 29 PM" src="https://user-images.githubusercontent.com/116035587/214650390-7f6d07b6-c041-495a-9256-3d2d1c934c28.png">

2. The file is on codecov, but the code reports a 404 error
I found that this was due to the header phrasing being incorrect. It should have been `Bearer`
- Ex. [Issue on Sentry](https://sentry.io/organizations/sentry/issues/3837572788/?project=1)
- - This is in the private `getSentry` repo. Thanks to Adrian and Armen for helping me realize the header was incorrect.