### PR TITLE
Add tests to frontend

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -224,16 +224,17 @@ jobs:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
 
-      # This job runs when FE or BE changes happen, however, we only upload coverage data for
-      # FE changes since it conflicts with codecov's carry forward functionality
+      # We only upload coverage data for FE changes since it conflicts with
+      # codecov's carry forward functionality.
       # Upload coverage data even if running the tests step fails since
-      # it reduces large coverage fluctuations
-      - name: Handle artifacts
-        uses: ./.github/actions/artifacts
-        if: ${{ always() && needs.files-changed.outputs.frontend_all == 'true' }}
-        with:
-          files: .artifacts/coverage/*
-          type: frontend
+      # it reduces large coverage fluctuations.
+      # TODO: Enable at the full switch
+      #- name: Handle artifacts
+      #  uses: ./.github/actions/artifacts
+      #  if: ${{ always() && needs.files-changed.outputs.frontend_all == 'true' }}
+      #  with:
+      #    files: .artifacts/coverage/*
+      #    type: frontend
 
   frontend-visual-diff:
     needs: [frontend-browser-tests]

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -149,10 +149,10 @@ jobs:
           windows_verbatim_arguments: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  frontend-visual-tests:
+  frontend-browser-tests:
     if: needs.files-changed.outputs.frontend == 'true'
     needs: files-changed
-    name: frontend visual tests
+    name: Browser tests
     # If you change the runs-on image, you must also change the runner in jest-balance.yml
     # so that the balancer runs in the same environment as the tests.
     runs-on: ubuntu-20.04
@@ -236,10 +236,11 @@ jobs:
           type: frontend
 
   frontend-visual-diff:
-    needs: [frontend-visual-tests]
-    name: Frontend Visual Diff
+    needs: [frontend-browser-tests]
+    name: Visual diff
     runs-on: ubuntu-20.04
     timeout-minutes: 20
+    if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
     steps:
       - name: Diff snapshots
         uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
@@ -255,7 +256,7 @@ jobs:
   # It symbolizes that all required Frontend checks have succesfully passed (Or skipped)
   # This check is the only required Github check
   frontend-required-check:
-    needs: [typescript-and-lint, webpack]
+    needs: [typescript-and-lint, webpack, frontend-browser-tests]
     name: Frontend
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -149,6 +149,108 @@ jobs:
           windows_verbatim_arguments: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+  frontend-visual-tests:
+    if: needs.files-changed.outputs.frontend == 'true'
+    needs: files-changed
+    name: frontend visual tests
+    # If you change the runs-on image, you must also change the runner in jest-balance.yml
+    # so that the balancer runs in the same environment as the tests.
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
+      # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
+      fail-fast: false
+      matrix:
+        # XXX: When updating this, make sure you also update CI_NODE_TOTAL.
+        instance: [0, 1, 2, 3]
+
+    env:
+      VISUAL_HTML_ENABLE: 1
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+        name: Checkout sentry
+
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
+      - uses: getsentry/action-setup-volta@54775a59c41065f54ecc76d1dd5f2cdc7a1550cb # v1.1.0
+
+      - name: node_modules cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7  # v3.0.11
+        id: nodemodulescache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
+
+      - name: Install Javascript Dependencies
+        if: steps.nodemodulescache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Build CSS
+        run: NODE_ENV=production yarn build-css
+
+      - name: jest
+        env:
+          GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          GITHUB_PR_REF: ${{ github.event.pull_request.head.ref || github.ref }}
+          # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
+          #      Otherwise, if there are other things in the matrix, using strategy.job-total
+          #      wouldn't be correct.
+          CI_NODE_TOTAL: 4
+          CI_NODE_INDEX: ${{ matrix.instance }}
+        run: |
+          SENTRY_PROFILER_LOGGING_MODE=eager JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
+
+      - name: Save HTML artifacts
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb  # v3.1.1
+        with:
+          retention-days: 14
+          name: jest-html
+          path: .artifacts/visual-snapshots/jest
+
+      - name: Create Images from HTML
+        uses: getsentry/action-html-to-image@dc153dae538e6e1138f77156d8e62e3b2b897f41 # main
+        with:
+          base-path: .artifacts/visual-snapshots/jest
+          css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
+
+      - name: Save snapshots
+        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
+        with:
+          artifact-name: frontend-snapshots
+          save-only: true
+          snapshot-path: .artifacts/visual-snapshots
+
+      # This job runs when FE or BE changes happen, however, we only upload coverage data for
+      # FE changes since it conflicts with codecov's carry forward functionality
+      # Upload coverage data even if running the tests step fails since
+      # it reduces large coverage fluctuations
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts
+        if: ${{ always() && needs.files-changed.outputs.frontend_all == 'true' }}
+        with:
+          files: .artifacts/coverage/*
+          type: frontend
+
+  frontend-visual-diff:
+    needs: [frontend-visual-tests]
+    name: Frontend Visual Diff
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+      - name: Diff snapshots
+        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
+        with:
+          action-name: 'Visual Snapshot: Frontend'
+          artifact-name: 'frontend-snapshots'
+          base-branch: 'master'
+          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
+          gcs-bucket: 'sentry-visual-snapshots'
+          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
+
   # This check runs once all dependant jobs have passed
   # It symbolizes that all required Frontend checks have succesfully passed (Or skipped)
   # This check is the only required Github check

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -218,7 +218,7 @@ jobs:
           css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
+        uses: getsentry/action-visual-snapshot@ea663f1be8b73c86b18081d714423ce52352e934
         with:
           artifact-name: frontend-snapshots
           save-only: true
@@ -244,7 +244,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
     steps:
       - name: Diff snapshots
-        uses: getsentry/action-visual-snapshot@d08945864bd75129863897062b8c1687f1600a2d
+        uses: getsentry/action-visual-snapshot@ea663f1be8b73c86b18081d714423ce52352e934
         with:
           action-name: 'Visual Snapshot: Frontend'
           artifact-name: 'frontend-snapshots'


### PR DESCRIPTION
These tests will be removed from the acceptance workflow once I've confirmed they work in the frontend workflow.

Couple of things to note:

1. On a push to master we don't run the visual snapshots, so I've added an if to only run the diff on PRs
2. In acceptance we do fail when the tests themselves fail, so I've added `frontend-browser-tests` as a required job