### PR TITLE
ref(hybrid-cloud): RPC strong types spike

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -210,8 +210,10 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 {
                     "activity": serialize(activity, request.user),
                     "seenBy": seen_by,
-                    "participants": user_service.serialize_users(
-                        user_ids=GroupSubscriptionManager.get_participating_user_ids(group),
+                    "participants": user_service.serialize_many(
+                        filter={
+                            "user_ids": GroupSubscriptionManager.get_participating_user_ids(group)
+                        },
                         as_user=request.user,
                     ),
                     "pluginActions": action_list,

--- a/src/sentry/api/endpoints/group_participants.py
+++ b/src/sentry/api/endpoints/group_participants.py
@@ -14,4 +14,6 @@ class GroupParticipantsEndpoint(GroupEndpoint):
     def get(self, request: Request, group, organization_slug: str | None = None) -> Response:
         participants = GroupSubscriptionManager.get_participating_user_ids(group)
 
-        return Response(user_service.serialize_users(user_ids=participants, as_user=request.user))
+        return Response(
+            user_service.serialize_many(filter={"user_ids": participants}, as_user=request.user)
+        )

--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -12,8 +12,8 @@ class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (MemberPermission,)
 
     def get(self, request: Request, organization, user_id) -> Response:
-        users = user_service.serialize_users(
-            user_ids=[user_id], organization_id=organization.id, as_user=request.user
+        users = user_service.serialize_many(
+            filter={"user_ids": [user_id], "organization_id": organization.id}, as_user=request.user
         )
         if len(users) == 0:
             return Response(status=404)

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -16,7 +16,7 @@ class ActivitySerializer(Serializer):
     def get_attrs(self, item_list, user):
         # TODO(dcramer); assert on relations
         user_ids = [i.user_id for i in item_list if i.user_id]
-        user_list = user_service.serialize_users(user_ids=user_ids, as_user=user)
+        user_list = user_service.serialize_many(filter={"user_ids": user_ids}, as_user=user)
         users = {u["id"]: u for u in user_list}
 
         commit_ids = {

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -100,10 +100,12 @@ class DashboardListSerializer(Serializer):
 
         serialized_users = {
             user["id"]: user
-            for user in user_service.serialize_users(
-                user_ids=[
-                    dashboard.created_by_id for dashboard in item_list if dashboard.created_by
-                ],
+            for user in user_service.serialize_many(
+                filter={
+                    "user_ids": [
+                        dashboard.created_by_id for dashboard in item_list if dashboard.created_by
+                    ]
+                },
                 as_user=user,
             )
         }
@@ -153,7 +155,7 @@ class DashboardDetailsSerializer(Serializer):
             "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
-            "createdBy": user_service.serialize_users(user_ids=[obj.created_by_id])[0],
+            "createdBy": user_service.serialize_many(filter={"user_ids": [obj.created_by_id]})[0],
             "widgets": attrs["widgets"],
             "projects": [project.id for project in obj.projects.all()],
             "filters": {},

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -236,8 +236,9 @@ class GroupSerializerBase(Serializer, ABC):
         actor_ids = {r[-1] for r in release_resolutions.values()}
         actor_ids.update(r.actor_id for r in ignore_items.values())
         if actor_ids:
-            serialized_users = user_service.serialize_users(
-                user_ids=actor_ids, as_user=user, is_active=True
+            serialized_users = user_service.serialize_many(
+                filter={"user_ids": actor_ids, "is_active": True},
+                as_user=user,
             )
             actors = {id: u for id, u in zip(actor_ids, serialized_users)}
         else:

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -7,7 +7,9 @@ from sentry.services.hybrid_cloud.user import user_service
 @register(GroupTombstone)
 class GroupTombstoneSerializer(Serializer):
     def get_attrs(self, item_list, user):
-        user_list = user_service.serialize_users(user_ids=[item.actor_id for item in item_list])
+        user_list = user_service.serialize_many(
+            filter={"user_ids": [item.actor_id for item in item_list]}
+        )
         users = {int(u["id"]): u for u in user_list}
 
         attrs = {}

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -331,8 +331,8 @@ class OnboardingTasksSerializer(Serializer):  # type: ignore
     def get_attrs(
         self, item_list: OrganizationOnboardingTask, user: User, **kwargs: Any
     ) -> MutableMapping[OrganizationOnboardingTask, _OnboardingTasksAttrs]:
-        serialized_users = user_service.serialize_users(
-            user_ids=list({item.user_id for item in item_list if item.user_id})
+        serialized_users = user_service.serialize_many(
+            filter={"user_ids": list({item.user_id for item in item_list if item.user_id})}
         )
         user_map = {user["id"]: user for user in serialized_users}
 

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -36,9 +36,9 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             }
         )
         users_by_id: Mapping[str, Any] = {
-            u["id"]: u for u in user_service.serialize_users(user_ids=users_set)
+            u["id"]: u for u in user_service.serialize_many(filter={"user_ids": users_set})
         }
-        actor_ids = [u.actor_id for u in user_service.get_many(user_ids=users_set)]
+        actor_ids = [u.actor_id for u in user_service.get_many(filter={"user_ids": users_set})]
         external_users_map = defaultdict(list)
 
         if "externalUsers" in self.expand:

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -92,10 +92,12 @@ def get_users_for_authors(organization_id, authors, user=None) -> Mapping[str, U
     if missed:
         # Filter users based on the emails provided in the commits
         # and that belong to the organization associated with the release
-        users: Sequence[UserSerializerResponse] = user_service.serialize_users(
-            emails=[a.email for a in missed],
-            organization_id=organization_id,
-            is_active=True,
+        users: Sequence[UserSerializerResponse] = user_service.serialize_many(
+            filter={
+                "emails": [a.email for a in missed],
+                "organization_id": organization_id,
+                "is_active": True,
+            },
             as_user=user,
         )
         # Figure out which email address matches to a user
@@ -360,8 +362,8 @@ class ReleaseSerializer(Serializer):
 
         owners = {
             d["id"]: d
-            for d in user_service.serialize_users(
-                user_ids=[i.owner_id for i in item_list if i.owner_id], as_user=user
+            for d in user_service.serialize_many(
+                filter={"user_ids": [i.owner_id for i in item_list if i.owner_id]}, as_user=user
             )
         }
 

--- a/src/sentry/api/serializers/rest_framework/mentions.py
+++ b/src/sentry/api/serializers/rest_framework/mentions.py
@@ -19,8 +19,11 @@ def extract_user_ids_from_mentions(organization_id, mentions):
     actors: Sequence[APIUser | Team] = ActorTuple.resolve_many(mentions)
     actor_mentions = separate_resolved_actors(actors)
 
-    team_users = user_service.query_users(
-        organization_id=organization_id, team_ids=[t.id for t in actor_mentions["teams"]]
+    team_users = user_service.get_many(
+        filter={
+            "organization_id": organization_id,
+            "team_ids": [t.id for t in actor_mentions["teams"]],
+        }
     )
     mentioned_team_users = {u.id for u in team_users} - set({u.id for u in actor_mentions["users"]})
 
@@ -56,10 +59,12 @@ class MentionsMixin:
 
             projects = self.context["projects"]
             organization_id = self.context["organization_id"]
-            users = user_service.query_users(
-                user_ids=mentioned_user_ids,
-                organization_id=organization_id,
-                project_ids=[p.id for p in projects],
+            users = user_service.get_many(
+                filter={
+                    "user_ids": mentioned_user_ids,
+                    "organization_id": organization_id,
+                    "project_ids": [p.id for p in projects],
+                },
             )
             user_ids = [u.id for u in users]
 

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -170,7 +170,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
         results = {}
         for type, _actors in actors_by_type.items():
             if type == User:
-                for instance in user_service.get_many([a.id for a in _actors]):
+                for instance in user_service.get_many(filter={"user_ids": [a.id for a in _actors]}):
                     results[(type, instance.id)] = instance
             else:
                 for instance in type.objects.filter(id__in=[a.id for a in _actors]):

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -287,7 +287,7 @@ class Organization(Model, SnowflakeIdMixin):
         owner_memberships = OrganizationMember.objects.filter(
             role=roles.get_top_dog().id, organization=self
         ).values_list("user_id", flat=True)
-        return user_service.get_many(owner_memberships)
+        return user_service.get_many(filter={"user_ids": owner_memberships})
 
     def get_default_owner(self) -> APIUser:
         if not hasattr(self, "_default_owner"):

--- a/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
@@ -41,7 +41,7 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
         for member in members:
             self.set_member_in_cache(member)
         # convert members to users
-        return user_service.get_many(member.user_id for member in members)
+        return user_service.get_many(filter={"user_ids": [member.user_id for member in members]})
 
     @abstractmethod
     def determine_member_recipients(self) -> Iterable[OrganizationMember]:

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, MutableMapping, Sequence
 
 from sentry import features
 from sentry.models import (
@@ -330,7 +330,7 @@ def _get_release_committers(release: Release) -> Sequence[APIUser]:
     author_users: Mapping[str, Author] = get_users_for_commits(commits)
 
     if features.has("organizations:active-release-notifications-enable", release.organization):
-        user_ids: set[int] = {au["id"] for au in author_users.values() if au.get("id")}
+        user_ids: List[int] = [au["id"] for au in author_users.values() if au.get("id")]
         return user_service.get_many(filter={"user_ids": user_ids})
     return []
 
@@ -446,7 +446,7 @@ def get_users_from_team_fall_back(
         # Fall back to notifying each subscribed user if there aren't team notification settings
         member_list = team.member_set.values_list("user_id", flat=True)
         user_ids |= set(member_list)
-    return user_service.get_many(filter={"user_ids": user_ids})
+    return user_service.get_many(filter={"user_ids": list(user_ids)})
 
 
 def combine_recipients_by_provider(

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -331,7 +331,7 @@ def _get_release_committers(release: Release) -> Sequence[APIUser]:
 
     if features.has("organizations:active-release-notifications-enable", release.organization):
         user_ids: set[int] = {au["id"] for au in author_users.values() if au.get("id")}
-        return user_service.get_many(user_ids)
+        return user_service.get_many(filter={"user_ids": user_ids})
     return []
 
 
@@ -372,7 +372,11 @@ def get_fallthrough_recipients(
     elif fallthrough_choice == FallthroughChoiceType.ACTIVE_MEMBERS:
         if project.organization.flags.early_adopter.is_set:
             return user_service.get_many(
-                project.member_set.order_by("-user__last_active").values_list("user_id", flat=True)
+                filter={
+                    "user_ids": project.member_set.order_by("-user__last_active").values_list(
+                        "user_id", flat=True
+                    )
+                }
             )[:FALLTHROUGH_NOTIFICATION_LIMIT_EA]
 
         # Return all members for non-EA orgs. This line will be removed once EA is over.
@@ -442,7 +446,7 @@ def get_users_from_team_fall_back(
         # Fall back to notifying each subscribed user if there aren't team notification settings
         member_list = team.member_set.values_list("user_id", flat=True)
         user_ids |= set(member_list)
-    return user_service.get_many(user_ids)
+    return user_service.get_many(filter={"user_ids": user_ids})
 
 
 def combine_recipients_by_provider(

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -7,7 +7,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.models import Group, GroupAssignee, Organization, SentryFunction, Team, User
 from sentry.services.hybrid_cloud.app import ApiSentryAppInstallation, app_service
-from sentry.services.hybrid_cloud.user import APIUser, UserSerializeType, user_service
+from sentry.services.hybrid_cloud.user import APIUser, user_service
 from sentry.signals import (
     comment_created,
     comment_deleted,
@@ -107,8 +107,9 @@ def send_workflow_webhooks(
         )
     if features.has("organizations:sentry-functions", organization, actor=user):
         if user:
-            data["user"] = user_service.serialize_users(
-                user_ids=[user.id], detailed=UserSerializeType.SIMPLE
+            data["user"] = user_service.serialize_many(
+                filter={"user_ids": [user.id]},
+                serializer=UserSerializer(),
             )[0]
         for fn in SentryFunction.objects.get_sentry_functions(organization, "issue"):
             send_sentry_function_webhook.delay(fn.external_id, event, issue.id, data)

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -43,7 +43,8 @@ from sentry.services.hybrid_cloud.organization import (
     organization_service,
 )
 from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user.impl import serialize_rpc_user
 from sentry.silo import SiloMode
 from sentry.utils.auth import AuthUserPasswordExpired
 from sentry.utils.types import Any
@@ -179,7 +180,7 @@ class DatabaseBackedAuthService(AuthService):
 
         return AuthenticationContext(
             auth=AuthenticatedToken.from_token(token) if token else None,
-            user=user_service.serialize_user(user) if user else None,
+            user=serialize_rpc_user(user) if user else None,
         )
 
     def authenticate(self, *, request: AuthenticationRequest) -> MiddlewareAuthenticationResponse:
@@ -204,13 +205,13 @@ class DatabaseBackedAuthService(AuthService):
         )
 
         if expired_user is not None:
-            result.user = user_service.serialize_user(expired_user)
+            result.user = serialize_rpc_user(expired_user)
             result.expired = True
         elif fake_request.user is not None and not fake_request.user.is_anonymous:
             from django.db import connections, transaction
 
             with transaction.atomic():
-                result.user = user_service.serialize_user(fake_request.user)
+                result.user = serialize_rpc_user(fake_request.user)
                 transaction.set_rollback(True)
             if SiloMode.single_process_silo_mode():
                 connections.close_all()
@@ -267,7 +268,7 @@ class DatabaseBackedAuthService(AuthService):
         # TODO: Might be able to keep hold of the APIUser object whose ID was
         #  originally passed to construct the ApiAuthIdentity object
         user = User.objects.get(id=auth_identity.user_id)
-        serial_user = user_service.serialize_user(user)
+        serial_user = serialize_rpc_user(user)
 
         # This raises an AvailabilityError
         # TODO: Extract ApiInviteHelper methods into new service methods

--- a/src/sentry/services/hybrid_cloud/filter_query.py
+++ b/src/sentry/services/hybrid_cloud/filter_query.py
@@ -1,0 +1,135 @@
+import abc
+from typing import TYPE_CHECKING, Callable, Generic, List, Optional, TypeVar, Union
+
+BASE_MODEL = TypeVar("BASE_MODEL")
+FILTER_ARGS = TypeVar("FILTER_ARGS")  # A typedict
+RPC_RESPONSE = TypeVar("RPC_RESPONSE")
+SERIALIZER_RESPONSE = TypeVar("SERIALIZER_RESPONSE")
+
+if TYPE_CHECKING:
+    from sentry.api.serializers import Serializer
+    from sentry.db.models.manager.base_query_set import BaseQuerySet
+    from sentry.models.user import User
+    from sentry.services.hybrid_cloud.user import APIUser
+
+
+# A collection of classes that can be used to quickly provision interfaces & implementations for basic RPC Hybrid Cloud service implementations.
+# It enforces several niceties:
+#   * Type safety at call sites: the public API can be inferred, unknown arguments are rejected,
+#     all filter arguments are optional, and nullable filters are explicitly Optional[...]
+#   * Filter argument validation: an arbitrary function can be used to ensure that proper filters are applied
+#     e.g. we don't want to just query for every row, so we can enforce that at least one filter key is provided
+#   * A standard interface across most of our simple rpc services
+
+# This class can be inherited from to add this functionality to the public interface for a service.
+# E.g. class UserService(FilterQueryInterface[
+#        UserQueryArgs, APIUser, Union[UserSerializerResponse, UserSerializerResponseSelf]
+#      ], InterfaceWithLifecycle):
+#         ...
+class FilterQueryInterface(Generic[FILTER_ARGS, RPC_RESPONSE, SERIALIZER_RESPONSE], abc.ABC):
+    @abc.abstractmethod
+    def serialize_many(
+        self,
+        filter: FILTER_ARGS,
+        as_user: Union["User", "APIUser", None] = None,
+        # An API Serializer instance to render results
+        serializer: Optional["Serializer"] = None,
+    ) -> List[SERIALIZER_RESPONSE]:
+        pass
+
+    @abc.abstractmethod
+    def get_many(self, filter: FILTER_ARGS) -> List[RPC_RESPONSE]:
+        pass
+
+
+class FilterQueryDatabaseImpl(
+    Generic[BASE_MODEL, FILTER_ARGS, RPC_RESPONSE, SERIALIZER_RESPONSE], abc.ABC
+):
+    # Required Overrides
+
+    # This should return a QuerySet for the model in question along with any other required data
+    # that is not a filter
+    @abc.abstractmethod
+    def _base_query(self) -> "BaseQuerySet":
+        pass
+
+    @abc.abstractmethod
+    def _filter_arg_validator(self) -> Callable[[FILTER_ARGS], Optional[str]]:
+        pass
+
+    @abc.abstractmethod
+    def _apply_filters(self, query: "BaseQuerySet", filters: FILTER_ARGS) -> "BaseQuerySet":
+        pass
+
+    @abc.abstractmethod
+    def _rpc_serialize_object(self, object: BASE_MODEL) -> RPC_RESPONSE:
+        pass
+
+    # Utility Methods
+
+    def _filter_has_any_key_validator(self, *keys: str) -> Callable[[FILTER_ARGS], Optional[str]]:
+        def validator(d: FILTER_ARGS) -> Optional[str]:
+            for k in keys:
+                if k in d:  # type: ignore # We assume FILTER_ARGS is a dict
+                    return None
+
+            return f"Filter must contain at least one of: {keys}"
+
+        return validator
+
+    # Helpers
+
+    def _query_many(self, filter: FILTER_ARGS) -> "BaseQuerySet":
+        validation_error = self._filter_arg_validator()(filter)
+        if validation_error is not None:
+            raise TypeError(
+                f"Failed to validate filter arguments passed to {self.__class__.__name__}: {validation_error}"
+            )
+
+        query = self._base_query()
+        return self._apply_filters(query, filter)
+
+    # Public Interface
+
+    def serialize_many(
+        self,
+        filter: FILTER_ARGS,
+        as_user: Union["User", "APIUser", None] = None,
+        # An API Serializer instance to render results
+        serializer: Optional["Serializer"] = None,
+    ) -> List[SERIALIZER_RESPONSE]:
+        from sentry.api.serializers import serialize
+
+        return serialize(  # type: ignore
+            self._query_many(filter=filter),
+            user=as_user,
+            serializer=serializer,
+        )
+
+    def get_many(self, filter: FILTER_ARGS) -> List[RPC_RESPONSE]:
+        return [self._rpc_serialize_object(o) for o in self._query_many(filter=filter)]
+
+
+# class UserQueryArgs(TypedDict, total=False):
+#     user_id: int
+#     organization_id: int
+
+
+# class UserService(
+#     FilterQueryDatabaseImpl[
+#         User, UserQueryArgs, APIUser, Union[UserSerializerResponse, UserSerializerResponseSelf]
+#     ]
+# ):
+#     def _base_query(self) -> BaseQuerySet:
+#         return User.objects
+
+#     def _filter_arg_validator(self) -> Callable[[UserQueryArgs], Optional[str]]:
+#         return self._filter_has_any_key_validator(
+#             "user_ids", "organization_id", "team_ids", "project_ids", "emails"
+#         )
+
+#     def rpc_serialize_object(self, object: User) -> APIUser:
+#         pass
+
+
+# UserService().get_many(filter={"user_id": 2})

--- a/src/sentry/services/hybrid_cloud/filter_query.py
+++ b/src/sentry/services/hybrid_cloud/filter_query.py
@@ -76,7 +76,7 @@ class FilterQueryDatabaseImpl(
         pass
 
     @abc.abstractmethod
-    def _api_serializer(self, serializer: Optional[SERIALIZER_ENUM]) -> Serializer:
+    def _serialize_api(self, serializer: Optional[SERIALIZER_ENUM]) -> Serializer:
         # Returns the api serializer to use for this response.
         pass
 
@@ -85,7 +85,7 @@ class FilterQueryDatabaseImpl(
         pass
 
     @abc.abstractmethod
-    def _rpc_serialize_object(self, object: BASE_MODEL) -> RPC_RESPONSE:
+    def _serialize_rpc(self, object: BASE_MODEL) -> RPC_RESPONSE:
         pass
 
     # Utility Methods
@@ -130,8 +130,8 @@ class FilterQueryDatabaseImpl(
         return serialize(  # type: ignore
             self._query_many(filter=filter),
             user=as_user,
-            serializer=self._api_serializer(serializer),
+            serializer=self._serialize_api(serializer),
         )
 
     def get_many(self, *, filter: FILTER_ARGS) -> List[RPC_RESPONSE]:
-        return [self._rpc_serialize_object(o) for o in self._query_many(filter=filter)]
+        return [self._serialize_rpc(o) for o in self._query_many(filter=filter)]

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -4,10 +4,11 @@ import datetime
 from abc import abstractmethod
 from dataclasses import dataclass, fields
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, List, Optional, TypedDict
 
 from sentry.db.models import BaseQuerySet
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
+from sentry.services.hybrid_cloud.filter_query import FilterQueryInterface
 from sentry.silo import SiloMode
 
 if TYPE_CHECKING:
@@ -87,7 +88,17 @@ class UserSerializeType(IntEnum):
     SELF_DETAILED = 2
 
 
-class UserService(InterfaceWithLifecycle):
+class UserFilterArgs(TypedDict, total=False):
+    user_ids: List[int]
+    is_active: bool
+    organization_id: int
+    project_ids: List[int]
+    team_ids: List[int]
+    is_active_memberteam: bool
+    emails: List[str]
+
+
+class UserService(FilterQueryInterface, InterfaceWithLifecycle):
     @abstractmethod
     def get_many_by_email(
         self, emails: List[str], is_active: bool = True, is_verified: bool = True
@@ -153,18 +164,18 @@ class UserService(InterfaceWithLifecycle):
         else:
             return None
 
-    @abstractmethod
-    def query_users(
-        self,
-        user_ids: Optional[List[int]] = None,
-        is_active: Optional[bool] = None,
-        organization_id: Optional[int] = None,
-        project_ids: Optional[List[int]] = None,
-        team_ids: Optional[List[int]] = None,
-        is_active_memberteam: Optional[bool] = None,
-        emails: Optional[List[str]] = None,
-    ) -> List[User]:
-        pass
+    # @abstractmethod
+    # def query_users(
+    #     self,
+    #     user_ids: Optional[List[int]] = None,
+    #     is_active: Optional[bool] = None,
+    #     organization_id: Optional[int] = None,
+    #     project_ids: Optional[List[int]] = None,
+    #     team_ids: Optional[List[int]] = None,
+    #     is_active_memberteam: Optional[bool] = None,
+    #     emails: Optional[List[str]] = None,
+    # ) -> List[User]:
+    #     pass
 
     # NOTE: In the future if this becomes RPC, we can avoid the double serialization problem by using a special type
     # with its own json serialization that allows pass through (ie, a string type that does not serialize into a string,

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, List, Optional
+from dataclasses import fields
+from typing import Any, Callable, FrozenSet, Iterable, List, Optional
 
 from django.db.models import QuerySet
 
@@ -17,7 +18,9 @@ from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.filter_query import FilterQueryDatabaseImpl
 from sentry.services.hybrid_cloud.user import (
+    APIAvatar,
     APIUser,
+    APIUserEmail,
     UserFilterArgs,
     UserSerializeType,
     UserService,
@@ -37,8 +40,7 @@ class DatabaseBackedUserService(
         if is_active:
             query = query.filter(is_active=is_active)
         return [
-            UserService.serialize_user(user)
-            for user in query.filter(in_iexact("emails__email", emails))
+            self._serialize_rpc(user) for user in query.filter(in_iexact("emails__email", emails))
         ]
 
     def get_by_username(
@@ -98,7 +100,7 @@ class DatabaseBackedUserService(
 
     def get_from_group(self, group: Group) -> List[APIUser]:
         return [
-            UserService.serialize_user(u)
+            self._serialize_rpc(u)
             for u in self._base_query().filter(
                 sentry_orgmember_set__organization=group.organization,
                 sentry_orgmember_set__teams__in=group.project.teams.all(),
@@ -116,9 +118,7 @@ class DatabaseBackedUserService(
         )
 
     def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[APIUser]:
-        return [
-            UserService.serialize_user(u) for u in self._base_query().filter(actor_id__in=actor_ids)
-        ]
+        return [self._serialize_rpc(u) for u in self._base_query().filter(actor_id__in=actor_ids)]
 
     def close(self) -> None:
         pass
@@ -142,7 +142,7 @@ class DatabaseBackedUserService(
             "user_ids", "organization_id", "team_ids", "project_ids", "emails"
         )
 
-    def _api_serializer(self, serializer_type: Optional[UserSerializeType]) -> Serializer:
+    def _serialize_api(self, serializer_type: Optional[UserSerializeType]) -> Serializer:
         serializer: Serializer = UserSerializer()
         if serializer_type == UserSerializeType.DETAILED:
             serializer = DetailedUserSerializer()
@@ -150,5 +150,59 @@ class DatabaseBackedUserService(
             serializer = DetailedSelfUserSerializer()
         return serializer
 
-    def _rpc_serialize_object(self, user: User) -> APIUser:
-        return self.serialize_user(user)
+    def _serialize_rpc(self, user: User) -> APIUser:
+        args = {
+            field.name: getattr(user, field.name)
+            for field in fields(APIUser)
+            if hasattr(user, field.name)
+        }
+        args["pk"] = user.pk
+        args["display_name"] = user.get_display_name()
+        args["label"] = user.get_label()
+        args["is_superuser"] = user.is_superuser
+        args["is_sentry_app"] = user.is_sentry_app
+        args["password_usable"] = user.has_usable_password()
+        args["emails"] = frozenset([email.email for email in user.get_verified_emails()])
+
+        # And process the _base_user_query special data additions
+        permissions: FrozenSet[str] = frozenset({})
+        if hasattr(user, "permissions") and user.permissions is not None:
+            permissions = frozenset(user.permissions)
+        args["permissions"] = permissions
+
+        roles: FrozenSet[str] = frozenset({})
+        if hasattr(user, "roles") and user.roles is not None:
+            roles = frozenset(flatten(user.roles))
+        args["roles"] = roles
+
+        useremails: FrozenSet[APIUserEmail] = frozenset({})
+        if hasattr(user, "useremails") and user.useremails is not None:
+            useremails = frozenset(
+                {
+                    APIUserEmail(
+                        id=e["id"],
+                        email=e["email"],
+                        is_verified=e["is_verified"],
+                    )
+                    for e in user.useremails
+                }
+            )
+        args["useremails"] = useremails
+        avatar = user.avatar.first()
+        if avatar is not None:
+            avatar = APIAvatar(
+                id=avatar.id,
+                file_id=avatar.file_id,
+                ident=avatar.ident,
+                avatar_type=avatar.avatar_type,
+            )
+        args["avatar"] = avatar
+        return APIUser(**args)
+
+
+def flatten(iter: Iterable[Any]) -> List[Any]:
+    return (
+        ((flatten(iter[0]) + flatten(iter[1:])) if len(iter) > 0 else [])
+        if type(iter) is list or isinstance(iter, BaseQuerySet)
+        else [iter]
+    )

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Optional
+from typing import Any, Callable, List, Optional, Union
 
 from django.db.models import QuerySet
 
@@ -10,19 +10,32 @@ from sentry.api.serializers import (
     UserSerializer,
     serialize,
 )
+from sentry.api.serializers.models.user import UserSerializerResponse, UserSerializerResponseSelf
+from sentry.db.models import BaseQuerySet
 from sentry.db.models.query import in_iexact
 from sentry.models import Project
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
-from sentry.services.hybrid_cloud.user import APIUser, UserSerializeType, UserService
+from sentry.services.hybrid_cloud.filter_query import FilterQueryDatabaseImpl
+from sentry.services.hybrid_cloud.user import (
+    APIUser,
+    UserFilterArgs,
+    UserSerializeType,
+    UserService,
+)
 
 
-class DatabaseBackedUserService(UserService):
+class DatabaseBackedUserService(
+    FilterQueryDatabaseImpl[
+        User, UserFilterArgs, APIUser, Union[UserSerializerResponse, UserSerializerResponseSelf]
+    ],
+    UserService,
+):
     def get_many_by_email(
         self, emails: List[str], is_active: bool = True, is_verified: bool = True
     ) -> List[APIUser]:
-        query = self.__base_user_query()
+        query = self._base_query()
         if is_verified:
             query = query.filter(emails__is_verified=is_verified)
         if is_active:
@@ -54,40 +67,40 @@ class DatabaseBackedUserService(UserService):
                 return list(qs.filter(email__iexact=username))
         return []
 
-    def query_users(
+    def _apply_filters(
         self,
-        user_ids: Optional[List[int]] = None,
-        is_active: Optional[bool] = None,
-        organization_id: Optional[int] = None,
-        project_ids: Optional[List[int]] = None,
-        team_ids: Optional[List[int]] = None,
-        is_active_memberteam: Optional[bool] = None,
-        emails: Optional[List[str]] = None,
+        query: BaseQuerySet,
+        filters: UserFilterArgs,
     ) -> List[User]:
-        query = self.__base_user_query()
-        if user_ids is not None:
-            query = query.filter(id__in=user_ids)
-        if is_active is not None:
-            query = query.filter(is_active=is_active)
-        if organization_id is not None:
-            query = query.filter(sentry_orgmember_set__organization_id=organization_id)
-        if is_active_memberteam is not None:
+        query = self._base_query()
+        if "user_ids" in filters:
+            query = query.filter(id__in=filters["user_ids"])
+        if "is_active" in filters:
+            query = query.filter(is_active=filters["is_active"])
+        if "organization_id" in filters:
+            query = query.filter(sentry_orgmember_set__organization_id=filters["organization_id"])
+        if "is_active_memberteam" in filters:
             query = query.filter(
-                sentry_orgmember_set__organizationmemberteam__is_active=is_active_memberteam,
+                sentry_orgmember_set__organizationmemberteam__is_active=filters[
+                    "is_active_memberteam"
+                ],
             )
-        if project_ids is not None:
+        if "project_ids" in filters:
             query = query.filter(
-                sentry_orgmember_set__organizationmemberteam__team__projectteam__project_id__in=project_ids
+                sentry_orgmember_set__organizationmemberteam__team__projectteam__project_id__in=filters[
+                    "project_ids"
+                ]
             )
-        if team_ids is not None:
+        if "team_ids" in filters:
             query = query.filter(
-                sentry_orgmember_set__organizationmemberteam__team_id__in=team_ids,
+                sentry_orgmember_set__organizationmemberteam__team_id__in=filters["team_ids"],
             )
-        if emails is not None:
-            query = query.filter(in_iexact("emails__email", emails))
+        if "emails" in filters:
+            query = query.filter(in_iexact("emails__email", filters["emails"]))
 
         return list(query)
 
+    # TODO: replace this with serialize_many. Only piece missing is auth_context
     def serialize_users(
         self,
         *,
@@ -131,16 +144,16 @@ class DatabaseBackedUserService(UserService):
     def get_from_group(self, group: Group) -> List[APIUser]:
         return [
             UserService.serialize_user(u)
-            for u in self.__base_user_query().filter(
+            for u in self._base_query().filter(
                 sentry_orgmember_set__organization=group.organization,
                 sentry_orgmember_set__teams__in=group.project.teams.all(),
                 is_active=True,
             )
         ]
 
-    def get_many(self, user_ids: Iterable[int]) -> List[APIUser]:
-        query = self.__base_user_query().filter(id__in=user_ids)
-        return [UserService.serialize_user(u) for u in query]
+    # def get_many(self, user_ids: Iterable[int]) -> List[APIUser]:
+    #     query = self._base_query().filter(id__in=user_ids)
+    #     return [UserService.serialize_user(u) for u in query]
 
     def get_from_project(self, project_id: int) -> List[APIUser]:
         try:
@@ -151,14 +164,13 @@ class DatabaseBackedUserService(UserService):
 
     def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[APIUser]:
         return [
-            UserService.serialize_user(u)
-            for u in self.__base_user_query().filter(actor_id__in=actor_ids)
+            UserService.serialize_user(u) for u in self._base_query().filter(actor_id__in=actor_ids)
         ]
 
     def close(self) -> None:
         pass
 
-    def __base_user_query(self) -> QuerySet:
+    def _base_query(self) -> QuerySet:
         return User.objects.select_related("avatar").extra(
             select={
                 "permissions": "select array_agg(permission) from sentry_userpermission where user_id=auth_user.id",
@@ -171,3 +183,11 @@ class DatabaseBackedUserService(UserService):
                 "useremails": "select array_agg(row_to_json(sentry_useremail)) from sentry_useremail where user_id=auth_user.id",
             }
         )
+
+    def _filter_arg_validator(self) -> Callable[[UserFilterArgs], Optional[str]]:
+        return self._filter_has_any_key_validator(
+            "user_ids", "organization_id", "team_ids", "project_ids", "emails"
+        )
+
+    def _rpc_serialize_object(self, user: User) -> APIUser:
+        return self.serialize_user(user)

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -312,7 +312,7 @@ def get_serialized_event_file_committers(
             return []
         commit = Commit.objects.get(id=owner.context.get("commitId"))
         author = (
-            user_service.serialize_users(user_ids=[owner.user_id])[0]
+            user_service.serialize_many(filter={"user_ids": [owner.user_id]})[0]
             if owner.user
             else {"email": commit.author.email, "name": commit.author.name}
         )

--- a/src/sentry/utils/email/manager.py
+++ b/src/sentry/utils/email/manager.py
@@ -37,7 +37,7 @@ def get_email_addresses(
         user_option_service.delete_options(option_ids=[o.id for o in to_delete])
 
     if pending:
-        users = user_service.get_many(pending)
+        users = user_service.get_many(filter={"user_ids": pending})
         for (user_id, email) in [(user.id, user.email) for user in users]:
             if email and not is_fake_email(email):
                 results[user_id] = email

--- a/src/sentry/utils/email/manager.py
+++ b/src/sentry/utils/email/manager.py
@@ -37,7 +37,7 @@ def get_email_addresses(
         user_option_service.delete_options(option_ids=[o.id for o in to_delete])
 
     if pending:
-        users = user_service.get_many(filter={"user_ids": pending})
+        users = user_service.get_many(filter={"user_ids": list(pending)})
         for (user_id, email) in [(user.id, user.email) for user in users]:
             if email and not is_fake_email(email):
                 results[user_id] = email

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -230,9 +230,9 @@ def get_client_config(request=None):
         },
     }
     if user and user.is_authenticated:
-        (serialized_user,) = user_service.serialize_users(
-            user_ids=[user.id],
-            detailed=UserSerializeType.SELF_DETAILED,
+        (serialized_user,) = user_service.serialize_many(
+            filter={"user_ids": [user.id]},
+            serializer=UserSerializeType.SELF_DETAILED,
             auth_context=AuthenticationContext(
                 auth=getattr(request, "auth", None),
                 user=request.user,

--- a/tests/sentry/api/serializers/test_group_tombstone.py
+++ b/tests/sentry/api/serializers/test_group_tombstone.py
@@ -9,7 +9,7 @@ from sentry.testutils.silo import region_silo_test
 class GroupTombstoneSerializerTest(TestCase):
     def test_simple(self):
         user = self.create_user("foo@example.com")
-        self.user = user_service.get_many(user_ids=[user.id])[0]
+        self.user = user_service.get_many(filter={"user_ids": [user.id]})[0]
         self.login_as(user=user)
         org = self.create_organization(owner=self.user)
         project = self.create_project(organization=org, name="CoolProj")

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -20,7 +20,7 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.user import user_service
+from sentry.services.hybrid_cloud.user.impl import serialize_rpc_user
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import APITestCase, IntegrationTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
@@ -587,7 +587,7 @@ class JiraIntegrationTest(APITestCase):
 
     @responses.activate
     def test_sync_assignee_outbound_case_insensitive(self):
-        user = user_service.serialize_user(self.create_user(email="bob@example.com"))
+        user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         issue_id = "APP-123"
         installation = self.integration.get_installation(self.organization.id)
         assign_issue_url = "https://example.atlassian.net/rest/api/2/issue/%s/assignee" % issue_id
@@ -612,7 +612,7 @@ class JiraIntegrationTest(APITestCase):
 
     @responses.activate
     def test_sync_assignee_outbound_no_email(self):
-        user = user_service.serialize_user(self.create_user(email="bob@example.com"))
+        user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         issue_id = "APP-123"
         installation = self.integration.get_installation(self.organization.id)
         external_issue = ExternalIssue.objects.create(
@@ -631,7 +631,7 @@ class JiraIntegrationTest(APITestCase):
     @override_settings(JIRA_USE_EMAIL_SCOPE=True)
     @responses.activate
     def test_sync_assignee_outbound_use_email_api(self):
-        user = user_service.serialize_user(self.create_user(email="bob@example.com"))
+        user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         issue_id = "APP-123"
         installation = self.integration.get_installation(self.organization.id)
         assign_issue_url = "https://example.atlassian.net/rest/api/2/issue/%s/assignee" % issue_id

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -18,7 +18,7 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.user import user_service
+from sentry.services.hybrid_cloud.user.impl import serialize_rpc_user
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
@@ -631,7 +631,7 @@ class JiraServerIntegrationTest(APITestCase):
 
     @responses.activate
     def test_sync_assignee_outbound_case_insensitive(self):
-        user = user_service.serialize_user(self.create_user(email="bob@example.com"))
+        user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         issue_id = "APP-123"
         assign_issue_url = "https://jira.example.org/rest/api/2/issue/%s/assignee" % issue_id
         external_issue = ExternalIssue.objects.create(
@@ -657,7 +657,7 @@ class JiraServerIntegrationTest(APITestCase):
 
     @responses.activate
     def test_sync_assignee_outbound_no_email(self):
-        user = user_service.serialize_user(self.create_user(email="bob@example.com"))
+        user = serialize_rpc_user(self.create_user(email="bob@example.com"))
         issue_id = "APP-123"
         external_issue = ExternalIssue.objects.create(
             organization_id=self.organization.id,

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -6,7 +6,7 @@ from django.test import RequestFactory
 from sentry.middleware.auth import AuthenticationMiddleware
 from sentry.models import ApiKey, ApiToken, UserIP
 from sentry.services.hybrid_cloud.auth import AuthenticatedToken
-from sentry.services.hybrid_cloud.user import user_service
+from sentry.services.hybrid_cloud.user.impl import serialize_rpc_user
 from sentry.silo import SiloMode
 from sentry.testutils import TestCase
 from sentry.testutils.outbox import outbox_runner
@@ -22,7 +22,7 @@ class AuthenticationMiddlewareTestCase(TestCase):
         if SiloMode.get_current_mode() == SiloMode.MONOLITH:
             assert request.user == self.user
         else:
-            assert request.user == user_service.serialize_user(self.user)
+            assert request.user == serialize_rpc_user(self.user)
 
     def setUp(self):
         from django.core.cache import cache


### PR DESCRIPTION
# Context

Many of the hybrid cloud services are going to be implemented as a simple RPC wrapper around silo specific business logic, most of which involves simple querying for objects. We've been developing these interfaces in an ad-hoc way for each service, which has worked fine, but has also illustrated that we don't adequately enforce certain invariants we would like our APIs to maintain:
* Optional arguments: all arguments to RPC methods are optional
* Strongly typed arguments: We want to enforce type safety at call sites no matter which interface users consume. We can also use this to generate documentation or codegen clients
* Cross silo querying safely: we want to enforce filtering & pagination requirements on query methods to sanity check queries
* Serialization across silos: This is a bit of a cludge that both avoids double serialization and allows regions to "own" serialization domains for specific objects. It's a problematic pattern that we're forced to propagate to maintain backward compatibility with our existing APIs. Usage could possibly result in infinite loops between silos. Resolving this will require breaking API changes in many places across the app, which is work that this allows us to defer.

# Implementation

This PR defines a base `FilterQueryInterface` that adds public methods to hybrid cloud service classes for fetching RPC representations of objects and API serialized representations of objects.
It also defines `FilterQueryDatabaseImpl` which provides a standard implementation for DatabaseBacked implementations of hybrid cloud service interfaces.

Both of these definitions are Generic, which allows for strong type checking of api methods at call sites at "compile" (type check) time.

# Alternatives considered:
## Code Gen
* This could just generate concrete (non-generic) implementations of these ideas based on defined types. It would provide better type checking errors for hybrid cloud service class definitions than the Generic implementation does, at the expense of a more complicated workflow.

## Dynamically building classes
* Mypy doesn't respect dynamic types at typecheck time, so this would only work with runtime enforcement and doesn't enable codegen of clients/docs

Implementation is mostly in [src/sentry/services/hybrid_cloud/filter_query.py](https://github.com/getsentry/sentry/compare/master...ihbe/hc-rpc-base#diff-5f4678c668f37aa70770743c98d89e4a23c090663e102dcf43004bf80fb48a9fL4) and [src/sentry/services/hybrid_cloud/user/__init__.py](https://github.com/getsentry/sentry/compare/master...ihbe/hc-rpc-base#diff-5f4678c668f37aa70770743c98d89e4a23c090663e102dcf43004bf80fb48a9fL4)
