### PR TITLE
bug(replays): Replace broken buttons in discover with `replayId`

### DIFF
--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -349,6 +349,9 @@ function TableView(props: TableViewProps) {
       }
     } else if (columnKey === 'replayId') {
       if (dataRow.replayId) {
+        if (!dataRow['project.name']) {
+          return <TabularNums>{dataRow.replayId}</TabularNums>;
+        }
         const target = replayLinkGenerator(organization, dataRow, undefined);
         cell = (
           <ViewReplayLink replayId={dataRow.replayId} to={target}>
@@ -627,6 +630,10 @@ const StyledLink = styled(Link)`
   & div {
     display: inline;
   }
+`;
+
+const TabularNums = styled('span')`
+  font-variant-numeric: tabular-nums;
 `;
 
 const StyledIcon = styled(IconStack)`

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -154,7 +154,7 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
     _query: Query | undefined
   ): LocationDescriptor => {
     const replayId = tableRow.replayId;
-    if (!replayId) {
+    if (!replayId || !tableRow['project.name']) {
       return {};
     }
 


### PR DESCRIPTION
**Repro:**
1. Open Discover and query for Only the columns `replayId` and `count()`

Notice that you get three columns in the table:
1. "Open Group" icon
2. "View Replay" button
3. `count()` column

<img width="551" alt="SCR-20230201-n9v" src="https://user-images.githubusercontent.com/187460/216204828-dccde2f3-fe36-4a5d-ad98-cae668f06f7e.png">

The issue is that the `project` isn't loaded, so the View Replay button points to the wrong url. It's because of the aggregate `count()` column in the query.

Clicking through the "Open Group" icon loads the project data, so links to the event and to the replay both work:
<img width="548" alt="SCR-20230201-naa" src="https://user-images.githubusercontent.com/187460/216205002-9faf2d55-df90-45f8-ba29-967630604af9.png">

**Iterating on the Problem:**

Instead of showing the View Replay button when there is an aggregate like `count()`, we'll just show the raw `replayId`

<img width="549" alt="SCR-20230201-ndf" src="https://user-images.githubusercontent.com/187460/216205089-70d4d481-0e12-40f2-bf3b-fc16509c1eea.png">

The button before didn't work, and we've got no links here. But at least we don't render a link, and we're showing something more interesting than an icon.

Users can still click through with the `Open Group` icon and get links direct into the replay, although that's kind of hidden until you learn about it.

Fixes https://github.com/getsentry/sentry/issues/40981