### PR TITLE
feat(profiling): add wasd navigation to profiling view

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -62,6 +62,7 @@ import {useProfileTransaction} from 'sentry/views/profiling/profileGroupProvider
 
 import {FlamegraphDrawer} from './flamegraphDrawer/flamegraphDrawer';
 import {FlamegraphWarnings} from './flamegraphOverlays/FlamegraphWarnings';
+import {useViewKeyboardNavigation} from './interactions/useViewKeyboardNavigation';
 import {FlamegraphLayout} from './flamegraphLayout';
 import {FlamegraphSpans} from './flamegraphSpans';
 import {FlamegraphUIFrames} from './flamegraphUIFrames';
@@ -425,6 +426,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
   useEffect(() => {
     if (flamegraphView && spansView) {
       const minWidthBetweenViews = Math.min(flamegraphView.minWidth, spansView.minWidth);
+
       flamegraphView.setMinWidth(minWidthBetweenViews);
       spansView.setMinWidth(minWidthBetweenViews);
 
@@ -643,6 +645,9 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
     },
     [flamegraphRenderer]
   );
+
+  // Register keyboard navigation
+  useViewKeyboardNavigation(flamegraphView, canvasPoolManager);
 
   // referenceNode is passed down to the flamegraphdrawer and is used to determine
   // the weights of each frame. In other words, in case there is no user selected root, then all

--- a/static/app/components/profiling/flamegraph/interactions/useCanvasScroll.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useCanvasScroll.tsx
@@ -1,9 +1,9 @@
 import {useCallback} from 'react';
-import {mat3, vec2} from 'gl-matrix';
 
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {getTranslationMatrixFromPhysicalSpace} from 'sentry/utils/profiling/gl/utils';
 
 export function useCanvasScroll(
   canvas: FlamegraphCanvas | null,
@@ -16,29 +16,10 @@ export function useCanvasScroll(
         return;
       }
 
-      {
-        const physicalDelta = vec2.fromValues(evt.deltaX * 0.8, evt.deltaY);
-        const physicalToConfig = mat3.invert(
-          mat3.create(),
-          view.fromConfigView(canvas.physicalSpace)
-        );
-        const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
-
-        const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
-          m00,
-          m01,
-          m02,
-          m10,
-          m11,
-          m12,
-          0,
-          0,
-          0,
-        ]);
-
-        const translate = mat3.fromTranslation(mat3.create(), configDelta);
-        canvasPoolManager.dispatch('transform config view', [translate, view]);
-      }
+      canvasPoolManager.dispatch('transform config view', [
+        getTranslationMatrixFromPhysicalSpace(evt.deltaX, evt.deltaY, view, canvas),
+        view,
+      ]);
     },
     [canvas, view, canvasPoolManager]
   );

--- a/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useRef} from 'react';
+import {vec2} from 'gl-matrix';
 
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
@@ -27,6 +28,11 @@ export function useViewKeyboardNavigation(
         return;
       }
 
