### PR TITLE
fix(txnames): Skip deleted projects

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -48,7 +48,13 @@ def get_active_projects() -> Iterator[Project]:
         # NOTE: Would be nice to do a `select_related` on project.organization
         # because we need it for the feature flag, but I don't know how to do
         # it with `get_from_cache`.
-        yield Project.objects.get_from_cache(id=project_id)
+        try:
+            yield Project.objects.get_from_cache(id=project_id)
+        except Project.DoesNotExist:
+            # The project has been deleted.
+            # Could theoretically delete the key here, but it has a lifetime
+            # of 24h, so probably not worth it.
+            pass
 
 
 def _store_transaction_name(project: Project, transaction_name: str) -> None:

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -1,4 +1,5 @@
 """ Write transactions into redis sets """
+import logging
 from typing import Any, Iterator, Mapping
 
 import sentry_sdk
@@ -25,6 +26,7 @@ SET_TTL = 24 * 60 * 60
 REDIS_KEY_PREFIX = "txnames:"
 
 add_to_set = redis.load_script("utils/sadd_capped.lua")
+logger = logging.getLogger(__name__)
 
 
 def _get_redis_key(project: Project) -> str:
@@ -54,7 +56,7 @@ def get_active_projects() -> Iterator[Project]:
             # The project has been deleted.
             # Could theoretically delete the key here, but it has a lifetime
             # of 24h, so probably not worth it.
-            pass
+            logger.debug("Could not find project %s in db", project_id)
 
 
 def _store_transaction_name(project: Project, transaction_name: str) -> None:

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -7,6 +7,7 @@ from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _store_transaction_name,
     clear_transaction_names,
+    get_active_projects,
     get_transaction_names,
     record_transaction_name,
 )
@@ -202,6 +203,13 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
             "/test/path/*/**",
             "/users/trans/*/**",
         }
+
+
+@pytest.mark.django_db
+def test_get_deleted_project():
+    deleted_project = Project(pk=666)
+    _store_transaction_name(deleted_project, "foo")
+    assert list(get_active_projects()) == []
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
We previously assumed that for any key in the transaction clusterer redis store, we have an existing project in postgres. This is not the case when a project gets deleted.

Catch the exception when a project does not exist for a redis key, so we do not crash the entire celery task spawning the clusterers.

Fixes SENTRY-XWX.