### PR TITLE
fix(sourcemaps): ease check on valid url and add data for invalid url issue

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -135,12 +135,13 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
 
         urlparts = urlparse(abs_path)
 
-        if not (urlparts.netloc and urlparts.scheme and urlparts.path):
+        if not (urlparts.scheme and urlparts.path):
             return Response(
                 {
                     "errors": [
                         SourceMapProcessingIssue(
-                            SourceMapProcessingIssue.URL_NOT_VALID
+                            SourceMapProcessingIssue.URL_NOT_VALID,
+                            data={"absPath": abs_path},
                         ).get_api_context()
                     ],
                 }

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -213,3 +213,4 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         error = resp.data["errors"][0]
         assert error["type"] == "url_not_valid"
         assert error["message"] == "The absolute path url is not valid"
+        assert error["data"] == {"absPath": "app.example.com/static/static/js/main.fa8fe19f.js"}


### PR DESCRIPTION
this pr eases the check on a valid url . previously it was too strict in the check causing some valid urls to fail. in addition, it send the absolute path as part of the response for the invalid url issue now (previously no data was being sent). 