### PR TITLE
fix(domains) Fix join-request requiring authentication

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -550,7 +550,7 @@ urlpatterns += [
     # Discover
     url(r"^discover/", react_page_view, name="discover"),
     # Request to join an organization
-    url(r"^join-request/", react_page_view, name="join-request"),
+    url(r"^join-request/", GenericReactPageView.as_view(auth_required=False), name="join-request"),
     # Activity
     url(r"^activity/", react_page_view, name="activity"),
     # Stats

--- a/static/app/views/organizationJoinRequest.tsx
+++ b/static/app/views/organizationJoinRequest.tsx
@@ -68,7 +68,7 @@ class OrganizationJoinRequest extends Component<Props, State> {
     return (
       <NarrowLayout maxWidth="650px">
         <StyledIconMegaphone size="xxl" />
-        <StyledHeader>{t('Request to Join')}</StyledHeader>
+        <StyledHeader data-test-id="join-request">{t('Request to Join')}</StyledHeader>
         <StyledText>
           {tct('Ask the admins if you can join the [orgId] organization.', {
             orgId: params.orgId,

--- a/tests/acceptance/test_organization_join_request.py
+++ b/tests/acceptance/test_organization_join_request.py
@@ -1,0 +1,16 @@
+from sentry.testutils import AcceptanceTestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class OrganizationJoinRequestTest(AcceptanceTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user("foo@example.com")
+        self.org = self.create_organization(name="Rowdy Tiger", owner=self.user)
+
+    def test_view(self):
+        self.browser.get(f"/join-request/{self.org.slug}/")
+        self.browser.wait_until('[data-test-id="join-request"]')
+        self.browser.snapshot(name="organization join request")
+        assert self.browser.element_exists('[data-test-id="join-request"]')


### PR DESCRIPTION
The join-request view should not require authentication. Doing so means that users can't actually use it.
