### PR TITLE
feat(n1-api-calls): Omit unparameterized spans from detection

### DIFF
--- a/fixtures/events/performance_problems/n-plus-one-api-calls/n-plus-one-api-calls-in-weather-app.json
+++ b/fixtures/events/performance_problems/n-plus-one-api-calls/n-plus-one-api-calls-in-weather-app.json
@@ -62,127 +62,181 @@
       "timestamp": 1668545349.728,
       "start_timestamp": 1668545349.596,
       "exclusive_time": 131.999969,
-      "description": "GET /1001/weather.json",
+      "description": "GET /country/canada/weather?city_id=1001",
       "op": "http.client",
       "span_id": "a96cd1a09beaf517",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1001/weather.json"},
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1001"
+      },
       "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.732,
       "start_timestamp": 1668545349.597,
       "exclusive_time": 135.000229,
-      "description": "GET /1002/weather.json",
+      "description": "GET /country/canada/weather?city_id=1002",
       "op": "http.client",
       "span_id": "92d4d11d67bd7b11",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1002/weather.json"},
-      "hash": "d8fee0ab2e868c86"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1002"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.732,
       "start_timestamp": 1668545349.597,
       "exclusive_time": 135.000229,
-      "description": "GET /1003/weather.json",
+      "description": "GET /country/canada/weather?city_id=1003",
       "op": "http.client",
       "span_id": "87860b9710086321",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1003/weather.json"},
-      "hash": "c5e299c2ac92635c"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1003"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.748,
       "start_timestamp": 1668545349.598,
       "exclusive_time": 149.999857,
-      "description": "GET /1004/weather.json",
+      "description": "GET /country/canada/weather?city_id=1004",
       "op": "http.client",
       "span_id": "bd1bdd517a14e373",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1004/weather.json"},
-      "hash": "02005e7f3d43645e"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1004"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.742,
       "start_timestamp": 1668545349.598,
       "exclusive_time": 144.000053,
-      "description": "GET /1005/weather.json",
+      "description": "GET /country/canada/weather?city_id=1005",
       "op": "http.client",
       "span_id": "b49820cc40d4b3f3",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1005/weather.json"},
-      "hash": "7f0d40c5e1a6008a"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1005"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.748,
       "start_timestamp": 1668545349.599,
       "exclusive_time": 148.999929,
-      "description": "GET /1006/weather.json",
+      "description": "GET /country/canada/weather?city_id=1006",
       "op": "http.client",
       "span_id": "bcf1978a5c3d5e85",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1006/weather.json"},
-      "hash": "9940a1669b7b340d"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1006"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.819,
       "start_timestamp": 1668545349.599,
       "exclusive_time": 220.000028,
-      "description": "GET /1007/weather.json",
+      "description": "GET /country/canada/weather?city_id=1007",
       "op": "http.client",
       "span_id": "9ae3037832ae9087",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1007/weather.json"},
-      "hash": "dbdd01c7a2317d09"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1007"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.748,
       "start_timestamp": 1668545349.599,
       "exclusive_time": 148.999929,
-      "description": "GET /1008/weather.json",
+      "description": "GET /country/canada/weather?city_id=1008",
       "op": "http.client",
       "span_id": "b318d62b647b48eb",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1008/weather.json"},
-      "hash": "78f8c7e5d77b6884"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1008"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545349.766,
       "start_timestamp": 1668545349.599,
       "exclusive_time": 167.000055,
-      "description": "GET /1009/weather.json",
+      "description": "GET /country/canada/weather?city_id=1009",
       "op": "http.client",
       "span_id": "8fe40e9ce9a29d8d",
       "parent_span_id": "829b196a0d42cb39",
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/1009/weather.json"},
-      "hash": "3e228a5dc2af00ba"
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1009"
+      },
+      "hash": "19024ee371da3e81"
+    },
+    {
+      "timestamp": 1668545349.601,
+      "start_timestamp": 1668545349.601,
+      "exclusive_time": 158.000055,
+      "description": "GET /country/canada/weather?city_id=1010",
+      "op": "http.client",
+      "span_id": "40e9ce9a29d8d8fe",
+      "parent_span_id": "829b196a0d42cb39",
+      "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
+      "status": "ok",
+      "tags": {"http.status_code": "200"},
+      "data": {
+        "method": "GET",
+        "type": "fetch",
+        "url": "/country/canada/weather?city_id=1010"
+      },
+      "hash": "19024ee371da3e81"
     },
     {
       "timestamp": 1668545348.856,

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -217,7 +217,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         )
 
     def _fingerprint(self) -> str:
-        parameterized_first_url = self.parameterize_url(get_url_from_span(self.spans[0]))
+        first_url = get_url_from_span(self.spans[0])
+        parameterized_first_url = self.parameterize_url(first_url)
+
         parsed_first_url = urlparse(parameterized_first_url)
         path = parsed_first_url.path
 

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -240,3 +240,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             span_a["hash"] == span_b["hash"]
             and span_a["parent_span_id"] == span_b["parent_span_id"]
         )
