### PR TITLE
feat(tags): updates tag values to link correctly

### DIFF
--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -3,7 +3,19 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 
 import TagFacets, {TAGS_FORMATTER} from 'sentry/components/group/tagFacets';
 
-const {organization} = initializeOrg();
+const mockProject = TestStubs.Project();
+const {router, organization, routerContext} = initializeOrg({
+  organization: {},
+  project: mockProject,
+  projects: [mockProject],
+  router: {
+    routes: [],
+    location: {
+      pathname: '/organizations/org-slug/issues/1/',
+      query: {},
+    },
+  },
+});
 describe('Tag Facets', function () {
   let tagsMock;
   const project = TestStubs.Project();
@@ -176,6 +188,68 @@ describe('Tag Facets', function () {
       expect(
         screen.getByRole('button', {name: 'Expand os tag distribution'})
       ).toBeInTheDocument();
+    });
+
+    it('links to events with selected tag value', async function () {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          project={project}
+          tagKeys={tags}
+          tagFormatter={TAGS_FORMATTER}
+        />,
+        {
+          context: routerContext,
+          organization,
+          router,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+      userEvent.click(
+        screen.getByRole('button', {name: 'Expand device tag distribution'})
+      );
+      expect(
+        screen.getByRole('link', {
+          name: 'device, iPhone10, 27% of all events. View events with this tag value.',
+        })
+      ).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/issues/1/events/?query=device%3AiPhone10'
+      );
+    });
+
+    it('links to tags tab', async function () {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          project={project}
+          tagKeys={tags}
+          tagFormatter={TAGS_FORMATTER}
+        />,
+        {
+          context: routerContext,
+          organization,
+          router,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+      userEvent.click(
+        screen.getByRole('button', {name: 'Expand device tag distribution'})
+      );
+      expect(
+        screen.getByRole('link', {
+          name: 'Other device tag values, 13% of all events. View all tags.',
+        })
+      ).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/issues/1/tags/device/?referrer=tag-distribution-meter'
+      );
     });
   });
 });

