### PR TITLE
feat(roles): refactor EventAttachmentDetails

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -33,19 +33,14 @@ class EventAttachmentDetailsPermission(ProjectPermission):
         )
 
         try:
-            current_role = (
-                OrganizationMember.objects.filter(
-                    organization=organization, user_id=request.user.id
-                )
-                .values_list("role", flat=True)
-                .get()
-            )
+            om = OrganizationMember.objects.get(organization=organization, user_id=request.user.id)
         except OrganizationMember.DoesNotExist:
             return False
 
         required_role = roles.get(required_role)
-        current_role = roles.get(current_role)
-        return current_role.priority >= required_role.priority
+        return any(
+            role.priority >= required_role.priority for role in om.get_all_org_roles_sorted()
+        )
 
 
 @region_silo_endpoint

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -98,6 +98,14 @@ class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentM
             self.assert_member_cannot_access(self.path)
             close_streaming_response(self.assert_can_access(self.owner, self.path))
 
+    def test_member_on_owner_team_can_access_for_owner_role(self):
+        self.organization.update_option("sentry:attachments_role", "owner")
+        owner_team = self.create_team(organization=self.organization, org_role="owner")
+        user = self.create_user()
+        self.create_member(organization=self.organization, user=user, teams=[owner_team, self.team])
+        with self.feature("organizations:event-attachments"):
+            close_streaming_response(self.assert_can_access(user, self.path))
+
     def test_random_user_cannot_access(self):
         self.organization.update_option("sentry:attachments_role", "owner")
         user = self.create_user()


### PR DESCRIPTION
For ER-1354

`get_all_org_roles_sorted()` return a list of OrganizationRoles as opposed to `get_all_org_roles()` which return a list of strings