### PR TITLE
feat(perf-issues): Add issue type property to some analytics events

### DIFF
--- a/static/app/components/events/eventCause.tsx
+++ b/static/app/components/events/eventCause.tsx
@@ -9,7 +9,7 @@ import {Panel} from 'sentry/components/panels';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {AvatarProject, Commit, Group, IssueCategory} from 'sentry/types';
+import {AvatarProject, Commit, Group, IssueCategory, IssueType} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useCommitters from 'sentry/utils/useCommitters';
@@ -59,6 +59,7 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
       project_id: parseInt(project.id as string, 10),
       group_id: parseInt(group?.id as string, 10),
       issue_category: group?.issueCategory ?? IssueCategory.ERROR,
+      issue_type: group?.issueType ?? IssueType.ERROR,
     });
   };
 
@@ -68,6 +69,7 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
       project_id: parseInt(project.id as string, 10),
       group_id: parseInt(group?.id as string, 10),
       issue_category: group?.issueCategory ?? IssueCategory.ERROR,
+      issue_type: group?.issueType ?? IssueType.ERROR,
       has_pull_request: commit.pullRequest?.id !== undefined,
     });
   };

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -31,6 +31,7 @@ import {
   CurrentRelease,
   Environment,
   Group,
+  IssueType,
   Organization,
   Project,
   TagWithTopValues,
@@ -91,6 +92,7 @@ class BaseGroupSidebar extends Component<Props, State> {
       project_id: parseInt(project.id, 10),
       group_id: parseInt(group.id, 10),
       issue_category: group.issueCategory,
+      issue_type: group.issueType ?? IssueType.ERROR,
       action_type: 'assign',
       alert_date:
         typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,

--- a/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -9,7 +9,7 @@ import * as SidebarSection from 'sentry/components/sidebarSection';
 import {IconCheckmark} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import type {Actor, Commit, Group, Organization, Release} from 'sentry/types';
+import {Actor, Commit, Group, IssueType, Organization, Release} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 
 type Owner = {
@@ -45,11 +45,12 @@ const SuggestedAssignees = ({
         project_id: parseInt(projectId!, 10),
         group_id: parseInt(group.id, 10),
         issue_category: group.issueCategory,
+        issue_type: group.issueType ?? IssueType.ERROR,
         action_type: 'assign',
         assigned_suggestion_reason: owner.source,
       });
     },
-    [onAssign, group.id, group.issueCategory, projectId, organization]
+    [onAssign, group.id, group.issueCategory, group.issueType, projectId, organization]
   );
 
   if (loading) {

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -1,4 +1,4 @@
-import type {IssueCategory, ResolutionStatus} from 'sentry/types';
+import type {IssueCategory, IssueType, ResolutionStatus} from 'sentry/types';
 import {Tab} from 'sentry/views/issueDetails/types';
 
 type RuleViewed = {
@@ -9,6 +9,7 @@ type RuleViewed = {
 type IssueDetailsWithAlert = {
   group_id: number;
   issue_category: IssueCategory;
+  issue_type: IssueType;
   project_id: number;
   /** The time that the alert was initially fired. */
   alert_date?: string;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -9,6 +9,7 @@ import {
   GroupActivityType,
   GroupTombstone,
   IssueCategory,
+  IssueType,
   TreeLabelPart,
 } from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
@@ -312,6 +313,7 @@ export function getAnalyicsDataForGroup(group: Group | null) {
     // overload group_id with the issue_id
     issue_id: groupId,
     issue_category: group?.issueCategory ?? IssueCategory.ERROR,
+    issue_type: group?.issueType ?? IssueType.ERROR,
     issue_status: group?.status,
     issue_age: group?.firstSeen ? getDaysSinceDate(group.firstSeen) : -1,
     issue_level: group?.level,

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -34,6 +34,7 @@ import space from 'sentry/styles/space';
 import {
   Group,
   GroupStatusResolution,
+  IssueType,
   Organization,
   Project,
   ResolutionStatus,
@@ -113,6 +114,7 @@ class Actions extends Component<Props> {
       project_id: parseInt(project.id, 10),
       group_id: parseInt(group.id, 10),
       issue_category: group.issueCategory,
+      issue_type: group.issueType ?? IssueType.ERROR,
       action_type: action,
       // Alert properties track if the user came from email/slack alerts
       alert_date:

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -17,7 +17,14 @@ import {t} from 'sentry/locale';
 import SentryTypes from 'sentry/sentryTypes';
 import GroupStore from 'sentry/stores/groupStore';
 import space from 'sentry/styles/space';
-import {AvatarProject, Group, IssueCategory, Organization, Project} from 'sentry/types';
+import {
+  AvatarProject,
+  Group,
+  IssueCategory,
+  IssueType,
+  Organization,
+  Project,
+} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
@@ -525,6 +532,7 @@ class GroupDetails extends Component<Props, State> {
       organization,
       group_id: parseInt(group.id, 10),
       issue_category: group.issueCategory,
+      issue_type: group.issueType ?? IssueType.ERROR,
       project_id: parseInt(project.id, 10),
       tab,
     });


### PR DESCRIPTION
This is useful to compare different issue type UI behaviour against each other. Closes PERF-1938. Supported by https://github.com/getsentry/reload/pull/303
