### PR TITLE
fix(test): Add known non-common string to test assertion

### DIFF
--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -89,6 +89,7 @@ class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
             #: to the indexer because they already exist in the release health
             #: indexer db.
             known_non_common_strings = {
+                "foo",
                 "other",
                 "platform",
                 "d:transactions/measurements.inp@millisecond",


### PR DESCRIPTION
The transaction name "foo" is extracted as tag value during transaction metrics
extraction. It's not clear to me how this hasn't been flagged before.