+
+
+def without_query_params(url: str) -> str:
+    return urlparse(url)._replace(query="").geturl()

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -14,6 +14,9 @@ from sentry.testutils.performance_issues.event_generators import (
 from sentry.testutils.silo import region_silo_test
 from sentry.types.issues import GroupType
 from sentry.utils.performance_issues.detectors import NPlusOneAPICallsDetector
+from sentry.utils.performance_issues.detectors.n_plus_one_api_calls_detector import (
+    without_query_params,
+)
 from sentry.utils.performance_issues.performance_detection import (
     DetectorType,
     PerformanceProblem,
@@ -366,6 +369,20 @@ def test_allows_eligible_spans(span):
 )
 def test_rejects_ineligible_spans(span):
     assert not NPlusOneAPICallsDetector.is_span_eligible(span)
+
+
+@pytest.mark.parametrize(
+    "url,url_without_query",
+    [
+        ("", ""),
+        ("http://service.io", "http://service.io"),
+        ("http://service.io/resource", "http://service.io/resource"),
+        ("/resource?id=1", "/resource"),
+        ("/resource?id=1&sort=down", "/resource"),
+    ],
+)
+def test_removes_query_params(url, url_without_query):
+    assert without_query_params(url) == url_without_query
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -101,6 +101,10 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         ]
         assert problems[0].title == "N+1 API Call"
 
+    def test_does_not_detect_problem_with_unparameterized_urls(self):
+        event = get_event("n-plus-one-api-calls/n-plus-one-api-calls-in-weather-app")
+        assert self.find_problems(event) == []
+
     def test_does_not_detect_problem_with_concurrent_calls_to_different_urls(self):
         event = get_event("n-plus-one-api-calls/not-n-plus-one-api-calls")
         assert self.find_problems(event) == []

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -145,25 +145,25 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         assert not detector.is_creation_allowed_for_project(project)
 
     def test_fingerprints_events(self):
-        event = self.create_event(lambda i: "GET /clients/info")
+        event = self.create_event(lambda i: "GET /clients/11/info")
         [problem] = self.find_problems(event)
 
-        assert problem.fingerprint == "1-1010-3378cb14bc594ab8c1c32beca224f9c4d0b830aa"
+        assert problem.fingerprint == "1-1010-e9daac10ea509a0bf84a8b8da45d36394868ad67"
 
     def test_fingerprints_identical_relative_urls_together(self):
-        event1 = self.create_event(lambda i: "GET /clients/info")
+        event1 = self.create_event(lambda i: "GET /clients/11/info")
         [problem1] = self.find_problems(event1)
 
-        event2 = self.create_event(lambda i: "GET /clients/info")
+        event2 = self.create_event(lambda i: "GET /clients/11/info")
         [problem2] = self.find_problems(event2)
 
         assert problem1.fingerprint == problem2.fingerprint
 
     def test_fingerprints_same_relative_urls_together(self):
-        event1 = self.create_event(lambda i: f"GET /clients/info?id={i}")
+        event1 = self.create_event(lambda i: f"GET /clients/42/info?id={i}")
         [problem1] = self.find_problems(event1)
 
-        event2 = self.create_event(lambda i: f"GET /clients/info?id={i*2}")
+        event2 = self.create_event(lambda i: f"GET /clients/42/info?id={i*2}")
         [problem2] = self.find_problems(event2)
 
         assert problem1.fingerprint == problem2.fingerprint
@@ -178,19 +178,19 @@ class NPlusOneAPICallsDetectorTest(TestCase):
         assert problem1.fingerprint == problem2.fingerprint
 
     def test_fingerprints_different_relative_url_separately(self):
-        event1 = self.create_event(lambda i: f"GET /clients/info?id={i}")
+        event1 = self.create_event(lambda i: f"GET /clients/11/info?id={i}")
         [problem1] = self.find_problems(event1)
 
-        event2 = self.create_event(lambda i: f"GET /projects/details?pid={i}")
+        event2 = self.create_event(lambda i: f"GET /projects/11/details?pid={i}")
         [problem2] = self.find_problems(event2)
 
         assert problem1.fingerprint != problem2.fingerprint
 
     def test_ignores_hostname_for_fingerprinting(self):
-        event1 = self.create_event(lambda i: f"GET http://service.io/clients/info?id={i}")
+        event1 = self.create_event(lambda i: f"GET http://service.io/clients/42/info?id={i}")
         [problem1] = self.find_problems(event1)
 
-        event2 = self.create_event(lambda i: f"GET /clients/info?id={i}")
+        event2 = self.create_event(lambda i: f"GET /clients/42/info?id={i}")
         [problem2] = self.find_problems(event2)
 
         assert problem1.fingerprint == problem2.fingerprint


### PR DESCRIPTION
Closes PERF-1957. When we fingerprint N+1 API Calls, we use the URL path of the first span. All spans are guaranteed to have the same path, so using the first one is fine. This PR will choose to not fingerprint if the span doesn't have any wildcard characters in it. We use a very similar approach in N+1 DB Queries detection, we don't try to fingerprint something where we didn't at least _attempt_ to parameterize.

## Changes

- Update the weather app fixture. Restructure the URLs so that they _would_ be normally eligible for detection under current conditions, but ineligible under the new parameterization requirement
- Add a test for checking parameterization requirement
- Add parameterization requirement
