### PR TITLE
feat(file-io): Handle duplicate file-io spans

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1383,14 +1383,14 @@ class FileIOMainThreadDetector(PerformanceDetector):
                 )
 
     def _fingerprint(self, span_list) -> str:
-        call_stack_strings = []
-        overall_stack = []
+        call_stack_strings = set()
+        overall_stack = set()
         for span in span_list:
             for item in span.get("data", {}).get("call_stack", []):
                 module = self._deobfuscate_module(item.get("module", ""))
                 function = self._deobfuscate_function(item)
-                call_stack_strings.append(f"{module}.{function}")
-            overall_stack.append(".".join(call_stack_strings))
+                call_stack_strings.add(f"{module}.{function}")
+            overall_stack.add(".".join(call_stack_strings))
         call_stack = "-".join(overall_stack).encode("utf8")
         hashed_stack = hashlib.sha1(call_stack).hexdigest()
         return f"1-{GroupType.PERFORMANCE_FILE_IO_MAIN_THREAD.value}-{hashed_stack}"

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1383,15 +1383,20 @@ class FileIOMainThreadDetector(PerformanceDetector):
                 )
 
     def _fingerprint(self, span_list) -> str:
-        call_stack_strings = set()
-        overall_stack = set()
+        call_stack_strings = []
+        overall_stack = []
         for span in span_list:
             for item in span.get("data", {}).get("call_stack", []):
                 module = self._deobfuscate_module(item.get("module", ""))
                 function = self._deobfuscate_function(item)
-                call_stack_strings.add(f"{module}.{function}")
-            overall_stack.add(".".join(call_stack_strings))
-        call_stack = "-".join(overall_stack).encode("utf8")
+                call_stack_strings.append(f"{module}.{function}")
+            # Use set to remove dupes, and list index to preserve order
+            overall_stack.append(
+                ".".join(sorted(set(call_stack_strings), key=lambda c: call_stack_strings.index(c)))
+            )
+        call_stack = "-".join(
+            sorted(set(overall_stack), key=lambda s: overall_stack.index(s))
+        ).encode("utf8")
         hashed_stack = hashlib.sha1(call_stack).hexdigest()
         return f"1-{GroupType.PERFORMANCE_FILE_IO_MAIN_THREAD.value}-{hashed_stack}"
 

--- a/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
@@ -77,6 +77,16 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         problem = self.find_problems(event)[0]
         assert problem.title == "File IO on Main Thread"
 
+    def test_duplicate_calls_do_not_change_callstackc(self):
+        event = get_event("file-io-on-main-thread")
+        event["spans"][0]["data"]["blocked_main_thread"] = True
+        single_span_problem = self.find_problems(event)[0]
+        single_problem_fingerprint = single_span_problem.fingerprint
+        event["spans"].append(event["spans"][0])
+        double_span_problem = self.find_problems(event)[0]
+        assert double_span_problem.title == "File IO on Main Thread"
+        assert double_span_problem.fingerprint == single_problem_fingerprint
+
     def test_file_io_with_proguard(self):
         event = get_event("file-io-on-main-thread-with-obfuscation")
         event["project"] = self.project.id

--- a/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
@@ -35,7 +35,7 @@ org.slf4j.helpers.Util$ClassContextSecurityManager -> org.a.b.g$a:
 
 @region_silo_test
 @pytest.mark.django_db
-class NPlusOneAPICallsDetectorTest(TestCase):
+class FileIOMainThreadDetectorTest(TestCase):
     def setUp(self):
         super().setUp()
         self.settings = get_detection_settings()
@@ -77,7 +77,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         problem = self.find_problems(event)[0]
         assert problem.title == "File IO on Main Thread"
 
-    def test_duplicate_calls_do_not_change_callstackc(self):
+    def test_duplicate_calls_do_not_change_callstack(self):
         event = get_event("file-io-on-main-thread")
         event["spans"][0]["data"]["blocked_main_thread"] = True
         single_span_problem = self.find_problems(event)[0]


### PR DESCRIPTION
- Today when there are duplicate file spans blocking main thread, the number of file-io spans will change the fingerprinting. This change updates this so that regardless of the number of duplicates the fingerprint does not change