### PR TITLE
bug(replays): Properly quote transaction name when loading Txn → Replays tab

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -53,7 +53,7 @@ const getComponent = ({
         pathname: '/organizations/org-slug/replays/',
         query: {
           project: '1',
-          transaction: 'transaction',
+          transaction: 'Settings Page',
         },
         ...location,
       },
@@ -142,7 +142,7 @@ describe('TransactionReplays', () => {
               SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
             ]),
             per_page: 50,
-            query: 'event.type:transaction transaction:transaction !replayId:""',
+            query: 'event.type:transaction transaction:"Settings Page" !replayId:""',
           }),
         })
       );

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -84,7 +84,7 @@ function generateEventView({
     name: `Replay events within a transaction`,
     version: 2,
     fields,
-    query: `event.type:transaction transaction:${transactionName} !replayId:""`,
+    query: `event.type:transaction transaction:"${transactionName}" !replayId:""`,
     projects: [Number(location.query.project)],
   });
 }


### PR DESCRIPTION
Fixes #43968 

