### PR TITLE
feat(codeowners): Add feature flagged higher max

### DIFF
--- a/src/sentry/api/endpoints/codeowners/__init__.py
+++ b/src/sentry/api/endpoints/codeowners/__init__.py
@@ -30,7 +30,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
     def get_max_length(self) -> int:
         if features.has(
             "organizations:scaleable-codeowners-search",
-            self.context["ownership"].project.organization,
+            self.context["project"].organization,
         ):
             return HIGHER_MAX_RAW_LENGTH
         return MAX_RAW_LENGTH

--- a/src/sentry/api/endpoints/codeowners/__init__.py
+++ b/src/sentry/api/endpoints/codeowners/__init__.py
@@ -27,7 +27,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
         model = ProjectCodeOwners
         fields = ["raw", "code_mapping_id", "organization_integration_id"]
 
-    def get_max_length(self):
+    def get_max_length(self) -> int:
         if features.has(
             "organizations:scaleable-codeowners-search",
             self.context["ownership"].project.organization,

--- a/src/sentry/api/endpoints/codeowners/__init__.py
+++ b/src/sentry/api/endpoints/codeowners/__init__.py
@@ -15,6 +15,7 @@ from sentry.utils import metrics
 
 # Max accepted string length of the CODEOWNERS file
 MAX_RAW_LENGTH = 100_000
+HIGHER_MAX_RAW_LENGTH = 3_000_000
 
 
 class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
@@ -25,6 +26,14 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
     class Meta:
         model = ProjectCodeOwners
         fields = ["raw", "code_mapping_id", "organization_integration_id"]
+
+    def get_max_length(self):
+        if features.has(
+            "organizations:scaleable-codeowners-search",
+            self.context["ownership"].project.organization,
+        ):
+            return HIGHER_MAX_RAW_LENGTH
+        return MAX_RAW_LENGTH
 
     def validate(self, attrs: Mapping[str, Any]) -> Mapping[str, Any]:
         # If it already exists, set default attrs with existing values
@@ -43,9 +52,10 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
         # we temporarily allow rows that already exceed this limit to still be updated.
         # We do something similar with ProjectOwnership at the API level.
         existing_raw = self.instance.raw if self.instance else ""
-        if len(attrs["raw"]) > MAX_RAW_LENGTH and len(existing_raw) <= MAX_RAW_LENGTH:
+        max_length = self.get_max_length()
+        if len(attrs["raw"]) > max_length and len(existing_raw) <= max_length:
             raise serializers.ValidationError(
-                {"raw": f"Raw needs to be <= {MAX_RAW_LENGTH} characters in length"}
+                {"raw": f"Raw needs to be <= {max_length} characters in length"}
             )
 
         # Ignore association errors and continue parsing CODEOWNERS for valid lines.


### PR DESCRIPTION
## Objective

We want to allow for a higher max size for the CODEOWNERS file. This higher max is feature flagged to sentry and my test-org. I want to run a simulation of a higher load and collect metrics against the baseline python implementation and the experiment rust implementation.