### PR TITLE
test(snuba): Avoid risk of future events in snuba tests

### DIFF
--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -441,14 +441,14 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             self.user.id,
             [f"{GroupType.PROFILE_BLOCKED_THREAD.value}-group1"],
             "prod",
-            timezone.now().replace(hour=0, minute=0, second=0) + timedelta(minutes=1),
+            before_now(hours=1).replace(tzinfo=timezone.utc),
         )
         event_2, _, _ = self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{GroupType.PROFILE_BLOCKED_THREAD.value}-group1"],
             "prod",
-            timezone.now().replace(hour=0, minute=0, second=0) + timedelta(minutes=1),
+            before_now(hours=1).replace(tzinfo=timezone.utc),
         )
 
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -611,7 +611,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
             self.user.id,
             [f"{GroupType.PROFILE_BLOCKED_THREAD.value}-group1"],
             "prod",
-            timezone.now().replace(hour=0, minute=0, second=0) + timedelta(minutes=1),
+            before_now(hours=1).replace(tzinfo=timezone.utc),
             user=user_data,
         )
 
@@ -3020,7 +3020,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
             1,
             ["group1-fingerprint"],
             None,
-            timezone.now().replace(hour=0, minute=0, second=0) + timedelta(minutes=10),
+            before_now(hours=1).replace(tzinfo=timezone.utc),
             user=user_data,
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -120,7 +119,7 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTest
             self.user.id,
             [f"{GroupType.PROFILE_BLOCKED_THREAD.value}-group1"],
             "prod",
-            timezone.now().replace(hour=0, minute=0, second=0) + timedelta(minutes=1),
+            before_now(hours=1).replace(tzinfo=timezone.utc),
         )
         url = reverse(
             "sentry-api-0-organization-events-meta",


### PR DESCRIPTION
This change does the following:

1. Remove the risk of timestamps being in the future (occurs at midnight)
2. Uses a timestamp - 1hr to avoid complications in tests if snuba rounds the data (it seems that 10mins or less can encounter this)

I've run these test files 50x each to ensure this don't flake and I've also run these tests with `before_now(days=23)` so the date is a yesterday to ensure that as we cross midnight, this shouldn't fail due to the date being yesterday.. 