### PR TITLE
fix(profiling): ts fails to infer | null

### DIFF
--- a/static/app/utils/profiling/hooks/useCurrentProjectFromRouteParam.tsx
+++ b/static/app/utils/profiling/hooks/useCurrentProjectFromRouteParam.tsx
@@ -1,7 +1,8 @@
+import {Project} from 'sentry/types';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 
-export function useCurrentProjectFromRouteParam() {
+export function useCurrentProjectFromRouteParam(): Project | null {
   const params = useParams();
   const projects = useProjects({limit: 1, slugs: [params?.projectId]});
   return projects.projects?.[0] ?? null;

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -122,13 +122,13 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
       {
         type: 'profile summary',
         payload: {
-          projectSlug: project.slug,
+          projectSlug: project?.slug ?? '',
           query: props.location.query,
           transaction: transaction ?? '',
         },
       },
     ];
-  }, [props.location.query, project.slug, transaction]);
+  }, [props.location.query, project?.slug, transaction]);
 
   return (
     <SentryDocumentTitle


### PR DESCRIPTION
It seems TS fails to infer Project|null return type which caused a runtime error when we attempted to access project.slug property on null

<img width="463" alt="CleanShot 2023-01-26 at 16 57 13@2x" src="https://user-images.githubusercontent.com/9317857/214966041-7e142dee-149f-46d5-9f3f-bc66476aef01.png">
