### PR TITLE
test: Deflake test_generic_issue_calculated_interval

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -136,26 +136,28 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         """Test that a 4h interval returns the correct generic event stats.
         This follows a different code path than 1h or 1d as the IssuePlatformTimeSeriesQueryBuilder
         does some calculation to create the time column."""
+        # Use an event window that is unaffected by other tests.
+        start = self.day_ago - timedelta(hours=4)
         _, _, group_info = self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{GroupType.PROFILE_BLOCKED_THREAD.value}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(minutes=1),
+            start.replace(tzinfo=utc) + timedelta(minutes=10),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{GroupType.PROFILE_BLOCKED_THREAD.value}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(minutes=1),
+            start.replace(tzinfo=utc) + timedelta(minutes=10),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{GroupType.PROFILE_BLOCKED_THREAD.value}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=utc) + timedelta(minutes=2),
+            start.replace(tzinfo=utc) + timedelta(minutes=11),
         )
         with self.feature(
             [
@@ -164,8 +166,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         ):
             response = self.do_request(
                 {
-                    "start": iso_format(self.day_ago),
-                    "end": iso_format(self.day_ago + timedelta(hours=4)),
+                    "start": iso_format(start),
+                    "end": iso_format(start + timedelta(hours=4)),
                     "interval": "4h",
                     "query": f"issue:{group_info.group.qualified_short_id}",
                     "dataset": "issuePlatform",


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/sentry/issues/3886776727/?project=2423079&query=is%3Aunresolved+pytest_environ.GITHUB_EVENT_NAME%3Apush+pytest_environ.GITHUB_REF%3Arefs%2Fheads%2Fmaster+tests%2Fsnuba%2F&referrer=issue-stream&statsPeriod=14d

I couldn't get this test to run reliably because the count would typically be 6. Giving this test its own event window ensures the assertion of `count: 3` is reliable.

NOTE: I've run this test file 20 times locally without issue