### PR TITLE
feat(features): Enable project stats view without checking global-views

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -224,7 +224,24 @@ describe('OrganizationStats', function () {
   /**
    * Project Selection
    */
-  it('renders with no projects selected', () => {
+  it('renders single project without global-views', () => {
+    const newOrg = initializeOrg();
+    newOrg.organization.features = [
+      'team-insights',
+      // TODO(Leander): Remove the following check once the project-stats flag is GA
+      'project-stats',
+    ];
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
+      context: newOrg.routerContext,
+    });
+
+    expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('usage-stats-chart')).toBeInTheDocument();
+    expect(screen.queryByText('usage-stats-table')).not.toBeInTheDocument();
+  });
+
+  it('renders default projects with global-views', () => {
     const newOrg = initializeOrg();
     newOrg.organization.features = [
       'global-views',
@@ -345,11 +362,7 @@ describe('OrganizationStats', function () {
       ...defaultSelection,
       projects: selectedProject,
     };
-    for (const features of [
-      ['team-insights'],
-      ['team-insights', 'project-stats'],
-      ['team-insights', 'global-views'],
-    ]) {
+    for (const features of [['team-insights'], ['team-insights', 'project-stats']]) {
       const newOrg = initializeOrg();
       newOrg.organization.features = features;
       render(
@@ -362,7 +375,6 @@ describe('OrganizationStats', function () {
       );
       act(() => PageFiltersStore.updateProjects(selectedProject, []));
       expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
-      expect(screen.getByTestId('usage-stats-table')).toBeInTheDocument();
       cleanup();
     }
   });

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -161,15 +161,12 @@ export class OrganizationStats extends Component<Props> {
   }
 
   /**
-   * Note: For now, we're checking for both project-stats and global-views to enable this new UI
-   * This may change once we GA the project-stats feature flag. These are the planned scenarios:
-   *  - w/o global-views: Project Selector defaults to first project, hence no more 'Org Stats' w/o global-views
-   *  - w/ global-views: Project Selector defaults to 'My Projects', behaviour for 'Org Stats' is preserved
+   * Note: Since we're not checking for 'global-views', orgs without that flag will only ever get
+   * the single page view. This is a trade-off of using the global project header,
+   * but creates product consistency, since it's a paid feature to view data across projects
    */
   get hasProjectStats(): boolean {
-    return ['project-stats', 'global-views'].every(flag =>
-      this.props.organization.features.includes(flag)
-    );
+    return this.props.organization.features.includes('project-stats');
   }
 
   getNextLocations = (project: Project): Record<string, LocationDescriptorObject> => {

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -162,8 +162,8 @@ export class OrganizationStats extends Component<Props> {
 
   /**
    * Note: Since we're not checking for 'global-views', orgs without that flag will only ever get
-   * the single page view. This is a trade-off of using the global project header,
-   * but creates product consistency, since it's a paid feature to view data across projects
+   * the single project view. This is a trade-off of using the global project header, but creates
+   * product consistency, since multi-project selection should be controlled by this flag.
    */
   get hasProjectStats(): boolean {
     return this.props.organization.features.includes('project-stats');


### PR DESCRIPTION
Currently, the project-stats view is only visible if the organization is flagged in, and has the `global-views` flag. This was done to prevent locking the stats page in project-stats mode -- since the header disables multiple project selection if it doesn't find that flag. 

Removing this check makes the Sentry experience more consistent. If you could not view info from multiple projects on the issues page, it makes sense to also hide info from multiple projects on the stats page. 
