### PR TITLE
fix(stacktrace): make web and mobile consistent

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -312,6 +312,6 @@ const Wrapper = styled('ol')<{startLineNo: number}>`
   counter-reset: frame ${p => p.startLineNo - 1};
 
   && {
-    border-radius: 0;
+    border-radius: 0 !important;
   }
 `;

--- a/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
@@ -32,7 +32,6 @@ export function FrameRegisters({registers, deviceArch, meta}: Props) {
 
   return (
     <Wrapper>
-      <Title>{t('Registers')}</Title>
       <StyledClippedBox
         isRevealed={isRevealed}
         renderedHeight={renderedHeight}
@@ -43,6 +42,7 @@ export function FrameRegisters({registers, deviceArch, meta}: Props) {
           return <ClipFade>{showMoreButton}</ClipFade>;
         }}
       >
+        <RegistersTitle>{t('Registers')}</RegistersTitle>
         <Registers>
           {sortedRegisters.map(([name, value]) => {
             if (!defined(value)) {
@@ -62,32 +62,23 @@ export function FrameRegisters({registers, deviceArch, meta}: Props) {
 }
 
 const Wrapper = styled('div')`
-  padding: ${space(1)} ${space(1)} ${space(0.5)} calc(${space(4)} + ${space(0.25)});
-  display: grid;
-  font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 1rem;
-  margin-top: ${space(0.5)};
-  border-top: 1px solid ${p => p.theme.innerBorder};
+  padding: ${space(0.5)} ${space(1.5)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 132px 1fr;
+    padding: 18px 36px;
   }
 `;
 
-const Title = styled('div')`
-  padding-right: ${space(1)};
-  padding-bottom: ${space(1)};
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    padding-bottom: 0;
-    padding-right: ${space(1)};
-  }
+const RegistersTitle = styled('div')`
+  width: 80px;
+  padding: ${space(1)} 0;
 `;
 
 const Registers = styled('div')`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(14.063rem, 1fr));
   gap: ${space(1)};
+  flex-grow: 1;
 `;
 
 const Register = styled('div')`
@@ -110,6 +101,10 @@ const StyledClippedBox = styled(ClippedBox)<{
   margin-right: 0;
   padding: 0;
   border-top: 0;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    display: flex;
+  }
 
   ${p =>
     !p.isRevealed &&

--- a/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/index.tsx
@@ -119,7 +119,7 @@ const StyledClippedBox = styled(ClippedBox)<{
       }
 
       > *:last-child {
-        background: ${p.theme.white};
+        background: ${p.theme.background};
         right: 0;
         bottom: 0;
         width: 100%;
@@ -129,7 +129,7 @@ const StyledClippedBox = styled(ClippedBox)<{
 `;
 
 const ClipFade = styled('div')`
-  background: ${p => p.theme.white};
+  background: ${p => p.theme.background};
   display: flex;
   justify-content: flex-end;
   /* Let pointer-events pass through ClipFade to visible elements underneath it */

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -438,7 +438,7 @@ const RowHeader = styled('span')`
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: auto 150px 120px 4fr auto auto 16px;
-    padding: ${space(1)} ${space(1.5)};
+    padding: ${space(0.5)} ${space(1.5)};
     min-height: 32px;
   }
 `;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -403,7 +403,7 @@ const Registers = styled(Context)`
   margin: 0;
 `;
 
-const PackageNote = styled('span')`
+const PackageNote = styled('div')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -30,7 +30,6 @@ import space from 'sentry/styles/space';
 import {Frame, PlatformType, SentryAppComponent} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
-import {ColorOrAlias} from 'sentry/utils/theme';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import DebugImage from './debugMeta/debugImage';
@@ -252,23 +251,19 @@ function NativeFrame({
           <PackageCell>
             {!fullStackTrace && !expanded && leadsToApp && (
               <Fragment>
-                {!nextFrame ? t('Crashed in Non-App:') : t('Called from:')}
+                {!nextFrame ? t('Crashed in Non-App') : t('Called from')}
               </Fragment>
             )}
-            <span>
-              <Tooltip
-                title={frame.package ?? t('Go to images loaded')}
-                delay={tooltipDelay}
-                disabled={frame.package ? false : !packageClickable}
-                containerDisplayMode="inline-flex"
-              >
-                <Package onClick={packageClickable ? handleGoToImagesLoaded : undefined}>
-                  {frame.package ? trimPackage(frame.package) : `<${t('unknown')}>`}
-                </Package>
-              </Tooltip>
-            </span>
+            <Tooltip
+              title={frame.package ?? t('Go to images loaded')}
+              delay={tooltipDelay}
+            >
+              <Package>
+                {frame.package ? trimPackage(frame.package) : `<${t('unknown')}>`}
+              </Package>
+            </Tooltip>
           </PackageCell>
-          <AddressCell>
+          <AddressCell onClick={packageClickable ? handleGoToImagesLoaded : undefined}>
             <Tooltip
               title={addressTooltip}
               disabled={!(foundByStackScanning || inlineFrame)}
@@ -302,10 +297,10 @@ function NativeFrame({
           <GroupingCell>
             {isUsedForGrouping && (
               <Tooltip
-                title={t('Repeated in every event of this issue')}
+                title={t('This frame is repeated in every event of this issue')}
                 containerDisplayMode="inline-flex"
               >
-                <IconRepeat size="sm" color="linkColor" />
+                <IconRepeat size="sm" color="textColor" />
               </Tooltip>
             )}
           </GroupingCell>
@@ -333,7 +328,7 @@ function NativeFrame({
         </RowHeader>
       </StrictClick>
       {expanded && (
-        <Registers
+        <RowBody
           frame={frame}
           event={event}
           registers={registers}
@@ -366,23 +361,36 @@ const StatusCell = styled(Cell)``;
 const PackageCell = styled(Cell)``;
 
 const AddressCell = styled(Cell)`
-  color: ${p => p.theme.subText};
+  ${p => p.onClick && `cursor: pointer`};
+  ${p => p.onClick && `color:` + p.theme.linkColor};
 `;
-
-const GroupingCell = styled(Cell)``;
 
 const FunctionNameCell = styled(Cell)`
   font-family: ${p => p.theme.text.familyMono};
+
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    grid-column: 2/6;
+  }
 `;
 
-const TypeCell = styled(Cell)``;
+const GroupingCell = styled(Cell)`
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    grid-row: 2/3;
+  }
+`;
 
-const ExpandCell = styled(Cell)``;
+const TypeCell = styled(Cell)`
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    grid-column: 5/6;
+    grid-row: 1/2;
+  }
+`;
 
-const Registers = styled(Context)`
-  border-bottom: 1px solid ${p => p.theme.border};
-  padding: 0;
-  margin: 0;
+const ExpandCell = styled(Cell)`
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    grid-column: 6/7;
+    grid-row: 1/2;
+  }
 `;
 
 const ToggleButton = styled(Button)`
@@ -390,11 +398,13 @@ const ToggleButton = styled(Button)`
   height: 16px;
 `;
 
-const Package = styled('span')<{color?: ColorOrAlias}>`
-  border-bottom: 1px dashed ${p => p.theme.border};
-  ${p => p.color && `color: ${p.theme[p.color]}`};
-  ${p => p.onClick && `cursor: pointer;`}
+const Registers = styled(Context)`
+  border-bottom: 1px solid ${p => p.theme.border};
+  padding: 0;
+  margin: 0;
 `;
+
+const Package = styled('span')``;
 
 const FileName = styled('span')`
   color: ${p => p.theme.subText};
@@ -407,13 +417,20 @@ const FrameRow = styled('li')<{expandable: boolean; expanded: boolean}>`
 
 const RowHeader = styled('span')`
   display: grid;
+  grid-template-columns: repeat(2, auto) 1fr repeat(2, auto) 16px;
+  grid-template-rows: repeat(2, auto);
   align-items: center;
-  grid-template-columns: minmax(16px, auto) repeat(2, minmax(130px, 1fr)) 4fr repeat(
-      3,
-      minmax(16px, auto)
-    );
-  grid-column-gap: ${space(2)};
+  grid-column-gap: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
   background-color: ${p => p.theme.bodyBackground};
-  padding: ${space(0.5)} ${space(1)};
+  font-size: ${p => p.theme.codeFontSize};
+  padding: ${space(1)};
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-columns: auto minmax(140px, auto) minmax(120px, auto) 1fr auto auto 16px;
+    min-height: 32px;
+    padding: ${space(0.5)} ${space(2)};
+  }
 `;
+
+const RowBody = styled(Registers)``;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -218,7 +218,7 @@ function NativeFrame({
   const status = getStatus();
 
   return (
-    <FrameRow data-test-id="stack-trace-frame">
+    <li data-test-id="stack-trace-frame">
       <StrictClick onClick={handleToggleContext}>
         <RowHeader expandable={expandable} expanded={expanded}>
           <div>
@@ -342,7 +342,7 @@ function NativeFrame({
           frameMeta={frameMeta}
         />
       )}
-    </FrameRow>
+    </li>
   );
 }
 
@@ -410,15 +410,13 @@ const FileName = styled('span')`
   border-bottom: 1px dashed ${p => p.theme.border};
 `;
 
-const FrameRow = styled('li')``;
-
 const RowHeader = styled('span')<{expandable: boolean; expanded: boolean}>`
   display: grid;
   grid-template-columns: repeat(2, auto) 1fr repeat(2, auto);
   grid-template-rows: repeat(2, auto);
   align-items: center;
   align-content: center;
-  grid-column-gap: ${space(1)};
+  column-gap: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
   background-color: ${p => p.theme.bodyBackground};
   font-size: ${p => p.theme.codeFontSize};

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -19,6 +19,7 @@ import StrictClick from 'sentry/components/strictClick';
 import Tag from 'sentry/components/tag';
 import {Tooltip} from 'sentry/components/tooltip';
 import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
+import {IconCheckmark} from 'sentry/icons/iconCheckmark';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconFileBroken} from 'sentry/icons/iconFileBroken';
 import {IconRepeat} from 'sentry/icons/iconRepeat';
@@ -218,41 +219,26 @@ function NativeFrame({
   const status = getStatus();
 
   return (
-    <GridRow
+    <FrameRow
       expandable={expandable}
       expanded={expanded}
-      className="frame"
       data-test-id="stack-trace-frame"
     >
       <StrictClick onClick={handleToggleContext}>
-        <StrictClickContent>
+        <RowHeader>
           <StatusCell>
-            {(status === 'error' || status === undefined) &&
-              (packageClickable ? (
-                <PackageStatusButton
-                  onClick={handleGoToImagesLoaded}
-                  aria-label={t('Go to images loaded')}
-                  icon={
-                    status === 'error' ? (
-                      <IconFileBroken size="sm" color="errorText" />
-                    ) : (
-                      <IconWarning size="sm" color="warningText" />
-                    )
-                  }
-                  size="zero"
-                  borderless
-                />
-              ) : status === 'error' ? (
-                <IconFileBroken size="sm" color="errorText" />
-              ) : (
-                <IconWarning size="sm" color="warningText" />
-              ))}
+            {status === 'error' ? (
+              <IconFileBroken size="sm" color="errorText" />
+            ) : status === undefined ? (
+              <IconWarning size="sm" color="warningText" />
+            ) : (
+              <IconCheckmark size="sm" color="successText" />
+            )}
           </StatusCell>
           <PackageCell>
             {!fullStackTrace && !expanded && leadsToApp && (
               <Fragment>
-                {!nextFrame ? t('Crashed in non-app') : t('Called from')}
-                {':'}&nbsp;
+                {!nextFrame ? t('Crashed in Non-App:') : t('Called from:')}
               </Fragment>
             )}
             <span>
@@ -278,13 +264,11 @@ function NativeFrame({
             </Tooltip>
           </AddressCell>
           <FunctionNameCell>
-            <div>
-              {functionName ? (
-                <AnnotatedText value={functionName.value} meta={functionName.meta} />
-              ) : (
-                `<${t('unknown')}>`
-              )}
-            </div>
+            {functionName ? (
+              <AnnotatedText value={functionName.value} meta={functionName.meta} />
+            ) : (
+              `<${t('unknown')}>`
+            )}
             {frame.filename && (
               <Tooltip
                 title={frame.absPath}
@@ -312,7 +296,11 @@ function NativeFrame({
             )}
           </GroupingCell>
           <TypeCell>
-            {frame.inApp ? <Tag>{t('In App')}</Tag> : <Tag>{t('System')}</Tag>}
+            {frame.inApp ? (
+              <Tag>{t('In App')}</Tag>
+            ) : (
+              <Tag type="info">{t('System')}</Tag>
+            )}
           </TypeCell>
           <ExpandCell>
             {expandable && (
@@ -328,28 +316,26 @@ function NativeFrame({
               />
             )}
           </ExpandCell>
-        </StrictClickContent>
+        </RowHeader>
       </StrictClick>
-      <RegistersCell>
-        {expanded && (
-          <Registers
-            frame={frame}
-            event={event}
-            registers={registers}
-            components={components}
-            hasContextSource={hasContextSource(frame)}
-            hasContextVars={hasContextVars(frame)}
-            hasContextRegisters={hasContextRegisters(registers)}
-            emptySourceNotation={emptySourceNotation}
-            hasAssembly={hasAssembly(frame, platform)}
-            expandable={expandable}
-            isExpanded={expanded}
-            registersMeta={registersMeta}
-            frameMeta={frameMeta}
-          />
-        )}
-      </RegistersCell>
-    </GridRow>
+      {expanded && (
+        <Registers
+          frame={frame}
+          event={event}
+          registers={registers}
+          components={components}
+          hasContextSource={hasContextSource(frame)}
+          hasContextVars={hasContextVars(frame)}
+          hasContextRegisters={hasContextRegisters(registers)}
+          emptySourceNotation={emptySourceNotation}
+          hasAssembly={hasAssembly(frame, platform)}
+          expandable={expandable}
+          isExpanded={expanded}
+          registersMeta={registersMeta}
+          frameMeta={frameMeta}
+        />
+      )}
+    </FrameRow>
   );
 }
 
@@ -359,62 +345,28 @@ const Cell = styled('div')`
   display: flex;
   flex-wrap: wrap;
   word-break: break-all;
-  align-items: flex-start;
 `;
 
-const StatusCell = styled(Cell)`
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-column: 1/1;
-    grid-row: 1/1;
-  }
-`;
+const StatusCell = styled(Cell)``;
 
-const PackageCell = styled(Cell)`
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-column: 2/2;
-    grid-row: 1/1;
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: repeat(2, auto);
-  }
-`;
+const PackageCell = styled(Cell)``;
 
 const AddressCell = styled(Cell)`
   color: ${p => p.theme.subText};
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-column: 3/3;
-    grid-row: 1/1;
-  }
 `;
 
-const GroupingCell = styled(Cell)`
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-column: 1/1;
-    grid-row: 2/2;
-  }
-`;
+const GroupingCell = styled(Cell)``;
 
 const FunctionNameCell = styled(Cell)`
   font-family: ${p => p.theme.text.familyMono};
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-column: 2/-1;
-    grid-row: 2/2;
-  }
 `;
 
 const TypeCell = styled(Cell)``;
 
 const ExpandCell = styled(Cell)``;
 
-const RegistersCell = styled('div')`
-  grid-column: 1/-1;
-  margin-left: -${space(0.5)};
-  margin-right: -${space(0.5)};
-  margin-bottom: -${space(0.5)};
-  cursor: default;
-`;
-
 const Registers = styled(Context)`
