### PR TITLE
bug(replays): Re-render the replay search bar based on location

### DIFF
--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -1,4 +1,3 @@
-import {useEffect, useRef} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -17,25 +16,8 @@ const DEFAULT_QUERY = 'duration:>=5';
 
 function ReplaysFilters() {
   const {selection} = usePageFilters();
-  const location = useLocation();
+  const {pathname, query} = useLocation();
   const organization = useOrganization();
-  const didMount = useRef(false);
-
-  const {pathname, query} = location;
-
-  useEffect(() => {
-    if (!didMount.current && !query?.query) {
-      browserHistory.push({
-        pathname,
-        query: {
-          ...query,
-          cursor: undefined,
-          query: DEFAULT_QUERY,
-        },
-      });
-    }
-    didMount.current = true;
-  }, [pathname, query]);
 
   return (
     <FilterContainer>
@@ -48,6 +30,7 @@ function ReplaysFilters() {
         organization={organization}
         pageFilters={selection}
         defaultQuery={decodeScalar(query?.query ?? DEFAULT_QUERY, '')}
+        query={decodeScalar(query.query ?? DEFAULT_QUERY, '')}
         onSearch={searchQuery => {
           browserHistory.push({
             pathname,

--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -37,7 +37,7 @@ type Props = React.ComponentProps<typeof SmartSearchBar> & {
   pageFilters: PageFilters;
 };
 
-function SearchBar(props: Props) {
+function ReplaySearchBar(props: Props) {
   return (
     <SmartSearchBar
       {...props}
@@ -55,4 +55,4 @@ function SearchBar(props: Props) {
   );
 }
 
-export default SearchBar;
+export default ReplaySearchBar;


### PR DESCRIPTION
This simplifies and fixes the search bar so that the query displayed matches the `?query=` url param. 

Test case:
1. Open Replay index page
2. Type in a search for something, like `browser.name:SeaMonkey`
  - notice the url gets updated with `/replays/?query=browser.name%3ASeaMonkey`
3. Click the Left side nav
  - notice the url changes to `/replays/` without a query param
  - Actual: the search box still says `browser.name:SeaMonkey`
  - This is fixed with this PR: the search box is reset to the default value. 

Clearing the search box continues to work, you can remove the default query and the url will say `/replays/?query=`