### PR TITLE
feat(replays): Move timestamp column to the left of console tab

### DIFF
--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -72,6 +72,11 @@ function ConsoleMessage({breadcrumb, breadcrumbs, startTimestampMs, style}: Prop
       style={style}
     >
       <Icon level={breadcrumb.level} />
+      <TimestampButton
+        onClick={onClickTimestamp}
+        startTimestampMs={startTimestampMs}
+        timestampMs={breadcrumb.timestamp || ''}
+      />
       <Message>
         {breadcrumbHasIssue(breadcrumb) ? (
           <IssueLinkWrapper>
@@ -82,11 +87,6 @@ function ConsoleMessage({breadcrumb, breadcrumbs, startTimestampMs, style}: Prop
           <MessageFormatter breadcrumb={breadcrumb} />
         </ErrorBoundary>
       </Message>
-      <TimestampButton
-        onClick={onClickTimestamp}
-        startTimestampMs={startTimestampMs}
-        timestampMs={breadcrumb.timestamp || ''}
-      />
     </ConsoleLog>
   );
 }


### PR DESCRIPTION
<img width="572" alt="SCR-20230127-eo1" src="https://user-images.githubusercontent.com/187460/215124988-e208986c-379b-4e29-80aa-14b1aab836c1.png">
