### PR TITLE
Revert "ref(hybrid-cloud): add optional orgId route param to AcceptOrganizationInvite"

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -154,10 +154,6 @@ function buildRoutes() {
     <Fragment>
       <IndexRoute component={make(() => import('sentry/views/app/root'))} />
       <Route
-        path="/accept/:orgId/:memberId/:token/"
-        component={make(() => import('sentry/views/acceptOrganizationInvite'))}
-      />
-      <Route
         path="/accept/:memberId/:token/"
         component={make(() => import('sentry/views/acceptOrganizationInvite'))}
       />

--- a/static/app/views/acceptOrganizationInvite.spec.jsx
+++ b/static/app/views/acceptOrganizationInvite.spec.jsx
@@ -9,7 +9,7 @@ jest.mock('sentry/actionCreators/account');
 
 const addMock = body =>
   MockApiClient.addMockResponse({
-    url: '/accept-invite/org-slug/1/abc/',
+    url: '/accept-invite/1/abc/',
     method: 'GET',
     body,
   });
@@ -35,14 +35,10 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: false,
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     const acceptMock = MockApiClient.addMockResponse({
-      url: '/accept-invite/org-slug/1/abc/',
+      url: '/accept-invite/1/abc/',
       method: 'POST',
     });
 
@@ -81,7 +77,7 @@ describe('AcceptOrganizationInvite', function () {
     render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     const acceptMock = MockApiClient.addMockResponse({
-      url: '/accept-invite/org-slug/1/abc/',
+      url: '/accept-invite/1/abc/',
       method: 'POST',
     });
 
@@ -106,11 +102,7 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: false,
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -136,11 +128,7 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -167,11 +155,7 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -198,11 +182,7 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -229,11 +209,7 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
 
@@ -254,11 +230,7 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(screen.getByTestId('action-info-sso')).toBeInTheDocument();
 
@@ -275,11 +247,7 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: true,
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
     userEvent.click(screen.getByTestId('existing-member-link'));
@@ -298,11 +266,7 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: false,
     });
 
-    render(
-      <AcceptOrganizationInvite
-        params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
-      />
-    );
+    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(
       screen.getByRole('button', {name: 'Configure Two-Factor Auth'})

--- a/static/app/views/acceptOrganizationInvite.tsx
+++ b/static/app/views/acceptOrganizationInvite.tsx
@@ -26,7 +26,7 @@ type InviteDetails = {
   ssoProvider?: string;
 };
 
-type Props = RouteComponentProps<{memberId: string; token: string; orgId?: string}, {}>;
+type Props = RouteComponentProps<{memberId: string; token: string}, {}>;
 
 type State = AsyncView['state'] & {
   acceptError: boolean | undefined;
@@ -37,23 +37,8 @@ type State = AsyncView['state'] & {
 class AcceptOrganizationInvite extends AsyncView<Props, State> {
   disableErrorReport = false;
 
-  get orgSlug(): string | null {
-    const {params} = this.props;
-    if (params.orgId) {
-      return params.orgId;
-    }
-    const {customerDomain} = window.__initialData;
-    if (customerDomain?.subdomain) {
-      return customerDomain.subdomain;
-    }
-    return null;
-  }
-
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {memberId, token} = this.props.params;
-    if (this.orgSlug) {
-      return [['inviteDetails', `/accept-invite/${this.orgSlug}/${memberId}/${token}/`]];
-    }
     return [['inviteDetails', `/accept-invite/${memberId}/${token}/`]];
   }
 
@@ -76,18 +61,9 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
 
     this.setState({accepting: true});
     try {
-      if (this.orgSlug) {
-        await this.api.requestPromise(
-          `/accept-invite/${this.orgSlug}/${memberId}/${token}/`,
-          {
-            method: 'POST',
-          }
-        );
-      } else {
-        await this.api.requestPromise(`/accept-invite/${memberId}/${token}/`, {
-          method: 'POST',
-        });
-      }
+      await this.api.requestPromise(`/accept-invite/${memberId}/${token}/`, {
+        method: 'POST',
+      });
       browserHistory.replace(`/${this.state.inviteDetails.orgSlug}/`);
     } catch {
       this.setState({acceptError: true});


### PR DESCRIPTION
Reverts #42277 as `AcceptOrganizationInvite` will be on the control silo and won't need to have the org slug in the URL.