### PR TITLE
fix(release-health) fixes get_crash_free_breakdown returning empty results when no environment is specified

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1115,21 +1115,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         start: datetime,
         environments: Optional[Sequence[EnvironmentName]] = None,
     ) -> Callable[[datetime], CrashFreeBreakdown]:
-        def generate_defaults(end: datetime) -> CrashFreeBreakdown:
-            """Function to use if querying snuba is not necessary"""
-            return {
-                "crash_free_sessions": None,
-                "crash_free_users": None,
-                "date": end,
-                "total_sessions": 0,
-                "total_users": 0,
-            }
 
         projects = self._get_projects([project_id])
-
-        if environments is None:
-            return generate_defaults
-        environments = list(environments)
 
         where = [
             Condition(
@@ -1139,7 +1126,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             )
         ]
 
-        if len(environments) > 0:
+        if environments:
+            environments = list(environments)
             where.append(
                 Condition(
                     lhs=Column(name="tags[environment]"),

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -507,39 +507,42 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
 
     def test_get_crash_free_breakdown(self):
         start = timezone.now() - timedelta(days=4)
-        data = self.backend.get_crash_free_breakdown(
-            project_id=self.project.id,
-            release=self.session_release,
-            start=start,
-            environments=["prod"],
-        )
 
-        # Last returned date is generated within function, should be close to now:
-        last_date = data[-1].pop("date")
-        assert timezone.now() - last_date < timedelta(seconds=1)
+        # it should work with and without environments
+        for environments in [None, ["prod"]]:
+            data = self.backend.get_crash_free_breakdown(
+                project_id=self.project.id,
+                release=self.session_release,
+                start=start,
+                environments=environments,
+            )
 
-        assert data == [
-            {
-                "crash_free_sessions": None,
-                "crash_free_users": None,
-                "date": start + timedelta(days=1),
-                "total_sessions": 0,
-                "total_users": 0,
-            },
-            {
-                "crash_free_sessions": None,
-                "crash_free_users": None,
-                "date": start + timedelta(days=2),
-                "total_sessions": 0,
-                "total_users": 0,
-            },
-            {
-                "crash_free_sessions": 100.0,
-                "crash_free_users": 100.0,
-                "total_sessions": 2,
-                "total_users": 1,
-            },
-        ]
+            # Last returned date is generated within function, should be close to now:
+            last_date = data[-1].pop("date")
+            assert timezone.now() - last_date < timedelta(seconds=1)
+
+            assert data == [
+                {
+                    "crash_free_sessions": None,
+                    "crash_free_users": None,
+                    "date": start + timedelta(days=1),
+                    "total_sessions": 0,
+                    "total_users": 0,
+                },
+                {
+                    "crash_free_sessions": None,
+                    "crash_free_users": None,
+                    "date": start + timedelta(days=2),
+                    "total_sessions": 0,
+                    "total_users": 0,
+                },
+                {
+                    "crash_free_sessions": 100.0,
+                    "crash_free_users": 100.0,
+                    "total_sessions": 2,
+                    "total_users": 1,
+                },
+            ]
 
         data = self.backend.get_crash_free_breakdown(
             project_id=self.project.id,


### PR DESCRIPTION
This PR fixes a bug in release_health backend implementation of get_crash_free_breakdown

When no environments were specified the function returned an empty structure.