### PR TITLE
feat(perf-issues): Improve render blocking asset issue hashing

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -556,10 +556,10 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
     def _url_hash(self, span: Span) -> str:
         url = urlparse(span.get("description") or "")
         path = url.path
-        path = self.UUID_REGEX.sub("%s", path)
-        path = self.CHUNK_HASH_REGEX.sub(".%s.chunk", path)
-        path = self.TRAILING_HASH_REGEX.sub("\\1%s.\\2", path)
-        path = self.ASSET_HASH_REGEX.sub("%s", path)
+        path = self.UUID_REGEX.sub("*", path)
+        path = self.CHUNK_HASH_REGEX.sub(".*.chunk", path)
+        path = self.TRAILING_HASH_REGEX.sub("\\1*.\\2", path)
+        path = self.ASSET_HASH_REGEX.sub("*", path)
         stripped_url = url._replace(path=path, query="").geturl()
         return hashlib.sha1(stripped_url.encode("utf-8")).hexdigest()
 

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -4,7 +4,6 @@ from typing import List
 import pytest
 
 from sentry.eventstore.models import Event
-from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.testutils.performance_issues.event_generators import (
     PROJECT_ID,
     create_span,
@@ -18,8 +17,6 @@ from sentry.utils.performance_issues.performance_detection import (
     get_detection_settings,
     run_detector_on_data,
 )
-
-hash_config = load_span_grouping_config()
 
 
 def _valid_render_blocking_asset_event(url: str) -> Event:
@@ -51,7 +48,6 @@ def _valid_render_blocking_asset_event(url: str) -> Event:
         },
         "transaction": "/",
     }
-    hash_config.execute_strategy(event).write_to_event(event)
     return event
 
 

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -1,9 +1,11 @@
 import unittest
+from copy import deepcopy
 from typing import List
 
 import pytest
 
 from sentry.eventstore.models import Event
+from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.testutils.performance_issues.event_generators import (
     PROJECT_ID,
     create_span,
@@ -48,7 +50,7 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
 
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1004-da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                fingerprint="1-1004-ae5ce0e354aeee83e6184c77edd50dfb56244ba9",
                 op="resource.script",
                 desc="SELECT count() FROM table WHERE id = %s",
                 type=GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN,
@@ -123,3 +125,81 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
         }
 
         assert self.find_problems(event) == []
+
+    def test_assets_with_different_query_strings_have_same_fingerprint(self):
+        first_event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "measurements": {
+                "fcp": {
+                    "value": 2500.0,
+                    "unit": "millisecond",
+                }
+            },
+            "spans": [
+                create_span("resource.script", desc="https://example.com/a.js?foo", duration=1000.0)
+            ],
+            "contexts": {
+                "trace": {
+                    "span_id": "c" * 16,
+                }
+            },
+            "transaction": "/",
+        }
+        second_event = deepcopy(first_event)
+        second_event["spans"] = [
+            create_span("resource.script", desc="https://example.com/a.js?bar", duration=1000.0)
+        ]
+
+        hash_config = load_span_grouping_config()
+        for e in [first_event, second_event]:
+            hash_config.execute_strategy(e).write_to_event(e)
+
+        first_problems = self.find_problems(first_event)
+        second_problems = self.find_problems(second_event)
+        assert len(first_problems) == 1
+        assert len(second_problems) == 1
+        assert first_problems[0].fingerprint == second_problems[0].fingerprint
+
+    def test_assets_with_different_rails_content_hashes_have_same_fingerprint(self):
+        first_event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "measurements": {
+                "fcp": {
+                    "value": 2500.0,
+                    "unit": "millisecond",
+                }
+            },
+            "spans": [
+                create_span(
+                    "resource.script",
+                    desc="https://example.com/global-908e25f4bf641868d8683022a5b62f54.css",
+                    duration=1000.0,
+                )
+            ],
+            "contexts": {
+                "trace": {
+                    "span_id": "c" * 16,
+                }
+            },
+            "transaction": "/",
+        }
+        second_event = deepcopy(first_event)
+        second_event["spans"] = [
+            create_span(
+                "resource.script",
+                desc="https://example.com/global-c2abefee2aa141eeb2e61a2c6bbf0d53.css",
+                duration=1000.0,
+            )
+        ]
+
+        hash_config = load_span_grouping_config()
+        for e in [first_event, second_event]:
+            hash_config.execute_strategy(e).write_to_event(e)
+
+        first_problems = self.find_problems(first_event)
+        second_problems = self.find_problems(second_event)
+        assert len(first_problems) == 1
+        assert len(second_problems) == 1
+        assert first_problems[0].fingerprint == second_problems[0].fingerprint

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -1,5 +1,4 @@
 import unittest
-from copy import deepcopy
 from typing import List
 
 import pytest
@@ -27,13 +26,14 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.settings = get_detection_settings()
+        self.hash_config = load_span_grouping_config()
 
     def find_problems(self, event: Event) -> List[PerformanceProblem]:
         detector = RenderBlockingAssetSpanDetector(self.settings, event)
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
-    def test_detects_render_blocking_asset(self):
+    def _valid_render_blocking_asset_event(self, url: str) -> Event:
         event = {
             "event_id": "a" * 16,
             "project": PROJECT_ID,
@@ -43,16 +43,24 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
                     "unit": "millisecond",
                 }
             },
