### PR TITLE
ref(marked): Add Prism code highlighting

### DIFF
--- a/static/app/utils/marked.tsx
+++ b/static/app/utils/marked.tsx
@@ -1,5 +1,6 @@
 import dompurify from 'dompurify';
 import marked from 'marked'; // eslint-disable-line no-restricted-imports
+import Prism from 'prismjs';
 
 import {IS_ACCEPTANCE_TEST, NODE_ENV} from 'sentry/constants';
 
@@ -49,6 +50,13 @@ class NoParagraphRenderer extends SafeRenderer {
 marked.setOptions({
   renderer: new SafeRenderer(),
   sanitize: true,
+
+  highlight: (code, lang) => {
+    if (Prism.languages[lang]) {
+      return Prism.highlight(code, Prism.languages[lang], lang);
+    }
+    return code;
+  },
 
   // Silence sanitize deprecation warning in test / ci (CI sets NODE_NV
   // to production, but specifies `CI`).


### PR DESCRIPTION
(Part of https://github.com/getsentry/sentry/issues/43765)

Add Prism code highlighting to the `marked` util, used to render markdown content in `<ActivityItem />`

**Before ——**
<img width="926" alt="Screenshot 2023-01-27 at 11 39 02 AM" src="https://user-images.githubusercontent.com/44172267/215182323-1a5c3e8f-8eae-469f-9af7-727f297f38f4.png">

**After ——**
<img width="926" alt="Screenshot 2023-01-27 at 11 39 19 AM" src="https://user-images.githubusercontent.com/44172267/215182328-36a52aa0-73b3-4384-8284-1e519b61d9d6.png">
