### PR TITLE
feat(profiling): Add profile.id column to discover dataset

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1265,12 +1265,17 @@ class QueryBuilder(BaseQueryBuilder):
             if not search_filter.value.is_span_id():
                 raise InvalidSearchQuery(INVALID_SPAN_ID.format(name))
 
-        # Validate event ids and trace ids are uuids
-        if name in {"id", "trace"}:
+        # Validate event ids, trace ids, and profile ids are uuids
+        if name in {"id", "trace", "profile.id"}:
             if search_filter.value.is_wildcard():
                 raise InvalidSearchQuery(WILDCARD_NOT_ALLOWED.format(name))
             elif not search_filter.value.is_event_id():
-                label = "Filter ID" if name == "id" else "Filter Trace ID"
+                if name == "trace":
+                    label = "Filter Trace ID"
+                elif name == "profile.id":
+                    label = "Filter Profile ID"
+                else:
+                    label = "Filter ID"
                 raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))
 
         if name in constants.TIMESTAMP_FIELDS:

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -685,3 +685,11 @@ class Columns(Enum):
         discover_name="app_start_type",
         alias="app_start_type",
     )
+
+    PROFILE_ID = Column(
+        group_name=None,
+        event_name=None,
+        transaction_name="profile_id",
+        discover_name="profile_id",
+        alias="profile.id",
+    )

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -14,6 +14,7 @@ from sentry.search.events import constants
 from sentry.search.events.builder import QueryBuilder
 from sentry.testutils.cases import TestCase
 from sentry.utils.snuba import Dataset, QueryOutsideRetentionError
+from sentry.utils.validators import INVALID_ID_DETAILS
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -774,4 +775,37 @@ class QueryBuilderTest(TestCase):
                 groupby_columns=[
                     "transaction",
                 ],
+            )
+
+    def test_id_filter_non_uuid(self):
+        with pytest.raises(
+            InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("Filter ID"))
+        ):
+            QueryBuilder(
+                Dataset.Discover,
+                self.params,
+                query="id:foo",
+                selected_columns=["count()"],
+            )
+
+    def test_trace_id_filter_non_uuid(self):
+        with pytest.raises(
+            InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("Filter Trace ID"))
+        ):
+            QueryBuilder(
+                Dataset.Discover,
+                self.params,
+                query="trace:foo",
+                selected_columns=["count()"],
+            )
+
+    def test_profile_id_filter_non_uuid(self):
+        with pytest.raises(
+            InvalidSearchQuery, match=re.escape(INVALID_ID_DETAILS.format("Filter Profile ID"))
+        ):
+            QueryBuilder(
+                Dataset.Discover,
+                self.params,
+                query="profile.id:foo",
+                selected_columns=["count()"],
             )


### PR DESCRIPTION
Following up with getsentry/snuba#3640, this adds the profile.id column to the discover dataset. This field is only available on the transactions table.