### PR TITLE
bug(replays): Add default filter behavior for object type fields

### DIFF
--- a/src/sentry/replays/lib/query.py
+++ b/src/sentry/replays/lib/query.py
@@ -89,7 +89,6 @@ class Field:
         value: Union[List[str], str],
         is_wildcard: bool = False,
     ) -> Condition:
-
         return Condition(Column(self.query_alias or self.attribute_name), operator, value)
 
 

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -405,6 +405,14 @@ class ReplayQueryConfig(QueryConfig):
     sdk_name = String(field_alias="sdk.name", query_alias="sdk_name")
     sdk_version = String(field_alias="sdk.version", query_alias="sdk_version")
 
+    # These are object-type fields.  User's who query by these fields are likely querying by
+    # the "name" value.
+    user = String(field_alias="user", query_alias="user_name")
+    os = String(field_alias="os", query_alias="os_name")
+    browser = String(field_alias="browser", query_alias="browser_name")
+    device = String(field_alias="device", query_alias="device_name")
+    sdk = String(field_alias="sdk", query_alias="sdk_name")
+
     # Tag
     tags = Tag(field_alias="*")
 

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -813,3 +813,21 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             )
             assert response.status_code == 200
             assert len(response.json()["data"]) == 0
+
+    def test_filter_by_object_field(self):
+        """Test filtering a query by an object field."""
+        replay1_id = uuid.uuid4().hex
+        timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=30)
+        timestamp2 = datetime.datetime.now() - datetime.timedelta(seconds=20)
+
+        self.store_replays(mock_replay(timestamp1, self.project.id, replay1_id, user_name="test"))
+        self.store_replays(mock_replay(timestamp2, self.project.id, replay1_id))
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.get(self.url + "?query=user:test")
+            assert response.status_code == 200
+            assert len(response.json()["data"]) == 1
+
+            response = self.client.get(self.url + "?query=!user:test")
+            assert response.status_code == 200
+            assert len(response.json()["data"]) == 0

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -463,6 +463,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "release:[a,version@1.3]",
                 "duration:>15",
                 "user.id:123",
+                "user:username123",
                 "user.name:username123",
                 "user.email:username@example.com",
                 "user.email:*@example.com",
@@ -811,23 +812,5 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             response = self.client.get(
                 self.url + f"?start={timestamp1.isoformat()}&end={timestamp2.isoformat()}"
             )
-            assert response.status_code == 200
-            assert len(response.json()["data"]) == 0
-
-    def test_filter_by_object_field(self):
-        """Test filtering a query by an object field."""
-        replay1_id = uuid.uuid4().hex
-        timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=30)
-        timestamp2 = datetime.datetime.now() - datetime.timedelta(seconds=20)
-
-        self.store_replays(mock_replay(timestamp1, self.project.id, replay1_id, user_name="test"))
-        self.store_replays(mock_replay(timestamp2, self.project.id, replay1_id))
-
-        with self.feature(REPLAYS_FEATURES):
-            response = self.client.get(self.url + "?query=user:test")
-            assert response.status_code == 200
-            assert len(response.json()["data"]) == 1
-
-            response = self.client.get(self.url + "?query=!user:test")
             assert response.status_code == 200
             assert len(response.json()["data"]) == 0


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/266

If a user queries by an object type field such as `user` or `browser` the API would raise an exception because those fields are not valid columns.  This PR accepts those object type filters and applies them to a chosen default column.  In these cases `*_name` was the chosen column to target.