### PR TITLE
fix(perf-issues): ignore graphql from consecutive db detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -696,12 +696,15 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
 
     @classmethod
     def is_event_eligible(cls, event, project: Project = None) -> bool:
-        # temporary hardcode of org
-        if project is not None:
-            organization = cast(Organization, project.organization)
-            if organization is not None and organization.slug == "laracon-eu":
-                return True
+        request = event.get("request", None) or None
         sdk_name = get_sdk_name(event) or ""
+
+        if request:
+            url = request.get("url", "") or ""
+            method = request.get("method", "") or ""
+            if url.endswith("/graphql") or method.lower() in ["post", "get"]:
+                return False
+
         return "php" not in sdk_name.lower()
 
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -712,7 +712,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         if request:
             url = request.get("url", "") or ""
             method = request.get("method", "") or ""
-            if url.endswith("/graphql") or method.lower() in ["post", "get"]:
+            if url.endswith("/graphql") and method.lower() in ["post", "get"]:
                 return False
 
         return "php" not in sdk_name.lower()

--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -270,6 +270,7 @@ class ConsecutiveDbDetectorTest(TestCase):
 
     def test_ignores_graphql(self):
         event = self.create_issue_event()
+        event["request"] = {"url": "https://url.dev/api/my-endpoint"}
         assert len(self.find_problems(event)) == 1
-        event["request"] = {"url": "https://url.dev/api/graphql", "method": "POST"}
+        event["request"]["url"] = "https://url.dev/api/graphql"
         assert self.find_problems(event) == []

--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -321,25 +321,7 @@ class ConsecutiveDbDetectorTest(TestCase):
         assert self.find_problems(event) == []
 
     def test_ignores_graphql(self):
-        span_duration = 50
-        spans = [
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
-            ),
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `order`.`id` FROM `books_author` WHERE `author`.`type` = $1",
-            ),
-            create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
-        ]
-        spans = [
-            modify_span_start(span, span_duration * spans.index(span)) for span in spans
-        ]  # ensure spans don't overlap
-
-        event = create_event(spans)
+        event = self.create_issue_event()
         assert len(self.find_problems(event)) == 1
         event["request"] = {"url": "https://url.dev/api/graphql", "method": "POST"}
         assert self.find_problems(event) == []

--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -270,7 +270,7 @@ class ConsecutiveDbDetectorTest(TestCase):
 
     def test_ignores_graphql(self):
         event = self.create_issue_event()
-        event["request"] = {"url": "https://url.dev/api/my-endpoint"}
+        event["request"] = {"url": "https://url.dev/api/my-endpoint", "method": "POST"}
         assert len(self.find_problems(event)) == 1
         event["request"]["url"] = "https://url.dev/api/graphql"
         assert self.find_problems(event) == []


### PR DESCRIPTION
From my EA audit, I noticed Graphql can have a bunch of different db queries that occur consecutively, the order can also change, this makes it harder to fingerprint. I've only found one EA account with graphql consecutive db issues, so its fine to just ignore graphql alltogether.

I also removed the hardcoded laracon-eu org, as it is a small change that is no longer needed.

Also, if there's a more elegant way to ignore graphql (checking different properties in the event), then lmk!