### PR TITLE
ref(ui): Improve sidebarItem focus state

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -7,6 +7,7 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import Link from 'sentry/components/links/link';
 import TextOverflow from 'sentry/components/textOverflow';
 import {Tooltip} from 'sentry/components/tooltip';
+import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import localStorage from 'sentry/utils/localStorage';
@@ -259,12 +260,13 @@ const StyledSidebarItem = styled(Link)`
 
   &.focus-visible {
     outline: none;
-    background: #584c66;
-    padding: 0 19px;
-    margin: 0 -19px;
+    box-shadow: 0 0 0 2px ${p => p.theme.purple300};
+    border-radius: ${p => p.theme.borderRadius};
+    padding: 0 ${space(1)} 0 ${space(0.25)};
+    margin: 0 -${space(1)} 0 -${space(0.25)};
 
     &:before {
-      left: 0;
+      left: -18px;
     }
   }
 


### PR DESCRIPTION
<img alt="clipboard.png"  src="https://i.imgur.com/zrEmfw2.png" />

Bette than before

<img alt="clipboard.png"  src="https://i.imgur.com/9Rmbwbc.png" />