### PR TITLE
feat(perf-issues): Update N+1 API Call alert email evidence section

### DIFF
--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -391,7 +391,7 @@ class PerformanceProblemContext:
 class NPlusOneAPICallProblemContext(PerformanceProblemContext):
     def to_dict(self):
         return {
-            "transaction_name": get_span_evidence_value_problem(self.problem, False),
+            "transaction_name": get_span_evidence_value_problem(self.problem),
             "repeating_spans": self.path_prefix,
             "num_repeating_spans": str(len(self.problem.offender_span_ids))
             if self.problem.offender_span_ids

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -493,7 +493,7 @@ class PerformanceProblemContext:
 class NPlusOneAPICallProblemContext(PerformanceProblemContext):
     def to_dict(self) -> Dict[str, str | List[str]]:
         return {
-            "transaction_name": get_span_evidence_value_problem(self.problem),
+            "transaction_name": self.problem.desc,
             "repeating_spans": self.path_prefix,
             "parameters": self.parameters,
             "num_repeating_spans": str(len(self.problem.offender_span_ids))
@@ -508,7 +508,7 @@ class NPlusOneAPICallProblemContext(PerformanceProblemContext):
 
         url = get_url_from_span(self.repeating_spans)
         parsed_url = urlparse(url)
-        return f"{parsed_url.path}[Parameters]"
+        return parsed_url.path
 
     @property
     def parameters(self) -> List[str]:

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -507,4 +507,4 @@ class NPlusOneAPICallProblemContext(PerformanceProblemContext):
 
         url = get_url_from_span(self.repeating_spans)
         parsed_url = urlparse(url)
-        return f"{parsed_url.path}[Parameters]"
+        return f"{parsed_url.path}"

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -508,7 +508,7 @@ class NPlusOneAPICallProblemContext(PerformanceProblemContext):
 
         url = get_url_from_span(self.repeating_spans)
         parsed_url = urlparse(url)
-        return parsed_url.path
+        return parsed_url.path or ""
 
     @property
     def parameters(self) -> List[str]:

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -464,13 +464,13 @@ class PerformanceProblemContext:
     problem: PerformanceProblem
     spans: Union[List[Dict[str, Union[str, float]]], None]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         parent_span, repeating_spans = get_parent_and_repeating_spans(self.spans, self.problem)
 
         self.parent_span = parent_span
         self.repeating_spans = repeating_spans
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, str | List[str]]:
         return {
             "transaction_name": get_span_evidence_value_problem(self.problem),
             "parent_span": get_span_evidence_value(self.parent_span),
@@ -483,7 +483,7 @@ class PerformanceProblemContext:
     @classmethod
     def from_problem_and_spans(
         cls, problem: PerformanceProblem, spans: Union[List[Dict[str, Union[str, float]]], None]
-    ):
+    ) -> PerformanceProblemContext:
         if problem.type == GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS:
             return NPlusOneAPICallProblemContext(problem, spans)
         else:
@@ -491,7 +491,7 @@ class PerformanceProblemContext:
 
 
 class NPlusOneAPICallProblemContext(PerformanceProblemContext):
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, str | List[str]]:
         return {
             "transaction_name": get_span_evidence_value_problem(self.problem),
             "repeating_spans": self.path_prefix,
@@ -502,7 +502,7 @@ class NPlusOneAPICallProblemContext(PerformanceProblemContext):
         }
 
     @property
-    def path_prefix(self):
+    def path_prefix(self) -> str:
         if not self.repeating_spans or len(self.repeating_spans) == 0:
             return ""
 
@@ -511,9 +511,9 @@ class NPlusOneAPICallProblemContext(PerformanceProblemContext):
         return f"{parsed_url.path}[Parameters]"
 
     @property
-    def parameters(self):
+    def parameters(self) -> List[str]:
         if not self.spans or len(self.spans) == 0:
-            return ""
+            return []
 
         urls = [
             get_url_from_span(span)
@@ -521,7 +521,7 @@ class NPlusOneAPICallProblemContext(PerformanceProblemContext):
             if span.get("span_id") in self.problem.offender_span_ids
         ]
 
