### PR TITLE
fix(discovery): Allows for negation of non-existent or unselected projects

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -921,6 +921,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
                             "environment_id": environment_ids,
                         },
                     )
+
                     # if no re-formatted conditions, use fallback method
                     new_condition = None
                     if formatted_conditions:
@@ -934,6 +935,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
                                 "environment_id": environment_ids,
                             },
                         )
+
                     if new_condition:
                         conditions.append(new_condition)
         self.conditions = conditions

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -922,10 +922,11 @@ class GroupSerializerSnuba(GroupSerializerBase):
                         },
                     )
                     # if no re-formatted conditions, use fallback method
-                    conditions.append(
-                        formatted_conditions[0]
-                        if formatted_conditions
-                        else convert_search_filter_to_snuba_query(
+                    new_condition = None
+                    if formatted_conditions:
+                        new_condition = formatted_conditions[0]
+                    elif group_ids:
+                        new_condition = convert_search_filter_to_snuba_query(
                             search_filter,
                             params={
                                 "organization_id": organization_id,
@@ -933,7 +934,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
                                 "environment_id": environment_ids,
                             },
                         )
-                    )
+                    if new_condition:
+                        conditions.append(new_condition)
         self.conditions = conditions
 
     def _seen_stats_error(

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -27,7 +27,6 @@ from sentry.search.events.constants import (
     ARRAY_FIELDS,
     EQUALITY_OPERATORS,
     ERROR_UNHANDLED_ALIAS,
-    INEQUALITY_OPERATORS,
     ISSUE_ALIAS,
     ISSUE_ID_ALIAS,
     MAX_SEARCH_RELEASES,
@@ -967,16 +966,6 @@ def format_search_filter(term, params):
                 raise InvalidSearchQuery(
                     f"Invalid query. Project(s) {oxfordize_list(missing)} do not exist or are not actively selected."
                 )
-            elif term.operator in INEQUALITY_OPERATORS:
-                # Set search filter to project name instead of id
-                term = SearchFilter(
-                    SearchKey("project.name"),
-                    term.operator,
-                    SearchValue(missing if term.is_in_filter else missing[0]),
-                )
-                converted_filter = convert_search_filter_to_snuba_query(term)
-                if converted_filter:
-                    conditions.append(converted_filter)
 
         project_ids = list(sorted(projects.values()))
         if project_ids:

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -968,11 +968,11 @@ def format_search_filter(term, params):
                     f"Invalid query. Project(s) {oxfordize_list(missing)} do not exist or are not actively selected."
                 )
             elif term.operator in INEQUALITY_OPERATORS:
-                # Set non-existent excluded projects to empty value
+                # Set search filter to project name instead of id
                 term = SearchFilter(
-                    SearchKey("project_id"),
+                    SearchKey("project.name"),
                     term.operator,
-                    SearchValue(""),
+                    SearchValue(missing if term.is_in_filter else missing[0]),
                 )
                 converted_filter = convert_search_filter_to_snuba_query(term)
                 if converted_filter:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -164,19 +164,23 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                     "environment": environments,
                 },
             )
-            # if no re-formatted conditions, use fallback method
-            converted_filters.append(
-                conditions[0]
-                if conditions
-                else convert_search_filter_to_snuba_query(
+
+            # if no re-formatted conditions, use fallback method for selected groups
+            new_condition = None
+            if conditions:
+                new_condition = conditions[0]
+            elif group_ids:
+                new_condition = convert_search_filter_to_snuba_query(
                     search_filter,
                     params={
                         "organization_id": organization_id,
                         "project_id": project_ids,
-                        "environment": environments,
+                        "environment_id": environments,
                     },
                 )
-            )
+
+            if new_condition:
+                converted_filters.append(new_condition)
 
         return converted_filters
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -175,7 +175,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                     params={
                         "organization_id": organization_id,
                         "project_id": project_ids,
-                        "environment_id": environments,
+                        "environment": environments,
                     },
                 )
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -463,6 +463,23 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_success_response(query="!project:[invalid-project,also-invalid]")
         assert len(response.data) == 1
 
+    def test_project_negation_mixed(self):
+        self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group1"],
+                "timestamp": iso_format(self.min_ago),
+                "environment": "production",
+            },
+            project_id=self.project.id,
+        )
+        project = self.project
+
+        self.login_as(user=self.user)
+        response = self.get_success_response(
+            query=f"!project:[{project.slug},invalid-project,also-invalid]"
+        )
+        assert len(response.data) == 0
+
     def test_auto_resolved(self):
         project = self.project
         project.update_option("sentry:resolve_age", 1)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -460,7 +460,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.get_success_response(query="!project:invalid-project")
+        response = self.get_success_response(query="!project:[invalid-project,also-invalid]")
         assert len(response.data) == 1
 
     def test_auto_resolved(self):

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -449,6 +449,20 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_success_response(query=f"project:{project.slug}")
         assert len(response.data) == 1
 
+    def test_project_negation_invalid(self):
+        self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group1"],
+                "timestamp": iso_format(self.min_ago),
+                "environment": "production",
+            },
+            project_id=self.project.id,
+        )
+
+        self.login_as(user=self.user)
+        response = self.get_success_response(query="!project:invalid-project")
+        assert len(response.data) == 1
+
     def test_auto_resolved(self):
         project = self.project
         project.update_option("sentry:resolve_age", 1)


### PR DESCRIPTION
Allows for negation of non-existent or unselected projects. Adds an empty value and essentially ignores the search term.

 Fixes SENTRY-YS6