### PR TITLE
ref(perf-issues): Add proj option for unc. detector w/ refactor

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -10,19 +10,15 @@ MAX_VALUE = 2147483647
 SETTINGS_PROJECT_OPTION_KEY = "sentry:performance_issue_settings"
 
 
+RateField = serializers.FloatField(required=False, min_value=0, max_value=1)
+EnabledField = serializers.BooleanField(required=False)
+
+
 class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
-    n_plus_one_db_detection_rate = serializers.FloatField(required=False, min_value=0, max_value=1)
-    n_plus_one_db_issue_rate = serializers.FloatField(required=False, min_value=0, max_value=1)
-    n_plus_one_db_count = serializers.IntegerField(required=False, min_value=0, max_value=MAX_VALUE)
-    n_plus_one_db_duration_threshold = serializers.IntegerField(
-        required=False, min_value=0, max_value=MAX_VALUE
-    )
-    n_plus_one_api_calls_detection_rate = serializers.FloatField(
-        required=False, min_value=0, max_value=1
-    )
-    consecutive_db_queries_detection_rate = serializers.FloatField(
-        required=False, min_value=0, max_value=1
-    )
+    n_plus_one_db_detection_rate = RateField
+    n_plus_one_api_calls_detection_rate = RateField
+    consecutive_db_queries_detection_rate = RateField
+    uncompressed_assets_detection_enabled = EnabledField
 
 
 @region_silo_endpoint
@@ -69,14 +65,21 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        performance_issue_settings = projectoptions.get_well_known_default(
+        performance_issue_settings_default = projectoptions.get_well_known_default(
             SETTINGS_PROJECT_OPTION_KEY,
             project=project,
         )
 
+        performance_issue_settings = project.get_option(
+            SETTINGS_PROJECT_OPTION_KEY, default=performance_issue_settings_default
+        )
+
         data = serializer.validated_data
 
-        project.update_option(SETTINGS_PROJECT_OPTION_KEY, {**performance_issue_settings, **data})
+        project.update_option(
+            SETTINGS_PROJECT_OPTION_KEY,
+            {**performance_issue_settings_default, **performance_issue_settings, **data},
+        )
 
         return Response(data)
 

--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -15,10 +15,14 @@ EnabledField = serializers.BooleanField(required=False)
 
 
 class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
-    n_plus_one_db_detection_rate = RateField
-    n_plus_one_api_calls_detection_rate = RateField
-    consecutive_db_queries_detection_rate = RateField
-    uncompressed_assets_detection_enabled = EnabledField
+    n_plus_one_db_detection_rate = serializers.FloatField(required=False, min_value=0, max_value=1)
+    n_plus_one_api_calls_detection_rate = serializers.FloatField(
+        required=False, min_value=0, max_value=1
+    )
+    consecutive_db_queries_detection_rate = serializers.FloatField(
+        required=False, min_value=0, max_value=1
+    )
+    uncompressed_assets_detection_enabled = serializers.BooleanField(required=False)
 
 
 @region_silo_endpoint

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -91,25 +91,17 @@ register(key="sentry:span_attributes", epoch_defaults={1: ["exclusive-time"]})
 # Can be used to turn off a projects detection for users if there is a project-specific issue.
 register(key="sentry:performance_issue_creation_rate", default=1.0)
 
+DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
+    "n_plus_one_db_detection_rate": 1.0,
+    "n_plus_one_api_calls_detection_rate": 1.0,
+    "consecutive_db_queries_detection_rate": 1.0,
+    "uncompressed_assets_detection_enabled": True,
+}
 # A dict containing all the specific detection thresholds and rates.
 register(
     key="sentry:performance_issue_settings",
-    default={
-        "n_plus_one_db_detection_rate": 0,
-        "n_plus_one_db_issue_rate": 0,
-        "n_plus_one_db_count": 5,
-        "n_plus_one_db_duration_threshold": 500,
-        "render_blocking_fcp_min": 2000.0,
-        "render_blocking_fcp_max": 10000.0,
-        "render_blocking_fcp_ratio": 0.33,
-        "render_blocking_bytes_min": 1000000,
-        "n_plus_one_api_calls_detection_rate": 1.0,
-        "consecutive_db_queries_detection_rate": 1.0,
-    },
+    default=DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS,
 )
-
-# Using simple bools instead of rates for disabling individual detectors
-register(key="sentry:performance_issue_creation_enabled_n_plus_one_db", default=True)
 
 # Replacement rules for transaction names discovered by the transaction clusterer.
 # Contains a mapping from rule to last seen timestamp,

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -84,7 +84,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         )
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:
-        return True  # Detection always allowed by project for now
+        return self.settings["detection_enabled"]
 
     def is_event_eligible(cls, event):
         tags = event.get("tags", [])

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -167,7 +167,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         else {}
     )
 
