### PR TITLE
fix: Avoid logging a `bad_report` for .NET events

### DIFF
--- a/src/sentry/lang/native/error.py
+++ b/src/sentry/lang/native/error.py
@@ -15,6 +15,7 @@ USER_FIXABLE_ERRORS = (
     EventError.NATIVE_MISSING_OPTIONALLY_BUNDLED_DSYM,
     EventError.NATIVE_BAD_DSYM,
     EventError.NATIVE_MISSING_SYMBOL,
+    EventError.FETCH_GENERIC_ERROR,
     # Emitted for e.g. broken minidumps
     EventError.NATIVE_SYMBOLICATOR_FAILED,
     # We want to let the user know when calling symbolicator failed, even

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -16,7 +16,7 @@ WINDOWS_PATH_RE = re.compile(r"^([a-z]:\\|\\\\)", re.IGNORECASE)
 # "csharp" events are also considered "native" as they are processed by symbolicator.
 # This includes il2cpp events that are symbolicated using native debug files,
 # as well as .NET with Portable PDB files which are handled by symbolicator.
-NATIVE_PLATFORMS = ("cocoa", "native", "csharp")
+NATIVE_PLATFORMS = ("objc", "cocoa", "swift", "native", "c", "csharp")
 
 # Debug image types that can be handled by the symbolicator
 NATIVE_IMAGE_TYPES = (

--- a/src/sentry/reprocessing.py
+++ b/src/sentry/reprocessing.py
@@ -9,7 +9,8 @@ logger = logging.getLogger("sentry.events")
 
 def event_supports_reprocessing(data):
     """Only events of a certain format support reprocessing."""
-    from sentry.stacktraces.platform import JAVASCRIPT_PLATFORMS, NATIVE_PLATFORMS
+    from sentry.lang.native.utils import NATIVE_PLATFORMS
+    from sentry.stacktraces.platform import JAVASCRIPT_PLATFORMS
     from sentry.stacktraces.processing import find_stacktraces_in_data
 
     platform = data.get("platform")


### PR DESCRIPTION
.NET events (csharp) are now going through symbolicator, have debug images with statuses, etc. This means they should support reprocessing (?), and should thus not trigger a bogus `processing_issue.bad_report` error.

It seems there is two separate sets called `NATIVE_PLATFORMS`, one that decides if an event is potentially considered for symbolication / reprocessing. The other one is being used for grouping and I am not touching that one.

hopefully fixes SENTRY-V89