### PR TITLE
Revert "ref(tsdb): port over non-outcomes tsdb models to use SnQL (#4…

### DIFF
--- a/src/sentry/issues/query.py
+++ b/src/sentry/issues/query.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Optional
-
-from snuba_sdk import Column, Function
-from snuba_sdk.query import SelectableExpression
+from typing import TYPE_CHECKING, Any, List
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
@@ -12,44 +9,3 @@ if TYPE_CHECKING:
 def apply_performance_conditions(conditions: List[Any], group: Group) -> List[Any]:
     conditions.append([["has", ["group_ids", group.id]], "=", 1])
     return conditions
-
-
-def manual_group_on_time_aggregation(rollup: int, time_column_alias: str) -> SelectableExpression:
-    def rollup_agg(rollup_granularity: int, alias: str) -> Optional[SelectableExpression]:
-        if rollup_granularity == 60:
-            return Function(
-                "toUnixTimestamp", [Function("toStartOfMinute", [Column("timestamp")])], alias
-            )
-        elif rollup_granularity == 3600:
-            return Function(
-                "toUnixTimestamp", [Function("toStartOfHour", [Column("timestamp")])], alias
-            )
-        elif rollup_granularity == 3600 * 24:
-            return Function(
-                "toUnixTimestamp",
-                [Function("toDateTime", [Function("toDate", [Column("timestamp")])])],
-                alias,
-            )
-        else:
-            return None
-
-    # if we don't have an explicit function mapped to this rollup, we have to calculate it on the fly
-    # multiply(intDiv(toUInt32(toUnixTimestamp(timestamp)), granularity)))
-    synthetic_rollup = Function(
-        "multiply",
-        [
-            Function(
-                "intDiv",
-                [
-                    Function("toUInt32", [Function("toUnixTimestamp", [Column("timestamp")])]),
-                    rollup,
-                ],
-            ),
-            rollup,
-        ],
-        time_column_alias,
-    )
-
-    known_rollups = rollup_agg(rollup, time_column_alias)
-
-    return known_rollups if known_rollups else synthetic_rollup

--- a/src/sentry/search/events/builder/issue_platform.py
+++ b/src/sentry/search/events/builder/issue_platform.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
-from sentry.issues.query import manual_group_on_time_aggregation
+from snuba_sdk import Column, Function
+
 from sentry.search.events.builder import TimeseriesQueryBuilder
 from sentry.search.events.types import ParamsType
 from sentry.utils.snuba import Dataset
@@ -33,5 +34,39 @@ class IssuePlatformTimeseriesQueryBuilder(TimeseriesQueryBuilder):
             has_metrics=has_metrics,
             skip_tag_resolution=skip_tag_resolution,
         )
-        self.time_column = manual_group_on_time_aggregation(interval, "time")
+        rollup_to_start_func = {
+            60: "toStartOfMinute",
+            3600: "toStartOfHour",
+            3600 * 24: "toDate",
+        }
+        rollup_func = rollup_to_start_func.get(interval)
+        if rollup_func:
+            if rollup_func == "toDate":
+                self.time_column = Function(
+                    "toUnixTimestamp",
+                    [Function("toDateTime", [Function(rollup_func, [Column("timestamp")])])],
+                    alias="time",
+                )
+            else:
+                self.time_column = Function(
+                    "toUnixTimestamp", [Function(rollup_func, [Column("timestamp")])], alias="time"
+                )
+        else:
+            self.time_column = Function(
+                "multiply",
+                [
+                    Function(
+                        "intDiv",
+                        [
+                            Function(
+                                "toUInt32", [Function("toUnixTimestamp", [Column("timestamp")])]
+                            ),
+                            interval,
+                        ],
+                    ),
+                    interval,
+                ],
+                alias="time",
+            )
+
         self.groupby = [self.time_column]

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -50,7 +50,6 @@ from sentry.utils.hashlib import md5_text
 from sentry.utils.snuba import (
     _prepare_start_end,
     get_organization_id_from_project_ids,
-    get_snuba_translators,
     nest_groups,
     raw_snql_query,
 )
@@ -97,14 +96,16 @@ def get_project_list(project_id):
 
 
 def _translate_filter_keys(project_ids, group_ids, environment_ids) -> Dict[str, Any]:
-    filter_keys = {"project_id": project_ids}
+    from sentry.utils.snuba import get_snuba_translators
 
