### PR TITLE
feat(perf): Use metrics in transaction summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -156,7 +156,11 @@ function TransactionSummaryCharts({
   };
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    organization,
+    location
+  );
 
   return (
     <Panel>

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -156,10 +156,7 @@ function TransactionSummaryCharts({
   };
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(
-    mepSetting,
-    display as DisplayModes
-  );
+  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
 
   return (
     <Panel>

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -15,8 +15,11 @@ import {t} from 'sentry/locale';
 import {Organization, SelectValue} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
+import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 import {TransactionsListOption} from 'sentry/views/releases/detail/overview';
 
 import {TrendColumnField, TrendFunctionField} from '../../trends/types';
@@ -31,15 +34,6 @@ import LatencyChart from './latencyChart';
 import TrendChart from './trendChart';
 import UserMiseryChart from './userMiseryChart';
 import VitalsChart from './vitalsChart';
-
-export enum DisplayModes {
-  DURATION_PERCENTILE = 'durationpercentile',
-  DURATION = 'duration',
-  LATENCY = 'latency',
-  TREND = 'trend',
-  VITALS = 'vitals',
-  USER_MISERY = 'usermisery',
-}
 
 function generateDisplayOptions(
   currentFilter: SpanOperationBreakdownFilter
@@ -161,6 +155,12 @@ function TransactionSummaryCharts({
         : undefined,
   };
 
+  const mepSetting = useMEPSettingContext();
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    display as DisplayModes
+  );
+
   return (
     <Panel>
       <ChartContainer data-test-id="transaction-summary-charts">
@@ -175,6 +175,7 @@ function TransactionSummaryCharts({
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
             currentFilter={currentFilter}
+            queryExtras={queryExtras}
           />
         )}
         {display === DisplayModes.DURATION && (
@@ -189,6 +190,7 @@ function TransactionSummaryCharts({
             statsPeriod={eventView.statsPeriod}
             currentFilter={currentFilter}
             withoutZerofill={withoutZerofill}
+            queryExtras={queryExtras}
           />
         )}
         {display === DisplayModes.DURATION_PERCENTILE && (
@@ -202,6 +204,7 @@ function TransactionSummaryCharts({
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
             currentFilter={currentFilter}
+            queryExtras={queryExtras}
           />
         )}
         {display === DisplayModes.TREND && (
@@ -230,6 +233,7 @@ function TransactionSummaryCharts({
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
             withoutZerofill={withoutZerofill}
+            queryExtras={queryExtras}
           />
         )}
         {display === DisplayModes.USER_MISERY && (

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -178,7 +178,7 @@ function SummaryContent({
 
   function generateActionBarItems(_org: Organization, _location: Location) {
     if (!_org.features.includes('performance-metrics-backed-transaction-summary')) {
-      return null;
+      return undefined;
     }
 
     return !canUseTransactionMetricsData(_org, _location)
@@ -192,7 +192,7 @@ function SummaryContent({
                     'Based on your search criteria and sample rate, the events available may be limited.'
                   )}
                 >
-                  <StyledWarningIcon />
+                  <StyledIconWarning size="sm" color="warningText" />
                 </Tooltip>
               ),
               menuItem: {
@@ -201,7 +201,7 @@ function SummaryContent({
             }),
           },
         ]
-      : null;
+      : undefined;
   }
 
   const hasPerformanceChartInterpolation = organization.features.includes(
@@ -530,15 +530,8 @@ const StyledSearchBar = styled(SearchBar)`
   }
 `;
 
-const StyledWarningIcon = styled(IconWarning)`
-  color: ${p => p.theme.alert.warning.iconColor};
-  height: ${p => p.theme.iconSizes.sm};
-  width: ${p => p.theme.iconSizes.sm};
+const StyledIconWarning = styled(IconWarning)`
   display: block;
-
-  &:hover {
-    color: ${p => p.theme.alert.warning.iconHoverColor};
-  }
 `;
 
 export default withProjects(SummaryContent);

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -13,7 +13,9 @@ import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import Tooltip from 'sentry/components/tooltip';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
+import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
@@ -34,6 +36,7 @@ import withProjects from 'sentry/utils/withProjects';
 import {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import {TableColumn} from 'sentry/views/discover/table/types';
 import Tags from 'sentry/views/discover/tags';
+import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {
   PERCENTILE as VITAL_PERCENTILE,
   VITAL_GROUPS,
@@ -173,6 +176,30 @@ function SummaryContent({
     return sortedEventView;
   }
 
+  function generateActionBarItems(_org: Organization, _location: Location) {
+    return !canUseTransactionMetricsData(_org, _location)
+      ? [
+          {
+            key: 'alert',
+            makeAction: () => ({
+              Button: () => (
+                <Tooltip
+                  title={t(
+                    'Based on your search criteria and sample rate, the events available may be limited.'
+                  )}
+                >
+                  <StyledWarningIcon />
+                </Tooltip>
+              ),
+              menuItem: {
+                key: 'filter-alert',
+              },
+            }),
+          },
+        ]
+      : [];
+  }
+
   const hasPerformanceChartInterpolation = organization.features.includes(
     'performance-chart-interpolation'
   );
@@ -293,6 +320,7 @@ function SummaryContent({
             fields={eventView.fields}
             onSearch={handleSearch}
             maxQueryLength={MAX_QUERY_LENGTH}
+            actionBarItems={generateActionBarItems(organization, location)}
           />
         </FilterActions>
         <TransactionSummaryCharts
@@ -495,6 +523,17 @@ const StyledSearchBar = styled(SearchBar)`
   @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
     order: initial;
     grid-column: auto;
+  }
+`;
+
+const StyledWarningIcon = styled(IconWarning)`
+  color: ${p => p.theme.alert.warning.iconColor};
+  height: ${p => p.theme.iconSizes.sm};
+  width: ${p => p.theme.iconSizes.sm};
+  display: block;
+
+  &:hover {
+    color: ${p => p.theme.alert.warning.iconHoverColor};
   }
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -177,6 +177,10 @@ function SummaryContent({
   }
 
   function generateActionBarItems(_org: Organization, _location: Location) {
+    if (!_org.features.includes('performance-metrics-backed-transaction-summary')) {
+      return null;
+    }
+
     return !canUseTransactionMetricsData(_org, _location)
       ? [
           {
@@ -197,7 +201,7 @@ function SummaryContent({
             }),
           },
         ]
-      : [];
+      : null;
   }
 
   const hasPerformanceChartInterpolation = organization.features.includes(

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
@@ -28,6 +28,7 @@ type Props = ViewProps & {
   organization: OrganizationSummary;
   queryExtra: Query;
   withoutZerofill: boolean;
+  queryExtras?: Record<string, string>;
 };
 
 enum DurationFunctionField {
@@ -53,6 +54,7 @@ function DurationChart({
   withoutZerofill,
   start: propsStart,
   end: propsEnd,
+  queryExtras,
 }: Props) {
   const router = useRouter();
   const location = useLocation();
@@ -144,6 +146,7 @@ function DurationChart({
         partial
         withoutZerofill={withoutZerofill}
         referrer="api.performance.transaction-summary.duration-chart"
+        queryExtras={queryExtras}
       >
         {({results, errored, loading, reloading, timeframe: timeFrame}) => (
           <Content

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/content.tsx
@@ -26,6 +26,7 @@ type Props = AsyncComponent['props'] &
     fields: string[];
     location: Location;
     organization: OrganizationSummary;
+    queryExtras?: Record<string, string>;
   };
 
 type State = AsyncComponent['state'] & {
@@ -52,6 +53,7 @@ class Content extends AsyncComponent<Props, State> {
       project,
       fields,
       location,
+      queryExtras,
     } = this.props;
 
     const eventView = EventView.fromSavedQuery({
@@ -67,8 +69,12 @@ class Content extends AsyncComponent<Props, State> {
       start,
       end,
     });
-    const apiPayload = eventView.getEventsAPIPayload(location);
-    apiPayload.referrer = 'api.performance.durationpercentilechart';
+    let apiPayload = eventView.getEventsAPIPayload(location);
+    apiPayload = {
+      ...apiPayload,
+      ...queryExtras,
+      referrer: 'api.performance.durationpercentilechart',
+    };
     const endpoint = `/organizations/${organization.slug}/events/`;
 
     return [['chartData', endpoint, {query: apiPayload}]];

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/index.tsx
@@ -4,7 +4,8 @@ import {Location} from 'history';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
-import {OrganizationSummary} from 'sentry/types';
+import {Organization, OrganizationSummary} from 'sentry/types';
+import {getPercentiles} from 'sentry/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils';
 
 import {ViewProps} from '../../../types';
 import {filterToField, SpanOperationBreakdownFilter} from '../../filter';
@@ -19,6 +20,7 @@ type Props = ViewProps & {
 };
 
 function DurationPercentileChart({currentFilter, ...props}: Props) {
+  const percentiles = getPercentiles(props.organization as Organization);
   const header = (
     <HeaderTitleLegend>
       {currentFilter === SpanOperationBreakdownFilter.None
@@ -37,36 +39,16 @@ function DurationPercentileChart({currentFilter, ...props}: Props) {
   );
 
   function generateFields() {
-    // TODO check for metrics here
+    let field: string | undefined;
     if (currentFilter === SpanOperationBreakdownFilter.None) {
-      return [
-        'percentile(transaction.duration, 0.10)',
-        'percentile(transaction.duration, 0.25)',
-        'percentile(transaction.duration, 0.50)',
-        'percentile(transaction.duration, 0.75)',
-        'percentile(transaction.duration, 0.90)',
-        'percentile(transaction.duration, 0.95)',
-        'percentile(transaction.duration, 0.99)',
-        'percentile(transaction.duration, 0.995)',
-        'percentile(transaction.duration, 0.999)',
-        'p100()',
-      ];
+      field = 'transaction.duration';
+    } else {
+      field = filterToField(currentFilter);
     }
 
-    const field = filterToField(currentFilter);
-
-    return [
-      `percentile(${field}, 0.10)`,
-      `percentile(${field}, 0.25)`,
-      `percentile(${field}, 0.50)`,
-      `percentile(${field}, 0.75)`,
-      `percentile(${field}, 0.90)`,
-      `percentile(${field}, 0.95)`,
-      `percentile(${field}, 0.99)`,
-      `percentile(${field}, 0.995)`,
-      `percentile(${field}, 0.999)`,
-      `p100(${field})`,
-    ];
+    return percentiles.map(percentile =>
+      percentile === '1' ? `p100(${field})` : `percentile(${field}, ${percentile})`
+    );
   }
 
   const fields = generateFields();

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/index.tsx
@@ -15,6 +15,7 @@ type Props = ViewProps & {
   currentFilter: SpanOperationBreakdownFilter;
   location: Location;
   organization: OrganizationSummary;
+  queryExtras?: Record<string, string>;
 };
 
 function DurationPercentileChart({currentFilter, ...props}: Props) {
@@ -36,6 +37,7 @@ function DurationPercentileChart({currentFilter, ...props}: Props) {
   );
 
   function generateFields() {
+    // TODO check for metrics here
     if (currentFilter === SpanOperationBreakdownFilter.None) {
       return [
         'percentile(transaction.duration, 0.10)',

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
@@ -1,4 +1,6 @@
 import {t} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 
 const AGGREGATE_ALIAS_VALUE_EXTRACT_PATTERN = /(\d+)$/;
 const FUNCTION_FIELD_VALUE_EXTRACT_PATTERN = /(\d+)\)$/;
@@ -44,4 +46,22 @@ export function transformData(
       data: extractedData.map(i => ({value: i[1], name: `${i[0].toLocaleString()}%`})),
     },
   ];
+}
+
+export function getPercentiles(organization: Organization) {
+  const isUsingMetrics = canUseMetricsData(organization);
+  const METRICS_PERCENTILES = ['0.25', '0.5', '0.75', '0.9', '0.95', '0.99', '1'];
+  const INDEXED_PERCENTILES = [
+    '0.10',
+    '0.25',
+    '0.50',
+    '0.75',
+    '0.90',
+    '0.95',
+    '0.99',
+    '0.995',
+    '0.999',
+    '1',
+  ];
+  return isUsingMetrics ? METRICS_PERCENTILES : INDEXED_PERCENTILES;
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -10,7 +10,10 @@ import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {Column, isAggregateField, QueryFieldValue} from 'sentry/utils/discover/fields';
 import {WebVital} from 'sentry/utils/fields';
-import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {
+  MEPSettingProvider,
+  useMEPSettingContext,
+} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -18,6 +21,8 @@ import useApi from 'sentry/utils/useApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
+import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
 import {addRoutePerformanceContext} from '../../utils';
 import {
@@ -85,6 +90,13 @@ function OverviewContentWrapper(props: ChildProps) {
     transactionThresholdMetric,
   } = props;
 
+  const mepSetting = useMEPSettingContext();
+  const display = decodeScalar(
+    location.query.display,
+    DisplayModes.DURATION
+  ) as DisplayModes;
+  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, display);
+
   const queryData = useDiscoverQuery({
     eventView: getTotalsEventView(organization, eventView),
     orgSlug: organization.slug,
@@ -92,6 +104,7 @@ function OverviewContentWrapper(props: ChildProps) {
     transactionThreshold,
     transactionThresholdMetric,
     referrer: 'api.performance.transaction-summary',
+    queryExtras,
   });
 
   const {data: tableData, isLoading, error} = queryData;

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -22,7 +22,6 @@ import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
-import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
 import {addRoutePerformanceContext} from '../../utils';
 import {
@@ -91,11 +90,7 @@ function OverviewContentWrapper(props: ChildProps) {
   } = props;
 
   const mepSetting = useMEPSettingContext();
-  const display = decodeScalar(
-    location.query.display,
-    DisplayModes.DURATION
-  ) as DisplayModes;
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, display);
+  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
 
   const queryData = useDiscoverQuery({
     eventView: getTotalsEventView(organization, eventView),

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -134,7 +134,6 @@ function OverviewContentWrapper(props: ChildProps) {
 
   const totals: TotalValues | null =
     (tableData?.data?.[0] as {[k: string]: number}) ?? null;
-
   return (
     <SummaryContent
       location={location}

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -90,7 +90,11 @@ function OverviewContentWrapper(props: ChildProps) {
   } = props;
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    organization,
+    location
+  );
 
   const queryData = useDiscoverQuery({
     eventView: getTotalsEventView(organization, eventView),

--- a/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
@@ -30,6 +30,7 @@ type Props = ViewProps & {
   currentFilter: SpanOperationBreakdownFilter;
   location: Location;
   organization: OrganizationSummary;
+  queryExtras?: Record<string, string>;
 };
 
 /**
@@ -50,6 +51,7 @@ function Content({
   project,
   location,
   currentFilter,
+  queryExtras,
 }: Props) {
   const [zoomError, setZoomError] = useState(false);
 
@@ -152,7 +154,6 @@ function Content({
     },
     location
   );
-
   const {min, max} = decodeHistogramZoom(location);
 
   const field = filterToField(currentFilter) ?? 'transaction.duration';
@@ -169,6 +170,7 @@ function Content({
           min={min}
           max={max}
           dataFilter={activeFilter.value}
+          queryExtras={queryExtras}
         >
           {({histograms, isLoading, error}) => {
             if (isLoading) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/index.tsx
@@ -15,6 +15,7 @@ type Props = ViewProps & {
   currentFilter: SpanOperationBreakdownFilter;
   location: Location;
   organization: OrganizationSummary;
+  queryExtras?: Record<string, string>;
 };
 
 function LatencyChart({currentFilter, ...props}: Props) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -38,7 +38,6 @@ import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
-import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
 import {
   anomaliesRouteWithQuery,
@@ -248,11 +247,7 @@ function SidebarChartsContainer({
   const utc = normalizeDateTimeParams(location.query).utc === 'true';
 
   const mepSetting = useMEPSettingContext();
-  const display = decodeScalar(
-    location.query.display,
-    DisplayModes.DURATION
-  ) as DisplayModes;
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, display);
+  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
 
   const axisLineConfig = {
     scale: true,

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -247,7 +247,11 @@ function SidebarChartsContainer({
   const utc = normalizeDateTimeParams(location.query).utc === 'true';
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    organization,
+    location
+  );
 
   const axisLineConfig = {
     scale: true,

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -30,12 +30,15 @@ import {
 } from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import AnomaliesQuery from 'sentry/utils/performance/anomalies/anomaliesQuery';
+import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
 import {
   anomaliesRouteWithQuery,
@@ -244,6 +247,13 @@ function SidebarChartsContainer({
   const query = eventView.query;
   const utc = normalizeDateTimeParams(location.query).utc === 'true';
 
+  const mepSetting = useMEPSettingContext();
+  const display = decodeScalar(
+    location.query.display,
+    DisplayModes.DURATION
+  ) as DisplayModes;
+  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, display);
+
   const axisLineConfig = {
     scale: true,
     axisLine: {
@@ -374,6 +384,7 @@ function SidebarChartsContainer({
       yAxis={['apdex()', 'failure_rate()', 'epm()']}
       partial
       referrer="api.performance.transaction-summary.sidebar-chart"
+      queryExtras={queryExtras}
     >
       {({results, errored, loading, reloading}) => {
         const series = results

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -44,7 +44,10 @@ function UserStats({
   let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
 
   if (!isLoading && error === null && totals) {
-    const threshold: number | undefined = totals.project_threshold_config[1];
+    // TODO how to get this using metrics?
+    const threshold: number | undefined = totals.project_threshold_config
+      ? totals.project_threshold_config[1]
+      : undefined;
     const miserableUsers: number | undefined = totals['count_miserable_user()'];
     const userMiseryScore: number = totals['user_misery()'];
     const totalUsers = totals['count_unique_user()'];

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -14,8 +14,10 @@ import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {WebVital} from 'sentry/utils/fields';
+import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {vitalsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionVitals/utils';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 import VitalInfo from 'sentry/views/performance/vitalDetail/vitalInfo';
@@ -71,6 +73,13 @@ function UserStats({
     query: location.query,
   });
 
+  const mepSetting = useMEPSettingContext();
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    organization,
+    location
+  );
+
   return (
     <Fragment>
       {hasWebVitals && (
@@ -101,6 +110,7 @@ function UserStats({
             project={eventView.project}
             hideVitalThresholds
             hideDurationDetail
+            queryExtras={queryExtras}
           />
           <SidebarSpacer />
         </Fragment>

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -44,12 +44,11 @@ function UserStats({
   let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
 
   if (!isLoading && error === null && totals) {
-    // TODO how to get this using metrics?
     const threshold: number | undefined = totals.project_threshold_config
       ? totals.project_threshold_config[1]
       : undefined;
     const miserableUsers: number | undefined = totals['count_miserable_user()'];
-    const userMiseryScore: number = totals['user_misery()'];
+    const userMiseryScore: number = totals['user_misery()'] | 0;
     const totalUsers = totals['count_unique_user()'];
     userMisery = (
       <UserMisery

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -48,7 +48,7 @@ function UserStats({
       ? totals.project_threshold_config[1]
       : undefined;
     const miserableUsers: number | undefined = totals['count_miserable_user()'];
-    const userMiseryScore: number = totals['user_misery()'] | 0;
+    const userMiseryScore: number = totals['user_misery()'] || 0;
     const totalUsers = totals['count_unique_user()'];
     userMisery = (
       <UserMisery

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -1,4 +1,7 @@
+import {Location} from 'history';
+
 import {MetricsEnhancedSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -6,10 +9,29 @@ const DISPLAY_MAP_DENY_LIST = [DisplayModes.TREND];
 
 export function getTransactionMEPParamsIfApplicable(
   mepContext: MetricsEnhancedSettingContext,
-  display: DisplayModes
+  location: Location
 ) {
+  const display = decodeScalar(
+    location.query.display,
+    DisplayModes.DURATION
+  ) as DisplayModes;
+  const breakdown = decodeScalar(location.query.breakdown, '');
+  const query = decodeScalar(location.query.query, '');
+
+  // certain charts aren't compatible with metrics
   if (DISPLAY_MAP_DENY_LIST.includes(display)) {
     return undefined;
   }
+
+  // span op breakdown filters aren't compatible with metrics
+  if (breakdown) {
+    return undefined;
+  }
+
+  // in the short term, using any filter will force indexed event search
+  if (query) {
+    return undefined;
+  }
+
   return getMEPQueryParams(mepContext);
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -48,6 +48,10 @@ export function getTransactionMEPParamsIfApplicable(
   organization: Organization,
   location: Location
 ) {
+  if (!organization.features.includes('performance-metrics-backed-transaction-summary')) {
+    return undefined;
+  }
+
   if (!canUseTransactionMetricsData(organization, location)) {
     return undefined;
   }

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -1,0 +1,15 @@
+import {MetricsEnhancedSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
+import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
+
+const DISPLAY_MAP_DENY_LIST = [DisplayModes.TREND];
+
+export function getTransactionMEPParamsIfApplicable(
+  mepContext: MetricsEnhancedSettingContext,
+  display: DisplayModes
+) {
+  if (DISPLAY_MAP_DENY_LIST.includes(display)) {
+    return undefined;
+  }
+  return getMEPQueryParams(mepContext);
+}

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -9,7 +9,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
-const DISPLAY_MAP_DENY_LIST = [DisplayModes.TREND];
+const DISPLAY_MAP_DENY_LIST = [DisplayModes.TREND, DisplayModes.LATENCY];
 
 export function canUseTransactionMetricsData(organization, location) {
   const isUsingMetrics = canUseMetricsData(organization);

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
@@ -25,6 +25,7 @@ type Props = ViewProps & {
   organization: OrganizationSummary;
   queryExtra: Query;
   withoutZerofill: boolean;
+  queryExtras?: Record<string, string>;
 };
 
 function VitalsChart({
@@ -37,6 +38,7 @@ function VitalsChart({
   withoutZerofill,
   start: propsStart,
   end: propsEnd,
+  queryExtras,
 }: Props) {
   const location = useLocation();
   const router = useRouter();
@@ -137,6 +139,7 @@ function VitalsChart({
         partial
         withoutZerofill={withoutZerofill}
         referrer="api.performance.transaction-summary.vitals-chart"
+        queryExtras={queryExtras}
       >
         {({results, errored, loading, reloading, timeframe: timeFrame}) => (
           <Content

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -11,7 +11,14 @@ import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
-import {DisplayModes} from './transactionOverview/charts';
+export enum DisplayModes {
+  DURATION_PERCENTILE = 'durationpercentile',
+  DURATION = 'duration',
+  LATENCY = 'latency',
+  TREND = 'trend',
+  VITALS = 'vitals',
+  USER_MISERY = 'usermisery',
+}
 
 export enum TransactionFilterOptions {
   FASTEST = 'fastest',

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -32,9 +32,10 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
-
-import {DisplayModes} from '../transactionSummary/transactionOverview/charts';
-import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
+import {
+  DisplayModes,
+  transactionSummaryRouteWithQuery,
+} from 'sentry/views/performance/transactionSummary/utils';
 
 import Chart from './chart';
 import {

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -30,13 +30,13 @@ import VitalsDetailsTableQuery, {
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import {TableColumn} from 'sentry/views/discover/table/types';
-
-import {DisplayModes} from '../transactionSummary/transactionOverview/charts';
 import {
+  DisplayModes,
   normalizeSearchConditionsWithTransactionName,
   TransactionFilterOptions,
   transactionSummaryRouteWithQuery,
-} from '../transactionSummary/utils';
+} from 'sentry/views/performance/transactionSummary/utils';
+
 import {getSelectedProjectPlatforms} from '../utils';
 
 import {

--- a/static/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/static/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -3,8 +3,12 @@ import {Location} from 'history';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {WebVital} from 'sentry/utils/fields';
+import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import VitalsCardDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
+import {decodeScalar} from 'sentry/utils/queryString';
 import toArray from 'sentry/utils/toArray';
+import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
 import {VitalBar} from '../landing/vitalsCards';
 
@@ -46,8 +50,19 @@ function VitalInfo({
     showDurationDetail: !hideDurationDetail,
   };
 
+  const mepSetting = useMEPSettingContext();
+  const display = decodeScalar(
+    location.query.display,
+    DisplayModes.DURATION
+  ) as DisplayModes;
+  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, display);
+
   return (
-    <VitalsCardDiscoverQuery location={location} vitals={vitals}>
+    <VitalsCardDiscoverQuery
+      location={location}
+      vitals={vitals}
+      queryExtras={queryExtras}
+    >
       {({isLoading: loading, vitalsData}) => (
         <VitalBar
           {...contentCommonProps}

--- a/static/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/static/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -6,6 +6,7 @@ import {WebVital} from 'sentry/utils/fields';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import VitalsCardDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import toArray from 'sentry/utils/toArray';
+import useOrganization from 'sentry/utils/useOrganization';
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 import {VitalBar} from '../landing/vitalsCards';
@@ -49,7 +50,12 @@ function VitalInfo({
   };
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
+  const organization = useOrganization();
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    organization,
+    location
+  );
 
   return (
     <VitalsCardDiscoverQuery

--- a/static/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/static/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -3,11 +3,8 @@ import {Location} from 'history';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {WebVital} from 'sentry/utils/fields';
-import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import VitalsCardDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import toArray from 'sentry/utils/toArray';
-import useOrganization from 'sentry/utils/useOrganization';
-import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 import {VitalBar} from '../landing/vitalsCards';
 
@@ -27,6 +24,7 @@ type Props = ViewProps & {
   hideVitalThresholds?: boolean;
   isLoading?: boolean;
   p75AllTransactions?: number;
+  queryExtras?: Record<string, string>;
 };
 
 function VitalInfo({
@@ -38,6 +36,7 @@ function VitalInfo({
   hideVitalPercentNames,
   hideVitalThresholds,
   hideDurationDetail,
+  queryExtras,
 }: Props) {
   const vitals = toArray(vital);
   const contentCommonProps = {
@@ -48,14 +47,6 @@ function VitalInfo({
     showVitalThresholds: !hideVitalThresholds,
     showDurationDetail: !hideDurationDetail,
   };
-
-  const mepSetting = useMEPSettingContext();
-  const organization = useOrganization();
-  const queryExtras = getTransactionMEPParamsIfApplicable(
-    mepSetting,
-    organization,
-    location
-  );
 
   return (
     <VitalsCardDiscoverQuery

--- a/static/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/static/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -5,10 +5,8 @@ import EventView from 'sentry/utils/discover/eventView';
 import {WebVital} from 'sentry/utils/fields';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import VitalsCardDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
-import {decodeScalar} from 'sentry/utils/queryString';
 import toArray from 'sentry/utils/toArray';
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
-import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
 import {VitalBar} from '../landing/vitalsCards';
 
@@ -51,11 +49,7 @@ function VitalInfo({
   };
 
   const mepSetting = useMEPSettingContext();
-  const display = decodeScalar(
-    location.query.display,
-    DisplayModes.DURATION
-  ) as DisplayModes;
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, display);
+  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, location);
 
   return (
     <VitalsCardDiscoverQuery

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -40,8 +40,10 @@ import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import AsyncView from 'sentry/views/asyncView';
-import {DisplayModes} from 'sentry/views/performance/transactionSummary/transactionOverview/charts';
-import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+import {
+  DisplayModes,
+  transactionSummaryRouteWithQuery,
+} from 'sentry/views/performance/transactionSummary/utils';
 import {TrendChangeType, TrendView} from 'sentry/views/performance/trends/types';
 import {
   platformToPerformanceType,


### PR DESCRIPTION
When query is compatible with metrics dataset, use it to power transaction summary. When it's not possible, use indexed event and show a warning explaining the change.
<img width="1293" alt="Screen Shot 2023-02-02 at 6 35 42 PM" src="https://user-images.githubusercontent.com/23648387/216475362-cce90792-08f1-45b6-b924-9ad1bc3dacac.png">
<img width="977" alt="Screen Shot 2023-02-02 at 6 36 04 PM" src="https://user-images.githubusercontent.com/23648387/216475391-89e0316e-e4d7-4b46-8389-6ffb7ab68d5c.png">
<img width="971" alt="Screen Shot 2023-02-02 at 6 36 14 PM" src="https://user-images.githubusercontent.com/23648387/216475398-a1df9883-e6ba-4319-9910-5cdc1460d846.png">
