### PR TITLE
fix(derived_code_mappings): Do not abort if a repo fails to process

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -236,9 +236,11 @@ class GitHubClientMixin(ApiClient):  # type: ignore
                 )
             except ApiError as error:
                 process_error(error, extra)
-            except Exception as error:
+            except Exception:
                 # Report for investigatagiation but do not stop processing
-                logger.exception(error, extra=extra)
+                logger.exception(
+                    "Failed to populate_tree. Investigate. Contining execution.", extra=extra
+                )
 
             remaining_requests -= 1
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -191,7 +191,7 @@ class GitHubClientMixin(ApiClient):  # type: ignore
         """
 
         def process_error(error: ApiError, extra: Dict[str, str]) -> None:
-            msg = "Continuing exectuion."
+            msg = "Continuing execution."
             txt = error.text
             if error.json:
                 json_data: JSONData = error.json
@@ -237,7 +237,7 @@ class GitHubClientMixin(ApiClient):  # type: ignore
             except ApiError as error:
                 process_error(error, extra)
             except Exception:
-                # Report for investigatagiation but do not stop processing
+                # Report for investigation but do not stop processing
                 logger.exception(
                     "Failed to populate_tree. Investigate. Contining execution.", extra=extra
                 )

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -609,16 +609,15 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_get_trees_for_org_works(self):
         """Fetch the tree representation of a repo"""
         installation = self.get_installation_helper()
+        cache.clear()
         self.set_rate_limit(MINIMUM_REQUESTS + 50)
         expected_trees = {
-            "Test-Organization/xyz": RepoTree(
-                Repo("Test-Organization/xyz", "master"), ["src/foo.py"]
-            ),
             "Test-Organization/foo": RepoTree(
                 Repo("Test-Organization/foo", "master"), ["src/sentry/api/endpoints/auth_login.py"]
             ),
-            "Test-Organization/bar": RepoTree(Repo("Test-Organization/bar", "main"), []),
-            "Test-Organization/baz": RepoTree(Repo("Test-Organization/baz", "master"), []),
+            "Test-Organization/xyz": RepoTree(
+                Repo("Test-Organization/xyz", "master"), ["src/foo.py"]
+            ),
         }
 
         repos_key = "githubtrees:repositories:Test-Organization"
@@ -645,6 +644,8 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_get_trees_for_org_prevent_exhaustion_some_repos(self):
         """Some repos will hit the network but the rest will grab from the cache."""
         gh_org = "Test-Organization"
+        repos_key = "githubtrees:repositories:Test-Organization"
+        cache.clear()
         installation = self.get_installation_helper()
         expected_trees = {
             f"{gh_org}/xyz": RepoTree(Repo(f"{gh_org}/xyz", "master"), ["src/foo.py"]),
@@ -656,8 +657,15 @@ class GitHubIntegrationTest(IntegrationTestCase):
         with patch("sentry.integrations.github.client.MINIMUM_REQUESTS", new=5, autospec=False):
             # We start with one request left before reaching the minimum remaining requests floor
             self.set_rate_limit(remaining=6)
+            assert cache.get(repos_key) is None
             trees = installation.get_trees_for_org()
             assert trees == expected_trees  # xyz will have files but not foo
+            assert cache.get(repos_key) == [
+                {"full_name": "Test-Organization/xyz", "default_branch": "master"},
+                {"full_name": "Test-Organization/foo", "default_branch": "master"},
+                {"full_name": "Test-Organization/bar", "default_branch": "main"},
+                {"full_name": "Test-Organization/baz", "default_branch": "master"},
+            ]
 
             # Another call should not make us loose the files for xyz
             self.set_rate_limit(remaining=5)
@@ -667,8 +675,10 @@ class GitHubIntegrationTest(IntegrationTestCase):
             # We reset the remaining values
             self.set_rate_limit(remaining=20)
             trees = installation.get_trees_for_org()
-            # Now that the rate limit is reset we should get files for foo
-            expected_trees[f"{gh_org}/foo"] = RepoTree(
-                Repo(f"{gh_org}/foo", "master"), ["src/sentry/api/endpoints/auth_login.py"]
-            )
-            assert trees == expected_trees
+            assert trees == {
+                f"{gh_org}/xyz": RepoTree(Repo(f"{gh_org}/xyz", "master"), ["src/foo.py"]),
+                # Now that the rate limit is reset we should get files for foo
+                f"{gh_org}/foo": RepoTree(
+                    Repo(f"{gh_org}/foo", "master"), ["src/sentry/api/endpoints/auth_login.py"]
+                ),
+            }

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -611,15 +611,14 @@ class GitHubIntegrationTest(IntegrationTestCase):
         installation = self.get_installation_helper()
         self.set_rate_limit(MINIMUM_REQUESTS + 50)
         expected_trees = {
-            "Test-Organization/bar": RepoTree(Repo("Test-Organization/bar", "main"), []),
-            "Test-Organization/baz": RepoTree(Repo("Test-Organization/baz", "master"), []),
-            "Test-Organization/foo": RepoTree(
-                Repo("Test-Organization/foo", "master"),
-                ["src/sentry/api/endpoints/auth_login.py"],
-            ),
             "Test-Organization/xyz": RepoTree(
                 Repo("Test-Organization/xyz", "master"), ["src/foo.py"]
             ),
+            "Test-Organization/foo": RepoTree(
+                Repo("Test-Organization/foo", "master"), ["src/sentry/api/endpoints/auth_login.py"]
+            ),
+            "Test-Organization/bar": RepoTree(Repo("Test-Organization/bar", "main"), []),
+            "Test-Organization/baz": RepoTree(Repo("Test-Organization/baz", "master"), []),
         }
 
         repos_key = "githubtrees:repositories:Test-Organization"


### PR DESCRIPTION
This fixes an issue where we would give up processing as soon as any Github API error would be returned (to the exception of some defined cases).

This also moves handling of errors to the caller in order to have a centralized processing.

This needs to land after #44110.

It seems that [we raise unidentified API errors](https://github.com/getsentry/sentry/blob/d0252f70b97ceef909c86128566716255fab7eab/src/sentry/integrations/github/client.py#L124-L126) in get_tree. [get_cached_repo_files does not catch it](https://github.com/getsentry/sentry/blob/d0252f70b97ceef909c86128566716255fab7eab/src/sentry/integrations/github/client.py#L130-L161). [The iteration of the repositories happens within the try/block](https://github.com/getsentry/sentry/blob/d0252f70b97ceef909c86128566716255fab7eab/src/sentry/integrations/github/client.py#L170-L176), thus, failing to work as soon as one repo fails to process.