### PR TITLE
ref(perf-issues): Increase unc asset duration threshold

### DIFF
--- a/fixtures/events/performance_problems/uncompressed-assets/uncompressed-script-asset.json
+++ b/fixtures/events/performance_problems/uncompressed-assets/uncompressed-script-asset.json
@@ -61,9 +61,9 @@
       "hash": "b2978b51d54d9078"
     },
     {
-      "timestamp": 1667330086.5292,
+      "timestamp": 1667330086.9292,
       "start_timestamp": 1667330086.2861,
-      "exclusive_time": 243.100167,
+      "exclusive_time": 643.100167,
       "description": "https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_components_charts_utils_tsx-app_utils_performance_quickTrace_utils_tsx-app_utils_withPage-3926ec.bc434924850c44d4057f.js",
       "op": "resource.script",
       "span_id": "b66a5642da1edb52",

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -284,7 +284,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         },
         DetectorType.UNCOMPRESSED_ASSETS: {
             "size_threshold_bytes": 500 * 1024,
-            "duration_threshold": 200,  # ms
+            "duration_threshold": 500,  # ms
             "allowed_span_ops": ["resource.css", "resource.script"],
         },
     }


### PR DESCRIPTION
### Summary
After looking at some samples for detected asset thresholds, 200ms is probably too low for the recommendation to compress an asset to actually have a meaningful impact on our users browser performance. Since uncompressed assets already targets relatively large assets, there shouldn't be too much of a dip of detected problems. We can raise this later and see how it affects resolve/ignore rates.
