### PR TITLE
fix(transaction-details): Missing instrumentation details compatibili…

### DIFF
--- a/static/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/static/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -16,6 +16,7 @@ type Props = {
   orgSlug: string;
   platform: string;
   projectSlug: string;
+  resetCellMeasureCache: () => void;
 };
 
 type State = {
@@ -35,6 +36,12 @@ class InlineDocs extends Component<Props, State> {
     this.fetchData();
   }
 
+  componentDidUpdate(_prevProps: Props, prevState: State) {
+    if (this.state.loading === false && prevState.loading === true) {
+      this.props.resetCellMeasureCache();
+    }
+  }
+
   fetchData = async () => {
     const {platform, api, orgSlug, projectSlug} = this.props;
 
@@ -45,23 +52,16 @@ class InlineDocs extends Component<Props, State> {
     this.setState({loading: true});
 
     let tracingPlatform: PlatformKey;
-    switch (platform) {
-      case 'sentry.python': {
-        tracingPlatform = 'python-tracing';
-        break;
-      }
-      case 'sentry.javascript.node': {
-        tracingPlatform = 'node-tracing';
-        break;
-      }
-      case 'sentry.javascript.react-native': {
-        tracingPlatform = 'react-native-tracing';
-        break;
-      }
-      default: {
-        this.setState({loading: false});
-        return;
-      }
+
+    if (platform.startsWith('sentry.python')) {
+      tracingPlatform = 'python-tracing';
+    } else if (platform.startsWith('sentry.javascript.node')) {
+      tracingPlatform = 'node-tracing';
+    } else if (platform.startsWith('sentry.javascript.react-native')) {
+      tracingPlatform = 'react-native-tracing';
+    } else {
+      this.setState({loading: false});
+      return;
     }
 
     try {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -125,6 +125,7 @@ export type SpanBarProps = {
   organization: Organization;
   removeContentSpanBarRef: (instance: HTMLDivElement | null) => void;
   removeExpandedSpan: (span: Readonly<ProcessedSpanType>, callback?: () => void) => void;
+  resetCellMeasureCache: () => void;
   showEmbeddedChildren: boolean;
   showSpanTree: boolean;
   span: Readonly<ProcessedSpanType>;
@@ -304,6 +305,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
         childTransactions={transactions}
         relatedErrors={errors}
         scrollToHash={this.scrollIntoView}
+        resetCellMeasureCache={this.props.resetCellMeasureCache}
       />
     );
   }

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -73,6 +73,7 @@ type Props = {
   isRoot: boolean;
   organization: Organization;
   relatedErrors: TraceError[] | null;
+  resetCellMeasureCache: () => void;
   scrollToHash: (hash: string) => void;
   span: Readonly<ProcessedSpanType>;
   trace: Readonly<ParsedTraceType>;
@@ -337,15 +338,16 @@ function SpanDetail(props: Props) {
   }
 
   function renderSpanDetails() {
-    const {span, event, organization, scrollToHash} = props;
+    const {span, event, organization, resetCellMeasureCache, scrollToHash} = props;
 
     if (isGapSpan(span)) {
       return (
         <SpanDetails>
           <InlineDocs
-            platform={event.sdk?.name || ''}
             orgSlug={organization.slug}
+            platform={event.sdk?.name || ''}
             projectSlug={event?.projectSlug ?? ''}
+            resetCellMeasureCache={resetCellMeasureCache}
           />
         </SpanDetails>
       );

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -438,7 +438,7 @@ class SpanTree extends Component<PropType> {
     const isEmbeddedSpanTree = waterfallModel.isEmbeddedSpanTree;
 
     const {spanTree, outOfViewSpansAbove, filteredSpansAbove} = spans.reduce(
-      (acc: AccType, payload: EnhancedProcessedSpanType) => {
+      (acc: AccType, payload: EnhancedProcessedSpanType, index: number) => {
         const {type} = payload;
 
         switch (payload.type) {
@@ -603,6 +603,7 @@ class SpanTree extends Component<PropType> {
             removeContentSpanBarRef,
             storeSpanBar,
             getCurrentLeftPos: this.props.getCurrentLeftPos,
+            resetCellMeasureCache: () => this.cache.clear(index, 0),
           },
         });
 
@@ -630,46 +631,6 @@ class SpanTree extends Component<PropType> {
 
     return spanTree;
   };
-
-  renderSpanNode(
-    node: SpanTreeNode,
-    extraProps: {
-      cellMeasurerCache: CellMeasurerCache;
-      listRef: React.RefObject<ReactVirtualizedList>;
-      measure: () => void;
-    } & SpanContext.SpanContextProps
-  ) {
-    switch (node.type) {
-      case SpanTreeNodeType.SPAN:
-        return (
-          <ProfiledSpanBar
-            key={getSpanID(node.props.span, `span-${node.props.spanNumber}`)}
-            {...node.props}
-            {...extraProps}
-          />
-        );
-      case SpanTreeNodeType.DESCENDANT_GROUP:
-        return (
-          <SpanDescendantGroupBar
-            key={`${node.props.spanNumber}-span-group`}
-            {...node.props}
-            didAnchoredSpanMount={extraProps.didAnchoredSpanMount}
-          />
-        );
-      case SpanTreeNodeType.SIBLING_GROUP:
-        return (
-          <SpanSiblingGroupBar
-            key={`${node.props.spanNumber}-span-sibling`}
-            {...node.props}
-            didAnchoredSpanMount={extraProps.didAnchoredSpanMount}
-          />
-        );
-      case SpanTreeNodeType.MESSAGE:
-        return node.element;
-      default:
-        return null;
-    }
-  }
 
   renderRow(props: ListRowProps, spanTree: SpanTreeNode[]) {
     return (


### PR DESCRIPTION
…ty with react virtualized

When expanding the missing instrumentation spans, if there are customized docs, we need to clear the cache for that row because when CellMeasurer will not remeasure when dynamically loading in new content.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/216439713-b588ad3e-4cd1-46b3-8155-f6e97fed8aa3.png)

## After

![image](https://user-images.githubusercontent.com/10239353/216439416-9f350f16-3a07-4555-9129-475454ac3fde.png)
