### PR TITLE
feat(roles): refactor OrganizationMember model and API

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -334,8 +334,16 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 if acting_member != member:
                     if not request.access.has_scope("member:admin"):
                         return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
-                    elif not roles.can_manage(acting_member.role, member.role):
-                        return Response({"detail": ERR_INSUFFICIENT_ROLE}, status=400)
+                    else:
+                        can_manage = False
+                        # check org roles through teams
+                        for role in acting_member.get_all_org_roles():
+                            if roles.can_manage(role, member.role):
+                                can_manage = True
+                                break
+
+                        if not can_manage:
+                            return Response({"detail": ERR_INSUFFICIENT_ROLE}, status=400)
 
         # TODO(dcramer): do we even need this check?
         elif not request.access.has_scope("member:admin"):

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -7,7 +7,7 @@ from typing import FrozenSet, Optional, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 from django.db.models.signals import post_delete
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
@@ -629,7 +629,7 @@ class Organization(Model, SnowflakeIdMixin):
         if role:
             return Team.objects.filter(org_role=role, organization=self)
 
-        return Team.objects.filter(~Q(org_role=None), organization=self)
+        return Team.objects.filter(organization=self).exclude(org_role=None)
 
     # TODO(hybrid-cloud): Replace with Region tombstone when it's implemented
     @classmethod

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -7,7 +7,7 @@ from typing import FrozenSet, Optional, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.db.models.signals import post_delete
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
@@ -622,6 +622,14 @@ class Organization(Model, SnowflakeIdMixin):
         if not self.get_option("sentry:alerts_member_write", ALERTS_MEMBER_WRITE_DEFAULT):
             scopes.discard("alerts:write")
         return frozenset(scopes)
+
+    def get_teams_with_org_role(self, role):
+        from sentry.models.team import Team
+
+        if role:
+            return Team.objects.filter(org_role=role, organization=self)
+
+        return Team.objects.filter(~Q(org_role=None), organization=self)
 
     # TODO(hybrid-cloud): Replace with Region tombstone when it's implemented
     @classmethod

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -533,7 +533,9 @@ class OrganizationMember(Model):
             )
             .exclude(id=self.id)
             .exists()
-        ) or not OrganizationMemberTeam.objects.filter(
+        ) and not OrganizationMemberTeam.objects.filter(
             team__in=self.organization.get_teams_with_org_role(organization_roles.get_top_dog().id)
+        ).exclude(
+            organizationmember_id=self.id
         ).exists()
         return is_only_owner

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
@@ -407,7 +407,7 @@ class OrganizationMember(Model):
     def get_org_roles_from_teams(self):
         # results in an extra query when calling get_scopes()
         return list(
-            self.teams.all().filter(~Q(org_role=None)).values_list("org_role", flat=True).distinct()
+            self.teams.all().exclude(org_role=None).values_list("org_role", flat=True).distinct()
         )
 
     def get_all_org_roles(self):

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -4,8 +4,6 @@ import dataclasses
 from collections import defaultdict
 from typing import TYPE_CHECKING, Iterable, List, MutableMapping, Optional, Set, cast
 
-from django.db.models import Q
-
 from sentry.models import (
     Organization,
     OrganizationMember,
@@ -298,7 +296,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def get_all_org_roles(self, organization_member: ApiOrganizationMember) -> List[str]:
         team_ids = [mt.team_id for mt in organization_member.member_teams]
         org_roles = list(
-            Team.objects.filter(~Q(org_role=None), id__in=team_ids)
+            Team.objects.filter(id__in=team_ids)
+            .exclude(org_role=None)
             .values_list("org_role", flat=True)
             .distinct()
         )

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -489,7 +489,7 @@ class StatusActionTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         assert (
             resp.data["text"]
-            == "You do not have permission approve a member invitation with the role owner."
+            == "You do not have permission to approve a member invitation with the role owner."
         )
 
     def test_identity_not_linked(self):

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -351,9 +351,27 @@ class OrganizationMemberTest(TestCase):
         user = self.create_user()
         with pytest.raises(
             UnableToAcceptMemberInvitationException,
-            match="You do not have permission approve a member invitation with the role admin.",
+            match="You do not have permission to approve a member invitation with the role admin.",
         ):
             member.validate_invitation(user, [roles.get("member")])
+
+    def test_validate_invitation_with_org_role_from_team(self):
+        team = self.create_team(org_role="admin")
+        member = self.create_member(
+            organization=self.organization,
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+            email="hello@sentry.io",
+            role="member",
+            teams=[team],
+        )
+        user = self.create_user()
+        assert member.validate_invitation(user, [roles.get("admin"), roles.get("member")])
+
+        with pytest.raises(
+            UnableToAcceptMemberInvitationException,
+            match="You do not have permission to approve a member invitation with the role admin.",
+        ):
+            member.validate_invitation(user, [roles.get("manager")])
 
     def test_approve_member_invitation(self):
         member = self.create_member(


### PR DESCRIPTION
Refactors the `validate_invitation` and `is_only_owner` functions on the `OrganizationMember` model + the `DELETE OrganizationMember` API to account for org roles through teams.

Also replaces ~Q with exclude()

For ER-1352