### PR TITLE
fix(ui) Fix settings page not being defined without customer domains

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -637,7 +637,7 @@ function buildRoutes() {
       )}
     >
       {hook('routes:organization')}
-      {usingCustomerDomain && (
+      {!usingCustomerDomain && (
         <IndexRoute
           name={t('General')}
           component={make(


### PR DESCRIPTION
Revert part of #44207 as the condition logic was flipped. the `/settings/:slug` route should be connected when customer domains is not enabled.
