### PR TITLE
bug(replays): Fix default search on the replays list

### DIFF
--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -19,6 +20,20 @@ function ReplaysFilters() {
   const {pathname, query} = useLocation();
   const organization = useOrganization();
 
+  useEffect(() => {
+    if (query.query === undefined) {
+      // Set default query into url if there is no query set
+      browserHistory.replace({
+        pathname,
+        query: {
+          ...query,
+          cursor: undefined,
+          query: DEFAULT_QUERY,
+        },
+      });
+    }
+  });
+
   return (
     <FilterContainer>
       <PageFilterBar condensed>
@@ -29,8 +44,8 @@ function ReplaysFilters() {
       <ReplaySearchBar
         organization={organization}
         pageFilters={selection}
-        defaultQuery={decodeScalar(query?.query ?? DEFAULT_QUERY, '')}
-        query={decodeScalar(query.query ?? DEFAULT_QUERY, '')}
+        defaultQuery={DEFAULT_QUERY}
+        query={decodeScalar(query.query, DEFAULT_QUERY)}
         onSearch={searchQuery => {
           browserHistory.push({
             pathname,


### PR DESCRIPTION
**Before:**
The default search value wasn't being picked up by the replay table because it wasn't getting put into the url.
This meant that you'd see `duration:>=5 ` in the search box, but the results didn't respect it:

<img width="1570" alt="SCR-20230201-lzp" src="https://user-images.githubusercontent.com/187460/216194300-15cf7dd5-2bf2-43e3-9a77-cfb7dee9b0d8.png">

**After:**
This change shoves `?query=duration:>=5` into the url if there is no `?query` present. (It is valid for the query param to be set to the empty string. ie: `?query=`)

When the `browserHistory.replace` is being called one request gets fired, but then cancelled by the browser:

<img width="1315" alt="SCR-20230201-lxv" src="https://user-images.githubusercontent.com/187460/216194754-a4aaf70f-87c3-47e8-a1ac-9114077849b5.png">
