### PR TITLE
fix(dropdownMenu): Use type-only import/export for `MenuItemProps`

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -9,10 +9,10 @@ import DropdownButton, {DropdownButtonProps} from 'sentry/components/dropdownBut
 import {FormSize} from 'sentry/utils/theme';
 import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
 
-import {MenuItemProps} from './item';
+import type {MenuItemProps} from './item';
 import DropdownMenuList, {DropdownMenuContext, DropdownMenuListProps} from './list';
 
-export {MenuItemProps};
+export type {MenuItemProps};
 
 /**
  * Recursively removes hidden items, including those nested in submenus


### PR DESCRIPTION
Use type-only import/export for `MenuItemProps`, to remove this webpack warning in dev:

<img width="696" alt="Screenshot 2023-02-06 at 12 12 00 PM" src="https://user-images.githubusercontent.com/44172267/217075394-38dffc62-9c6b-4695-8f1b-10524b67c9b7.png">
