### PR TITLE
fix: Make Automatic LPQ actually work (it *never* did)

### DIFF
--- a/src/sentry/processing/realtime_metrics/base.py
+++ b/src/sentry/processing/realtime_metrics/base.py
@@ -12,6 +12,7 @@ class RealtimeMetricsStore(Service):
         "projects",
         "get_used_budget_for_project",
         "get_lpq_projects",
+        "is_lpq_project",
         "add_project_to_lpq",
         "remove_projects_from_lpq",
     )

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -68,6 +68,7 @@ class TestScanForSuspectProjects:
     ) -> None:
         store.add_project_to_lpq(17)
         assert store.get_lpq_projects() == {17}
+        assert store.is_lpq_project(17)
 
         with TaskRunner():
             _scan_for_suspect_projects()
@@ -107,6 +108,7 @@ class TestUpdateLpqEligibility:
 
         _update_lpq_eligibility(project_id=17)
         assert store.get_lpq_projects() == {17}
+        assert store.is_lpq_project(17)
 
     @freeze_time(datetime.fromtimestamp(0))
     def test_is_eligible_in_lpq(self, store: RealtimeMetricsStore) -> None:
@@ -116,6 +118,7 @@ class TestUpdateLpqEligibility:
 
         _update_lpq_eligibility(project_id=17)
         assert store.get_lpq_projects() == {17}
+        assert store.is_lpq_project(17)
 
     def test_not_eligible_in_lpq(self, store: RealtimeMetricsStore) -> None:
         store.add_project_to_lpq(17)
@@ -144,3 +147,5 @@ class TestUpdateLpqEligibility:
 
         _update_lpq_eligibility(17)
         assert store.get_lpq_projects() == {17}
+        assert not store.is_lpq_project(16)
+        assert store.is_lpq_project(17)


### PR DESCRIPTION
Okay, so here is the thing:

`LazyServiceWrapper.expose` is using `__all__` to, well, "expose" all the class methods as free functions in the module. The `should_demote_symbolication` function which checks for automatic LPQ selection uses the `is_lpq_project` as a free function from the module. But, `is_lpq_project` was never listed in `__all__`, and thus never exposed as a free function. There has been a try/except around that code since basically forever that silenced the resulting error, so noone ever noticed this.

The `is_lpq_project` was added back in https://github.com/getsentry/sentry/pull/28950, though it was never exposed in `__all__`.
https://github.com/getsentry/sentry/pull/30030 then added the try/except silencing this oversight forever since.