### PR TITLE
fix(n1-api-calls): Parameterize short hashes

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -61,18 +61,15 @@ URL_PARAMETER_REGEX = re.compile(
             [0-9a-fA-F]{12}
         \b
     ) |
-    (?P<sha1>
-        \b[0-9a-fA-F]{40}\b
-    ) |
-    (?P<md5>
-        \b[0-9a-fA-F]{32}\b
+    (?P<hashlike>
+        \b[0-9a-fA-F]{10}([0-9a-fA-F]{14})?([0-9a-fA-F]{8})?([0-9a-fA-F]{8})?\b
     ) |
     (?P<int>
         -\d+\b |
         \b\d+\b
     )
 """
-)  # From message.py
+)  # Adapted from message.py
 
 
 class DetectorType(Enum):

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -171,6 +171,22 @@ class NPlusOneAPICallsDetectorTest(TestCase):
             "/clients/hello-123s/project/1343",  # uuid-like
             "/clients/hello-123s/project/*",
         ),
+        (
+            "/item/5c9b9b609c172be2a013f534/details",  # short hash
+            "/item/*/details",
+        ),
+        (
+            "/item/be9a25322d/details",  # shorter short hash
+            "/item/*/details",
+        ),
+        (
+            "/item/defaced12/details",  # false short hash
+            "/item/defaced12/details",
+        ),
+        (
+            "/item/defaced12-abba/details",  # false short hash 2
+            "/item/defaced12-abba/details",
+        ),
     ],
 )
 def test_parameterizes_url(url, parameterized_url):


### PR DESCRIPTION
Some clients use parameters that _look_ like hashes, but they're not the right length, like `"563712f9722fb099"`. So far I've seen ones of length 10 (seems like an intuitive length to trim a long sha1 to) and 24 (unsure of this one, but it showed up). This PR expands the parameterization regex to include those length of hashes.

This should not cause any false positives because the longest English word that matches the hash-like regular expression is only 7 characters long. Besides, the tradeoff is well worth it, since the risk is so low, and it's incredibly unlikely this _actually_ causes fingerprint collapse.
