### PR TITLE
fix(perf): Add link to url in transaction details

### DIFF
--- a/static/app/components/tagsTableRow.tsx
+++ b/static/app/components/tagsTableRow.tsx
@@ -1,13 +1,18 @@
+import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {KeyValueTableRow} from 'sentry/components/keyValueTable';
+import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {Tooltip} from 'sentry/components/tooltip';
 import Version from 'sentry/components/version';
+import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {EventTag} from 'sentry/types/event';
+import {isUrl} from 'sentry/utils';
 
 interface Props {
   generateUrl: (tag: EventTag) => LocationDescriptor;
@@ -50,6 +55,18 @@ function TagsTableRow({tag, query, generateUrl, meta}: Props) {
           <StyledTooltip title={t('This tag is in the current filter conditions')}>
             <ValueContainer>{renderTagValue()}</ValueContainer>
           </StyledTooltip>
+        ) : tag.key === 'url' ? (
+          <ValueWithExtraContainer>
+            <StyledTooltip title={renderTagValue()} showOnlyOnOverflow>
+              <Link to={target || ''}>{renderTagValue()}</Link>
+            </StyledTooltip>
+
+            {isUrl(tag.value) && (
+              <ExternalLink href={tag.value} className="external-icon">
+                <IconOpen size="xs" />
+              </ExternalLink>
+            )}
+          </ValueWithExtraContainer>
         ) : (
           <StyledTooltip title={renderTagValue()} showOnlyOnOverflow>
             <Link to={target || ''}>{renderTagValue()}</Link>
@@ -71,4 +88,9 @@ const ValueContainer = styled('span')`
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: normal;
+`;
+
+const ValueWithExtraContainer = styled('span')`
+  display: flex;
+  align-items: center;
 `;

--- a/static/app/components/tagsTableRow.tsx
+++ b/static/app/components/tagsTableRow.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 


### PR DESCRIPTION
### Summary
This adds a link out to a url on transaction details so it's easier to follow where a frontend transaction took place.

![Screen Shot 2023-02-06 at 2 49 23 PM](https://user-images.githubusercontent.com/6111995/217070433-af476980-eee7-4a6c-a270-dd13f13a58ee.png)
