### PR TITLE
Revert "feat(crons): Remove frontend feature checks"

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -229,14 +229,16 @@ function Sidebar({location, organization}: Props) {
   );
 
   const monitors = hasOrganization && (
-    <SidebarItem
-      {...sidebarItemProps}
-      icon={<IconTimer size="md" />}
-      label={t('Crons')}
-      to={`/organizations/${organization.slug}/crons/`}
-      id="crons"
-      isBeta
-    />
+    <Feature features={['monitors']} organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        icon={<IconTimer size="md" />}
+        label={t('Crons')}
+        to={`/organizations/${organization.slug}/crons/`}
+        id="crons"
+        isBeta
+      />
+    </Feature>
   );
 
   const replays = hasOrganization && (

--- a/static/app/views/monitors/index.tsx
+++ b/static/app/views/monitors/index.tsx
@@ -1,8 +1,13 @@
+import Feature from 'sentry/components/acl/feature';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
 const MonitorsContainer: React.FC = ({children}) => {
-  return <PageFiltersContainer>{children}</PageFiltersContainer>;
+  return (
+    <Feature features={['monitors']} renderDisabled>
+      <PageFiltersContainer>{children}</PageFiltersContainer>
+    </Feature>
+  );
 };
 
 export default withPageFilters(MonitorsContainer);


### PR DESCRIPTION
Reverts getsentry/sentry#43526

can't be removed yet because it shouldn't be showing for single tenant