### PR TITLE
feat(ecosystem): Show codemap suggestions in stacktrace modal

### DIFF
--- a/static/app/utils/analytics/integrations/stacktraceLinkAnalyticsEvents.ts
+++ b/static/app/utils/analytics/integrations/stacktraceLinkAnalyticsEvents.ts
@@ -22,6 +22,7 @@ type StacktraceLinkEventsLiterals = `${StacktraceLinkEvents}`;
 export type StacktraceLinkEventParameters = {
   [key in StacktraceLinkEventsLiterals]: {
     error_reason?: StacktraceErrorMessage;
+    is_suggestion?: boolean;
     platform?: PlatformType;
     project_id?: string;
     provider?: string;


### PR DESCRIPTION
In the issue details code map modal, show some code mapping suggestions from the newish api added in #41465

[WOR-2422](https://getsentry.atlassian.net/browse/WOR-2422)

![Screenshot 2023-02-03 at 3 43 51 PM](https://user-images.githubusercontent.com/1400464/216731532-41359613-0b2b-424a-af07-971d0d8c1893.png)


[WOR-2422]: https://getsentry.atlassian.net/browse/WOR-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