### PR TITLE
fix(release_health) : bad granularity was causing limit validation error in MetricsLayer

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -714,7 +714,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             select=select,
             start=start,
             end=end,
-            granularity=Granularity(MINUTE),
+            granularity=Granularity(LEGACY_SESSIONS_DEFAULT_ROLLUP),
             groupby=groupby,
             where=where_clause,
             include_series=False,


### PR DESCRIPTION
This PR fixes release_health MetricsLayer implementation `check_releases_have_health_data`
Query wrongly used minute granularity which was causing validation errors on query Limit

Now granularity is set to `LEGACY_SESSIONS_DEFAULT_ROLLUP` i.e. 1 hour