### PR TITLE
feat(perf): Register new feature flag for metrics-backed transaction summary

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1149,6 +1149,8 @@ SENTRY_FEATURES = {
     "organizations:performance-mep-bannerless-ui": False,
     # Enable updated landing page widget designs
     "organizations:performance-new-widget-designs": False,
+    # Enable metrics-backed transaction summary view
+    "organizations:performance-metrics-backed-transaction-summary": False,
     # Enable consecutive db performance issue type
     "organizations:performance-consecutive-db-issue": False,
     # Enable slow DB performance issue type

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -129,6 +129,7 @@ default_manager.add("organizations:performance-vitals-inp", OrganizationFeature,
 default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
 default_manager.add("organizations:performance-new-widget-designs", OrganizationFeature, True)
+default_manager.add("organizations:performance-metrics-backed-transaction-summary", OrganizationFeature, True)
 default_manager.add("organizations:performance-slow-db-issue", OrganizationFeature)
 default_manager.add("organizations:profiling", OrganizationFeature)
 default_manager.add("organizations:profiling-flamechart-spans", OrganizationFeature, True)


### PR DESCRIPTION
Register new [flag](https://flagr.getsentry.net/#/flags/304) `organizations:performance-metrics-backed-transaction-summary` to be used in conditionally using processed events dataset on the transaction summary page.