### PR TITLE
fix(audit-log): propagate ip_address through to audit_log_entry when creating alert rules

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -98,7 +98,9 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
                 status=403,
             )
         try:
-            delete_alert_rule(alert_rule)
+            delete_alert_rule(
+                alert_rule, user=request.user, ip_address=request.META.get("REMOTE_ADDR")
+            )
             return Response(status=status.HTTP_204_NO_CONTENT)
         except AlreadyDeletedError:
             return Response(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -62,7 +62,12 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
 
     def put(self, request: Request, organization, alert_rule) -> Response:
         serializer = DrfAlertRuleSerializer(
-            context={"organization": organization, "access": request.access, "user": request.user},
+            context={
+                "organization": organization,
+                "access": request.access,
+                "user": request.user,
+                "ip_address": request.META.get("REMOTE_ADDR"),
+            },
             instance=alert_rule,
             data=request.data,
         )

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -63,7 +63,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
 
     def delete(self, request: Request, project, alert_rule) -> Response:
         try:
-            delete_alert_rule(alert_rule, request.user)
+            delete_alert_rule(alert_rule, request.user, ip_address=request.META.get("REMOTE_ADDR"))
             return Response(status=status.HTTP_204_NO_CONTENT)
         except AlreadyDeletedError:
             return Response(

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -94,6 +94,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
                 "organization": project.organization,
                 "access": request.access,
                 "user": request.user,
+                "ip_address": request.META.get("REMOTE_ADDR"),
             },
             data=data,
         )

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -521,6 +521,7 @@ def create_alert_rule(
         if user:
             create_audit_entry_from_user(
                 user,
+                ip_address=kwargs.get("ip_address") if kwargs else None,
                 organization_id=organization.id,
                 target_object=alert_rule.id,
                 data=alert_rule.get_audit_log_data(),

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -771,6 +771,7 @@ def update_alert_rule(
     if user:
         create_audit_entry_from_user(
             user,
+            ip_address=kwargs.get("ip_address") if kwargs else None,
             organization_id=alert_rule.organization_id,
             target_object=alert_rule.id,
             data=alert_rule.get_audit_log_data(),

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -807,7 +807,7 @@ def disable_alert_rule(alert_rule):
         bulk_disable_snuba_subscriptions(alert_rule.snuba_query.subscriptions.all())
 
 
-def delete_alert_rule(alert_rule, user=None):
+def delete_alert_rule(alert_rule, user=None, ip_address=None):
     """
     Marks an alert rule as deleted and fires off a task to actually delete it.
     :param alert_rule:
@@ -819,6 +819,7 @@ def delete_alert_rule(alert_rule, user=None):
         if user:
             create_audit_entry_from_user(
                 user,
+                ip_address=ip_address,
                 organization_id=alert_rule.organization_id,
                 target_object=alert_rule.id,
                 data=alert_rule.get_audit_log_data(),

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -410,6 +410,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             alert_rule = create_alert_rule(
                 user=self.context.get("user", None),
                 organization=self.context["organization"],
+                ip_address=self.context.get("ip_address"),
                 **validated_data,
             )
             self._handle_triggers(alert_rule, triggers)

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -422,7 +422,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             validated_data.pop("id")
         with transaction.atomic():
             alert_rule = update_alert_rule(
-                instance, user=self.context.get("user", None), **validated_data
+                instance,
+                user=self.context.get("user", None),
+                ip_address=self.context.get("ip_address"),
+                **validated_data,
             )
             self._handle_triggers(alert_rule, triggers)
             return alert_rule

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -524,11 +524,22 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):
         self.login_as(self.user)
 
         with self.feature("organizations:incidents"):
-            self.get_success_response(self.organization.slug, self.alert_rule.id, status_code=204)
+            resp = self.get_success_response(
+                self.organization.slug, self.alert_rule.id, status_code=204
+            )
 
         assert not AlertRule.objects.filter(id=self.alert_rule.id).exists()
         assert not AlertRule.objects_with_snapshots.filter(name=self.alert_rule.name).exists()
         assert not AlertRule.objects_with_snapshots.filter(id=self.alert_rule.id).exists()
+
+        audit_log_entry = AuditLogEntry.objects.filter(
+            event=audit_log.get_event_id("ALERT_RULE_REMOVE"), target_object=self.alert_rule.id
+        )
+        assert len(audit_log_entry) == 1
+        assert (
+            resp.renderer_context["request"].META["REMOTE_ADDR"]
+            == list(audit_log_entry)[0].ip_address
+        )
 
     def test_no_feature(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -128,6 +128,10 @@ class AlertRuleCreateEndpointTest(APITestCase):
             event=audit_log.get_event_id("ALERT_RULE_ADD"), target_object=alert_rule.id
         )
         assert len(audit_log_entry) == 1
+        assert (
+            resp.renderer_context["request"].META["REMOTE_ADDR"]
+            == list(audit_log_entry)[0].ip_address
+        )
 
     @override_settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=1)
     def test_enforce_max_subscriptions(self):


### PR DESCRIPTION
Fixes an issue where `sentry_auditlogentry.ip_address` value wasn't being populated when creating alert rules.

Resolves sentry#42083