### PR TITLE
ref(perf-issues): Remove badge for unc asset

### DIFF
--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -274,14 +274,6 @@ function GroupHeader({
             )}
           />
         )}
-        {group.issueType === IssueType.PERFORMANCE_UNCOMPRESSED_ASSET && (
-          <FeatureBadge
-            type="alpha"
-            title={t(
-              'Uncompressed Asset Performance Issues are in active development and may change'
-            )}
-          />
-        )}
       </ShortIdBreadrcumb>
     </GuideAnchor>
   );


### PR DESCRIPTION
### Summary
Removes the badge now that we're in the process of GA'ing. gpo
