### PR TITLE
fix(txnames): Run clusterer at fixed time every hour

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -827,7 +827,7 @@ CELERYBEAT_SCHEDULE = {
     },
     "transaction-name-clusterer": {
         "task": "sentry.ingest.transaction_clusterer.tasks.spawn_clusterers",
-        "schedule": timedelta(hours=1),
+        "schedule": crontab(minute=17),
         "options": {"expires": 3600},
     },
     "hybrid-cloud-repair-mappings": {


### PR DESCRIPTION
We noticed that the main task of the transaction name clusterer did not run reliably every hour. This may be caused by restarts of the the process that runs the celerybeat schedule, which pushes the execution of the task into the future:

> Using a [timedelta](https://docs.python.org/dev/library/datetime.html#datetime.timedelta) for the schedule means the task will be sent in 30 second intervals (the first task will be sent 30 seconds after celery beat starts, and then every 30 seconds after the last run).

https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html

Use a predefined time to run the job instead.

Fixes https://github.com/getsentry/team-ingest/issues/57.