### PR TITLE
fix(profiling): Restore profile received timestamp after vroom

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -497,9 +497,11 @@ def _track_outcome(
 
 @metrics.wraps("process_profile.insert_vroom_profile")
 def _insert_vroom_profile(profile: Profile) -> bool:
+    original_timestamp = profile["received"]
+
     try:
         profile["received"] = (
-            datetime.utcfromtimestamp(profile["received"]).replace(tzinfo=timezone.utc).isoformat()
+            datetime.utcfromtimestamp(original_timestamp).replace(tzinfo=timezone.utc).isoformat()
         )
 
         response = get_from_profiling_service(method="POST", path="/profile", json_data=profile)
@@ -525,3 +527,5 @@ def _insert_vroom_profile(profile: Profile) -> bool:
             sample_rate=1.0,
         )
         return False
+    finally:
+        profile["received"] = original_timestamp


### PR DESCRIPTION
If a profile is modified, the modification persists in a retry so the received timestamp needs to be restored or it'll be a string instead of an integer.