### PR TITLE
feat(hybrid-cloud): Add Django route for /issues/project_slug/issue_id/tags/tag_key/export/

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -81,7 +81,14 @@ class ProjectAlertRulePermission(ProjectPermission):
 class ProjectEndpoint(Endpoint):
     permission_classes = (ProjectPermission,)
 
-    def convert_args(self, request: Request, organization_slug, project_slug, *args, **kwargs):
+    def convert_args(
+        self,
+        request: Request,
+        organization_slug: str,
+        project_slug: str,
+        *args,
+        **kwargs,
+    ):
         try:
             project = (
                 Project.objects.filter(organization__slug=organization_slug, slug=project_slug)

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any, Mapping, Protocol
 
@@ -303,7 +304,11 @@ class BaseView(View, OrganizationMixin):  # type: ignore[misc]
         if self.is_sudo_required(request, *args, **kwargs):
             return self.handle_sudo_required(request, *args, **kwargs)
 
-        if is_using_customer_domain(request) and "organization_slug" not in kwargs:
+        if (
+            is_using_customer_domain(request)
+            and "organization_slug" in inspect.signature(self.convert_args).parameters
+            and "organization_slug" not in kwargs
+        ):
             # In customer domain contexts, we will need to pre-populate the organization_slug keyword argument.
             kwargs["organization_slug"] = organization_slug
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 from typing import Any, Mapping, Protocol
 
@@ -304,11 +303,7 @@ class BaseView(View, OrganizationMixin):  # type: ignore[misc]
         if self.is_sudo_required(request, *args, **kwargs):
             return self.handle_sudo_required(request, *args, **kwargs)
 
-        if (
-            is_using_customer_domain(request)
-            and "organization_slug" in inspect.signature(self.convert_args).parameters
-            and "organization_slug" not in kwargs
-        ):
+        if is_using_customer_domain(request) and "organization_slug" not in kwargs:
             # In customer domain contexts, we will need to pre-populate the organization_slug keyword argument.
             kwargs["organization_slug"] = organization_slug
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any, Mapping, Protocol
 
@@ -302,6 +303,14 @@ class BaseView(View, OrganizationMixin):  # type: ignore[misc]
 
         if self.is_sudo_required(request, *args, **kwargs):
             return self.handle_sudo_required(request, *args, **kwargs)
+
+        if (
+            is_using_customer_domain(request)
+            and "organization_slug" in inspect.signature(self.convert_args).parameters
+            and "organization_slug" not in kwargs
+        ):
+            # In customer domain contexts, we will need to pre-populate the organization_slug keyword argument.
+            kwargs["organization_slug"] = organization_slug
 
         args, kwargs = self.convert_args(request, *args, **kwargs)
 

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -535,6 +535,11 @@ urlpatterns += [
         name="integration-installation",
     ),
     # Issues
+    url(
+        r"^issues/(?P<project_slug>[\w_-]+)/(?P<group_id>\d+)/tags/(?P<key>[^\/]+)/export/$",
+        GroupTagExportView.as_view(),
+        name="sentry-customer-domain-sentry-group-tag-export",
+    ),
     url(r"^issues/", react_page_view, name="issues"),
     # Alerts
     url(r"^alerts/", react_page_view, name="alerts"),

--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -9,109 +9,77 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test
 class GroupTagExportTest(TestCase, SnubaTestCase):
-    def test_simple(self):
-        key, value = "foo", "b\xe4r"
-        project = self.create_project()
+    def setUp(self):
+        super().setUp()
+        self.url = None
+        self.key = "foo"
+        self.value = "b\xe4r"
+        self.project = self.create_project()
 
         event_timestamp = iso_format(before_now(seconds=1))
 
-        event = self.store_event(
+        self.event = self.store_event(
             data={
-                "tags": {key: value},
+                "tags": {self.key: self.value},
                 "timestamp": event_timestamp,
                 "environment": self.environment.name,
             },
-            project_id=project.id,
+            project_id=self.project.id,
             assert_no_errors=False,
         )
 
-        group = event.group
+        self.group = self.event.group
 
-        first_seen = datetime.strptime(event_timestamp, "%Y-%m-%dT%H:%M:%S").strftime(
+        self.first_seen = datetime.strptime(event_timestamp, "%Y-%m-%dT%H:%M:%S").strftime(
             "%Y-%m-%dT%H:%M:%S.%fZ"
         )
-        last_seen = first_seen
-
+        self.last_seen = self.first_seen
         self.login_as(user=self.user)
 
+    def verify_test(self, response):
+        assert response.status_code == 200
+        assert response.streaming
+        assert response["Content-Type"] == "text/csv"
+        rows = list(response.streaming_content)
+        for idx, row in enumerate(rows):
+            row = row.decode("utf-8")
+            assert row.endswith("\r\n")
+            bits = row[:-2].split(",")
+            if idx == 0:
+                assert bits == ["value", "times_seen", "last_seen", "first_seen"]
+            else:
+                assert bits[0] == self.value
+                assert bits[1] == "1"
+                assert bits[2] == self.last_seen
+                assert bits[3] == self.first_seen
+
+    def test_simple(self):
         url = reverse(
             "sentry-group-tag-export",
             kwargs={
-                "organization_slug": project.organization.slug,
-                "project_slug": project.slug,
-                "group_id": group.id,
-                "key": key,
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+                "group_id": self.group.id,
+                "key": self.key,
             },
         )
-        url = f"{url}?environment={self.environment.name}"
+        self.url = f"{url}?environment={self.environment.name}"
 
-        response = self.client.get(url)
-
-        assert response.status_code == 200
-        assert response.streaming
-        assert response["Content-Type"] == "text/csv"
-        rows = list(response.streaming_content)
-        for idx, row in enumerate(rows):
-            row = row.decode("utf-8")
-            assert row.endswith("\r\n")
-            bits = row[:-2].split(",")
-            if idx == 0:
-                assert bits == ["value", "times_seen", "last_seen", "first_seen"]
-            else:
-                assert bits[0] == value
-                assert bits[1] == "1"
-                assert bits[2] == last_seen
-                assert bits[3] == first_seen
+        response = self.client.get(self.url)
+        self.verify_test(response)
 
     def test_simple_customer_domain(self):
-        key, value = "foo", "b\xe4r"
-        project = self.create_project()
-
-        event_timestamp = iso_format(before_now(seconds=1))
-
-        event = self.store_event(
-            data={
-                "tags": {key: value},
-                "timestamp": event_timestamp,
-                "environment": self.environment.name,
-            },
-            project_id=project.id,
-            assert_no_errors=False,
-        )
-
-        group = event.group
-
-        first_seen = datetime.strptime(event_timestamp, "%Y-%m-%dT%H:%M:%S").strftime(
-            "%Y-%m-%dT%H:%M:%S.%fZ"
-        )
-        last_seen = first_seen
-
-        self.login_as(user=self.user)
-
         url = reverse(
             "sentry-customer-domain-sentry-group-tag-export",
             kwargs={
-                "project_slug": project.slug,
-                "group_id": group.id,
-                "key": key,
+                "project_slug": self.project.slug,
+                "group_id": self.group.id,
+                "key": self.key,
             },
         )
-        url = f"{url}?environment={self.environment.name}"
+        self.url = f"{url}?environment={self.environment.name}"
 
-        response = self.client.get(url, SERVER_NAME=f"{project.organization.slug}.testserver")
-
-        assert response.status_code == 200
-        assert response.streaming
-        assert response["Content-Type"] == "text/csv"
-        rows = list(response.streaming_content)
-        for idx, row in enumerate(rows):
-            row = row.decode("utf-8")
-            assert row.endswith("\r\n")
-            bits = row[:-2].split(",")
-            if idx == 0:
-                assert bits == ["value", "times_seen", "last_seen", "first_seen"]
-            else:
-                assert bits[0] == value
-                assert bits[1] == "1"
-                assert bits[2] == last_seen
-                assert bits[3] == first_seen
+        response = self.client.get(
+            self.url, SERVER_NAME=f"{self.project.organization.slug}.testserver"
+        )
+        self.verify_test(response)

--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from django.urls import reverse
+
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -32,9 +34,71 @@ class GroupTagExportTest(TestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/{project.organization.slug}/{project.slug}/issues/{group.id}/tags/{key}/export/?environment={self.environment.name}"
+        url = reverse(
+            "sentry-group-tag-export",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "group_id": group.id,
+                "key": key,
+            },
+        )
+        url = f"{url}?environment={self.environment.name}"
 
         response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.streaming
+        assert response["Content-Type"] == "text/csv"
+        rows = list(response.streaming_content)
+        for idx, row in enumerate(rows):
+            row = row.decode("utf-8")
+            assert row.endswith("\r\n")
+            bits = row[:-2].split(",")
+            if idx == 0:
+                assert bits == ["value", "times_seen", "last_seen", "first_seen"]
+            else:
+                assert bits[0] == value
+                assert bits[1] == "1"
+                assert bits[2] == last_seen
+                assert bits[3] == first_seen
+
+    def test_simple_customer_domain(self):
+        key, value = "foo", "b\xe4r"
+        project = self.create_project()
+
+        event_timestamp = iso_format(before_now(seconds=1))
+
+        event = self.store_event(
+            data={
+                "tags": {key: value},
+                "timestamp": event_timestamp,
+                "environment": self.environment.name,
+            },
+            project_id=project.id,
+            assert_no_errors=False,
+        )
+
+        group = event.group
+
+        first_seen = datetime.strptime(event_timestamp, "%Y-%m-%dT%H:%M:%S").strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        last_seen = first_seen
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-customer-domain-sentry-group-tag-export",
+            kwargs={
+                "project_slug": project.slug,
+                "group_id": group.id,
+                "key": key,
+            },
+        )
+        url = f"{url}?environment={self.environment.name}"
+
+        response = self.client.get(url, SERVER_NAME=f"{project.organization.slug}.testserver")
 
         assert response.status_code == 200
         assert response.streaming


### PR DESCRIPTION
This adds the org slug omitted variation of the route for the issue tag export Django route: https://github.com/getsentry/sentry/blob/1abd29e8d049084e4f221cf931cf1bb40263adc0/src/sentry/web/urls.py#L841-L845

The update for this route on the frontend will follow later.