### PR TITLE
feat(roles): get org roles using organization_service

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -105,6 +105,10 @@ class OrganizationService(InterfaceWithLifecycle):
     def update_membership_flags(self, *, organization_member: ApiOrganizationMember) -> None:
         pass
 
+    @abstractmethod
+    def get_all_org_roles(self, organization_member: ApiOrganizationMember) -> List[str]:
+        pass
+
 
 def impl_with_db() -> OrganizationService:
     from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
@@ -134,6 +138,7 @@ class ApiTeam:
     organization_id: int = -1
     slug: str = ""
     actor_id: int | None = None
+    org_role: str = ""
 
     def class_name(self) -> str:
         return "Team"

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -4,6 +4,8 @@ import dataclasses
 from collections import defaultdict
 from typing import TYPE_CHECKING, Iterable, List, MutableMapping, Optional, Set, cast
 
+from django.db.models import Q
+
 from sentry.models import (
     Organization,
     OrganizationMember,
@@ -101,6 +103,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             status=team.status,
             organization_id=team.organization_id,
             slug=team.slug,
+            org_role=team.org_role,
         )
 
     @classmethod
@@ -291,3 +294,11 @@ class DatabaseBackedOrganizationService(OrganizationService):
     @classmethod
     def _serialize_invite(cls, om: OrganizationMember) -> ApiOrganizationInvite:
         return ApiOrganizationInvite(om.id, om.token, om.email)
+
+    def get_all_org_roles(self, organization_member: ApiOrganizationMember) -> List[str]:
+        team_ids = [mt.team_id for mt in organization_member.member_teams]
+        return list(
+            Team.objects.filter(~Q(org_role=None), id__in=team_ids)
+            .values_list("org_role", flat=True)
+            .distinct()
+        )

--- a/tests/sentry/hybrid_cloud/test_organization.py
+++ b/tests/sentry/hybrid_cloud/test_organization.py
@@ -85,6 +85,7 @@ def assert_team_equals(orm_team: Team, team: ApiTeam):
     assert team.slug == orm_team.slug
     assert team.status == orm_team.status
     assert team.organization_id == orm_team.organization_id
+    assert team.org_role == orm_team.org_role
 
 
 def assert_project_equals(orm_project: Project, project: ApiProject):


### PR DESCRIPTION
Update `organization_service` so that when checking if `request.access` has a role, we can check all of the org roles that a member has including through team membership.

Auth has a check for `self.api_user_organization_context.member.role` which will need to include all org roles.

For ER-1352