### PR TITLE
feat(roles): refactor OrganizationMemberTeam model and API

### DIFF
--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -114,8 +114,8 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         if not self._can_admin_team(request, team):
             return False
 
-        org_role = request.access.get_organization_role()
-        if org_role and org_role.can_manage_team_role(new_role):
+        org_roles = request.access.get_organization_roles()
+        if any(org_role.can_manage_team_role(new_role) for org_role in org_roles):
             return True
 
         team_role = request.access.get_team_role(team)

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -510,10 +510,7 @@ class OrganizationMember(Model):
         Return a list of org-level roles which that member could invite
         Must check if member member has member:admin first before checking
         """
-        all_org_roles = self.get_all_org_roles()
-        highest_role_priority = sorted(
-            [organization_roles.get(role) for role in all_org_roles], key=lambda r: r.priority
-        )[-1].priority
+        highest_role_priority = self.get_all_org_roles_sorted()[0].priority
 
         if not features.has("organizations:team-roles", self.organization):
             return [r for r in organization_roles.get_all() if r.priority <= highest_role_priority]

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -31,6 +31,7 @@ from sentry.exceptions import UnableToAcceptMemberInvitationException
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
 from sentry.models.team import TeamStatus
 from sentry.roles import organization_roles
+from sentry.roles.manager import OrganizationRole
 from sentry.signals import member_invited
 from sentry.utils.http import absolute_uri
 
@@ -404,18 +405,18 @@ class OrganizationMember(Model):
             scopes.update(self.organization.get_scopes(role_obj))
         return frozenset(scopes)
 
-    def get_org_roles_from_teams(self):
+    def get_org_roles_from_teams(self) -> List[str]:
         # results in an extra query when calling get_scopes()
         return list(
             self.teams.all().exclude(org_role=None).values_list("org_role", flat=True).distinct()
         )
 
-    def get_all_org_roles(self):
+    def get_all_org_roles(self) -> List[str]:
         all_org_roles = self.get_org_roles_from_teams()
         all_org_roles.append(self.role)
         return all_org_roles
 
-    def get_all_org_roles_sorted(self):
+    def get_all_org_roles_sorted(self) -> List[OrganizationRole]:
         return sorted(
             [organization_roles.get(role) for role in self.get_all_org_roles()],
             key=lambda r: r.priority,

--- a/src/sentry/models/organizationmemberteam.py
+++ b/src/sentry/models/organizationmemberteam.py
@@ -51,7 +51,9 @@ class OrganizationMemberTeam(BaseModel):
         If the role field is null, resolve to the minimum team role given by this
         member's organization role.
         """
-        minimum_role = roles.get_minimum_team_role(self.organizationmember.role)
+        highest_org_role = self.organizationmember.get_all_org_roles_sorted()[0].id
+        minimum_role = roles.get_minimum_team_role(highest_org_role)
+
         if self.role and features.has(
             "organizations:team-roles", self.organizationmember.organization
         ):

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -139,7 +139,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 49 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 51
+        expected_queries = 50 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 52
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -624,3 +624,24 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
             team=self.team, organizationmember=other_member
         )
         assert target_omt.role is None
+
+    @with_feature("organizations:team-roles")
+    def test_member_on_owner_team_can_promote_member(self):
+        owner_team = self.create_team(org_role="owner")
+        member = self.create_member(
+            organization=self.org,
+            user=self.create_user(),
+            role="member",
+            teams=[owner_team],
+        )
+
+        self.login_as(member.user)
+        resp = self.get_response(
+            self.org.slug, self.member_on_team.id, self.team.slug, teamRole="admin"
+        )
+        assert resp.status_code == 200
+
+        updated_omt = OrganizationMemberTeam.objects.get(
+            team=self.team, organizationmember=self.member_on_team
+        )
+        assert updated_omt.role == "admin"

--- a/tests/sentry/models/test_organizationmemberteam.py
+++ b/tests/sentry/models/test_organizationmemberteam.py
@@ -8,9 +8,9 @@ from sentry.testutils.silo import region_silo_test
 @region_silo_test(stable=True)
 class OrganizationMemberTest(TestCase):
     def setUp(self):
-        organization = self.create_organization()
-        self.team = self.create_team(organization=organization)
-        self.member = self.create_member(organization=organization, user=self.create_user())
+        self.organization = self.create_organization()
+        self.team = self.create_team(organization=self.organization)
+        self.member = self.create_member(organization=self.organization, user=self.create_user())
 
     @with_feature("organizations:team-roles")
     def test_get_team_role(self):
@@ -27,3 +27,13 @@ class OrganizationMemberTest(TestCase):
         for org_role in ("admin", "manager", "owner"):
             self.member.role = org_role
             assert omt.get_team_role() == team_roles.get("admin")
+
+    @with_feature("organizations:team-roles")
+    def test_get_team_role_derives_minimum_role_from_team_membership(self):
+        manager_team = self.create_team(org_role="manager")
+        member = self.create_member(
+            organization=self.organization, user=self.create_user(), teams=[manager_team]
+        )
+        omt = OrganizationMemberTeam(organizationmember=member, team=manager_team)
+
+        assert omt.get_team_role() == team_roles.get("admin")


### PR DESCRIPTION
- Allow users to set the team role if they have the appropriate org role to do so through team membership
- Use the helper function to get all org roles sorted by priority in `OrganizationMember` and `OrganizationMemberTeam`

For ER-1354