### PR TITLE
fix(tsdb): pass along snuba override options to request

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -10,6 +10,7 @@ from snuba_sdk import (
     Column,
     Direction,
     Entity,
+    Flags,
     Function,
     Granularity,
     Limit,
@@ -436,6 +437,19 @@ class SnubaTSDB(BaseTSDB):
                         Condition(Column(time_column), Op.LT, end),
                     ]
 
+            extras = {
+                "consistent",
+                "turbo",
+                "debug",
+                "dry_run",
+            }
+            found = {
+                extra: snuba.OVERRIDE_OPTIONS.get(extra)
+                for extra in extras
+                if snuba.OVERRIDE_OPTIONS.get(extra)
+            }
+            flags = Flags(**found)
+
             snql_request = Request(
                 dataset=model_dataset.value,
                 app_id="tsdb.get_data",
@@ -448,6 +462,7 @@ class SnubaTSDB(BaseTSDB):
                     granularity=Granularity(rollup),
                     limit=Limit(limit),
                 ),
+                flags=flags,
             )
             query_result = raw_snql_query(
                 snql_request, referrer=f"tsdb-modelid:{model.value}", use_cache=use_cache


### PR DESCRIPTION
We weren't properly passing the `consistent` flag when switching over to using SnQL format. This should read from override options and pass those along as flags.