### PR TITLE
ref(compositeSelect): Show `textValue` warning

### DIFF
--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -106,7 +106,7 @@ function CompactSelect<Value extends React.Key>({
             return (
               <Section key={item.key} title={item.label}>
                 {item.options.map(opt => (
-                  <Item key={opt.value} textValue={String(opt.label)} {...opt}>
+                  <Item key={opt.value} {...opt}>
                     {opt.label}
                   </Item>
                 ))}
@@ -115,7 +115,7 @@ function CompactSelect<Value extends React.Key>({
           }
 
           return (
-            <Item key={item.value} textValue={String(item.label)} {...item}>
+            <Item key={item.value} {...item}>
               {item.label}
             </Item>
           );

--- a/static/app/components/compactSelect/types.tsx
+++ b/static/app/components/compactSelect/types.tsx
@@ -1,11 +1,6 @@
-import {MenuListItemProps} from 'sentry/components/menuListItem';
+import {SelectValue} from 'sentry/types';
 
-export interface SelectOption<Value extends React.Key> extends MenuListItemProps {
-  /**
-   * The option's value, must be unique within the selector.
-   */
-  value: Value;
-}
+export interface SelectOption<Value extends React.Key> extends SelectValue<Value> {}
 
 export interface SelectSection<Value extends React.Key> {
   options: SelectOption<Value>[];

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -146,6 +146,7 @@ function BreadcrumbsContainer({data, event, organization, projectSlug, isShare}:
 
         filterLevels.push({
           value: `level-${level}`,
+          textValue: level,
           label: (
             <LevelWrap>
               <Level level={level} />

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidates.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidates.tsx
@@ -166,6 +166,7 @@ class Candidates extends Component<Props, State> {
         label: filterOptionCategories.status,
         options: candidateStatus.map(status => ({
           value: `status-${status}`,
+          textValue: status,
           label: <Status status={status} />,
         })),
       });

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -342,6 +342,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
         label: t('Status'),
         options: [...new Set(images.map(image => image.status))].map(status => ({
           value: status,
+          textValue: status,
           label: <Status status={status} />,
         })),
       },

--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -439,8 +439,8 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   };
 
   const filterOptions = createFilter({
-    // Use plainTextLabel if available
-    stringify: option => option.data.plainTextLabel ?? `${option.label} ${option.value}`,
+    // Use `textValue` if available
+    stringify: option => option.data.textValue ?? `${option.label} ${option.value}`,
   });
 
   return (

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingSidebar.tsx
@@ -87,6 +87,7 @@ export function ProfilingOnboardingSidebar(props: CommonSidebarProps) {
       project => {
         return {
           value: project.id,
+          textValue: project.id,
           label: (
             <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />
           ),
@@ -98,6 +99,7 @@ export function ProfilingOnboardingSidebar(props: CommonSidebarProps) {
       project => {
         return {
           value: project.id,
+          textValue: project.id,
           label: (
             <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />
           ),

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -53,7 +53,7 @@ export interface SelectValue<T> extends MenuListItemProps {
    * will be unable to filter to that label. Use this to specify the plain text of
    * the label.
    */
-  plainTextLabel?: string;
+  textValue?: string;
 }
 
 /**

--- a/static/app/views/releases/detail/commitsAndFiles/repositorySwitcher.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/repositorySwitcher.tsx
@@ -37,6 +37,7 @@ class RepositorySwitcher extends PureComponent<Props> {
         value={activeRepo}
         options={repositories.map(repo => ({
           value: repo.name,
+          textValue: repo.name,
           label: <RepoLabel>{repo.name}</RepoLabel>,
         }))}
         onChange={opt => this.handleRepoFilterChange(String(opt?.value))}


### PR DESCRIPTION
**Start showing a warning when `CompactSelect` receives options with non-text labels and no alternative `textValue`, and amend existing usages to avoid those warnings.**

Currently, the `label` property is typed as `ReactNode`. This allows us to render styled components inside option labels:
<img width="306" alt="Screenshot 2023-02-07 at 5 00 19 PM" src="https://user-images.githubusercontent.com/44172267/217401795-7d998581-6ef8-4a80-83d4-fa3c6b2fadda.png">

This works okay and leads to no major error. However, certain features, including typeahead and filtering, will not work or work incorrectly with a non-text label. The fix for this is relatively easy: we can provide a `textValue` entry that will be used by those features:
<img width="306" alt="Screenshot 2023-02-07 at 5 06 01 PM" src="https://user-images.githubusercontent.com/44172267/217402398-d0b059cf-3013-4f0c-b70a-19c10f63346d.png">

`react-aria` automatically falls back to `textValue` when `label` is not a string. It sends a warning message if no `textValue` was provided:
<img width="402" alt="Screenshot 2023-02-07 at 4 47 11 PM" src="https://user-images.githubusercontent.com/44172267/217403864-f6f1b649-0886-40ef-ae89-b7e61fee3494.png">

I temporarily bypassed these warnings to avoid flooding the app with them in the recent `CompactSelect` refactor (https://github.com/getsentry/sentry/pull/43449). This PR brings them back (they're pretty useful!) and updates existing usages, adding alternative `textValue`s when necessary.