### PR TITLE
feat: Create useDismissAlert help react hook to replace some jank

### DIFF
--- a/static/app/components/replays/playerDOMAlert.spec.tsx
+++ b/static/app/components/replays/playerDOMAlert.spec.tsx
@@ -26,7 +26,7 @@ describe('PlayerDOMAlert', () => {
   });
 
   it('should not render the alert when the local storage key is set', () => {
-    mockGetItem.mockImplementationOnce(() => String(now.getTime()));
+    mockGetItem.mockImplementationOnce(() => now.getTime().toString());
     render(<PlayerDOMAlert />);
 
     expect(screen.queryByTestId('player-dom-alert')).not.toBeInTheDocument();
@@ -38,11 +38,12 @@ describe('PlayerDOMAlert', () => {
     expect(screen.getByTestId('player-dom-alert')).toBeVisible();
 
     screen.getByLabelText('Close Alert').click();
+    jest.runAllTicks();
 
     expect(screen.queryByTestId('player-dom-alert')).not.toBeInTheDocument();
     expect(localStorage.setItem).toHaveBeenCalledWith(
       'replay-player-dom-alert-dismissed',
-      String(now.getTime())
+      '"1577836800000"'
     );
   });
 });

--- a/static/app/components/replays/playerDOMAlert.spec.tsx
+++ b/static/app/components/replays/playerDOMAlert.spec.tsx
@@ -5,8 +5,20 @@ import localStorage from 'sentry/utils/localStorage';
 import PlayerDOMAlert from './playerDOMAlert';
 
 jest.mock('sentry/utils/localStorage');
