### PR TITLE
feat(endpoint): Introduce MissingReleaseFiles endpoint to improve upload performance

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_release_files.py
+++ b/src/sentry/api/endpoints/organization_missing_release_files.py
@@ -1,0 +1,34 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
+from sentry.api.endpoints.project_release_files import ReleaseFilesMixin
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import Release
+
+
+@region_silo_endpoint
+class OrganizationMissingReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseFilesMixin):
+    def get(self, request: Request, organization, version) -> Response:
+        """
+        List a Missing Organization Release's Files based on provided checksums
+        ````````````````````````````````````
+
+        Retrieve a list of files for a given release.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string version: the version identifier of the release.
+        :qparam string[] checksums: checksums to be used for filtering.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(organization_id=organization.id, version=version)
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise ResourceDoesNotExist
+
+        return self.find_missing_releasefiles(request, release)

--- a/src/sentry/api/endpoints/project_missing_release_files.py
+++ b/src/sentry/api/endpoints/project_missing_release_files.py
@@ -1,0 +1,37 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.endpoints.project_release_files import ReleaseFilesMixin
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import Release
+
+
+@region_silo_endpoint
+class ProjectMissingReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
+    permission_classes = (ProjectReleasePermission,)
+
+    def get(self, request: Request, project, version) -> Response:
+        """
+        List a Missing Project Release's Files based on provided checksums
+        ````````````````````````````````````
+
+        Retrieve a list of files for a given release.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to list the
+                                     release files of.
+        :pparam string version: the version identifier of the release.
+        :qparam string[] checksums: checksums to be used for filtering.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id, projects=project, version=version
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return self.find_missing_releasefiles(request, release)

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -162,6 +162,11 @@ class ReleaseFilesMixin:
 
         return Response(serialize(releasefile, request.user), status=201)
 
+    def find_missing_releasefiles(self, request: Request, release) -> Response:
+        checksums = request.GET.getlist("checksums")
+        missing = ReleaseFile.objects.find_missing(checksums, release=release)
+        return Response(missing)
+
 
 class ArtifactSource:
     """Provides artifact data to ChainPaginator on-demand"""

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -310,6 +310,7 @@ from .endpoints.organization_metrics_meta import (
     OrganizationMetricsCompatibility,
     OrganizationMetricsCompatibilitySums,
 )
+from .endpoints.organization_missing_release_files import OrganizationMissingReleaseFilesEndpoint
 from .endpoints.organization_monitors import OrganizationMonitorsEndpoint
 from .endpoints.organization_onboarding_continuation_email import (
     OrganizationOnboardingContinuationEmail,
@@ -390,6 +391,7 @@ from .endpoints.project_key_details import ProjectKeyDetailsEndpoint
 from .endpoints.project_key_stats import ProjectKeyStatsEndpoint
 from .endpoints.project_keys import ProjectKeysEndpoint
 from .endpoints.project_member_index import ProjectMemberIndexEndpoint
+from .endpoints.project_missing_release_files import ProjectMissingReleaseFilesEndpoint
 from .endpoints.project_ownership import ProjectOwnershipEndpoint
 from .endpoints.project_performance_issue_settings import ProjectPerformanceIssueSettingsEndpoint
 from .endpoints.project_platforms import ProjectPlatformsEndpoint
@@ -1472,6 +1474,11 @@ urlpatterns = [
                     name="sentry-api-0-organization-release-file-details",
                 ),
                 url(
+                    r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/missing-files/$",
+                    OrganizationMissingReleaseFilesEndpoint.as_view(),
+                    name="sentry-api-0-organization-missing-release-files",
+                ),
+                url(
                     r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/commitfiles/$",
                     CommitFileChangeEndpoint.as_view(),
                     name="sentry-api-0-release-commitfilechange",
@@ -2066,6 +2073,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/files/(?P<file_id>[^/]+)/$",
                     ProjectReleaseFileDetailsEndpoint.as_view(),
                     name="sentry-api-0-project-release-file-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/(?P<version>[^/]+)/missing-files/$",
+                    ProjectMissingReleaseFilesEndpoint.as_view(),
+                    name="sentry-api-0-project-missing-release-files",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/$",


### PR DESCRIPTION
Replaced by https://github.com/getsentry/sentry/pull/44016

---

Last year, sentry-cli introduced a feature, that queries our Sentry releases in order to decide what files should be uploaded.
Prior to this change, no matter what was the state of an archive, everything was sent straight away, whether it was already there or not.

The change works by calling `/api/0/projects/<org>/<proj>/releases/<version>/files/` and then using the received data to compare checksums of local files, with those that already live on our servers.
The problem, however, is that this endpoint is paginated, and there are cases, where people have thousands of files, which result in hundreds of API calls, draining their quota and sometimes resulting in `429`s.

The solution to this would be replicating the behavior of our dif-upload, which sends a request to the special endpoint and gives it precalculated hashes of all files that are about to be uploaded. The server then collects all the files it already has, and discards those already present from the provided list. The list is then returned to the sender, and it now knows what files should be uploaded. 

~This PR aims to do just that, with one large caveat; we don't store `sha1` field of each file in the database. It's calculated on the fly inside `update_artifact_index` function by calling `_compute_sha1(archive, filename)`. This makes it impossible to perform an optimized query that'll make this whole thing work, as currently `ReleaseFile.objects.filter(ident__in=checksums)` is incorrect (as `ident` is not `sha1` of the file, but rather its `name/dist` pair) and `values("sha1")` is not possible to be extracted, as this field doesn't exist.~

Edit: we do in the foreign model under `releasefile.file.checksum`.

An alternative to creating a separate API endpoint would be to greatly extend `OrganizationReleaseFilesEndpoint` and `ProjectReleaseFilesEndpoint` (which use the same `ReleaseFilesMixin` under the hood for release files fetching), and allow `/files` endpoint to accept a predefined set of filter queries.

In the near future, we'll need similar functionality for the symbolicator, to query for files' existence based on the set of filenames, so maybe the second idea is even better.

WDYT? I'd love to get some help with this task, as it's mostly outside of my scope.