### PR TITLE
bug(replays): Catch InvalidSearchQuery exceptions and return 400 HTTP status code

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -12,6 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization_events import OrganizationEventsV2EndpointBase
 from sentry.api.event_search import parse_search_query
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Organization
 from sentry.replays.query import query_replays_count
 from sentry.search.events.builder import QueryBuilder
@@ -59,6 +60,8 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
             replay_ids_mapping = get_replay_id_mappings(request, params, snuba_params)
         except ValueError as e:
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except InvalidSearchQuery:
+            return Response({"detail": "Invalid search query"}, status=status.HTTP_400_BAD_REQUEST)
 
         replay_results = query_replays_count(
             project_ids=[p.id for p in snuba_params.projects],

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -58,10 +58,8 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
 
         try:
             replay_ids_mapping = get_replay_id_mappings(request, params, snuba_params)
-        except ValueError as e:
+        except (InvalidSearchQuery, ValueError) as e:
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        except InvalidSearchQuery:
-            return Response({"detail": "Invalid search query"}, status=status.HTTP_400_BAD_REQUEST)
 
         replay_results = query_replays_count(
             project_ids=[p.id for p in snuba_params.projects],

--- a/tests/sentry/replays/test_organization_replay_count.py
+++ b/tests/sentry/replays/test_organization_replay_count.py
@@ -313,4 +313,7 @@ class OrganizationReplayCountEndpointTest(APITestCase, SnubaTestCase, ReplaysSnu
             response = self.client.get(self.url, query, format="json")
 
         assert response.status_code == 400, response.content
-        assert response.content == b'{"detail":"Invalid search query"}', response.content
+        assert response.content == (
+            b'{"detail":"Invalid quote at \'[\\"root\': quotes must enclose text or be '
+            b'escaped."}'
+        ), response.content

--- a/tests/sentry/replays/test_organization_replay_count.py
+++ b/tests/sentry/replays/test_organization_replay_count.py
@@ -296,3 +296,21 @@ class OrganizationReplayCountEndpointTest(APITestCase, SnubaTestCase, ReplaysSnu
         expected = {replay1_id: 1, replay2_id: 1}
         assert response.status_code == 200, response.content
         assert response.data == expected
+
+    def test_replay_count_invalid_search_query(self):
+        replay1_id = uuid.uuid4().hex
+
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay1_id,
+            )
+        )
+
+        with self.feature(self.features):
+            query = {"query": 'transaction:["root ("/")"]'}
+            response = self.client.get(self.url, query, format="json")
+
+        assert response.status_code == 400, response.content
+        assert response.content == b'{"detail":"Invalid search query"}', response.content


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/267

Currently a malformed search query on the `?query` param can cause an exception to be raised.  This pull catches the exception and returns the error to the user.