### PR TITLE
feat(issue-platform): Support issue platform events in post process group

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -358,7 +358,6 @@ def post_process_group(
         from sentry.models import Organization, Project
         from sentry.reprocessing2 import is_reprocessed_event
 
-        occurrence = None
         if occurrence_id is None:
             data = event_processing_store.get(cache_key)
             if not data:
@@ -370,6 +369,7 @@ def post_process_group(
             with metrics.timer("tasks.post_process.delete_event_cache"):
                 event_processing_store.delete_by_key(cache_key)
 
+            occurrence = None
             event = process_event(data, group_id)
         else:
             # Note: We attempt to acquire the lock here, but we don't release it and instead just

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -9,8 +9,9 @@ import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
 
-from sentry import analytics, features
+from sentry import analytics, eventstore, features
 from sentry.exceptions import PluginError
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
@@ -339,6 +340,8 @@ def post_process_group(
     cache_key,
     group_id=None,
     group_states: Optional[GroupStates] = None,
+    occurrence_id: Optional[str] = None,
+    project_id: Optional[int] = None,
     **kwargs,
 ):
     """
@@ -354,18 +357,48 @@ def post_process_group(
         from sentry.models import Organization, Project
         from sentry.reprocessing2 import is_reprocessed_event
 
-        data = event_processing_store.get(cache_key)
-        if not data:
-            logger.info(
-                "post_process.skipped",
-                extra={"cache_key": cache_key, "reason": "missing_cache"},
+        if occurrence_id is None:
+            data = event_processing_store.get(cache_key)
+            if not data:
+                logger.info(
+                    "post_process.skipped",
+                    extra={"cache_key": cache_key, "reason": "missing_cache"},
+                )
+                return
+            with metrics.timer("tasks.post_process.delete_event_cache"):
+                event_processing_store.delete_by_key(cache_key)
+
+            event = process_event(data, group_id)
+        else:
+            # Note: We attempt to acquire the lock here, but we don't release it and instead just
+            # rely on the ttl. The goal here is to make sure we only ever run post process group
+            # at most once per occurrence. Even though we don't use retries on the task, this is
+            # still necessary since the consumer that sends these might reprocess a batch.
+            # TODO: It might be better to instead set a value that we delete here, similar to what
+            # we do with `event_processing_store`. If we could do this *before* the occurrence ends
+            # up in Kafka (IE via the api that will sit in front of it), then we could guarantee at
+            # most once running of post process group.
+            lock = locks.get(
+                f"ppg:{occurrence_id}-once",
+                duration=600,
+                name="post_process_w_o",
             )
-            return
 
-        with metrics.timer("tasks.post_process.delete_event_cache"):
-            event_processing_store.delete_by_key(cache_key)
+            try:
+                lock.acquire()
+            except Exception:
+                # If we fail to acquire the lock, we've already run post process group for this
+                # occurrence
+                return
 
-        event = process_event(data, group_id)
+            occurrence = IssueOccurrence.fetch(occurrence_id, project_id=project_id)
+            # Issue platform events don't use `event_processing_store`. Fetch from eventstore
+            # instead.
+            event = eventstore.get_event_by_id(project_id, occurrence.event_id, group_id=group_id)
+            event: GroupEvent = event.for_group(event.group)
+            event.occurrence = occurrence
+
+        set_current_event_project(event.project_id)
 
         # Re-bind Project and Org since we're reading the Event object
         # from cache which may contain stale parent models.
@@ -467,8 +500,6 @@ def process_event(data: dict, group_id: Optional[int]) -> Event:
     event = Event(
         project_id=data["project"], event_id=data["event_id"], group_id=group_id, data=data
     )
-
-    set_current_event_project(event.project_id)
 
     # Re-bind node data to avoid renormalization. We only want to
     # renormalize when loading old data from the database.

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from sentry import buffer
 from sentry.buffer.redis import RedisBuffer
 from sentry.eventstore.processing import event_processing_store
-from sentry.issues.ingest import save_issue_from_occurrence
+from sentry.issues.ingest import save_issue_occurrence
 from sentry.models import (
     Activity,
     Group,
@@ -64,12 +64,12 @@ class EventMatcher:
 
 class BasePostProgressGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def create_event(self, data, project_id):
+    def create_event(self, data, project_id, assert_no_errors=True):
         pass
 
     @abc.abstractmethod
     def call_post_process_group(
-        self, is_new, is_regression, is_new_group_environment, cache_key, group_id
+        self, is_new, is_regression, is_new_group_environment, event, cache_key=None
     ):
         pass
 
@@ -101,8 +101,8 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
+            event=event,
             cache_key=cache_key,
-            group_id=None,
         )
 
         assert mock_processor.call_count == 0
@@ -114,44 +114,40 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_no_cache_abort(self, mock_processor):
-        event = self.store_event(data={}, project_id=self.project.id)
+        event = self.create_event(data={}, project_id=self.project.id)
 
         self.call_post_process_group(
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
+            event=event,
             cache_key="total-rubbish",
-            group_id=event.group_id,
         )
 
         assert mock_processor.call_count == 0
 
     def test_processing_cache_cleared(self):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
 
-        self.call_post_process_group(
+        cache_key = self.call_post_process_group(
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assert event_processing_store.get(cache_key) is None
 
     def test_processing_cache_cleared_with_commits(self):
         # Regression test to guard against suspect commit calculations breaking the
         # cache
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
 
         self.create_commit(repo=self.create_repo())
-        self.call_post_process_group(
+        cache_key = self.call_post_process_group(
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assert event_processing_store.get(cache_key) is None
 
@@ -160,14 +156,12 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
 @apply_feature_flag_on_cls("organizations:derive-code-mappings-dry-run")
 class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
     def _call_post_process_group(self, data: Dict[str, str]) -> None:
-        event = self.store_event(data=data, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data=data, project_id=self.project.id)
         self.call_post_process_group(
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
     @patch("sentry.tasks.derive_code_mappings.derive_code_mappings")
@@ -185,8 +179,7 @@ class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
 class RuleProcessorTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_rule_processor_backwards_compat(self, mock_processor):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
 
         mock_callback = Mock()
         mock_futures = [Mock()]
@@ -197,8 +190,7 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            group_id=event.group_id,
-            cache_key=cache_key,
+            event=event,
         )
 
         mock_processor.assert_called_once_with(EventMatcher(event), True, False, True, False)
@@ -208,8 +200,7 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_rule_processor(self, mock_processor):
-        event = self.store_event(data={"message": "testing"}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         mock_callback = Mock()
         mock_futures = [Mock()]
@@ -220,8 +211,7 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         mock_processor.assert_called_once_with(EventMatcher(event), True, False, True, False)
@@ -260,38 +250,33 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
                 project=self.project, data={"conditions": conditions, "actions": actions}
             )
 
-            event = self.store_event(
+            event = self.create_event(
                 data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id
             )
-            event_2 = self.store_event(
+            event_2 = self.create_event(
                 data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id
             )
-            cache_key = write_event_to_cache(event)
             self.call_post_process_group(
                 is_new=True,
                 is_regression=False,
                 is_new_group_environment=True,
-                cache_key=cache_key,
-                group_id=event.group_id,
+                event=event,
             )
             event.group.update(times_seen=2)
             assert MockAction.return_value.after.call_count == 0
 
-            cache_key = write_event_to_cache(event_2)
             buffer.incr(Group, {"times_seen": 15}, filters={"pk": event.group.id})
             self.call_post_process_group(
                 is_new=True,
                 is_regression=False,
                 is_new_group_environment=True,
-                cache_key=cache_key,
-                group_id=event_2.group_id,
+                event=event_2,
             )
             assert MockAction.return_value.after.call_count == 1
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_group_refresh(self, mock_processor):
-        event = self.store_event(data={"message": "testing"}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         group1 = event.group
         group2 = self.create_group(project=self.project)
@@ -311,8 +296,7 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         # Ensure that rule processing sees the merged group.
         mock_processor.assert_called_with(
@@ -323,8 +307,7 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
 class ServiceHooksTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.tasks.servicehooks.process_service_hook")
     def test_service_hook_fires_on_new_event(self, mock_process_service_hook):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
         hook = self.create_service_hook(
             project=self.project,
             organization=self.project.organization,
@@ -337,8 +320,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
-                cache_key=cache_key,
-                group_id=event.group_id,
+                event=event,
             )
 
         mock_process_service_hook.delay.assert_called_once_with(
@@ -348,8 +330,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.tasks.servicehooks.process_service_hook")
     @patch("sentry.rules.processor.RuleProcessor")
     def test_service_hook_fires_on_alert(self, mock_processor, mock_process_service_hook):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
 
         mock_callback = Mock()
         mock_futures = [Mock()]
@@ -368,8 +349,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
-                cache_key=cache_key,
-                group_id=event.group_id,
+                event=event,
             )
 
         mock_process_service_hook.delay.assert_called_once_with(
@@ -381,8 +361,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
     def test_service_hook_does_not_fire_without_alert(
         self, mock_processor, mock_process_service_hook
     ):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
 
         mock_processor.return_value.apply.return_value = []
 
@@ -398,16 +377,14 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
-                cache_key=cache_key,
-                group_id=event.group_id,
+                event=event,
             )
 
         assert not mock_process_service_hook.delay.mock_calls
 
     @patch("sentry.tasks.servicehooks.process_service_hook")
     def test_service_hook_does_not_fire_without_event(self, mock_process_service_hook):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
 
         self.create_service_hook(
             project=self.project, organization=self.project.organization, actor=self.user, events=[]
@@ -418,8 +395,7 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
                 is_new=True,
                 is_regression=False,
                 is_new_group_environment=False,
-                cache_key=cache_key,
-                group_id=event.group_id,
+                event=event,
             )
 
         assert not mock_process_service_hook.delay.mock_calls
@@ -428,15 +404,13 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
 class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_on_new_group(self, delay):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
         self.call_post_process_group(
             is_new=True,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         delay.assert_called_once_with(action="created", sender="Group", instance_id=group.id)
@@ -444,7 +418,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
     @with_feature("organizations:integrations-event-hooks")
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_on_error_events(self, delay):
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "Foo bar",
                 "exception": {"type": "Foo", "value": "oh no"},
@@ -454,7 +428,6 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
             project_id=self.project.id,
             assert_no_errors=False,
         )
-        cache_key = write_event_to_cache(event)
 
         self.create_service_hook(
             project=self.project,
@@ -467,8 +440,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         delay.assert_called_once_with(
@@ -481,38 +453,34 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
     @with_feature("organizations:integrations-event-hooks")
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_not_called_for_non_errors(self, delay):
-        event = self.store_event(
+        event = self.create_event(
             data={"message": "Foo bar", "level": "info", "timestamp": iso_format(timezone.now())},
             project_id=self.project.id,
             assert_no_errors=False,
         )
-        cache_key = write_event_to_cache(event)
 
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         assert not delay.called
 
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_not_called_without_feature_flag(self, delay):
-        event = self.store_event(
+        event = self.create_event(
             data={"message": "Foo bar", "level": "info", "timestamp": iso_format(timezone.now())},
             project_id=self.project.id,
             assert_no_errors=False,
         )
-        cache_key = write_event_to_cache(event)
 
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         assert not delay.called
@@ -520,7 +488,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
     @with_feature("organizations:integrations-event-hooks")
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_not_called_without_error_created(self, delay):
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "Foo bar",
                 "level": "error",
@@ -530,8 +498,6 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
             project_id=self.project.id,
             assert_no_errors=False,
         )
-        cache_key = write_event_to_cache(event)
-
         self.create_service_hook(
             project=self.project, organization=self.project.organization, actor=self.user, events=[]
         )
@@ -540,8 +506,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         assert not delay.called
@@ -550,8 +515,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
 class InboxTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_group_inbox_regression(self, mock_processor):
-        event = self.store_event(data={"message": "testing"}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         group = event.group
 
@@ -559,32 +523,30 @@ class InboxTestMixin(BasePostProgressGroupMixin):
             is_new=True,
             is_regression=True,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
-        # assert GroupInbox.objects.filter(group=group, reason=GroupInboxReason.NEW.value).exists()
-        # GroupInbox.objects.filter(
-        #     group=group
-        # ).delete()  # Delete so it creates the .REGRESSION entry.
+        assert GroupInbox.objects.filter(group=group, reason=GroupInboxReason.NEW.value).exists()
+        GroupInbox.objects.filter(
+            group=group
+        ).delete()  # Delete so it creates the .REGRESSION entry.
 
         mock_processor.assert_called_with(EventMatcher(event), True, True, False, False)
 
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         self.call_post_process_group(
             is_new=False,
             is_regression=True,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         mock_processor.assert_called_with(EventMatcher(event), False, True, False, False)
 
         group = Group.objects.get(id=group.id)
         assert group.status == GroupStatus.UNRESOLVED
-        # assert GroupInbox.objects.filter(
-        #     group=group, reason=GroupInboxReason.REGRESSION.value
-        # ).exists()
+        assert GroupInbox.objects.filter(
+            group=group, reason=GroupInboxReason.REGRESSION.value
+        ).exists()
 
 
 class AssignmentTestMixin(BasePostProgressGroupMixin):
@@ -609,7 +571,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
 
     def test_owner_assignment_order_precedence(self):
         self.make_ownership()
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -617,13 +579,11 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == self.user
@@ -649,7 +609,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         self.make_ownership(
             [Rule(Matcher("path", "src/app/things/in/*"), [Owner("user", extra_user.email)])],
         )
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -657,13 +617,11 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == extra_user
@@ -689,7 +647,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             user=self.user,
             type=GroupOwnerType.OWNERSHIP_RULE.value,
         )
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -697,13 +655,11 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user is None
@@ -716,7 +672,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
 
     def test_owner_assignment_assign_user(self):
         self.make_ownership()
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -724,20 +680,18 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == self.user
         assert assignee.team is None
 
     def test_owner_assignment_ownership_no_matching_owners(self):
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -745,19 +699,17 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assert not event.group.assignee_set.exists()
 
     def test_owner_assignment_existing_assignment(self):
         self.make_ownership()
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -765,14 +717,12 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         event.group.assignee_set.create(team=self.team, project=self.project)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user is None
@@ -780,7 +730,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
 
     def test_only_first_assignment_works(self):
         self.make_ownership()
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -789,19 +739,17 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == self.user
         assert assignee.team is None
 
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -810,13 +758,11 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         # Assignment shouldn't change.
@@ -828,7 +774,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         # Remove the team so the rule match will fail to resolve
         self.team.delete()
 
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -836,13 +782,11 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assignee = event.group.assignee_set.first()
         assert assignee is None
@@ -854,7 +798,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         """
         # Create rules and check assignees
         self.make_ownership()
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -862,7 +806,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        event_2 = self.store_event(
+        event_2 = self.create_event(
             data={
                 "message": "Exception",
                 "platform": "python",
@@ -870,21 +814,17 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
-        cache_key_2 = write_event_to_cache(event_2)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key_2,
-            group_id=event_2.group_id,
+            event=event_2,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == self.user
@@ -903,21 +843,17 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         self.prj_ownership.schema = dump_schema(rules)
         self.prj_ownership.save()
 
-        cache_key = write_event_to_cache(event)
-        cache_key_2 = write_event_to_cache(event_2)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key_2,
-            group_id=event_2.group_id,
+            event=event_2,
         )
 
         # Group should be re-assigned to the new group owner
@@ -945,21 +881,17 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             schema=dump_schema([code_owners_rule]),
         )
 
-        cache_key = write_event_to_cache(event)
-        cache_key_2 = write_event_to_cache(event_2)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key_2,
-            group_id=event_2.group_id,
+            event=event_2,
         )
 
         # Group should be re-assigned to the new group owner
@@ -968,7 +900,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
 
     def test_ensure_when_assignees_and_owners_are_cached_does_not_cause_unbound_errors(self):
         self.make_ownership()
-        event = self.store_event(
+        event = self.create_event(
             data={
                 "message": "oh no",
                 "platform": "python",
@@ -976,7 +908,6 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
-        cache_key = write_event_to_cache(event)
 
         assignee_cache_key = "assignee_exists:1:%s" % event.group.id
         owner_cache_key = "owner_exists:1:%s" % event.group.id
@@ -988,8 +919,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
 
@@ -1077,7 +1007,6 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_invalidates_snooze(self, mock_processor, send_robust):
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
 
         group = event.group
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(hours=1))
@@ -1087,8 +1016,7 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
         assert GroupInbox.objects.filter(group=group, reason=GroupInboxReason.NEW.value).exists()
         GroupInbox.objects.filter(group=group).delete()  # Delete so it creates the UNIGNORED entry.
@@ -1096,14 +1024,13 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
 
         mock_processor.assert_called_with(EventMatcher(event), True, False, True, False)
 
-        cache_key = write_event_to_cache(event)
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         # Check for has_reappeared=True if is_new=False
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         mock_processor.assert_called_with(EventMatcher(event), False, False, True, True)
@@ -1138,31 +1065,26 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
             group.update(times_seen=50)
             snooze = GroupSnooze.objects.create(group=group, count=100, state={"times_seen": 0})
 
-            cache_key = write_event_to_cache(event)
             self.call_post_process_group(
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=True,
-                cache_key=cache_key,
-                group_id=event.group_id,
+                event=event,
             )
             assert GroupSnooze.objects.filter(id=snooze.id).exists()
-            cache_key = write_event_to_cache(event_2)
 
             buffer.incr(Group, {"times_seen": 60}, filters={"pk": event.group.id})
             self.call_post_process_group(
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=True,
-                cache_key=cache_key,
-                group_id=event.group_id,
+                event=event_2,
             )
             assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_maintains_valid_snooze(self, mock_processor):
         event = self.create_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
         group = event.group
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() + timedelta(hours=1))
 
@@ -1170,8 +1092,7 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
-            cache_key=cache_key,
-            group_id=event.group_id,
+            event=event,
         )
 
         mock_processor.assert_called_with(EventMatcher(event), True, False, True, False)
@@ -1192,19 +1113,22 @@ class PostProcessGroupErrorTest(
     ServiceHooksTestMixin,
     SnoozeTestMixin,
 ):
-    def create_event(self, data, project_id):
-        return self.store_event(data=data, project_id=project_id)
+    def create_event(self, data, project_id, assert_no_errors=True):
+        return self.store_event(data=data, project_id=project_id, assert_no_errors=assert_no_errors)
 
     def call_post_process_group(
-        self, is_new, is_regression, is_new_group_environment, cache_key, group_id
+        self, is_new, is_regression, is_new_group_environment, event, cache_key=None
     ):
+        if cache_key is None:
+            cache_key = write_event_to_cache(event)
         post_process_group(
             is_new=is_new,
             is_regression=is_regression,
             is_new_group_environment=is_new_group_environment,
             cache_key=cache_key,
-            group_id=group_id,
+            group_id=event.group_id,
         )
+        return cache_key
 
 
 @region_silo_test
@@ -1217,7 +1141,7 @@ class PostProcessGroupPerformanceTest(
     RuleProcessorTestMixin,
     SnoozeTestMixin,
 ):
-    def create_event(self, data, project_id):
+    def create_event(self, data, project_id, assert_no_errors=True):
         fingerprint = data["fingerprint"][0] if data.get("fingerprint") else "some_group"
         fingerprint = f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-{fingerprint}"
         # Store a performance event
@@ -1229,20 +1153,22 @@ class PostProcessGroupPerformanceTest(
         return event.for_group(event.groups[0])
 
     def call_post_process_group(
-        self, is_new, is_regression, is_new_group_environment, cache_key, group_id
+        self, is_new, is_regression, is_new_group_environment, event, cache_key=None
     ):
         group_states = (
             [
                 {
-                    "id": group_id,
+                    "id": event.group_id,
                     "is_new": is_new,
                     "is_regression": is_regression,
                     "is_new_group_environment": is_new_group_environment,
                 }
             ]
-            if group_id
+            if event.group_id
             else None
         )
+        if cache_key is None:
+            cache_key = write_event_to_cache(event)
         post_process_group(
             is_new=is_new,
             is_regression=is_regression,
@@ -1250,6 +1176,7 @@ class PostProcessGroupPerformanceTest(
             cache_key=cache_key,
             group_states=group_states,
         )
+        return cache_key
 
     @patch("sentry.tasks.post_process.run_post_process_job")
     @patch("sentry.rules.processor.RuleProcessor")
@@ -1374,23 +1301,38 @@ class PostProcessGroupGenericTest(
     RuleProcessorTestMixin,
     SnoozeTestMixin,
 ):
-    def create_event(self, data, project_id):
+    def create_event(self, data, project_id, assert_no_errors=True):
         data["type"] = "generic"
-        event = self.store_event(data=data, project_id=project_id)
+        event = self.store_event(
+            data=data, project_id=project_id, assert_no_errors=assert_no_errors
+        )
 
-        occurrence = self.build_occurrence(event_id=event.event_id)
-        group_info = save_issue_from_occurrence(occurrence, event, None)
+        occurrence_data = self.build_occurrence_data(event_id=event.event_id)
+        occurrence, group_info = save_issue_occurrence(occurrence_data, event)
         assert group_info is not None
 
-        return event.for_group(group_info.group)
+        group_event = event.for_group(group_info.group)
+        group_event.occurrence = occurrence
+        return group_event
 
     def call_post_process_group(
-        self, is_new, is_regression, is_new_group_environment, cache_key, group_id
+        self, is_new, is_regression, is_new_group_environment, event, cache_key=None
     ):
         post_process_group(
             is_new=is_new,
             is_regression=is_regression,
             is_new_group_environment=is_new_group_environment,
-            cache_key=cache_key,
-            group_id=group_id,
+            cache_key=None,
+            group_id=event.group_id,
+            occurrence_id=event.occurrence.id,
+            project_id=event.group.project_id,
         )
+        return cache_key
+
+    def test_issueless(self):
+        # Skip this test since there's no way to have issueless events in the issue platform
+        pass
+
+    def test_no_cache_abort(self):
+        # We don't use the cache for generic issues, so skip this test
+        pass

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -990,8 +990,7 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
                 is_new=True,
                 is_regression=False,
                 is_new_group_environment=True,
-                cache_key=self.cache_key,
-                group_id=self.created_event.group_id,
+                event=self.created_event,
             )
         assert GroupOwner.objects.get(
             group=self.created_event.group,


### PR DESCRIPTION
Issue platform events come in via a different process to standard events. We could rely on adding these values to `event_processing_store`, but I think that it will be simpler to just fetch the events and occurrence from nodestore directly.

This should help with some ingestion backlogging issues as well, once all issue types are on the platform. Previously, we wouldn't remove events from `event_processing_store` until the `post_process_group` step, which is pretty slow. In this new model, we could choose to remove values from `event_processing_store` after ingestion finishes and not worry about post process group at all.

The current implementation of this has some tradeoffs. Previously, since values are inserted into `event_processing_store` at a much earlier step, we have a guarantee (or close to a guarantee) that the `post_process_group` task will only ever be run once, even if the post process forwarder restarts and replays some events.

In this new model we attempt to do the same. However the ttl is only 10 minutes, and so if there was enough of a delay we could potentially run post process group multiple times on a replay. In practice this might not be all that big of a deal, because it requires multiple factors to cause the replay and will likely only affect a small number of events anyway. But if we want to fix it, we could consider adding this key prior to inserting the occurrence into the issue platform kafka queue.

This also relies on us passing the occurrence id and project id via post process forwarder, which I'll follow up with in a separate pr.
