### PR TITLE
feat(view-hierarchy): Selections in the tree highlight in the wireframe

### DIFF
--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -154,13 +154,16 @@ describe('View Hierarchy', function () {
       'view-hierarchy-wireframe-overlay'
     ) as HTMLCanvasElement;
 
-    userEvent.click(screen.getAllByText('Nested Container - nested')[0]);
-
-    // This is the nested container, the x, y positions are shifted by the parent
     const context = canvas.getContext('2d');
     if (!context) {
       throw new Error('Canvas context is not defined');
     }
+
+    expect(context.fillRect).not.toHaveBeenCalledWith(210, 11, 3, 4);
+
+    userEvent.click(screen.getByText('Nested Container - nested'));
+
+    // This is the nested container, the x, y positions are shifted by the parent
     expect(context.fillRect).toHaveBeenCalledWith(210, 11, 3, 4);
   });
 });

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -147,8 +147,6 @@ describe('View Hierarchy', function () {
   it('draws the selected node when a tree selection is made', function () {
     render(<ViewHierarchy viewHierarchy={MOCK_DATA} project={project} />);
 
-    expect(screen.getByTestId('view-hierarchy-wireframe')).toBeInTheDocument();
-
     const canvas = screen.getByTestId(
       'view-hierarchy-wireframe-overlay'
     ) as HTMLCanvasElement;
@@ -164,5 +162,21 @@ describe('View Hierarchy', function () {
 
     // This is the nested container, the x, y positions are shifted by the parent
     expect(context.fillRect).toHaveBeenCalledWith(210, 11, 3, 4);
+  });
+
+  it('does not render a wireframe selection initially', function () {
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} project={project} />);
+
+    const canvas = screen.getByTestId(
+      'view-hierarchy-wireframe-overlay'
+    ) as HTMLCanvasElement;
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Canvas context is not defined');
+    }
+
+    // The overlay should not have rendered anything before any interactions
+    expect(context.fillRect).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -26,6 +26,10 @@ const DEFAULT_MOCK_DATA = {
         {
           ...DEFAULT_VALUES,
           type: 'Nested Container',
+          x: 10,
+          y: 10,
+          width: 3,
+          height: 4,
           identifier: 'nested',
           children: [
             {
@@ -138,5 +142,25 @@ describe('View Hierarchy', function () {
     render(<ViewHierarchy viewHierarchy={MOCK_DATA} project={mockUnityProject} />);
 
     expect(screen.queryByTestId('view-hierarchy-wireframe')).not.toBeInTheDocument();
+  });
+
+  it('draws the selected node when a tree selection is made', function () {
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} project={project} />);
+
+    expect(screen.getByTestId('view-hierarchy-wireframe')).toBeInTheDocument();
+
+    // mock the canvas fillRect method
+    const canvas = screen.getByTestId(
+      'view-hierarchy-wireframe-overlay'
+    ) as HTMLCanvasElement;
+
+    userEvent.click(screen.getAllByText('Nested Container - nested')[0]);
+
+    // This is the nested container, the x, y positions are shifted by the parent
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Canvas context is not defined');
+    }
+    expect(context.fillRect).toHaveBeenCalledWith(210, 11, 3, 4);
   });
 });

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -149,7 +149,6 @@ describe('View Hierarchy', function () {
 
     expect(screen.getByTestId('view-hierarchy-wireframe')).toBeInTheDocument();
 
-    // mock the canvas fillRect method
     const canvas = screen.getByTestId(
       'view-hierarchy-wireframe-overlay'
     ) as HTMLCanvasElement;

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -147,7 +147,11 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
         </Left>
         {showWireframe && (
           <Right>
-            <Wireframe hierarchy={hierarchy} onNodeSelect={onWireframeNodeSelect} />
+            <Wireframe
+              hierarchy={hierarchy}
+              selectedNode={selectedNode}
+              onNodeSelect={onWireframeNodeSelect}
+            />
           </Right>
         )}
       </Content>

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -48,6 +48,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
   const [selectedNode, setSelectedNode] = useState<ViewHierarchyWindow | undefined>(
     viewHierarchy.windows[0]
   );
+  const [userHasSelected, setUserHasSelected] = useState(false);
   const hierarchy = useMemo(() => {
     return viewHierarchy.windows;
   }, [viewHierarchy.windows]);
@@ -82,6 +83,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
         onClick={e => {
           handleRowClick(e);
           setSelectedNode(r.item.node);
+          setUserHasSelected(true);
         }}
       >
         {depthMarkers}
@@ -117,6 +119,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
   // Scroll to the selected node when it changes
   const onWireframeNodeSelect = useCallback(
     (node?: ViewHierarchyWindow) => {
+      setUserHasSelected(true);
       setSelectedNode(node);
       handleScrollTo(item => item === node);
     },
@@ -149,7 +152,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
           <Right>
             <Wireframe
               hierarchy={hierarchy}
-              selectedNode={selectedNode}
+              selectedNode={userHasSelected ? selectedNode : undefined}
               onNodeSelect={onWireframeNodeSelect}
             />
           </Right>

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -116,7 +116,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
 
   // Scroll to the selected node when it changes
   const onWireframeNodeSelect = useCallback(
-    (node: ViewHierarchyWindow) => {
+    (node?: ViewHierarchyWindow) => {
       setSelectedNode(node);
       handleScrollTo(item => item === node);
     },

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -101,7 +101,7 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect}: WireframeProps) {
       const overlay = overlayRef?.getContext('2d');
       if (overlay) {
         setupCanvasContext(overlay, modelToView);
-        overlay.fillStyle = theme.pink200;
+        overlay.fillStyle = theme.blue200;
 
         if (selectedRect) {
           overlay.fillRect(
@@ -113,12 +113,12 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect}: WireframeProps) {
         }
 
         if (hoverRect) {
-          overlay.fillStyle = theme.pink100;
+          overlay.fillStyle = theme.blue100;
           overlay.fillRect(hoverRect.x, hoverRect.y, hoverRect.width, hoverRect.height);
         }
       }
     },
-    [overlayRef, setupCanvasContext, theme.pink100, theme.pink200]
+    [overlayRef, setupCanvasContext, theme.blue100, theme.blue200]
   );
 
   const drawViewHierarchy = useCallback(

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -156,9 +156,7 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect}: WireframeProps) {
     let start: vec2 | null;
     let isDragging = false;
     const selectedRect: Rect | null =
-      selectedNode && nodeLookupMap.has(selectedNode)
-        ? nodeLookupMap.get(selectedNode)!.rect
-        : null;
+      (selectedNode && nodeLookupMap.get(selectedNode)?.rect) ?? null;
     let hoveredRect: Rect | null = null;
     const currTransformationMatrix = mat3.clone(transformationMatrix);
 

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -211,6 +211,11 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect}: WireframeProps) {
           transformationMatrix,
           window.devicePixelRatio
         );
+
+        if (!clickedNode) {
+          return;
+        }
+
         drawOverlay(transformationMatrix, clickedNode?.rect ?? null, null);
         onNodeSelect(clickedNode?.node);
       }


### PR DESCRIPTION
When a user selects an element in the tree, the wireframe should draw the corresponding rect.

~Currently the first node is selected so the wireframe is probably going to have a huge rect that corresponds to the viewport or something, but the design on that is up for discussion still, so I'm going to move forward with this functionality for now.~