### PR TITLE
feat(commit-context): Get the commit context for all the code mappings

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Sequence
+from typing import Any, List, Mapping, Sequence, Tuple
 
 import sentry_sdk
 
@@ -12,16 +12,15 @@ from sentry.utils.committers import get_stacktrace_path_from_event_frame
 def find_commit_context_for_event(
     code_mappings: Sequence[RepositoryProjectPathConfig],
     frame: Mapping[str, Any],
-    logger: Any,
     extra: Mapping[str, Any],
-):
+) -> List[Tuple[Mapping[str, Any], RepositoryProjectPathConfig]]:
     """
-    Returns the Commit Context for an event frame using a source code integration, if it exists.
+
+    Get all the Commit Context for an event frame using a source code integration for all the matching code mappings
     code_mappings: List of RepositoryProjectPathConfig
     frame: Event frame
     """
-    commit_context = None
-    selected_code_mapping = None
+    result = []
     for code_mapping in code_mappings:
         if not code_mapping.organization_integration:
             continue
@@ -57,20 +56,7 @@ def find_commit_context_for_event(
                 error_message=e.text,
             )
 
-        logger.info(
-            "find_commit_context_for_event.integration_fetch",
-            extra=(extra or {}).update(
-                {
-                    "src_path": src_path,
-                    "stacktrace_path": stacktrace_path,
-                    "code_mapping_id": code_mapping.id,
-                    "found": True if commit_context else False,
-                }
-            ),
-        )
-
         if commit_context:
-            selected_code_mapping = code_mapping
-            break
+            result.append((commit_context, code_mapping))
 
-    return commit_context, selected_code_mapping
+    return result

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -248,3 +248,62 @@ class TestCommitContext(TestCase):
         assert owner.user is None
         assert owner.team is None
         assert owner.context == {"commitId": self.commit_2.id}
+
+    @patch(
+        "sentry.integrations.github.GitHubIntegration.get_commit_context",
+        return_value={
+            "commitId": "somekey",
+            "committedDate": "",
+            "commitMessage": "placeholder commit message",
+            "commitAuthorName": "",
+            "commitAuthorEmail": "randomuser@sentry.io",
+        },
+    )
+    def test_multiple_matching_code_mappings_but_only_1_repository_has_the_commit_in_db(
+        self, mock_get_commit_context
+    ):
+
+        self.integration_2 = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="GitHub",
+            external_id="github:2",
+        )
+
+        self.repo_2 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="another/example",
+            integration_id=self.integration_2.id,
+        )
+        self.code_mapping_2 = self.create_code_mapping(
+            repo=self.repo_2, project=self.project, stack_root="src", source_root="src"
+        )
+
+        self.commit_author_2 = self.create_commit_author(
+            project=self.project,
+        )
+        self.commit_2 = self.create_commit(
+            project=self.project,
+            repo=self.repo_2,
+            author=self.commit_author_2,
+            key="somekey",
+            message="placeholder commit message",
+        )
+
+        with self.tasks():
+            assert not GroupOwner.objects.filter(group=self.event.group).exists()
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+        assert GroupOwner.objects.filter(group=self.event.group).exists()
+        assert len(GroupOwner.objects.filter(group=self.event.group)) == 1
+        owner = GroupOwner.objects.get(group=self.event.group)
+        assert owner.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert owner.user is None
+        assert owner.team is None
+        assert owner.context == {"commitId": self.commit_2.id}


### PR DESCRIPTION
## Objective

Currently we break the loop once we find a code mapping that returns a commit context from the integration. However, not all the repositories may have the commit in sentry_commit. Multiple code mappings may find the commit context and we may have the commit for those repositories in sentry_commit.


Once we find a code mapping with commit context whose repository has the commit in sentry_commit, then we break the loop.