### PR TITLE
fix(onboarding): adds logic to close onboarding sidebar when clicking start on an item

### DIFF
--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -171,6 +171,7 @@ function OnboardingWizardSidebar({collapsed, orientation, onClose, projects}: Pr
         key={`${task.task}`}
         onSkip={makeTaskUpdater('skipped')}
         onMarkComplete={makeTaskUpdater('complete')}
+        hidePanel={onClose}
       />
     );
   }

--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -37,11 +37,13 @@ const recordAnalytics = (
 
 type Props = {
   forwardedRef: React.Ref<HTMLDivElement>;
+  hidePanel: () => void;
   /**
    * Fired when a task is completed. This will typically happen if there is a
    * supplemental component with the ability to complete a task
    */
   onMarkComplete: (taskKey: OnboardingTaskKey) => void;
+
   /**
    * Fired when the task has been skipped
    */
@@ -55,7 +57,7 @@ type Props = {
 };
 
 function Task(props: Props) {
-  const {task, onSkip, onMarkComplete, forwardedRef, organization} = props;
+  const {task, onSkip, onMarkComplete, forwardedRef, organization, hidePanel} = props;
   const routeContext = useRouteContext();
   const {router} = routeContext;
   const handleSkip = () => {
@@ -84,6 +86,7 @@ function Task(props: Props) {
       url.searchParams.append('referrer', 'onboarding_task');
       navigateTo(url.toString(), router);
     }
+    hidePanel();
   };
 
   if (taskIsDone(task) && task.completionSeen) {


### PR DESCRIPTION
If you click on an onboarding item it takes you to the URL for that item which will cause the page to-reload. But if you're already there then the page won't reload and the onboarding sidebar guide stays open. This closes it explicitly every time you click on an item.