### PR TITLE
feat(profiling): Skip steps already done on retries

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -82,7 +82,7 @@ def _should_deobfuscate(profile: Profile) -> bool:
     return platform in SHOULD_DEOBFUSCATE and not profile.get("deobfuscated", False)
 
 
-def _symbolicate_profile(profile: Profile, project: Project, event_id: str):
+def _symbolicate_profile(profile: Profile, project: Project, event_id: str) -> None:
     try:
         if _should_symbolicate(profile):
             if "debug_meta" not in profile or not profile["debug_meta"]:
@@ -117,7 +117,7 @@ def _symbolicate_profile(profile: Profile, project: Project, event_id: str):
         return
 
 
-def _deobfuscate_profile(profile: Profile, project: Project):
+def _deobfuscate_profile(profile: Profile, project: Project) -> None:
     try:
         if _should_deobfuscate(profile):
             if "profile" not in profile or not profile["profile"]:
@@ -141,7 +141,7 @@ def _deobfuscate_profile(profile: Profile, project: Project):
         return
 
 
-def _normalize_profile(profile: Profile, organization: Organization, project: Project):
+def _normalize_profile(profile: Profile, organization: Organization, project: Project) -> None:
     try:
         if not profile.get("normalized", False):
             _normalize(profile=profile, organization=organization)
@@ -528,7 +528,7 @@ def _insert_vroom_profile(profile: Profile) -> bool:
         return False
 
 
-def _push_profile_to_vroom(profile: Profile, project: Project):
+def _push_profile_to_vroom(profile: Profile, project: Project) -> None:
     if not _insert_vroom_profile(profile=profile):
         _track_outcome(
             profile=profile,

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -428,7 +428,6 @@ def get_frame_index_map(frames: List[dict[str, Any]]) -> dict[int, List[int]]:
 def _deobfuscate(profile: Profile, project: Project) -> None:
     debug_file_id = profile.get("build_id")
     if debug_file_id is None or debug_file_id == "":
-        profile["deobfuscated"] = True
         return
 
     dif_paths = ProjectDebugFile.difcache.fetch_difs(project, [debug_file_id], features=["mapping"])


### PR DESCRIPTION
When Celery retries, it pushes the modified payload to a new queue. It means, if it fails when sending to `vroom`, we don't have to redo symbolication or deobfuscation. This PR will let the task skips part of the processing that was already done.