### PR TITLE
fix(segmentedControl): Fix text ellipsization

### DIFF
--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -306,6 +306,7 @@ const LabelWrap = styled('span')`
   position: relative;
   display: flex;
   line-height: 1;
+  min-width: 0;
 `;
 
 const HiddenLabel = styled('span')`


### PR DESCRIPTION
The change made in https://github.com/getsentry/sentry/pull/44075 broke text ellipsization. This PR fixes it.

**Before ——**
<img width="433" alt="Screenshot 2023-02-03 at 1 55 46 PM" src="https://user-images.githubusercontent.com/44172267/216718501-faff4810-e4b1-4491-9ff6-808c04da1aa1.png">

**After ——**
<img width="433" alt="Screenshot 2023-02-03 at 1 55 27 PM" src="https://user-images.githubusercontent.com/44172267/216718543-8f737a27-7878-409d-bfc0-1ce7cf6de5c9.png">

