### PR TITLE
chore(discover): Removes usage of quick context feature flag from frontend

### DIFF
--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -16,7 +16,7 @@ import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
-import {Container, NumberContainer, VersionContainer} from 'sentry/utils/discover/styles';
+import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getShortEventId} from 'sentry/utils/events';
 import {EventsResults} from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
@@ -188,22 +188,14 @@ function ProfileEventsCell<F extends FieldType>(props: ProfileEventsCellProps<F>
 
   if (key === 'release') {
     if (value) {
-      if (props.baggage.organization.features.includes('discover-quick-context')) {
-        return (
-          <QuickContextHoverWrapper
-            dataRow={props.dataRow}
-            contextType={ContextType.RELEASE}
-            organization={props.baggage.organization}
-          >
-            <Version version={value} truncate />
-          </QuickContextHoverWrapper>
-        );
-      }
-
       return (
-        <VersionContainer>
-          <Version version={value} anchor={false} tooltipRawVersion truncate />
-        </VersionContainer>
+        <QuickContextHoverWrapper
+          dataRow={props.dataRow}
+          contextType={ContextType.RELEASE}
+          organization={props.baggage.organization}
+        >
+          <Version version={value} truncate />
+        </QuickContextHoverWrapper>
       );
     }
   }

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -479,21 +479,15 @@ const SPECIAL_FIELDS: SpecialFields = {
 
       return (
         <Container>
-          {organization.features.includes('discover-quick-context') ? (
-            <QuickContextHoverWrapper
-              dataRow={data}
-              contextType={ContextType.ISSUE}
-              organization={organization}
-            >
-              <StyledLink to={target} aria-label={issueID}>
-                <OverflowFieldShortId shortId={`${data.issue}`} />
-              </StyledLink>
-            </QuickContextHoverWrapper>
-          ) : (
+          <QuickContextHoverWrapper
+            dataRow={data}
+            contextType={ContextType.ISSUE}
+            organization={organization}
+          >
             <StyledLink to={target} aria-label={issueID}>
               <OverflowFieldShortId shortId={`${data.issue}`} />
             </StyledLink>
-          )}
+          </QuickContextHoverWrapper>
         </Container>
       );
     },
@@ -593,17 +587,13 @@ const SPECIAL_FIELDS: SpecialFields = {
     renderFunc: (data, {organization}) =>
       data.release ? (
         <VersionContainer>
-          {organization.features.includes('discover-quick-context') ? (
-            <QuickContextHoverWrapper
-              dataRow={data}
-              contextType={ContextType.RELEASE}
-              organization={organization}
-            >
-              <Version version={data.release} truncate />
-            </QuickContextHoverWrapper>
-          ) : (
-            <Version version={data.release} tooltipRawVersion truncate />
-          )}
+          <QuickContextHoverWrapper
+            dataRow={data}
+            contextType={ContextType.RELEASE}
+            organization={organization}
+          >
+            <Version version={data.release} truncate />
+          </QuickContextHoverWrapper>
         </VersionContainer>
       ) : (
         <Container>{emptyValue}</Container>

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -201,14 +201,6 @@ function TableView(props: TableViewProps) {
         </StyledLink>
       );
 
-      if (!organization.features.includes('discover-quick-context')) {
-        return [
-          <Tooltip key={`eventlink${rowIndex}`} title={t('View Event')}>
-            {eventIdLink}
-          </Tooltip>,
-        ];
-      }
-
       return [
         <QuickContextHoverWrapper
           key={`quickContextEventHover${rowIndex}`}
@@ -316,7 +308,7 @@ function TableView(props: TableViewProps) {
         </StyledLink>
       );
 
-      cell = organization.features.includes('discover-quick-context') ? (
+      cell = (
         <QuickContextHoverWrapper
           organization={organization}
           dataRow={dataRow}
@@ -326,8 +318,6 @@ function TableView(props: TableViewProps) {
         >
           {idLink}
         </QuickContextHoverWrapper>
-      ) : (
-        <StyledTooltip title={t('View Event')}>{idLink}</StyledTooltip>
       );
     } else if (columnKey === 'trace') {
       const dateSelection = eventView.normalizeDateSelection(location);


### PR DESCRIPTION
Quick Context in Discover no longer needs to be behind a feature flag. Removes the feature flag for Quick Context from the frontend.