### PR TITLE
fix(domains) Use our link component instead or react-router link

### DIFF
--- a/static/app/components/discover/performanceCardTable.tsx
+++ b/static/app/components/discover/performanceCardTable.tsx
@@ -1,11 +1,11 @@
 import {Fragment} from 'react';
-import {Link} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Alert} from 'sentry/components/alert';
 import {AsyncComponentProps} from 'sentry/components/asyncComponent';
+import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NotAvailable from 'sentry/components/notAvailable';
 import {PanelItem} from 'sentry/components/panels';

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -1,5 +1,4 @@
 import {Component, Fragment} from 'react';
-import {Link} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -7,6 +6,7 @@ import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
 import {Button} from 'sentry/components/button';
 import Input from 'sentry/components/input';
+import Link from 'sentry/components/links/link';
 import {IconChevron, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';

--- a/static/app/components/profiling/arrayLinks.tsx
+++ b/static/app/components/profiling/arrayLinks.tsx
@@ -1,8 +1,8 @@
 import {useState} from 'react';
-import {Link} from 'react-router';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 
+import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 

--- a/static/app/components/profiling/functionsMiniGrid.tsx
+++ b/static/app/components/profiling/functionsMiniGrid.tsx
@@ -1,7 +1,7 @@
 import {CSSProperties, Fragment, SyntheticEvent} from 'react';
-import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
+import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PerformanceDuration from 'sentry/components/performanceDuration';
 import {Flex} from 'sentry/components/profiling/flex';

--- a/static/app/views/issueDetails/quickTrace/traceLink.tsx
+++ b/static/app/views/issueDetails/quickTrace/traceLink.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useContext} from 'react';
-import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
+import Link from 'sentry/components/links/link';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -34,7 +34,6 @@ export function TraceLink({event}: TraceLinkProps) {
   ) {
     return null;
   }
-
   return (
     <LinkContainer>
       <Link to={generateTraceTarget(event, organization)} onClick={handleTraceLink}>

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
-import {Link} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -8,6 +7,7 @@ import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -1,9 +1,9 @@
 import {Fragment} from 'react';
-import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
 import Duration from 'sentry/components/duration';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';
 import Tag, {Background} from 'sentry/components/tag';
 import TimeSince from 'sentry/components/timeSince';

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionRow/index.tsx
@@ -1,6 +1,6 @@
-import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
+import Link from 'sentry/components/links/link';
 import {PanelItem} from 'sentry/components/panels';
 import {IconInput} from 'sentry/icons';
 import space from 'sentry/styles/space';


### PR DESCRIPTION
Our link includes URL normalization which doesn't trigger redirects for customers with customer-domains enabled.