### PR TITLE
ref(issue platform): Update performance fingerprints to use GroupClass dataclass

### DIFF
--- a/src/sentry/grouptype/grouptype.py
+++ b/src/sentry/grouptype/grouptype.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from sentry.event_manager import DEFAULT_GROUPHASH_IGNORE_LIMIT
+# from sentry.event_manager import DEFAULT_GROUPHASH_IGNORE_LIMIT
 from sentry.types.issues import GroupCategory
 
 _group_type_registry = {}
@@ -12,7 +12,8 @@ class GroupType:
     slug: str
     description: str
     category: int
-    ignore_limit: int = DEFAULT_GROUPHASH_IGNORE_LIMIT
+    ignore_limit: int = 3  # CEO temp fix in a tower of dependent PRs
+    # ignore_limit: int = DEFAULT_GROUPHASH_IGNORE_LIMIT
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -49,7 +50,7 @@ class ErrorGroupType(GroupType):
 
 
 @dataclass(frozen=True)
-class SlowDBQueryGroupType(GroupType):
+class PerformanceSlowDBQueryGroupType(GroupType):
     type_id = 1001
     slug = "performance_slow_db_query"
     description = "Slow DB Query"

--- a/src/sentry/grouptype/grouptype.py
+++ b/src/sentry/grouptype/grouptype.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-# from sentry.event_manager import DEFAULT_GROUPHASH_IGNORE_LIMIT
 from sentry.types.issues import GroupCategory
 
 _group_type_registry = {}
@@ -12,8 +11,7 @@ class GroupType:
     slug: str
     description: str
     category: int
-    ignore_limit: int = 3  # CEO temp fix in a tower of dependent PRs
-    # ignore_limit: int = DEFAULT_GROUPHASH_IGNORE_LIMIT
+    ignore_limit: int = 3  # CEO temp fix - this is the value of DEFAULT_GROUPHASH_IGNORE_LIMIT
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -9,8 +9,8 @@ from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
 from sentry import features
+from sentry.grouptype.grouptype import PerformanceNPlusOneAPICallsGroupType
 from sentry.models import Organization, Project
