### PR TITLE
feat(roles): update team and project serializers with all org roles

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -102,17 +102,12 @@ def get_access_by_project(
     for project in projects:
         is_member = any(t.id in team_memberships for t in project_team_map.get(project.id, []))
         org_roles = all_org_roles.get(project.organization_id) or []
-        has_access = False
-
-        for org_role in org_roles:
-            if is_member:
-                has_access = True
-            elif is_superuser:
-                has_access = True
-            elif project.organization.flags.allow_joinleave:
-                has_access = True
-            elif org_role and roles.get(org_role).is_global:
-                has_access = True
+        has_access = bool(
+            is_member
+            or is_superuser
+            or project.organization.flags.allow_joinleave
+            or any(roles.get(org_role).is_global for org_role in org_roles)
+        )
         result[project] = {"is_member": is_member, "has_access": has_access}
     return result
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -94,24 +94,25 @@ def get_access_by_project(
         project_team_map[pt.project_id].append(pt.team)
 
     team_memberships = set(_get_team_memberships([pt.team for pt in project_teams], user))
-    org_roles = get_org_roles({i.organization_id for i in projects}, user)
+    all_org_roles = get_org_roles({i.organization_id for i in projects}, user)
     prefetch_related_objects(projects, "organization")
 
     is_superuser = request and is_active_superuser(request) and request.user == user
     result = {}
     for project in projects:
         is_member = any(t.id in team_memberships for t in project_team_map.get(project.id, []))
-        org_role = org_roles.get(project.organization_id)
-        if is_member:
-            has_access = True
-        elif is_superuser:
-            has_access = True
-        elif project.organization.flags.allow_joinleave:
-            has_access = True
-        elif org_role and roles.get(org_role).is_global:
-            has_access = True
-        else:
-            has_access = False
+        org_roles = all_org_roles.get(project.organization_id) or []
+        has_access = False
+
+        for org_role in org_roles:
+            if is_member:
+                has_access = True
+            elif is_superuser:
+                has_access = True
+            elif project.organization.flags.allow_joinleave:
+                has_access = True
+            elif org_role and roles.get(org_role).is_global:
+                has_access = True
         result[project] = {"is_member": is_member, "has_access": has_access}
     return result
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -96,8 +96,8 @@ def get_member_totals(team_list: Sequence[Team], user: User) -> Mapping[str, int
 
 def get_org_roles(
     org_ids: Set[int], user: User, optimization: SingularApiAccessOrgOptimization | None = None
-) -> Mapping[int, List[str]]:
-    """Get the role the user has in each org"""
+) -> Mapping[int, Sequence[str]]:
+    """Get the roles the user has in each org"""
     if not user.is_authenticated:
         return {}
 
@@ -119,7 +119,7 @@ def get_org_roles(
     }
 
 
-def _get_all_org_roles(member: OrganizationMember) -> List[str]:
+def _get_all_org_roles(member: OrganizationMember) -> Sequence[str]:
     sorted_roles: List[OrganizationRole] = sorted(
         [organization_roles.get(role) for role in member.get_all_org_roles()],
         key=lambda r: r.priority,

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -216,7 +216,8 @@ class TeamSerializer(Serializer):  # type: ignore
                     minimum_team_role = roles.get_minimum_team_role(top_org_role)
                     if (
                         not team_role
-                        or minimum_team_role.priority > team_roles.get(team_role).priority
+                        or minimum_team_role.priority
+                        > team_roles.get(team_role.lower().replace("team ", "")).priority
                     ):
                         team_role = minimum_team_role.id
 

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -415,6 +415,13 @@ class OrganizationMember(Model):
         all_org_roles.append(self.role)
         return all_org_roles
 
+    def get_all_org_roles_sorted(self):
+        return sorted(
+            [organization_roles.get(role) for role in self.get_all_org_roles()],
+            key=lambda r: r.priority,
+            reverse=True,
+        )
+
     def validate_invitation(self, user_to_approve, allowed_roles):
         """
         Validates whether an org has the options to invite members, handle join requests,

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -139,7 +139,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 45 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 47
+        expected_queries = 49 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 51
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -179,8 +179,11 @@ class TeamSerializerTest(TestCase):
     def test_member_on_owner_team_access(self):
         user = self.create_user(username="foo")
         organization = self.create_organization()
+        manager_team = self.create_team(organization=organization, org_role="manager")
         owner_team = self.create_team(organization=organization, org_role="owner")
-        self.create_member(user=user, organization=organization, role="member", teams=[owner_team])
+        self.create_member(
+            user=user, organization=organization, role="member", teams=[manager_team, owner_team]
+        )
         team = self.create_team(organization=organization)
 
         result = serialize(team, user)

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -217,7 +217,7 @@ class TeamSerializerTest(TestCase):
             user=user, organization=organization, role="member", teams=[manager_team]
         )
         team = self.create_team(organization=organization)
-        OrganizationMemberTeam(organizationmember=member, team=team, role="contributor")
+        OrganizationMemberTeam(organizationmember=member, team=team, role="admin")
 
         result = serialize(team, user)
         result.pop("dateCreated")


### PR DESCRIPTION
Updates `TeamSerializer` to respect the `org_role` of the team.

To determine access, we fetch all the org roles of the member for the organization. To determine the team role, we sort the org roles to get the team role from the highest priority org role.

Also updates `ProjectSerializer` to determine access via all org roles.

Ups the number of expected queries for `test_with_projects` in `test_organization_details.py` because of the additional queries needed to fetch the member's teams to get all org roles.

For ER-1353