### PR TITLE
feat(perf): add frontend code to increase performance landing stats period

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -738,7 +738,7 @@ class DashboardDetail extends Component<Props, State> {
       dashboardState !== DashboardState.CREATE &&
       hasUnsavedFilterChanges(dashboard, location);
 
-    const eventView = generatePerformanceEventView(location, projects);
+    const eventView = generatePerformanceEventView(location, projects, {}, organization);
 
     const isDashboardUsingTransaction = dashboard.widgets.some(
       isWidgetUsingTransactionName

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -26,7 +26,7 @@ import useProjects from 'sentry/utils/useProjects';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
 import {getLandingDisplayFromParam} from './landing/utils';
-import {DEFAULT_STATS_PERIOD, generatePerformanceEventView} from './data';
+import {generatePerformanceEventView, getDefaultStatsPeriod} from './data';
 import {PerformanceLanding} from './landing';
 import {
   addRoutePerformanceContext,
@@ -53,9 +53,14 @@ function PerformanceContent({selection, location, demoMode, router}: Props) {
   const previousDateTime = usePrevious(selection.datetime);
   const [state, setState] = useState<State>({error: undefined});
   const withStaticFilters = canUseMetricsData(organization);
-  const eventView = generatePerformanceEventView(location, projects, {
-    withStaticFilters,
-  });
+  const eventView = generatePerformanceEventView(
+    location,
+    projects,
+    {
+      withStaticFilters,
+    },
+    organization
+  );
 
   function getOnboardingProject(): Project | undefined {
     // XXX used by getsentry to bypass onboarding for the upsell demo state.
@@ -161,7 +166,7 @@ function PerformanceContent({selection, location, demoMode, router}: Props) {
               start: null,
               end: null,
               utc: false,
-              period: DEFAULT_STATS_PERIOD,
+              period: getDefaultStatsPeriod(organization),
             },
           }}
         >

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -40,6 +40,13 @@ export const COLUMN_TITLES = [
 
 const TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH = ['transaction'];
 
+export const getDefaultStatsPeriod = (organization: Organization) => {
+  if (organization?.features?.includes('performance-landing-page-stats-period')) {
+    return '7d';
+  }
+  return DEFAULT_STATS_PERIOD;
+};
+
 export enum PERFORMANCE_TERM {
   TPM = 'tpm',
   THROUGHPUT = 'throughput',
@@ -401,7 +408,8 @@ function isUsingLimitedSearch(location: Location, withStaticFilters: boolean) {
 
 function generateGenericPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean
+  withStaticFilters: boolean,
+  organization: Organization
 ): EventView {
   const {query} = location;
 
@@ -434,7 +442,7 @@ function generateGenericPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = DEFAULT_STATS_PERIOD;
+    savedQuery.range = getDefaultStatsPeriod(organization);
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -482,7 +490,8 @@ function generateGenericPerformanceEventView(
 
 function generateBackendPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean
+  withStaticFilters: boolean,
+  organization: Organization
 ): EventView {
   const {query} = location;
 
@@ -517,7 +526,7 @@ function generateBackendPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = DEFAULT_STATS_PERIOD;
+    savedQuery.range = getDefaultStatsPeriod(organization);
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -554,7 +563,8 @@ function generateMobilePerformanceEventView(
   location: Location,
   projects: Project[],
   genericEventView: EventView,
-  withStaticFilters: boolean
+  withStaticFilters: boolean,
+  organization: Organization
 ): EventView {
   const {query} = location;
 
@@ -599,7 +609,7 @@ function generateMobilePerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = DEFAULT_STATS_PERIOD;
+    savedQuery.range = getDefaultStatsPeriod(organization);
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -635,7 +645,8 @@ function generateMobilePerformanceEventView(
 
 function generateFrontendPageloadPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean
+  withStaticFilters: boolean,
+  organization: Organization
 ): EventView {
   const {query} = location;
 
@@ -668,7 +679,7 @@ function generateFrontendPageloadPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = DEFAULT_STATS_PERIOD;
+    savedQuery.range = getDefaultStatsPeriod(organization);
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -705,7 +716,8 @@ function generateFrontendPageloadPerformanceEventView(
 
 function generateFrontendOtherPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean
+  withStaticFilters: boolean,
+  organization: Organization
 ): EventView {
   const {query} = location;
 
@@ -738,7 +750,7 @@ function generateFrontendOtherPerformanceEventView(
   savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = DEFAULT_STATS_PERIOD;
+    savedQuery.range = getDefaultStatsPeriod(organization);
   }
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
@@ -776,9 +788,14 @@ function generateFrontendOtherPerformanceEventView(
 export function generatePerformanceEventView(
   location: Location,
   projects: Project[],
-  {isTrends = false, withStaticFilters = false} = {}
+  {isTrends = false, withStaticFilters = false} = {},
+  organization: Organization
 ) {
-  const eventView = generateGenericPerformanceEventView(location, withStaticFilters);
+  const eventView = generateGenericPerformanceEventView(
+    location,
+    withStaticFilters,
+    organization
+  );
   if (isTrends) {
     return eventView;
   }
@@ -786,24 +803,40 @@ export function generatePerformanceEventView(
   const display = getCurrentLandingDisplay(location, projects, eventView);
   switch (display?.field) {
     case LandingDisplayField.FRONTEND_PAGELOAD:
-      return generateFrontendPageloadPerformanceEventView(location, withStaticFilters);
+      return generateFrontendPageloadPerformanceEventView(
+        location,
+        withStaticFilters,
+        organization
+      );
     case LandingDisplayField.FRONTEND_OTHER:
-      return generateFrontendOtherPerformanceEventView(location, withStaticFilters);
+      return generateFrontendOtherPerformanceEventView(
+        location,
+        withStaticFilters,
+        organization
+      );
     case LandingDisplayField.BACKEND:
-      return generateBackendPerformanceEventView(location, withStaticFilters);
+      return generateBackendPerformanceEventView(
+        location,
+        withStaticFilters,
+        organization
+      );
     case LandingDisplayField.MOBILE:
       return generateMobilePerformanceEventView(
         location,
         projects,
         eventView,
-        withStaticFilters
+        withStaticFilters,
+        organization
       );
     default:
       return eventView;
   }
 }
 
-export function generatePerformanceVitalDetailView(location: Location): EventView {
+export function generatePerformanceVitalDetailView(
+  location: Location,
+  organization: Organization
+): EventView {
   const {query} = location;
 
   const vitalName = vitalNameFromLocation(location);
@@ -831,7 +864,7 @@ export function generatePerformanceVitalDetailView(location: Location): EventVie
   };
 
   if (!query.statsPeriod && !hasStartAndEnd) {
-    savedQuery.range = DEFAULT_STATS_PERIOD;
+    savedQuery.range = getDefaultStatsPeriod(organization);
   }
   savedQuery.orderby = decodeScalar(query.sort, '-count');
 

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -23,9 +23,14 @@ import {LandingDisplayField} from 'sentry/views/performance/landing/utils';
 const searchHandlerMock = jest.fn();
 
 const WrappedComponent = ({data, withStaticFilters = false}) => {
-  const eventView = generatePerformanceEventView(data.router.location, data.projects, {
-    withStaticFilters,
-  });
+  const eventView = generatePerformanceEventView(
+    data.router.location,
+    data.projects,
+    {
+      withStaticFilters,
+    },
+    data.organization
+  );
 
   const client = new QueryClient();
 

--- a/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -11,9 +11,14 @@ import {generatePerformanceEventView} from 'sentry/views/performance/data';
 import {PerformanceLanding} from 'sentry/views/performance/landing';
 
 const WrappedComponent = ({data, withStaticFilters = true}) => {
-  const eventView = generatePerformanceEventView(data.router.location, data.projects, {
-    withStaticFilters,
-  });
+  const eventView = generatePerformanceEventView(
+    data.router.location,
+    data.projects,
+    {
+      withStaticFilters,
+    },
+    data.organization
+  );
 
   const client = new QueryClient();
 

--- a/static/app/views/performance/trends/index.tsx
+++ b/static/app/views/performance/trends/index.tsx
@@ -34,16 +34,26 @@ class TrendsSummary extends Component<Props, State> {
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,
-      eventView: generatePerformanceEventView(nextProps.location, nextProps.projects, {
-        isTrends: true,
-      }),
+      eventView: generatePerformanceEventView(
+        nextProps.location,
+        nextProps.projects,
+        {
+          isTrends: true,
+        },
+        nextProps.organization
+      ),
     };
   }
 
   state: State = {
-    eventView: generatePerformanceEventView(this.props.location, this.props.projects, {
-      isTrends: true,
-    }),
+    eventView: generatePerformanceEventView(
+      this.props.location,
+      this.props.projects,
+      {
+        isTrends: true,
+      },
+      this.props.organization
+    ),
     error: undefined,
   };
 

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -44,13 +44,19 @@ type State = {
 
 class VitalDetail extends Component<Props, State> {
   state: State = {
-    eventView: generatePerformanceVitalDetailView(this.props.location),
+    eventView: generatePerformanceVitalDetailView(
+      this.props.location,
+      this.props.organization
+    ),
   };
 
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,
-      eventView: generatePerformanceVitalDetailView(nextProps.location),
+      eventView: generatePerformanceVitalDetailView(
+        nextProps.location,
+        nextProps.organization
+      ),
     };
   }
 


### PR DESCRIPTION
Frontend work for PERF-1833
This is adds some temporary code that allows us to rollout a new landing page stats period and monitor its performance overhead.
This PR compliments #44302 