--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -244,7 +244,7 @@ describe('Tag Facets', function () {
       );
       expect(
         screen.getByRole('link', {
-          name: 'Other device tag values, 13% of all events. View all tags.',
+          name: 'Other device tag values, 13% of all events. View other tags.',
         })
       ).toHaveAttribute(
         'href',

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -1,5 +1,6 @@
 import {Fragment, ReactNode, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import {LocationDescriptor} from 'history';
 import keyBy from 'lodash/keyBy';
 
 import Placeholder from 'sentry/components/placeholder';
@@ -8,7 +9,9 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Environment, Event, Organization, Project, TagWithTopValues} from 'sentry/types';
 import {formatVersion} from 'sentry/utils/formatters';
+import {appendTagCondition} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import TagFacetsDistributionMeter from './tagFacetsDistributionMeter';
@@ -175,6 +178,8 @@ function TagFacetsDistributionMeterWrapper({
   tagsData: Record<string, TagWithTopValues>;
   expandFirstTag?: boolean;
 }) {
+  const location = useLocation();
+  const query = {...location.query};
   return (
     <TagFacetsList>
       {tagKeys.map((tagKey, index) => {
@@ -182,13 +187,26 @@ function TagFacetsDistributionMeterWrapper({
         const topValues = tagWithTopValues ? tagWithTopValues.topValues : [];
         const topValuesTotal = tagWithTopValues ? tagWithTopValues.totalValues : 0;
 
-        const url = `/organizations/${organization.slug}/issues/${groupId}/tags/${tagKey}/?referrer=tag-distribution-meter`;
+        const otherTagValuesUrl = `/organizations/${organization.slug}/issues/${groupId}/tags/${tagKey}/?referrer=tag-distribution-meter`;
+        const eventsPath = `/organizations/${organization.slug}/issues/${groupId}/events/`;
 
         const segments = topValues
-          ? topValues.map(value => ({
-              ...value,
-              url,
-            }))
+          ? topValues.map(value => {
+              // Create a link to the events page with a tag condition on the selected value
+              const url: LocationDescriptor = {
+                ...location,
+                query: {
+                  ...query,
+                  query: appendTagCondition(null, tagKey, value.value),
+                },
+                pathname: eventsPath,
+              };
+
+              return {
+                ...value,
+                url,
+              };
+            })
           : [];
 
         return (
@@ -200,6 +218,7 @@ function TagFacetsDistributionMeterWrapper({
               onTagClick={() => undefined}
               project={project}
               expandByDefault={expandFirstTag && index === 0}
+              otherUrl={otherTagValuesUrl}
             />
           </li>
         );

--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -179,7 +179,7 @@ function TagFacetsDistributionMeter({
             index === topSegments.length - 1 && segment.value === 'other';
           const linkLabel = isOtherSegment
             ? t(
-                'Other %s tag values, %s of all events. View all tags.',
+                'Other %s tag values, %s of all events. View other tags.',
                 title,
                 `${pctLabel}%`
               )

--- a/static/app/utils/queryString.spec.tsx
+++ b/static/app/utils/queryString.spec.tsx
@@ -76,6 +76,34 @@ describe('appendTagCondition', function () {
   });
 });
 
+describe('appendExcludeTagValuesCondition', function () {
+  it('excludes tag values', function () {
+    const result = utils.appendExcludeTagValuesCondition(null, 'color', [
+      'red',
+      'blue',
+      'green',
+    ]);
+    expect(result).toEqual('!color:[red, blue, green]');
+  });
+  it('excludes tag values on an existing query', function () {
+    const result = utils.appendExcludeTagValuesCondition('user.id:123', 'color', [
+      'red',
+      'blue',
+      'green',
+    ]);
+    expect(result).toEqual('user.id:123 !color:[red, blue, green]');
+  });
+  it('wraps double quotes when a space exists in the tag value', function () {
+    const result = utils.appendExcludeTagValuesCondition(null, 'color', [
+      'red',
+      'ocean blue',
+      '"green"',
+      '"sky blue"',
+    ]);
+    expect(result).toEqual('!color:[red, "ocean blue", "\\"green\\"", "\\"sky blue\\""]');
+  });
+});
+
 describe('decodeScalar()', function () {
   it('unwraps array values', function () {
     expect(utils.decodeScalar(['one', 'two'])).toEqual('one');

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -55,6 +55,30 @@ export function appendTagCondition(
   return currentQuery;
 }
 
+export function appendExcludeTagValuesCondition(
+  query: QueryValue,
+  key: string,
+  values: string[]
+): string {
+  let currentQuery = Array.isArray(query) ? query.pop() : isString(query) ? query : '';
+  const filteredValuesCondition = `[${values
+    .map(value => {
+      if (typeof value === 'string' && /[\s"]/g.test(value)) {
+        value = `"${escapeDoubleQuotes(value)}"`;
+      }
+      return value;
+    })
+    .join(', ')}]`;
+
+  if (currentQuery) {
+    currentQuery += ` !${key}:${filteredValuesCondition}`;
+  } else {
+    currentQuery = `!${key}:${filteredValuesCondition}`;
+  }
+
+  return currentQuery;
+}
+
 // This function has multiple signatures to help with typing in callers.
 export function decodeScalar(value: QueryValue): string | undefined;
 export function decodeScalar(value: QueryValue, fallback: string): string;
@@ -102,6 +126,7 @@ const queryString = {
   formatQueryString,
   addQueryParamsToExistingUrl,
   appendTagCondition,
+  appendExcludeTagValuesCondition,
 };
 
 export default queryString;

--- a/static/app/views/discover/tags.spec.jsx
+++ b/static/app/views/discover/tags.spec.jsx
@@ -192,7 +192,7 @@ describe('Tags', function () {
     userEvent.click(screen.getByRole('button', {name: 'Expand color tag distribution'}));
     expect(
       screen.getByRole('link', {
-        name: 'Other color tag values, 16% of all events. View all tags.',
+        name: 'Other color tag values, 16% of all events. View other tags.',
       })
     ).toHaveAttribute(
       'href',

--- a/static/app/views/discover/tags.spec.jsx
+++ b/static/app/views/discover/tags.spec.jsx
@@ -22,18 +22,24 @@ describe('Tags', function () {
       body: [
         {
           key: 'release',
-          topValues: [{count: 3, value: '123abcd', name: '123abcd'}],
+          topValues: [{count: 30, value: '123abcd', name: '123abcd'}],
         },
         {
           key: 'environment',
           topValues: [
-            {count: 2, value: 'abcd123', name: 'abcd123'},
-            {count: 1, value: 'anotherOne', name: 'anotherOne'},
+            {count: 20, value: 'abcd123', name: 'abcd123'},
+            {count: 10, value: 'anotherOne', name: 'anotherOne'},
           ],
         },
         {
           key: 'color',
-          topValues: [{count: 3, value: 'red', name: 'red'}],
+          topValues: [
+            {count: 10, value: 'red', name: 'red'},
+            {count: 5, value: 'blue', name: 'blue'},
+            {count: 5, value: 'green', name: 'green'},
+            {count: 5, value: 'yellow', name: 'yellow'},
+            {count: 5, value: 'orange', name: 'orange'},
+          ],
         },
       ],
     });
@@ -56,7 +62,7 @@ describe('Tags', function () {
       <Tags
         eventView={view}
         api={api}
-        totalValues={3}
+        totalValues={30}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
         location={{query: {}}}
@@ -95,7 +101,7 @@ describe('Tags', function () {
         eventView={view}
         api={api}
         organization={org}
-        totalValues={3}
+        totalValues={30}
         selection={{projects: [], environments: [], datetime: {}}}
         location={initialData.router.location}
         generateUrl={generateUrl}
@@ -132,7 +138,7 @@ describe('Tags', function () {
       <Tags
         eventView={view}
         api={api}
-        totalValues={3}
+        totalValues={30}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
         location={{query: {}}}
@@ -148,5 +154,49 @@ describe('Tags', function () {
     expect(screen.getByRole('listitem', {name: 'release'})).toBeInTheDocument();
     expect(screen.getByRole('listitem', {name: 'environment'})).toBeInTheDocument();
     expect(screen.getByRole('listitem', {name: 'color'})).toBeInTheDocument();
+  });
+
+  it('excludes top tag values on current page query', async function () {
+    const api = new Client();
+
+    const initialData = initializeOrg({
+      organization: org,
+      router: {
+        location: {pathname: '/organizations/org-slug/discover/homepage/', query: {}},
+      },
+    });
+
+    const view = new EventView({
+      fields: [],
+      sorts: [],
+      query: '',
+    });
+
+    render(
+      <Tags
+        eventView={view}
+        api={api}
+        totalValues={30}
+        organization={org}
+        selection={{projects: [], environments: [], datetime: {}}}
+        location={initialData.router.location}
+        generateUrl={generateUrl}
+        confirmedQuery={false}
+      />,
+      {context: initialData.routerContext}
+    );
+
+    await waitForElementToBeRemoved(
+      () => screen.queryAllByTestId('loading-placeholder')[0]
+    );
+    userEvent.click(screen.getByRole('button', {name: 'Expand color tag distribution'}));
+    expect(
+      screen.getByRole('link', {
+        name: 'Other color tag values, 16% of all events. View all tags.',
+      })
+    ).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/discover/homepage/?query=%21color%3A%5Bred%2C%20blue%2C%20green%2C%20yellow%5D'
+    );
   });
 });


### PR DESCRIPTION
Updates the tag value legends in the tag summary with more relevant links:
- in issue tags, clicking on a tag value goes to the all events tab, prefiltered by the selected tag value
- in issue tags, clicking on other goes to the tags tab on the selected tag key
- in performance and discover, clicking on a tag value appends the tag value to the current query (no change here)
- in performance and discover, clicking on other excludes top tag values from the current query