### PR TITLE
feat(sourcemaps): add more data about filepaths to sourcemaps debug endpoint

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -121,10 +121,9 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
         )
 
         artifact_names = [artifact.name for artifact in release_artifacts]
+        unified_url = self._unify_url(urlparts)
 
-        full_matches, partial_matches = self._find_matches(
-            release_artifacts, self._unify_url(urlparts)
-        )
+        full_matches, partial_matches = self._find_matches(release_artifacts, unified_url)
 
         if len(full_matches) == 0:
             if len(partial_matches) > 0:
@@ -134,7 +133,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
                         "absPath": abs_path,
                         "partialMatchPath": partial_matches[0].name,
                         "fileName": filename,
-                        "unifiedPath": self._unify_url(urlparts),
+                        "unifiedPath": unified_url,
                         "artifactNames": artifact_names,
                     },
                 )
@@ -143,7 +142,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
                 data={
                     "absPath": abs_path,
                     "fileName": filename,
-                    "unifiedPath": self._unify_url(urlparts),
+                    "unifiedPath": unified_url,
                     "artifactNames": artifact_names,
                 },
             )

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -116,7 +116,12 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
                 issue=SourceMapProcessingIssue.URL_NOT_VALID, data={"absPath": abs_path}
             )
 
-        release_artifacts = ReleaseFile.objects.filter(release_id=release.id)
+        release_artifacts = ReleaseFile.objects.filter(release_id=release.id).exclude(
+            artifact_count=0
+        )
+
+        artifact_names = [artifact.name for artifact in release_artifacts]
+
         full_matches, partial_matches = self._find_matches(
             release_artifacts, self._unify_url(urlparts)
         )
@@ -129,11 +134,18 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
                         "absPath": abs_path,
                         "partialMatchPath": partial_matches[0].name,
                         "fileName": filename,
+                        "unifiedPath": self._unify_url(urlparts),
+                        "artifactNames": artifact_names,
                     },
                 )
             return self._create_response(
                 issue=SourceMapProcessingIssue.NO_URL_MATCH,
-                data={"absPath": abs_path, "fileName": filename},
+                data={
+                    "absPath": abs_path,
+                    "fileName": filename,
+                    "unifiedPath": self._unify_url(urlparts),
+                    "artifactNames": artifact_names,
+                },
             )
 
         artifact = full_matches[0]

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -338,6 +338,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             "absPath": "https://app.example.com/static/static/js/application.js",
             "partialMatchPath": "http://example.com/application.js",
             "fileName": "/static/static/js/application.js",
+            "artifactNames": ["http://example.com/application.js"],
+            "unifiedPath": "~/static/static/js/application.js",
         }
 
     @with_feature("organizations:fix-source-map-cta")
@@ -389,6 +391,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert error["data"] == {
             "absPath": "https://app.example.com/static/static/js/main.fa8fe19f.js",
             "fileName": "/static/static/js/main.fa8fe19f.js",
+            "artifactNames": ["http://example.com/application.js"],
+            "unifiedPath": "~/static/static/js/main.fa8fe19f.js",
         }
 
     @with_feature("organizations:fix-source-map-cta")


### PR DESCRIPTION
this pr adds more data for debugging to the response for the sourcemaps debug endpoint. it will add the url that it is trying to match and the release files that it is trying to match against to the response's data. 