### PR TITLE
fix(codecov): Simplify analytics for line coverage

### DIFF
--- a/static/app/components/events/interfaces/frame/context.spec.tsx
+++ b/static/app/components/events/interfaces/frame/context.spec.tsx
@@ -39,7 +39,6 @@ describe('Frame - Context', function () {
   it('converts coverage data to the right colors', function () {
     expect(getCoverageColorClass(lines, lineCoverage, primaryLineNumber)).toEqual([
       ['partial', 'covered', 'active', 'uncovered'],
-      false,
       true,
     ]);
   });

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -56,10 +56,9 @@ export function getCoverageColorClass(
   lines: [number, string][],
   lineCov: LineCoverage[],
   activeLineNo: number
-): [Array<string>, boolean, boolean] {
+): [Array<string>, boolean] {
   const lineCoverage = keyBy(lineCov, 0);
-  let primaryLineCovered = true;
-  let surroundingLinesCovered = true;
+  let hasCoverage = false;
   const lineColors = lines.map(([lineNo]) => {
     const coverage = lineCoverage[lineNo]
       ? lineCoverage[lineNo][1]
@@ -79,12 +78,11 @@ export function getCoverageColorClass(
       case Coverage.NOT_APPLICABLE:
       // fallthrough
       default:
-        if (lineNo === activeLineNo) {
-          primaryLineCovered = false;
-        } else {
-          surroundingLinesCovered = false;
-        }
         break;
+    }
+
+    if (color !== '') {
+      hasCoverage = true;
     }
 
     if (activeLineNo !== lineNo) {
@@ -93,7 +91,7 @@ export function getCoverageColorClass(
     return color === '' ? 'active' : `active ${color}`;
   });
 
-  return [lineColors, primaryLineCovered, surroundingLinesCovered];
+  return [lineColors, hasCoverage];
 }
 
 const Context = ({
@@ -144,7 +142,7 @@ const Context = ({
   const hasCoverageData =
     !isLoading && data?.codecov?.status === CodecovStatusCode.COVERAGE_EXISTS;
 
-  const [lineColors = [], primaryLineCovered, surroundingLinesCovered] =
+  const [lineColors = [], hasCoverage] =
     hasCoverageData && data!.codecov?.lineCoverage && !!frame.lineNo! && contextLines
       ? getCoverageColorClass(contextLines, data!.codecov?.lineCoverage, frame.lineNo)
       : [];
@@ -152,8 +150,7 @@ const Context = ({
   useRouteAnalyticsParams(
     hasCoverageData
       ? {
-          primary_line_covered: primaryLineCovered,
-          surrounding_lines_covered: surroundingLinesCovered,
+          has_line_coverage: hasCoverage,
         }
       : {}
   );


### PR DESCRIPTION
Spoke with @Dhrumil-Sentry and we can simplify the amplitude analytics to indicate whether the frame had any coverage information instead of distinguishing between primary and surrounding lines.