### PR TITLE
(perf-issues): Add ratio threshold to consecutive db detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -204,7 +204,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             # time saved by running all queries in parallel
             "min_time_saved": 100,  # ms
             # ratio between time saved and total db span durations
-            "min_time_saved_ratio": 0.1,  # ms
+            "min_time_saved_ratio": 0.1,
             # The minimum duration of a single independent span in ms, used to prevent scenarios with a ton of small spans
             "span_duration_threshold": 30,  # ms
             "consecutive_count_threshold": 2,
@@ -597,9 +597,12 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         total_time = self._sum_span_duration(self.consecutive_db_spans)
 
         exceeds_time_saved_threshold = time_saved >= self.settings.get("min_time_saved")
-        exceeds_time_saved_threshold_ratio = time_saved / total_time >= self.settings.get(
-            "min_time_saved_ratio"
-        )
+        
+        exceeds_time_saved_threshold_ratio = False
+        if total_time > 0:
+            time_saved / total_time >= self.settings.get(
+                "min_time_saved_ratio"
+            )
 
         if (
             exceeds_count_threshold

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -203,6 +203,8 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         DetectorType.CONSECUTIVE_DB_OP: {
             # time saved by running all queries in parallel
             "min_time_saved": 50,  # ms
+            # ratio between time saved and total db span durations
+            "min_time_saved_ratio": 0.1,  # ms
             # The minimum duration of a single independent span in ms, used to prevent scenarios with a ton of small spans
             "span_duration_threshold": 30,  # ms
             "consecutive_count_threshold": 2,
@@ -591,14 +593,19 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
             for span in self.independent_db_spans
         )
 
-        exceeds_time_saved_threshold = self._calculate_time_saved(
-            self.independent_db_spans
-        ) > self.settings.get("min_time_saved")
+        time_saved = self._calculate_time_saved(self.independent_db_spans)
+        total_time = self._sum_span_duration(self.consecutive_db_spans)
+
+        exceeds_time_saved_threshold = time_saved > self.settings.get("min_time_saved")
+        exceeds_time_saved_threshold_ratio = time_saved / total_time >= self.settings.get(
+            "min_time_saved_ratio"
+        )
 
         if (
             exceeds_count_threshold
             and exceeds_span_duration_threshold
             and exceeds_time_saved_threshold
+            and exceeds_time_saved_threshold_ratio
         ):
             self._store_performance_problem()
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, deque
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+from urllib.parse import urlparse
 
 import sentry_sdk
 from symbolic import ProguardMapper  # type: ignore
@@ -20,8 +21,15 @@ from sentry.utils import metrics
 from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.safe import get_path
 
-from .base import DETECTOR_TYPE_TO_GROUP_TYPE, DetectorType, PerformanceDetector, get_span_duration
-from .detectors import NPlusOneAPICallsDetector
+from .base import (
+    DETECTOR_TYPE_TO_GROUP_TYPE,
+    DetectorType,
+    PerformanceDetector,
+    fingerprint_span,
+    fingerprint_spans,
+    get_span_duration,
+)
+from .detectors import NPlusOneAPICallsDetector, UncompressedAssetSpanDetector
 from .performance_problem import PerformanceProblem
 from .types import Span
 
@@ -308,45 +316,6 @@ def run_detector_on_data(detector, data):
     detector.on_complete()
 
 
-def fingerprint_group(transaction_name, span_op, hash, problem_class):
-    signature = (str(transaction_name) + str(span_op) + str(hash)).encode("utf-8")
-    full_fingerprint = hashlib.sha1(signature).hexdigest()
-    return f"1-{problem_class}-{full_fingerprint}"
-
-
-# Creates a stable fingerprint given the same span details using sha1.
-def fingerprint_span(span: Span):
-    op = span.get("op", None)
-    description = span.get("description", None)
-    if not description or not op:
-        return None
-
-    signature = (str(op) + str(description)).encode("utf-8")
-    full_fingerprint = hashlib.sha1(signature).hexdigest()
-    fingerprint = full_fingerprint[
-        :20
-    ]  # 80 bits. Not a cryptographic usage, we don't need all of the sha1 for collision detection
-
-    return fingerprint
-
-
-def fingerprint_spans(spans: List[Span]):
-    span_hashes = []
-    for span in spans:
-        hash = span.get("hash", "") or ""
-        span_hashes.append(str(hash))
-    joined_hashes = "-".join(span_hashes)
-    return hashlib.sha1(joined_hashes.encode("utf8")).hexdigest()
-
-
-# Simple fingerprint for broader checks, using the span op.
-def fingerprint_span_op(span: Span):
-    op = span.get("op", None)
-    if not op:
-        return None
-    return op
-
-
 def contains_complete_query(span: Span, is_source: Optional[bool] = False) -> bool:
     # Remove the truncation check from the n_plus_one db detector.
     query = span.get("description", None)
@@ -538,9 +507,31 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         fcp_ratio_threshold = self.settings.get("fcp_ratio_threshold")
         return span_duration / self.fcp > fcp_ratio_threshold
 
-    def _fingerprint(self, span):
-        hashed_spans = fingerprint_spans([span])
-        return f"1-{GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN.value}-{hashed_spans}"
+    def _fingerprint(self, span: Span):
+        url_hash = self._url_hash(span)
+        return f"1-{GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN.value}-{url_hash}"
+
+    # Finds dash-separated UUIDs. (Without dashes will be caught by
+    # ASSET_HASH_REGEX).
+    UUID_REGEX = re.compile(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", re.I)
+    # Preserves filename in e.g. main.[hash].js, but includes number when chunks
+    # are numbered (e.g. 2.[hash].js, 3.[hash].js, etc).
+    CHUNK_HASH_REGEX = re.compile(r"(?:[0-9]+)?\.[a-f0-9]{8}\.chunk", re.I)
+    # Finds trailing hashes before the final extension.
+    TRAILING_HASH_REGEX = re.compile(r"([-.])[a-f0-9]{8,64}\.([a-z0-9]{2,6})$", re.I)
+    # Looks for anything hex hash-like, but with a larger min size than the
+    # above to limit false positives.
+    ASSET_HASH_REGEX = re.compile(r"[a-f0-9]{16,64}", re.I)
+
+    def _url_hash(self, span: Span) -> str:
+        url = urlparse(span.get("description") or "")
+        path = url.path
+        path = self.UUID_REGEX.sub("*", path)
+        path = self.CHUNK_HASH_REGEX.sub(".*.chunk", path)
+        path = self.TRAILING_HASH_REGEX.sub("\\1*.\\2", path)
+        path = self.ASSET_HASH_REGEX.sub("*", path)
+        stripped_url = url._replace(path=path, query="").geturl()
+        return hashlib.sha1(stripped_url.encode("utf-8")).hexdigest()
 
 
 class ConsecutiveDBSpanDetector(PerformanceDetector):
@@ -597,7 +588,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         total_time = self._sum_span_duration(self.consecutive_db_spans)
 
         exceeds_time_saved_threshold = time_saved >= self.settings.get("min_time_saved")
-        
+
         exceeds_time_saved_threshold_ratio = False
         if total_time > 0:
             exceeds_time_saved_threshold_ratio = time_saved / total_time >= self.settings.get(
@@ -1280,106 +1271,6 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
     def on_complete(self) -> None:
         if performance_problem := self.state.finish():
             self.stored_problems[performance_problem.fingerprint] = performance_problem
-
-
-class UncompressedAssetSpanDetector(PerformanceDetector):
-    """
-    Checks for large assets that are affecting load time.
-    """
-
-    __slots__ = ("stored_problems", "any_compression")
-
-    settings_key = DetectorType.UNCOMPRESSED_ASSETS
-    type: DetectorType = DetectorType.UNCOMPRESSED_ASSETS
-
-    def init(self):
-        self.stored_problems = {}
-        self.any_compression = False
-
-    def visit_span(self, span: Span) -> None:
-        op = span.get("op", None)
-        if not op:
-            return
-
-        allowed_span_ops = self.settings.get("allowed_span_ops")
-        if op not in allowed_span_ops:
-            return
-
-        data = span.get("data", None)
-        transfer_size = data and data.get("Transfer Size", None)
-        encoded_body_size = data and data.get("Encoded Body Size", None)
-        decoded_body_size = data and data.get("Decoded Body Size", None)
-        if not (encoded_body_size and decoded_body_size and transfer_size):
-            return
-
-        # Ignore assets from cache, either directly (nothing transferred) or via
-        # a 304 Not Modified response (transfer is smaller than asset size).
-        if transfer_size <= 0 or transfer_size < encoded_body_size:
-            return
-
-        # Ignore assets that are already compressed.
-        if encoded_body_size != decoded_body_size:
-            # Met criteria for a compressed span somewhere in the event.
-            self.any_compression = True
-            return
-
-        # Ignore assets that aren't big enough to worry about.
-        size_threshold_bytes = self.settings.get("size_threshold_bytes")
-        if encoded_body_size < size_threshold_bytes:
-            return
-
-        # Ignore assets under a certain duration threshold
-        if get_span_duration(span).total_seconds() * 1000 <= self.settings.get(
-            "duration_threshold"
-        ):
-            return
-
-        fingerprint = self._fingerprint(span)
-        span_id = span.get("span_id", None)
-        if fingerprint and span_id and not self.stored_problems.get(fingerprint, False):
-            self.stored_problems[fingerprint] = PerformanceProblem(
-                fingerprint=fingerprint,
-                op=span.get("op"),
-                desc=span.get("description", ""),
-                parent_span_ids=[],
-                type=GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS,
-                cause_span_ids=[],
-                offender_span_ids=[span.get("span_id", None)],
-            )
-
-    def _fingerprint(self, span) -> str:
-        hashed_spans = fingerprint_spans([span])
-        return f"1-{GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS.value}-{hashed_spans}"
-
-    def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
-        return features.has(
-            "organizations:performance-issues-compressed-assets-detector", organization, actor=None
-        )
-
-    def is_creation_allowed_for_project(self, project: Project) -> bool:
-        return True  # Detection always allowed by project for now
-
-    def is_event_eligible(cls, event):
-        tags = event.get("tags", [])
-        browser_name = next(
-            (tag[1] for tag in tags if tag[0] == "browser.name" and len(tag) == 2), ""
-        )
-        if browser_name.lower() in [
-            "chrome",
-            "firefox",
-            "safari",
-            "edge",
-        ]:
-            # Only use major browsers as some mobile browser may be responsible for not sending accept-content header,
-            # which isn't fixable since you can't control what headers your users are sending.
-            # This can be extended later.
-            return True
-        return False
-
-    def on_complete(self) -> None:
-        if not self.any_compression:
-            # Must have a compressed asset in the event to emit this perf problem.
-            self.stored_problems = {}
 
 
 # Reports metrics and creates spans for detection

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -202,7 +202,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         },
         DetectorType.CONSECUTIVE_DB_OP: {
             # time saved by running all queries in parallel
-            "min_time_saved": 50,  # ms
+            "min_time_saved": 100,  # ms
             # ratio between time saved and total db span durations
             "min_time_saved_ratio": 0.1,  # ms
             # The minimum duration of a single independent span in ms, used to prevent scenarios with a ton of small spans
@@ -596,7 +596,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         time_saved = self._calculate_time_saved(self.independent_db_spans)
         total_time = self._sum_span_duration(self.consecutive_db_spans)
 
-        exceeds_time_saved_threshold = time_saved > self.settings.get("min_time_saved")
+        exceeds_time_saved_threshold = time_saved >= self.settings.get("min_time_saved")
         exceeds_time_saved_threshold_ratio = time_saved / total_time >= self.settings.get(
             "min_time_saved_ratio"
         )

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -600,7 +600,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         
         exceeds_time_saved_threshold_ratio = False
         if total_time > 0:
-            time_saved / total_time >= self.settings.get(
+            exceeds_time_saved_threshold_ratio = time_saved / total_time >= self.settings.get(
                 "min_time_saved_ratio"
             )
 

--- a/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_db_detector.py
@@ -204,9 +204,9 @@ class ConsecutiveDbDetectorTest(TestCase):
                 span_duration,
                 "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
             ),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
             create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
         ]
         spans_1 = [
@@ -219,11 +219,11 @@ class ConsecutiveDbDetectorTest(TestCase):
                 span_duration,
                 "SELECT `customer`.`id` FROM `customers` WHERE `customer`.`name` = $1",
             ),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
-            create_span("db", 10, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
+            create_span("db", 20, "SELECT `customer`.`id` FROM `customers`..."),
             create_span("db", 900, "SELECT COUNT(*) FROM `products`"),
         ]
         spans_2 = [


### PR DESCRIPTION
This PR is adds threshold adjustments, and an additional threshold to help resolve some issues.

Currently were using an absolute value as a threshold for the amount of time saved via parallelization (remember this is the maximum time). 
However there are cases where there are very large db queries, that overrule the small ones.
I.e say there's a 30s query, that can be independent to a 100ms, the 100ms query is pretty insignificant, so let's just use a ratio as well to help this.