### PR TITLE
security(password): increase minimum password complexity requirements

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -435,13 +435,20 @@ AUTHENTICATION_BACKENDS = (
 )
 
 AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {
         "NAME": "sentry.auth.password_validation.MinimumLengthValidator",
-        "OPTIONS": {"min_length": 6},
+        "OPTIONS": {"min_length": 8},
     },
     {
         "NAME": "sentry.auth.password_validation.MaximumLengthValidator",
         "OPTIONS": {"max_length": 256},
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 


### PR DESCRIPTION
Our original password complexity requirements were pretty lax. Our only requirement was that they be between 6 and 256 characters. 

As a result, passwords like the below were valid and accepted:

```
password
123456
password1
qwerty
monkey
hello5
```

This PR tightens up our password complexity requirements to a reasonable, but not overly restrict standard.

- disallow passwords too similar to the user's name, email, or username
- increase minimum required length from 6 to 8 characters
- disallow use of the top 20k most common passwords ([here](https://gist.github.com/roycewilliams/281ce539915a947a23db17137d91aeb7))
- disallow use of entirely numeric passwords

All of these are enforced via [Django's built-in password validators.](https://docs.djangoproject.com/en/2.2/topics/auth/passwords/#enabling-password-validation)

Users with passwords that do not meet the new requirements will not be impacted. They will still be able to login with their password. When resetting their password though, they'll need to comply with the stronger controls.

Partially resolves #10067 (not a custom password policy for organization owners, but does increase our complexity requirements 🙂 ). Organizations with unique password policies should configure SSO/SAML and enforce their controls there to be most effective.