### PR TITLE
fix(perf): Fix icon rendering in the transaction summary search

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -370,7 +370,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     const {
       query: lastQuery,
       customPerformanceMetrics: lastCustomPerformanceMetrics,
-      actionBarItems: _actionBarItems,
+      actionBarItems: lastAcionBarItems,
     } = prevProps;
 
     if (
@@ -381,7 +381,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
       this.setState(this.makeQueryState(addSpace(query ?? undefined)));
     }
 
-    if (_actionBarItems?.length !== actionBarItems?.length) {
+    if (lastAcionBarItems?.length !== actionBarItems?.length) {
       this.setState({numActionsVisible: actionBarItems?.length ?? 0});
     }
   }

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -366,9 +366,12 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const {query, customPerformanceMetrics} = this.props;
-    const {query: lastQuery, customPerformanceMetrics: lastCustomPerformanceMetrics} =
-      prevProps;
+    const {query, customPerformanceMetrics, actionBarItems} = this.props;
+    const {
+      query: lastQuery,
+      customPerformanceMetrics: lastCustomPerformanceMetrics,
+      actionBarItems: _actionBarItems,
+    } = prevProps;
 
     if (
       (query !== lastQuery && (defined(query) || defined(lastQuery))) ||
@@ -376,6 +379,10 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     ) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(this.makeQueryState(addSpace(query ?? undefined)));
+    }
+
+    if (_actionBarItems?.length !== actionBarItems?.length) {
+      this.setState({numActionsVisible: actionBarItems?.length ?? 0});
     }
   }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -196,7 +196,7 @@ function SummaryContent({
                 </Tooltip>
               ),
               menuItem: {
-                key: 'filter-alert',
+                key: 'alert',
               },
             }),
           },


### PR DESCRIPTION
Sometimes when the search component needs to be rerendered with the alert icon, there's some state bug where an icon is hidden behind a vertical ellipsis icon. This ensures that the component state is rerun when the `actionBarItems` prop changes.
