### PR TITLE
feat(replays): Add support for duration-type filters on duration column

### DIFF
--- a/src/sentry/replays/lib/query.py
+++ b/src/sentry/replays/lib/query.py
@@ -89,7 +89,6 @@ class Field:
         value: Union[List[str], str],
         is_wildcard: bool = False,
     ) -> Condition:
-
         return Condition(Column(self.query_alias or self.attribute_name), operator, value)
 
 
@@ -113,6 +112,19 @@ class String(Field):
 class Number(Field):
     _operators = [Op.EQ, Op.NEQ, Op.GT, Op.GTE, Op.LT, Op.LTE, Op.IN, Op.NOT_IN]
     _python_type = int
+
+
+class Duration(Number):
+    def as_condition(
+        self,
+        field_alias: str,
+        operator: Op,
+        value: Union[List[str], str],
+        is_wildcard: bool = False,
+    ) -> Condition:
+        # Duration columns map to milliseconds by default but replays have a resolution
+        # of 1 second.
+        return Condition(Column(self.query_alias or self.attribute_name), operator, value // 1000)
 
 
 class ListField(Field):

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -23,6 +23,7 @@ from snuba_sdk.orderby import Direction, OrderBy
 
 from sentry.api.event_search import ParenExpression, SearchConfig, SearchFilter
 from sentry.replays.lib.query import (
+    Duration,
     ListField,
     Number,
     QueryConfig,
@@ -371,7 +372,7 @@ replay_url_parser_config = SearchConfig(
 
 class ReplayQueryConfig(QueryConfig):
     # Numeric filters.
-    duration = Number()
+    duration = Duration()
     count_errors = Number(query_alias="count_errors")
     count_segments = Number(query_alias="count_segments")
     count_urls = Number(query_alias="count_urls")

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -364,7 +364,8 @@ def _sorted_aggregated_urls(agg_urls_column, alias):
 # Filter
 
 replay_url_parser_config = SearchConfig(
-    numeric_keys={"duration", "count_errors", "count_segments", "count_urls", "activity"},
+    duration_keys={"duration"},
+    numeric_keys={"count_errors", "count_segments", "count_urls", "activity"},
 )
 
 

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -829,6 +829,11 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert response.status_code == 200
             assert len(response.json()["data"]) == 1
 
+            # Row meets string condition on numeric duration column.
+            response = self.client.get(self.url + "?query=duration:20000")
+            assert response.status_code == 200
+            assert len(response.json()["data"]) == 1
+
             # Row fails string condition on numeric duration column.
             response = self.client.get(self.url + "?query=duration:>1h")
             assert response.status_code == 200


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/275

Previously we defined `duration` as a numeric column in our SearchConfig.   Defining it as a `duration_key` allows users to filter with suffixes such as `1h`, `10m`, `3d`.  The string value is translated by the config to the appropriate integer value.

This pull changes the filter resolution from 1 second to 1 millisecond.  This means these two filters are now equivalent `duration:20s` == `duration:20000`.  This is not ideal behavior for the replays product so more time will be needed to either iterate on the front-end or to adapt the SearchConfig to support  a 1 second resolution.