### PR TITLE
feat(perf): Add linear regression in discover

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1440,7 +1440,7 @@ class QueryBuilder(BaseQueryBuilder):
         )
 
     @classmethod
-    def handle_invalid_float(cls, value: float) -> float:
+    def handle_invalid_float(cls, value: float) -> Optional[float]:
         if math.isnan(value):
             return 0
         elif math.isinf(value):
@@ -1498,7 +1498,7 @@ class QueryBuilder(BaseQueryBuilder):
                             value = None
                         value = self.handle_invalid_float(value)
                     if isinstance(value, list):
-                        for index, item in enumerate(value):
+                        for index, item in enumerate(value:
                             if isinstance(item, float):
                                 value[index] = self.handle_invalid_float(item)
                     if key in self.value_resolver_map:

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1439,6 +1439,14 @@ class QueryBuilder(BaseQueryBuilder):
             flags=Flags(turbo=self.turbo),
         )
 
+    @classmethod
+    def handle_invalid_float(cls, value: float) -> float:
+        if math.isnan(value):
+            return 0
+        elif math.isinf(value):
+            return None
+        return value
+
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
         return raw_snql_query(self.get_snql_query(), referrer, use_cache)
 
@@ -1488,6 +1496,11 @@ class QueryBuilder(BaseQueryBuilder):
                             value = 0
                         elif math.isinf(value):
                             value = None
+                        value = self.handle_invalid_float(value)
+                    if isinstance(value, list):
+                        for index, item in enumerate(value):
+                            if isinstance(item, float):
+                                value[index] = self.handle_invalid_float(item)
                     if key in self.value_resolver_map:
                         new_value = self.value_resolver_map[key](value)
                     else:

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1498,7 +1498,7 @@ class QueryBuilder(BaseQueryBuilder):
                             value = None
                         value = self.handle_invalid_float(value)
                     if isinstance(value, list):
-                        for index, item in enumerate(value:
+                        for index, item in enumerate(value):
                             if isinstance(item, float):
                                 value[index] = self.handle_invalid_float(item)
                     if key in self.value_resolver_map:

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -586,6 +586,15 @@ class DiscoverDatasetConfig(DatasetConfig):
                     redundant_grouping=True,
                 ),
                 SnQLFunction(
+                    "linear_regression",
+                    required_args=[NumericColumn("column1"), NumericColumn("column2")],
+                    snql_aggregate=lambda args, alias: Function(
+                        "simpleLinearRegression", [args["column1"], args["column2"]], alias
+                    ),
+                    default_result_type="number",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
                     "sum",
                     required_args=[NumericColumn("column")],
                     snql_aggregate=lambda args, alias: Function("sum", [args["column"]], alias),

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -3494,6 +3494,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
                 "var(transaction.duration)",
                 "cov(transaction.duration, transaction.duration)",
                 "corr(transaction.duration, transaction.duration)",
+                "linear_regression(transaction.duration, transaction.duration)",
                 "sum(transaction.duration)",
             ],
             "query": "event.type:transaction",
@@ -3512,6 +3513,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
         assert data[0]["var(transaction.duration)"] == 0.0
         assert data[0]["cov(transaction.duration, transaction.duration)"] == 0.0
         assert data[0]["corr(transaction.duration, transaction.duration)"] == 0.0
+        assert data[0]["linear_regression(transaction.duration, transaction.duration)"] == [0, 0]
         assert data[0]["sum(transaction.duration)"] == 10000
 
     @requires_not_arm64


### PR DESCRIPTION
### Summary
This makes an unpublished field for linear regression so we can try out the list data (y = mx + b) for (m, b) for the time being and then make it a published field if it has utility and its performance isn't horrible.