+      const elementType = document.activeElement?.nodeName.toLowerCase();
+      if (elementType === 'input' || elementType === 'textarea') {
+        return;
+      }
+
       if (event.key === 'w') {
         if (inertia.current === null) {
           inertia.current = 1;
@@ -34,8 +40,7 @@ export function useViewKeyboardNavigation(
         canvasPoolManager.dispatch('transform config view', [
           getCenterScaleMatrixFromConfigPosition(
             0.99 * inertia.current,
-            view.configView.centerX,
-            view.configView.y
+            vec2.fromValues(view.configView.centerX, view.configView.y)
           ),
           view,
         ]);
@@ -49,8 +54,7 @@ export function useViewKeyboardNavigation(
         canvasPoolManager.dispatch('transform config view', [
           getCenterScaleMatrixFromConfigPosition(
             1.01 * inertia.current,
-            view.configView.centerX,
-            view.configView.y
+            vec2.fromValues(view.configView.centerX, view.configView.y)
           ),
           view,
         ]);

--- a/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
@@ -1,0 +1,95 @@
+import {useEffect, useRef} from 'react';
+
+import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {
+  getCenterScaleMatrixFromConfigPosition,
+  getTranslationMatrixFromConfigSpace,
+} from 'sentry/utils/profiling/gl/utils';
+
+const KEYDOWN_LISTENER_OPTIONS: AddEventListenerOptions & EventListenerOptions = {
+  passive: true,
+};
+
+export function useViewKeyboardNavigation(
+  view: CanvasView<any> | null,
+  canvasPoolManager: CanvasPoolManager
+) {
+  const inertia = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!view) {
+      return undefined;
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (!view) {
+        return;
+      }
+
+      if (event.key === 'w') {
+        if (inertia.current === null) {
+          inertia.current = 1;
+        }
+        canvasPoolManager.dispatch('transform config view', [
+          getCenterScaleMatrixFromConfigPosition(
+            0.99 * inertia.current,
+            view.configView.centerX,
+            view.configView.y
+          ),
+          view,
+        ]);
+        inertia.current = Math.max(Math.abs(inertia.current * 0.99), 0.01);
+      }
+
+      if (event.key === 's') {
+        if (inertia.current === null) {
+          inertia.current = 1;
+        }
+        canvasPoolManager.dispatch('transform config view', [
+          getCenterScaleMatrixFromConfigPosition(
+            1.01 * inertia.current,
+            view.configView.centerX,
+            view.configView.y
+          ),
+          view,
+        ]);
+        inertia.current = inertia.current * 1.01;
+      }
+      if (event.key === 'a') {
+        if (inertia.current === null) {
+          // We'll start at 1% of the view width
+          inertia.current = view.configView.width / 100;
+        }
+        canvasPoolManager.dispatch('transform config view', [
+          getTranslationMatrixFromConfigSpace(1 * -inertia.current, 0),
+          view,
+        ]);
+        inertia.current = inertia.current * 1.18;
+      }
+      if (event.key === 'd') {
+        if (inertia.current === null) {
+          // We'll start at 1% of the view width
+          inertia.current = view.configView.width / 100;
+        }
+        canvasPoolManager.dispatch('transform config view', [
+          getTranslationMatrixFromConfigSpace(1 * inertia.current, 0),
+          view,
+        ]);
+        inertia.current = inertia.current * 1.18;
+      }
+    }
+
+    function onKeyUp() {
+      inertia.current = null;
+    }
+
+    document.addEventListener('keyup', onKeyUp, KEYDOWN_LISTENER_OPTIONS);
+    document.addEventListener('keydown', onKeyDown, KEYDOWN_LISTENER_OPTIONS);
+
+    return () => {
+      document.removeEventListener('keyup', onKeyUp, KEYDOWN_LISTENER_OPTIONS);
+      document.removeEventListener('keydown', onKeyDown, KEYDOWN_LISTENER_OPTIONS);
+    };
+  }, [view, canvasPoolManager]);
+}

--- a/static/app/components/profiling/flamegraph/interactions/useWheelCenterZoom.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useWheelCenterZoom.tsx
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {getCenterScaleMatrix} from 'sentry/utils/profiling/gl/utils';
+import {getCenterScaleMatrixFromMousePosition} from 'sentry/utils/profiling/gl/utils';
 
 export function useWheelCenterZoom(
   canvas: FlamegraphCanvas | null,
@@ -18,7 +18,13 @@ export function useWheelCenterZoom(
 
       const scale = 1 - evt.deltaY * 0.01 * -1; // -1 to invert scale
       canvasPoolManager.dispatch('transform config view', [
-        getCenterScaleMatrix(scale, evt.offsetX, evt.offsetY, view, canvas),
+        getCenterScaleMatrixFromMousePosition(
+          scale,
+          evt.offsetX,
+          evt.offsetY,
+          view,
+          canvas
+        ),
         view,
       ]);
     },

--- a/static/app/components/profiling/flamegraph/interactions/useWheelCenterZoom.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useWheelCenterZoom.tsx
@@ -1,4 +1,5 @@
 import {useCallback} from 'react';
+import {vec2} from 'gl-matrix';
 
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
@@ -20,8 +21,7 @@ export function useWheelCenterZoom(
       canvasPoolManager.dispatch('transform config view', [
         getCenterScaleMatrixFromMousePosition(
           scale,
-          evt.offsetX,
-          evt.offsetY,
+          vec2.fromValues(evt.offsetX, evt.offsetY),
           view,
           canvas
         ),

--- a/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
+++ b/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
@@ -148,10 +148,6 @@ const keyDirectionMap: Record<string, Direction> = {
   ArrowRight: 'right',
   Tab: 'down',
   'Shift+Tab': 'up',
-  w: 'up',
-  s: 'down',
-  a: 'left',
-  d: 'right',
 } as const;
 
 export function handleFlamegraphKeyboardNavigation(

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -874,11 +874,7 @@ export function getCenterScaleMatrixFromConfigPosition(
   centerY: number
 ) {
   const configCenter = vec2.fromValues(centerX, centerY);
-  const invertedConfigCenter = vec2.multiply(
-    vec2.create(),
-    vec2.fromValues(-1, -1),
-    vec2.fromValues(centerX, centerY)
-  );
+  const invertedConfigCenter = vec2.fromValues(-centerX, -centerY);
 
   const centerScaleMatrix = mat3.create();
   mat3.fromTranslation(centerScaleMatrix, configCenter);

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -868,16 +868,11 @@ export function getPhysicalSpacePositionFromOffset(offsetX: number, offsetY: num
   return vec2.scale(vec2.create(), logicalMousePos, window.devicePixelRatio);
 }
 
-export function getCenterScaleMatrixFromConfigPosition(
-  scale: number,
-  centerX: number,
-  centerY: number
-) {
-  const configCenter = vec2.fromValues(centerX, centerY);
-  const invertedConfigCenter = vec2.fromValues(-centerX, -centerY);
+export function getCenterScaleMatrixFromConfigPosition(scale: number, center: vec2) {
+  const invertedConfigCenter = vec2.fromValues(-center[0], -center[1]);
 
   const centerScaleMatrix = mat3.create();
-  mat3.fromTranslation(centerScaleMatrix, configCenter);
+  mat3.fromTranslation(centerScaleMatrix, center);
   mat3.scale(centerScaleMatrix, centerScaleMatrix, vec2.fromValues(scale, 1));
   mat3.translate(centerScaleMatrix, centerScaleMatrix, invertedConfigCenter);
   return centerScaleMatrix;
@@ -887,18 +882,14 @@ export function getCenterScaleMatrixFromConfigPosition(
 // and apply the scaling transformation from there
 export function getCenterScaleMatrixFromMousePosition(
   scale: number,
-  offsetX: number,
-  offsetY: number,
+  cursor: vec2,
   view: CanvasView<any>,
   canvas: FlamegraphCanvas
 ): mat3 {
-  const configSpaceMouse = view.getConfigViewCursor(
-    vec2.fromValues(offsetX, offsetY),
-    canvas
-  );
+  const configSpaceMouse = view.getConfigViewCursor(cursor, canvas);
 
   const configCenter = vec2.fromValues(configSpaceMouse[0], view.configView.y);
-  return getCenterScaleMatrixFromConfigPosition(scale, configCenter[0], configCenter[1]);
+  return getCenterScaleMatrixFromConfigPosition(scale, configCenter);
 }
 
 export function getTranslationMatrixFromConfigSpace(deltaX: number, deltaY: number) {


### PR DESCRIPTION
I dropped wasd keys from keyboard navigation on the stack so that we can distinguish between arrow keys for (flamechart) and wasd for view navigation.