### PR TITLE
feat(perf-issues): ensure consecutive db spans open in span tree

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -28,8 +28,17 @@ export function SpanEvidenceSection({event, organization}: Props) {
   const offendingSpanIDs = event?.perfProblem?.offenderSpanIds ?? [];
 
   const affectedSpanIds = [...offendingSpanIDs];
-  if (event?.perfProblem?.issueType !== IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS) {
+  const focusedSpanIds: string[] = [];
+  const issueType = event?.perfProblem?.issueType;
+  if (issueType !== IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS) {
     affectedSpanIds.push(...parentSpanIDs);
+  }
+  if (issueType === IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES) {
+    const consecutiveSpanIds = event?.perfProblem?.causeSpanIds ?? [];
+
+    if (consecutiveSpanIds.length < 11) {
+      focusedSpanIds.push(...consecutiveSpanIds);
+    }
   }
 
   return (
@@ -45,7 +54,9 @@ export function SpanEvidenceSection({event, organization}: Props) {
       <TraceViewWrapper>
         <TraceView
           organization={organization}
-          waterfallModel={new WaterfallModel(event as EventTransaction, affectedSpanIds)}
+          waterfallModel={
+            new WaterfallModel(event as EventTransaction, affectedSpanIds, focusedSpanIds)
+          }
           isEmbedded
         />
       </TraceViewWrapper>

--- a/static/app/components/events/interfaces/spans/traceView.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.spec.tsx
@@ -510,4 +510,23 @@ describe('TraceView', () => {
     const lcpLabelContainer = screen.getByText(/lcp/i).parentElement?.parentElement;
     expect(lcpLabelContainer).toBeInTheDocument();
   });
+
+  it('should have all focused spans visible', async () => {
+    data = initializeData({});
+
+    const event = generateSampleEvent();
+    for (let i = 0; i < 10; i++) {
+      generateSampleSpan(`desc${i}`, 'db', `id${i}`, 'c000000000000000', event);
+    }
+
+    const waterfallModel = new WaterfallModel(event, ['id3'], ['id3', 'id4']);
+
+    render(
+      <TraceView organization={data.organization} waterfallModel={waterfallModel} />
+    );
+
+    expect(await screen.findByTestId('span-row-1')).toHaveTextContent('desc3');
+    expect(await screen.findByTestId('span-row-2')).toHaveTextContent('desc4');
+    expect(screen.queryByTestId('span-row-3')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -37,7 +37,11 @@ class WaterfallModel {
   traceBounds: Array<TraceBound>;
   focusedSpanIds: Set<string> | undefined = undefined;
 
-  constructor(event: Readonly<EventTransaction>, affectedSpanIds?: string[]) {
+  constructor(
+    event: Readonly<EventTransaction>,
+    affectedSpanIds?: string[],
+    focusedSpanIds?: string[]
+  ) {
     this.event = event;
 
     this.parsedTrace = parseTrace(event);
@@ -60,8 +64,15 @@ class WaterfallModel {
     this.hiddenSpanSubTrees = new Set();
 
     // When viewing the span waterfall from a Performance Issue, a set of span IDs may be provided
+
     this.affectedSpanIds = affectedSpanIds;
-    this.focusedSpanIds = affectedSpanIds ? new Set(affectedSpanIds) : undefined;
+
+    if (affectedSpanIds || focusedSpanIds) {
+      affectedSpanIds ??= [];
+      focusedSpanIds ??= [];
+      this.focusedSpanIds = new Set([...affectedSpanIds, ...focusedSpanIds]);
+    }
+
     // If the set of span IDs is provided, this waterfall is for an embedded span tree
     this.isEmbeddedSpanTree = !!this.focusedSpanIds;
 


### PR DESCRIPTION
This PR adds the ability to show all the consecutive db spans in the span tree when the user first opens the issue, without expanding the tree.
This only works if the number of spans to open is <= 10 (to prevent overwhelming UI)
The >10 case will be handled in the future, but this is an improvement to what we have now.

Before
<img width="900" alt="image" src="https://user-images.githubusercontent.com/44422760/217096094-7f25cec5-98a6-4582-905e-32ac1774186e.png">

After
<img width="901" alt="image" src="https://user-images.githubusercontent.com/44422760/217096152-2232fc91-985e-4714-aa17-32c1ca3e3e0f.png">
