### PR TITLE
feat(n1-api-calls): Add metrics for a suspicious parameter format

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -5,11 +5,14 @@ import os
 import random
 import re
 from datetime import timedelta
+from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
 from sentry import features
 from sentry.models import Organization, Project
 from sentry.types.issues import GroupType
+from sentry.utils import metrics
+from sentry.utils.event_frames import get_sdk_name
 
 from ..base import DETECTOR_TYPE_TO_GROUP_TYPE, DetectorType, PerformanceDetector, get_span_duration
 from ..performance_problem import PerformanceProblem
@@ -36,6 +39,8 @@ URL_PARAMETER_REGEX = re.compile(
 """
 )  # Adapted from message.py
 
+ESOTERIC_PARAMETER_REGEX = re.compile(r"\b[a-zA-Z]{3,20}_[a-zA-z\d_-]{18,}\b")
+
 
 class NPlusOneAPICallsDetector(PerformanceDetector):
     """
@@ -59,6 +64,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         # TODO: Only store the span IDs and timestamps instead of entire span objects
         self.stored_problems: PerformanceProblemsMap = {}
         self.spans: list[Span] = []
+        self.sdk_name = get_sdk_name(self._event)
 
     def visit_span(self, span: Span) -> None:
         if not NPlusOneAPICallsDetector.is_span_eligible(span):
@@ -95,7 +101,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         return self.settings["detection_rate"] > random.random()
 
     @staticmethod
-    def parameterize_url(url: str) -> str:
+    def parameterize_url(url: str, sdk_name: Optional[str] = None) -> str:
         parsed_url = urlparse(str(url))
 
         protocol_fragments = []
@@ -113,6 +119,13 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
                 path_fragments.append("*")
             else:
                 path_fragments.append(str(fragment))
+
+            if sdk_name and ESOTERIC_PARAMETER_REGEX.search(fragment):
+                metrics.incr(
+                    "performance.performance_issues.esoteric_url_parameter",
+                    sample_rate=1.0,
+                    tags={"sdk_name": sdk_name},
+                )
 
         query = parse_qs(parsed_url.query)
 
@@ -206,7 +219,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         )
 
     def _fingerprint(self) -> str:
-        parameterized_first_url = self.parameterize_url(get_url_from_span(self.spans[0]))
+        parameterized_first_url = self.parameterize_url(
+            get_url_from_span(self.spans[0]), self.sdk_name
+        )
         parsed_first_url = urlparse(parameterized_first_url)
         path = parsed_first_url.path
 

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -1,4 +1,5 @@
 from typing import Callable, List, cast
+from unittest.mock import call, patch
 from uuid import uuid4
 
 import pytest
@@ -136,6 +137,27 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         detector = NPlusOneAPICallsDetector(settings, event)
 
         assert not detector.is_creation_allowed_for_project(project)
+
+    @patch("sentry.utils.metrics.incr")
+    def test_reports_unusual_parameter_metrics(self, incr_mock):
+        NPlusOneAPICallsDetector.parameterize_url(
+            "/resource/00009whsfm7cF8niHp5h7x/details", "sentry.javascript.react"
+        )
+
+        incr_mock.assert_not_called()
+
+        NPlusOneAPICallsDetector.parameterize_url(
+            "/resource/user_00009whsfm7cF8niHp5h7x/details", "sentry.javascript.react"
+        )
+        incr_mock.assert_has_calls(
+            [
+                call(
+                    "performance.performance_issues.esoteric_url_parameter",
+                    sample_rate=1.0,
+                    tags={"sdk_name": "sentry.javascript.react"},
+                )
+            ]
+        )
 
     def test_fingerprints_events(self):
         event = self.create_event(lambda i: "GET /clients/info")


### PR DESCRIPTION
I'm seeing parameters that look like this: `"/resource/user_9whs7fm7cFiHp5h7xZX/details"`. This looks like some kind of prefixed nanoid. I'm probably going to parameterize these, but I wanted to gather some metrics first. Namely, what SDK is this, and how often does this happen?
