### PR TITLE
feat(roles): allow unsetting team org role

### DIFF
--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -16,7 +16,10 @@ from sentry.models import ScheduledDeletion, Team, TeamStatus
 
 class TeamSerializer(CamelSnakeModelSerializer):
     slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50)
-    org_role = serializers.ChoiceField(choices=roles.get_choices(), default=None)
+    org_role = serializers.ChoiceField(
+        choices=tuple(list(roles.get_choices()) + [("", None)]),
+        default="",
+    )
 
     class Meta:
         model = Team
@@ -80,7 +83,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
                                owners can set this value.
         :auth: required
         """
-        if request.data.get("orgRole"):
+        if team.org_role != request.data.get("orgRole"):
             if team.idp_provisioned:
                 return Response(
                     {

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -157,6 +157,26 @@ class TeamUpdateTest(TeamDetailsTestBase):
         team = Team.objects.get(id=team.id)
         assert not team.org_role
 
+    def test_put_team_org_role__remove_success(self):
+        team = self.create_team(org_role="owner")
+        user = self.create_user("foo@example.com")
+        self.create_member(user=user, organization=self.organization, role="owner")
+        self.login_as(user)
+        self.get_success_response(team.organization.slug, team.slug, orgRole="")
+
+        team = Team.objects.get(id=team.id)
+        assert not team.org_role
+
+    def test_put_team_org_role__remove_error(self):
+        team = self.create_team(org_role="owner")
+        user = self.create_user("foo@example.com")
+        self.create_member(user=user, organization=self.organization, role="admin")
+        self.login_as(user)
+        self.get_error_response(team.organization.slug, team.slug, orgRole="", status_code=403)
+
+        team = Team.objects.get(id=team.id)
+        assert team.org_role == "owner"
+
 
 @region_silo_test
 class TeamDeleteTest(TeamDetailsTestBase):


### PR DESCRIPTION
Missed this in #43886

The top dawg should be the only one allowed to unset an existing org role for a team.

For ER-1353