### PR TITLE
feat(perf-issues): Use shared url hashing for unc. assets

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -4,7 +4,12 @@ from sentry import features
 from sentry.models import Organization, Project
 from sentry.types.issues import GroupType
 
-from ..base import DetectorType, PerformanceDetector, fingerprint_spans, get_span_duration
+from ..base import (
+    DetectorType,
+    PerformanceDetector,
+    fingerprint_resource_span,
+    get_span_duration,
+)
 from ..performance_problem import PerformanceProblem
 from ..types import Span
 
@@ -75,8 +80,8 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
             )
 
     def _fingerprint(self, span) -> str:
-        hashed_spans = fingerprint_spans([span])
-        return f"1-{GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS.value}-{hashed_spans}"
+        resource_span = fingerprint_resource_span(span)
+        return f"1-{GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS.value}-{resource_span}"
 
     def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
         return features.has(

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -4,12 +4,7 @@ from sentry import features
 from sentry.models import Organization, Project
 from sentry.types.issues import GroupType
 
-from ..base import (
-    DetectorType,
-    PerformanceDetector,
-    fingerprint_resource_span,
-    get_span_duration,
-)
+from ..base import DetectorType, PerformanceDetector, fingerprint_resource_span, get_span_duration
 from ..performance_problem import PerformanceProblem
 from ..types import Span
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -24,8 +24,8 @@ from .base import (
     DETECTOR_TYPE_TO_GROUP_TYPE,
     DetectorType,
     PerformanceDetector,
-    fingerprint_span,
     fingerprint_resource_span,
+    fingerprint_span,
     fingerprint_spans,
     get_span_duration,
 )

--- a/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
@@ -69,7 +69,7 @@ class UncompressedAssetsDetectorTest(TestCase):
 
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1012-da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                fingerprint="1-1012-6893fb5a8a875d692da96590f40dc6bddd6fcabc",
                 op="resource.script",
                 desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
                 type=GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS,
@@ -101,7 +101,7 @@ class UncompressedAssetsDetectorTest(TestCase):
 
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1012-da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                fingerprint="1-1012-7f5aaccd4a1347f512fc3d04068b9621baff2783",
                 op="resource.script",
                 desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.css",
                 type=GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS,
@@ -204,7 +204,7 @@ class UncompressedAssetsDetectorTest(TestCase):
 
         assert self.find_problems(event) == [
             PerformanceProblem(
-                fingerprint="1-1012-cd13ad1ab06d25a36fb216047291643e48228608",
+                fingerprint="1-1012-385f4476d848360e4cb90cbe31457f6bba5bd6a9",
                 op="resource.script",
                 desc="https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_components_charts_utils_tsx-app_utils_performance_quickTrace_utils_tsx-app_utils_withPage-3926ec.bc434924850c44d4057f.js",
                 type=GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS,


### PR DESCRIPTION
This re-uses the url hashing introduced for render blocking assets for the uncompressed asset detector.
