### PR TITLE
ref(crons): Add crons feature flag to sentry, defaulted to true

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1065,6 +1065,8 @@ SENTRY_FEATURES = {
     "organizations:metric-alert-chartcuterie": False,
     # Extract metrics for sessions during ingestion.
     "organizations:metrics-extraction": False,
+    # Enable crons monitoring feature
+    "organizations:monitors": True,
     # Normalize transaction names during ingestion.
     "organizations:transaction-name-normalize": False,
     # Try to derive normalization rules by clustering transaction names.


### PR DESCRIPTION
already GA'ed so should be true, this will let us also get rid of the flagr entry. Has to be here because ST needs to disable the feature flag explicitly.