### PR TITLE
fix(metrics): use upstream retention_days from relay

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -344,7 +344,9 @@ class IndexerBatch:
                     )
                 continue
 
-            new_payload_value["retention_days"] = 90
+            if "retention_days" not in new_payload_value:
+                new_payload_value["retention_days"] = 90
+
             new_payload_value["mapping_meta"] = output_message_meta
             new_payload_value["use_case_id"] = self.use_case_id.value
 

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -344,8 +344,7 @@ class IndexerBatch:
                     )
                 continue
 
-            if "retention_days" not in new_payload_value:
-                new_payload_value["retention_days"] = 90
+            new_payload_value["retention_days"] = new_payload_value.get("retention_days", 90)
 
             new_payload_value["mapping_meta"] = output_message_meta
             new_payload_value["use_case_id"] = self.use_case_id.value


### PR DESCRIPTION
Following https://github.com/getsentry/relay/pull/1780 we are going to rely on the upstream retention_days set for metrics, falling back to current default 90 if TTL isn't set