### PR TITLE
ref: fix xdist initialization in getsentry

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -308,7 +308,7 @@ def show_big_error(message: str | list[str]) -> None:
 def initialize_app(config: dict[str, Any], skip_service_validation: bool = False) -> None:
     settings = config["settings"]
 
-    if settings.DEBUG:
+    if settings.DEBUG and hasattr(sys.stderr, "fileno"):
         # Enable line buffering for stderr, TODO(py3.9) can be removed after py3.9, see bpo-13601
         sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 1)
         sys.stdout = os.fdopen(sys.stdout.fileno(), "w", 1)


### PR DESCRIPTION
this was failing before with:

```
INTERNALERROR>   File "/Users/asottile/workspace/sentry/src/sentry/utils/pytest/sentry.py", line 220, in pytest_configure
INTERNALERROR>     initialize_app({"settings": settings, "options": None})
INTERNALERROR>   File "/Users/asottile/workspace/sentry/src/sentry/runner/initializer.py", line 313, in initialize_app
INTERNALERROR>     sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 1)
INTERNALERROR> AttributeError: 'ChannelFileWrite' object has no attribute 'fileno'
```




<!-- Describe your PR here. -->