### PR TITLE
test: enable test_metrics_extraction

### DIFF
--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -1,7 +1,6 @@
 import uuid
 
 import confluent_kafka as kafka
-import pytest
 
 from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
 from sentry.tasks.relay import compute_projectkey_config
@@ -12,9 +11,6 @@ from sentry.utils import json
 
 
 class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
-    @pytest.mark.skip(
-        "TET-627: We need to release new metric first in relay and than adjust the test"
-    )
     def test_all_transaction_metrics_emitted(self):
         with Feature(
             {


### PR DESCRIPTION
This PR enables tests back, after releasing relay changes.


Skip tag was introduced in this PR https://github.com/getsentry/sentry/pull/43167