### PR TITLE
fix(tags): makes legend container overflow dynamic based on expanded state

### DIFF
--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -175,6 +175,7 @@ function TagFacetsDistributionMeter({
   function renderLegend() {
     return (
       <LegendAnimateContainer
+        expanded={expanded}
         animate={expanded ? {height: '100%', opacity: 1} : {height: '0', opacity: 0}}
       >
         <LegendContainer>
@@ -326,10 +327,10 @@ const Segment = styled('span', {shouldForwardProp: isPropValid})<{color: string}
   padding: 1px ${space(0.5)} 0 0;
 `;
 
-const LegendAnimateContainer = styled(motion.div)`
-  overflow: hidden;
+const LegendAnimateContainer = styled(motion.div)<{expanded: boolean}>`
   height: 0;
   opacity: 0;
+  ${p => (!p.expanded ? 'overflow: hidden;' : null)}
 `;
 
 const LegendContainer = styled('ol')`

--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -330,7 +330,7 @@ const Segment = styled('span', {shouldForwardProp: isPropValid})<{color: string}
 const LegendAnimateContainer = styled(motion.div)<{expanded: boolean}>`
   height: 0;
   opacity: 0;
-  ${p => (!p.expanded ? 'overflow: hidden;' : null)}
+  ${p => (!p.expanded ? 'overflow: hidden;' : '')}
 `;
 
 const LegendContainer = styled('ol')`


### PR DESCRIPTION
Small fix to make the overflow style of the legend container dynamic based on expanded state. This is because some of the hover effects rely on overflowing to display properly (otherwise it gets clipped a bit).

before
![image](https://user-images.githubusercontent.com/83961295/217378602-c3084d53-f015-4f41-b8fd-d6b88e0e9596.png)
after
![image](https://user-images.githubusercontent.com/83961295/217378621-2cc68481-24a2-4790-91c7-4367d5ff59d8.png)
