### PR TITLE
fix(profiling): Set CanvasView mode depending on configView

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphPreview.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.spec.tsx
@@ -32,10 +32,16 @@ describe('computePreviewConfigView', function () {
     const configView = new Rect(0, 0, 2, 3);
 
     // go from timestamps 0 to 2
-    const previewConfigView = computePreviewConfigView(flamegraph, configView, 0, 2);
+    const {configView: previewConfigView, mode} = computePreviewConfigView(
+      flamegraph,
+      configView,
+      0,
+      2
+    );
 
     // y is 0 here because the config view is taller than the flamegraph
     expect(previewConfigView).toEqual(new Rect(0, 0, 2, 3));
+    expect(mode).toEqual('anchorTop');
   });
 
   it('uses max depth', function () {
@@ -65,11 +71,17 @@ describe('computePreviewConfigView', function () {
     const configView = new Rect(0, 0, 2, 2);
 
     // go from timestamps 0 to 2
-    const previewConfigView = computePreviewConfigView(flamegraph, configView, 0, 2);
+    const {configView: previewConfigView, mode} = computePreviewConfigView(
+      flamegraph,
+      configView,
+      0,
+      2
+    );
 
     // y is 1 here because the config view has height 2 so it can only
     // show 2 frames and we show the inner most frames
     expect(previewConfigView).toEqual(new Rect(0, 1, 2, 2));
+    expect(mode).toEqual('anchorBottom');
   });
 
   it('uses max depth in window', function () {
@@ -100,11 +112,17 @@ describe('computePreviewConfigView', function () {
     const configView = new Rect(0, 0, 3, 2);
 
     // go from timestamps 1 to 3 to exclude the first stack
-    const previewConfigView = computePreviewConfigView(flamegraph, configView, 1, 3);
+    const {configView: previewConfigView, mode} = computePreviewConfigView(
+      flamegraph,
+      configView,
+      1,
+      3
+    );
 
     // y is 1 here because the config view has height 2 so it can only
     // show 2 frames and we show the inner most frames
     expect(previewConfigView).toEqual(new Rect(1, 1, 2, 2));
+    expect(mode).toEqual('anchorBottom');
   });
 
   it('uses 0 when view is taller than profile', function () {
@@ -133,11 +151,17 @@ describe('computePreviewConfigView', function () {
     // make taller than profile's deepest stack
     const configView = new Rect(0, 0, 2, 3);
 
-    const previewConfigView = computePreviewConfigView(flamegraph, configView, 0, 2);
+    const {configView: previewConfigView, mode} = computePreviewConfigView(
+      flamegraph,
+      configView,
+      0,
+      2
+    );
 
     // y is 0 here because the config view has height 3
     // so the whole flamechart fits
     expect(previewConfigView).toEqual(new Rect(0, 0, 2, 3));
+    expect(mode).toEqual('anchorTop');
   });
 
   it('uses parent frame depth', function () {
@@ -165,11 +189,17 @@ describe('computePreviewConfigView', function () {
 
     const configView = new Rect(0, 0, 4, 2);
 
-    const previewConfigView = computePreviewConfigView(flamegraph, configView, 1, 3);
+    const {configView: previewConfigView, mode} = computePreviewConfigView(
+      flamegraph,
+      configView,
+      1,
+      3
+    );
 
     // y is 1 here because we found a frame `f1` that is wraps
     // around the window at depth 1
     expect(previewConfigView).toEqual(new Rect(1, 1, 2, 2));
+    expect(mode).toEqual('anchorTop');
   });
 
   it('uses max depth because there is room above parent to show more', function () {
@@ -197,11 +227,17 @@ describe('computePreviewConfigView', function () {
 
     const configView = new Rect(0, 0, 4, 3);
 
-    const previewConfigView = computePreviewConfigView(flamegraph, configView, 1, 3);
+    const {configView: previewConfigView, mode} = computePreviewConfigView(
+      flamegraph,
+      configView,
+      1,
+      3
+    );
 
     // y is 0 here because the config view has height 3
     // so the whole flamechart fits even though the parent
     // is at depth 1
     expect(previewConfigView).toEqual(new Rect(1, 0, 2, 3));
+    expect(mode).toEqual('anchorTop');
   });
 });

--- a/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
@@ -81,14 +81,15 @@ export function FlamegraphPreview({
       mode: 'anchorBottom',
     });
 
-    canvasView.setConfigView(
-      computePreviewConfigView(
-        flamegraph,
-        canvasView.configView,
-        formatTo(relativeStartTimestamp, 'second', 'nanosecond'),
-        formatTo(relativeStopTimestamp, 'second', 'nanosecond')
-      )
+    const {configView, mode} = computePreviewConfigView(
+      flamegraph,
+      canvasView.configView,
+      formatTo(relativeStartTimestamp, 'second', 'nanosecond'),
+      formatTo(relativeStopTimestamp, 'second', 'nanosecond')
     );
+
+    canvasView.setConfigView(configView);
+    canvasView.mode = mode;
 
     return canvasView;
   }, [
@@ -192,19 +193,34 @@ export function computePreviewConfigView(
   configView: Rect,
   relativeStartNs: number,
   relativeStopNs: number
-): Rect {
+): {
+  configView: Rect;
+  mode: CanvasView<FlamegraphModel>['mode'];
+} {
   if (flamegraph.depth < configView.height) {
     // if the flamegraph height is less than the config view height,
     // the whole flamechart will fit on the view so we can just use y = 0
-    return new Rect(
-      relativeStartNs,
-      0,
-      relativeStopNs - relativeStartNs,
-      configView.height
-    );
+    return {
+      configView: new Rect(
+        relativeStartNs,
+        0,
+        relativeStopNs - relativeStartNs,
+        configView.height
+      ),
+      // If we're setting y = 0, we'll anchor the config view at the top
+      // because we want to show more from the bottom
+      mode: 'anchorTop',
+    };
   }
 
   const frames: FlamegraphFrame[] = flamegraph.root.children.slice();
+
+  // If we're using the max depth in the window, then we want to anchor it
+  // from the bottom because if the config view grows, we want to show more
+  // frames from the top. If we showed more frames from the bottom then it
+  // would just show whitespace.
+  let mode: CanvasView<FlamegraphModel>['mode'] = 'anchorBottom';
+
   let maxDepthInWindow = 0;
   let innerMostParentFrame: FlamegraphFrame | null = null;
 
@@ -234,15 +250,24 @@ export function computePreviewConfigView(
   // If we were able to find a frame that is likely the parent of the span,
   // we should bias towards that frame.
   if (defined(innerMostParentFrame)) {
-    depth = Math.min(depth, innerMostParentFrame.depth);
+    if (depth > innerMostParentFrame.depth) {
+      // If we find the inner most parent frame, then we anchor it top the top
+      // because there may be more frames out of view at the bottom, so if the
+      // config view grows, we want to show those first
+      mode = 'anchorTop';
+      depth = innerMostParentFrame.depth;
+    }
   }
 
-  return new Rect(
-    relativeStartNs,
-    depth,
-    relativeStopNs - relativeStartNs,
-    configView.height
-  );
+  return {
+    configView: new Rect(
+      relativeStartNs,
+      depth,
+      relativeStopNs - relativeStartNs,
+      configView.height
+    ),
+    mode,
+  };
 }
 
 const CanvasContainer = styled('div')`


### PR DESCRIPTION
Depending on the window, we want to set different modes on the canvas view so that resizing will still show the most relevant window of the profile. If we use the max depth in the window to determine the config view, then there are no additional frames below except perhaps whitespace. In this case, we'd want to anchor it on the bottom. If we use a parent frame to determine the config view, then there may be additional frames below the parent frame. In this case, we'd want to anchor it on the top so we can show more child frames.