### PR TITLE
fix(crons): Constrain clipboard zone for monitor header

### DIFF
--- a/static/app/views/monitors/monitorHeader.tsx
+++ b/static/app/views/monitors/monitorHeader.tsx
@@ -76,6 +76,7 @@ const MonitorId = styled('div')`
   margin-top: ${space(1)};
   color: ${p => p.theme.subText};
   cursor: pointer;
+  width: max-content;
 `;
 
 const MonitorStats = styled('div')`


### PR DESCRIPTION
Previously a very large area was clickable.

Before:
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/9372512/214972163-2a1916a0-2cf6-4146-bd2e-fc1eaf498298.png">


After:
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/9372512/214972192-fce0768b-83b6-4ce2-932d-1c2dff9c6275.png">
