### PR TITLE
feat(perf-issues): Use rounded percentage value in duration impact

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -136,7 +136,7 @@ describe('SpanEvidenceKeyValueList', () => {
 
       expect(
         screen.getByTestId('span-evidence-key-value-list.duration-impact')
-      ).toHaveTextContent('46.154% (300ms/650ms)');
+      ).toHaveTextContent('46% (300ms/650ms)');
     });
   });
 
@@ -396,7 +396,7 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(screen.getByRole('cell', {name: 'Duration Impact'})).toBeInTheDocument();
       expect(
         screen.getByTestId('span-evidence-key-value-list.duration-impact')
-      ).toHaveTextContent('52.309% (487ms/931ms)');
+      ).toHaveTextContent('52% (487ms/931ms)');
     });
   });
 });

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -5,7 +5,7 @@ import mapValues from 'lodash/mapValues';
 
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
-import {toPercent} from 'sentry/components/performance/waterfall/utils';
+import {toRoundedPercent} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {
   Entry,
@@ -284,7 +284,7 @@ function getDurationImpact(event: EventTransaction, durationAdded: number) {
     return null;
   }
   const percent = durationAdded / transactionTime;
-  return `${toPercent(percent)} (${getPerformanceDuration(
+  return `${toRoundedPercent(percent)} (${getPerformanceDuration(
     durationAdded
   )}/${getPerformanceDuration(transactionTime)})`;
 }

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -178,6 +178,8 @@ export const getHumanDuration = (duration: number): string => {
 
 export const toPercent = (value: number) => `${(value * 100).toFixed(3)}%`;
 
+export const toRoundedPercent = (value: number) => `${Math.round(value * 100)}%`;
+
 type Rect = {
   height: number;
   width: number;


### PR DESCRIPTION
Rounds off the percentage to a whole number in the duration impact field

### Before
![image](https://user-images.githubusercontent.com/16740047/217595766-2f103391-b521-4f6b-b34f-a54d2e19e131.png)

### After
![image](https://user-images.githubusercontent.com/16740047/217595816-4a7c9b2c-a993-4393-9b04-52f8f0ffd0a0.png)
