### PR TITLE
feat(profiling): add analytic events to profiling links

### DIFF
--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -5,6 +5,7 @@ import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {Event, ProfileContext, ProfileContextKey} from 'sentry/types/event';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -86,7 +87,16 @@ function getProfileKnownDataDetails({
         subject: t('Profile ID'),
         value: data.profile_id,
         actionButton: target && (
-          <Button size="xs" to={target}>
+          <Button
+            size="xs"
+            to={target}
+            onClick={() =>
+              trackAdvancedAnalyticsEvent('profiling_views.go_to_flamegraph', {
+                organization,
+                source: 'events.profile_event_context',
+              })
+            }
+          >
             {t('Go to Profile')}
           </Button>
         ),

--- a/static/app/components/profiling/arrayLinks.tsx
+++ b/static/app/components/profiling/arrayLinks.tsx
@@ -9,6 +9,7 @@ import space from 'sentry/styles/space';
 type Item = {
   target: LocationDescriptor;
   value: string;
+  onClick?: () => void;
 };
 
 interface ArrayLinksProps {
@@ -41,7 +42,9 @@ function ArrayLinks({items}: ArrayLinksProps) {
 function LinkedItem({item}: {item: Item}) {
   return (
     <ArrayItem>
-      <Link to={item.target}>{item.value}</Link>
+      <Link to={item.target} onClick={item?.onClick}>
+        {item.value}
+      </Link>
     </ArrayItem>
   );
 }

--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -11,6 +11,7 @@ import {ArrayLinks} from 'sentry/components/profiling/arrayLinks';
 import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import {SuspectFunction} from 'sentry/types/profiling/core';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getShortEventId} from 'sentry/utils/events';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
@@ -62,6 +63,11 @@ function FunctionsTable(props: FunctionsTableProps) {
           const profileId = example.replaceAll('-', '');
           return {
             value: getShortEventId(profileId),
+            onClick: () =>
+              trackAdvancedAnalyticsEvent('profiling_views.go_to_flamegraph', {
+                organization,
+                source: 'profiling_transaction.suspect_functions_table',
+              }),
             target: generateProfileFlamechartRouteWithQuery({
               orgSlug: organization.slug,
               projectSlug: props.project.slug,
@@ -77,7 +83,7 @@ function FunctionsTable(props: FunctionsTableProps) {
         }),
       };
     });
-  }, [organization.slug, props.project.slug, props.functions]);
+  }, [organization, props.project.slug, props.functions]);
 
   const generateSortLink = useCallback(
     (column: TableColumnKey) => {

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -6,7 +6,10 @@ type ProfilingEventSource =
   | 'transaction_hovercard.trigger'
   | 'transaction_hovercard.latest_profile'
   | 'transaction_hovercard.slowest_profile'
-  | 'transaction_hovercard.suspect_function';
+  | 'transaction_hovercard.suspect_function'
+  | 'events.profile_event_context'
+  | 'profiling_transaction.suspect_functions_table'
+  | 'discover.table';
 
 interface EventPayloadWithProjectDetails {
   project_id: string | number | undefined;

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -19,6 +19,7 @@ import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView, {
@@ -360,7 +361,16 @@ function TableView(props: TableViewProps) {
 
         cell = (
           <StyledTooltip title={t('View Profile')}>
-            <StyledLink data-test-id="view-profile" to={target}>
+            <StyledLink
+              data-test-id="view-profile"
+              to={target}
+              onClick={() =>
+                trackAdvancedAnalyticsEvent('profiling_views.go_to_flamegraph', {
+                  organization,
+                  source: 'discover.table',
+                })
+              }
+            >
               {cell}
             </StyledLink>
           </StyledTooltip>


### PR DESCRIPTION
## Summary
This PR adds `trackAdvancedAnalyticEvent` calls to links linking into profiling to better track users. We plan to use these events to gauge the effectiveness of new UI/X.