-            "spans": [
-                create_span("resource.script", duration=1000.0),
-            ],
+            "spans": [create_span("resource.script", desc=url, duration=1000.0)],
+            "contexts": {
+                "trace": {
+                    "span_id": "c" * 16,
+                }
+            },
+            "transaction": "/",
         }
+        self.hash_config.execute_strategy(event).write_to_event(event)
+        return event
 
+    def test_detects_render_blocking_asset(self):
+        event = self._valid_render_blocking_asset_event("https://example.com/a.js")
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1004-ae5ce0e354aeee83e6184c77edd50dfb56244ba9",
+                fingerprint="1-1004-ba43281143a88ba902029356cb543dd0bff8f41c",
                 op="resource.script",
-                desc="SELECT count() FROM table WHERE id = %s",
+                desc="https://example.com/a.js",
                 type=GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN,
                 parent_span_ids=[],
                 cause_span_ids=[],
@@ -126,80 +134,39 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
 
         assert self.find_problems(event) == []
 
-    def test_assets_with_different_query_strings_have_same_fingerprint(self):
-        first_event = {
-            "event_id": "a" * 16,
-            "project": PROJECT_ID,
-            "measurements": {
-                "fcp": {
-                    "value": 2500.0,
-                    "unit": "millisecond",
-                }
-            },
-            "spans": [
-                create_span("resource.script", desc="https://example.com/a.js?foo", duration=1000.0)
-            ],
-            "contexts": {
-                "trace": {
-                    "span_id": "c" * 16,
-                }
-            },
-            "transaction": "/",
-        }
-        second_event = deepcopy(first_event)
-        second_event["spans"] = [
-            create_span("resource.script", desc="https://example.com/a.js?bar", duration=1000.0)
-        ]
-
-        hash_config = load_span_grouping_config()
-        for e in [first_event, second_event]:
-            hash_config.execute_strategy(e).write_to_event(e)
+    def test_assets_with_different_urls_have_different_fingerprints(self):
+        first_event = self._valid_render_blocking_asset_event("https://example.com/foo.js")
+        second_event = self._valid_render_blocking_asset_event("https://example.com/bar.js")
 
         first_problems = self.find_problems(first_event)
         second_problems = self.find_problems(second_event)
+
+        assert len(first_problems) == 1
+        assert len(second_problems) == 1
+        assert first_problems[0].fingerprint != second_problems[0].fingerprint
+
+    def test_assets_with_different_query_strings_have_same_fingerprint(self):
+        first_event = self._valid_render_blocking_asset_event("https://example.com/a.js?foo")
+        second_event = self._valid_render_blocking_asset_event("https://example.com/a.js?bar")
+
+        first_problems = self.find_problems(first_event)
+        second_problems = self.find_problems(second_event)
+
         assert len(first_problems) == 1
         assert len(second_problems) == 1
         assert first_problems[0].fingerprint == second_problems[0].fingerprint
 
     def test_assets_with_different_rails_content_hashes_have_same_fingerprint(self):
-        first_event = {
-            "event_id": "a" * 16,
-            "project": PROJECT_ID,
-            "measurements": {
-                "fcp": {
-                    "value": 2500.0,
-                    "unit": "millisecond",
-                }
-            },
-            "spans": [
-                create_span(
-                    "resource.script",
-                    desc="https://example.com/global-908e25f4bf641868d8683022a5b62f54.css",
-                    duration=1000.0,
-                )
-            ],
-            "contexts": {
-                "trace": {
-                    "span_id": "c" * 16,
-                }
-            },
-            "transaction": "/",
-        }
-        second_event = deepcopy(first_event)
-        second_event["spans"] = [
-            create_span(
-                "resource.script",
-                desc="https://example.com/global-c2abefee2aa141eeb2e61a2c6bbf0d53.css",
-                duration=1000.0,
-            )
-        ]
-
-        hash_config = load_span_grouping_config()
-        for e in [first_event, second_event]:
-            hash_config.execute_strategy(e).write_to_event(e)
+        first_event = self._valid_render_blocking_asset_event(
+            "https://example.com/global-908e25f4bf641868d8683022a5b62f54.css"
+        )
+        second_event = self._valid_render_blocking_asset_event(
+            "https://example.com/global-c2abefee2aa141eeb2e61a2c6bbf0d53.css"
+        )
 
         first_problems = self.find_problems(first_event)
         second_problems = self.find_problems(second_event)
+
         assert len(first_problems) == 1
         assert len(second_problems) == 1
         assert first_problems[0].fingerprint == second_problems[0].fingerprint


### PR DESCRIPTION
Large Render Blocking Asset issues are hashed using the span hash of the asset's `resource.*` span. That span hash is based on the complete asset URL. Improve issue hashing by:

* removing the query string (like we do when generating span hashes for `http.client` spans)
* removing content hashes from asset file names, in all the formats I could find:
  * UUIDs in path/filename
  * hashes in path/filename (e.g. /foo/6a7a65d8bf641868d8683022a5b62f54.js)
  * hex hashes with chunks (e.g. `foo.abcd1234.chunk.js`)
  * hex hashes with numbered chunks (e.g. `2.abcd1234.chunk.js`)
  * trailing hashes (e.g. `foo-6a7a65d8bf641868d8683022a5b62f54.js`)