### PR TITLE
feat: Always use the streaming version of the post process forwarder

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -394,7 +394,7 @@ def post_process_forwarder(**options):
             concurrency=options["concurrency"],
             initial_offset_reset=options["initial_offset_reset"],
             strict_offset_reset=options["strict_offset_reset"],
-            use_streaming_consumer=bool(options["use_streaming_consumer"]),
+            use_streaming_consumer=True,
         )
     except ForwarderNotRequired:
         sys.stdout.write(


### PR DESCRIPTION
The streaming consumer has been successfully rolled out in prod, this change switches to using the streaming (Arroyo based) post process forwarder everywhere.

The --use-streaming-consumer flag will be removed as a follow up once no one is passing that option anymore.
