### PR TITLE
ref(hybrid-cloud): update shared issue acceptance test url to include org slug

### DIFF
--- a/tests/acceptance/test_shared_issue.py
+++ b/tests/acceptance/test_shared_issue.py
@@ -22,7 +22,9 @@ class SharedIssueTest(AcceptanceTestCase):
 
         GroupShare.objects.create(project_id=event.group.project_id, group=event.group)
 
-        self.browser.get(f"/share/issue/{event.group.get_share_id()}/")
+        self.browser.get(
+            f"/organizations/{self.org.slug}/share/issue/{event.group.get_share_id()}/"
+        )
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until_test_id("event-entries-loading-false")
         self.browser.snapshot("shared issue python")


### PR DESCRIPTION
Use the issue share url with the org slug in the path.

For HC-520