### PR TITLE
feat(metrics): Implement gradual rollout of release health cardinality limiter

### DIFF
--- a/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
@@ -79,16 +79,15 @@ class TimeseriesCardinalityLimiter:
     ) -> CardinalityLimiterState:
         request_hashes = defaultdict(set)
         hash_to_offset = {}
+
+        if use_case_id == UseCaseKey.PERFORMANCE:
+            rollout_option = "sentry-metrics.cardinality-limiter.orgs-rollout-rate"
+        elif use_case_id == UseCaseKey.RELEASE_HEALTH:
+            rollout_option = "sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate"
+
         for key, message in messages.items():
             org_id = message["org_id"]
-            if use_case_id == UseCaseKey.PERFORMANCE and not sample_modulo(
-                "sentry-metrics.cardinality-limiter.orgs-rollout-rate", org_id
-            ):
-                continue
-
-            elif use_case_id == UseCaseKey.RELEASE_HEALTH and not sample_modulo(
-                "sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", org_id
-            ):
+            if not sample_modulo(rollout_option, org_id):
                 continue
 
             message_hash = int(

--- a/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
@@ -81,7 +81,14 @@ class TimeseriesCardinalityLimiter:
         hash_to_offset = {}
         for key, message in messages.items():
             org_id = message["org_id"]
-            if not sample_modulo("sentry-metrics.cardinality-limiter.orgs-rollout-rate", org_id):
+            if use_case_id == UseCaseKey.PERFORMANCE and not sample_modulo(
+                "sentry-metrics.cardinality-limiter.orgs-rollout-rate", org_id
+            ):
+                continue
+
+            elif use_case_id == UseCaseKey.RELEASE_HEALTH and not sample_modulo(
+                "sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", org_id
+            ):
                 continue
 
             message_hash = int(

--- a/tests/sentry/sentry_metrics/limiters/test_cardinality_limiter.py
+++ b/tests/sentry/sentry_metrics/limiters/test_cardinality_limiter.py
@@ -16,8 +16,8 @@ from sentry.sentry_metrics.indexer.limiters.cardinality import TimeseriesCardina
 
 
 @pytest.fixture(autouse=True)
-def rollout_all_orgs(set_sentry_option):
-    with set_sentry_option("sentry-metrics.cardinality-limiter.orgs-rollout-rate", 1.0):
+def rollout_all_orgs_release_health(set_sentry_option):
+    with set_sentry_option("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", 1.0):
         yield
 
 
@@ -134,7 +134,7 @@ def test_sample_rate_zero(set_sentry_option):
     with set_sentry_option(
         "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
         [{"window_seconds": 3600, "granularity_seconds": 60, "limit": 0}],
-    ), set_sentry_option("sentry-metrics.cardinality-limiter.orgs-rollout-rate", 0.0):
+    ), set_sentry_option("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", 0.0):
         backend = MockCardinalityLimiter()
         backend.grant_hashes = 0
         backend.assert_requests = []
@@ -164,7 +164,7 @@ def test_sample_rate_half(set_sentry_option):
     with set_sentry_option(
         "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
         [{"window_seconds": 3600, "granularity_seconds": 60, "limit": 0}],
-    ), set_sentry_option("sentry-metrics.cardinality-limiter.orgs-rollout-rate", 0.5):
+    ), set_sentry_option("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", 0.5):
 
         backend = MockCardinalityLimiter()
         backend.grant_hashes = 0

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -507,7 +507,7 @@ def test_process_messages_cardinality_limited(
     with set_sentry_option(
         "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
         [{"window_seconds": 3600, "granularity_seconds": 60, "limit": 0}],
-    ), set_sentry_option("sentry-metrics.cardinality-limiter.orgs-rollout-rate", 1.0):
+    ), set_sentry_option("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", 1.0):
 
         class MockCardinalityLimiter(CardinalityLimiter):
             def check_within_quotas(self, requested_quotas):


### PR DESCRIPTION
Implementing the usage of the release health gradual rollout flag for controlling the percentage of organizations that are using the release health cardinality limiter. We will now have two separate rollout flags for the two separate use cases (performance and release health).