### PR TITLE
feat(view-hierarchy): Show all windows in tree

### DIFF
--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useMemo} from 'react';
 import * as Sentry from '@sentry/react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -20,10 +20,10 @@ type Props = {
 };
 
 function EventViewHierarchy({projectSlug, viewHierarchies}: Props) {
-  const [selectedViewHierarchy] = useState(0);
   const organization = useOrganization();
 
-  const hierarchyMeta = viewHierarchies[selectedViewHierarchy];
+  // There should be only one view hierarchy
+  const hierarchyMeta = viewHierarchies[0];
   const {isLoading, data} = useQuery<string>(
     [
       getAttachmentUrl({

--- a/static/app/components/events/viewHierarchy/detailsPanel.spec.tsx
+++ b/static/app/components/events/viewHierarchy/detailsPanel.spec.tsx
@@ -5,7 +5,7 @@ import {DetailsPanel} from './detailsPanel';
 const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
 const MOCK_DATA = {
   ...DEFAULT_VALUES,
-  id: 'parent',
+  identifier: 'parent',
   type: 'Container',
   x: 200,
   y: 201,
@@ -14,12 +14,12 @@ const MOCK_DATA = {
   children: [
     {
       ...DEFAULT_VALUES,
-      id: 'intermediate',
+      identifier: 'intermediate',
       type: 'Nested Container',
       children: [
         {
           ...DEFAULT_VALUES,
-          id: 'leaf',
+          identifier: 'leaf',
           type: 'Text',
           children: [],
         },
@@ -29,20 +29,19 @@ const MOCK_DATA = {
 };
 
 describe('View Hierarchy Details Panel', function () {
-  it('omits id and children from rendered data', function () {
+  it('omits children from rendered data', function () {
     render(<DetailsPanel data={MOCK_DATA} />);
 
     expect(screen.getByRole('cell', {name: '200'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '201'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '202'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '203'})).toBeInTheDocument();
-    expect(screen.queryByRole('cell', {name: 'id'})).not.toBeInTheDocument();
     expect(screen.queryByRole('cell', {name: 'children'})).not.toBeInTheDocument();
   });
 
   it('accepts a custom title renderer', function () {
     const testGetTitle = jest.fn().mockImplementation(data => {
-      return `${data.type} - ${data.id}`;
+      return `${data.type} - ${data.identifier}`;
     });
     render(<DetailsPanel data={MOCK_DATA} getTitle={testGetTitle} />);
 

--- a/static/app/components/events/viewHierarchy/detailsPanel.tsx
+++ b/static/app/components/events/viewHierarchy/detailsPanel.tsx
@@ -14,13 +14,11 @@ type DetailsPanelProps = {
 };
 
 function DetailsPanel({data, getTitle}: DetailsPanelProps) {
-  const keyValueData = Object.entries(omit(data, 'id', 'children')).map(
-    ([key, value]) => ({
-      key,
-      value,
-      subject: key,
-    })
-  );
+  const keyValueData = Object.entries(omit(data, 'children')).map(([key, value]) => ({
+    key,
+    value,
+    subject: key,
+  }));
 
   return (
     <Container>

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -14,25 +14,22 @@ window.Element.prototype.scrollTo = jest.fn();
 window.Element.prototype.scrollIntoView = jest.fn();
 
 const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
-const MOCK_DATA = {
+const DEFAULT_MOCK_DATA = {
   rendering_system: 'test-rendering-system',
   windows: [
     {
       ...DEFAULT_VALUES,
-      id: 'parent',
       type: 'Container',
       identifier: 'test_identifier',
       x: 200,
       children: [
         {
           ...DEFAULT_VALUES,
-          id: 'intermediate',
           type: 'Nested Container',
           identifier: 'nested',
           children: [
             {
               ...DEFAULT_VALUES,
-              id: 'leaf',
               type: 'Text',
               children: [],
             },
@@ -44,6 +41,11 @@ const MOCK_DATA = {
 };
 
 describe('View Hierarchy', function () {
+  let MOCK_DATA;
+  beforeEach(() => {
+    MOCK_DATA = DEFAULT_MOCK_DATA;
+  });
+
   it('can continue make selections for inspecting data', function () {
     render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
 
@@ -106,5 +108,26 @@ describe('View Hierarchy', function () {
     userEvent.keyboard('{Enter}');
 
     expect(screen.getByText('Text')).toBeInTheDocument();
+  });
+
+  it('can render multiple windows together', function () {
+    MOCK_DATA.windows = [
+      ...MOCK_DATA.windows,
+      {
+        ...DEFAULT_VALUES,
+        type: 'Second Window',
+        children: [
+          {
+            ...DEFAULT_VALUES,
+            type: 'Second Window Child',
+            children: [],
+          },
+        ],
+      },
+    ];
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} />);
+
+    expect(screen.getByText('Second Window')).toBeInTheDocument();
+    expect(screen.getByText('Second Window Child')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -19,7 +19,6 @@ function getNodeLabel({identifier, type}: ViewHierarchyWindow) {
 export type ViewHierarchyWindow = {
   alpha: number;
   height: number;
-  id: string;
   type: string;
   visible: boolean;
   width: number;
@@ -43,13 +42,12 @@ function ViewHierarchy({viewHierarchy}: ViewHierarchyProps) {
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(
     null
   );
-  const [selectedWindow] = useState(0);
   const [selectedNode, setSelectedNode] = useState<ViewHierarchyWindow | undefined>(
     viewHierarchy.windows[0]
   );
   const hierarchy = useMemo(() => {
-    return [viewHierarchy.windows[selectedWindow]];
-  }, [selectedWindow, viewHierarchy.windows]);
+    return viewHierarchy.windows;
+  }, [viewHierarchy.windows]);
 
   const renderRow: UseVirtualizedListProps<ViewHierarchyWindow>['renderRow'] = (
     r,


### PR DESCRIPTION
We do not have to worry about the case of multiple view hierarchy attachments, but we do have to worry about multiple windows in a single attachment. We've decided to show all of the windows together, with separate windows as distinct root nodes.

This PR contains some cleanup to remove the `useState` calls I thought were needed to switch between the windows and also removes `id` as a property since it's not being used anymore. It used to be a value we generated to be keys for mapping the children, but the hook generates its own keys that we've started using. `id` here is different from `identifier`, which is a value we expect SDKs to send in the view hierarchy.