### PR TITLE
fix(n1-api-calls): Fix span URL parsing for mobile SDKs

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -216,7 +216,7 @@ describe('SpanEvidenceKeyValueList', () => {
         ).toEqual('http://service.io/');
       });
 
-      it('Pulls out a relative URL is a base is provided', () => {
+      it('Pulls out a relative URL if a base is provided', () => {
         expect(
           extractSpanURLString(
             {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -229,6 +229,18 @@ describe('SpanEvidenceKeyValueList', () => {
           )?.toString()
         ).toEqual('http://service.io/item');
       });
+
+      it('Falls back to span description if URL is faulty', () => {
+        expect(
+          extractSpanURLString({
+            span_id: 'a',
+            description: 'GET http://service.io/item',
+            data: {
+              url: '/item',
+            },
+          })?.toString()
+        ).toEqual('http://service.io/item');
+      });
     });
 
     describe('extractQueryParameters', () => {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -9,6 +9,7 @@ import {EntryType, IssueType} from 'sentry/types';
 
 import {
   extractQueryParameters,
+  extractSpanURLString,
   SpanEvidenceKeyValueList,
 } from './spanEvidenceKeyValueList';
 
@@ -201,6 +202,33 @@ describe('SpanEvidenceKeyValueList', () => {
 
       expect(parametersKeyValue).toHaveTextContent('book_id:{7,8}');
       expect(parametersKeyValue).toHaveTextContent('sort:{up,down}');
+    });
+
+    describe('extractSpanURLString', () => {
+      it('Tries to pull a URL from the span data', () => {
+        expect(
+          extractSpanURLString({
+            span_id: 'a',
+            data: {
+              url: 'http://service.io',
+            },
+          })?.toString()
+        ).toEqual('http://service.io/');
+      });
+
+      it('Pulls out a relative URL is a base is provided', () => {
+        expect(
+          extractSpanURLString(
+            {
+              span_id: 'a',
+              data: {
+                url: '/item',
+              },
+            },
+            'http://service.io'
+          )?.toString()
+        ).toEqual('http://service.io/item');
+      });
     });
 
     describe('extractQueryParameters', () => {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -345,7 +345,7 @@ function formatChangingQueryParameters(spans: Span[], baseURL?: string): string[
   return pairs;
 }
 
-const extractSpanURLString = (span: Span, baseURL?: string): URL | null => {
+export const extractSpanURLString = (span: Span, baseURL?: string): URL | null => {
   try {
     let URLString = span?.data?.url;
     if (!URLString) {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -346,17 +346,27 @@ function formatChangingQueryParameters(spans: Span[], baseURL?: string): string[
 }
 
 export const extractSpanURLString = (span: Span, baseURL?: string): URL | null => {
-  try {
-    let URLString = span?.data?.url;
-    if (!URLString) {
-      const [_method, _url] = (span?.description ?? '').split(' ', 2);
-      URLString = _url;
-    }
+  let URLString;
 
-    return new URL(URLString, baseURL);
-  } catch (e) {
-    return null;
+  URLString = span?.data?.url;
+  if (URLString) {
+    try {
+      return new URL(span?.data?.url, baseURL);
+    } catch (e) {
+      // Ignore error
+    }
   }
+
+  const [_method, _url] = (span?.description ?? '').split(' ', 2);
+  URLString = _url;
+
+  try {
+    return new URL(_url, baseURL);
+  } catch (e) {
+    // Ignore error
+  }
+
+  return null;
 };
 
 export function extractQueryParameters(URLs: URL[]): ParameterLookup {


### PR DESCRIPTION
Fixes PERF-1935, where some mobile SDK users were not seeing span evidence.

Account for cases when `span.data.url` is a relative URL but the trace doesn't have an absolute URL available as a base. This happens on mobile SDKs for whatever reason. In this case, use the full span description, because it'll have an absolute URL.

e.g., the span's description is `"GET http://service.io/data"`, the trace doesn't have a base URL to work with, and the span data URL is `"/data"`.
