### PR TITLE
fix(n1-api-calls): Exclude Next.js stack traces from detection

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -171,7 +171,15 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if "_next/data" in description:
             return False
 
+        if "__nextjs_original-stack-frame" in description:
+            return False
+
         url = get_url_from_span(span)
+
+        # Next.js error pages cause an N+1 API Call that isn't useful to anyone
+        if "__nextjs_original-stack-frame" in url:
+            return False
+
         if not url:
             return False
 

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -171,9 +171,6 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if "_next/data" in description:
             return False
 
-        if "__nextjs_original-stack-frame" in description:
-            return False
-
         url = get_url_from_span(span)
 
         # Next.js error pages cause an N+1 API Call that isn't useful to anyone

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -352,6 +352,12 @@ def test_allows_eligible_spans(span):
             "hash": "b",
             "description": "GET /_next/data/LjdprRSkUtLP0bMUoWLur/items.json?collection=hello",
         },
+        {
+            "span_id": "a",
+            "op": "http.client",
+            "hash": "b",
+            "description": "GET /__nextjs_original-stack-frame?isServerSide=false&file=webpack-internal%3A%2F%2F%2F.%2Fnode_modules%2Freact-dom%2Fcjs%2Freact-dom.development.js&methodName=Object.invokeGuardedCallbackDev&arguments=&lineNumber=73&column=3`",
+        },
     ],
 )
 def test_rejects_ineligible_spans(span):


### PR DESCRIPTION
These spans are of no use to anyone, we should ignore them. They come from Next.js error pages, as far as I can tell.

Closes PERF-1958.
