### PR TITLE
test(alerts): Mock update onboarding in alert tests

### DIFF
--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -1,7 +1,7 @@
 import selectEvent from 'react-select-event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
@@ -12,6 +12,8 @@ import AlertBuilderProjectProvider from 'sentry/views/alerts/builder/projectProv
 import ProjectAlertsCreate from 'sentry/views/alerts/create';
 
 jest.unmock('sentry/utils/recreateRoute');
+// updateOnboardingTask triggers an out of band state update
+jest.mock('sentry/actionCreators/onboardingTasks');
 jest.mock('sentry/actionCreators/members', () => ({
   fetchOrgMembers: jest.fn(() => Promise.resolve([])),
   indexMembersByProject: jest.fn(() => {
@@ -162,9 +164,6 @@ describe('ProjectAlertsCreate', function () {
           })
         );
       });
-
-      // updateOnboardingTask triggers an out of band state update
-      await act(tick);
     });
 
     it('can remove triggers', async function () {
@@ -216,9 +215,6 @@ describe('ProjectAlertsCreate', function () {
           })
         );
       });
-
-      // updateOnboardingTask triggers an out of band state update
-      await act(tick);
     });
 
     it('can remove actions', async function () {
@@ -258,9 +254,6 @@ describe('ProjectAlertsCreate', function () {
           })
         );
       });
-
-      // updateOnboardingTask triggers an out of band state update
-      await act(tick);
     });
 
     describe('updates and saves', function () {


### PR DESCRIPTION
seeing some issue with overlapping act calls that seem to be related to a fix we made before https://github.com/getsentry/sentry/actions/runs/4046584826/jobs/6959556620
