### PR TITLE
fix(heroku): Use app webhooks

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -155,7 +155,6 @@ class HerokuPlugin(CorePluginMixin, ReleaseTrackingPlugin):
         secret_field = get_secret_field_config(
             webhook_secret,
             "Enter the webhook signing secret shown after running the Heroku CLI command.",
-            include_prefix=True,
         )
         secret_field.update(
             {

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -69,7 +69,10 @@ class HerokuReleaseHook(ReleaseHook):
             )
         commit = data.get("slug", {}).get("commit")
         app_name = data.get("app", {}).get("name")
-        self.finish_release(version=commit, url=f"http://{app_name}.herokuapp.com", owner=user)
+        if app_name:
+            self.finish_release(version=commit, url=f"http://{app_name}.herokuapp.com", owner=user)
+        else:
+            self.finish_release(version=commit, owner=user)
 
     def set_refs(self, release, **values):
         if not values.get("owner", None):

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -148,11 +148,6 @@ class HerokuPlugin(CorePluginMixin, ReleaseTrackingPlugin):
         ]
 
     def get_release_doc_html(self, hook_url):
-        # return f"""
-        # <p>Add Sentry as a deploy hook to automatically track new releases.</p>
-        # <pre class="clippy">heroku addons:create deployhooks:http --url={hook_url}</pre>
-        # """
-
         return f"""
         <p>Add a Sentry release webhook to automatically track new releases.</p>
         <pre class="clippy">heroku webhooks:add -i api:release -l notify -u {hook_url} -a YOUR_APP_NAME</pre>

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -29,7 +29,7 @@ class HerokuReleaseHook(ReleaseHook):
     def handle(self, request: Request) -> Response:
         body = json.loads(request.body)
         data = body.get("data")
-        email = data.get("user").get("email") or data.get("actor").get("email")
+        email = data.get("user", {}).get("email") or data.get("actor", {}).get("email")
 
         try:
             user = User.objects.get(
@@ -45,8 +45,8 @@ class HerokuReleaseHook(ReleaseHook):
                     "email": email,
                 },
             )
-        commit = data.get("slug").get("commit")
-        app_name = data.get("app").get("name")
+        commit = data.get("slug", {}).get("commit")
+        app_name = data.get("app", {}).get("name")
         self.finish_release(version=commit, url=f"http://{app_name}.herokuapp.com", owner=user)
 
     def set_refs(self, release, **values):

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -130,6 +130,7 @@ class HookHandleTest(TestCase):
         organization = self.create_organization(owner=user)
         project = self.create_project(organization=organization)
         hook = HerokuReleaseHook(project)
+        hook.is_valid_signature = Mock()
         hook.set_refs = Mock()
 
         req = Mock()
@@ -150,6 +151,7 @@ class HookHandleTest(TestCase):
         organization = self.create_organization(owner=user)
         project = self.create_project(organization=organization)
         hook = HerokuReleaseHook(project)
+        hook.is_valid_signature = Mock()
         hook.set_refs = Mock()
 
         req = Mock()
@@ -170,6 +172,7 @@ class HookHandleTest(TestCase):
         organization = self.create_organization(owner=user)
         project = self.create_project(organization=organization)
         hook = HerokuReleaseHook(project)
+        hook.is_valid_signature = Mock()
 
         req = Mock()
         body = {
@@ -187,6 +190,7 @@ class HookHandleTest(TestCase):
         project = self.create_project()
         user = self.create_user()
         hook = HerokuReleaseHook(project)
+        hook.is_valid_signature = Mock()
 
         req = Mock()
         body = {

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -17,6 +17,7 @@ from sentry.models import (
     User,
 )
 from sentry.testutils import TestCase
+from sentry.utils import json
 from sentry_plugins.heroku.plugin import HerokuReleaseHook
 
 
@@ -132,9 +133,16 @@ class HookHandleTest(TestCase):
         hook.set_refs = Mock()
 
         req = Mock()
-        req.POST = {"head_long": "abcd123", "url": "http://example.com", "user": user.email}
+        body = {
+            "data": {
+                "user": {"email": user.email},
+                "slug": {"commit": "abcd123"},
+                "app": {"name": "example"},
+            }
+        }
+        req.body = bytes(json.dumps(body), "utf-8")
         hook.handle(req)
-        assert Release.objects.filter(version=req.POST["head_long"]).exists()
+        assert Release.objects.filter(version=body["data"]["slug"]["commit"]).exists()
         assert hook.set_refs.call_count == 1
 
     def test_actor_email_success(self):
@@ -145,13 +153,16 @@ class HookHandleTest(TestCase):
         hook.set_refs = Mock()
 
         req = Mock()
-        req.POST = {
-            "head_long": "v999",
-            "url": "http://example.com",
-            "actor": {"email": user.email},
+        body = {
+            "data": {
+                "actor": {"email": user.email},
+                "slug": {"commit": "abcd123"},
+                "app": {"name": "example"},
+            }
         }
+        req.body = bytes(json.dumps(body), "utf-8")
         hook.handle(req)
-        assert Release.objects.filter(version=req.POST["head_long"]).exists()
+        assert Release.objects.filter(version=body["data"]["slug"]["commit"]).exists()
         assert hook.set_refs.call_count == 1
 
     def test_email_mismatch(self):
@@ -161,9 +172,16 @@ class HookHandleTest(TestCase):
         hook = HerokuReleaseHook(project)
 
         req = Mock()
-        req.POST = {"head_long": "v999", "url": "http://example.com", "user": "wrong@example.com"}
+        body = {
+            "data": {
+                "user": {"email": "wrong@example.com"},
+                "slug": {"commit": "v999"},
+                "app": {"name": "example"},
+            }
+        }
+        req.body = bytes(json.dumps(body), "utf-8")
         hook.handle(req)
-        assert Release.objects.filter(version=req.POST["head_long"]).exists()
+        assert Release.objects.filter(version=body["data"]["slug"]["commit"]).exists()
 
     def test_bad_version(self):
         project = self.create_project()
@@ -171,6 +189,13 @@ class HookHandleTest(TestCase):
         hook = HerokuReleaseHook(project)
 
         req = Mock()
-        req.POST = {"head_long": "", "url": "http://example.com", "user": user.email}
+        body = {
+            "data": {
+                "actor": {"email": user.email},
+                "slug": {"commit": ""},
+                "app": {"name": "example"},
+            }
+        }
+        req.body = bytes(json.dumps(body), "utf-8")
         with pytest.raises(HookValidationError):
             hook.handle(req)


### PR DESCRIPTION
Heroku is about to sunset their [deploy hooks](https://blog.heroku.com/deployhooks-sunset) which we use to listen for a deploy and create a release. This PR updates the usage to the newer [app webhooks](https://devcenter.heroku.com/articles/app-webhooks). 

I left the old code in for now so users can have a bit of time to migrate (really just 17 days now) and that can be deleted after the sunset.

This also [secures the webhook request](https://devcenter.heroku.com/articles/app-webhooks#securing-webhook-requests) by comparing the `Heroku-Webhook-Hmac-SHA256` header against the webhook secret. This does alter the plugin setup slightly in that the user will need to generate the webhook secret and then go back and save it, and existing users will need to go into their setup and add the webhook secret after [following the Heroku migration steps](https://blog.heroku.com/deployhooks-sunset). It's slightly annoying but better than leaving it unsecured and vulnerable.

<img width="484" alt="Screen Shot 2023-01-30 at 1 49 59 PM" src="https://user-images.githubusercontent.com/29959063/215603602-ac8a6769-78cd-4754-9d7b-2e8721f20b12.png">
