### PR TITLE
fix(domains) Preserve query string on domain redirects

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -1,5 +1,6 @@
 from random import randint
 from typing import Optional
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib import messages
@@ -145,9 +146,10 @@ class AuthLoginView(BaseView):
             ]
             # Only redirect if the URL is not register or login paths.
             if request.path_info not in urls:
-                url = urls[0]
                 url_prefix = generate_organization_url(request.subdomain)
-                url = absolute_uri(url, url_prefix=url_prefix)
+                url = absolute_uri(urls[0], url_prefix=url_prefix)
+                if request.GET:
+                    url = f"{url}?{urlencode(request.GET)}"
                 return HttpResponseRedirect(url)
 
         can_register = self.can_register(request)

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -1,6 +1,5 @@
 from random import randint
 from typing import Optional
-from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib import messages
@@ -149,7 +148,7 @@ class AuthLoginView(BaseView):
                 url_prefix = generate_organization_url(request.subdomain)
                 url = absolute_uri(urls[0], url_prefix=url_prefix)
                 if request.GET:
-                    url = f"{url}?{urlencode(request.GET)}"
+                    url = f"{url}?{request.GET.urlencode()}"
                 return HttpResponseRedirect(url)
 
         can_register = self.can_register(request)

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -474,6 +474,17 @@ class AuthLoginCustomerDomainTest(TestCase):
         assert resp.redirect_chain == [("http://baz.testserver/auth/login/baz/", 302)]
         self.assertTemplateUsed("sentry/organization-login.html")
 
+    def test_renders_correct_template_existent_org_preserve_querystring(self):
+        resp = self.client.get(
+            f"{self.path}?one=two",
+            HTTP_HOST=f"{self.organization.slug}.testserver",
+            follow=True,
+        )
+
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [("http://baz.testserver/auth/login/baz/?one=two", 302)]
+        self.assertTemplateUsed("sentry/organization-login.html")
+
     def test_renders_correct_template_nonexistent_org(self):
         resp = self.client.get(
             self.path,


### PR DESCRIPTION
We need to keep the query string around when we do a login redirect for customer-domains so that invite flows behave correctly.
