### PR TITLE
feat(crons): Support configuring timezone

### DIFF
--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -1,5 +1,6 @@
 from croniter import croniter
 from django.core.exceptions import ValidationError
+from django.utils.timezone import pytz
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -46,6 +47,7 @@ class CronJobValidator(serializers.Serializer):
     schedule = ObjectField()
     checkin_margin = EmptyIntegerField(required=False, allow_null=True, default=None)
     max_runtime = EmptyIntegerField(required=False, allow_null=True, default=None)
+    timezone = serializers.ChoiceField(choices=pytz.all_timezones, required=False)
 
     def validate_schedule_type(self, value):
         if value:

--- a/tests/sentry/api/endpoints/test_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_details.py
@@ -98,6 +98,20 @@ class UpdateMonitorTest(MonitorTestCase):
             monitor = Monitor.objects.get(id=monitor.id)
             assert monitor.status == MonitorStatus.OK
 
+    def test_timezone(self):
+        monitor = self._create_monitor()
+
+        for i, path_func in enumerate(self._get_path_functions()):
+            monitor = self._create_monitor()
+            path = path_func(monitor)
+            resp = self.client.put(path, data={"config": {"timezone": "America/Los_Angeles"}})
+
+            assert resp.status_code == 200, resp.content
+            assert resp.data["id"] == str(monitor.guid)
+
+            monitor = Monitor.objects.get(id=monitor.id)
+            assert monitor.config["timezone"] == "America/Los_Angeles"
+
     def test_checkin_margin(self):
         for path_func in self._get_path_functions():
             monitor = self._create_monitor()

--- a/tests/sentry/models/test_monitor.py
+++ b/tests/sentry/models/test_monitor.py
@@ -38,6 +38,26 @@ class MonitorTestCase(TestCase):
             2019, 1, 1, 1, 15, tzinfo=timezone.utc
         )
 
+    def test_next_run_crontab_explicit_timezone(self):
+        monitor = Monitor(
+            last_checkin=datetime(2019, 1, 1, 1, 10, 20, tzinfo=timezone.utc),
+            config={
+                "schedule": "0 12 * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "timezone": "UTC",
+            },
+        )
+        assert monitor.get_next_scheduled_checkin() == datetime(
+            2019, 1, 1, 12, 00, tzinfo=timezone.utc
+        )
+
+        # Europe/Berlin == UTC+01:00.
+        # the run should be represented 1 hours earlier in UTC time
+        monitor.config["timezone"] = "Europe/Berlin"
+        assert monitor.get_next_scheduled_checkin() == datetime(
+            2019, 1, 1, 11, 00, tzinfo=timezone.utc
+        )
+
     def test_next_run_interval(self):
         monitor = Monitor(
             last_checkin=datetime(2019, 1, 1, 1, 10, 20, tzinfo=timezone.utc),


### PR DESCRIPTION
Adds a `timezone` parameter to the config object for a monitor.

We were already reading this parameter within the [monitor.get_next_scheduled_checkin][0]. But we were not testing it, I have added a test.

[0]: https://github.com/getsentry/sentry/blob/651cfc308e9ca1128f5860a6547f45a9a5a84705/src/sentry/models/monitor.py#L160

Refs https://github.com/getsentry/sentry/issues/43625