### PR TITLE
CI(acceptance): Remove fake checks from acceptance

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -354,30 +354,20 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
-      - name: Diff snapshots
-        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
-        with:
-          action-name: 'Chartcuterie Visual Snapshot'
-          artifact-name: 'chartcuterie-snapshots'
-          base-branch: 'master'
-          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
-          gcs-bucket: 'sentry-visual-snapshots'
-          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
-
-  # This is a required check and is helpful to flag to users when something
-  # has gone wrong with a previous step
-  trigger-visual-snapshots:
-    needs: [chartcuterie-visual-diff, backend-visual-diff, frontend-visual-diff]
-    name: triggers visual snapshot
-    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
-    if: always()
-    runs-on: ubuntu-20.04
-    steps:
       # If any jobs we depend on fail, we will fail
       - name: Check for failures
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
+      - name: Diff snapshots
+        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
+        with:
+          action-name: 'Visual Snapshot: Chartcuterie'
+          artifact-name: 'chartcuterie-snapshots'
+          base-branch: 'master'
+          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
+          gcs-bucket: 'sentry-visual-snapshots'
+          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
   # The following fake-*visual-snapshot steps do the following:
   #     - The sentry GitHub repo is configured to require "* Visual Snapshot"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -158,6 +158,7 @@ jobs:
           gcs-bucket: 'sentry-visual-snapshots'
           gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
+
   backend:
     if: needs.files-changed.outputs.acceptance_backend == 'true'
     needs: files-changed

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -158,7 +158,6 @@ jobs:
           gcs-bucket: 'sentry-visual-snapshots'
           gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
-
   backend:
     if: needs.files-changed.outputs.acceptance_backend == 'true'
     needs: files-changed

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -137,6 +137,7 @@ jobs:
   frontend-visual-diff:
     # This guarantees that we will only schedule Visual Snapshots if all
     # workflows that generate artifacts succeed
+    if: always()
     needs: [frontend]
     name: 'Acceptance: Frontend'
     runs-on: ubuntu-20.04
@@ -248,6 +249,7 @@ jobs:
   backend-visual-diff:
     # This guarantees that we will only schedule Visual Snapshots if all
     # workflows that generate artifacts succeed
+    if: always()
     needs: [backend]
     name: 'Acceptance: Backend'
     runs-on: ubuntu-20.04
@@ -346,6 +348,7 @@ jobs:
   chartcuterie-visual-diff:
     # This guarantees that we will only schedule Visual Snapshots if all
     # workflows that generate artifacts succeed
+    if: always()
     needs: [chartcuterie]
     name: 'Acceptance: Chartcuterie'
     runs-on: ubuntu-20.04
@@ -356,15 +359,6 @@ jobs:
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
-      - name: Diff snapshots
-        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
-        with:
-          action-name: 'Visual Snapshot: Chartcuterie'
-          artifact-name: 'chartcuterie-snapshots'
-          base-branch: 'master'
-          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
-          gcs-bucket: 'sentry-visual-snapshots'
-          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
   # The following fake-*visual-snapshot steps do the following:
   #     - The sentry GitHub repo is configured to require "* Visual Snapshot"
@@ -374,28 +368,6 @@ jobs:
   #       steps in this workflow.
   #     - If the acceptance tests aren't run, then the fake-*-visual-snapshot
   #       step will run, creating a check that statisfies the repo requirement.
-  # TODO (mattgaunt): Remove this once the required check is changed for the
-  # new visual snapshots.
-  fake-visual-snapshot:
-    name: Visual Snapshot
-    if: always()
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Sentaur attack
-        run: |
-          echo "This check pretends to be the Visual Snapshot to satisfy Github required checks"
-
-  # TODO (mattgaunt): Remove this once the required check is changed for the
-  # new visual snapshots.
-  fake-trigger-visual-snapshots:
-    name: triggers visual snapshot
-    if: always()
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Sentaur attack
-        run: |
-          echo "This check pretends to be the triggers visual snapshot to satisfy Github required checks"
-
   fake-frontend-visual-snapshot:
     name: 'Visual Snapshot: Frontend'
     needs: [files-changed]

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -354,11 +354,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
-      # If any jobs we depend on fail we will make this required check fail
-      - name: Check for failures
-        if: contains(needs.*.result, 'failure')
-        run: |
-          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
       - name: Diff snapshots
         uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
         with:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -354,11 +354,20 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
-      # If any jobs we depend on fail, we will fail
+      # If any jobs we depend on fail we will make this required check fail
       - name: Check for failures
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        if: contains(needs.*.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
+      - name: Diff snapshots
+        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
+        with:
+          action-name: 'Chartcuterie Visual Snapshot'
+          artifact-name: 'chartcuterie-snapshots'
+          base-branch: 'master'
+          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
+          gcs-bucket: 'sentry-visual-snapshots'
+          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
   # The following fake-*visual-snapshot steps do the following:
   #     - The sentry GitHub repo is configured to require "* Visual Snapshot"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -369,6 +369,21 @@ jobs:
           gcs-bucket: 'sentry-visual-snapshots'
           gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
+  # This is a required check and is helpful to flag to users when something
+  # has gone wrong with a previous step
+  trigger-visual-snapshots:
+    needs: [chartcuterie-visual-diff, backend-visual-diff, frontend-visual-diff]
+    name: triggers visual snapshot
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      # If any jobs we depend on fail, we will fail
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
+
   # The following fake-*visual-snapshot steps do the following:
   #     - The sentry GitHub repo is configured to require "* Visual Snapshot"
   #       actions.


### PR DESCRIPTION
This should be done once we the other PR has landed, we've confirmed it works and altered the required checks.