### PR TITLE
feat(issue-platform): Send occurrence id to `post_process_group` via `post_process_forwarder`

### DIFF
--- a/src/sentry/eventstream/kafka/consumer_strategy.py
+++ b/src/sentry/eventstream/kafka/consumer_strategy.py
@@ -38,6 +38,7 @@ def dispatch_post_process_group_task(
     queue: str,
     skip_consume: bool = False,
     group_states: Optional[GroupStates] = None,
+    occurrence_id: Optional[str] = None,
 ) -> None:
     _dispatch_post_process_group_task(
         event_id,
@@ -50,6 +51,7 @@ def dispatch_post_process_group_task(
         queue,
         skip_consume,
         group_states,
+        occurrence_id=occurrence_id,
     )
 
 

--- a/src/sentry/eventstream/kafka/postprocessworker.py
+++ b/src/sentry/eventstream/kafka/postprocessworker.py
@@ -102,6 +102,7 @@ def dispatch_post_process_group_task(
     queue: str,
     skip_consume: bool = False,
     group_states: Optional[GroupStates] = None,
+    occurrence_id: Optional[str] = None,
 ) -> None:
     if skip_consume:
         logger.info("post_process.skip.raw_event", extra={"event_id": event_id})
@@ -117,6 +118,7 @@ def dispatch_post_process_group_task(
                 "cache_key": cache_key,
                 "group_id": group_id,
                 "group_states": group_states,
+                "occurrence_id": occurrence_id,
             },
             queue=queue,
         )

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -39,6 +39,7 @@ def basic_protocol_handler(
             "project_id": event_data["project_id"],
             "group_id": event_data["group_id"],
             "primary_hash": event_data["primary_hash"],
+            "occurrence_id": event_data.get("occurrence_id"),
         }
 
         for name in ("is_new", "is_regression", "is_new_group_environment"):
@@ -184,6 +185,7 @@ def get_task_kwargs_for_message_from_headers(
                 "group_id": group_id,
                 "project_id": project_id,
                 "primary_hash": primary_hash,
+                "occurrence_id": decode_optional_str(header_data.get("occurrence_id")),
             }
 
             skip_consume = decode_bool(cast(bytes, header_data["skip_consume"]))

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -394,6 +394,12 @@ def post_process_group(
                 return
 
             occurrence = IssueOccurrence.fetch(occurrence_id, project_id=project_id)
+            if not occurrence:
+                logger.error(
+                    "Failed to fetch occurrence",
+                    extra={"occurrence_id": occurrence_id, "project_id": project_id},
+                )
+                return
             # Issue platform events don't use `event_processing_store`. Fetch from eventstore
             # instead.
             event = eventstore.get_event_by_id(project_id, occurrence.event_id, group_id=group_id)

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -724,6 +724,7 @@ class BatchedConsumerTest(TestCase):
             queue="post_process_errors",
             is_new_group_environment=False,
             group_states=None,
+            occurrence_id=None,
         )
 
     @patch(
@@ -780,6 +781,7 @@ class BatchedConsumerTest(TestCase):
             queue="post_process_errors",
             is_new_group_environment=False,
             group_states=None,
+            occurrence_id=None,
         )
 
         consumer.signal_shutdown()

--- a/tests/sentry/eventstream/kafka/test_consumer_strategy.py
+++ b/tests/sentry/eventstream/kafka/test_consumer_strategy.py
@@ -64,6 +64,7 @@ def test_dispatch_task(mock_dispatch: Mock) -> None:
         is_new_group_environment=False,
         queue="post_process_errors",
         group_states=None,
+        occurrence_id=None,
     )
 
     strategy.join()

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -39,6 +39,7 @@ def test_get_task_kwargs_for_message_version_1():
         },
         "extra": {},
         "primary_hash": "49f68a5c8493ec2c0bf489821c21fc3b",
+        "occurrence_id": "123456",
     }
 
     task_state = {
@@ -59,6 +60,7 @@ def test_get_task_kwargs_for_message_version_1():
     assert kwargs.pop("is_new_group_environment") is True
     assert kwargs.pop("group_states") is None
     assert kwargs.pop("queue") == "post_process_errors"
+    assert kwargs.pop("occurrence_id") == "123456"
 
     assert not kwargs, f"unexpected values remaining: {kwargs!r}"
 
@@ -94,6 +96,7 @@ def test_get_task_kwargs_for_message_version_1_kafka_headers():
         ("operation", b"insert"),
         ("skip_consume", b"0"),
         ("queue", b"post_process_errors"),
+        ("occurrence_id", b"1234"),
     ]
 
     kwargs = get_task_kwargs_for_message_from_headers(kafka_headers)
@@ -105,3 +108,4 @@ def test_get_task_kwargs_for_message_version_1_kafka_headers():
     assert kwargs["is_regression"] is False
     assert kwargs["is_new_group_environment"] is True
     assert kwargs["queue"] == "post_process_errors"
+    assert kwargs["occurrence_id"] == "1234"


### PR DESCRIPTION
This modifies the post process forwarder to extract `occurrence_id` from either the headers or message body, and passes it along to post process group. This should be the last piece we need to have `post_process_group` work.
