### PR TITLE
bug(replays): Archived segments are always considered before returning a replay

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -702,7 +702,7 @@ TAG_QUERY_ALIAS_COLUMN_MAP = {
 def collect_aliases(fields: List[str]) -> List[str]:
     """Return a unique list of aliases required to satisfy the fields."""
     # is_archived is a required field.  It must always be selected.
-    result = {"is_archived"}
+    result = {"is_archived", "finished_at"}
 
     saw_tags = False
     for field in fields:

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -779,3 +779,37 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             response = self.client.get(self.url)
             assert response.status_code == 200
             assert len(response.json()["data"]) == 0
+
+    def test_archived_records_not_returned_with_environment_filtered(self):
+        self.create_environment(name="prod", project=self.project)
+
+        replay1_id = uuid.uuid4().hex
+        timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=30)
+        timestamp2 = datetime.datetime.now() - datetime.timedelta(seconds=20)
+
+        self.store_replays(mock_replay(timestamp1, self.project.id, replay1_id, environment="prod"))
+        self.store_replays(mock_replay(timestamp2, self.project.id, replay1_id, is_archived=True))
+
+        with self.feature(REPLAYS_FEATURES):
+            # We can't manipulate environment to hide the archival state.
+            response = self.client.get(self.url + "?environment=prod")
+            assert response.status_code == 200
+            assert len(response.json()["data"]) == 0
+
+    def test_archived_records_not_returned_with_selective_date_range(self):
+        """If the archive entry falls outside the date range ensure it can still be returned."""
+        replay1_id = uuid.uuid4().hex
+        timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=30)
+        timestamp2 = datetime.datetime.now() - datetime.timedelta(seconds=20)
+        timestamp3 = datetime.datetime.now() - datetime.timedelta(seconds=10)
+
+        self.store_replays(mock_replay(timestamp1, self.project.id, replay1_id))
+        self.store_replays(mock_replay(timestamp3, self.project.id, replay1_id, is_archived=True))
+
+        with self.feature(REPLAYS_FEATURES):
+            # We can't manipulate dates to hide the archival state.
+            response = self.client.get(
+                self.url + f"?start={timestamp1.isoformat()}&end={timestamp2.isoformat()}"
+            )
+            assert response.status_code == 200
+            assert len(response.json()["data"]) == 0


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/269

Fixes an issue where deleted replays were appearing on the index page.  This pull does three things:

- Fixes a case where using the environment filter could show deleted records.
- Fixes a case where using a timestamp range could be cleverly selected to show deleted records.
- Adds documentation to remind myself and future engineers of the pitfalls of using where clause conditions (in our aggregated use case).

We may also want to consider a more robust solution to handle these "out of band" updates.  Perhaps they should be merged on the segment 0 record?