### PR TITLE
fix(globalStyles): Allow code elements to wrap

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -35,12 +35,11 @@ const styles = (theme: Theme, isDark: boolean) => css`
   pre,
   code {
     color: ${theme.textColor};
-    white-space: pre-wrap;
   }
 
   pre {
     background-color: ${theme.backgroundSecondary};
-    word-break: break-all;
+    white-space: pre-wrap;
     overflow-x: auto;
   }
 

--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -35,18 +35,17 @@ const styles = (theme: Theme, isDark: boolean) => css`
   pre,
   code {
     color: ${theme.textColor};
+    white-space: pre-wrap;
   }
 
   pre {
     background-color: ${theme.backgroundSecondary};
     word-break: break-all;
-    white-space: pre-wrap;
     overflow-x: auto;
   }
 
   code {
     background-color: transparent;
-    white-space: pre;
   }
 
   ${prismStyles(theme)}


### PR DESCRIPTION
Revert some of the global styles added in https://github.com/getsentry/sentry/pull/43761

**Before ——**
<img width="298" alt="Screenshot 2023-01-30 at 12 05 44 PM" src="https://user-images.githubusercontent.com/44172267/215583630-5d03d9d5-8145-44ef-843f-1e069d217ce9.png">

**After ——**
<img width="291" alt="Screenshot 2023-01-30 at 12 05 27 PM" src="https://user-images.githubusercontent.com/44172267/215583587-dca7fdff-2e26-4f49-92a3-b8f47a06b709.png">

Fixes https://github.com/getsentry/sentry/issues/43824
Fixes https://github.com/getsentry/sentry/issues/43825
