### PR TITLE
fix(tags): removes the arrow marker from details and summary element

### DIFF
--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -233,12 +233,12 @@ function TagFacetsDistributionMeter({
   return (
     <TagSummary>
       <details open={expanded} onClick={e => e.preventDefault()}>
-        <summary>
+        <StyledSummary>
           <TagHeader clickable onClick={() => setExpanded(!expanded)}>
             {renderTitle()}
             {renderSegments()}
           </TagHeader>
-        </summary>
+        </StyledSummary>
         {renderLegend()}
       </details>
     </TagSummary>
@@ -373,4 +373,10 @@ const ExpandToggleButton = styled(Button)`
 
 const NotApplicableLabel = styled('span')`
   color: ${p => p.theme.gray300};
+`;
+
+const StyledSummary = styled('summary')`
+  &::-webkit-details-marker {
+    display: none;
+  }
 `;


### PR DESCRIPTION
Removes the arrow marker from details and summary element that appears on some browsers (safari)
![image](https://user-images.githubusercontent.com/83961295/216676917-c4483c60-efd8-4c2c-9b8c-7aa894f28479.png)