### PR TITLE
feat(flamegraph): track count across profiles

### DIFF
--- a/static/app/utils/profiling/callTreeNode.tsx
+++ b/static/app/utils/profiling/callTreeNode.tsx
@@ -5,6 +5,7 @@ export class CallTreeNode extends WeightedNode {
   readonly frame: Frame;
 
   private locked = false;
+  count: number = 0;
 
   parent: CallTreeNode | null;
   recursive: CallTreeNode | null;
@@ -23,6 +24,10 @@ export class CallTreeNode extends WeightedNode {
 
   setRecursiveThroughNode(node: CallTreeNode): void {
     this.recursive = node;
+  }
+
+  incrementCount(): void {
+    this.count++;
   }
 
   isRecursive(): boolean {

--- a/static/app/utils/profiling/profile/eventedProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.spec.tsx
@@ -337,4 +337,31 @@ describe('EventedProfile - flamegraph', () => {
     expect(profile.weights[1]).toBe(1);
     expect(profile.weights.length).toBe(2);
   });
+
+  it('flamegraph tracks node count', () => {
+    const trace: Profiling.EventedProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      threadID: 0,
+      type: 'evented',
+      events: [
+        {type: 'O', at: 0, frame: 0},
+        {type: 'O', at: 10, frame: 1},
+        {type: 'C', at: 20, frame: 1},
+        {type: 'C', at: 30, frame: 0},
+      ],
+    };
+
+    const profile = EventedProfile.FromProfile(
+      trace,
+      createFrameIndex('mobile', [{name: 'f0'}, {name: 'f1'}]),
+      {type: 'flamegraph'}
+    );
+
+    // frame 0 is opened twice, so the weight gets merged
+    expect(profile.callTree.children[0].count).toBe(3);
+    expect(profile.callTree.children[0].children[0].count).toBe(1);
+  });
 });

--- a/static/app/utils/profiling/profile/eventedProfile.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.tsx
@@ -1,7 +1,7 @@
 import {lastOfArray} from 'sentry/utils';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {Frame} from 'sentry/utils/profiling/frame';
-import {makeFormatTo} from 'sentry/utils/profiling/units/units';
+import {formatTo} from 'sentry/utils/profiling/units/units';
 
 import {Profile} from './profile';
 import {createFrameIndex} from './utils';
@@ -31,10 +31,11 @@ export class EventedProfile extends Profile {
     // If frames are offset, we need to set lastValue to profile start, so that delta between
     // samples is correctly offset by the start value.
     profile.lastValue = Math.max(0, eventedProfile.startValue);
-    profile.samplingIntervalApproximation = makeFormatTo(
+    profile.samplingIntervalApproximation = formatTo(
+      10,
       'milliseconds',
       eventedProfile.unit
-    )(10);
+    );
 
     for (const event of eventedProfile.events) {
       const frame = frameIndex[event.frame];

--- a/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
@@ -383,4 +383,40 @@ describe('jsSelfProfile', () => {
       ['f0', 'close'],
     ]);
   });
+
+  it('flamegraph tracks node occurences', () => {
+    const trace: JSSelfProfiling.Trace = {
+      resources: ['app.js'],
+      frames: [
+        {name: 'f1', line: 1, column: 1, resourceId: 0},
+        {name: 'f0', line: 1, column: 1, resourceId: 0},
+      ],
+      samples: [
+        {
+          stackId: 0,
+          timestamp: 0,
+        },
+        {
+          timestamp: 10,
+          stackId: 1,
+        },
+        {
+          timestamp: 20,
+          stackId: 0,
+        },
+      ],
+      stacks: [
+        {frameId: 0, parentId: undefined},
+        {frameId: 1, parentId: 0},
+      ],
+    };
+    const profile = JSSelfProfile.FromProfile(
+      trace,
+      createFrameIndex('web', trace.frames, trace),
+      {type: 'flamechart'}
+    );
+
+    expect(profile.callTree.children[0].count).toBe(3);
+    expect(profile.callTree.children[0].children[0].count).toBe(1);
+  });
 });

--- a/static/app/utils/profiling/profile/jsSelfProfile.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.tsx
@@ -162,6 +162,7 @@ export class JSSelfProfile extends Profile {
 
     for (const stackNode of framesInStack) {
       stackNode.frame.addToTotalWeight(weight);
+      stackNode.incrementCount();
     }
 
     // If node is the same as the previous sample, add the weight to the previous sample

--- a/static/app/utils/profiling/profile/sampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.spec.tsx
@@ -300,4 +300,26 @@ describe('SampledProfile', () => {
     expect(profile.callTree.children[0].children[0].children[1]).toBe(undefined);
     expect(profile.callTree.children[0].children[0].children[0].frame.selfWeight).toBe(6);
   });
+
+  it('flamegraph tracks node occurences', () => {
+    const trace: Profiling.SampledProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      threadID: 0,
+      type: 'sampled',
+      weights: [1, 1, 1],
+      samples: [[0], [0, 1], [0]],
+    };
+
+    const profile = SampledProfile.FromProfile(
+      trace,
+      createFrameIndex('node', [{name: 'f0'}, {name: 'f1'}, {name: 'f2'}]),
+      {type: 'flamechart'}
+    );
+
+    expect(profile.callTree.children[0].count).toBe(3);
+    expect(profile.callTree.children[0].children[0].count).toBe(1);
+  });
 });

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -184,6 +184,7 @@ export class SampledProfile extends Profile {
 
     for (const stackNode of framesInStack) {
       stackNode.frame.addToTotalWeight(weight);
+      stackNode.incrementCount();
     }
 
     // If node is the same as the previous sample, add the weight to the previous sample

--- a/static/app/utils/profiling/profile/sentrySampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.tsx
@@ -133,6 +133,7 @@ export class SentrySampledProfile extends Profile {
 
     for (const stackNode of framesInStack) {
       stackNode.frame.addToTotalWeight(weight);
+      stackNode.incrementCount();
     }
 
     // If node is the same as the previous sample, add the weight to the previous sample

--- a/static/app/utils/profiling/units/units.ts
+++ b/static/app/utils/profiling/units/units.ts
@@ -44,7 +44,9 @@ export function makeFormatTo(
       return v;
     };
   }
-  return (v: number) => formatTo(v, from, to);
+  return function format(v: number) {
+    return formatTo(v, from, to);
+  };
 }
 export function formatTo(
   v: number,


### PR DESCRIPTION
Track sample count when we are in flamegraph mode. Use the same approximation as backend in case of evented profiles (duration/100hz sampling interval)