### PR TITLE
chore(relay): Cleanup option for clientBased

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -419,11 +419,6 @@ register("relay.drop-transaction-metrics", default=[])
 # [Unused] Sample rate for opting in orgs into transaction metrics extraction.
 register("relay.transaction-metrics-org-sample-rate", default=0.0)
 
-# Sample rate for opting in orgs into the new transaction name handling.
-# old behavior: Treat transactions from old SDKs as high-cardinality.
-# new behavior: Treat transactions from old SDKs as low-cardinality, except for browser JS.
-register("relay.transaction-names-client-based", default=0.0)
-
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True)
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -546,11 +546,6 @@ def _should_extract_transaction_metrics(project: Project) -> bool:
     )
 
 
-def _accept_transaction_names_strategy(project: Project) -> TransactionNameStrategy:
-    is_selected_org = sample_modulo("relay.transaction-names-client-based", project.organization_id)
-    return "clientBased" if is_selected_org else "strict"
-
-
 def get_transaction_metrics_settings(
     project: Project, breakdowns_config: Optional[Mapping[str, Any]]
 ) -> TransactionMetricsSettings:
@@ -594,5 +589,5 @@ def get_transaction_metrics_settings(
         "extractMetrics": metrics,
         "extractCustomTags": custom_tags,
         "customMeasurements": {"limit": CUSTOM_MEASUREMENT_LIMIT},
-        "acceptTransactionNames": _accept_transaction_names_strategy(project),
+        "acceptTransactionNames": "clientBased",
     }

--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -6,12 +6,10 @@ from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import Feature
-from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
 
 class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
-    @override_options({"relay.transaction-names-client-based": 1.0})
     def test_all_transaction_metrics_emitted(self):
         with Feature(
             {

--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -6,10 +6,12 @@ from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import Feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
 
 class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
+    @override_options({"relay.transaction-names-client-based": 1.0})
     def test_all_transaction_metrics_emitted(self):
         with Feature(
             {
@@ -19,6 +21,7 @@ class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
             event_data = {
                 "type": "transaction",
                 "transaction": "foo",
+                "transaction_info": {"source": "url"},  # 'transaction' tag not extracted
                 "timestamp": iso_format(before_now(seconds=1)),
                 "start_timestamp": iso_format(before_now(seconds=2)),
                 "contexts": {

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-17T00:14:25.449555Z'
+created: '2023-02-08T13:30:33.857547Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -916,7 +916,7 @@ metricConditionalTagging:
   - d:transactions/measurements.fcp@millisecond
   targetTag: histogram_outlier
 transactionMetrics:
-  acceptTransactionNames: strict
+  acceptTransactionNames: clientBased
   customMeasurements:
     limit: 10
   extractCustomTags: []

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-01-17T00:14:25.295001Z'
+created: '2023-02-08T13:30:33.504452Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -916,7 +916,7 @@ metricConditionalTagging:
   - d:transactions/measurements.fcp@millisecond
   targetTag: histogram_outlier
 transactionMetrics:
-  acceptTransactionNames: strict
+  acceptTransactionNames: clientBased
   customMeasurements:
     limit: 10
   extractCustomTags: []

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -618,26 +618,17 @@ def test_has_metric_extraction(default_project, feature_flag, killswitch):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("org_sample", (0.0, 1.0), ids=("no_orgs", "all_orgs"))
-def test_accept_transaction_names(default_project, org_sample):
-    options = override_options(
-        {
-            "relay.transaction-names-client-based": org_sample,
-        }
-    )
+def test_accept_transaction_names(default_project):
     feature = Feature(
         {
             "organizations:transaction-metrics-extraction": True,
         }
     )
-    with feature, options:
+    with feature:
         config = get_project_config(default_project).to_dict()["config"]
         transaction_metrics_config = config["transactionMetrics"]
-        assert (
-            transaction_metrics_config["acceptTransactionNames"] == "clientBased"
-            if org_sample
-            else "strict"
-        )
+
+        assert transaction_metrics_config["acceptTransactionNames"] == "clientBased"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The option that controlled the rollout rate for client-based acceptance of transaction names was set to 100% a long time ago, so remove the option and hard-code the value in project configs.
