### PR TITLE
feat(perf-issues): simplify tests for consecutive db detector

### DIFF
--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -35,8 +35,7 @@ class ConsecutiveDbDetectorTest(TestCase):
         run_detector_on_data(detector, event, project)
         return list(detector.stored_problems.values())
 
-    def create_issue_event(self):
-        span_duration = 50
+    def create_issue_event(self, span_duration=50):
         spans = [
             create_span(
                 "db",
@@ -178,48 +177,12 @@ class ConsecutiveDbDetectorTest(TestCase):
         ]
 
     def test_does_not_detect_consecutive_db_with_low_time_saving(self):
-        span_duration = 10
-        spans = [
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
-            ),
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `order`.`id` FROM `books_author` WHERE `author`.`type` = $1",
-            ),
-            create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
-        ]
-        spans = [
-            modify_span_start(span, span_duration * spans.index(span)) for span in spans
-        ]  # ensure spans don't overlap
-
-        event = create_event(spans)
+        event = self.create_issue_event(10)
 
         assert self.find_problems(event) == []
 
     def test_detects_consecutive_db_with_high_time_saving(self):
-        span_duration = 50
-        spans = [
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
-            ),
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `order`.`id` FROM `books_author` WHERE `author`.`type` = $1",
-            ),
-            create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
-        ]
-        spans = [
-            modify_span_start(span, span_duration * spans.index(span)) for span in spans
-        ]  # ensure spans don't overlap
-
-        event = create_event(spans)
+        event = self.create_issue_event()
 
         assert self.find_problems(event) == [
             PerformanceProblem(
@@ -297,25 +260,10 @@ class ConsecutiveDbDetectorTest(TestCase):
         assert not detector.is_creation_allowed_for_project(project)
 
     def test_detects_consecutive_db_does_not_detect_php(self):
-        span_duration = 50
-        spans = [
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
-            ),
-            create_span(
-                "db",
-                span_duration,
-                "SELECT `order`.`id` FROM `books_author` WHERE `author`.`type` = $1",
-            ),
-            create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
-        ]
-        spans = [
-            modify_span_start(span, span_duration * spans.index(span)) for span in spans
-        ]  # ensure spans don't overlap
+        event = self.create_issue_event()
 
-        event = create_event(spans)
+        assert len(self.find_problems(event)) == 1
+
         event["sdk"] = {"name": "sentry.php.laravel"}
 
         assert self.find_problems(event) == []


### PR DESCRIPTION
In some test cases, we want to use known events that have a consecutive db issue, but were testing something around that issue such as if an sdk is ignored, if an org is ignored, etc. 
So we don't care about specific event contents, just that it has an issue, and we can reuse this event across these tests.

This PR makes use of `self.create_issue_event()` to accomplish this.
