### PR TITLE
feat(replays): Create new Feature Flags for Session Replay GA

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1185,6 +1185,10 @@ SENTRY_FEATURES = {
     "organizations:sentry-functions": False,
     # Enable experimental session replay backend APIs
     "organizations:session-replay": False,
+    # Enabled for those orgs who participated in the Replay Beta program
+    "organizations:session-replay-beta-grace": False,
+    # Enable replay GA messaging (update paths from AM1 to AM2)
+    "organizations:session-replay-ga": False,
     # Enable experimental session replay SDK for recording on Sentry
     "organizations:session-replay-sdk": False,
     "organizations:session-replay-sdk-errors-only": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -155,6 +155,8 @@ default_manager.add("organizations:scim-orgmember-roles", OrganizationFeature, T
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, True)
 default_manager.add("organizations:sentry-functions", OrganizationFeature, False)
 default_manager.add("organizations:session-replay", OrganizationFeature)
+default_manager.add("organizations:session-replay-beta-grace", OrganizationFeature, True)
+default_manager.add("organizations:session-replay-ga", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-sdk", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-sdk-errors-only", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-ui", OrganizationFeature, True)


### PR DESCRIPTION
`organizations:session-replay-ga`
- Controls whether to show am1->am2 update messaging (onboarding panel) for all orgs

`organizations:session-replay-beta-orgs`
- Controls which orgs see 'beta is ending' alert messaging
- Lifetime: this will only need to be in the app for 2 billing cycles + 90 days (end of July). After that data will have expired and the beta process is filly complete.


Relates to: https://github.com/getsentry/getsentry/issues/9452