### PR TITLE
feat(tags): allows expanding tags with only a single value

### DIFF
--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -69,8 +69,7 @@ function TagFacetsDistributionMeter({
 }: Props) {
   const location = useLocation();
   const organization = useOrganization();
-  const multiValueTag = segments.length > 1;
-  const [expanded, setExpanded] = useState<boolean>(multiValueTag && !!expandByDefault);
+  const [expanded, setExpanded] = useState<boolean>(!!expandByDefault);
   const [hoveredValue, setHoveredValue] = useState<TagSegment | null>(null);
   const topSegments = segments.slice(0, MAX_SEGMENTS);
 
@@ -87,7 +86,7 @@ function TagFacetsDistributionMeter({
       <Title>
         <TitleType>{title}</TitleType>
         <TitleDescription>{topSegments[0].name || t('n/a')}</TitleDescription>
-        {multiValueTag && (
+        {
           <ExpandToggleButton
             borderless
             size="zero"
@@ -98,7 +97,7 @@ function TagFacetsDistributionMeter({
               title
             )}
           />
-        )}
+        }
       </Title>
     );
   }
@@ -237,10 +236,7 @@ function TagFacetsDistributionMeter({
     <TagSummary>
       <details open={expanded} onClick={e => e.preventDefault()}>
         <summary>
-          <TagHeader
-            clickable={multiValueTag}
-            onClick={() => multiValueTag && setExpanded(!expanded)}
-          >
+          <TagHeader clickable onClick={() => setExpanded(!expanded)}>
             {renderTitle()}
             {renderSegments()}
           </TagHeader>

--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -86,18 +86,16 @@ function TagFacetsDistributionMeter({
       <Title>
         <TitleType>{title}</TitleType>
         <TitleDescription>{topSegments[0].name || t('n/a')}</TitleDescription>
-        {
-          <ExpandToggleButton
-            borderless
-            size="zero"
-            icon={<IconChevron direction={expanded ? 'up' : 'down'} size="xs" />}
-            aria-label={t(
-              '%s %s tag distribution',
-              expanded ? 'Collapse' : 'Expand',
-              title
-            )}
-          />
-        }
+        <ExpandToggleButton
+          borderless
+          size="zero"
+          icon={<IconChevron direction={expanded ? 'up' : 'down'} size="xs" />}
+          aria-label={t(
+            '%s %s tag distribution',
+            expanded ? 'Collapse' : 'Expand',
+            title
+          )}
+        />
       </Title>
     );
   }


### PR DESCRIPTION
Allows tags with just a single value to be expanded
![image](https://user-images.githubusercontent.com/83961295/215888569-636e5e19-6391-46fe-bf44-252c6036b105.png)
