### PR TITLE
feat(perf): add backend flags for increasing performance landing page stats period

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1159,6 +1159,8 @@ SENTRY_FEATURES = {
     "organizations:performance-mep-reintroduce-histograms": False,
     # Enable showing INP web vital in default views
     "organizations:performance-vitals-inp": False,
+    # Enables a longer stats period for the performance landing page
+    "organizations:performance-landing-page-stats-period": False,
     # Enable internal view for bannerless MEP view
     "organizations:performance-mep-bannerless-ui": False,
     # Enable updated landing page widget designs

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -124,7 +124,7 @@ default_manager.add("organizations:performance-transaction-name-only-search", Or
 default_manager.add("organizations:performance-transaction-name-only-search-indexed", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)
 default_manager.add("organizations:performance-vitals-inp", OrganizationFeature, True)
-default_manager.add("organizations:performance-landing-page-stats-period", OrganizationFeature)
+default_manager.add("organizations:performance-landing-page-stats-period", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
 default_manager.add("organizations:performance-new-widget-designs", OrganizationFeature, True)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -124,6 +124,7 @@ default_manager.add("organizations:performance-transaction-name-only-search", Or
 default_manager.add("organizations:performance-transaction-name-only-search-indexed", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)
 default_manager.add("organizations:performance-vitals-inp", OrganizationFeature, True)
+default_manager.add("organizations:performance-landing-page-stats-period", OrganizationFeature)
 default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
 default_manager.add("organizations:performance-new-widget-designs", OrganizationFeature, True)


### PR DESCRIPTION
Backend side for PERF-1833
We want to increase the stats period from 24h to 7d or 14d on the performance landing period because 24h often isn't that helpful.
This adds a backend flag so that we can wrap this change in a flag, in order to monitor how it affects the load on our database based on who we roll this change out to.