### PR TITLE
feat(metrics): Register release health limiter rollout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -555,6 +555,7 @@ register("sentry-metrics.writes-limiter.limits.releasehealth.global", default=[]
 register("sentry-metrics.cardinality-limiter.limits.performance.per-org", default=[])
 register("sentry-metrics.cardinality-limiter.limits.releasehealth.per-org", default=[])
 register("sentry-metrics.cardinality-limiter.orgs-rollout-rate", default=0.0)
+register("sentry-metrics.cardinality-limiter-release-health.orgs-rollout-rate", default=0.0)
 
 # Flag to determine whether abnormal_mechanism tag should be extracted
 register("sentry-metrics.releasehealth.abnormal-mechanism-extraction-rate", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -555,7 +555,7 @@ register("sentry-metrics.writes-limiter.limits.releasehealth.global", default=[]
 register("sentry-metrics.cardinality-limiter.limits.performance.per-org", default=[])
 register("sentry-metrics.cardinality-limiter.limits.releasehealth.per-org", default=[])
 register("sentry-metrics.cardinality-limiter.orgs-rollout-rate", default=0.0)
-register("sentry-metrics.cardinality-limiter-release-health.orgs-rollout-rate", default=0.0)
+register("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", default=0.0)
 
 # Flag to determine whether abnormal_mechanism tag should be extracted
 register("sentry-metrics.releasehealth.abnormal-mechanism-extraction-rate", default=0.0)


### PR DESCRIPTION
Adding this option in order to implement gradual rollout of the release health cardinality limiter (as part of the scaling release health cluster project).