### PR TITLE
ref(perf): Allow private operations from URL

### DIFF
--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -564,6 +564,10 @@ class ColumnEditCollection extends Component<Props, State> {
               }
               const operation =
                 AGGREGATIONS[col.function[0]] ?? SESSIONS_OPERATIONS[col.function[0]];
+              if (!operation || !operation.parameters) {
+                // Operation should be in the look-up table, but not all operations are (eg. private). This should be changed at some point.
+                return 3;
+              }
               return operation.parameters.length === 2 ? 3 : 2;
             })
           );


### PR DESCRIPTION
This fixes a bug when using operations that aren't listed yet and trying to use the column editor.