### PR TITLE
ref(sentry-perf): Elide analytic spans from transaction

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -93,6 +93,15 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       }
       return tracesSampleRate;
     },
+    beforeSendTransaction(event) {
+      event.spans = event.spans?.filter(span => {
+        // Filter analytic timeout spans.
+        return ['reload.getsentry.net', 'amplitude.com'].every(
+          partialDesc => !span.description?.includes(partialDesc)
+        );
+      });
+      return event;
+    },
     /**
      * There is a bug in Safari, that causes `AbortError` when fetch is
      * aborted, and you are in the middle of reading the response. In Chrome


### PR DESCRIPTION
### Summary
This uses the recently added `beforeSendTransaction` in the sdk and modifies the event to remove 2 spans that are causing trouble because of our analytics auto-instrumentation timeouts causing the idleTimeout of the sdk's idleTransaction to be refreshed. Trying out removing the spans from the transaction data sent to see if `transaction.duration` improves system-wide. 

![Screen Shot 2023-02-06 at 12 07 34 PM](https://user-images.githubusercontent.com/6111995/217038385-7f22ba09-497e-48bd-be59-ae2e1a9312ec.png)
*These spans are potentially causing timeout blocks to be hit, making transaction durations artificially longer for frontend transactions.*

Ultimately `duration` isn't as important for frontend events, but we have a bunch of dashboard events without `LCP` so this should help cut down on noise when evaluating them and any other transaction in our frontend.

