### PR TITLE
fix(analytics): Need to store precise numbers

### DIFF
--- a/src/sentry/analytics/events/issue_owners_time_durations.py
+++ b/src/sentry/analytics/events/issue_owners_time_durations.py
@@ -8,8 +8,8 @@ class IssueOwnersTimeDurationsEvent(analytics.Event):
         analytics.Attribute("group_id"),
         analytics.Attribute("event_id"),
         analytics.Attribute("project_id"),
-        analytics.Attribute("baseline_duration", type=int),
-        analytics.Attribute("experiment_duration", type=int),
+        analytics.Attribute("baseline_duration"),
+        analytics.Attribute("experiment_duration"),
     )
 
 


### PR DESCRIPTION
## Objective

The runs are taking fractions of a second. Running the `int()` operator on the value returns `0`. We want to store the precise value. So, we will store them as strings and the cast them into ints in our sql queries