### PR TITLE
chore(issues) Add more context to missing project error

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -434,7 +434,12 @@ class GroupDetails extends Component<Props, State> {
       const project = this.props.projects.find(p => p.id === data.project.id);
 
       if (!project) {
-        Sentry.withScope(() => {
+        Sentry.withScope(scope => {
+          const projectIds = this.props.projects.map(item => item.id);
+          scope.setContext('missingProject', {
+            projectId: data.project.id,
+            availableProjects: projectIds,
+          });
           Sentry.captureException(new Error('Project not found'));
         });
       } else {


### PR DESCRIPTION
We're getting a good amount of volume on JAVASCRIPT-2CBB and from the spot checking I did this occurs when an issue is visited *after* the project has been deleted. I want to collect more context about this missing project error to verify if that is the situation in more accounts.