### PR TITLE
feat(scim): update APIs to respect idp flags

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -221,7 +221,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         if assigned_role and getattr(member.flags, "idp:role-restricted"):
             return Response(
                 {
-                    "role": "This user's role is managed through your organization's identity provider."
+                    "role": "This user's org-role is managed through your organization's identity provider."
                 },
                 status=403,
             )

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -145,6 +145,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         member: OrganizationMember,
         team_slug: str,
     ) -> Response:
+        omt = None
         try:
             omt = OrganizationMemberTeam.objects.get(
                 team__slug=team_slug, organizationmember=member
@@ -221,6 +222,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         except Team.DoesNotExist:
             raise ResourceDoesNotExist
 
+        omt = None
         try:
             omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
         except OrganizationMemberTeam.DoesNotExist:
@@ -288,6 +290,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         if not self._can_delete(request, member, team):
             return Response({"detail": ERR_INSUFFICIENT_ROLE}, status=400)
 
+        omt = None
         try:
             omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
         except OrganizationMemberTeam.DoesNotExist:

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -290,17 +290,17 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         if not self._can_delete(request, member, team):
             return Response({"detail": ERR_INSUFFICIENT_ROLE}, status=400)
 
-        omt = None
-        try:
-            omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
-        except OrganizationMemberTeam.DoesNotExist:
-            pass
-
         if team.idp_provisioned:
             return Response(
                 {"detail": "This team is managed through your organization's identity provider."},
                 status=403,
             )
+
+        omt = None
+        try:
+            omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
+        except OrganizationMemberTeam.DoesNotExist:
+            pass
 
         else:
             self.create_audit_entry(

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -27,6 +27,10 @@ class OrganizationMemberTeamTestBase(APITestCase):
         return self.create_team(organization=self.org)
 
     @cached_property
+    def idp_team(self):
+        return self.create_team(organization=self.org, idp_provisioned=True)
+
+    @cached_property
     def owner(self):
         return OrganizationMember.objects.get(organization=self.org, user=self.user)
 
@@ -199,6 +203,21 @@ class CreateWithOpenMembershipTest(OrganizationMemberTeamTestBase):
             team=self.team, organizationmember=self.admin
         ).exists()
 
+    def test_cannot_join_idp_team(self):
+        self.login_as(self.admin.user)
+        self.get_error_response(self.org.slug, self.admin.id, self.idp_team.slug, status_code=403)
+
+        assert not OrganizationMemberTeam.objects.filter(
+            team=self.team, organizationmember=self.admin
+        ).exists()
+
+        self.login_as(self.member.user)
+        self.get_error_response(self.org.slug, self.member.id, self.idp_team.slug, status_code=403)
+
+        assert not OrganizationMemberTeam.objects.filter(
+            team=self.team, organizationmember=self.member
+        ).exists()
+
     def test_member_can_add_member_to_team(self):
         target_member = self.create_member(
             organization=self.org, user=self.create_user(), role="member"
@@ -220,6 +239,27 @@ class CreateWithOpenMembershipTest(OrganizationMemberTeamTestBase):
         )
 
         assert OrganizationMemberTeam.objects.filter(
+            team=self.team, organizationmember=self.member
+        ).exists()
+
+    def test_cannot_add_to_idp_team(self):
+        target_member = self.create_member(
+            organization=self.org, user=self.create_user(), role="member"
+        )
+
+        self.login_as(self.member.user)
+        self.get_error_response(
+            self.org.slug, target_member.id, self.idp_team.slug, status_code=403
+        )
+
+        assert not OrganizationMemberTeam.objects.filter(
+            team=self.team, organizationmember=target_member
+        ).exists()
+
+        self.login_as(self.admin.user)
+        self.get_error_response(self.org.slug, self.member.id, self.idp_team.slug, status_code=403)
+
+        assert not OrganizationMemberTeam.objects.filter(
             team=self.team, organizationmember=self.member
         ).exists()
 
@@ -473,6 +513,23 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         assert not ax_after_leaving.has_team_access(team)
         assert not ax_after_leaving.has_project_access(project)
         assert not ax_after_leaving.has_project_membership(project)
+
+    def test_cannot_leave_idp_provisioned_team(self):
+        user = self.create_user()
+        organization = self.create_organization(flags=0)
+        idp_team = self.create_team(organization=organization, idp_provisioned=True)
+        member = self.create_member(organization=organization, user=user, teams=[idp_team])
+
+        self.login_as(user)
+        self.get_error_response(
+            organization.slug,
+            member.id,
+            idp_team.slug,
+            status_code=403,
+        )
+        assert OrganizationMemberTeam.objects.filter(
+            team=idp_team, organizationmember=member
+        ).exists()
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
SCIM for roles adds flags to the `OrganizationMember` model if they are provisioned through an IdP (`idp:provisioned`) and if they have their Sentry org role set through an IdP (`idp:role-restricted`). We also set the `idp_provisioned` field on the `Team` model if a team is provisioned through an IdP.

The frontend has some features disabled if these flags / fields are True (#42152), but people can still go through the API to bypass the limitations from the frontend, so those capabilities should be restricted on the backend as well.

`OrganizationMember`
- `PUT`: Cannot change role if member is `idp:role-restricted`
- `DELETE`: Cannot remove member if they’re `idp:provisioned`

`OrganizationMemberTeam`
- `POST`: Cannot join or request to join a team that is `idp_provisioned`
- `DELETE`: Cannot leave a team that is `idp_provisioned`


For ER-1249