### PR TITLE
feat(roles): update OrganizationMember get_scopes

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
@@ -395,8 +395,20 @@ class OrganizationMember(Model):
         )
 
     def get_scopes(self) -> FrozenSet[str]:
-        role_obj = organization_roles.get(self.role)
-        return self.organization.get_scopes(role_obj)
+        # include org roles from team membership
+        team_org_roles = self.get_org_roles_from_teams()
+        team_org_roles.append(self.role)
+        scopes = set()
+
+        for role in team_org_roles:
+            role_obj = organization_roles.get(role)
+            scopes.update(self.organization.get_scopes(role_obj))
+        return frozenset(scopes)
+
+    def get_org_roles_from_teams(self):
+        return list(
+            self.teams.all().filter(~Q(org_role=None)).values_list("org_role", flat=True).distinct()
+        )
 
     def validate_invitation(self, user_to_approve, allowed_roles):
         """

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -406,6 +406,7 @@ class OrganizationMember(Model):
         return frozenset(scopes)
 
     def get_org_roles_from_teams(self):
+        # results in an extra query when calling get_scopes()
         return list(
             self.teams.all().filter(~Q(org_role=None)).values_list("org_role", flat=True).distinct()
         )

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -139,7 +139,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 44 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 46
+        expected_queries = 45 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 47
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)


### PR DESCRIPTION
Update `OrganizationMember` `get_scopes` to include scopes from org roles through team membership

This will cause every API call to have an extra DB query to get all the possible scopes from the teams a member is a part of

For ER-1352