### PR TITLE
fix(domains) Add django URLS for sentry-apps and docs-integrations

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -481,6 +481,16 @@ urlpatterns += [
                     name="sentry-customer-domain-developer-settings-settings",
                 ),
                 url(
+                    r"^document-integrations/",
+                    react_page_view,
+                    name="sentry-customer-domain-document-integrations-settings",
+                ),
+                url(
+                    r"^sentry-apps/",
+                    react_page_view,
+                    name="sentry-customer-domain-sentry-apps-settings",
+                ),
+                url(
                     r"^billing/",
                     react_page_view,
                     name="sentry-customer-domain-billing-settings",


### PR DESCRIPTION
Fix reload for these paths going to a bad place.
