### PR TITLE
feat(profiling): prevent initializing with incompatible state

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
@@ -16,7 +16,7 @@ interface FlamegraphOptionsMenuProps {
 function FlamegraphOptionsMenu({
   canvasPoolManager,
 }: FlamegraphOptionsMenuProps): React.ReactElement {
-  const {colorCoding, xAxis} = useFlamegraphPreferences();
+  const {colorCoding, xAxis, type} = useFlamegraphPreferences();
   const dispatch = useDispatchFlamegraphState();
 
   const options = useMemo(() => {
@@ -28,6 +28,7 @@ function FlamegraphOptionsMenu({
         options: Object.entries(X_AXIS).map(([value, label]) => ({
           label,
           value,
+          disabled: type === 'flamegraph' && value === 'transaction',
         })),
         onChange: value =>
           dispatch({

--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -136,7 +136,7 @@ declare namespace Profiling {
     name: string;
     profileID: string;
     activeProfileIndex: number;
-    profiles: ReadonlyArray<ProfileTypes>;
+    profiles: ReadonlyArray<ProfileInput>;
   };
 
   type FrameRender = {
@@ -148,7 +148,9 @@ declare namespace Profiling {
   // sentry related features to the flamegraphs. This should happen after the MVP integration
   type Schema = {
     profileID: string;
-    profiles: ReadonlyArray<Readonly<ProfileTypes>>;
+    profiles: ReadonlyArray<
+      Readonly<EventedProfile | SampledProfile | JSSelfProfiling.Trace>
+    >;
     projectID: number;
     shared: {
       frames: ReadonlyArray<Omit<FrameInfo, 'key'>>;

--- a/static/app/utils/profiling/profile/importProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/importProfile.spec.tsx
@@ -228,7 +228,7 @@ describe('parseDroppedProfile', () => {
   });
 
   it('imports dropped schema file', async () => {
-    const schema: Profiling.Schema = {
+    const schema: Readonly<Profiling.Schema> = {
       activeProfileIndex: 0,
       profileID: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       profiles: [

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -5,6 +5,42 @@ import {Frame} from './../frame';
 import {Profile} from './profile';
 import {createFrameIndex} from './utils';
 
+function sortStacks(
+  a: {stack: number[]; weight: number},
+  b: {stack: number[]; weight: number}
+) {
+  const max = Math.max(a.stack.length, b.stack.length);
+
+  for (let i = 0; i < max; i++) {
+    if (a.stack[i] === undefined) {
+      return -1;
+    }
+    if (b.stack[i] === undefined) {
+      return 1;
+    }
+    if (a.stack[i] === b.stack[i]) {
+      continue;
+    }
+    return a.stack[i] - b.stack[i];
+  }
+  return 0;
+}
+
+function stacksWithWeights(profile: Readonly<Profiling.SampledProfile>) {
+  return profile.samples.map((stack, index) => {
+    return {
+      stack,
+      weight: profile.weights[index],
+    };
+  });
+}
+
+function sortSamples(
+  profile: Readonly<Profiling.SampledProfile>
+): {stack: number[]; weight: number}[] {
+  return stacksWithWeights(profile).sort(sortStacks);
+}
+
 // This is a simplified port of speedscope's profile with a few simplifications and some removed functionality.
 // head at commit e37f6fa7c38c110205e22081560b99cb89ce885e
 
@@ -30,9 +66,14 @@ export class SampledProfile extends Profile {
       );
     }
 
-    for (let i = 0; i < sampledProfile.samples.length; i++) {
-      const stack = sampledProfile.samples[i];
-      let weight = sampledProfile.weights[i];
+    const samples =
+      options.type === 'flamegraph'
+        ? sortSamples(sampledProfile)
+        : stacksWithWeights(sampledProfile);
+
+    for (let i = 0; i < samples.length; i++) {
+      const stack = samples[i].stack;
+      let weight = samples[i].weight;
 
       let resolvedStack = stack.map(n => {
         if (!frameIndex[n]) {
@@ -55,7 +96,7 @@ export class SampledProfile extends Profile {
           '(garbage collector) [native code]'
       ) {
         // The next stack we append will be previous stack + gc frame placed on top of it
-        resolvedStack = sampledProfile.samples[i - 1]
+        resolvedStack = samples[i - 1].stack
           .map(n => {
             if (!frameIndex[n]) {
               throw new Error(`Could not resolve frame ${n} in frame index`);
@@ -67,16 +108,15 @@ export class SampledProfile extends Profile {
 
         // Now collect all weights of all the consecutive gc frames and skip the samples
         while (
-          sampledProfile.samples[i + 1] &&
+          samples[i + 1] &&
           // We check for size <= 2 because we have so far only seen node profiles
           // where GC is either marked as the root node or is directly under the root node.
           // There is a good chance that this logic will at some point live on the backend
           // and when that happens, we do not want to enter this case as the GC will already
           // be placed at the top of the previous stack and the new stack length will be > 2
-          sampledProfile.samples[i + 1].length <= 2 &&
-          frameIndex[
-            sampledProfile.samples[i + 1][sampledProfile.samples[i + 1].length - 1]
-          ]?.name === '(garbage collector) [native code]'
+          samples[i + 1].stack.length <= 2 &&
+          frameIndex[samples[i + 1][samples[i + 1].stack.length - 1]]?.name ===
+            '(garbage collector) [native code]'
         ) {
           weight += sampledProfile.weights[++i];
         }

--- a/static/app/utils/profiling/profile/sentrySampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.tsx
@@ -5,6 +5,14 @@ import {Frame} from './../frame';
 import {Profile} from './profile';
 import {createSentrySampleProfileFrameIndex} from './utils';
 
+function sortSentrySampledProfileSamples(
+  samples: Readonly<Profiling.SentrySampledProfile['profile']['samples']>
+) {
+  return [...samples].sort((a, b) => {
+    return a.stack_id - b.stack_id;
+  });
+}
+
 // This is a simplified port of speedscope's profile with a few simplifications and some removed functionality.
 // head at commit e37f6fa7c38c110205e22081560b99cb89ce885e
 
@@ -15,7 +23,12 @@ export class SentrySampledProfile extends Profile {
     frameIndex: ReturnType<typeof createSentrySampleProfileFrameIndex>,
     options: {type: 'flamechart' | 'flamegraph'}
   ): Profile {
-    const {samples, stacks, thread_metadata = {}} = sampledProfile.profile;
+    const {stacks, thread_metadata = {}} = sampledProfile.profile;
+    const samples =
+      options.type === 'flamegraph'
+        ? sortSentrySampledProfileSamples(sampledProfile.profile.samples)
+        : sampledProfile.profile.samples;
+
     const startedAt = parseInt(samples[0].elapsed_since_start_ns, 10);
     const endedAt = parseInt(samples[samples.length - 1].elapsed_since_start_ns, 10);
     if (Number.isNaN(startedAt) || Number.isNaN(endedAt)) {

--- a/static/app/views/profiling/profileGroupProvider.tsx
+++ b/static/app/views/profiling/profileGroupProvider.tsx
@@ -1,10 +1,6 @@
 import {createContext, useContext, useEffect, useState} from 'react';
 
-import {
-  importProfile,
-  ProfileGroup,
-  sortProfileSamples,
-} from 'sentry/utils/profiling/profile/importProfile';
+import {importProfile, ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 
 type ProfileGroupContextValue = ProfileGroup;
 
@@ -43,14 +39,7 @@ export function ProfileGroupProvider(props: ProfileGroupProviderProps) {
       return;
     }
 
-    if (props.type === 'flamegraph') {
-      const profiles = sortProfileSamples(props.input);
-      setProfileGroup(importProfile(profiles, props.traceID, 'flamegraph'));
-    } else if (props.type === 'flamechart') {
-      setProfileGroup(importProfile(props.input, props.traceID, 'flamechart'));
-    } else {
-      throw new TypeError(`Unknown view type: ${props.type}`);
-    }
+    setProfileGroup(importProfile(props.input, props.traceID, props.type));
   }, [props.input, props.traceID, props.type]);
 
   return (


### PR DESCRIPTION
If we are looking at flamegraphs and our stored user preferences or query string somehow end up being the transaction duration axis, we want to escape that and only ever show the flamegraph axis