### PR TITLE
style(prettier): Upgrade prettier to 2.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,6 @@
   "APIMethod": "stub",
   "proxyURL": "http://localhost:8000",
   "scripts": {
-    "prettier": "prettier --write static/app/**/*",
     "test-wrap": "node scripts/test.js",
     "test": "yarn test-wrap --watch",
     "test-ci": "yarn test-wrap --ci --coverage --maxWorkers=100% --colors",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "pegjs-loader": "^0.5.6",
     "platformicons": "^5.4.0",
     "po-catalog-loader": "2.0.0",
-    "prettier": "2.7.1",
+    "prettier": "^2.8.3",
     "prismjs": "^1.27.0",
     "process": "^0.11.10",
     "prop-types": "^15.8.1",
@@ -235,6 +235,7 @@
   "APIMethod": "stub",
   "proxyURL": "http://localhost:8000",
   "scripts": {
+    "prettier": "prettier --write static/app/**/*",
     "test-wrap": "node scripts/test.js",
     "test": "yarn test-wrap --watch",
     "test-ci": "yarn test-wrap --ci --coverage --maxWorkers=100% --colors",

--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -90,7 +90,7 @@ type BaseProps = DefaultProps & {
   /**
    * This is the size of the remote image to request.
    */
-  remoteImageSize?: typeof ALLOWED_SIZES[number];
+  remoteImageSize?: (typeof ALLOWED_SIZES)[number];
   size?: number;
   title?: string;
   /**

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -41,7 +41,7 @@ const ZoomPropKeys = [
   'onFinished',
 ] as const;
 
-export type ZoomRenderProps = Pick<Props, typeof ZoomPropKeys[number]> & {
+export type ZoomRenderProps = Pick<Props, (typeof ZoomPropKeys)[number]> & {
   dataZoom?: DataZoomComponentOption[];
   end?: Date;
   isGroupedByDate?: boolean;

--- a/static/app/components/deprecatedforms/genericField.tsx
+++ b/static/app/components/deprecatedforms/genericField.tsx
@@ -53,7 +53,7 @@ interface FormData {
 type Props = {
   config: Config | SelectFieldConfig | AsyncSelectFieldConfig;
   formData: FormData;
-  formState: typeof FormState[keyof typeof FormState];
+  formState: (typeof FormState)[keyof typeof FormState];
   onChange: FormField['props']['onChange'];
   formErrors?: object;
 };

--- a/static/app/components/deprecatedforms/passwordField.tsx
+++ b/static/app/components/deprecatedforms/passwordField.tsx
@@ -4,7 +4,7 @@ import FormState from 'sentry/components/forms/state';
 
 type Props = InputField['props'] & {
   prefix: string;
-  formState?: typeof FormState[keyof typeof FormState];
+  formState?: (typeof FormState)[keyof typeof FormState];
   hasSavedValue?: boolean;
 };
 

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -49,8 +49,8 @@ type ObservedFn<_P, T> = (props: FormFieldPropModel) => T;
 type ObservedFnOrValue<P, T> = T | ObservedFn<P, T>;
 
 type ObservedPropResolver = [
-  typeof propsToObserve[number],
-  () => ResolvedObservableProps[typeof propsToObserve[number]]
+  (typeof propsToObserve)[number],
+  () => ResolvedObservableProps[(typeof propsToObserve)[number]]
 ];
 
 /**

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -206,7 +206,7 @@ export type Field = (
   | SentryProjectSelectorType
   | SelectAsyncType
   | ChoiceMapperType
-  | {type: typeof FieldType[number]}
+  | {type: (typeof FieldType)[number]}
   | FileType
   | DateTimeType
 ) &

--- a/static/app/components/letterAvatar.tsx
+++ b/static/app/components/letterAvatar.tsx
@@ -19,7 +19,7 @@ const COLORS = [
   '#847a8c', // gray
 ] as const;
 
-type Color = typeof COLORS[number];
+type Color = (typeof COLORS)[number];
 
 function hashIdentifier(identifier: string) {
   identifier += '';

--- a/static/app/components/multiPlatformPicker.tsx
+++ b/static/app/components/multiPlatformPicker.tsx
@@ -25,8 +25,8 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 const PLATFORM_CATEGORIES = [{id: 'all', name: t('All')}, ...categoryList] as const;
 
 // Category needs the all option while CategoryObj does not
-type Category = typeof PLATFORM_CATEGORIES[number]['id'];
-type CategoryObj = typeof categoryList[number];
+type Category = (typeof PLATFORM_CATEGORIES)[number]['id'];
+type CategoryObj = (typeof categoryList)[number];
 type Platform = CategoryObj['platforms'][number];
 
 // create a lookup table for each platform
@@ -52,7 +52,7 @@ const getIndexOfPlatformInCategory = (
 
 const isPopular = (platform: PlatformIntegration) =>
   popularPlatformCategories.includes(
-    platform.id as typeof popularPlatformCategories[number]
+    platform.id as (typeof popularPlatformCategories)[number]
   );
 
 const popularIndex = (platform: PlatformIntegration) =>

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -27,7 +27,7 @@ const PlatformList = styled('div')`
   margin-bottom: ${space(2)};
 `;
 
-type Category = typeof PLATFORM_CATEGORIES[number]['id'];
+type Category = (typeof PLATFORM_CATEGORIES)[number]['id'];
 
 interface PlatformPickerProps {
   setPlatform: (key: PlatformKey | null) => void;

--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -11,8 +11,9 @@ export const supportedProfilingPlatformSDKs = [
   'python',
   'rust',
 ] as const;
-export type SupportedProfilingPlatform = typeof supportedProfilingPlatforms[number];
-export type SupportedProfilingPlatformSDK = typeof supportedProfilingPlatformSDKs[number];
+export type SupportedProfilingPlatform = (typeof supportedProfilingPlatforms)[number];
+export type SupportedProfilingPlatformSDK =
+  (typeof supportedProfilingPlatformSDKs)[number];
 
 const platformToDocsPlatformSDK: Record<
   SupportedProfilingPlatform,
@@ -52,7 +53,7 @@ export const profilingOnboardingDocKeys = [
   '4-upload',
 ] as const;
 
-type ProfilingOnboardingDocKeys = typeof profilingOnboardingDocKeys[number];
+type ProfilingOnboardingDocKeys = (typeof profilingOnboardingDocKeys)[number];
 
 export const supportedPlatformExpectedDocKeys: Record<
   SupportedProfilingPlatformSDK,
@@ -74,7 +75,7 @@ function makeDocKey(platformId: PlatformKey, key: string) {
   return `${platformId}-profiling-onboarding-${key}`;
 }
 
-type DocKeyMap = Record<typeof profilingOnboardingDocKeys[number], string>;
+type DocKeyMap = Record<(typeof profilingOnboardingDocKeys)[number], string>;
 export function makeDocKeyMap(platformId: PlatformKey | undefined) {
   if (!platformId || !platformToDocsPlatformSDK[platformId]) {
     return null;

--- a/static/app/components/profiling/profileEventsTable.spec.tsx
+++ b/static/app/components/profiling/profileEventsTable.spec.tsx
@@ -139,7 +139,7 @@ describe('ProfileEventsTable', function () {
       'count()',
     ] as const;
 
-    const data: EventsResults<typeof columns[number]> = {
+    const data: EventsResults<(typeof columns)[number]> = {
       data: [
         {
           id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',

--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -282,7 +282,7 @@ const FIELDS = [
   'count()',
 ] as const;
 
-type FieldType = typeof FIELDS[number];
+type FieldType = (typeof FIELDS)[number];
 
 const RIGHT_ALIGNED_FIELDS = new Set<FieldType>([
   'profile.duration',

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -140,7 +140,7 @@ function ReplayOptionsMenu({speedOptions}: {speedOptions: number[]}) {
           defaultValue: isSkippingInactive ? [SKIP_OPTION_VALUE] : [],
           label: '',
           value: 'fast_forward',
-          onChange: (value: typeof SKIP_OPTION_VALUE[]) => {
+          onChange: (value: (typeof SKIP_OPTION_VALUE)[]) => {
             toggleSkipInactive(value.length > 0);
           },
           options: [

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -328,13 +328,13 @@ export const filterAliases: Partial<Record<PlatformKey, string[]>> = {
 };
 
 export type PlatformKey =
-  | typeof popularPlatformCategories[number]
-  | typeof frontend[number]
-  | typeof mobile[number]
-  | typeof backend[number]
-  | typeof desktop[number]
-  | typeof tracing[number]
-  | typeof serverless[number]
+  | (typeof popularPlatformCategories)[number]
+  | (typeof frontend)[number]
+  | (typeof mobile)[number]
+  | (typeof backend)[number]
+  | (typeof desktop)[number]
+  | (typeof tracing)[number]
+  | (typeof serverless)[number]
   | 'other';
 
 export default categoryList;

--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -13,7 +13,7 @@ type Field = {
 } & Parameters<typeof PluginComponentBase.prototype.renderField>[0]['config'];
 
 type ActionType = 'link' | 'create' | 'unlink';
-type FieldStateValue = typeof FormState[keyof typeof FormState];
+type FieldStateValue = (typeof FormState)[keyof typeof FormState];
 
 type Props = {
   actionType: ActionType;

--- a/static/app/styles/space.tsx
+++ b/static/app/styles/space.tsx
@@ -12,7 +12,7 @@ const SPACES = {
 
 export type ValidSize = keyof typeof SPACES;
 
-function space<S extends ValidSize>(size: S): typeof SPACES[S] {
+function space<S extends ValidSize>(size: S): (typeof SPACES)[S] {
   return SPACES[size];
 }
 

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -30,7 +30,7 @@ export type Actor = {
   email?: string;
 };
 
-export type Scope = typeof API_ACCESS_SCOPES[number];
+export type Scope = (typeof API_ACCESS_SCOPES)[number];
 
 export type DateString = Date | string | null;
 

--- a/static/app/types/experiments.tsx
+++ b/static/app/types/experiments.tsx
@@ -42,7 +42,7 @@ export type ExperimentConfig = {
 //
 // [0]: app/data/experimentConfig.tsx
 
-type ExperimentList = typeof experimentList[number];
+type ExperimentList = (typeof experimentList)[number];
 
 type ExperimentSelect<
   C extends ExperimentConfig,

--- a/static/app/utils/docs.tsx
+++ b/static/app/utils/docs.tsx
@@ -21,7 +21,7 @@ const platforms = [
   'unity',
 ] as const;
 
-export type DocPlatform = typeof platforms[number];
+export type DocPlatform = (typeof platforms)[number];
 
 const performancePlatforms: DocPlatform[] = [
   'dotnet',

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -262,7 +262,7 @@ const numberFormats = [
 export function formatAbbreviatedNumber(number: number | string) {
   number = Number(number);
 
-  let lookup: typeof numberFormats[number];
+  let lookup: (typeof numberFormats)[number];
 
   // eslint-disable-next-line no-cond-assign
   for (let i = 0; (lookup = numberFormats[i]); i++) {

--- a/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
@@ -32,7 +32,7 @@ describe('useProfileEvents', function () {
   it('handles querying the api', async function () {
     const fields = ['count()'];
 
-    const body: EventsResults<typeof fields[number]> = {
+    const body: EventsResults<(typeof fields)[number]> = {
       data: [],
       meta: {fields: {}, units: {}},
     };

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -12,7 +12,7 @@ import {mergeProps} from '@react-aria/utils';
 import {useOverlayTriggerState} from '@react-stately/overlays';
 import {OverlayTriggerProps as OverlayTriggerStateProps} from '@react-types/overlays';
 
-type PreventOverflowOptions = NonNullable<typeof preventOverflow['options']>;
+type PreventOverflowOptions = NonNullable<(typeof preventOverflow)['options']>;
 
 /**
  * PopperJS modifier to change the popper element's width/height to prevent

--- a/static/app/views/admin/adminQueue.tsx
+++ b/static/app/views/admin/adminQueue.tsx
@@ -9,7 +9,7 @@ import AsyncView from 'sentry/views/asyncView';
 
 const TIME_WINDOWS = ['1h', '1d', '1w'] as const;
 
-type TimeWindow = typeof TIME_WINDOWS[number];
+type TimeWindow = (typeof TIME_WINDOWS)[number];
 
 type State = AsyncView['state'] & {
   activeTask: string;

--- a/static/app/views/app/alertMessage.tsx
+++ b/static/app/views/app/alertMessage.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import AlertStore from 'sentry/stores/alertStore';
 
 type Props = {
-  alert: ReturnType<typeof AlertStore['getState']>[number];
+  alert: ReturnType<(typeof AlertStore)['getState']>[number];
   system: boolean;
 };
 

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -53,7 +53,7 @@ import {
   ReprocessingStatus,
 } from './utils';
 
-type Error = typeof ERROR_TYPES[keyof typeof ERROR_TYPES] | null;
+type Error = (typeof ERROR_TYPES)[keyof typeof ERROR_TYPES] | null;
 
 type Props = {
   api: Client;

--- a/static/app/views/performance/types.tsx
+++ b/static/app/views/performance/types.tsx
@@ -2,4 +2,4 @@ import EventView from 'sentry/utils/discover/eventView';
 
 import {QUERY_KEYS} from './utils';
 
-export type ViewProps = Pick<EventView, typeof QUERY_KEYS[number]>;
+export type ViewProps = Pick<EventView, (typeof QUERY_KEYS)[number]>;

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -254,7 +254,7 @@ const FIELDS = [
   'count()',
 ] as const;
 
-type FieldType = typeof FIELDS[number];
+type FieldType = (typeof FIELDS)[number];
 
 const ActionBar = styled('div')`
   display: grid;

--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -30,7 +30,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
 const fields = ['transaction', 'project.id', 'last_seen()', 'p95()', 'count()'] as const;
-type SlowestTransactionsFields = typeof fields[number];
+type SlowestTransactionsFields = (typeof fields)[number];
 
 export function ProfilingSlowestTransactionsPanel() {
   const profilingTransactionsQuery = useProfileEvents({

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -323,7 +323,7 @@ const tableColumnKey = [
   'tids',
 ] as const;
 
-type TableColumnKey = typeof tableColumnKey[number];
+type TableColumnKey = (typeof tableColumnKey)[number];
 
 type TableDataRow = Partial<Row<TableColumnKey>>;
 

--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -173,7 +173,7 @@ const ALL_FIELDS = [
   'profile.duration',
 ] as const;
 
-export type ProfilingFieldType = typeof ALL_FIELDS[number];
+export type ProfilingFieldType = (typeof ALL_FIELDS)[number];
 
 export function getProfilesTableFields(platform: Project['platform']) {
   if (mobile.includes(platform as any)) {

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -146,7 +146,7 @@ class ProjectContext extends Component<Props, State> {
   );
 
   unsubscribeMembers = MemberListStore.listen(
-    (memberList: typeof MemberListStore['state']) => this.setState({memberList}),
+    (memberList: (typeof MemberListStore)['state']) => this.setState({memberList}),
     undefined
   );
 

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -265,7 +265,7 @@ class ProjectCardContainer extends Component<ContainerProps, ContainerState> {
     }, undefined),
   ];
 
-  onProjectStatsStoreUpdate(itemsBySlug: typeof ProjectsStatsStore['itemsBySlug']) {
+  onProjectStatsStoreUpdate(itemsBySlug: (typeof ProjectsStatsStore)['itemsBySlug']) {
     const {project} = this.props;
 
     // Don't update state if we already have stats

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -45,7 +45,7 @@ export const SELF_NOTIFICATION_SETTINGS_TYPES = [
 ];
 
 // 'alerts' | 'activeRelease' | 'workflow' ...
-export type NotificationSettingsType = typeof NOTIFICATION_SETTINGS_TYPES[number];
+export type NotificationSettingsType = (typeof NOTIFICATION_SETTINGS_TYPES)[number];
 
 export const NOTIFICATION_SETTINGS_PATHNAMES: Record<NotificationSettingsType, string> = {
   alerts: 'alerts',

--- a/static/app/views/settings/organizationApiKeys/types.tsx
+++ b/static/app/views/settings/organizationApiKeys/types.tsx
@@ -1,6 +1,6 @@
 import {API_ACCESS_SCOPES} from 'sentry/constants';
 
-type Scope = typeof API_ACCESS_SCOPES[number];
+type Scope = (typeof API_ACCESS_SCOPES)[number];
 
 export type DeprecatedApiKey = {
   allowed_origins: string;

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -9,7 +9,7 @@ import {
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import SubscriptionBox from 'sentry/views/settings/organizationDeveloperSettings/subscriptionBox';
 
-type Resource = typeof EVENT_CHOICES[number];
+type Resource = (typeof EVENT_CHOICES)[number];
 
 type DefaultProps = {
   webhookDisabled: boolean;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionSubscriptions.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {EVENT_CHOICES} from './constants';
 import SubscriptionBox from './subscriptionBox';
 
-type Resource = typeof EVENT_CHOICES[number];
+type Resource = (typeof EVENT_CHOICES)[number];
 
 type Props = {
   events: string[];

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -13,7 +13,7 @@ import {
   PERMISSIONS_MAP,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 
-type Resource = typeof EVENT_CHOICES[number];
+type Resource = (typeof EVENT_CHOICES)[number];
 
 type Props = {
   checked: boolean;

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -436,7 +436,7 @@ const InviteField = styled('div')`
 const InviteSection = styled('div')`
   flex-grow: 1;
   display: flex;
-  gap: ${space(1)}; ;
+  gap: ${space(1)};
 `;
 
 const Footer = styled('div')`

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -200,7 +200,7 @@ type Props = {
 };
 
 type State = {
-  hooksDisabled: ReturnType<typeof HookStore['get']>;
+  hooksDisabled: ReturnType<(typeof HookStore)['get']>;
 } & AsyncComponent['state'];
 
 class ProjectFiltersSettings extends AsyncComponent<Props, State> {

--- a/tests/js/instrumentedEnv/userEventIntegration.ts
+++ b/tests/js/instrumentedEnv/userEventIntegration.ts
@@ -6,7 +6,7 @@ export function instrumentUserEvent(getCurrentHub: () => Hub): void {
   ACTIONS.forEach((action: Action) => _patchAction(pkg.default, action, getCurrentHub));
 }
 
-type Action = typeof ACTIONS[number];
+type Action = (typeof ACTIONS)[number];
 
 const ACTIONS = [
   'click',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12287,15 +12287,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
-
 "prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+
+prettier@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
+  integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Importantly, Prettier 2.8 [supports the new satisfies operator](https://prettier.io/blog/2022/11/23/2.8.0.html#support-typescript-49-satisfies-operatorhttpsdevblogsmicrosoftcomtypescriptannouncing-typescript-4-9satisfies-13764httpsgithubcomprettierprettierpull13764-13783httpsgithubcomprettierprettierpull13783-13872httpsgithubcomprettierprettierpull13872-by-sosukesuzukihttpsgithubcomsosukesuzuki), which 2.7 did not allow.

This updates the library and runs new formatter on all files.