### PR TITLE
fix: replace `structlog.threadlocal` with `structlog.contextvars`

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -241,7 +241,7 @@ def configure_structlog() -> None:
     from sentry.logging import LoggingFormat
 
     kwargs: dict[str, Any] = {
-        "context_class": structlog.contextvars,
+        "context_class": structlog.contextvars.get_contextvars(),
         "wrapper_class": structlog.stdlib.BoundLogger,
         "cache_logger_on_first_use": True,
         "processors": [

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -240,9 +240,8 @@ def configure_structlog() -> None:
     from sentry import options
     from sentry.logging import LoggingFormat
 
-    WrappedDictClass = structlog.threadlocal.wrap_dict(dict)
     kwargs: dict[str, Any] = {
-        "context_class": WrappedDictClass,
+        "context_class": structlog.contextvars,
         "wrapper_class": structlog.stdlib.BoundLogger,
         "cache_logger_on_first_use": True,
         "processors": [


### PR DESCRIPTION
DeprecationWarning: `structlog.threadlocal` is deprecated, please use `structlog.contextvars` instead.