+    filter_keys = {"project_id": project_ids}
     if environment_ids:
         filter_keys["environment"] = environment_ids
     if group_ids:
         filter_keys["group_id"] = group_ids
 
     forward, reverse = get_snuba_translators(filter_keys, is_grouprelease=False)
+
     return forward(filter_keys)
 
 

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -18,22 +18,16 @@ from snuba_sdk import (
     Request,
 )
 from snuba_sdk.conditions import Condition, ConditionGroup, Op
-from snuba_sdk.entity import get_required_time_column
 from snuba_sdk.legacy import parse_condition
 from snuba_sdk.query import SelectableExpression
 
 from sentry.constants import DataCategory
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
-from sentry.issues.query import manual_group_on_time_aggregation
+from sentry.tagstore.snuba.backend import _translate_filter_keys
 from sentry.tsdb.base import BaseTSDB, TSDBModel
 from sentry.utils import outcomes, snuba
 from sentry.utils.dates import to_datetime
-from sentry.utils.snuba import (
-    get_snuba_translators,
-    infer_project_ids_from_related_models,
-    nest_groups,
-    raw_snql_query,
-)
+from sentry.utils.snuba import infer_project_ids_from_related_models, nest_groups, raw_snql_query
 
 
 @dataclasses.dataclass
@@ -80,6 +74,54 @@ class SnubaTSDB(BaseTSDB):
     Read methods are supported only for models based on group/event data and
     will return empty results for unsupported models.
     """
+
+    # Since transactions are currently (and temporarily) written to Snuba's events storage we need to
+    # include this condition to ensure they are excluded from the query. Once we switch to the
+    # errors storage in Snuba, this can be omitted and transactions will be excluded by default.
+    events_type_condition = ["type", "!=", "transaction"]
+    # ``non_outcomes_query_settings`` are all the query settings for non outcomes based TSDB models.
+    # Single tenant reads Snuba for these models, and writes to DummyTSDB. It reads and writes to Redis for all the
+    # other models.
+    non_outcomes_query_settings = {
+        TSDBModel.project: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "project_id", None, [events_type_condition]
+        ),
+        TSDBModel.group: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "group_id", None, [events_type_condition]
+        ),
+        TSDBModel.group_performance: SnubaModelQuerySettings(
+            snuba.Dataset.Transactions,
+            "group_id",
+            None,
+            [],
+            [["arrayJoin", "group_ids", "group_id"]],
+        ),
+        TSDBModel.release: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "tags[sentry:release]", None, [events_type_condition]
+        ),
+        TSDBModel.users_affected_by_group: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "group_id", "tags[sentry:user]", [events_type_condition]
+        ),
+        TSDBModel.users_affected_by_perf_group: SnubaModelQuerySettings(
+            snuba.Dataset.Transactions,
+            "group_id",
+            "tags[sentry:user]",
+            [],
+            [["arrayJoin", "group_ids", "group_id"]],
+        ),
+        TSDBModel.users_affected_by_project: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "project_id", "tags[sentry:user]", [events_type_condition]
+        ),
+        TSDBModel.frequent_environments_by_group: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "group_id", "environment", [events_type_condition]
+        ),
+        TSDBModel.frequent_releases_by_group: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "group_id", "tags[sentry:release]", [events_type_condition]
+        ),
+        TSDBModel.frequent_issues_by_project: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "project_id", "group_id", [events_type_condition]
+        ),
+    }
 
     # ``project_filter_model_query_settings`` and ``outcomes_partial_query_settings`` are all the TSDB models for
     # outcomes
@@ -157,46 +199,8 @@ class SnubaTSDB(BaseTSDB):
         ),
     }
 
-    # ``non_outcomes_query_settings`` are all the query settings for non outcomes based TSDB models.
-    # Single tenant reads Snuba for these models, and writes to DummyTSDB. It reads and writes to Redis for all the
-    # other models.
     # these query settings should use SnQL style parameters instead of the legacy format
     non_outcomes_snql_query_settings = {
-        TSDBModel.project: SnubaModelQuerySettings(snuba.Dataset.Events, "project_id", None, []),
-        TSDBModel.group: SnubaModelQuerySettings(snuba.Dataset.Events, "group_id", None, []),
-        TSDBModel.group_performance: SnubaModelQuerySettings(
-            snuba.Dataset.Transactions,
-            "group_id",
-            None,
-            [],
-            # [["arrayJoin", "group_ids", "group_id"]],
-            [Function("arrayJoin", [Column("group_ids")], "group_id")],
-        ),
-        TSDBModel.release: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "tags[sentry:release]", None, []
-        ),
-        TSDBModel.users_affected_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "tags[sentry:user]", []
-        ),
-        TSDBModel.users_affected_by_perf_group: SnubaModelQuerySettings(
-            snuba.Dataset.Transactions,
-            "group_id",
-            "tags[sentry:user]",
-            [],
-            [Function("arrayJoin", [Column("group_ids")], "group_id")],
-        ),
-        TSDBModel.users_affected_by_project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", "tags[sentry:user]", []
-        ),
-        TSDBModel.frequent_environments_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "environment", []
-        ),
-        TSDBModel.frequent_releases_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "tags[sentry:release]", []
-        ),
-        TSDBModel.frequent_issues_by_project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", "group_id", []
-        ),
         TSDBModel.group_generic: SnubaModelQuerySettings(
             snuba.Dataset.IssuePlatform,
             "group_id",
@@ -218,6 +222,7 @@ class SnubaTSDB(BaseTSDB):
         itertools.chain(
             project_filter_model_query_settings.items(),
             outcomes_partial_query_settings.items(),
+            non_outcomes_query_settings.items(),
             non_outcomes_snql_query_settings.items(),
         )
     )
@@ -259,6 +264,48 @@ class SnubaTSDB(BaseTSDB):
 
         return known_rollups if known_rollups else synthetic_rollup
 
+    def __manual_group_on_time_aggregation_sqnl(
+        self, rollup, time_column_alias
+    ) -> SelectableExpression:
+        def rollup_agg(rollup_granularity: int, alias: str):
+            if rollup_granularity == 60:
+                return Function(
+                    "toUnixTimestamp", [Function("toStartOfMinute", [Column("timestamp")])], alias
+                )
+            elif rollup_granularity == 3600:
+                return Function(
+                    "toUnixTimestamp", [Function("toStartOfHour", [Column("timestamp")])], alias
+                )
+            elif rollup_granularity == 3600 * 24:
+                return Function(
+                    "toUnixTimestamp",
+                    [Function("toDateTime", [Function("toDate", [Column("timestamp")])])],
+                    alias,
+                )
+            else:
+                return None
+
+        # if we don't have an explicit function mapped to this rollup, we have to calculate it on the fly
+        # multiply(intDiv(toUInt32(toUnixTimestamp(timestamp)), granularity)))
+        synthetic_rollup = Function(
+            "multiply",
+            [
+                Function(
+                    "intDiv",
+                    [
+                        Function("toUInt32", [Function("toUnixTimestamp", [Column("timestamp")])]),
+                        rollup,
+                    ],
+                ),
+                rollup,
+            ],
+            time_column_alias,
+        )
+
+        known_rollups = rollup_agg(rollup, time_column_alias)
+
+        return known_rollups if known_rollups else synthetic_rollup
+
     def get_data(
         self,
         model,
@@ -293,7 +340,6 @@ class SnubaTSDB(BaseTSDB):
                 manual_group_on_time=(
                     model in (TSDBModel.group_generic, TSDBModel.users_affected_by_generic_group)
                 ),
-                is_grouprelease=(model == TSDBModel.frequent_releases_by_group),
             )
         else:
             return self.__get_data_legacy(
@@ -326,7 +372,6 @@ class SnubaTSDB(BaseTSDB):
         use_cache: bool = False,
         jitter_value: Optional[int] = None,
         manual_group_on_time: bool = False,
-        is_grouprelease: bool = False,
     ):
         """
         Similar to __get_data_legacy but uses the SnQL format. For future additions, prefer using this impl over
