### PR TITLE
feat(analytics): Add group_id to more events on the issue details page

### DIFF
--- a/static/app/components/events/eventCause.tsx
+++ b/static/app/components/events/eventCause.tsx
@@ -9,8 +9,9 @@ import {Panel} from 'sentry/components/panels';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {AvatarProject, Commit, Group, IssueCategory, IssueType} from 'sentry/types';
+import {AvatarProject, Commit, Group} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useCommitters from 'sentry/utils/useCommitters';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -57,9 +58,7 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
     trackAdvancedAnalyticsEvent('issue_details.suspect_commits.pull_request_clicked', {
       organization,
       project_id: parseInt(project.id as string, 10),
-      group_id: parseInt(group?.id as string, 10),
-      issue_category: group?.issueCategory ?? IssueCategory.ERROR,
-      issue_type: group?.issueType ?? IssueType.ERROR,
+      ...getAnalyticsDataForGroup(group),
     });
   };
 
@@ -67,10 +66,8 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
     trackAdvancedAnalyticsEvent('issue_details.suspect_commits.commit_clicked', {
       organization,
       project_id: parseInt(project.id as string, 10),
-      group_id: parseInt(group?.id as string, 10),
-      issue_category: group?.issueCategory ?? IssueCategory.ERROR,
-      issue_type: group?.issueType ?? IssueType.ERROR,
       has_pull_request: commit.pullRequest?.id !== undefined,
+      ...getAnalyticsDataForGroup(group),
     });
   };
 

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -29,7 +29,7 @@ import {
 } from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {StacktraceLinkEvents} from 'sentry/utils/analytics/integrations/stacktraceLinkAnalyticsEvents';
-import {getAnalyicsDataForEvent} from 'sentry/utils/events';
+import {getAnalyticsDataForEvent} from 'sentry/utils/events';
 import {
   getIntegrationIcon,
   trackIntegrationAnalytics,
@@ -93,7 +93,7 @@ function StacktraceLinkSetup({organization, project, event}: StacktraceLinkSetup
     trackIntegrationAnalytics(StacktraceLinkEvents.DISMISS_CTA, {
       view: 'stacktrace_issue_details',
       organization,
-      ...getAnalyicsDataForEvent(event),
+      ...getAnalyticsDataForEvent(event),
     });
   };
 
@@ -196,7 +196,8 @@ function CodecovLink({
       trackIntegrationAnalytics(StacktraceLinkEvents.CODECOV_LINK_CLICKED, {
         view: 'stacktrace_issue_details',
         organization,
-        ...getAnalyicsDataForEvent(event),
+        group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
+        ...getAnalyticsDataForEvent(event),
       });
     };
 
@@ -288,7 +289,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
           : !isPromptDismissed
           ? 'prompt'
           : 'empty',
-      ...getAnalyicsDataForEvent(event),
+      ...getAnalyticsDataForEvent(event),
     });
     // excluding isPromptDismissed because we want this only to record once
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -303,7 +304,8 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
           view: 'stacktrace_issue_details',
           provider: provider.key,
           organization,
-          ...getAnalyicsDataForEvent(event),
+          group_id: event.groupID ? parseInt(event.groupID, 10) : -1,
+          ...getAnalyticsDataForEvent(event),
         },
         {startSession: true}
       );
@@ -389,7 +391,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
                 view: 'stacktrace_issue_details',
                 platform: event.platform,
                 organization,
-                ...getAnalyicsDataForEvent(event),
+                ...getAnalyticsDataForEvent(event),
               },
               {startSession: true}
             );

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -26,13 +26,13 @@ import {
   CurrentRelease,
   Environment,
   Group,
-  IssueType,
   Organization,
   Project,
 } from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {userDisplayName} from 'sentry/utils/formatters';
 import {isMobilePlatform} from 'sentry/utils/platform';
 import withApi from 'sentry/utils/withApi';
@@ -76,14 +76,12 @@ class BaseGroupSidebar extends Component<Props, State> {
     trackAdvancedAnalyticsEvent('issue_details.action_clicked', {
       organization,
       project_id: parseInt(project.id, 10),
-      group_id: parseInt(group.id, 10),
-      issue_category: group.issueCategory,
-      issue_type: group.issueType ?? IssueType.ERROR,
       action_type: 'assign',
       alert_date:
         typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,
       alert_rule_id: typeof alert_rule_id === 'string' ? alert_rule_id : undefined,
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
+      ...getAnalyticsDataForGroup(group),
     });
   };
 

--- a/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -9,8 +9,9 @@ import * as SidebarSection from 'sentry/components/sidebarSection';
 import {IconCheckmark} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Actor, Commit, Group, IssueType, Organization, Release} from 'sentry/types';
