### PR TITLE
feat(api): Allow for querying release files/archives with checksums

### DIFF
--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -22,6 +22,8 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
         :pparam string organization_slug: the slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
+        :qparam string query: If set, only files with these partial names will be returned.
+        :qparam string checksum: If set, only files with these exact checksums will be returned.
         :auth: required
         """
         try:


### PR DESCRIPTION
Last year, sentry-cli introduced a feature, that queries our Sentry releases in order to decide what files should be uploaded.
Prior to this change, no matter what was the state of an archive, everything was sent straight away, whether it was already there or not.

The problem, however, is that this endpoint is paginated, and there are cases, where people have thousands of files, which result in hundreds of API calls, draining their quota and sometimes resulting in 429s.

The change works by allowing to query our `/files` endpoint for the presence of a predefined set of checksums. This way we can easily filter already uploaded files on the client-side, without the need to pull _all_ the files in the first place, and then do `sha1` filtering. It should be enough, as we rarely send thousands of files _at once_, and even if we do, usually those are duplicates, which we will drop thanks to this query.

Yes, it will still be paginated, but will drastically reduce the number of requests for the majority of cases.
It will also fix our symbolicator case for mapping JS files, as for this purpose, we only need a handful of files, which will definitely fit into a single request page.

Note that `query` was always there, but not documented. (tbh I'd prefer to call it `name`, but didn't see a reason to break it)

Replaces: https://github.com/getsentry/sentry/pull/43778