### PR TITLE
fix(hybrid-cloud): Lowercase org slugs on save.

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -215,7 +215,7 @@ class Organization(Model, SnowflakeIdMixin):
         if slugify_target is not None:
             lock = locks.get("slug:organization", duration=5, name="organization_slug")
             with TimedRetryPolicy(10)(lock.acquire):
-                slugify_target = slugify_target.replace("_", "-").strip("-")
+                slugify_target = slugify_target.lower().replace("_", "-").strip("-")
                 slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
 
         if SENTRY_USE_SNOWFLAKE:


### PR DESCRIPTION
We have org slugs that have uppercase letters. We prefer that they only contain lowercase letters.

This is something I forgot to include in https://github.com/getsentry/sentry/pull/36384. I'm remedying that here.