+import {Actor, Commit, Group, Organization, Release} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 
 type Owner = {
   actor: Actor;
@@ -43,14 +44,12 @@ const SuggestedAssignees = ({
       trackAdvancedAnalyticsEvent('issue_details.action_clicked', {
         organization,
         project_id: parseInt(projectId!, 10),
-        group_id: parseInt(group.id, 10),
-        issue_category: group.issueCategory,
-        issue_type: group.issueType ?? IssueType.ERROR,
         action_type: 'assign',
         assigned_suggestion_reason: owner.source,
+        ...getAnalyticsDataForGroup(group),
       });
     },
-    [onAssign, group.id, group.issueCategory, group.issueType, projectId, organization]
+    [onAssign, organization, projectId, group]
   );
 
   if (loading) {

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -1,4 +1,5 @@
-import type {IssueCategory, IssueType, ResolutionStatus} from 'sentry/types';
+import type {ResolutionStatus} from 'sentry/types';
+import {CommonGroupAnalyticsData} from 'sentry/utils/events';
 import {Tab} from 'sentry/views/issueDetails/types';
 
 type RuleViewed = {
@@ -6,10 +7,7 @@ type RuleViewed = {
   project_id: string;
 };
 
-type IssueDetailsWithAlert = {
-  group_id: number;
-  issue_category: IssueCategory;
-  issue_type: IssueType;
+interface IssueDetailsWithAlert extends CommonGroupAnalyticsData {
   project_id: number;
   /** The time that the alert was initially fired. */
   alert_date?: string;
@@ -17,10 +15,11 @@ type IssueDetailsWithAlert = {
   alert_rule_id?: string;
   /**  The type of alert notification - email/slack */
   alert_type?: string;
-};
+}
 
 export type BaseEventAnalyticsParams = {
   event_id: string;
+  group_id: number;
   has_commit: boolean;
   has_release: boolean;
   has_source_maps: boolean;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -284,7 +284,7 @@ function getAssignmentIntegration(group: Group) {
   return integrationAssignments?.data.integration || '';
 }
 
-export function getAnalyicsDataForEvent(event?: Event) {
+export function getAnalyticsDataForEvent(event?: Event) {
   return {
     event_id: event?.eventID || '-1',
     num_commits: event?.release?.commitCount || 0,
@@ -306,7 +306,24 @@ export function getAnalyicsDataForEvent(event?: Event) {
   };
 }
 
-export function getAnalyicsDataForGroup(group: Group | null) {
+export type CommonGroupAnalyticsData = {
+  error_count: number;
+  group_has_replay: boolean;
+  group_id: number;
+  has_external_issue: boolean;
+  has_owner: boolean;
+  integration_assignment_source: string;
+  issue_age: number;
+  issue_category: IssueCategory;
+  issue_id: number;
+  issue_type: IssueType;
+  num_comments: number;
+  is_assigned?: boolean;
+  issue_level?: string;
+  issue_status?: string;
+};
+
+export function getAnalyticsDataForGroup(group?: Group | null): CommonGroupAnalyticsData {
   const groupId = group ? parseInt(group.id, 10) : -1;
   return {
     group_id: groupId,

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -34,7 +34,6 @@ import space from 'sentry/styles/space';
 import {
   Group,
   GroupStatusResolution,
-  IssueType,
   Organization,
   Project,
   ResolutionStatus,
@@ -46,6 +45,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import {getUtcDateString} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
 import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
+import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {getIssueCapability} from 'sentry/utils/groupCapabilities';
 import {uniqueId} from 'sentry/utils/guid';
 import withApi from 'sentry/utils/withApi';
@@ -113,15 +113,13 @@ class Actions extends Component<Props> {
     trackAdvancedAnalyticsEvent('issue_details.action_clicked', {
       organization,
       project_id: parseInt(project.id, 10),
-      group_id: parseInt(group.id, 10),
-      issue_category: group.issueCategory,
-      issue_type: group.issueType ?? IssueType.ERROR,
       action_type: action,
       // Alert properties track if the user came from email/slack alerts
       alert_date:
         typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,
       alert_rule_id: typeof alert_rule_id === 'string' ? alert_rule_id : undefined,
       alert_type: typeof alert_type === 'string' ? alert_type : undefined,
+      ...getAnalyticsDataForGroup(group),
     });
   }
 

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -17,20 +17,13 @@ import {t} from 'sentry/locale';
 import SentryTypes from 'sentry/sentryTypes';
 import GroupStore from 'sentry/stores/groupStore';
 import space from 'sentry/styles/space';
-import {
-  AvatarProject,
-  Group,
-  IssueCategory,
-  IssueType,
-  Organization,
-  Project,
-} from 'sentry/types';
+import {AvatarProject, Group, IssueCategory, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {
-  getAnalyicsDataForEvent,
-  getAnalyicsDataForGroup,
+  getAnalyticsDataForEvent,
+  getAnalyticsDataForGroup,
   getMessage,
   getTitle,
 } from 'sentry/utils/events';
@@ -160,8 +153,8 @@ class GroupDetails extends Component<Props, State> {
 
     this.props.setEventNames('issue_details.viewed', 'Issue Details: Viewed');
     this.props.setRouteAnalyticsParams({
-      ...getAnalyicsDataForGroup(group),
-      ...getAnalyicsDataForEvent(event),
+      ...getAnalyticsDataForGroup(group),
+      ...getAnalyticsDataForEvent(event),
       ...getAnalyicsDataForProject(project),
       // Alert properties track if the user came from email/slack alerts
       alert_date:
@@ -530,11 +523,9 @@ class GroupDetails extends Component<Props, State> {
 
     trackAdvancedAnalyticsEvent('issue_details.tab_changed', {
       organization,
-      group_id: parseInt(group.id, 10),
-      issue_category: group.issueCategory,
-      issue_type: group.issueType ?? IssueType.ERROR,
       project_id: parseInt(project.id, 10),
       tab,
+      ...getAnalyticsDataForGroup(group),
     });
 
     if (group.issueCategory !== IssueCategory.ERROR) {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/44074

- Fix typo `getAnalyicsDataForEvent` -> `getAnalyticsDataForGroup`
- Use the above function to add extra group data to the action clicked event, suspect commit click events, and tab click events
- Add just `group_id` to stacktrace link and codecov click events (There was no access to the full group object here. We could add some sort of GroupContext if we want these deeply nested event components to send group data but I'll leave that for another time).