### PR TITLE
ref: delete unused sentry.logging.{bind,unbind}

### DIFF
--- a/src/sentry/logging/__init__.py
+++ b/src/sentry/logging/__init__.py
@@ -1,21 +1,3 @@
-from structlog import get_logger
-
-
 class LoggingFormat:
     HUMAN = "human"
     MACHINE = "machine"
-
-
-def bind(name, **kwargs):
-    """
-    Syntactic sugar for binding arbitrary kv pairs to a given logger instantiated from
-    logging.getLogger instead of structlog.get_logger.
-    """
-    return get_logger(name=name).bind(**kwargs)
-
-
-def unbind(name, *keys):
-    try:
-        get_logger(name=name).unbind(*keys)
-    except KeyError:
-        pass


### PR DESCRIPTION
last used here: 69cdde9185c4e824fd9edaf8b77d93b18f2dc7a7