### PR TITLE
ref(profiling): Use `SegmentedControl` in `FlamegraphViewSelectMenu`

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphViewSelectMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphViewSelectMenu.tsx
@@ -1,7 +1,6 @@
-import {Fragment, useCallback} from 'react';
+import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
-import ButtonBar from 'sentry/components/buttonBar';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
 import {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences';
 
@@ -18,42 +17,30 @@ function FlamegraphViewSelectMenu({
   sorting,
   onSortingChange,
 }: FlamegraphViewSelectMenuProps): React.ReactElement {
-  const onCallOrderClick = useCallback(() => {
-    onSortingChange('call order');
-  }, [onSortingChange]);
-
-  const onLeftHeavyClick = useCallback(() => {
-    onSortingChange('left heavy');
-  }, [onSortingChange]);
-
-  const onBottomUpClick = useCallback(() => {
-    onViewChange('bottom up');
-  }, [onViewChange]);
-
-  const onTopDownClick = useCallback(() => {
-    onViewChange('top down');
-  }, [onViewChange]);
-
   return (
-    <Fragment>
-      <ButtonBar merged active={sorting}>
-        <Button barId="call order" size="xs" onClick={onCallOrderClick}>
-          {t('Call Order')}
-        </Button>
-        <Button barId="left heavy" size="xs" onClick={onLeftHeavyClick}>
-          {t('Left Heavy')}
-        </Button>
-      </ButtonBar>
-      <ButtonBar merged active={view}>
-        <Button barId="bottom up" size="xs" onClick={onBottomUpClick}>
-          {t('Bottom Up')}
-        </Button>
-        <Button barId="top down" size="xs" onClick={onTopDownClick}>
-          {t('Top Down')}
-        </Button>
-      </ButtonBar>
-    </Fragment>
+    <FlamegraphViewSelectMenuWrap>
+      <SegmentedControl
+        aria-label="Sorting"
+        size="xs"
+        value={sorting}
+        onChange={onSortingChange}
+      >
+        <SegmentedControl.Item key="call order">{t('Call Order')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="left heavy">{t('Left Heavy')}</SegmentedControl.Item>
+      </SegmentedControl>
+      <SegmentedControl aria-label="View" size="xs" value={view} onChange={onViewChange}>
+        <SegmentedControl.Item key="bottom up">{t('Bottom Up')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="top down">{t('Top Down')}</SegmentedControl.Item>
+      </SegmentedControl>
+    </FlamegraphViewSelectMenuWrap>
   );
 }
 
 export {FlamegraphViewSelectMenu};
+
+const FlamegraphViewSelectMenuWrap = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  gap: inherit;
+  min-width: max-content;
+`;


### PR DESCRIPTION
**Before ——**
<img width="791" alt="Screenshot 2023-01-31 at 3 30 52 PM" src="https://user-images.githubusercontent.com/44172267/215907525-6eb5fa43-fa15-4efb-b733-7d9f00da0cf1.png">

**After ——**
<img width="791" alt="Screenshot 2023-01-31 at 3 31 09 PM" src="https://user-images.githubusercontent.com/44172267/215907573-2b8fd294-07de-4345-a4f9-d6be8c5b9428.png">

Part of https://github.com/getsentry/sentry/issues/43865