### PR TITLE
fix(tx-clusterer): Exclude 404 transactions from clustering

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/__init__.py
@@ -1,2 +1,3 @@
 TRANSACTION_SOURCE_URL = "url"
 TRANSACTION_SOURCE_SANITIZED = "sanitized"
+HTTP_404_TAG = ["http.status_code", "404"]

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -109,7 +109,6 @@ def _must_store_event(event_data: Mapping[str, Any]) -> bool:
     source = transaction_info.get("source")
 
     if tags and HTTP_404_TAG in tags:
-        print(f"discarding transaction for tags: {tags=}")
         return False
 
     # For now, we also feed back transactions into the clustering algorithm

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -83,7 +83,6 @@ def clear_transaction_names(project: Project) -> None:
 
 
 def record_transaction_name(project: Project, event_data: Mapping[str, Any], **kwargs: Any) -> None:
-
     transaction_name = event_data.get("transaction")
 
     if transaction_name and features.has(
@@ -91,8 +90,8 @@ def record_transaction_name(project: Project, event_data: Mapping[str, Any], **k
     ):
         if not _must_store_event(event_data):
             return
-
         safe_execute(_store_transaction_name, project, transaction_name, _with_transaction=False)
+
         # TODO: For every transaction that had a rule applied to it, we should
         # bump the rule's lifetime here such that it stays alive while it is
         # being used.
@@ -103,7 +102,6 @@ def record_transaction_name(project: Project, event_data: Mapping[str, Any], **k
 def _must_store_event(event_data: Mapping[str, Any]) -> bool:
     """Returns whether the given event must be stored as input for the
     transaction clusterer."""
-
     tags = event_data.get("tags")
     transaction_info = event_data.get("transaction_info") or {}
     source = transaction_info.get("source")

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -7,6 +7,7 @@ from django.conf import settings
 
 from sentry import features
 from sentry.ingest.transaction_clusterer.datasource import (
+    HTTP_404_TAG,
     TRANSACTION_SOURCE_SANITIZED,
     TRANSACTION_SOURCE_URL,
 )
@@ -107,7 +108,7 @@ def _must_store_event(event_data: Mapping[str, Any]) -> bool:
     transaction_info = event_data.get("transaction_info") or {}
     source = transaction_info.get("source")
 
-    if tags and ["http.status_code", "404"] in tags:
+    if tags and HTTP_404_TAG in tags:
         print(f"discarding transaction for tags: {tags=}")
         return False
 

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -88,7 +88,7 @@ def record_transaction_name(project: Project, event_data: Mapping[str, Any], **k
     if (
         transaction_name
         and features.has("organizations:transaction-name-clusterer", project.organization)
-        and _must_store_event(event_data)
+        and _should_store_transaction_name(event_data)
     ):
         safe_execute(_store_transaction_name, project, transaction_name, _with_transaction=False)
 
@@ -99,7 +99,7 @@ def record_transaction_name(project: Project, event_data: Mapping[str, Any], **k
         # payload so we can check it here.
 
 
-def _must_store_event(event_data: Mapping[str, Any]) -> bool:
+def _should_store_transaction_name(event_data: Mapping[str, Any]) -> bool:
     """Returns whether the given event must be stored as input for the
     transaction clusterer."""
     tags = event_data.get("tags")

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -82,9 +82,10 @@ def clear_transaction_names(project: Project) -> None:
 
 
 def record_transaction_name(project: Project, event_data: Mapping[str, Any], **kwargs: Any) -> None:
-    transaction_info = event_data.get("transaction_info") or {}
 
     transaction_name = event_data.get("transaction")
+
+    transaction_info = event_data.get("transaction_info") or {}
     source = transaction_info.get("source")
     if transaction_name and features.has(
         "organizations:transaction-name-clusterer", project.organization

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -106,9 +106,6 @@ def _must_store_event(event_data: Mapping[str, Any]) -> bool:
     transaction_info = event_data.get("transaction_info") or {}
     source = transaction_info.get("source")
 
-    if tags and HTTP_404_TAG in tags:
-        return False
-
     # For now, we also feed back transactions into the clustering algorithm
     # that have already been sanitized, so we have a chance to discover
     # more high cardinality segments after partial sanitation.
@@ -118,6 +115,9 @@ def _must_store_event(event_data: Mapping[str, Any]) -> bool:
     # Disadvantage: the load on redis does not decrease over time.
     #
     if source not in (TRANSACTION_SOURCE_URL, TRANSACTION_SOURCE_SANITIZED):
+        return False
+
+    if tags and HTTP_404_TAG in tags:
         return False
 
     return True

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -85,11 +85,11 @@ def clear_transaction_names(project: Project) -> None:
 def record_transaction_name(project: Project, event_data: Mapping[str, Any], **kwargs: Any) -> None:
     transaction_name = event_data.get("transaction")
 
-    if transaction_name and features.has(
-        "organizations:transaction-name-clusterer", project.organization
+    if (
+        transaction_name
+        and features.has("organizations:transaction-name-clusterer", project.organization)
+        and _must_store_event(event_data)
     ):
-        if not _must_store_event(event_data):
-            return
         safe_execute(_store_transaction_name, project, transaction_name, _with_transaction=False)
 
         # TODO: For every transaction that had a rule applied to it, we should


### PR DESCRIPTION
404 transactions are currently provided as input for the transaction clusterer and degrade the quality of produced rules, creating rules that are too aggressive due to the high cardinality on every level of the tree. This PR excludes those transactions before providing them to the clusterer. The way to determine whether a transaction is coming from a 404 is looking at the tag `http.status_code` -- a transaction is considered a 404 if that tag exists and its value is `404`.

### Approach

Initially, I was looking for a way to introduce this logic in the clusterer, so that it's datasource agnostic. However, the clusterer is only aware of transaction names, so that isn't possible. The simplest alternative is to plug the logic into the datasource, and leave its extraction to another component for a later time when the need exists.

Resolves https://github.com/getsentry/team-ingest/issues/67.
