### PR TITLE
feat: Give the new `newstyle:2023-01-11` grouping its own enhancers

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -1,0 +1,402 @@
+## * The default configuration of stacktrace grouping enhancers
+
+# iOS known apps
+family:native package:/var/containers/Bundle/Application/**          +app
+family:native package:/private/var/containers/Bundle/Application/**  +app
+
+# iOS apps in simulator
+family:native package:**/Developer/CoreSimulator/Devices/**          +app
+family:native package:**/Containers/Bundle/Application/**            +app
+
+# known well locations for unix paths
+family:native package:/lib/**                                        -app
+family:native package:/usr/lib/**                                    -app
+family:native path:/usr/local/lib/**                                 -app
+family:native path:/usr/local/Cellar/**                              -app
+family:native package:linux-gate.so*                                 -app
+
+# well known path components for mac paths
+family:native package:**.app/Contents/**                             +app
+family:native package:/Users/**                                      +app
+
+# rust common modules
+family:native function:std::*                                     -app
+family:native function:core::*                                    -app
+family:native function:alloc::*                                   -app
+family:native function:__rust_*                                   -app
+
+# rust borders
+family:native function:std::panicking::begin_panic                ^-group -group ^-app -app
+family:native function:core::panicking::begin_panic               ^-group -group ^-app -app
+family:native function:failure::backtrace::Backtrace::new         ^-group -group ^-app -app
+family:native function:error_chain::make_backtrace                ^-group -group ^-app -app
+
+# C++ borders
+family:native function:_CxxThrowException                         ^-group -group ^-app -app
+family:native function:__cxa_throw                                ^-group -group ^-app -app
+family:native function:__assert_rtn                               ^-group -group ^-app -app
+
+# Objective-C
+family:native function:_NSRaiseError                              ^-group -group ^-app -app
+family:native function:_mh_execute_header                         -group -app
+
+# Breakpad
+family:native function:google_breakpad::*                         -app -group
+family:native function:google_breakpad::ExceptionHandler::SignalHandler ^-group -group
+family:native function:google_breakpad::ExceptionHandler::WriteMinidumpWithException ^-group -group
+
+# Support frameworks that are not in-app
+family:native package:**/Frameworks/libswift*.dylib                  -app
+family:native package:**/Frameworks/KSCrash.framework/**             -app
+family:native package:**/Frameworks/SentrySwift.framework/**         -app
+family:native package:**/Frameworks/Sentry.framework/**              -app
+
+# Needed for versions < sentry-cocoa 7.0.0 and static linking.
+# Before sentry-cocoa 7.0.0, we marked all packages located inside the application bundle as inApp.
+# Since 7.0.0, the Cocoa SKD only marks the main executable as inApp. This change doesn't impact
+# applications using static libraries, as when using static libraries, all of them end up in the
+# main executable.
+family:native function:kscm_*                                     -app -group
+family:native function:sentrycrashcm_*                            -app -group
+family:native function:kscrash_*                                  -app -group
+family:native function:*sentrycrash_*                             -app -group
+family:native function:"?[[]KSCrash*"                             -app -group
+family:native function:"?[[]RNSentry*"                            -app -group
+
+# Projects shipping their own class called "SentryFoo" can then easily override this in their
+# own grouping enhancers.
+family:native function:"?[[]Sentry*"                              -app -group
+
+# Android ANR: Exception stack is a snapshot of the UI/main thread. The
+# *outermost* in-app frame is most indicative of which user action has led to ANR,
+# and that's what we want to group by. (innermost=crashing frame)
+#
+# Note: Newer Android SDKs send the snapshot flag with ANRs, so this rule is
+# not strictly necessary.
+error.mechanism:ANR invert-stacktrace=1
+
+# NSError iOS: Stacktrace is a thread snapshot as well.
+# Note: Newer iOS SDK sends snapshot flag, so this is not strictly necessary.
+error.mechanism:NSError invert-stacktrace=1
+
+# Dart/Flutter stacktraces that are not in-app
+family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
+family:javascript module:**/packages/flutter/** -app
+
+# Categorization of frames
+family:native package:"/System/Library/Frameworks/**" category=system
+family:native package:"C:/Windows/**" category=system
+family:native package:/usr/lib/** category=system
+family:native function:memset category=system
+family:native function:memcpy category=system
+family:native function:__memcpy category=system
+family:native function:memcmp category=system
+family:native package:CoreFoundation category=system
+family:native package:Foundation category=system
+family:native package:CFNetwork category=system
+family:native package:IOKit category=system
+family:native package:QuartzCore category=system
+family:native package:IOMobileFramebuffer category=system
+family:native package:libobjc* category=system
+family:native package:libsystem* category=system
+family:native package:/system/** category=system
+family:native package:/vendor/** category=system
+module:dalvik.system.* category=system
+module:com.android.* category=system
+family:native package:libdispatch.dylib category=system
+family:native package:WebKit category=system
+family:native package:**/libart.so category=system
+package:/apex/com.android.*/lib*/** category=system
+
+# (Presumably) preinstalled stuff on Lenovo Android devices
+module:com.lenovo.lsf.* category=system
+module:com.lenovo.payplus.* category=system
+
+family:native function:boost::* category=std
+family:native function:std::* category=std
+module:java.* category=std
+# common crypto library on android
+module:com.google.crypto.* category=std
+module:com.google.android.* category=std
+module:javax.crypto.* category=std
+
+module:android.database.* category=std
+module:androidx.* category=std
+module:android.* category=std
+module:android.os.* category=system
+
+family:native package:UIKit category=ui
+family:native package:UIKitCore category=ui
+family:native package:SwiftUI category=ui
+family:native package:AttributeGraph category=ui
+family:native package:CoreAutoLayout category=ui
+family:native package:GraphicsServices category=ui
+family:native function:"-\[NSISEngine*" category=ui  # auto-layout engine
+module:android.view.* category=ui
+module:android.text.* category=ui
+module:android.widget.* category=ui
+module:android.app.Dialog category=ui
+module:androidx.*.widget.* category=ui
+module:com.google.android.material.* category=ui
+category:ui function:handleMessage category=indirection
+category:ui function:run category=indirection
+
+family:native function:art::jit::* category=runtime
+
+family:native package:/system/lib/libmedia.so category=av
+family:native package:/System/lib/libaudioclient.so category=av
+family:native package:AudioToolbox* category=av
+family:native package:libAudioToolboxUtility.dylib category=av
+
+family:native function:std::_* category=internals
+family:native function:__swift_* category=internals
+family:native function:block_destroy_helper* category=internals
+family:native function:*_block_invoke* category=internals
+
+family:native package:/usr/lib/system/** function:start category=threadbase
+family:native package:libdyld.dylib function:start category=threadbase
+family:native package:UIKitCore function:UIApplicationMain category=threadbase
+family:native function:wWinMain category=threadbase
+family:native function:invoke_main category=threadbase
+family:native function:BaseThreadInitThunk category=threadbase
+family:native function:RtlUserThreadStart category=threadbase
+family:native function:thread_start category=threadbase
+family:native function:_pthread_start category=threadbase
+family:native function:__pthread_start category=threadbase
+family:native function:_pthread_body category=threadbase
+family:native function:_dispatch_worker_thread2 category=threadbase
+family:native function:_dispatch_client_callout category=threadbase
+family:native function:start_wqthread category=threadbase
+family:native function:_pthread_wqthread category=threadbase
+family:native function:boost::*::thread_proxy category=threadbase
+family:native package:/usr/lib/system/libsystem_pthread.dylib function:"<unknown>" category=threadbase
+module:android.os.AsyncTask* function:call category=threadbase
+family:native package:UIKit function:UIApplicationMain category=threadbase
+module:java.util.concurrent.ThreadPoolExecutor* function:runWorker category=threadbase
+module:android.os.* function:call category=threadbase
+module:android.app.ActivityThread function:main category=threadbase
+module:android.view.View function:layout category=threadbase
+module:android.os.Looper function:loop category=threadbase
+family:native function:TppWorkerThread category=threadbase
+family:native function:TppWorkpExecuteCallback category=threadbase
+family:native function:RtlpTpWorkCallback category=threadbase
+module:android.os.Handler function:dispatchMessage category=threadbase
+module:android.os.Handler function:handleCallback category=threadbase
+module:android.app.ActivityThread* function:handleMessage category=threadbase
+
+family:native package:"**/libsystem_malloc.dylib" category=malloc
+family:native function:malloc category=malloc
+family:native function:malloc_base category=malloc
+family:native function:RtlpAllocateHeapInternal category=malloc
+family:native function:std::*::allocator_traits* category=malloc
+
+family:native function:*::operator()* category=indirection
+family:native function:*<lambda>* category=indirection
+family:native function:destructor' category=indirection
+family:native function:__dynamic_cast category=indirection
+family:native function:boost::function* category=indirection
+family:native function:boost::_bi::* category=indirection
+family:native function:boost::detail::function::functor_manager* category=indirection
+family:native function:Array.subscript.* category=indirection
+module:java.lang.reflect.* category=indirection
+module:java.lang.Class function:getMethod category=indirection
+module:androidx.work.impl.utils.ForceStopRunnable category=indirection
+
+family:native function:"*::\\{dtor\\}" category=dtor
+family:native function:"destructor'" category=dtor
+
+family:native function:exit category=shutdown
+family:native function:RtlExitUserProcess category=shutdown
+family:native function:ExitProcessImplementation category=shutdown
+family:native function:RtlExitUserThread category=shutdown
+
+family:native function:RtlpExecuteHandlerForException category=handler
+family:native function:_sigtramp category=handler
+family:native function:DispatchHookW category=handler
+family:native function:execute_onexit_table category=handler
+
+family:native function:abort category=throw
+family:native function:raise category=throw
+family:native function:std::terminate category=throw
+family:native function:RtlExitUserThread category=throw
+family:native function:TppRaiseInvalidParameter category=throw
+family:native function:_CxxThrowException category=throw
+family:native function:RaiseException category=throw
+family:native function:RaiseComPlusException category=throw
+family:native function:_CFThrowFormattedException category=throw
+family:native function:objc_exception_throw category=throw
+family:native function:AG::precondition_failure* category=throw
+
+family:native package:"C:/WINDOWS/system32/DriverStore/**" category=driver
+family:native package:"/System/Library/Extensions/AppleIntel*GraphicsGLDriver.bundle/**" category=driver
+family:native function:*CUDA* category=driver
+family:native package:**/nvcuda.dll category=driver
+family:native package:"C:/Program Files/NVIDIA Corporation/**" category=driver
+family:native package:/System/Library/Extensions/GeForceGLDriver.bundle/** category=driver
+family:native package:/System/Library/Extensions/AMDRadeon*/** category=driver
+family:native package:/System/Library/PrivateFrameworks/GPUSupport.framework/** category=driver
+family:native package:libGPUSupportMercury.dylib category=driver
+family:native package:AGXGLDriver category=driver
+
+family:native function:RtlFreeHeap category=free
+family:native function:RtlFreeUnicodeString category=free
+family:native function:std::_Deallocate category=free
+family:native function:free category=free
+family:native function:objc_release category=free
+family:native function:_swift_release_dealloc category=free
+family:native function:_CFRelease category=free
+
+family:native package:C:/Windows/SYSTEM32/OPENGL32.dll category=gl
+family:native package:/System/Library/Frameworks/OpenGL.framework/** category=gl
+family:native package:OpenGLES category=gl
+family:native package:GLEngine category=gl
+family:native package:/system/lib/libEGL.so category=gl
+family:native package:**/libGLES*.so category=gl
+family:native package:**/libESXGLES*.so category=gl
+family:native package:/system/lib/libskia.so category=gl
+# Not a graphics library but we've seen it be interchangeable with OpenGL in stacktraces.
+family:native package:/System/Library/Frameworks/OpenCL.framework/** category=gl
+
+family:native package:"/System/Library/PrivateFrameworks/GPUSupport.framework/**" function:gpusGenerateCrashLog* category=telemetry
+family:native function:gpusKillClientExt category=telemetry
+family:native function:crashpad::* category=telemetry
+# Presumably some chinese user-tracking SDK. Wraps activity creation in Android.
+module:cn.gundam.sdk.* category=telemetry
+
+# No app actually uses this. This appears to be some type of framework that
+# comes up as part of some "Lenovo ID" activity (user login prompt?). Not
+# entirely sure if any of that is linked into the app, it's probably something
+# preinstalled on Lenovo devices.
+module:com.lenovo.payplus.analytics.* category=telemetry
+package:"**/libBugly.so" category=telemetry
+
+family:native function:dlopen category=load
+family:native function:dladdr category=load
+family:native function:ImageLoaderMachO::findClosestSymbol category=load
+family:native package:/system/lib/libnativeloader.so function:android::OpenNativeLibrary category=load
+module:java.lang.System function:loadLibrary category=load
+module:java.lang.Runtime function:loadLibrary* category=load
+
+family:native function:pthread_mutex_lock category=lock
+
+# not interesting at all, if for some reason this gets picked as grouping
+# frame, add the next one too
+category:free +prefix
+category:malloc +prefix
+
+# lock: fails to get acquired/released
+category:lock +sentinel +prefix
+
+# load: dylib/module fails to get loaded
+category:load +sentinel +prefix
+
+# driver crash, similar reasoning as for GL
+category:driver +sentinel +prefix
+
+# UI: This is mostly interesting for ANR, where we need to pick interesting UI
+# frames to group by. Sometimes it can also happen that some UI framework
+# crashes without the (calling) app being at fault, that's where this also gets
+# useful.
+category:ui +sentinel +prefix
+
+# GL: We've observed that the same sequence of app
+# ("submit data buffer") frames triggers very different crashes in there.
+category:gl +sentinel
+
+# runtime: frames from a garbage collector, JIT or something else in the language
+# runtime. Only add frames to this category if you think their presence makes it
+# unlikely that app frames are relevant, e.g. because app frames can't call the
+# JIT/GC directly, or at least not this way and it's really the runtime being
+# buggy, not the app (or at least unlikely that it's the app code currently running).
+category:runtime +sentinel
+
+
+# Ignore driver frame if it is directly calling another driver frame. This
+# removes a lot of noise from the stack especially if most of the called frames
+# failed symbolication, stack scanning was done or to paper over differences in
+# driver versions.
+category:driver | [ category:driver ] category=internals
+
+# Only group by top-level GL operaton, not any helper functions it may have called.
+
+[ category:gl ] | category:gl category=internals
+[ category:av ] | category:av  category=internals
+
+# Only group by top-level malloc op, not any helper function it may have called.
+[ category:malloc ] | category:malloc category=internals
+
+# abort() and exception raising is technically the culprit for crashes, but not
+# the thing we want to show.
+category:throw +prefix ^-group
+
+# On Windows, _purecall internally aborts when the function pointer is invalid.
+# We want to treat this the same as a segfault happening before calling
+# _purecall.
+[ function:_purecall ] | category:throw category=internals
+
+# raise() called by abort() should only group by abort()
+[ category:throw ] | category:throw category=internals
+
+# Thread bases such as `main()` are just noise and are called by noise.
+category:threadbase -group v-group
+
+# handler frames typically call code for crash reporting, so the frames below
+# are noise and do not represent the actual crash. We usually expect something to
+# be above handler frames that represents the actual crash. The stackwalker
+# has a bug where it cannot walk past _sigtramp on OS X but that is expected to
+# be fixed eventually.
+category:handler ^-group -group
+
+# Crash reporting tools are noise that can occur outside of signal handlers
+# too, apparently (Apple's GPUSupport module)
+category:telemetry -group
+
+category:indirection -group
+category:internals -group
+category:threadbase v-group -group
+
+# system frames starting with underscore are likely garbage
+# unsymbolicated system frames are likely system frames starting with underscore
+# _purecall is an exception as it is often the only important frame in a block of system frames
+family:native category:system function:_* !function:_purecall category=internals
+family:native category:system function:"<unknown>" category=internals
+family:native function:_INTERNAL* category=internals
+
+
+# We should be able to write this, but unfortunately sentry-cocoa 6.x is so
+# buggy with detecting compiler-generated code that we have decided to go with a
+# list of function name patterns instead:
+# path:"<compiler-generated>" category=internals
+
+family:native function:closure category=internals
+family:native function:Collection.map<T> category=internals
+family:native function:Array.subscript.getter category=internals
+family:native function:Array._getElement category=internals
+family:native function:_ArrayBuffer._nativeTypeChecked.getter category=internals
+family:native function:range category=internals
+family:native function:@callee_guaranteed category=internals
+
+# frames with .cold.1 are probably hotpaths vs slow paths but not relevant for grouping
+# e.g., two callstacks that should group together:
+#   foo -> bar
+#   foo -> foo.cold.1 -> bar
+family:native function:*.cold.1 category=indirection
+
+# System frame wedged between two other frames is just noise.
+[ !category:system ] | category:system | [ !category:system ] category=indirection
+
+# TODO: multi-category / category inheritance
+[ category:free ]       | category:system  category=internals
+[ category:system ]     | category:system  category=internals
+[ category:std ]        | category:system  category=internals
+[ category:std ]        | category:std     category=internals
+[ category:ui ]         | category:ui      category=internals
+[ category:ui ]         | category:system  category=internals
+[ category:internals ]  | category:system  category=internals
+[ category:internals ]  | category:ui      category=internals
+[ category:load ]       | category:system  category=internals
+[ category:load ]       | category:load    category=internals
+[ category:throw ]      | category:system  category=internals
+[ category:runtime ]    | category:system  category=internals
+[ category:runtime ]    | category:runtime category=internals
+[ category:dtor ]       | category:dtor    category=internals

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -192,6 +192,7 @@ register_strategy_config(
         * Initial version
     """,
     initial_context={},
+    enhancements_base="newstyle:2023-01-11",
 )
 
 

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/actix.pysnap
@@ -1,15 +1,15 @@
 ---
-created: '2023-01-11T11:41:27.430476Z'
+created: '2023-02-01T08:22:00.619240Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "703d3dd9cb763e3f5037f659d27da947"
+  hash: "738e7d2503464bc264b4f791286f5122"
   component:
     app*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame*
@@ -396,12 +396,12 @@ app:
           "Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here"
 --------------------------------------------------------------------------
 system:
-  hash: "1df163ce3be65319df4fcc9cb34b60c1"
+  hash: "19a96e0438d28e48355653def82f887a"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__pthread_start"
           frame*
@@ -422,12 +422,12 @@ system:
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "panic.rs"
             function*
               "std::panic::catch_unwind"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "panicking.rs"
             function*
@@ -442,17 +442,17 @@ system:
               "panicking.rs"
             function*
               "std::panicking::try::do_call"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "panic.rs"
             function*
               "std::panic::AssertUnwindSafe<T>::call_once"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "mod.rs"
             function*
               "std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "backtrace.rs"
             function*
@@ -482,7 +482,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -507,7 +507,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -532,7 +532,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -557,7 +557,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -602,7 +602,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "local.rs"
             function*
@@ -767,7 +767,7 @@ system:
               "local.rs"
             function*
               "std::thread::local::LocalKey<T>::with"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "local.rs"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.559327Z'
+created: '2023-02-01T08:22:00.885233Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -72,7 +72,7 @@ app:
               "choreographer.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
@@ -100,7 +100,7 @@ app:
               "viewrootimpl.java"
             function*
               "run"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
@@ -135,7 +135,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -163,7 +163,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -198,7 +198,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -226,7 +226,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -261,7 +261,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -289,7 +289,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -317,7 +317,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -345,7 +345,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -373,7 +373,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -401,7 +401,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -429,7 +429,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -457,7 +457,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -485,7 +485,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -520,7 +520,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -548,7 +548,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -576,7 +576,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -611,7 +611,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -639,7 +639,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -674,7 +674,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -702,7 +702,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
@@ -787,761 +787,761 @@ app:
               "getThreadStackTrace"
 --------------------------------------------------------------------------
 system:
-  hash: "2e41d71bc38b212d73f8d68415389f45"
+  hash: "2552498cfe69a6ddf1dcdde5440ce9c3"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit"
             filename (module takes precedence)
               "zygoteinit.java"
             function*
               "main"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
             filename (module takes precedence)
               "zygoteinit.java"
             function*
               "run"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)
               "method.java"
             function*
               "invoke"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.app.ActivityThread"
             filename (module takes precedence)
               "activitythread.java"
             function*
               "main"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.os.Looper"
             filename (module takes precedence)
               "looper.java"
             function*
               "loop"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
             filename (module takes precedence)
               "handler.java"
             function*
               "dispatchMessage"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.os.Handler"
             filename (module takes precedence)
               "handler.java"
             function*
               "handleCallback"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$FrameDisplayEventReceiver"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "doFrame"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "doCallbacks"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.Choreographer$CallbackRecord"
             filename (module takes precedence)
               "choreographer.java"
             function*
               "run"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl$TraversalRunnable"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "run"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "doTraversal"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "performTraversals"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
               "viewrootimpl.java"
             function*
               "performLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "layoutVertical"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
               "linearlayout.java"
             function*
               "setChildFrame"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
               "framelayout.java"
             function*
               "layoutChildren"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.ViewGroup"
             filename (module takes precedence)
               "viewgroup.java"
             function*
               "layout"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "android.view.View"
             filename (module takes precedence)
               "view.java"
             function*
               "layout"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "onLayout"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "dispatchLayout"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "dispatchLayoutStep1"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "processAdapterUpdatesAndSetAnimationFlags"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.AdapterHelper"
             filename (module takes precedence)
               "sourcefile"
             function*
               "consumeUpdatesInOnePass"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$6"
             filename (module takes precedence)
               "sourcefile"
             function*
               "offsetPositionsForAdd"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
               "sourcefile"
             function*
               "offsetPositionRecordsForInsert"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.ChildHelper"
             filename (module takes precedence)
               "sourcefile"
             function*
               "getUnfilteredChildAt"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "androidx.recyclerview.widget.RecyclerView$5"
             filename (module takes precedence)
@@ -1561,7 +1561,7 @@ system:
               "thread.java"
             function*
               "getStackTrace"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             module*
               "dalvik.system.VMStack"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2023-01-11T11:41:30.137493Z'
+created: '2023-02-01T08:22:07.751949Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "e2ea2eb86d26407f06b59beb3a444c91"
+  hash: "4ef1fb44d656c3be2a146971f2a222dc"
   component:
     app*
       exception*
@@ -12,13 +12,13 @@ app:
           frame (non app frame)
             function*
               "start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication _run]"
           frame (non app frame)
@@ -42,7 +42,7 @@ app:
           frame (non app frame)
             function*
               "_dispatch_call_block_and_release"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -56,7 +56,7 @@ app:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -69,7 +69,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -80,7 +80,7 @@ app:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -127,45 +127,45 @@ app:
           2
 --------------------------------------------------------------------------
 system:
-  hash: "d23d0dfeac5f1349ceb624b330670b25"
+  hash: "0211daaed35e19ba74b4d6f08cd00fef"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "-[UIApplication _run]"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "GSEventRunModal"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "CFRunLoopRunSpecific"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__CFRunLoopRun"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_main_queue_callback_4CF"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_client_callout"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_dispatch_call_block_and_release"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -179,7 +179,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -192,7 +192,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -203,7 +203,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.229136Z'
+created: '2023-02-01T08:22:06.277778Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,13 +20,13 @@ app:
           frame (non app frame)
             function*
               "start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "main"
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication _run]"
           frame (non app frame)
@@ -93,67 +93,67 @@ system:
     system (exception of app takes precedence)
       threads (exception of app takes precedence)
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "main"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication _run]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__eventFetcherSourceCallback"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__processEventQueue"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIApplicationAccessibility sendEvent:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIApplication sendEvent:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIWindow sendEvent:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIWindow _sendTouchesForEvent:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIControl touchesEnded:withEvent:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIControl _sendActionsForEvents:withEvent:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIControl sendAction:to:forEvent:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIApplication sendAction:to:from:forEvent:]"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.417889Z'
+created: '2023-02-01T08:22:03.397605Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,40 +18,40 @@ app:
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication _run]"
           frame (non app frame)
             function*
               "GSEventRunModal"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "objc_release"
         type*
           "EXC_BAD_ACCESS"
 --------------------------------------------------------------------------
 system:
-  hash: "b85897bf204fd8e90ff495b47502f281"
+  hash: "87497299851e09febfecf4e84e0d45ba"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication _run]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "objc_release"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,25 +1,28 @@
 ---
-created: '2023-01-11T11:41:29.997291Z'
+created: '2023-02-01T08:22:07.524066Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
-        frame*
+    app
+      stacktrace
+        frame (marked out of app by stack trace rule (family:javascript path:org-dartlang-sdk:///** -app -group))
           filename*
             "async_patch.dart"
           function*
             "_asyncStartSync"
 --------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
 system:
-  hash: "82639bcdd4eca16551e8cd3448f48ed4"
+  hash: null
   component:
-    system*
-      stacktrace*
-        frame*
+    system
+      stacktrace
+        frame (ignored by stack trace rule (family:javascript path:org-dartlang-sdk:///** -app -group))
           filename*
             "async_patch.dart"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.836591Z'
+created: '2023-02-01T08:22:01.298242Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,8 +7,8 @@ app:
   hash: null
   component:
     app (stacktrace of system takes precedence)
-      stacktrace (ignored because hash matches system variant)
-        frame*
+      stacktrace
+        frame (marked out of app by stack trace rule (family:javascript module:**/packages/flutter/** -app))
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
           filename (ignored because frame points to a URL)
@@ -21,7 +21,7 @@ system:
   component:
     system*
       stacktrace*
-        frame*
+        frame* (marked out of app by stack trace rule (family:javascript module:**/packages/flutter/** -app))
           module*
             "opt/hostedtoolcache/flutter/2.5.0-stable/x64/packages/flutter/lib/src/gestures/binding"
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.638149Z'
+created: '2023-02-01T08:21:59.369986Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -119,7 +119,7 @@ app:
           frame (non app frame)
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -143,12 +143,12 @@ app:
           "Fatal Error: EXC_BAD_ACCESS / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "725b26e5c390004cd0eca6018a7ad200"
+  hash: "3da34e8c72dbcd4a490ac36eb7130638"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -190,37 +190,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -249,31 +249,31 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "CFBundleGetFunctionPointerForName"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_CFBundleLoadExecutableAndReturnError"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "dlopen_internal"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "dyld::link"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoader::link"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoader::recursiveRebase"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoaderMachOCompressed::rebase"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.815025Z'
+created: '2023-02-01T08:22:05.603596Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -45,7 +45,7 @@ app:
           frame (non app frame)
             function*
               "destructor'"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
           frame (non app frame)
@@ -57,7 +57,7 @@ app:
           frame (non app frame)
             function*
               "RtlpFreeUserBlockToHeap"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
           frame (non app frame)
@@ -87,81 +87,81 @@ app:
           "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
 --------------------------------------------------------------------------
 system:
-  hash: "48a275d290e688b23878080257c9adc3"
+  hash: "ca733a48a19d237df8577d09449095d9"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "TppWorkpExecuteCallback"
           frame*
             function*
               "HTTP_THREAD_POOL::_StaticWorkItemCallback"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "HTTP_ASYNC_OVERLAPPED::OnWorkItem"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "WEBIO_REQUEST::OnIoComplete"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "HTTP_USER_REQUEST::OnSendRequest"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "HTTP_BASE_OBJECT::Dereference"
           frame*
             function*
               "destructor'"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "HTTP_USER_REQUEST::~HTTP_USER_REQUEST"
           frame*
             function*
               "destructor'"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "memset"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpFreeUserBlock"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpFreeUserBlockToHeap"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpFreeHeapInternal"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpFreeHeap"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlEnterCriticalSection"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpEnterCriticalSectionContended"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpWaitOnCriticalSection"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpWaitOnAddress"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpOptimizeWaitOnAddressWaitList"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.825643Z'
+created: '2023-02-01T08:21:59.594363Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -103,27 +103,27 @@ app:
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
 --------------------------------------------------------------------------
 system:
-  hash: "07fb068d9b0e76878c72b462ea20cab3"
+  hash: "2c1bbd635b64d5adccdb64a620044075"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queues_init_once"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_worker_thread2"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queue_drain"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_client_callout"
           frame*
@@ -132,7 +132,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -146,7 +146,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -193,7 +193,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.666204Z'
+created: '2023-02-01T08:22:05.318316Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -53,7 +53,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "glDeleteTextures_Exec"
           frame (non app frame)
@@ -71,7 +71,7 @@ app:
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gldCreateDevice"
           frame (non app frame)
@@ -80,7 +80,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -95,23 +95,23 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "94d5c188bc82790c397f7f97d5239ee0"
+  hash: "9c336f632f6764c0f082a6a66edbf22d"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "thread.cpp"
             function*
               "boost::thread::start_thread_noexcept"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "thread.cpp"
             function*
@@ -119,7 +119,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -127,7 +127,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -144,40 +144,40 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "glDeleteTextures_Exec"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gleUnbindDeleteHashNamesAndObjects"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gleUnbindTextureObject"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gldUpdateDispatch"
           frame (ignored due to recursion)
             function*
               "gldUpdateDispatch"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gldCreateDevice"
-          frame*
+          frame (ignored by stack trace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.585255Z'
+created: '2023-02-01T08:22:04.267297Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -72,7 +72,7 @@ app:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename*
               "memory"
             function*
@@ -119,7 +119,7 @@ app:
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::__1::thread::~thread"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
@@ -131,7 +131,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort_message"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -144,16 +144,16 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "b77a07388ce12082423da4abee4415fc"
+  hash: "49b6f72b6635cb43190c57ee56b026b0"
   component:
     system*
       exception*
         stacktrace*
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -165,7 +165,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -176,7 +176,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -187,17 +187,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -207,27 +207,27 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "utility"
             function*
@@ -256,25 +256,25 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__1::thread::~thread"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::__terminate"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "default_terminate_handler"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort_message"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.428740Z'
+created: '2023-02-01T08:22:06.540670Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -88,7 +88,7 @@ app:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename*
               "memory"
             function*
@@ -132,7 +132,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
@@ -144,7 +144,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort_message"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -159,27 +159,27 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "76e54b047bb34b5d0ec6d210fcd8d995"
+  hash: "49b6f72b6635cb43190c57ee56b026b0"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queues_init_once"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_wqthread"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_worker_thread2"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_root_queue_drain"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_dispatch_client_callout"
           frame*
@@ -188,7 +188,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -202,7 +202,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -213,17 +213,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "map"
             function*
               "std::__1::map<T>::~map"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -233,7 +233,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::~__tree"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "__tree"
             function*
@@ -243,22 +243,22 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "memory"
             function*
               "std::__1::allocator_traits<T>::__destroy<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "mac"
             function*
               "std::__1::pair<T>::~pair"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "utility"
             function*
@@ -287,25 +287,25 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::__terminate"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "demangling_terminate_handler"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort_message"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.462825Z'
+created: '2023-02-01T08:22:00.668495Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -63,18 +63,18 @@ app:
           "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
 --------------------------------------------------------------------------
 system:
-  hash: "b7c6253ad69f02d33e770f3050d72c88"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
           frame*
@@ -113,7 +113,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "__dynamic_cast"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.032666Z'
+created: '2023-02-01T08:22:05.948420Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -58,12 +58,12 @@ app:
           "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
 --------------------------------------------------------------------------
 system:
-  hash: "12c4b5346b5242ec65d3153bb45937b0"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.600768Z'
+created: '2023-02-01T08:22:06.826856Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -158,7 +158,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -177,7 +177,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__report_load.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -192,12 +192,12 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "57d5f9c178ebe1364226ed6c90d30174"
+  hash: "8be5979a334287a1b47457228f1d4612"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -239,37 +239,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -310,19 +310,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_objc_msgSend_uncached"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "lookUpImpOrForward"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "initializeAndMaybeRelock"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "initializeNonMetaClass"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -346,10 +346,10 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "dlopen_internal"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -359,19 +359,19 @@ system:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__report_load"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "__report_load.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.685695Z'
+created: '2023-02-01T08:22:06.989168Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -155,7 +155,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -182,7 +182,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__report_load"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -197,12 +197,12 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "51856c096282b824c59e92b79dda4eec"
+  hash: "8be5979a334287a1b47457228f1d4612"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -241,37 +241,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::function<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__value_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
               "std::__1::__function::__alloc_func<T>::operator()"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "__functional_base"
             function*
               "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "type_traits"
             function*
               "std::__1::__invoke<T>"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "initialize.cpp"
             function*
@@ -312,19 +312,19 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_objc_msgSend_uncached"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "lookUpImpOrForward"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "initializeAndMaybeRelock"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "initializeNonMetaClass"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CALLING_SOME_+initialize_METHOD"
           frame*
@@ -348,40 +348,40 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "dlopen_internal"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "dyld::runInitializers"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoader::runInitializers"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoader::processInitializers"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoader::recursiveInitialization"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoaderMachO::doInitialization"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ImageLoaderMachO::doModInitFunctions"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__report_load"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.141066Z'
+created: '2023-02-01T08:22:00.175091Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -81,7 +81,7 @@ app:
           frame (non app frame)
             function*
               "-[NSOpenGLContext flushBuffer]"
-          frame (non app frame)
+          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLFlushDrawable"
           frame (non app frame)
@@ -99,7 +99,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -111,7 +111,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (non app frame)
@@ -153,7 +153,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLTexImageIOSurface2D"
           frame (non app frame)
@@ -171,7 +171,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -183,7 +183,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -195,12 +195,12 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "e4714f9479fea40111888ca143e02d8f"
+  hash: "7e64037e487c78ce0439f750a2ef503f"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -224,37 +224,37 @@ system:
           frame*
             function*
               "-[NSApplication run]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_DPSNextEvent"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ReceiveNextEventCommon"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RunCurrentEventLoopInMode"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CFRunLoopRunSpecific"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSThreadPerformPerform"
           frame*
@@ -263,55 +263,55 @@ system:
           frame*
             function*
               "-[NSView displayIfNeeded]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "-[NSOpenGLContext flushBuffer]"
-          frame*
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLFlushDrawable"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "glSwap_Exec"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gldPresentFramebufferData"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "SwapFlush"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "intelSubmitCommands"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gpusSubmitDataBuffers"
-          frame*
+          frame (ignored by stack trace rule (category:telemetry -group))
             function*
               "gpusKillClientExt"
-          frame*
+          frame (ignored by stack trace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_sigtramp"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
@@ -320,64 +320,64 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "NSRunAlertPanel"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_NSTryRunModal"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Transaction::commit"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Context::commit_transaction"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Layer::display_if_needed"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLTexImageIOSurface2D"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLDescribeRenderer"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gliSetInteger"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gldFlushObject"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "intelSubmitCommands"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "IntelCommandBuffer::getNew"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusSubmitDataBuffers"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusKillClientExt"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.892068Z'
+created: '2023-02-01T08:21:59.678104Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -45,21 +45,21 @@ app:
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
 --------------------------------------------------------------------------
 system:
-  hash: "ba5ff7b8a3adc9b87681ff0f8275a72e"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "thread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_body"
           frame*
@@ -77,7 +77,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_pthread_testcancel"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.278030Z'
+created: '2023-02-01T08:22:00.360259Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -112,7 +112,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (non app frame)
@@ -129,21 +129,21 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "aeefa28dbbcc272df254d59c98aad03c"
+  hash: "6148c73af04344a8597354711f5951ea"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlpTpWorkCallback"
           frame*
@@ -155,7 +155,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -166,7 +166,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -177,7 +177,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -188,7 +188,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -196,7 +196,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -237,13 +237,13 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.038394Z'
+created: '2023-02-01T08:21:59.988672Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -112,7 +112,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (non app frame)
@@ -129,21 +129,21 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "50325a901e2db771dca1291283d8b54e"
+  hash: "1056f62d72ff8b4d0c3842d696dbb10a"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "TppWorkerThread"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlpTpWorkCallback"
           frame*
@@ -155,7 +155,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -166,7 +166,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -174,12 +174,12 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "xtree"
             function*
               "std::_Tree<T>::insert<T>"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "xtree"
             function*
@@ -196,7 +196,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -237,13 +237,13 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.522570Z'
+created: '2023-02-01T08:21:59.198550Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -136,7 +136,7 @@ app:
           frame (non app frame)
             function*
               "abort"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
           frame (non app frame)
@@ -150,26 +150,26 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "2fa6bd4588d2ae97b62ef1f8db5b12bf"
+  hash: "15526a7b64e9b5dc6d89e7ebec864260"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "RtlUserThreadStart"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "BaseThreadInitThunk"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "invoke_main"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "winmain.cpp"
             function*
@@ -179,7 +179,7 @@ system:
               "xstring"
             function*
               "std::basic_string<T>::{ctor}"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "xstring"
             function*
@@ -189,7 +189,7 @@ system:
               "xstring"
             function*
               "std::basic_string<T>::assign"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "xstring"
             function*
@@ -212,7 +212,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "functional"
             function*
@@ -223,7 +223,7 @@ system:
           frame*
             function*
               "DispatchMessageWorker"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "UserCallWinProcCheckWow"
           frame*
@@ -244,7 +244,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -252,7 +252,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -260,7 +260,7 @@ system:
           frame*
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "function_template.hpp"
             function*
@@ -274,18 +274,18 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             filename*
               "purevirt.cpp"
             function*
               "_purecall"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "abort"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2023-01-11T11:41:29.813731Z'
+created: '2023-02-01T08:22:07.216273Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "9b037f38798ea127aac3e8b8e1e1024a"
+  hash: "5b032559156688c9eabe4e4bd5ae6bd4"
   component:
     app*
       exception*
@@ -12,7 +12,7 @@ app:
           frame (non app frame)
             function*
               "start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "main.m"
             function*
@@ -20,7 +20,7 @@ app:
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication _run]"
           frame (non app frame)
@@ -64,7 +64,7 @@ app:
               "<compiler-generated>"
             function*
               "TableView.layoutSubviews"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UITableView layoutSubviews]"
           frame (non app frame)
@@ -88,7 +88,7 @@ app:
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -113,7 +113,7 @@ app:
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -149,59 +149,59 @@ app:
           "autoplayOption"
 --------------------------------------------------------------------------
 system:
-  hash: "fe8b15fe322c91ede2fc48363fe43587"
+  hash: "1921b991270e24c19ea1ed6863892d71"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "main.m"
             function*
               "main"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication _run]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "CFRunLoopRunSpecific"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopDoObservers"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CA::Transaction::observer_callback"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CA::Transaction::commit"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CA::Context::commit_transaction"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CA::Layer::layout_and_display_if_needed"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CA::Layer::layout_if_needed"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[CALayer layoutSublayers]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
           frame*
@@ -209,13 +209,13 @@ system:
               "<compiler-generated>"
             function*
               "TableView.layoutSubviews"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UITableView layoutSubviews]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UITableView _updateVisibleCellsNow:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
           frame*
@@ -233,7 +233,7 @@ system:
               "anytableviewcontroller.swift"
             function*
               "AnyTableViewController.tableView"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*
@@ -258,7 +258,7 @@ system:
               "<compiler-generated>"
             function*
               "Sequence.compactMap<T>"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             filename*
               "<compiler-generated>"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:26.953332Z'
+created: '2023-02-01T08:21:59.825357Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -407,33 +407,33 @@ default:
         "Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.ArithmeticException: / by zero] with root cause"
 --------------------------------------------------------------------------
 system:
-  hash: "ec87dd10e4f7512ecccb4a068c5774ae"
+  hash: "12f3d3df2e7804af98f4b56c602d17b0"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.lang.Thread"
             filename (module takes precedence)
               "thread.java"
             function*
               "run"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "org.apache.tomcat.util.threads.TaskThread$WrappingRunnable"
             filename (module takes precedence)
               "taskthread.java"
             function*
               "run"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor$Worker"
             filename (module takes precedence)
               "threadpoolexecutor.java"
             function*
               "run"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*
               "java.util.concurrent.ThreadPoolExecutor"
             filename (module takes precedence)
@@ -762,7 +762,7 @@ system:
               "invocablehandlermethod.java"
             function*
               "doInvoke"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             module*
               "java.lang.reflect.Method"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.628443Z'
+created: '2023-02-01T08:22:01.017659Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -126,7 +126,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (non app frame)
+          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "glTexSubImage2D"
           frame (non app frame)
@@ -139,14 +139,14 @@ app:
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
           frame (non app frame)
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -158,12 +158,12 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "6188cd480f18f1ce368de0500be00733"
+  hash: "b8baf791d22ac902d5f59a7eedd844fd"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
           frame*
@@ -208,19 +208,19 @@ system:
           frame*
             function*
               "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CFRunLoopRunSpecific"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopRun"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopDoSources0"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRunLoopDoSource0"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
           frame*
@@ -280,30 +280,30 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame*
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "glTexSubImage2D"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "glTexSubImage2D_Exec"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gleTextureImagePut"
           frame
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
-          frame
-          frame*
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (ignored by stack trace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.354567Z'
+created: '2023-02-01T08:22:02.978272Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -74,7 +74,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (non app frame)
+          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLTexImageIOSurface2D"
           frame (non app frame)
@@ -92,7 +92,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -104,7 +104,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (non app frame)
@@ -144,7 +144,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (non app frame)
+          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLTexImageIOSurface2D"
           frame (non app frame)
@@ -162,7 +162,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -174,7 +174,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -186,12 +186,12 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "ab793fe47359148c7fc95f684bc5308d"
+  hash: "36be6e0b6123ef6ecfbef62f5cb88406"
   component:
     system*
       exception*
         stacktrace*
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "start"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -218,19 +218,19 @@ system:
           frame*
             function*
               "-[NSApplication run]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_DPSNextEvent"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "_BlockUntilNextEventMatchingListInModeWithFilter"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "ReceiveNextEventCommon"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "RunCurrentEventLoopInMode"
           frame
@@ -238,7 +238,7 @@ system:
           frame (ignored due to recursion)
           frame (ignored due to recursion)
           frame (ignored due to recursion)
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSThreadPerformPerform"
           frame*
@@ -247,7 +247,7 @@ system:
           frame*
             function*
               "-[NSView displayIfNeeded]"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
           frame*
@@ -256,44 +256,44 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame*
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLTexImageIOSurface2D"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CGLDescribeRenderer"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gliSetInteger"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "gldFlushObject"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "intelSubmitCommands"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             function*
               "gpusSubmitDataBuffers"
-          frame*
+          frame (ignored by stack trace rule (category:telemetry -group))
             function*
               "gpusKillClientExt"
-          frame*
+          frame (ignored by stack trace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_sigtramp"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "code"
           frame (ignored due to recursion)
@@ -302,64 +302,64 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "NSRunAlertPanel"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_NSTryRunModal"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Transaction::commit"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Context::commit_transaction"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Layer::display_if_needed"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "code"
           frame (ignored due to recursion)
             function*
               "code"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLTexImageIOSurface2D"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLDescribeRenderer"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gliSetInteger"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gldFlushObject"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "intelSubmitCommands"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "IntelCommandBuffer::getNew"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusSubmitDataBuffers"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusKillClientExt"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.912280Z'
+created: '2023-02-01T08:22:07.372589Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -75,16 +75,16 @@ app:
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "free"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_report"
           frame (non app frame)
             function*
               "malloc_vreport"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
           frame (non app frame)
@@ -99,12 +99,12 @@ app:
           "<redacted>"
 --------------------------------------------------------------------------
 system:
-  hash: "2f4ae73b88dbbc7e1cee4f86e270c4b4"
+  hash: "70b7b816193e06eb5d6649989fbaf605"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "_pthread_start"
           frame*
@@ -167,25 +167,25 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "free"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_report"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "malloc_vreport"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "pthread_kill"
-          frame*
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.101529Z'
+created: '2023-02-01T08:22:06.052955Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "61d21e6d53c0837718af047c20e5e7ea"
+  hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
   component:
     system*
       exception*
@@ -35,7 +35,7 @@ system:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.292022Z'
+created: '2023-02-01T08:22:06.354055Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -27,14 +27,14 @@ app:
           frame (non app frame)
             function*
               "OpenAdapter10"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*
           "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
 --------------------------------------------------------------------------
 system:
-  hash: "a6befffdc310c28b165bbceb1c0f59a8"
+  hash: "2e0d26cae5986fcda5edf66612a78268"
   component:
     system*
       exception*
@@ -48,16 +48,16 @@ system:
           frame*
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "OpenAdapter10"
-          frame
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.732330Z'
+created: '2023-02-01T08:22:01.158167Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,14 +22,14 @@ app:
             function*
               "OpenAdapter10"
           frame (non app frame)
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*
           "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
 --------------------------------------------------------------------------
 system:
-  hash: "6fcc3bb4fac6aa6e81bb6d0faf40b0dd"
+  hash: "c85e23e804b52ea4b9f290ba838e77a0"
   component:
     system*
       exception*
@@ -37,17 +37,17 @@ system:
           frame*
             function*
               "CUseCountedObject<T>::UCDestroy"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "OpenAdapter10"
           frame
-          frame (ignored due to recursion)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.444267Z'
+created: '2023-02-01T08:22:03.508061Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -28,14 +28,14 @@ app:
           frame (non app frame)
             function*
               "OpenAdapter12"
-          frame (non app frame)
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*
           "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
 --------------------------------------------------------------------------
 system:
-  hash: "d69ad378fab4de58c7236a72ce3101ee"
+  hash: "784442a33bd16c15013bb8f69f68e7d6"
   component:
     system*
       exception*
@@ -49,17 +49,17 @@ system:
           frame*
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "CContext::LUCBeginLayerDestruction"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "NDXGI::CDevice::DestroyDriverInstance"
           frame
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "OpenAdapter12"
-          frame
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.744696Z'
+created: '2023-02-01T08:22:05.441437Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "9bb5de55b854491dacc677184c9b019a"
+  hash: "8f4c7709e4af98d3c47ce3519690e6d9"
   component:
     system*
       exception*
@@ -32,10 +32,10 @@ system:
           frame (ignored because only 1 frame is considered by stack trace rule (family:native max-frames=1))
             function*
               "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
-          frame (ignored because only 1 frame is considered by stack trace rule (family:native max-frames=1))
+          frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.872848Z'
+created: '2023-02-01T08:22:05.694657Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           frame (non app frame)
             function*
               "application_frame"
-          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_zone_malloc"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -33,7 +33,7 @@ app:
           "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
 --------------------------------------------------------------------------
 system:
-  hash: "69d066e455243e7c5762b7522b430ca9"
+  hash: "3ff01ce959249abecc6bc8a8f1432b0b"
   component:
     system*
       exception*
@@ -41,19 +41,19 @@ system:
           frame*
             function*
               "application_frame"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_zone_malloc"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "nanov2_malloc"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "nanov2_allocate"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "nanov2_allocate_from_block"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "nanov2_allocate_from_block.cold.1"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.707671Z'
+created: '2023-02-01T08:22:05.394174Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -57,7 +57,7 @@ app:
           "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "00719910980352c06ba93641057012e0"
+  hash: "bbcdb2e1d8df09ffe0fffd30fb361d4b"
   component:
     system*
       exception*
@@ -68,7 +68,7 @@ system:
           frame*
             function*
               "std::rt::lang_start"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start_internal"
           frame*
@@ -77,7 +77,7 @@ system:
           frame*
             function*
               "std::panicking::try::do_call"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.161092Z'
+created: '2023-02-01T08:22:00.202278Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app:
           "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "61d21e6d53c0837718af047c20e5e7ea"
+  hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
   component:
     system*
       exception*
@@ -35,7 +35,7 @@ system:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
-          frame*
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "<lambda>::operator()"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.865781Z'
+created: '2023-02-01T08:22:07.289846Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -40,17 +40,17 @@ app:
           "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
 --------------------------------------------------------------------------
 system:
-  hash: "15d397771f229af8dc42783542f81dd4"
+  hash: "46b84e4da51648cc9f9741abd2bdad51"
   component:
     system*
       exception*
         stacktrace*
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*
               "__scrt_common_main_seh"
-          frame*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
             filename*
               "exe_common.inl"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:27.956902Z'
+created: '2023-02-01T08:22:01.452226Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -36,7 +36,7 @@ app:
           "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "e0b4eea234ff891472cb927c00153bbe"
+  hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
   component:
     system*
       exception*
@@ -53,7 +53,7 @@ system:
           frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame* (marked in-app by stack trace rule (function:log_demo::* +app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.957167Z'
+created: '2023-02-01T08:22:07.460260Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -53,7 +53,7 @@ system:
           frame (ignored by stack trace rule (function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:28.518124Z'
+created: '2023-02-01T08:22:03.743111Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -36,7 +36,7 @@ app:
           "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "e0b4eea234ff891472cb927c00153bbe"
+  hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
   component:
     system*
       exception*
@@ -53,7 +53,7 @@ system:
           frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-11T11:41:29.146817Z'
+created: '2023-02-01T08:22:06.117061Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -36,7 +36,7 @@ app:
           "Holy shit everything is on fire!"
 --------------------------------------------------------------------------
 system:
-  hash: "9b33b65a645c66239cafcd276fcd0659"
+  hash: "0817e4e604fbe88c4534eff166df1db9"
   component:
     system*
       exception*
@@ -53,7 +53,7 @@ system:
           frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::panicking::try::do_call"
-          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))


### PR DESCRIPTION
The enhancers file starts out as a copy of the `mobile:2021-04-02` file which should have quite a few useful rules in it already.

The snapshots should give a small glimpse at the changes, which should primarily ignore a lot more irrelevant frames in stack traces.