### PR TITLE
test(snuba): Hopefully fixes flakes in test_organization_events

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -71,7 +71,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
 
         min_age = before_now(minutes=10)
         if timestamp > min_age:
-            # Snuba does some rounding of timestamps to improve cache hits.
+            # Sentry does some rounding of timestamps to improve cache hits in snuba.
             # This can result in events not being returns if the timestamps
             # are too recent.
             raise Exception(

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -67,7 +67,16 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
 
     def load_data(self, platform="transaction", timestamp=None, duration=None, **kwargs):
         if timestamp is None:
-            timestamp = before_now(minutes=1)
+            timestamp = self.ten_mins_ago
+
+        min_age = before_now(minutes=10)
+        if timestamp > min_age:
+            # Snuba does some rounding of timestamps to improve cache hits.
+            # This can result in events not being returns if the timestamps
+            # are too recent.
+            raise Exception(
+                f"Please define a timestamp older than 10 minutes to avoid flakey tests. Want a timestamp before {min_age}, got: {timestamp} "
+            )
 
         start_timestamp = None
         if duration is not None:
@@ -2135,7 +2144,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
 
         project2 = self.create_project()
 
-        data = self.load_data(timestamp=before_now(minutes=1))
+        data = self.load_data()
         data["transaction"] = "/count_miserable/horribilis/project2"
         data["user"] = {"email": "project2@example.com"}
         self.store_event(data, project_id=project2.id)
@@ -5449,9 +5458,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
         assert response.status_code == 400, response.content
 
     def test_tag_that_looks_like_aggregate(self):
-        data = self.load_data(
-            timestamp=before_now(minutes=1),
-        )
+        data = self.load_data()
         data["tags"] = {"p95": "<5k"}
         self.store_event(data, project_id=self.project.id)
 
@@ -5615,9 +5622,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
         assert set(fields) == unit_keys
 
     def test_readable_device_name(self):
-        data = self.load_data(
-            timestamp=before_now(minutes=1),
-        )
+        data = self.load_data()
         data["tags"] = {"device": "iPhone14,3"}
         self.store_event(data, project_id=self.project.id)
 


### PR DESCRIPTION
This is a somewhat speculative fix.

Running the test file `tests/snuba/api/endpoints/test_organization_events.py` 100 times produces the sentry errors [1](https://sentry.io/organizations/sentry/issues/3872128406/?project=2423079&query=is%3Aunresolved+pytest_environ.GITHUB_EVENT_NAME%3Apush+pytest_environ.GITHUB_REF%3Arefs%2Fheads%2Fmaster+tests%2Fsnuba%2Fapi%2Fendpoints%2Ftest_organization_events.py&referrer=issue-stream&statsPeriod=24h), [2](https://sentry.io/organizations/sentry/issues/3873753366/?project=2423079&query=is%3Aunresolved+pytest_environ.GITHUB_EVENT_NAME%3Apush+pytest_environ.GITHUB_REF%3Arefs%2Fheads%2Fmaster+tests%2Fsnuba%2Fapi%2Fendpoints%2Ftest_organization_events.py&referrer=issue-stream&statsPeriod=24h), [3](https://sentry.io/organizations/sentry/issues/3871686478/?project=2423079&query=is%3Aunresolved+pytest_environ.GITHUB_EVENT_NAME%3Apush+pytest_environ.GITHUB_REF%3Arefs%2Fheads%2Fmaster+tests%2Fsnuba%2Fapi%2Fendpoints%2Ftest_organization_events.py&referrer=issue-stream&statsPeriod=24h) three or more times.

With this change, running the tests 100x times there were no test failures, so it does seem to improve the reliability of the test.

