### PR TITLE
fix(mep): Return a valid empty result instead of a broken namedtuple

### DIFF
--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -153,7 +153,16 @@ def timeseries_query(
             functions_acl,
             has_metrics=has_metrics,
         )
-    return SnubaTSResult()
+    return SnubaTSResult(
+        {
+            "data": discover.zerofill([], params["start"], params["end"], rollup, "time")
+            if zerofill_results
+            else [],
+        },
+        params["start"],
+        params["end"],
+        rollup,
+    )
 
 
 def histogram_query(

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -124,7 +124,16 @@ def timeseries_query(
                 params["end"],
                 rollup,
             )
-    return SnubaTSResult()
+    return SnubaTSResult(
+        {
+            "data": discover.zerofill([], params["start"], params["end"], rollup, "time")
+            if zerofill_results
+            else [],
+        },
+        params["start"],
+        params["end"],
+        rollup,
+    )
 
 
 def histogram_query(


### PR DESCRIPTION
- SnubaTSResult is a namedtuple not a class, so it needs it params in order to return
- Fixes SENTRY-W2E