+jest.useFakeTimers();
+
+const mockGetItem = localStorage.getItem as jest.MockedFunction<
+  typeof localStorage.getItem
+>;
+
+const now = new Date('2020-01-01');
+jest.setSystemTime(now);
 
 describe('PlayerDOMAlert', () => {
+  beforeEach(() => {
+    mockGetItem.mockReset();
+  });
+
   it('should render the alert when local storage key is not set', () => {
     render(<PlayerDOMAlert />);
 
@@ -14,8 +26,7 @@ describe('PlayerDOMAlert', () => {
   });
 
   it('should not render the alert when the local storage key is set', () => {
-    // @ts-expect-error
-    localStorage.getItem.mockImplementationOnce(() => '1');
+    mockGetItem.mockImplementationOnce(() => String(now.getTime()));
     render(<PlayerDOMAlert />);
 
     expect(screen.queryByTestId('player-dom-alert')).not.toBeInTheDocument();
@@ -31,7 +42,7 @@ describe('PlayerDOMAlert', () => {
     expect(screen.queryByTestId('player-dom-alert')).not.toBeInTheDocument();
     expect(localStorage.setItem).toHaveBeenCalledWith(
       'replay-player-dom-alert-dismissed',
-      '1'
+      String(now.getTime())
     );
   });
 });

--- a/static/app/components/replays/playerDOMAlert.tsx
+++ b/static/app/components/replays/playerDOMAlert.tsx
@@ -1,26 +1,15 @@
-import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import {IconClose, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import localStorage from 'sentry/utils/localStorage';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
 
 const LOCAL_STORAGE_KEY = 'replay-player-dom-alert-dismissed';
 
 function PlayerDOMAlert() {
-  const [isDismissed, setIsDismissed] = useState(true);
-
-  const handleDismiss = () => {
-    localStorage.setItem(LOCAL_STORAGE_KEY, '1');
-    setIsDismissed(true);
-  };
-
-  useEffect(() => {
-    const val = localStorage.getItem(LOCAL_STORAGE_KEY);
-    setIsDismissed(val === '1');
-  }, []);
+  const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
 
   if (isDismissed) {
     return null;
@@ -36,7 +25,7 @@ function PlayerDOMAlert() {
           size="sm"
           icon={<IconClose size="xs" />}
           aria-label={t('Close Alert')}
-          onClick={handleDismiss}
+          onClick={dismiss}
         />
       </DOMAlert>
     </DOMAlertContainer>

--- a/static/app/utils/useDismissAlert.spec.tsx
+++ b/static/app/utils/useDismissAlert.spec.tsx
@@ -73,7 +73,7 @@ describe('useDismissAlert', () => {
     );
   });
 
-  it('should be dismissed if the timestamp in localstorage is older than the expiration', () => {
+  it('should be dismissed if the timestamp in localStorage is older than the expiration', () => {
     const today = new Date('2020-01-01');
     jest.setSystemTime(today);
 

--- a/static/app/utils/useDismissAlert.spec.tsx
+++ b/static/app/utils/useDismissAlert.spec.tsx
@@ -1,0 +1,115 @@
+import TestRenderer from 'react-test-renderer';
+
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import localStorage from 'sentry/utils/localStorage';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+
+const {act} = TestRenderer;
+
+jest.mock('sentry/utils/localStorage');
+jest.useFakeTimers();
+
+const mockSetItem = localStorage.setItem as jest.MockedFunction<
+  typeof localStorage.setItem
+>;
+const mockGetItem = localStorage.getItem as jest.MockedFunction<
+  typeof localStorage.getItem
+>;
+
+const key = 'test_123';
+const now = new Date('2020-01-01');
+
+describe('useDismissAlert', () => {
+  beforeEach(() => {
+    jest.setSystemTime(now);
+
+    mockSetItem.mockReset();
+    mockGetItem.mockReset();
+  });
+
+  it('should return a stable ref for the dismiss() function', () => {
+    const {result, rerender} = reactHooks.renderHook(useDismissAlert, {
+      initialProps: {key},
+    });
+
+    const initialRef = result.current.dismiss;
+
+    rerender();
+
+    expect(result.current.dismiss).toEqual(initialRef);
+  });
+
+  it('should not be dismissed if there is no value in localstorage', () => {
+    mockGetItem.mockReturnValue(null);
+
+    const {result} = reactHooks.renderHook(useDismissAlert, {
+      initialProps: {key},
+    });
+
+    expect(result.current.isDismissed).toBeFalsy();
+  });
+
+  it('should be dismissed if there is a value in localstorage', () => {
+    mockGetItem.mockReturnValue('some value');
+
+    const {result} = reactHooks.renderHook(useDismissAlert, {
+      initialProps: {key},
+    });
+
+    expect(result.current.isDismissed).toBeTruthy();
+  });
+
+  it('should set the current timestamp into localstorage when an alert is dismissed', () => {
+    const {result} = reactHooks.renderHook(useDismissAlert, {
+      initialProps: {key},
+    });
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(mockSetItem).toHaveBeenCalledWith(key, String(now.getTime()));
+  });
+
+  it('should be dismissed if the timestamp in localstorage is older than the expiration', () => {
+    const today = new Date('2020-01-01');
+    jest.setSystemTime(today);
+
+    // Dismissed on christmas
+    const christmas = new Date('2019-12-25').getTime();
+    mockGetItem.mockReturnValue(String(christmas));
+
+    // Expires after 2 days
+    const {result} = reactHooks.renderHook(useDismissAlert, {
+      initialProps: {key, expirationDays: 2},
+    });
+
+    // Dismissal has expired
+    expect(result.current.isDismissed).toBeFalsy();
+  });
+
+  it('should not be dismissed if the timestamp in localstorage is more recent than the expiration', () => {
+    // Dismissed on christmas
+    const christmas = new Date('2019-12-25').getTime();
+    mockGetItem.mockReturnValue(String(christmas));
+
+    // Expires after 30 days
+    const {result} = reactHooks.renderHook(useDismissAlert, {
+      initialProps: {key, expirationDays: 30},
+    });
+
+    // Not expired, dismissal is still active
+    expect(result.current.isDismissed).toBeTruthy();
+  });
+
+  it('should update the timestamp in localstorage if it not a number/timestamp', () => {
+    mockGetItem.mockReturnValue('foobar');
+
+    reactHooks.renderHook(useDismissAlert, {
+      initialProps: {key, expirationDays: 30},
+    });
+
+    expect(mockSetItem).toHaveBeenCalledWith(key, String(now.getTime()));
+  });
+});

--- a/static/app/utils/useDismissAlert.tsx
+++ b/static/app/utils/useDismissAlert.tsx
@@ -29,7 +29,7 @@ function isValid(timestamp: number, expirationDays: number) {
 
 /**
  * Nominally for tracking dismissal/acknowledgement of in-app alerts and
- * notifications, specfically those that don't need to be persisted server side.
+ * notifications, specifically those that don't need to be persisted server side.
  *
  * Dismissal can be 'permanent' or have an expiration after some number of days.
  *

--- a/static/app/utils/useDismissAlert.tsx
+++ b/static/app/utils/useDismissAlert.tsx
@@ -1,0 +1,59 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import localStorage from 'sentry/utils/localStorage';
+
+type Opts = {
+  /**
+   * Key in localstorage.
+   * Use a format like: `${organization.id}:my-feature`
+   */
+  key: string;
+
+  /**
+   * Number of days before the dismissal is expired.
+   * After expiration the the user will need to re-dismiss things.
+   */
+  expirationDays?: number;
+};
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * Nominally for tracking dismissal/acknowledgement of in-app alerts and
+ * notifications, specfically those that don't need to be persisted server side.
+ *
+ * Dismissal can be 'permanent' or have an expiration after some number of days.
+ *
+ * The real lifecycle depends on whether users reset localStorage or not, if you
+ * need something really permanent then save the users' preference to the server.
+ */
+function useDismissAlert({expirationDays = Number.MAX_SAFE_INTEGER, key}: Opts) {
+  const [isDismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const val = localStorage.getItem(key);
+
+    if (expirationDays === Number.MAX_SAFE_INTEGER) {
+      setDismissed(Boolean(val));
+    } else if (val) {
+      const timestamp = Number(val);
+      if (isNaN(timestamp)) {
+        localStorage.setItem(key, String(Date.now()));
+        setDismissed(true);
+      } else {
+        const duration = Date.now() - timestamp;
+        const days = duration / MS_PER_DAY;
+        setDismissed(days < expirationDays);
+      }
+    }
+  }, [key, expirationDays]);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    localStorage.setItem(key, String(Date.now()));
+  }, [key]);
+
+  return {isDismissed, dismiss};
+}
+
+export default useDismissAlert;

--- a/static/app/utils/useDismissAlert.tsx
+++ b/static/app/utils/useDismissAlert.tsx
@@ -4,7 +4,7 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 type Opts = {
   /**
-   * Key in localstorage.
+   * Key in localStorage.
    * Use a format like: `${organization.id}:my-feature`
    */
   key: string;


### PR DESCRIPTION
It was a manual process to deal with dismissing the React 'inspect your dom' alert.

We can do better by putting that behavior into a hook, and it'll be re-usable for some replay update/onboarding stuff coming up.