### PR TITLE
fix(perf-issues): ignore huge assets in render blocking assets detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -428,6 +428,8 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
     type: DetectorType = DetectorType.RENDER_BLOCKING_ASSET_SPAN
     settings_key = DetectorType.RENDER_BLOCKING_ASSET_SPAN
 
+    MAX_SIZE_BYTES = 1_000_000_000  # 1GB
+
     def init(self):
         self.stored_problems = {}
         self.transaction_start = timedelta(seconds=self.event().get("start_timestamp", 0))
@@ -498,7 +500,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         minimum_size_bytes = self.settings.get("minimum_size_bytes")
         data = span.get("data", None)
         encoded_body_size = data and data.get("Encoded Body Size", 0) or 0
-        if encoded_body_size < minimum_size_bytes:
+        if encoded_body_size < minimum_size_bytes or encoded_body_size > self.MAX_SIZE_BYTES:
             return False
 
         span_duration = get_span_duration(span)

--- a/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/utils/performance_issues/test_render_blocking_asset_detector.py
@@ -187,6 +187,31 @@ class RenderBlockingAssetDetectorTest(unittest.TestCase):
         }
         assert self.find_problems(event) == []
 
+    def test_does_not_detect_if_too_large(self):
+        event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "measurements": {
+                "fcp": {
+                    "value": 2500.0,
+                    "unit": "millisecond",
+                }
+            },
+            "spans": [
+                create_span(
+                    "resource.script",
+                    duration=1000.0,
+                    data={
+                        # A resource span with these stats was really logged.
+                        "Transfer Size": 299,
+                        "Encoded Body Size": 18446744073709552000,
+                        "Decoded Body Size": 0,
+                    },
+                ),
+            ],
+        }
+        assert self.find_problems(event) == []
+
 
 @pytest.mark.parametrize(
     "expected,first_url,second_url",


### PR DESCRIPTION
We found a real case in prod where a resource span was logged with an Encoded Body Size of 16 EiB. Ignore bogus data by puttting a cap on eligible asset sizes in the Render Blocking Assets detector.