### PR TITLE
feat(replays): Remove Session Replay 'beta' branding for `testorg-az` org

### DIFF
--- a/static/app/components/replays/replaysFeatureBadge.tsx
+++ b/static/app/components/replays/replaysFeatureBadge.tsx
@@ -1,8 +1,14 @@
 import FeatureBadge from 'sentry/components/featureBadge';
+import useOrganization from 'sentry/utils/useOrganization';
 
 function ReplaysFeatureBadge(
   props: Omit<React.ComponentProps<typeof FeatureBadge>, 'type'>
 ) {
+  // TODO(replay): Remove this special-case for our internal demo org
+  const organization = useOrganization();
+  if (organization.slug === 'testorg-az') {
+    return null;
+  }
   return <FeatureBadge {...props} type="beta" />;
 }
 

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -249,7 +249,8 @@ function Sidebar({location, organization}: Props) {
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"
-        isBeta
+        // TODO(replay): Remove this special-case for our internal demo org
+        isBeta={organization.slug !== 'testorg-az'}
       />
     </Feature>
   );


### PR DESCRIPTION
I'm putting in a special-case for our internal testing org: `testorg-az` so that marketing can record demo's from an org showing what replay's will look like once they exit beta.

They don't want to record demo's over and over as we move from 'beta' to 'new' to just a regular old feature.

This will be cleaned up in https://github.com/getsentry/sentry/pull/44195