### PR TITLE
fix(ci): Remove reset sequence

### DIFF
--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -47,11 +47,6 @@ def build_url(path: str, format: str = "html") -> str:
 
 
 class EmailTestCase(AcceptanceTestCase):
-    # This test requires ID's for issues to start from 1, so reset sequences
-    # to avoid the test failing if the order of tests mean issues are made
-    # before this test is run.
-    reset_sequences = True
-
     def setUp(self):
         super().setUp()
         # This email address is required to match FIXTURES.


### PR DESCRIPTION
With the sequence reset, we get the following error when running locally (Not sure why this started happening, it didn't at first):

```
E   psycopg2.errors.UniqueViolation: UniqueViolation('duplicate key value violates unique constraint "sentry_actor_pkey"\nDETAIL:  Key (id)=(1) already exists.\n')
E   SQL: INSERT INTO "sentry_actor" ("type") VALUES (%s) RETURNING "sentry_actor"."id"
```