### PR TITLE
bug(replays): Add environment as a default field

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -701,8 +701,8 @@ TAG_QUERY_ALIAS_COLUMN_MAP = {
 
 def collect_aliases(fields: List[str]) -> List[str]:
     """Return a unique list of aliases required to satisfy the fields."""
-    # is_archived is a required field.  It must always be selected.
-    result = {"is_archived", "finished_at"}
+    # Required fields.
+    result = {"is_archived", "finished_at", "agg_environment"}
 
     saw_tags = False
     for field in fields:

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -792,7 +792,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
 
         with self.feature(REPLAYS_FEATURES):
             # We can't manipulate environment to hide the archival state.
-            response = self.client.get(self.url + "?environment=prod")
+            response = self.client.get(self.url + "?field=id&environment=prod")
             assert response.status_code == 200
             assert len(response.json()["data"]) == 0
 


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/274

Fixes an issue where environment is filtered but not selected raising a 500 error.