### PR TITLE
DO NOT MERGE: Add a test demonstrating ID reuse across tests

### DIFF
--- a/src/sentry/utils/snowflake.py
+++ b/src/sentry/utils/snowflake.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Tuple
@@ -92,6 +93,10 @@ def generate_snowflake_id(redis_key: str) -> int:
         segment_values[TIME_DIFFERENCE],
         segment_values[REGION_SEQUENCE],
     ) = get_sequence_value_from_redis(redis_key, segment_values[TIME_DIFFERENCE])
+
+    if os.getenv("PYTEST_CURRENT_TEST") is not None:
+        segment_values[REGION_SEQUENCE] += abs(hash(os.getenv("PYTEST_CURRENT_TEST")))
+        segment_values[REGION_SEQUENCE] %= 0b1111
 
     for segment in BIT_SEGMENT_SCHEMA:
         segment.validate(segment_values[segment])

--- a/tests/sentry/utils/test_snowflake.py
+++ b/tests/sentry/utils/test_snowflake.py
@@ -18,6 +18,8 @@ from sentry.utils.snowflake import (
     get_redis_cluster,
 )
 
+prevID = 0
+
 
 class SnowflakeUtilsTest(TestCase):
     CURRENT_TIME = datetime(2022, 7, 21, 6, 0)
@@ -30,6 +32,23 @@ class SnowflakeUtilsTest(TestCase):
         )
 
         assert snowflake_id == expected_value
+
+    @freeze_time(CURRENT_TIME)
+    def test_generate_unique_ids(self):
+        snowflake_id_1 = generate_snowflake_id("test_redis_key")
+        snowflake_id_2 = generate_snowflake_id("test_redis_key")
+        assert snowflake_id_1 != snowflake_id_2
+
+    @freeze_time(CURRENT_TIME)
+    def test_unique_id_across_tests_1(self):
+        global prevID
+        prevID = generate_snowflake_id("test_redis_key")
+
+    @freeze_time(CURRENT_TIME)
+    def test_unique_id_across_tests_2(self):
+        global prevID
+        newID = generate_snowflake_id("test_redis_key")
+        assert prevID != newID
 
     @freeze_time(CURRENT_TIME)
     def test_generate_correct_ids_with_region_sequence(self):

--- a/tests/sentry/utils/test_snowflake.py
+++ b/tests/sentry/utils/test_snowflake.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 
 import pytest
@@ -26,6 +27,7 @@ class SnowflakeUtilsTest(TestCase):
 
     @freeze_time(CURRENT_TIME)
     def test_generate_correct_ids(self):
+        del os.environ["PYTEST_CURRENT_TEST"]
         snowflake_id = generate_snowflake_id("test_redis_key")
         expected_value = (16 << 48) + (
             int(self.CURRENT_TIME.timestamp() - settings.SENTRY_SNOWFLAKE_EPOCH_START) << 16
@@ -52,6 +54,7 @@ class SnowflakeUtilsTest(TestCase):
 
     @freeze_time(CURRENT_TIME)
     def test_generate_correct_ids_with_region_sequence(self):
+        del os.environ["PYTEST_CURRENT_TEST"]
         # next id in the same timestamp, should be 1 greater than last id up to 16 timestamps
         # the 17th will be at the previous timestamp
         snowflake_id = generate_snowflake_id("test_redis_key")


### PR DESCRIPTION
This is largely just me scratching an itch - I was curious about the snowflake IDs.

This one idea to reduce the risk of tests sharing the same snowflake ID when the redis sequence is being reset. I don't think it's a particularly good solution, and I'm not a big fan of adding logic like this for tests.