### PR TITLE
fix(js): Prefer copy-to-clipboard over navigator.clipboard

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -5,6 +5,7 @@ import 'prismjs/components/prism-bash.min';
 
 import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import copy from 'copy-text-to-clipboard';
 
 import {Button} from 'sentry/components/button';
 import {IconCopy} from 'sentry/icons';
@@ -39,12 +40,12 @@ export function CodeSnippet({
 
   const [tooltipState, setTooltipState] = useState<'copy' | 'copied' | 'error'>('copy');
 
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(children);
-      onCopy?.(children);
+  const handleCopy = () => {
+    const copied = copy(children);
+    onCopy?.(children);
+    if (copied) {
       setTooltipState('copied');
-    } catch (err) {
+    } else {
       setTooltipState('error');
     }
   };

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import copy from 'copy-text-to-clipboard';
 
 import {bulkUpdate} from 'sentry/actionCreators/group';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -130,7 +131,7 @@ function ShareIssueModal({
                 borderless
                 size="sm"
                 onClick={() => {
-                  navigator.clipboard.writeText(shareUrl);
+                  copy(shareUrl);
                   urlRef.current?.selectText();
                 }}
                 icon={<IconCopy />}
@@ -154,7 +155,7 @@ function ShareIssueModal({
           <Button
             priority="primary"
             onClick={() => {
-              navigator.clipboard.writeText(shareUrl);
+              copy(shareUrl);
               closeModal();
             }}
           >

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import copy from 'copy-text-to-clipboard';
 
 import commitImage from 'sentry-images/spot/releases-tour-commits.svg';
 import emailImage from 'sentry-images/spot/releases-tour-email.svg';
@@ -162,7 +163,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
     return newToken.token;
   };
 
-  const handleCopy = async () => {
+  const handleCopy = () => {
     if (!token || !selectedItem) {
       addErrorMessage(t('Select an integration for your auth token!'));
       return;
@@ -180,7 +181,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
       sentry-cli releases set-commits "$VERSION" --auto
       sentry-cli releases finalize "$VERSION"
       `;
-    await navigator.clipboard.writeText(current_text);
+    copy(current_text);
     addSuccessMessage(t('Copied to clipboard!'));
     trackQuickstartCopy();
   };

--- a/static/app/views/settings/organizationRelay/modals/form.tsx
+++ b/static/app/views/settings/organizationRelay/modals/form.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import copy from 'copy-text-to-clipboard';
 
 import Textarea from 'sentry/components/forms/controls/textarea';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
@@ -47,11 +48,7 @@ const Form = ({
     }
   };
 
-  // code below copied from app/views/organizationIntegrations/SplitInstallationIdModal.tsx
-  // TODO: fix the common method selectText
-  const onCopy = (value: string) => async () =>
-    // This hack is needed because the normal copying methods with TextCopyInput do not work correctly
-    await navigator.clipboard.writeText(value);
+  const onCopy = (value: string) => () => copy(value);
 
   return (
     <form onSubmit={handleSubmit} id="relay-form">


### PR DESCRIPTION
Switch back to using the copy-to-clipboard module that works on http self-hosted sentry

fixes #44025