### PR TITLE
feat(feature-flag): Add new feature flag to control the removal of multiselect platforms in the onboarding

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1218,6 +1218,8 @@ SENTRY_FEATURES = {
     "organizations:mobile-view-hierarchies": False,
     # Enable the onboarding heartbeat footer on the sdk setup page
     "organizations:onboarding-heartbeat-footer": False,
+    # Disables multiselect platform in the onboarding flow
+    "organizations:onboarding-remove-multi-select-platform": False,
     # Enable ANR rates in project details page
     "organizations:anr-rate": False,
     # Enable tag improvements in the issue details page

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1219,7 +1219,7 @@ SENTRY_FEATURES = {
     # Enable the onboarding heartbeat footer on the sdk setup page
     "organizations:onboarding-heartbeat-footer": False,
     # Disables multiselect platform in the onboarding flow
-    "organizations:onboarding-remove-multi-select-platform": False,
+    "organizations:onboarding-remove-multiselect-platform": False,
     # Enable ANR rates in project details page
     "organizations:anr-rate": False,
     # Enable tag improvements in the issue details page

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -203,6 +203,7 @@ default_manager.add("organizations:integrations-issue-sync", OrganizationFeature
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature)
 default_manager.add("organizations:onboarding-heartbeat-footer", OrganizationFeature, True)
+default_manager.add("organizations:onboarding-remove-multi-select-platform", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add("organizations:profile-blocked-main-thread-ingest", OrganizationFeature)
 default_manager.add("organizations:relay", OrganizationFeature)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -203,7 +203,7 @@ default_manager.add("organizations:integrations-issue-sync", OrganizationFeature
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature)
 default_manager.add("organizations:onboarding-heartbeat-footer", OrganizationFeature, True)
-default_manager.add("organizations:onboarding-remove-multi-select-platform", OrganizationFeature, True)
+default_manager.add("organizations:onboarding-remove-multiselect-platform", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add("organizations:profile-blocked-main-thread-ingest", OrganizationFeature)
 default_manager.add("organizations:relay", OrganizationFeature)


### PR DESCRIPTION
Adding a new feature flag that will control the removal of a multi-select platform in the onboarding of new orgs.

In the PR https://github.com/getsentry/sentry/pull/43779 the new behaviour is controlled by the `organizations:onboarding-heartbeat-footer` feature flag, but the code will be updated to use this new feature flag as we want to control both changes separately.

