### PR TITLE
ref(ui) Remove error for missing router context

### DIFF
--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -1,7 +1,6 @@
-import {forwardRef, useContext, useEffect} from 'react';
+import {forwardRef, useContext} from 'react';
 import {Link as RouterLink} from 'react-router';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import {Location, LocationDescriptor} from 'history';
 
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -39,15 +38,6 @@ export interface LinkProps
 function BaseLink({disabled, to, forwardedRef, ...props}: LinkProps): React.ReactElement {
   const route = useContext(RouteContext);
   const location = route?.location;
-  useEffect(() => {
-    // check if the router is present
-    if (!(route && location)) {
-      Sentry.captureException(
-        new Error('The link component was rendered without being wrapped by a <Router />')
-      );
-    }
-  }, [route, location]);
-
   to = normalizeUrl(to, location);
 
   if (!disabled && location) {


### PR DESCRIPTION
Remove the error we're tracking for links outside of routing context. We have a few of these links intentionally now, and they are just contributing volume to our issue list for no value as nothing is broken.

This check was first added in #17346 but I think it has outlived its utility.

Fixes JAVASCRIPT-2BR1
Fixes JAVASCRIPT-2BSJ
Fixes JAVASCRIPT-2BVP