### PR TITLE
test(snuba): Mark flakey snuba test with xfail

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1304,6 +1304,9 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert response.status_code == 200
             assert all([interval[1][0]["count"] == 0 for interval in response.data["data"]])
 
+    @pytest.mark.xfail(
+        reason="The response.data[Other] returns 15 locally and returns 16 or 15 remotely."
+    )
     def test_tag_with_conflicting_function_alias_with_other_single_grouping(self):
         event_data = [
             {


### PR DESCRIPTION
This test consistently returns 15 locally but returns 16 or 15 on CI. 

I can't tell why 16 would be returned as the setup seems to create 15 events and I've never seen 16 be set when run locally.

CI flakes: https://sentry.io/organizations/sentry/issues/3871731199/events/?project=2423079&referrer=issue-stream&statsPeriod=7d