### PR TITLE
ui(codecov): Fix codecov legend border

### DIFF
--- a/static/app/components/events/interfaces/frame/codecovLegend.tsx
+++ b/static/app/components/events/interfaces/frame/codecovLegend.tsx
@@ -74,7 +74,6 @@ const LegendIcon = styled('span')`
 const CodeCovLegendContainer = styled('div')`
   gap: ${space(1)};
   color: ${p => p.theme.subText};
-  background-color: ${p => p.theme.background};
   font-family: ${p => p.theme.text.family};
   border-bottom: 1px solid ${p => p.theme.border};
   padding: ${space(0.25)} ${space(3)};


### PR DESCRIPTION
Fix the gap in the codecov legend border 

Before:
<img width="108" alt="image" src="https://user-images.githubusercontent.com/16563948/214700169-5c6fc4fe-5912-4ded-af13-72ca7229bb29.png">
After: 
<img width="119" alt="image" src="https://user-images.githubusercontent.com/16563948/214700099-076d2d1a-c053-4c77-a727-db288c22abec.png">
