### PR TITLE
feat(monitors): Do not force UTC on the checkin chart

### DIFF
--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -116,7 +116,6 @@ const MonitorStats = ({monitor, orgId}: Props) => {
             isGroupedByDate
             showTimeInTooltip
             useShortDate
-            utc
             series={[success, failed, missed]}
             stacked
             additionalSeries={additionalSeries}


### PR DESCRIPTION
All other charts in sentry do not display UTC. We should not enforce it here either

(once #44009 lands it becomes a LOT more clear)