### PR TITLE
Remove `symbolicator.status_code` tagging with `project_id`

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -566,7 +566,7 @@ class SymbolicatorSession:
 
                 metrics.incr(
                     "events.symbolicator.status_code",
-                    tags={"status_code": response.status_code, "project_id": self.project_id},
+                    tags={"status_code": response.status_code},
                 )
 
                 if (


### PR DESCRIPTION
It turns out this is a very high cardinality metric which I believe noone has been looking at in detail. It does yield some interesting traffic patterns (attributing traffic spikes to certain projects), but that should be possible to do with other mechanisms (redis? S4S transactions?)