### PR TITLE
feat(expermient): Add useExperiment hook

### DIFF
--- a/static/app/utils/useExperiment.spec.tsx
+++ b/static/app/utils/useExperiment.spec.tsx
@@ -1,0 +1,83 @@
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+import * as analytics from 'sentry/utils/analytics';
+import {useExperiment} from 'sentry/utils/useExperiment';
+import * as useOrganization from 'sentry/utils/useOrganization';
+
+jest.mock('sentry/data/experimentConfig', () => ({
+  experimentConfig: {
+    orgExperiment: {
+      key: 'orgExperiment',
+      type: 'organization',
+      parameter: 'exposed',
+      assignments: [1, 0, -1],
+    },
+    userExperiment: {
+      key: 'userExperiment',
+      type: 'user',
+      parameter: 'exposed',
+      assignments: [1, 0, -1],
+    },
+  },
+}));
+
+describe('useExperiment', function () {
+  const organization = TestStubs.Organization({
+    id: 1,
+    experiments: {orgExperiment: 1},
+  });
+
+  beforeEach(function () {
+    jest.clearAllMocks();
+    jest.spyOn(useOrganization, 'default').mockReturnValue(organization);
+  });
+
+  it('injects org experiment assignment', function () {
+    const {result} = reactHooks.renderHook(useExperiment, {
+      initialProps: 'orgExperiment',
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        experimentAssignment: 1,
+      })
+    );
+  });
+
+  it('injects user experiment assignment', function () {
+    ConfigStore.set('user', TestStubs.User({id: 123, experiments: {userExperiment: 2}}));
+    const {result} = reactHooks.renderHook(useExperiment, {
+      initialProps: 'userExperiment',
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        experimentAssignment: 2,
+      })
+    );
+  });
+
+  it('logs experiment assignment', function () {
+    const logExperimentSpy = jest.spyOn(analytics, 'logExperiment').mockReturnValue();
+    reactHooks.renderHook(useExperiment, {
+      initialProps: 'orgExperiment',
+    });
+
+    expect(logExperimentSpy).toHaveBeenCalledWith({key: 'orgExperiment', organization});
+  });
+
+  it('defers logging when logExperimentOnMount is true', function () {
+    const logExperimentSpy = jest.spyOn(analytics, 'logExperiment').mockReturnValue();
+    const {result} = reactHooks.renderHook(
+      (args: Parameters<typeof useExperiment>) => useExperiment(args[0], args[1]),
+      {initialProps: ['orgExperiment', {logExperimentOnMount: false}]}
+    );
+
+    expect(logExperimentSpy).not.toHaveBeenCalled();
+
+    result.current.logExperiment();
+
+    expect(logExperimentSpy).toHaveBeenCalledWith({key: 'orgExperiment', organization});
+  });
+});

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -1,0 +1,84 @@
+import {useCallback, useEffect} from 'react';
+
+import {experimentConfig, unassignedValue} from 'sentry/data/experimentConfig';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {
+  ExperimentAssignment,
+  ExperimentKey,
+  ExperimentType,
+  OrgExperiments,
+  UserExperiments,
+} from 'sentry/types/experiments';
+import {logExperiment as logExperimentAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type UseExperimentOptions = {
+  /**
+   * By default this hook will log the exposure of the experiment upon mounting
+   * of the component.
+   *
+   * If this is undesirable, for example if the experiment is hidden behind
+   * some user action beyond this component being mounted, then you will want
+   * to customize when exposure to the experiment has been logged.
+   *
+   * NOTE: If set to false, YOU ARE RESPONSIBLE for logging exposure of the
+   *       experiment!! If you do not log exposure your experiment will not be
+   *       correct!!
+   */
+  logExperimentOnMount?: boolean;
+};
+
+type UseExperimentReturnValue<E extends ExperimentKey> = {
+  experimentAssignment: ExperimentAssignment[E];
+  /**
+   * Call this method when the user has been exposed to the experiment.
+   * You do not need to call this unless you have disabled logging on mount.
+   */
+  logExperiment: () => void;
+};
+
+function useExperimentAssignment(experiment: ExperimentKey) {
+  const organization = useOrganization();
+  const {user} = useLegacyStore(ConfigStore);
+  const {type} = experimentConfig[experiment];
+
+  if (type === ExperimentType.Organization) {
+    const key = experiment as keyof OrgExperiments;
+    return organization?.experiments?.[key] ?? unassignedValue;
+  }
+
+  if (type === ExperimentType.User) {
+    const key = experiment as keyof UserExperiments;
+    return user?.experiments?.[key] ?? unassignedValue;
+  }
+
+  return unassignedValue;
+}
+
+export function useExperiment<E extends ExperimentKey>(
+  experiment: E,
+  {logExperimentOnMount = true}: UseExperimentOptions = {}
+): UseExperimentReturnValue<E> {
+  const organization = useOrganization();
+
+  const logExperiment = useCallback(() => {
+    logExperimentAnalytics({
+      key: experiment,
+      organization,
+    });
+  }, [experiment, organization]);
+
+  useEffect(() => {
+    if (logExperimentOnMount) {
+      logExperiment();
+    }
+  }, [logExperiment, logExperimentOnMount]);
+
+  const experimentAssignment = useExperimentAssignment(experiment);
+
+  return {
+    experimentAssignment,
+    logExperiment,
+  };
+}

--- a/static/app/utils/withExperiment.spec.jsx
+++ b/static/app/utils/withExperiment.spec.jsx
@@ -30,10 +30,10 @@ describe('withConfig HoC', function () {
     jest.clearAllMocks();
   });
 
-  const organization = {
+  const organization = TestStubs.Organization({
     id: 1,
     experiments: {orgExperiment: 1},
-  };
+  });
 
   function MyComponent(props) {
     return <span>{props.experimentAssignment}</span>;
@@ -44,7 +44,7 @@ describe('withConfig HoC', function () {
 
   it('injects org experiment assignment', function () {
     const Container = withExperiment(MyComponent, {experiment: 'orgExperiment'});
-    render(<Container organization={organization} />);
+    render(<Container />, {organization});
 
     expect(screen.getByText('1')).toBeInTheDocument();
   });
@@ -53,14 +53,14 @@ describe('withConfig HoC', function () {
     ConfigStore.set('user', {id: 123, experiments: {userExperiment: 2}});
 
     const Container = withExperiment(MyComponent, {experiment: 'userExperiment'});
-    render(<Container />);
+    render(<Container />, {organization});
 
     expect(screen.getByText('2')).toBeInTheDocument();
   });
 
   it('logs experiment assignment', function () {
     const Container = withExperiment(MyComponent, {experiment: 'orgExperiment'});
-    render(<Container organization={organization} />);
+    render(<Container />, {organization});
 
     expect(logExperiment).toHaveBeenCalledWith({key: 'orgExperiment', organization});
   });
@@ -70,7 +70,7 @@ describe('withConfig HoC', function () {
       experiment: 'orgExperiment',
       injectLogExperiment: true,
     });
-    render(<Container organization={organization} />);
+    render(<Container />, {organization});
     expect(logExperiment).not.toHaveBeenCalled();
 
     // Call log experiment and verify it was called


### PR DESCRIPTION
This ports the existing `withExperiment` HoC to a hook. I'll leave in the HoC for now since we still have a significant number of class components, but this hook should be used when possible.