### PR TITLE
fix(serializers): Properly log errors when serialization fails

### DIFF
--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -1,3 +1,4 @@
+import logging
 from typing import (
     Any,
     Callable,
@@ -111,8 +112,8 @@ class Serializer:
     ) -> Optional[MutableMapping[str, JSONData]]:
         try:
             return self.serialize(obj, attrs, user, **kwargs)
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
+        except Exception:
+            logging.exception("Failed to serialize", extra={"instance": obj})
             return None
 
     def serialize(


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/41987. When serialization raises an exception locally, it silently returns a bunch of `None` values and doesn't log useful errors. This is because we use `capture_exception` vs the logging framework. Switching over to use `logging.exception` instead.

I'm not really sure I like this idea of silently returning `None` on serialization failure in general, but at least this allows us to see why things are broken.
