### PR TITLE
feat(roles): refactor slack integration to include all org roles

### DIFF
--- a/src/sentry/integrations/slack/utils/auth.py
+++ b/src/sentry/integrations/slack/utils/auth.py
@@ -12,7 +12,7 @@ ALLOWED_ROLES = ["admin", "manager", "owner"]
 
 
 def is_valid_role(org_member: "OrganizationMember") -> bool:
-    return org_member.role in ALLOWED_ROLES
+    return len(set(org_member.get_all_org_roles()) & set(ALLOWED_ROLES)) > 0
 
 
 def _encode_data(secret: str, data: bytes, timestamp: str) -> str:

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -84,6 +84,12 @@ class SlackIntegrationLinkTeamTestBase(TestCase):
             external_id=self.channel_id,
         )
 
+    def _create_user_with_valid_role_through_team(self):
+        user = self.create_user(email="foo@example.com")
+        admin_team = self.create_team(org_role="admin")
+        self.create_member(organization=self.organization, user=user, teams=[admin_team])
+        self.login_as(user)
+
 
 @region_silo_test
 class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
@@ -121,6 +127,13 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
             scope_type=NotificationScopeType.TEAM.value, target=self.team.actor.id
         )
         assert len(team_settings) == 1
+
+    @responses.activate
+    def test_link_team_with_valid_role_through_team(self):
+        """Test that we successfully link a team to a Slack channel with a valid role through a team"""
+        self._create_user_with_valid_role_through_team()
+
+        self.test_link_team()
 
     @responses.activate
     def test_link_team_already_linked(self):
@@ -200,6 +213,13 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
             scope_type=NotificationScopeType.TEAM.value, target=self.team.actor.id
         )
         assert len(team_settings) == 0
+
+    @responses.activate
+    def test_unlink_team_with_valid_role_through_team(self):
+        """Test that a team can be unlinked from a Slack channel with a valid role through a team"""
+        self._create_user_with_valid_role_through_team()
+
+        self.test_unlink_team()
 
     @responses.activate
     def test_unlink_multiple_teams(self):

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -93,6 +93,23 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         data = self.send_slack_message("link team", user_id=OTHER_SLACK_ID)
         assert INSUFFICIENT_ROLE_MESSAGE in get_response_text(data)
 
+    @responses.activate
+    def test_link_team_sufficient_role_through_team(self):
+        """
+        Test that when a user whose org role is sufficient through team membership
+        attempts to link a team, we allow it.
+        """
+        user2 = self.create_user()
+        admin_team = self.create_team(org_role="admin")
+        self.create_member(
+            teams=[admin_team], user=user2, role="member", organization=self.organization
+        )
+        self.login_as(user2)
+        link_user(user2, self.idp, slack_id=OTHER_SLACK_ID)
+
+        data = self.send_slack_message("link team", user_id=OTHER_SLACK_ID)
+        assert "Link your Sentry team to this Slack channel!" in get_response_text(data)
+
 
 @region_silo_test
 class SlackCommandsUnlinkTeamTest(SlackCommandsLinkTeamTestBase):


### PR DESCRIPTION
Refactors `is_valid_role` to account for all org roles from team membership

For ER-1354