### PR TITLE
fix(n1-api-call): Omit JPEGs from detection

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -188,7 +188,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         # Ignore anything that looks like an asset. Some frameworks (and apps)
         # fetch assets via XHR, which is not our concern
         _pathname, extension = os.path.splitext(parsed_url.path)
-        if extension and extension in [".js", ".css", ".svg", ".png", ".mp3"]:
+        if extension and extension in [".js", ".css", ".svg", ".png", ".mp3", ".jpg", ".jpeg"]:
             return False
 
         return True


### PR DESCRIPTION
Expanding the list of what counts as a resource.
