### PR TITLE
fix(codecov): Override marker content

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -283,6 +283,10 @@ const StyledContextLine = styled(ContextLine)`
   z-index: 1000;
   list-style: none;
 
+  &::marker {
+    content: none;
+  }
+
   &:before {
     content: counter(frame);
     counter-increment: frame;


### PR DESCRIPTION
We're using `::before` to handle the codecov background colors and border, add another disable on the marker