-        all_parameters = defaultdict(list)
+        all_parameters: Mapping[str, List[str]] = defaultdict(list)
 
         for url in urls:
             parsed_url = urlparse(url)

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -353,7 +353,7 @@ def perf_to_email_html(
 
     context = {
         "transaction_name": get_span_evidence_value_problem(problem),
-        "parent_span": get_span_evidence_value(parent_span),
+        "parent_span": get_span_evidence_value(parent_span) if parent_span else None,
         "repeating_spans": get_span_evidence_value(repeating_spans),
         "num_repeating_spans": str(len(problem.offender_span_ids))
         if problem.offender_span_ids

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -389,7 +389,7 @@ class PerformanceProblemContext:
 class NPlusOneAPICallProblemContext(PerformanceProblemContext):
     def to_dict(self):
         return {
-            "transaction_name": get_span_evidence_value_problem(self.problem),
+            "transaction_name": get_span_evidence_value_problem(self.problem, False),
             "repeating_spans": get_span_evidence_value(self.repeating_spans),
             "num_repeating_spans": str(len(self.problem.offender_span_ids))
             if self.problem.offender_span_ids

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -333,6 +333,10 @@
     word-break: break-word;
   }
 
+  .performance .parameter-placeholder {
+    color: rgb(223, 51, 56);
+  }
+
   .inner pre.message {
     margin: 0 0 10px !important;
   }

--- a/src/sentry/templates/sentry/emails/transactions.html
+++ b/src/sentry/templates/sentry/emails/transactions.html
@@ -32,7 +32,7 @@
         <tr>
             <th>{% blocktrans %} Repeating Spans ({{ num_repeating_spans }}) {% endblocktrans %}</th>
             <td>
-                <code>{{ repeating_spans|truncatechars:75 }}<span class="parameter-placeholder">[{% trans "Parameters" %}]</span></code>
+                <code>{{ repeating_spans|truncatechars:75 }}{% if parameters %}<span class="parameter-placeholder">[{% trans "Parameters" %}]</span>{% endif %}</code>
             </td>
         </tr>
         {% endif %}

--- a/src/sentry/templates/sentry/emails/transactions.html
+++ b/src/sentry/templates/sentry/emails/transactions.html
@@ -32,7 +32,7 @@
         <tr>
             <th>{% blocktrans %} Repeating Spans ({{ num_repeating_spans }}) {% endblocktrans %}</th>
             <td>
-                <code>{{ repeating_spans|truncatechars:75 }}</code>
+                <code>{{ repeating_spans|truncatechars:75 }}<span class="parameter-placeholder">[{% trans "Parameters" %}]</span></code>
             </td>
         </tr>
         {% endif %}

--- a/src/sentry/templates/sentry/emails/transactions.html
+++ b/src/sentry/templates/sentry/emails/transactions.html
@@ -36,5 +36,15 @@
             </td>
         </tr>
         {% endif %}
+        {% if parameters %}
+        <tr>
+            <th>{% trans "Parameters" %}</th>
+            {% for parameter in parameters %}
+            <td>
+                <code>{{ parameter|truncatechars:100 }}</code>
+            </td>
+            {% endfor %}
+        </tr>
+        {% endif %}
     </tbody>
 </table>

--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -135,3 +135,19 @@ def get_span_duration(span: Span) -> timedelta:
     return timedelta(seconds=span.get("timestamp", 0)) - timedelta(
         seconds=span.get("start_timestamp", 0)
     )
+
+
+def get_url_from_span(span: Span) -> str:
+    data = span.get("data") or {}
+    url = data.get("url") or ""
+    if not url:
+        # If data is missing, fall back to description
+        description = span.get("description") or ""
+        parts = description.split(" ", 1)
+        if len(parts) == 2:
+            url = parts[1]
+
+    if type(url) is dict:
+        url = url.get("pathname") or ""
+
+    return url

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -14,7 +14,13 @@ from sentry.types.issues import GroupType
 from sentry.utils import metrics
 from sentry.utils.event_frames import get_sdk_name
 
-from ..base import DETECTOR_TYPE_TO_GROUP_TYPE, DetectorType, PerformanceDetector, get_span_duration
+from ..base import (
+    DETECTOR_TYPE_TO_GROUP_TYPE,
+    DetectorType,
+    PerformanceDetector,
+    get_span_duration,
+    get_url_from_span,
+)
 from ..performance_problem import PerformanceProblem
 from ..types import PerformanceProblemsMap, Span
 
@@ -242,19 +248,3 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             span_a["hash"] == span_b["hash"]
             and span_a["parent_span_id"] == span_b["parent_span_id"]
         )
-
-
-def get_url_from_span(span: Span) -> str:
-    data = span.get("data") or {}
-    url = data.get("url") or ""
-    if not url:
-        # If data is missing, fall back to description
-        description = span.get("description") or ""
-        parts = description.split(" ", 1)
-        if len(parts) == 2:
-            url = parts[1]
-
-    if type(url) is dict:
-        url = url.get("pathname") or ""
-
-    return url

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -75,7 +75,7 @@ from sentry.web.frontend.debug.debug_weekly_report import DebugWeeklyReportView
 urlpatterns = [
     url(r"^debug/mail/error-alert/$", sentry.web.frontend.debug.mail.alert),
     url(
-        r"^debug/mail/performance-alert/(?P<sample_name>[^\/]+)?$",
+        r"^debug/mail/performance-alert/(?P<sample_name>[^\/]+)?/$",
         DebugPerformanceIssueEmailView.as_view(),
     ),
     url(r"^debug/mail/generic-alert/$", DebugGenericIssueEmailView.as_view()),

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -286,7 +286,7 @@ class PerformanceProblemContextTestCase(TestCase):
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
                 parent_span_ids=[],
                 cause_span_ids=[],
-                offender_span_ids=["b93d2be92cd64fd5", "054ba3a374d543eb"],
+                offender_span_ids=["b93d2be92cd64fd5", "054ba3a374d543eb", "563712f9722fb09"],
             ),
             [
                 {
@@ -297,6 +297,7 @@ class PerformanceProblemContextTestCase(TestCase):
                     "span_id": "054ba3a374d543eb",
                     "description": "GET https://resource.io/resource?id=2",
                 },
+                {"span_id": "563712f9722fb09", "description": "GET https://resource.io/resource"},
             ],
         )
 
@@ -304,5 +305,5 @@ class PerformanceProblemContextTestCase(TestCase):
             "transaction_name": "/resources",
             "repeating_spans": "/resource",
             "parameters": ["{id: 1,2}"],
-            "num_repeating_spans": "2",
+            "num_repeating_spans": "3",
         }


### PR DESCRIPTION
Fixes PERF-1921. Improves the "Evidence" section of the N+1 API Call to match it with the issue details page.

**e.g.,**

![Screen Shot 2023-01-31 at 3 13 47 PM](https://user-images.githubusercontent.com/989898/216105661-aa80ae76-dcda-4dc0-91f6-05a72ab014ae.png)

## Changes

- add a `PerformanceProblemContext` data class. Its job is to create the email context for a performance issue, and to generate contexts for issues based on their class. This mirrors the frontend code, where each detector's evidence is a little different, so they need subclasses with different attributes
- add a `NPlusOneAPICallProblemContext` subclass, which adds some specific fields that makes the N+1 API Call email look a little different.
- move some helper functions around
