### PR TITLE
feat(ecosystem): Add default branch in github repos response

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -137,14 +137,23 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
         """
         if not query:
             return [
-                {"name": i["name"], "identifier": i["full_name"]}
+                {
+                    "name": i["name"],
+                    "identifier": i["full_name"],
+                    "default_branch": i.get("default_branch"),
+                }
                 for i in self.get_client().get_repositories(fetch_max_pages)
             ]
 
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = self.get_client().search_repositories(full_query)
         return [
-            {"name": i["name"], "identifier": i["full_name"]} for i in response.get("items", [])
+            {
+                "name": i["name"],
+                "identifier": i["full_name"],
+                "default_branch": i.get("default_branch"),
+            }
+            for i in response.get("items", [])
         ]
 
     def search_issues(self, query: str) -> Mapping[str, Sequence[Mapping[str, Any]]]:

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -120,14 +120,23 @@ class GitHubEnterpriseIntegration(IntegrationInstallation, GitHubIssueBasic, Rep
     def get_repositories(self, query=None):
         if not query:
             return [
-                {"name": i["name"], "identifier": i["full_name"]}
+                {
+                    "name": i["name"],
+                    "identifier": i["full_name"],
+                    "default_branch": i.get("default_branch"),
+                }
                 for i in self.get_client().get_repositories()
             ]
 
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = self.get_client().search_repositories(full_query)
         return [
-            {"name": i["name"], "identifier": i["full_name"]} for i in response.get("items", [])
+            {
+                "name": i["name"],
+                "identifier": i["full_name"],
+                "default_branch": i.get("default_branch"),
+            }
+            for i in response.get("items", [])
         ]
 
     def search_issues(self, query):

--- a/tests/sentry/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repos.py
@@ -21,16 +21,20 @@ class OrganizationIntegrationReposTest(APITestCase):
     @patch("sentry.integrations.github.GitHubAppsClient.get_repositories", return_value=[])
     def test_simple(self, get_repositories):
         get_repositories.return_value = [
-            {"name": "rad-repo", "full_name": "Example/rad-repo"},
-            {"name": "cool-repo", "full_name": "Example/cool-repo"},
+            {"name": "rad-repo", "full_name": "Example/rad-repo", "default_branch": "main"},
+            {"name": "cool-repo", "full_name": "Example/cool-repo", "default_branch": "master"},
         ]
         response = self.client.get(self.path, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data == {
             "repos": [
-                {"name": "rad-repo", "identifier": "Example/rad-repo"},
-                {"name": "cool-repo", "identifier": "Example/cool-repo"},
+                {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
+                {
+                    "name": "cool-repo",
+                    "identifier": "Example/cool-repo",
+                    "default_branch": "master",
+                },
             ],
             "searchable": True,
         }

--- a/tests/sentry/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repos.py
@@ -22,18 +22,18 @@ class OrganizationIntegrationReposTest(APITestCase):
     def test_simple(self, get_repositories):
         get_repositories.return_value = [
             {"name": "rad-repo", "full_name": "Example/rad-repo", "default_branch": "main"},
-            {"name": "cool-repo", "full_name": "Example/cool-repo", "default_branch": "master"},
+            {"name": "cool-repo", "full_name": "Example/cool-repo"},
         ]
         response = self.client.get(self.path, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data == {
             "repos": [
-                {"name": "rad-repo", "identifier": "Example/rad-repo", "default_branch": "main"},
+                {"name": "rad-repo", "identifier": "Example/rad-repo", "defaultBranch": "main"},
                 {
                     "name": "cool-repo",
                     "identifier": "Example/cool-repo",
-                    "default_branch": "master",
+                    "defaultBranch": None,
                 },
             ],
             "searchable": True,

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -390,8 +390,8 @@ class GitHubIntegrationTest(IntegrationTestCase):
             f"{self.base_url}/search/repositories?{querystring}",
             json={
                 "items": [
-                    {"name": "example", "full_name": "test/example"},
-                    {"name": "exhaust", "full_name": "test/exhaust"},
+                    {"name": "example", "full_name": "test/example", "default_branch": "master"},
+                    {"name": "exhaust", "full_name": "test/exhaust", "default_branch": "master"},
                 ]
             },
         )
@@ -400,8 +400,8 @@ class GitHubIntegrationTest(IntegrationTestCase):
         # This searches for any repositories matching the term 'ex'
         result = installation.get_repositories("ex")
         assert result == [
-            {"identifier": "test/example", "name": "example"},
-            {"identifier": "test/exhaust", "name": "exhaust"},
+            {"identifier": "test/example", "name": "example", "default_branch": "master"},
+            {"identifier": "test/exhaust", "name": "exhaust", "default_branch": "master"},
         ]
 
     @responses.activate
@@ -416,9 +416,9 @@ class GitHubIntegrationTest(IntegrationTestCase):
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories(fetch_max_pages=True)
             assert result == [
-                {"name": "foo", "identifier": "Test-Organization/foo"},
-                {"name": "bar", "identifier": "Test-Organization/bar"},
-                {"name": "baz", "identifier": "Test-Organization/baz"},
+                {"name": "foo", "identifier": "Test-Organization/foo", "default_branch": "master"},
+                {"name": "bar", "identifier": "Test-Organization/bar", "default_branch": "main"},
+                {"name": "baz", "identifier": "Test-Organization/baz", "default_branch": "master"},
             ]
 
     @responses.activate
@@ -433,7 +433,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories()
             assert result == [
-                {"name": "foo", "identifier": "Test-Organization/foo"},
+                {"name": "foo", "identifier": "Test-Organization/foo", "default_branch": "master"},
             ]
 
     @responses.activate

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -173,8 +173,8 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
             f"{self.base_url}/search/repositories?{querystring}",
             json={
                 "items": [
-                    {"name": "example", "full_name": "test/example"},
-                    {"name": "exhaust", "full_name": "test/exhaust"},
+                    {"name": "example", "full_name": "test/example", "default_branch": "main"},
+                    {"name": "exhaust", "full_name": "test/exhaust", "default_branch": "main"},
                 ]
             },
         )
@@ -182,6 +182,6 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         installation = integration.get_installation(self.organization.id)
         result = installation.get_repositories("ex")
         assert result == [
-            {"identifier": "test/example", "name": "example"},
-            {"identifier": "test/exhaust", "name": "exhaust"},
+            {"identifier": "test/example", "name": "example", "default_branch": "main"},
+            {"identifier": "test/exhaust", "name": "exhaust", "default_branch": "main"},
         ]


### PR DESCRIPTION
We'd like to use this to automatically select the correct default branch since most people use main or master

[WOR-2425](https://getsentry.atlassian.net/browse/WOR-2425)

[WOR-2425]: https://getsentry.atlassian.net/browse/WOR-2425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