### PR TITLE
ref(crons): Remove '.' at end of search placeholder

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -133,7 +133,7 @@ class Monitors extends AsyncView<Props, State> {
                 <ProjectPageFilter resetParamsOnChange={['cursor']} />
                 <SearchBar
                   query={decodeScalar(qs.parse(location.search)?.query, '')}
-                  placeholder={t('Search for monitors.')}
+                  placeholder={t('Search for monitors')}
                   onSearch={this.handleSearch}
                 />
               </Filters>


### PR DESCRIPTION
Removes this `.`:
![image](https://user-images.githubusercontent.com/9372512/217116846-ebb3c5e9-c262-47cc-93ed-dbbfeb016679.png)
