### PR TITLE
feat(roles): update team put api to set org_role

### DIFF
--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -89,6 +89,8 @@ class TeamDetailsEndpoint(TeamEndpoint):
                     status=status.HTTP_403_FORBIDDEN,
                 )
 
+            # users should not be able to set the role of a team to something higher than themselves
+            # only allow the top dog to do this so they can set the org_role to any role in the org
             elif roles.get_top_dog() not in request.access.get_organization_roles():
                 return Response(
                     {

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -80,9 +80,14 @@ class TeamDetailsEndpoint(TeamEndpoint):
                                owners can set this value.
         :auth: required
         """
-        if request.data.get("orgRole") and str(request.access.get_organization_role()) != "Owner":
+        if (
+            request.data.get("orgRole")
+            and roles.get_top_dog() not in request.access.get_organization_roles()
+        ):
             return Response(
-                {"detail": "You must be an organization owner to perform this action."},
+                {
+                    "detail": f"You must have the role of {roles.get_top_dog().id} to perform this action."
+                },
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -80,16 +80,22 @@ class TeamDetailsEndpoint(TeamEndpoint):
                                owners can set this value.
         :auth: required
         """
-        if (
-            request.data.get("orgRole")
-            and roles.get_top_dog() not in request.access.get_organization_roles()
-        ):
-            return Response(
-                {
-                    "detail": f"You must have the role of {roles.get_top_dog().id} to perform this action."
-                },
-                status=status.HTTP_403_FORBIDDEN,
-            )
+        if request.data.get("orgRole"):
+            if team.idp_provisioned:
+                return Response(
+                    {
+                        "detail": "This team is managed through your organization's identity provider."
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            elif roles.get_top_dog() not in request.access.get_organization_roles():
+                return Response(
+                    {
+                        "detail": f"You must have the role of {roles.get_top_dog().id} to perform this action."
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
 
         serializer = TeamSerializer(team, data=request.data, partial=True)
         if serializer.is_valid():

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -4,21 +4,23 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log
+from sentry import audit_log, roles
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSerializer as ModelTeamSerializer
+from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.models import ScheduledDeletion, Team, TeamStatus
 
 
-class TeamSerializer(serializers.ModelSerializer):
+class TeamSerializer(CamelSnakeModelSerializer):
     slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50)
+    org_role = serializers.ChoiceField(choices=roles.get_choices(), default=None)
 
     class Meta:
         model = Team
-        fields = ("name", "slug")
+        fields = ("name", "slug", "org_role")
 
     def validate_slug(self, value):
         qs = Team.objects.filter(slug=value, organization=self.instance.organization).exclude(
@@ -74,8 +76,16 @@ class TeamDetailsEndpoint(TeamEndpoint):
         :param string name: the new name for the team.
         :param string slug: a new slug for the team.  It has to be unique
                             and available.
+        :param string orgRole: an organization role for the team. Only
+                               owners can set this value.
         :auth: required
         """
+        if request.data.get("orgRole") and str(request.access.get_organization_role()) != "Owner":
+            return Response(
+                {"detail": "You must be an organization owner to perform this action."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         serializer = TeamSerializer(team, data=request.data, partial=True)
         if serializer.is_valid():
             team = serializer.save()

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -135,10 +135,10 @@ class Access(abc.ABC):
             return cast(OrganizationRole, organization_roles.get(self.role))
         return None
 
-    def get_organization_roles(self) -> Iterable[OrganizationRole] | None:
+    def get_organization_roles(self) -> Iterable[OrganizationRole]:
         if self.roles is not None:
             return [cast(OrganizationRole, organization_roles.get(r)) for r in self.roles]
-        return None
+        return []
 
     @abc.abstractmethod
     def has_team_access(self, team: Team) -> bool:
@@ -221,7 +221,7 @@ class DbAccess(Access):
 
     @property
     def roles(self) -> Iterable[str] | None:
-        return self._member.get_all_roles() if self._member else None
+        return self._member.get_all_org_roles() if self._member else None
 
     @cached_property
     def _team_memberships(self) -> Mapping[Team, OrganizationMemberTeam]:

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -396,8 +396,7 @@ class OrganizationMember(Model):
 
     def get_scopes(self) -> FrozenSet[str]:
         # include org roles from team membership
-        team_org_roles = self.get_org_roles_from_teams()
-        team_org_roles.append(self.role)
+        team_org_roles = self.get_all_org_roles()
         scopes = set()
 
         for role in team_org_roles:
@@ -410,6 +409,11 @@ class OrganizationMember(Model):
         return list(
             self.teams.all().filter(~Q(org_role=None)).values_list("org_role", flat=True).distinct()
         )
+
+    def get_all_org_roles(self):
+        all_org_roles = self.get_org_roles_from_teams()
+        all_org_roles.append(self.role)
+        return all_org_roles
 
     def validate_invitation(self, user_to_approve, allowed_roles):
         """

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -297,8 +297,10 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
     def get_all_org_roles(self, organization_member: ApiOrganizationMember) -> List[str]:
         team_ids = [mt.team_id for mt in organization_member.member_teams]
-        return list(
+        org_roles = list(
             Team.objects.filter(~Q(org_role=None), id__in=team_ids)
             .values_list("org_role", flat=True)
             .distinct()
         )
+        org_roles.append(organization_member.role)
+        return org_roles

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -138,6 +138,22 @@ class TeamUpdateTest(TeamDetailsTestBase):
         team = Team.objects.get(id=team.id)
         assert not team.org_role
 
+    def test_put_team_org_role__idp_provisioned_team(self):
+        team = self.create_team(idp_provisioned=True)
+        user = self.create_user("foo@example.com")
+        self.create_member(user=user, organization=self.organization, role="owner")
+        self.login_as(user)
+        response = self.get_error_response(
+            team.organization.slug, team.slug, org_role="owner", status_code=403
+        )
+
+        assert (
+            response.data["detail"]
+            == "This team is managed through your organization's identity provider."
+        )
+        team = Team.objects.get(id=team.id)
+        assert not team.org_role
+
 
 @region_silo_test
 class TeamDeleteTest(TeamDetailsTestBase):

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -84,7 +84,7 @@ class TeamUpdateTest(TeamDetailsTestBase):
         user = self.create_user("foo@example.com")
         self.create_member(user=user, organization=self.organization, role="owner")
         self.login_as(user)
-        self.get_success_response(team.organization.slug, team.slug, org_role="owner")
+        self.get_success_response(team.organization.slug, team.slug, orgRole="owner")
 
         team = Team.objects.get(id=team.id)
         assert team.org_role == "owner"
@@ -98,26 +98,31 @@ class TeamUpdateTest(TeamDetailsTestBase):
         )
         self.login_as(user)
 
-        self.get_success_response(team.organization.slug, team.slug, org_role="owner")
+        self.get_success_response(team.organization.slug, team.slug, orgRole="owner")
 
         team = Team.objects.get(id=team.id)
         assert team.org_role == "owner"
 
-    def test_put_team_org_role__not_owner(self):
+    def test_put_team_org_role__member(self):
         team = self.team
         user = self.create_user("foo@example.com")
-        member = self.create_member(user=user, organization=self.organization, role="member")
+        self.create_member(user=user, organization=self.organization, role="member")
         self.login_as(user)
 
         response = self.get_error_response(
-            team.organization.slug, team.slug, org_role="owner", status_code=403
+            team.organization.slug, team.slug, orgRole="owner", status_code=403
         )
         assert response.data["detail"] == "You do not have permission to perform this action."
 
         team = Team.objects.get(id=team.id)
         assert not team.org_role
 
-        member.update(role="admin")
+    def test_put_team_org_role__admin(self):
+        team = self.team
+        user = self.create_user("foo@example.com")
+        self.create_member(user=user, organization=self.organization, role="admin")
+        self.login_as(user)
+
         response = self.get_error_response(
             team.organization.slug, team.slug, orgRole="owner", status_code=403
         )
@@ -131,9 +136,7 @@ class TeamUpdateTest(TeamDetailsTestBase):
         user = self.create_user("foo@example.com")
         self.create_member(user=user, organization=self.organization, role="owner")
         self.login_as(user)
-        self.get_error_response(
-            team.organization.slug, team.slug, org_role="onwer", status_code=400
-        )
+        self.get_error_response(team.organization.slug, team.slug, orgRole="onwer", status_code=400)
 
         team = Team.objects.get(id=team.id)
         assert not team.org_role
@@ -144,7 +147,7 @@ class TeamUpdateTest(TeamDetailsTestBase):
         self.create_member(user=user, organization=self.organization, role="owner")
         self.login_as(user)
         response = self.get_error_response(
-            team.organization.slug, team.slug, org_role="owner", status_code=403
+            team.organization.slug, team.slug, orgRole="owner", status_code=403
         )
 
         assert (

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -79,6 +79,41 @@ class TeamUpdateTest(TeamDetailsTestBase):
         assert team.name == "hello world"
         assert team.slug == "foobar"
 
+    def test_put_team_org_role__success(self):
+        team = self.team
+        user = self.create_user("foo@example.com")
+        self.create_member(user=user, organization=self.organization, role="owner")
+        self.login_as(user)
+        self.get_success_response(team.organization.slug, team.slug, org_role="owner")
+
+        team = Team.objects.get(id=team.id)
+        assert team.org_role == "owner"
+
+    def test_put_team_org_role__not_owner(self):
+        team = self.team
+        user = self.create_user("foo@example.com")
+        self.create_member(user=user, organization=self.organization, role="member")
+        self.login_as(user)
+
+        self.get_error_response(
+            team.organization.slug, team.slug, org_role="owner", status_code=403
+        )
+
+        team = Team.objects.get(id=team.id)
+        assert not team.org_role
+
+    def test_put_team_org_role__invalid_role(self):
+        team = self.team
+        user = self.create_user("foo@example.com")
+        self.create_member(user=user, organization=self.organization, role="owner")
+        self.login_as(user)
+        self.get_error_response(
+            team.organization.slug, team.slug, org_role="onwer", status_code=400
+        )
+
+        team = Team.objects.get(id=team.id)
+        assert not team.org_role
+
 
 @region_silo_test
 class TeamDeleteTest(TeamDetailsTestBase):

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -284,6 +284,21 @@ class FromUserTest(AccessFactoryTestCase):
             assert result.has_team_scope(team, "team:admin")
             assert result.has_project_scope(project, "team:admin")
 
+    def test_get_organization_roles_from_teams(self):
+        user = self.create_user()
+        organization = self.create_organization()
+        owner_team = self.create_team(organization=organization, org_role="owner")
+        admin_team = self.create_team(organization=organization, org_role="admin")
+        self.create_member(organization=organization, user=user, teams=[owner_team, admin_team])
+
+        request = self.make_request(user=user)
+        results = [self.from_user(user, organization), self.from_request(request, organization)]
+
+        for result in results:
+            assert "owner" in result.roles
+            assert "member" in result.roles
+            assert "admin" in result.roles
+
     def test_unlinked_sso(self):
         user = self.create_user()
         organization = self.create_organization(owner=user)


### PR DESCRIPTION
Allow setting the `org_role` field on the Team model through the `PUT Team` API

Requires #43911 although I have a fix in here for something I missed there

For ER-1353

To-dos will be addressed in ER-1350