+  border-bottom: 1px solid ${p => p.theme.border};
   padding: 0;
   margin: 0;
 `;
@@ -435,18 +387,19 @@ const FileName = styled('span')`
   border-bottom: 1px dashed ${p => p.theme.border};
 `;
 
-const PackageStatusButton = styled(Button)`
-  padding: 0;
-  border: none;
-`;
-
-const GridRow = styled('li')<{expandable: boolean; expanded: boolean}>`
+const FrameRow = styled('li')<{expandable: boolean; expanded: boolean}>`
   ${p => p.expandable && `cursor: pointer;`};
-  display: grid;
-  background-color: ${p => p.theme.bodyBackground};
-  grid-template-columns: repeat(7, 1fr);
 `;
 
-const StrictClickContent = styled('div')`
-  display: contents;
+const RowHeader = styled('span')`
+  display: grid;
+  align-items: center;
+  grid-template-columns: minmax(16px, auto) repeat(2, minmax(130px, 1fr)) 4fr repeat(
+      3,
+      minmax(16px, auto)
+    );
+  grid-column-gap: ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.border};
+  background-color: ${p => p.theme.bodyBackground};
+  padding: ${space(0.5)} ${space(1)};
 `;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -326,7 +326,7 @@ function NativeFrame({
         </RowHeader>
       </StrictClick>
       {expanded && (
-        <RowBody
+        <Registers
           frame={frame}
           event={event}
           registers={registers}
@@ -432,5 +432,3 @@ const RowHeader = styled('span')<{expandable: boolean; expanded: boolean}>`
     min-height: 32px;
   }
 `;
-
-const RowBody = styled(Registers)``;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -221,7 +221,7 @@ function NativeFrame({
     <FrameRow data-test-id="stack-trace-frame">
       <StrictClick onClick={handleToggleContext}>
         <RowHeader expandable={expandable} expanded={expanded}>
-          <StatusCell>
+          <div>
             {status === 'error' ? (
               <Tooltip
                 title={t(
@@ -243,8 +243,8 @@ function NativeFrame({
                 <IconCheckmark size="sm" color="successText" />
               </Tooltip>
             )}
-          </StatusCell>
-          <PackageCell>
+          </div>
+          <div>
             {!fullStackTrace && !expanded && leadsToApp && (
               <Fragment>
                 {!nextFrame ? (
@@ -264,7 +264,7 @@ function NativeFrame({
                 {frame.package ? trimPackage(frame.package) : `<${t('unknown')}>`}
               </Package>
             </Tooltip>
-          </PackageCell>
+          </div>
           <AddressCell onClick={packageClickable ? handleGoToImagesLoaded : undefined}>
             <Tooltip
               title={addressTooltip}
@@ -348,18 +348,12 @@ function NativeFrame({
 
 export default withSentryAppComponents(NativeFrame, {componentType: 'stacktrace-link'});
 
-const Cell = styled('div')``;
-
-const StatusCell = styled(Cell)``;
-
-const PackageCell = styled(Cell)``;
-
-const AddressCell = styled(Cell)`
+const AddressCell = styled('div')`
   ${p => p.onClick && `cursor: pointer`};
   ${p => p.onClick && `color:` + p.theme.linkColor};
 `;
 
