### PR TITLE
fix(gpu-context): Fix context key for known memory size field

### DIFF
--- a/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.tsx
@@ -25,7 +25,7 @@ export function getGPUKnownDataDetails({data, type}: Props): Output | undefined 
         subject: t('Version'),
         value: data.version,
       };
-    case GPUKnownDataType.MEMORY:
+    case GPUKnownDataType.MEMORY_SIZE:
       return {
         subject: t('Memory'),
         value: data.memory_size ? formatMemory(data.memory_size) : undefined,

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -17,7 +17,7 @@ export const gpuKnownDataValues = [
   GPUKnownDataType.NAME,
   GPUKnownDataType.VERSION,
   GPUKnownDataType.VENDOR_NAME,
-  GPUKnownDataType.MEMORY,
+  GPUKnownDataType.MEMORY_SIZE,
   GPUKnownDataType.NPOT_SUPPORT,
   GPUKnownDataType.MULTI_THREAD_RENDERING,
   GPUKnownDataType.API_TYPE,

--- a/static/app/components/events/contexts/gpu/types.tsx
+++ b/static/app/components/events/contexts/gpu/types.tsx
@@ -4,7 +4,7 @@ export enum GPUKnownDataType {
   VERSION = 'version',
   VENDOR_NAME = 'vendor_name',
   VENDOR_ID = 'vendor_id',
-  MEMORY = 'memory',
+  MEMORY_SIZE = 'memory_size',
   NPOT_SUPPORT = 'npot_support',
   MULTI_THREAD_RENDERING = 'multi_threaded_rendering',
   API_TYPE = 'api_type',


### PR DESCRIPTION
The memory size in the GPU context is currently not well formatted due to the mismatch of the type and structure keys:

![Wrongly formatted GPU context](https://user-images.githubusercontent.com/15310717/216115869-0d2ecde2-ccfd-485a-90ad-ecb2fd81c763.png)

While it should look like, and looks like with this PR, this:

![Correctly formatted GPU context](https://user-images.githubusercontent.com/15310717/216116098-51eb0d76-cfe1-4da5-8af0-55a637151e81.png)

This is the JSON of the given context:

```json
"gpu": {
  "name": "Intel(R) HD Graphics 4000",
  "version": "10.18.10.4425",
  "memory_size": 64,
  "type": "gpu"
},
```

It happens so because the memory size is currently not "marked" as a known data type.

-----

While this PR sounds like a breaking change, I do not think so because of the following reasons:

- The memory size is [already documented as `memory_size`](https://develop.sentry.dev/sdk/event-payloads/contexts/#gpu-context)
- The mocked GPU context already uses `memory_size`:
https://github.com/getsentry/sentry/blob/37b57997caaa57e502e114e135d540fb6f0ab981/static/app/components/events/contexts/gpu/index.spec.tsx#L12
- There happens to be a mismatch between the case type (`GPUKnownDataType.MEMORY = 'memory'`) and the object field:
https://github.com/getsentry/sentry/blob/37b57997caaa57e502e114e135d540fb6f0ab981/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.tsx#L28-L32

-----

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.