-    project_settings = (
+    project_option_settings = (
         ProjectOption.objects.get_value(
             project_id, "sentry:performance_issue_settings", default_project_settings
         )
@@ -175,16 +175,10 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         else DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
     )
 
-    use_project_option_settings = default_project_settings != project_settings
-    project_option_settings = {
+    project_settings = {
         **default_project_settings,
-        **project_settings,
+        **project_option_settings,
     }  # Merge saved project settings into default so updating the default to add new settings works in the future.
-
-    # Use project settings if they've been adjusted at all, to allow customization, otherwise fetch settings from system-wide options.
-    project_settings = (
-        project_option_settings if use_project_option_settings else default_project_settings
-    )
 
     settings = {**system_settings, **project_settings}
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -16,11 +16,11 @@ from symbolic import ProguardMapper  # type: ignore
 from sentry import features, nodestore, options, projectoptions
 from sentry.eventstore.models import Event
 from sentry.models import Organization, Project, ProjectDebugFile, ProjectOption
+from sentry.projectoptions.defaults import DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
 from sentry.types.issues import GroupType
 from sentry.utils import metrics
 from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.safe import get_path
-from sentry.projectoptions.defaults import DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
 
 from .base import (
     DETECTOR_TYPE_TO_GROUP_TYPE,

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -20,6 +20,7 @@ from sentry.types.issues import GroupType
 from sentry.utils import metrics
 from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.safe import get_path
+from sentry.projectoptions.defaults import DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
 
 from .base import (
     DETECTOR_TYPE_TO_GROUP_TYPE,
@@ -138,6 +139,25 @@ def detect_performance_problems(data: Event, project: Project) -> List[Performan
 # Duration thresholds are in milliseconds.
 # Allowed span ops are allowed span prefixes. (eg. 'http' would work for a span with 'http.client' as its op)
 def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorType, Any]:
+    system_settings = {
+        "n_plus_one_db_count": options.get("performance.issues.n_plus_one_db.count_threshold"),
+        "n_plus_one_db_duration_threshold": options.get(
+            "performance.issues.n_plus_one_db.duration_threshold"
+        ),
+        "render_blocking_fcp_min": options.get(
+            "performance.issues.render_blocking_assets.fcp_minimum_threshold"
+        ),
+        "render_blocking_fcp_max": options.get(
+            "performance.issues.render_blocking_assets.fcp_maximum_threshold"
+        ),
+        "render_blocking_fcp_ratio": options.get(
+            "performance.issues.render_blocking_assets.fcp_ratio_threshold"
+        ),
+        "render_blocking_bytes_min": options.get(
+            "performance.issues.render_blocking_assets.size_threshold"
+        ),
+    }
+
     default_project_settings = (
         projectoptions.get_well_known_default(
             "sentry:performance_issue_settings",
@@ -152,40 +172,21 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             project_id, "sentry:performance_issue_settings", default_project_settings
         )
         if project_id
-        else {}
+        else DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
     )
 
     use_project_option_settings = default_project_settings != project_settings
-    merged_project_settings = {
+    project_option_settings = {
         **default_project_settings,
         **project_settings,
     }  # Merge saved project settings into default so updating the default to add new settings works in the future.
 
     # Use project settings if they've been adjusted at all, to allow customization, otherwise fetch settings from system-wide options.
-    settings = (
-        merged_project_settings
-        if use_project_option_settings
-        else {
-            "n_plus_one_db_count": options.get("performance.issues.n_plus_one_db.count_threshold"),
-            "n_plus_one_db_duration_threshold": options.get(
-                "performance.issues.n_plus_one_db.duration_threshold"
-            ),
-            "render_blocking_fcp_min": options.get(
-                "performance.issues.render_blocking_assets.fcp_minimum_threshold"
-            ),
-            "render_blocking_fcp_max": options.get(
-                "performance.issues.render_blocking_assets.fcp_maximum_threshold"
-            ),
-            "render_blocking_fcp_ratio": options.get(
-                "performance.issues.render_blocking_assets.fcp_ratio_threshold"
-            ),
-            "render_blocking_bytes_min": options.get(
-                "performance.issues.render_blocking_assets.size_threshold"
-            ),
-            "n_plus_one_api_calls_detection_rate": 1.0,
-            "consecutive_db_queries_detection_rate": 1.0,
-        }
+    project_settings = (
+        project_option_settings if use_project_option_settings else default_project_settings
     )
+
+    settings = {**system_settings, **project_settings}
 
     return {
         DetectorType.SLOW_DB_QUERY: [
@@ -240,6 +241,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             "size_threshold_bytes": 500 * 1024,
             "duration_threshold": 500,  # ms
             "allowed_span_ops": ["resource.css", "resource.script"],
+            "detection_enabled": settings["uncompressed_assets_detection_enabled"],
         },
     }
 

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -34,8 +34,10 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data["n_plus_one_db_count"] == 5
-        assert response.data["n_plus_one_db_duration_threshold"] == 500
+        assert response.data["n_plus_one_db_detection_rate"] == 1.0
+        assert response.data["n_plus_one_api_calls_detection_rate"] == 1.0
+        assert response.data["consecutive_db_queries_detection_rate"] == 1.0
+        assert response.data["uncompressed_assets_detection_enabled"] == True
 
     def test_get_returns_error_without_feature_enabled(self):
         with self.feature({}):
@@ -47,32 +49,31 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             response = self.client.put(
                 self.url,
                 data={
-                    "n_plus_one_db_count": 17,
+                    "n_plus_one_db_detection_rate": 0.33,
                 },
             )
 
         assert response.status_code == 200, response.content
-        assert response.data["n_plus_one_db_count"] == 17
+        assert response.data["n_plus_one_db_detection_rate"] == 0.33
 
         with self.feature(PERFORMANCE_ISSUE_FEATURES):
             get_response = self.client.get(self.url, format="json")
 
         assert get_response.status_code == 200, response.content
-        assert get_response.data["n_plus_one_db_count"] == 17
-        assert get_response.data["n_plus_one_db_duration_threshold"] == 500
+        assert get_response.data["n_plus_one_db_detection_rate"] == 0.33
 
     def test_update_project_setting_check_validation(self):
         with self.feature(PERFORMANCE_ISSUE_FEATURES):
             response = self.client.put(
                 self.url,
                 data={
-                    "n_plus_one_db_count": -1,
+                    "n_plus_one_db_detection_rate": -1,
                 },
             )
 
         assert response.status_code == 400, response.content
         assert response.data == {
-            "n_plus_one_db_count": [
+            "n_plus_one_db_detection_rate": [
                 ErrorDetail(
                     string="Ensure this value is greater than or equal to 0.", code="min_value"
                 )
@@ -80,8 +81,13 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
         }
 
     def test_delete_all_project_settings(self):
-        self.project.update_option(SETTINGS_PROJECT_OPTION_KEY, {"n_plus_one_db_count": 42})
-        assert self.project.get_option(SETTINGS_PROJECT_OPTION_KEY)["n_plus_one_db_count"] == 42
+        self.project.update_option(
+            SETTINGS_PROJECT_OPTION_KEY, {"n_plus_one_db_detection_rate": 0.20}
+        )
+        assert (
+            self.project.get_option(SETTINGS_PROJECT_OPTION_KEY)["n_plus_one_db_detection_rate"]
+            == 0.20
+        )
         with self.feature(PERFORMANCE_ISSUE_FEATURES):
             response = self.client.delete(
                 self.url,

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -37,7 +37,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
         assert response.data["n_plus_one_db_detection_rate"] == 1.0
         assert response.data["n_plus_one_api_calls_detection_rate"] == 1.0
         assert response.data["consecutive_db_queries_detection_rate"] == 1.0
-        assert response.data["uncompressed_assets_detection_enabled"] == True
+        assert response.data["uncompressed_assets_detection_enabled"]
 
     def test_get_returns_error_without_feature_enabled(self):
         with self.feature({}):


### PR DESCRIPTION
### Summary
This adds a ProjectOption entry for uncompressed asset detector detection and does some light refactoring of options to fix some errors I found when testing out setting project options, on top of reducing some of the noise with having defaults set in multiple places. Now there is only the system defaults set by their default option value, and the project option dict default which is re-used to be merged into for outdated project options.

### Other changes
- Removed `n_plus_one_db_*` and other project options _thresholds_ since we aren't doing any per-project settings, going to remove it from the UI, since it's also not in the serializers. If we want it later we can add it, but as of right now it's not a feature and is adding noise to the configuration.
- Removed the `sentry:performance_issue_creation_enabled_n_plus_one_db` since that was meant to setup 1 project option boolean per detector, but we've already gone down the route of expanding the project option dict, so fixing that instead instead of having 2 ways of doing things.
- Switched uncompressed asset detector to 'BooleanField' since a rate isn't really useful except for when we were rolling out the Sentry project.
- This also should fix an issue with project options configuration endpoint where setting one option would cause others to revert to their defaults.

### Current option state
Here is what I'm proposing:
- Project Option settings (eg. `n_plus_one_api_calls_detection_rate`) only contain detection on/off (rate or bools) for now.
- Thresholds (eg. `performance.issues.n_plus_one_db.count_threshold`) are only set in the system for now, to allow tuning. Uses the defaults for fallback.