@@ -377,7 +422,7 @@ class SnubaTSDB(BaseTSDB):
         ]
 
         if group_on_time and manual_group_on_time:
-            aggregations.append(manual_group_on_time_aggregation(rollup, "time"))
+            aggregations.append(self.__manual_group_on_time_aggregation_sqnl(rollup, "time"))
 
         if keys:
             start = to_datetime(series[0])
@@ -397,38 +442,32 @@ class SnubaTSDB(BaseTSDB):
                 conditions += model_query_settings.conditions
 
             project_ids = infer_project_ids_from_related_models(keys_map)
-            keys_map["project_id"] = project_ids
-            forward, reverse = get_snuba_translators(keys_map, is_grouprelease)
+            group_ids = keys_map.get("group_id")
+            env_ids = keys_map.get("environment")
+
+            translated_filter_keys = _translate_filter_keys(project_ids, group_ids, env_ids)
 
             # resolve filter_key values to the right values environment.id -> environment.name, etc.
-            mapped_filter_conditions = []
-            for col, f_keys in forward(deepcopy(keys_map)).items():
-                if f_keys:
-                    if len(f_keys) == 1 and None in f_keys:
-                        mapped_filter_conditions.append(Condition(Column(col), Op.IS_NULL))
-                    else:
-                        mapped_filter_conditions.append(Condition(Column(col), Op.IN, f_keys))
-
-            where_conds = conditions + mapped_filter_conditions
-            if manual_group_on_time:
-                where_conds += [
+            mapped_filter_conditions = [
+                Condition(Column(k), Op.IN, list(v)) for k, v in translated_filter_keys.items()
+            ]
+            # map filter keys to conditional expressions
+            where_conds = (
+                [
                     Condition(Column("timestamp"), Op.GTE, start),
                     Condition(Column("timestamp"), Op.LT, end),
                 ]
-            else:
-                time_column = get_required_time_column(model_dataset.value)
-                if time_column:
-                    where_conds += [
-                        Condition(Column(time_column), Op.GTE, start),
-                        Condition(Column(time_column), Op.LT, end),
-                    ]
+                + conditions
+                + mapped_filter_conditions
+            )
 
             snql_request = Request(
                 dataset=model_dataset.value,
                 app_id="tsdb.get_data",
                 query=Query(
                     match=Entity(model_dataset.value),
-                    select=(model_query_settings.selected_columns or []) + aggregations,
+                    select=[Column(s) for s in model_query_settings.selected_columns or ()]
+                    + aggregations,
                     where=where_conds,
                     groupby=[Column(g) for g in groupby] if groupby else None,
                     orderby=orderby,
@@ -439,12 +478,8 @@ class SnubaTSDB(BaseTSDB):
             query_result = raw_snql_query(
                 snql_request, referrer=f"tsdb-modelid:{model.value}", use_cache=use_cache
             )
-            if manual_group_on_time:
-                translated_results = {"data": query_result["data"]}
-            else:
-                translated_results = {"data": [reverse(d) for d in query_result["data"]]}
-            result = nest_groups(translated_results["data"], groupby, [aggregated_as])
 
+            result = nest_groups(query_result["data"], groupby, [aggregated_as])
         else:
             # don't bother querying snuba since we probably won't have the proper filter conditions to return
             # reasonable data (invalid query)

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytz
-from snuba_sdk import Limit
 
 from sentry.models import Environment, Group, GroupRelease, Release
 from sentry.testutils import SnubaTestCase, TestCase
@@ -485,27 +484,26 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
 
     def test_calculated_limit(self):
 
-        with patch("sentry.tsdb.snuba.raw_snql_query") as snuba:
+        with patch("sentry.tsdb.snuba.snuba") as snuba:
             # 24h test
             rollup = 3600
             end = self.now
             start = end + timedelta(days=-1, seconds=rollup)
             self.db.get_data(TSDBModel.group, [1, 2, 3, 4, 5], start, end, rollup=rollup)
-
-            assert snuba.call_args.args[0].query.limit == Limit(120)
+            assert snuba.query.call_args[1]["limit"] == 120
 
             # 14 day test
             rollup = 86400
             start = end + timedelta(days=-14, seconds=rollup)
             self.db.get_data(TSDBModel.group, [1, 2, 3, 4, 5], start, end, rollup=rollup)
-            assert snuba.call_args.args[0].query.limit == Limit(70)
+            assert snuba.query.call_args[1]["limit"] == 70
 
             # 1h test
             rollup = 3600
             end = self.now
             start = end + timedelta(hours=-1, seconds=rollup)
             self.db.get_data(TSDBModel.group, [1, 2, 3, 4, 5], start, end, rollup=rollup)
-            assert snuba.call_args.args[0].query.limit == Limit(5)
+            assert snuba.query.call_args[1]["limit"] == 5
 
 
 @region_silo_test


### PR DESCRIPTION
…3674)"

This reverts commit a91f19836055cd76f5747e03e18d3da8c412df4c.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
