### PR TITLE
fix(issues): Prevent stacktrace link fetch on share page

### DIFF
--- a/static/app/components/events/interfaces/frame/codecovLegend.tsx
+++ b/static/app/components/events/interfaces/frame/codecovLegend.tsx
@@ -6,6 +6,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Event, Frame, Organization} from 'sentry/types';
 import {CodecovStatusCode} from 'sentry/types/integrations';
+import {defined} from 'sentry/utils';
 import useProjects from 'sentry/utils/useProjects';
 
 import useStacktraceLink from './useStacktraceLink';
@@ -23,12 +24,15 @@ export function CodecovLegend({event, frame, organization}: CodecovLegendProps) 
     [projects, event]
   );
 
-  const {data, isLoading} = useStacktraceLink({
-    event,
-    frame,
-    orgSlug: organization?.slug || '',
-    projectSlug: project?.slug,
-  });
+  const {data, isLoading} = useStacktraceLink(
+    {
+      event,
+      frame,
+      orgSlug: organization?.slug || '',
+      projectSlug: project?.slug,
+    },
+    {enabled: defined(project) && defined(organization)}
+  );
 
   if (isLoading || !data || !data.codecov) {
     return null;

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -109,8 +109,9 @@ const Context = ({
     },
     {
       enabled:
-        organization?.features.includes('codecov-stacktrace-integration') &&
-        organization?.codecovAccess &&
+        defined(organization) &&
+        organization.features.includes('codecov-stacktrace-integration') &&
+        organization.codecovAccess &&
         isExpanded,
     }
   );

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -111,7 +111,7 @@ const Context = ({
       enabled:
         defined(organization) &&
         defined(project) &&
-        organization.codecovAccess &&
+        !!organization.codecovAccess &&
         organization.features.includes('codecov-stacktrace-integration') &&
         isExpanded,
     }

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -110,8 +110,9 @@ const Context = ({
     {
       enabled:
         defined(organization) &&
-        organization.features.includes('codecov-stacktrace-integration') &&
+        defined(project) &&
         organization.codecovAccess &&
+        organization.features.includes('codecov-stacktrace-integration') &&
         isExpanded,
     }
   );

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -25,6 +25,7 @@ import {
   Project,
   StacktraceLinkResult,
 } from 'sentry/types';
+import {defined} from 'sentry/utils';
 import {StacktraceLinkEvents} from 'sentry/utils/analytics/integrations/stacktraceLinkAnalyticsEvents';
 import {getAnalyicsDataForEvent} from 'sentry/utils/events';
 import {
@@ -210,12 +211,17 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     data: match,
     isLoading,
     refetch,
-  } = useStacktraceLink({
-    event,
-    frame,
-    orgSlug: organization.slug,
-    projectSlug: project?.slug,
-  });
+  } = useStacktraceLink(
+    {
+      event,
+      frame,
+      orgSlug: organization.slug,
+      projectSlug: project?.slug,
+    },
+    {
+      enabled: defined(project),
+    }
+  );
 
   useEffect(() => {
     if (isLoading || prompt.isLoading || !match) {

--- a/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
@@ -34,6 +34,7 @@ function useStacktraceLink(
     {
       staleTime: Infinity,
       retry: false,
+      refetchOnWindowFocus: false,
       ...options,
     }
   );


### PR DESCRIPTION
since org is undefined enabled was undefined, adds a few more checks for the required variables
