### PR TITLE
fix(issues) Fix generated share link URL

### DIFF
--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -86,7 +86,7 @@ function ShareIssueModal({
   }, []);
 
   function getShareUrl() {
-    const path = `/organizations/${organization.slug}/share/issue/${group!.shareId}/`;
+    const path = `/share/issue/${group!.shareId}/`;
     const {host, protocol} = window.location;
     return `${protocol}//${host}${path}`;
   }


### PR DESCRIPTION
We don't have serverside routes for the /organizations/slug prefix on share, nor do we need that information. Having the organization present in the URL is a requirement for hybrid cloud (as we need the org to find the region) but with customer domains share URLs will have a subdomain with the organization in it.

fixes #43876