### PR TITLE
feat(perf-issues): Add min size to render-blocking asset detector

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -595,6 +595,7 @@ register("performance.issues.n_plus_one_db.duration_threshold", default=100.0)
 register("performance.issues.render_blocking_assets.fcp_minimum_threshold", default=2000.0)
 register("performance.issues.render_blocking_assets.fcp_maximum_threshold", default=10000.0)
 register("performance.issues.render_blocking_assets.fcp_ratio_threshold", default=0.33)
+register("performance.issues.render_blocking_assets.size_threshold", default=1000000)
 
 # Dynamic Sampling system wide options
 # Killswitch to disable new dynamic sampling behavior specifically new dynamic sampling biases

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -102,6 +102,7 @@ register(
         "render_blocking_fcp_min": 2000.0,
         "render_blocking_fcp_max": 10000.0,
         "render_blocking_fcp_ratio": 0.33,
+        "render_blocking_bytes_min": 1000000,
         "n_plus_one_api_calls_detection_rate": 1.0,
         "consecutive_db_queries_detection_rate": 1.0,
     },

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -171,6 +171,9 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             "render_blocking_fcp_ratio": options.get(
                 "performance.issues.render_blocking_assets.fcp_ratio_threshold"
             ),
+            "render_blocking_bytes_min": options.get(
+                "performance.issues.render_blocking_assets.size_threshold"
+            ),
             "n_plus_one_api_calls_detection_rate": 1.0,
             "consecutive_db_queries_detection_rate": 1.0,
         }
@@ -187,6 +190,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             "fcp_minimum_threshold": settings["render_blocking_fcp_min"],  # ms
             "fcp_maximum_threshold": settings["render_blocking_fcp_max"],  # ms
             "fcp_ratio_threshold": settings["render_blocking_fcp_ratio"],  # in the range [0, 1]
+            "minimum_size_bytes": settings["render_blocking_bytes_min"],  # in bytes
         },
         DetectorType.N_PLUS_ONE_DB_QUERIES: {
             "count": settings["n_plus_one_db_count"],
@@ -520,6 +524,12 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         span_end_timestamp = timedelta(seconds=span.get("timestamp", 0))
         fcp_timestamp = self.transaction_start + self.fcp
         if span_end_timestamp >= fcp_timestamp:
+            return False
+
+        minimum_size_bytes = self.settings.get("minimum_size_bytes")
+        data = span.get("data", None)
+        encoded_body_size = data and data.get("Encoded Body Size", 0) or 0
+        if encoded_body_size < minimum_size_bytes:
             return False
 
         span_duration = get_span_duration(span)

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -42,7 +42,15 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
                 }
             },
             "spans": [
-                create_span("resource.script", duration=1000.0),
+                create_span(
+                    "resource.script",
+                    duration=1000.0,
+                    data={
+                        "Transfer Size": 1200000,
+                        "Encoded Body Size": 1200000,
+                        "Decoded Body Size": 2000000,
+                    },
+                ),
             ],
         }
 
@@ -122,4 +130,28 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
             ],
         }
 
+        assert self.find_problems(event) == []
+
+    def test_does_not_detect_if_too_small(self):
+        event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "measurements": {
+                "fcp": {
+                    "value": 2500.0,
+                    "unit": "millisecond",
+                }
+            },
+            "spans": [
+                create_span(
+                    "resource.script",
+                    duration=1000.0,
+                    data={
+                        "Transfer Size": 900000,
+                        "Encoded Body Size": 900000,
+                        "Decoded Body Size": 1700000,
+                    },
+                ),
+            ],
+        }
         assert self.find_problems(event) == []

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -155,3 +155,19 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
             ],
         }
         assert self.find_problems(event) == []
+
+    def test_does_not_detect_if_missing_size(self):
+        event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "measurements": {
+                "fcp": {
+                    "value": 2500.0,
+                    "unit": "millisecond",
+                }
+            },
+            "spans": [
+                create_span("resource.script", duration=1000.0),
+            ],
+        }
+        assert self.find_problems(event) == []


### PR DESCRIPTION
In practice we're finding that some tiny assets are still frequently triggering this detector. In order to get rid of these outliers (and live up to the "Large Render Blocking Asset" label given to the issue type), add a minimum size threshold to the detector.