### PR TITLE
fix(ecosystem): Fix text wrapping in sourcemap modal

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -43,7 +43,7 @@ describe('StacktraceLinkModal', () => {
   });
 
   it('links to source code with one GitHub integration', () => {
-    const {container} = renderGlobalModal();
+    renderGlobalModal();
     act(() =>
       openModal(modalProps => (
         <StacktraceLinkModal
@@ -66,7 +66,7 @@ describe('StacktraceLinkModal', () => {
       'href',
       'https://github.com/test-integration'
     );
-    expect(container).toSnapshot();
+    expect(screen.getByRole('dialog')).toSnapshot();
   });
 
   it('closes modal after successful quick setup', async () => {

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -43,7 +43,7 @@ describe('StacktraceLinkModal', () => {
   });
 
   it('links to source code with one GitHub integration', () => {
-    renderGlobalModal();
+    const {container} = renderGlobalModal();
     act(() =>
       openModal(modalProps => (
         <StacktraceLinkModal
@@ -66,6 +66,7 @@ describe('StacktraceLinkModal', () => {
       'href',
       'https://github.com/test-integration'
     );
+    expect(container).toSnapshot();
   });
 
   it('closes modal after successful quick setup', async () => {

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -144,13 +144,15 @@ function StacktraceLinkModal({
                 : error}
             </StyledAlert>
           )}
-          {tct(
-            'We can’t find the file path for [filename] in your [provider] repo. Add the correct link below to enable git blame and suspect commits for this project.',
-            {
-              provider: providerName,
-              filename: <StyledCode>{filename}</StyledCode>,
-            }
-          )}
+          <div>
+            {tct(
+              'We can’t find the file path for [filename] in your [provider] repo. Add the correct link below to enable git blame and suspect commits for this project.',
+              {
+                provider: providerName,
+                filename: <StyledCode>{filename}</StyledCode>,
+              }
+            )}
+          </div>
           <StyledList symbol="colored-numeric">
             <li>
               <ItemContainer>

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -154,15 +154,17 @@ function StacktraceLinkModal({
           <StyledList symbol="colored-numeric">
             <li>
               <ItemContainer>
-                {hasOneSourceCodeIntegration
-                  ? tct('Go to [link]', {
-                      link: (
-                        <ExternalLink href={sourceUrl}>
-                          {sourceCodeProviders[0].provider.name}
-                        </ExternalLink>
-                      ),
-                    })
-                  : t('Go to your source code provider')}
+                <div>
+                  {hasOneSourceCodeIntegration
+                    ? tct('Go to [link]', {
+                        link: (
+                          <ExternalLink href={sourceUrl}>
+                            {sourceCodeProviders[0].provider.name}
+                          </ExternalLink>
+                        ),
+                      })
+                    : t('Go to your source code provider')}
+                </div>
               </ItemContainer>
             </li>
             <li>


### PR DESCRIPTION
This is from the span change to tct. still want the flexbox so that it stays lined up with the number.
before
![image](https://user-images.githubusercontent.com/1400464/216458182-1ed25571-65c8-4632-b558-7cc3991a924a.png)

after
![image](https://user-images.githubusercontent.com/1400464/216458073-5720bed9-9f3b-4191-916d-72082649e77f.png)
