### PR TITLE
fix(metric_alerts): Fix bug when updating a performance alert from metrics -> transactions.

### DIFF
--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -82,7 +82,12 @@ def create_subscription_in_snuba(query_subscription_id, **kwargs):
     max_retries=5,
 )
 def update_subscription_in_snuba(
-    query_subscription_id, old_query_type=None, old_dataset=None, **kwargs
+    query_subscription_id,
+    old_query_type=None,
+    old_dataset=None,
+    old_aggregate=None,
+    old_query=None,
+    **kwargs,
 ):
     """
     Task to update a corresponding subscription in Snuba from a `QuerySubscription` in
@@ -106,10 +111,14 @@ def update_subscription_in_snuba(
         query_type = SnubaQuery.Type(
             old_query_type if old_query_type is not None else subscription.snuba_query.type
         )
+        query = old_query if old_query is not None else subscription.snuba_query.query
+        aggregate = (
+            old_aggregate if old_aggregate is not None else subscription.snuba_query.aggregate
+        )
         old_entity_subscription = get_entity_subscription(
             query_type,
             dataset,
-            subscription.snuba_query.aggregate,
+            aggregate,
             subscription.snuba_query.time_window,
             extra_fields={
                 "org_id": subscription.project.organization_id,
@@ -118,7 +127,7 @@ def update_subscription_in_snuba(
         )
         old_entity_key = get_entity_key_from_query_builder(
             old_entity_subscription.build_query_builder(
-                subscription.snuba_query.query,
+                query,
                 [subscription.project_id],
                 None,
                 {"organization_id": subscription.project.organization_id},


### PR DESCRIPTION
This fixes a bug that occurs when a user updates an existing performance alert that was on the metrics dataset that moves to the transactions dataset. We end up throwing an error when attempting to delete the previous subscription, since we fail to resolve the entity correctly.

This actually works out fine in the end. Even though the update fails, we have a checker tasks that catches these kinds of problems and successfully creates the new subscription later. And when we receive an update from a snuba subscription that has no corresponding subscription in sentry, we delete that. So the state works out fine even without this fix. The fix just avoids this bug and any delay in getting the state to a good place.

Fixes SENTRY-YS5