### PR TITLE
ref: Remove a temporary metric meant to track down an issue

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -166,12 +166,6 @@ def process_profile_task(
 
     _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED)
 
-    metrics.gauge(
-        "process_profile.kafka_producer.queue.size",
-        len(_profiles_kafka_producer._KafkaProducer__producer),  # type: ignore
-        sample_rate=1.0,
-    )
-
 
 SHOULD_SYMBOLICATE = frozenset(["cocoa", "rust"])
 SHOULD_DEOBFUSCATE = frozenset(["android"])


### PR DESCRIPTION
We used this metric to understand an OOM issue with the Celery task. This didn't give too much helpful information, we're removing it.