-const FunctionNameCell = styled(Cell)`
+const FunctionNameCell = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   word-break: break-all;
 
@@ -368,20 +362,20 @@ const FunctionNameCell = styled(Cell)`
   }
 `;
 
-const GroupingCell = styled(Cell)`
+const GroupingCell = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-row: 2/3;
   }
 `;
 
-const TypeCell = styled(Cell)`
+const TypeCell = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-column: 5/6;
     grid-row: 1/2;
   }
 `;
 
-const ExpandCell = styled(Cell)`
+const ExpandCell = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-column: 6/7;
     grid-row: 1/2;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -251,11 +251,17 @@ function NativeFrame({
           <PackageCell>
             {!fullStackTrace && !expanded && leadsToApp && (
               <Fragment>
-                {!nextFrame ? t('Crashed in Non-App') : t('Called from')}
+                {!nextFrame ? (
+                  <PackageNote>{t('Crashed in Non-App')}</PackageNote>
+                ) : (
+                  <PackageNote>{t('Called from')}</PackageNote>
+                )}
               </Fragment>
             )}
             <Tooltip
               title={frame.package ?? t('Go to images loaded')}
+              position="bottom"
+              containerDisplayMode="inline-flex"
               delay={tooltipDelay}
             >
               <Package>
@@ -283,7 +289,6 @@ function NativeFrame({
                 title={frame.absPath}
                 disabled={!(defined(frame.absPath) && frame.absPath !== frame.filename)}
                 delay={tooltipDelay}
-                containerDisplayMode="inline-flex"
               >
                 <FileName>
                   {'('}
@@ -296,10 +301,7 @@ function NativeFrame({
           </FunctionNameCell>
           <GroupingCell>
             {isUsedForGrouping && (
-              <Tooltip
-                title={t('This frame is repeated in every event of this issue')}
-                containerDisplayMode="inline-flex"
-              >
+              <Tooltip title={t('This frame is repeated in every event of this issue')}>
                 <IconRepeat size="sm" color="textColor" />
               </Tooltip>
             )}
@@ -350,10 +352,7 @@ function NativeFrame({
 
 export default withSentryAppComponents(NativeFrame, {componentType: 'stacktrace-link'});
 
-const Cell = styled('div')`
-  display: flex;
-  flex-direction: column;
-`;
+const Cell = styled('div')``;
 
 const StatusCell = styled(Cell)``;
 
@@ -366,6 +365,7 @@ const AddressCell = styled(Cell)`
 
 const FunctionNameCell = styled(Cell)`
   font-family: ${p => p.theme.text.familyMono};
+  word-break: break-all;
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-column: 2/6;
@@ -403,12 +403,16 @@ const Registers = styled(Context)`
   margin: 0;
 `;
 
+const PackageNote = styled('span')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+`;
+
 const Package = styled('span')`
-  display: block;
-  width: 100%;
   white-space: nowrap;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
 `;
 
 const FileName = styled('span')`
@@ -425,6 +429,7 @@ const RowHeader = styled('span')`
   grid-template-columns: repeat(2, auto) 1fr repeat(2, auto) 16px;
   grid-template-rows: repeat(2, auto);
   align-items: center;
+  align-content: center;
   grid-column-gap: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.border};
   background-color: ${p => p.theme.bodyBackground};
@@ -432,9 +437,9 @@ const RowHeader = styled('span')`
   padding: ${space(1)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: auto 140px 120px 1fr auto auto 16px;
+    grid-template-columns: auto 150px 120px 4fr auto auto 16px;
+    padding: ${space(1)} ${space(1.5)};
     min-height: 32px;
-    padding: ${space(0.5)} ${space(1.5)};
   }
 `;
 

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -352,8 +352,7 @@ export default withSentryAppComponents(NativeFrame, {componentType: 'stacktrace-
 
 const Cell = styled('div')`
   display: flex;
-  flex-wrap: wrap;
-  word-break: break-all;
+  flex-direction: column;
 `;
 
 const StatusCell = styled(Cell)``;
@@ -404,7 +403,13 @@ const Registers = styled(Context)`
   margin: 0;
 `;
 
-const Package = styled('span')``;
+const Package = styled('span')`
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
 
 const FileName = styled('span')`
   color: ${p => p.theme.subText};
@@ -427,9 +432,9 @@ const RowHeader = styled('span')`
   padding: ${space(1)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: auto minmax(140px, auto) minmax(120px, auto) 1fr auto auto 16px;
+    grid-template-columns: auto 140px 120px 1fr auto auto 16px;
     min-height: 32px;
-    padding: ${space(0.5)} ${space(2)};
+    padding: ${space(0.5)} ${space(1.5)};
   }
 `;
 

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -228,11 +228,25 @@ function NativeFrame({
         <RowHeader>
           <StatusCell>
             {status === 'error' ? (
-              <IconFileBroken size="sm" color="errorText" />
+              <Tooltip
+                title={t(
+                  'This frame has missing deminification files and could not be symbolicated'
+                )}
+              >
+                <IconFileBroken size="sm" color="errorText" />
+              </Tooltip>
             ) : status === undefined ? (
-              <IconWarning size="sm" color="warningText" />
+              <Tooltip
+                title={t(
+                  'This frame has an unknown problem and could not be symbolicated'
+                )}
+              >
+                <IconWarning size="sm" color="warningText" />
+              </Tooltip>
             ) : (
-              <IconCheckmark size="sm" color="successText" />
+              <Tooltip title={t('This frame has been successfully symbolicated')}>
+                <IconCheckmark size="sm" color="successText" />
+              </Tooltip>
             )}
           </StatusCell>
           <PackageCell>

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -218,13 +218,9 @@ function NativeFrame({
   const status = getStatus();
 
   return (
-    <FrameRow
-      expandable={expandable}
-      expanded={expanded}
-      data-test-id="stack-trace-frame"
-    >
+    <FrameRow data-test-id="stack-trace-frame">
       <StrictClick onClick={handleToggleContext}>
-        <RowHeader>
+        <RowHeader expandable={expandable} expanded={expanded}>
           <StatusCell>
             {status === 'error' ? (
               <Tooltip
@@ -420,13 +416,11 @@ const FileName = styled('span')`
   border-bottom: 1px dashed ${p => p.theme.border};
 `;
 
-const FrameRow = styled('li')<{expandable: boolean; expanded: boolean}>`
-  ${p => p.expandable && `cursor: pointer;`};
-`;
+const FrameRow = styled('li')``;
 
-const RowHeader = styled('span')`
+const RowHeader = styled('span')<{expandable: boolean; expanded: boolean}>`
   display: grid;
-  grid-template-columns: repeat(2, auto) 1fr repeat(2, auto) 16px;
+  grid-template-columns: repeat(2, auto) 1fr repeat(2, auto);
   grid-template-rows: repeat(2, auto);
   align-items: center;
   align-content: center;
@@ -435,9 +429,13 @@ const RowHeader = styled('span')`
   background-color: ${p => p.theme.bodyBackground};
   font-size: ${p => p.theme.codeFontSize};
   padding: ${space(1)};
+  ${p => p.expandable && `cursor: pointer;`};
+  ${p =>
+    p.expandable && `grid-template-columns: repeat(2, auto) 1fr repeat(2, auto) 16px;`};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: auto 150px 120px 4fr auto auto 16px;
+    grid-template-columns: auto 150px 120px 4fr auto auto;
+    ${p => p.expandable && `grid-template-columns: auto 150px 120px 4fr auto auto 16px;`};
     padding: ${space(0.5)} ${space(1.5)};
     min-height: 32px;
   }


### PR DESCRIPTION
**Goal:**
Cleaning up mobile stacktrace to make it more aligned with web stacktrace. This was reviewed and approved in #discuss-issue-platform and #discuss-issue-workflow

**Changes Included:**
- Updated icons and added tooltips explaining the symbolication state
- Moved link to images loaded to the address
- Replaced subtle background color representing `system` and `in-app` with explicit tags

**Before:**
![Screenshot 2023-02-10 at 10 41 34 AM](https://user-images.githubusercontent.com/4830259/218172502-41886623-c5d4-4f16-9070-79038501d539.png)
![Screenshot 2023-02-10 at 10 51 54 AM](https://user-images.githubusercontent.com/4830259/218174076-85912f46-dda1-48c6-92ff-6d25c3517182.png)

_Jesse's notes for native stack trace
Column 1: Debug File Validation
(?) Missing File: Means symbolication wasn’t possible
/!\ Unknown Problem: Means symbolication wasn’t possible.
Column 2: Package Name
Blue means frame is symbolicated
Red means frame isn’t symbolicated
Column 3: Instruction Address
Theres a relative and absolute depending on whether symbolication was successful
Column 4: Grouping Icon
(i) Frame used for issue grouping
Column 5: Function title
Other stuff: The thee dot menu that has lots of extra options as well.
Rows background colour differs depending on whether its an in-app(Light Grey) vs system frame(White)_

**After:**
![Screenshot 2023-02-10 at 10 41 42 AM](https://user-images.githubusercontent.com/4830259/218174172-7b92a690-a96e-4e2e-8185-dde563620c96.png)
![Screenshot 2023-02-10 at 10 52 02 AM](https://user-images.githubusercontent.com/4830259/218174198-b179ed45-49a8-4510-8702-3443746e5bb1.png)

![legend](https://user-images.githubusercontent.com/4830259/217461272-bf84a015-9750-4fa9-97a4-cd68cc80475a.png)