### PR TITLE
ref(mep): Allow up to 10 custom measurements

### DIFF
--- a/src/sentry/relay/config/measurements.py
+++ b/src/sentry/relay/config/measurements.py
@@ -4,7 +4,7 @@
 from typing import Literal, Sequence, TypedDict
 
 #: The maximum number of custom measurements to be extracted from transactions.
-CUSTOM_MEASUREMENT_LIMIT = 5
+CUSTOM_MEASUREMENT_LIMIT = 10
 
 # Relay defines more units than this, but let's keep it simple for now.
 # See https://github.com/getsentry/relay/blob/1a7d016f8bc871e8f482611d6a31a01834e678e6/relay-common/src/constants.rs#L600-L627

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -131,7 +131,7 @@ config:
       unit: millisecond
     - name: ttfb
       unit: millisecond
-    maxCustomMeasurements: 5
+    maxCustomMeasurements: 10
   piiConfig:
     applications:
       $string:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -131,7 +131,7 @@ config:
       unit: millisecond
     - name: ttfb
       unit: millisecond
-    maxCustomMeasurements: 5
+    maxCustomMeasurements: 10
   piiConfig:
     applications:
       $string:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/MONOLITH.pysnap
@@ -53,7 +53,7 @@ config:
       unit: millisecond
     - name: ttfb
       unit: millisecond
-    maxCustomMeasurements: 5
+    maxCustomMeasurements: 10
   piiConfig:
     applications:
       $string:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/REGION.pysnap
@@ -53,7 +53,7 @@ config:
       unit: millisecond
     - name: ttfb
       unit: millisecond
-    maxCustomMeasurements: 5
+    maxCustomMeasurements: 10
   piiConfig:
     applications:
       $string:

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
@@ -918,7 +918,7 @@ metricConditionalTagging:
 transactionMetrics:
   acceptTransactionNames: strict
   customMeasurements:
-    limit: 5
+    limit: 10
   extractCustomTags: []
   extractMetrics:
   - d:transactions/duration@millisecond

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
@@ -918,7 +918,7 @@ metricConditionalTagging:
 transactionMetrics:
   acceptTransactionNames: strict
   customMeasurements:
-    limit: 5
+    limit: 10
   extractCustomTags: []
   extractMetrics:
   - d:transactions/duration@millisecond


### PR DESCRIPTION
The number of custom measurements per transaction event is limited, with an
inital value of 5. As per customer request, we're doubling this number to 10.

Custom measurements show up in two places:
 1. They are stored and indexed as part of indexed transaction payloads. Snuba
    uses a variable-sized array for measurements, so no change is needed there.
 2. Every measurement creates a distribution in performance metrics.

Storage and ingestion have sufficient capacity to accommodate this change.

FEEDBACK-1680