-from sentry.types.issues import GroupType
 
 from ..base import (
     DETECTOR_TYPE_TO_GROUP_TYPE,
@@ -236,7 +236,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
         fingerprint = hashlib.sha1(path.encode("utf8")).hexdigest()
 
-        return f"1-{GroupType.PERFORMANCE_N_PLUS_ONE_API_CALLS.value}-{fingerprint}"
+        return f"1-{PerformanceNPlusOneAPICallsGroupType.type_id}-{fingerprint}"
 
     def _spans_are_concurrent(self, span_a: Span, span_b: Span) -> bool:
         span_a_start: int = span_a.get("start_timestamp", 0) or 0

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sentry import features
+from sentry.grouptype.grouptype import PerformanceUncompressedAssetsGroupType
 from sentry.models import Organization, Project
 from sentry.types.issues import GroupType
 
@@ -76,7 +77,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
 
     def _fingerprint(self, span) -> str:
         resource_span = fingerprint_resource_span(span)
-        return f"1-{GroupType.PERFORMANCE_UNCOMPRESSED_ASSETS.value}-{resource_span}"
+        return f"1-{PerformanceUncompressedAssetsGroupType.type_id}-{resource_span}"
 
     def is_creation_allowed_for_organization(self, organization: Organization) -> bool:
         return features.has(

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -514,7 +514,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
 
     def _fingerprint(self, span: Span):
         resource_url_hash = fingerprint_resource_span(span)
-        return f"1-{PerformanceRenderBlockingAssetSpanGroupType}-{resource_url_hash}"
+        return f"1-{PerformanceRenderBlockingAssetSpanGroupType.type_id}-{resource_url_hash}"
 
 
 class ConsecutiveDBSpanDetector(PerformanceDetector):
@@ -675,7 +675,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         hashed_spans = fingerprint_spans(
             [self.consecutive_db_spans[prior_span_index]] + self.independent_db_spans
         )
-        return f"1-{PerformanceConsecutiveDBQueriesGroupType}-{hashed_spans}"
+        return f"1-{PerformanceConsecutiveDBQueriesGroupType.type_id}-{hashed_spans}"
 
     def on_complete(self) -> None:
         self._validate_and_store_performance_problem()

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -918,6 +918,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         self.n_spans = []
 
     def _fingerprint(self, parent_op, parent_hash, source_hash, n_hash) -> str:
+        # XXX: this has to be a hardcoded string otherwise grouping will break
         problem_class = "GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES"
         full_fingerprint = hashlib.sha1(
             (str(parent_op) + str(parent_hash) + str(source_hash) + str(n_hash)).encode("utf8"),

--- a/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, call
 import pytest
 
 from sentry.eventstore.models import Event
-from sentry.grouptype.grouptype import PerformanceMNPlusOneDBQueriesGroupType
 from sentry.testutils import TestCase
 from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
@@ -91,7 +90,7 @@ class MNPlusOneDBDetectorTest(TestCase):
                 call("_pi_transaction", "3818ae4f54ba4fa6ac6f68c9e32793c4"),
                 call(
                     "_pi_m_n_plus_one_db_fp",
-                    f"1-{PerformanceMNPlusOneDBQueriesGroupType.type_id}-de75036b0dce394e0b23aaabf553ad9f8156f22b",
+                    "1-1011-de75036b0dce394e0b23aaabf553ad9f8156f22b",
                 ),
                 call("_pi_m_n_plus_one_db", "9c5049407f37a364"),
             ]

--- a/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, call
 import pytest
 
 from sentry.eventstore.models import Event
+from sentry.grouptype.grouptype import PerformanceMNPlusOneDBQueriesGroupType
 from sentry.testutils import TestCase
 from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
@@ -35,7 +36,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         problems = self.find_problems(event)
         assert problems == [
             PerformanceProblem(
-                fingerprint="1-GroupType.PERFORMANCE_M_N_PLUS_ONE_DB_QUERIES-de75036b0dce394e0b23aaabf553ad9f8156f22b",
+                fingerprint=f"1-{PerformanceMNPlusOneDBQueriesGroupType.type_id}-de75036b0dce394e0b23aaabf553ad9f8156f22b",
                 op="db",
                 type=GroupType.PERFORMANCE_M_N_PLUS_ONE_DB_QUERIES,
                 desc="SELECT id, name FROM authors INNER JOIN book_authors ON author_id = id WHERE book_id = $1",
@@ -90,7 +91,7 @@ class MNPlusOneDBDetectorTest(TestCase):
                 call("_pi_transaction", "3818ae4f54ba4fa6ac6f68c9e32793c4"),
                 call(
                     "_pi_m_n_plus_one_db_fp",
-                    "1-GroupType.PERFORMANCE_M_N_PLUS_ONE_DB_QUERIES-de75036b0dce394e0b23aaabf553ad9f8156f22b",
+                    f"1-{PerformanceMNPlusOneDBQueriesGroupType.type_id}-de75036b0dce394e0b23aaabf553ad9f8156f22b",
                 ),
                 call("_pi_m_n_plus_one_db", "9c5049407f37a364"),
             ]

--- a/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
@@ -36,7 +36,7 @@ class MNPlusOneDBDetectorTest(TestCase):
         problems = self.find_problems(event)
         assert problems == [
             PerformanceProblem(
-                fingerprint=f"1-{PerformanceMNPlusOneDBQueriesGroupType.type_id}-de75036b0dce394e0b23aaabf553ad9f8156f22b",
+                fingerprint="1-1011-de75036b0dce394e0b23aaabf553ad9f8156f22b",
                 op="db",
                 type=GroupType.PERFORMANCE_M_N_PLUS_ONE_DB_QUERIES,
                 desc="SELECT id, name FROM authors INNER JOIN book_authors ON author_id = id WHERE book_id = $1",


### PR DESCRIPTION
Update the performance issue fingerprints to use the new `GroupClass` dataclass rather than the soon to be deprecated enum. Note that N+1 issues' fingerprints were incorrectly set as the problem class's name rather than the value, but since it's already live in prod I am hard coding the string to avoid breaking grouping. 

See https://github.com/getsentry/sentry/pull/44004 for the rest of the deprecation - this one seemed a bit delicate so I am pulling it out from the larger work. 