### PR TITLE
feat(heartbeat): Add Analytics code - [TET-685]

### DIFF
--- a/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
@@ -23,7 +23,8 @@ export type HeartbeatEventParameters = {
 export const heartbeatEventMap: Record<keyof HeartbeatEventParameters, string> = {
   'heartbeat.onboarding_explore_sentry_button_clicked':
     'Heartbeat: Onboarding Explore Sentry Button Clicked',
-  'heartbeat.onboarding_first_error_received': 'Heartbeat:  First Error Received',
+  'heartbeat.onboarding_first_error_received':
+    'Heartbeat: Onboarding First Error Received',
   'heartbeat.onboarding_first_transaction_received':
     'Heartbeat: Onboarding First Transaction Received',
   'heartbeat.onboarding_go_to_issues_button_clicked':

--- a/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
@@ -32,7 +32,7 @@ export const heartbeatEventMap: Record<keyof HeartbeatEventParameters, string> =
   'heartbeat.onboarding_go_to_my_error_button_clicked':
     'Heartbeat: Onboarding Go My Error Button Clicked',
   'heartbeat.onboarding_go_to_performance_button_clicked':
-    'Heartbeat: Onboarding Go Performance Button Clicked',
+    'Heartbeat: Onboarding Go To Performance Button Clicked',
   'heartbeat.onboarding_session_received': 'Heartbeat: Onboarding Session Received',
   'heartbeat.onboarding_back_button_clicked': 'Heartbeat: Onboarding Back Button Clicked',
 };

--- a/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
@@ -1,0 +1,37 @@
+export type HeartbeatEventParameters = {
+  'heartbeat.onboarding_back_button_clicked': {
+    from: string;
+    to: string;
+  };
+  'heartbeat.onboarding_explore_sentry_button_clicked': {};
+  'heartbeat.onboarding_first_error_received': {
+    new_organization: boolean;
+  };
+  'heartbeat.onboarding_first_transaction_received': {
+    new_organization: boolean;
+  };
+  'heartbeat.onboarding_go_to_issues_button_clicked': {};
+  'heartbeat.onboarding_go_to_my_error_button_clicked': {
+    new_organization: boolean;
+  };
+  'heartbeat.onboarding_go_to_performance_button_clicked': {};
+  'heartbeat.onboarding_session_received': {
+    new_organization: boolean;
+  };
+};
+
+export const heartbeatEventMap: Record<keyof HeartbeatEventParameters, string> = {
+  'heartbeat.onboarding_explore_sentry_button_clicked':
+    'Heartbeat: Onboarding Explore Sentry Button Clicked',
+  'heartbeat.onboarding_first_error_received': 'Heartbeat:  First Error Received',
+  'heartbeat.onboarding_first_transaction_received':
+    'Heartbeat: Onboarding First Transaction Received',
+  'heartbeat.onboarding_go_to_issues_button_clicked':
+    'Heartbeat: Onboarding Go To Issues Button Clicked',
+  'heartbeat.onboarding_go_to_my_error_button_clicked':
+    'Heartbeat: Onboarding Go My Error Button Clicked',
+  'heartbeat.onboarding_go_to_performance_button_clicked':
+    'Heartbeat: Onboarding Go Performance Button Clicked',
+  'heartbeat.onboarding_session_received': 'Heartbeat: Onboarding Session Received',
+  'heartbeat.onboarding_back_button_clicked': 'Heartbeat: Onboarding Back Button Clicked',
+};

--- a/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/heartbeatAnalyticsEvents.tsx
@@ -30,7 +30,7 @@ export const heartbeatEventMap: Record<keyof HeartbeatEventParameters, string> =
   'heartbeat.onboarding_go_to_issues_button_clicked':
     'Heartbeat: Onboarding Go To Issues Button Clicked',
   'heartbeat.onboarding_go_to_my_error_button_clicked':
-    'Heartbeat: Onboarding Go My Error Button Clicked',
+    'Heartbeat: Onboarding Go To My Error Button Clicked',
   'heartbeat.onboarding_go_to_performance_button_clicked':
     'Heartbeat: Onboarding Go To Performance Button Clicked',
   'heartbeat.onboarding_session_received': 'Heartbeat: Onboarding Session Received',

--- a/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
@@ -6,6 +6,7 @@ import {
   DynamicSamplingEventParameters,
 } from './dynamicSamplingAnalyticsEvents';
 import {growthEventMap, GrowthEventParameters} from './growthAnalyticsEvents';
+import {heartbeatEventMap, HeartbeatEventParameters} from './heartbeatAnalyticsEvents';
 import {issueEventMap, IssueEventParameters} from './issueAnalyticsEvents';
 import makeAnalyticsFunction from './makeAnalyticsFunction';
 import {monitorsEventMap, MonitorsEventParameters} from './monitorsAnalyticsEvents';
@@ -33,7 +34,8 @@ type EventParameters = GrowthEventParameters &
   SearchEventParameters &
   SettingsEventParameters &
   TeamInsightsEventParameters &
-  DynamicSamplingEventParameters;
+  DynamicSamplingEventParameters &
+  HeartbeatEventParameters;
 
 const allEventMap: Record<string, string | null> = {
   ...coreUIEventMap,
@@ -50,6 +52,7 @@ const allEventMap: Record<string, string | null> = {
   ...settingsEventMap,
   ...workflowEventMap,
   ...dynamicSamplingEventMap,
+  ...heartbeatEventMap,
 };
 
 /**

--- a/static/app/views/onboarding/components/heartbeatFooter/useHeartbeat.tsx
+++ b/static/app/views/onboarding/components/heartbeatFooter/useHeartbeat.tsx
@@ -20,10 +20,10 @@ export function useHeartbeat(
 
   const [firstError, setFirstError] = useState<string | null>(null);
   const [firstTransactionReceived, setFirstTransactionReceived] = useState(false);
-  const [hasSession, setHasSession] = useState(false);
+  const [sessionReceived, setSessionReceived] = useState(false);
   const [firstIssue, setFirstIssue] = useState<Group | undefined>(undefined);
 
-  const serverConnected = hasSession || firstTransactionReceived;
+  const serverConnected = sessionReceived || firstTransactionReceived;
 
   const {isLoading: eventIsLoading} = useQuery<Project>(
     [`/projects/${organization.slug}/${projectSlug}/`],
@@ -58,7 +58,7 @@ export function useHeartbeat(
         const hasHealthData =
           getCount(data.groups, SessionFieldWithOperation.SESSIONS) > 0;
 
-        setHasSession(hasHealthData);
+        setSessionReceived(hasHealthData);
       },
     }
   );
@@ -82,5 +82,7 @@ export function useHeartbeat(
     loading,
     serverConnected,
     firstErrorReceived,
+    firstTransactionReceived,
+    sessionReceived,
   };
 }

--- a/static/app/views/onboarding/index.tsx
+++ b/static/app/views/onboarding/index.tsx
@@ -154,6 +154,13 @@ function Onboarding(props: Props) {
     if (stepObj.cornerVariant !== previousStep.cornerVariant) {
       cornerVariantControl.start('none');
     }
+
+    trackAdvancedAnalyticsEvent('heartbeat.onboarding_back_button_clicked', {
+      organization,
+      from: onboardingSteps[stepIndex].id,
+      to: previousStep.id,
+    });
+
     browserHistory.replace(
       normalizeUrl(`/onboarding/${organization.slug}/${previousStep.id}/`)
     );

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -20,10 +20,10 @@ import {platformToIntegrationMap} from 'sentry/utils/integrationUtil';
 import useApi from 'sentry/utils/useApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withProjects from 'sentry/utils/withProjects';
+import {HeartbeatFooter} from 'sentry/views/onboarding/components/heartbeatFooter';
 
 import FirstEventFooter from './components/firstEventFooter';
 import FullIntroduction from './components/fullIntroduction';
-import {HeartbeatFooter} from './components/heartbeatFooter';
 import ProjectSidebarSection from './components/projectSidebarSection';
 import IntegrationSetup from './integrationSetup';
 import {StepProps} from './types';

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -50,6 +50,7 @@ function InnerAction({title, subText, cta, src}: TextWrapperProps) {
 function TargetedOnboardingWelcome({organization, ...props}: StepProps) {
   const source = 'targeted_onboarding';
   const [clientState, setClientState] = usePersistedOnboardingState();
+
   useEffect(() => {
     trackAdvancedAnalyticsEvent('growth.onboarding_start_onboarding', {
       organization,


### PR DESCRIPTION
This PR adds amplitude analytics code to the heartbeat solution to track the following:

- First Error Received
- First Transaction Received
- First Session Received
- Back Button Clicked (in the onboarding for new orgs)
- Go To My Error Button Clicked
- Go To Issues Button Clicked (in the onboarding for existing orgs)
- Explore Sentry Button Clicked (in the onboarding for new orgs)
- Go To Performance Button Clicked  (in the onboarding for existing orgs)

_The heartbeat feature is behind a feature flag and is currently only available for the telemetry experience team._