### PR TITLE
bug(replays): Fix the replay event node display in dark mode

### DIFF
--- a/static/app/views/issueDetails/quickTrace/replayNode.tsx
+++ b/static/app/views/issueDetails/quickTrace/replayNode.tsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 import {EventNode} from 'sentry/components/quickTrace/styles';
 import {IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -14,12 +12,11 @@ type Props = {
 
 function ReplayNode({hasReplay}: Props) {
   const location = useLocation();
-  const isDarkmode = useLegacyStore(ConfigStore).theme === 'dark';
 
   if (hasReplay) {
     return (
       <EventNodeReplay
-        icon={<StyledIcon size="xs" isDarkmode={isDarkmode} />}
+        icon={<StyledIcon size="xs" />}
         onClick={() => document.getElementById('breadcrumbs')?.scrollIntoView()}
         to={{...location, hash: '#breadcrumbs'}}
         type="black"
@@ -40,8 +37,8 @@ function ReplayNode({hasReplay}: Props) {
   );
 }
 
-const StyledIcon = styled(IconPlay)<{isDarkmode: boolean}>`
-  fill: ${p => (p.isDarkmode ? p.theme.black : p.theme.white)};
+const StyledIcon = styled(IconPlay)`
+  fill: ${p => p.theme.backgroundTertiary};
 `;
 
 export const EventNodeReplay = styled(EventNode)`

--- a/static/app/views/issueDetails/quickTrace/replayNode.tsx
+++ b/static/app/views/issueDetails/quickTrace/replayNode.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import {EventNode} from 'sentry/components/quickTrace/styles';
 import {IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -12,10 +14,12 @@ type Props = {
 
 function ReplayNode({hasReplay}: Props) {
   const location = useLocation();
+  const isDarkmode = useLegacyStore(ConfigStore).theme === 'dark';
+
   if (hasReplay) {
     return (
       <EventNodeReplay
-        icon={<IconPlay size="xs" />}
+        icon={<StyledIcon size="xs" isDarkmode={isDarkmode} />}
         onClick={() => document.getElementById('breadcrumbs')?.scrollIntoView()}
         to={{...location, hash: '#breadcrumbs'}}
         type="black"
@@ -35,6 +39,10 @@ function ReplayNode({hasReplay}: Props) {
     </EventNodeReplay>
   );
 }
+
+const StyledIcon = styled(IconPlay)<{isDarkmode: boolean}>`
+  fill: ${p => (p.isDarkmode ? p.theme.black : p.theme.white)};
+`;
 
 export const EventNodeReplay = styled(EventNode)`
   display: inline-flex;


### PR DESCRIPTION
**Before:**

<img width="145" alt="SCR-20230131-f5z" src="https://user-images.githubusercontent.com/187460/215855748-e522b29f-f513-49e7-8619-99b19b4c2da5.png">


**After:**
Using `backgroundTertiary`:

<img width="176" alt="SCR-20230201-l56" src="https://user-images.githubusercontent.com/187460/216188637-7150b44f-ec20-4900-b3e1-fec9caed15fc.png">
<img width="153" alt="SCR-20230201-l50" src="https://user-images.githubusercontent.com/187460/216188640-a62a03bc-c1d3-4cdb-babc-8da350976390.png">
