### PR TITLE
ref(compactSelect): Update prop names

### DIFF
--- a/static/app/components/compactSelect/composite.spec.tsx
+++ b/static/app/components/compactSelect/composite.spec.tsx
@@ -205,7 +205,7 @@ describe('CompactSelect', function () {
 
   it('can search', function () {
     render(
-      <CompositeSelect isSearchable placeholder="Search placeholder…">
+      <CompositeSelect searchable searchPlaceholder="Search placeholder…">
         <CompositeSelect.Region
           label="Region 1"
           onChange={() => {}}

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -4,7 +4,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {useKeyboard} from '@react-aria/interactions';
-import {AriaPositionProps} from '@react-aria/overlays';
 import {mergeProps} from '@react-aria/utils';
 import {ListState} from '@react-stately/list';
 import {OverlayTriggerState} from '@react-stately/overlays';
@@ -91,12 +90,6 @@ export interface ControlProps extends UseOverlayProps {
    */
   onSearch?: (value: string) => void;
   /**
-   * Position of the overlay menu relative to the trigger button. Allowed for backward
-   * compatibility only. Use the `position` prop instead.
-   * @deprecated
-   */
-  placement?: AriaPositionProps['placement'];
-  /**
    * The search input's placeholder text (applicable only when `searchable` is true).
    */
   searchPlaceholder?: string;
@@ -138,7 +131,6 @@ export function Control({
   onClose,
   disabled,
   position = 'bottom-start',
-  placement,
   offset,
   menuTitle,
   maxMenuHeight = '32rem',
@@ -211,26 +203,7 @@ export function Control({
     onClear?.();
   }, [onClear, listStates]);
 
-  // Get overlay props. We need to support both the `position` and `placement` props for
-  // backward compatibility. TODO: convert existing usages from `placement` to `position`
-  const overlayPosition = useMemo(
-    () =>
-      position ??
-      placement
-        ?.split(' ')
-        .map(key => {
-          switch (key) {
-            case 'right':
-              return 'end';
-            case 'left':
-              return 'start';
-            default:
-              return key;
-          }
-        })
-        .join('-'),
-    [position, placement]
-  );
+  // Manage overlay position
   const {
     isOpen: overlayIsOpen,
     state: overlayState,
@@ -240,7 +213,7 @@ export function Control({
     overlayProps,
   } = useOverlay({
     type: 'listbox',
-    position: overlayPosition,
+    position,
     offset,
     isOpen,
     onOpenChange: async open => {

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -64,20 +64,15 @@ export const SelectContext = createContext<SelectContextValue>({
 export interface ControlProps extends UseOverlayProps {
   children?: React.ReactNode;
   className?: string;
-  disabled?: boolean;
   /**
    * If true, there will be a "Clear" button in the menu header.
    */
-  isClearable?: boolean;
+  clearable?: boolean;
+  disabled?: boolean;
   /**
    * If true, there will be a loading indicator in the menu header.
    */
-  isLoading?: boolean;
-  /**
-   * If true, there will be a search box on top of the menu, useful for quickly finding
-   * menu items.
-   */
-  isSearchable?: boolean;
+  loading?: boolean;
   maxMenuHeight?: number | string;
   maxMenuWidth?: number | string;
   /**
@@ -86,25 +81,30 @@ export interface ControlProps extends UseOverlayProps {
   menuTitle?: React.ReactNode;
   menuWidth?: number | string;
   /**
-   * Called when the clear button is clicked (applicable only when `isClearable` is
+   * Called when the clear button is clicked (applicable only when `clearable` is
    * true).
    */
   onClear?: () => void;
   /**
-   * Called when the search input's value changes (applicable only when `isSearchable`
+   * Called when the search input's value changes (applicable only when `searchable`
    * is true).
    */
-  onInputChange?: (value: string) => void;
-  /**
-   * The search input's placeholder text (applicable only when `isSearchable` is true).
-   */
-  placeholder?: string;
+  onSearch?: (value: string) => void;
   /**
    * Position of the overlay menu relative to the trigger button. Allowed for backward
    * compatibility only. Use the `position` prop instead.
    * @deprecated
    */
   placement?: AriaPositionProps['placement'];
+  /**
+   * The search input's placeholder text (applicable only when `searchable` is true).
+   */
+  searchPlaceholder?: string;
+  /**
+   * If true, there will be a search box on top of the menu, useful for quickly finding
+   * menu items.
+   */
+  searchable?: boolean;
   size?: FormSize;
   /**
    * Optional replacement for the default trigger button. Note that the replacement must
@@ -147,12 +147,12 @@ export function Control({
 
   // Select props
   size = 'md',
-  isSearchable = false,
-  placeholder = 'Search…',
-  onInputChange,
-  isClearable = false,
+  searchable = false,
+  searchPlaceholder = 'Search…',
+  onSearch,
+  clearable = false,
   onClear,
-  isLoading = false,
+  loading = false,
   children,
   ...wrapperProps
 }: ControlProps) {
@@ -177,9 +177,9 @@ export function Control({
   const updateSearch = useCallback(
     (newValue: string) => {
       setSearch(newValue);
-      onInputChange?.(newValue);
+      onSearch?.(newValue);
     },
-    [onInputChange]
+    [onSearch]
   );
   const filterOption = useCallback<SelectContextValue['filterOption']>(
     opt =>
@@ -370,12 +370,12 @@ export function Control({
             maxHeightProp={maxMenuHeight}
           >
             <FocusScope contain={overlayIsOpen}>
-              {(menuTitle || isClearable) && (
+              {(menuTitle || clearable) && (
                 <MenuHeader size={size} data-header>
                   <MenuTitle>{menuTitle}</MenuTitle>
                   <MenuHeaderTrailingItems>
-                    {isLoading && <StyledLoadingIndicator size={12} mini />}
-                    {isClearable && (
+                    {loading && <StyledLoadingIndicator size={12} mini />}
+                    {clearable && (
                       <ClearButton onClick={clearSelection} size="zero" borderless>
                         {t('Clear')}
                       </ClearButton>
@@ -383,9 +383,9 @@ export function Control({
                   </MenuHeaderTrailingItems>
                 </MenuHeader>
               )}
-              {isSearchable && (
+              {searchable && (
                 <SearchInput
-                  placeholder={placeholder}
+                  placeholder={searchPlaceholder}
                   value={search}
                   onChange={e => updateSearch(e.target.value)}
                   visualSize={size}

--- a/static/app/components/compactSelect/index.spec.tsx
+++ b/static/app/components/compactSelect/index.spec.tsx
@@ -111,8 +111,8 @@ describe('CompactSelect', function () {
   it('can search', function () {
     render(
       <CompactSelect
-        isSearchable
-        placeholder="Search here…"
+        searchable
+        searchPlaceholder="Search here…"
         options={[
           {value: 'opt_one', label: 'Option One'},
           {value: 'opt_two', label: 'Option Two'},
@@ -136,9 +136,7 @@ describe('CompactSelect', function () {
     const onCloseMock = jest.fn();
     render(
       <CompactSelect
-        isSearchable
         onClose={onCloseMock}
-        placeholder="Search here…"
         options={[
           {value: 'opt_one', label: 'Option One'},
           {value: 'opt_two', label: 'Option Two'},

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -16,12 +16,6 @@ export {SelectOption, SelectOptionOrSection, SelectSection};
 
 interface BaseSelectProps<Value extends React.Key> extends ControlProps {
   options: SelectOptionOrSection<Value>[];
-  /**
-   * Same as `disabled` in ControlProps. Allowed only for backward compatibility.
-   * Will be removed soon.
-   * @deprecated
-   */
-  isDisabled?: boolean;
 }
 
 export interface SingleSelectProps<Value extends React.Key>
@@ -60,7 +54,6 @@ function CompactSelect<Value extends React.Key>({
 
   // Control props
   disabled,
-  isDisabled,
   size = 'md',
   closeOnSelect,
   triggerProps,
@@ -86,11 +79,16 @@ function CompactSelect<Value extends React.Key>({
     [options]
   );
 
+  const controlDisabled = useMemo(
+    () => disabled ?? options?.length === 0,
+    [disabled, options]
+  );
+
   return (
     <Control
       {...controlProps}
       triggerProps={{...triggerProps, id: triggerId}}
-      disabled={isDisabled ?? disabled ?? options?.length === 0}
+      disabled={controlDisabled}
       size={size}
     >
       <ListBox

--- a/static/app/components/events/interfaces/spans/filter.tsx
+++ b/static/app/components/events/interfaces/spans/filter.tsx
@@ -100,7 +100,7 @@ function Filter({
   return (
     <CompactSelect
       multiple
-      isClearable
+      clearable
       maxMenuWidth="24rem"
       options={menuOptions}
       onChange={onChange}

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -226,7 +226,7 @@ export function TraceEventDataSection({
                 size: 'xs',
                 title: sortByTooltip,
               }}
-              isDisabled={!!sortByTooltip}
+              disabled={!!sortByTooltip}
               position="bottom-end"
               onChange={selectedOption => {
                 setState({...state, sortBy: selectedOption.value});

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
@@ -81,7 +81,7 @@ function FlamegraphThreadSelector({
       ]}
       value={threadId ?? 0}
       onChange={handleChange}
-      isSearchable
+      searchable
     />
   );
 }

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -188,7 +188,7 @@ function BaseTabList({
             options={overflowMenuItems}
             value={[...state.selectionManager.selectedKeys][0]}
             onChange={opt => state.setSelectedKey(opt.value)}
-            isDisabled={disabled}
+            disabled={disabled}
             position="bottom-end"
             size="sm"
             offset={4}

--- a/static/app/views/alerts/list/rules/teamFilter.tsx
+++ b/static/app/views/alerts/list/rules/teamFilter.tsx
@@ -84,9 +84,9 @@ function TeamFilter({
   return (
     <CompactSelect
       multiple
-      isClearable
-      isSearchable
-      isLoading={fetching}
+      clearable
+      searchable
+      loading={fetching}
       menuTitle={t('Filter teams')}
       options={
         showSuggestedOptions
@@ -97,7 +97,7 @@ function TeamFilter({
           : teamOptions
       }
       value={selectedTeams}
-      onInputChange={debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}
+      onSearch={debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}
       onChange={opts => {
         // Compact select type inference does not work - onChange type is actually T | null.
         if (!opts) {

--- a/static/app/views/dashboards/releasesSelectControl.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.tsx
@@ -57,7 +57,7 @@ function ReleasesSelectControl({
       multiple
       clearable
       searchable
-      isDisabled={isDisabled}
+      disabled={isDisabled}
       loading={loading}
       menuTitle={<MenuTitleWrapper>{t('Filter Releases')}</MenuTitleWrapper>}
       className={className}

--- a/static/app/views/dashboards/releasesSelectControl.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.tsx
@@ -55,13 +55,13 @@ function ReleasesSelectControl({
   return (
     <CompactSelect
       multiple
-      isClearable
-      isSearchable
+      clearable
+      searchable
       isDisabled={isDisabled}
-      isLoading={loading}
+      loading={loading}
       menuTitle={<MenuTitleWrapper>{t('Filter Releases')}</MenuTitleWrapper>}
       className={className}
-      onInputChange={debounce(val => {
+      onSearch={debounce(val => {
         onSearch(val);
       }, DEFAULT_DEBOUNCE_DURATION)}
       options={[

--- a/static/app/views/discover/chartFooter.tsx
+++ b/static/app/views/discover/chartFooter.tsx
@@ -90,7 +90,7 @@ export default function ChartFooter({
         ) : (
           <OptionSelector
             multiple
-            isClearable
+            clearable
             menuTitle={
               yAxisOptions.length > 3 ? t('Select up to 3 options') : t('Y-axis')
             }

--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -61,7 +61,7 @@ function Filter(props: Props) {
   return (
     <GuideAnchor target="span_op_breakdowns_filter" position="top">
       <CompactSelect
-        isClearable
+        clearable
         disallowEmptySelection={false}
         menuTitle={t('Filter by operation')}
         options={menuOptions}

--- a/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.tsx
@@ -67,7 +67,7 @@ export default function OpsFilter(props: Props) {
     >
       {results => (
         <CompactSelect
-          isClearable
+          clearable
           maxMenuWidth="24rem"
           disallowEmptySelection={false}
           menuTitle={t('Filter by operation')}

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -184,7 +184,7 @@ export function ProfileDetailsTable() {
           multiple
           onChange={columnFilters.image.onChange}
           placement="bottom right"
-          isSearchable
+          searchable
         />
       </ActionBar>
 

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -137,7 +137,7 @@ export function ProfileDetailsTable() {
           triggerProps={{
             prefix: t('View'),
           }}
-          placement="bottom right"
+          position="bottom-end"
           onChange={option => {
             setSearchQuery('');
             setPaginationCursor(undefined);
@@ -166,7 +166,7 @@ export function ProfileDetailsTable() {
           }}
           multiple
           onChange={columnFilters.type.onChange}
-          placement="bottom right"
+          position="bottom-end"
         />
         <CompactSelect
           options={columnFilters.image.values.map(value => ({value, label: value}))}
@@ -183,7 +183,7 @@ export function ProfileDetailsTable() {
           }}
           multiple
           onChange={columnFilters.image.onChange}
-          placement="bottom right"
+          position="bottom-end"
           searchable
         />
       </ActionBar>

--- a/static/app/views/replays/detail/console/consoleFilters.tsx
+++ b/static/app/views/replays/detail/console/consoleFilters.tsx
@@ -28,7 +28,7 @@ function Filters({
         onChange={selected => setLogLevel(selected.map(_ => _.value))}
         size="sm"
         value={logLevel}
-        isDisabled={!logLevels.length}
+        disabled={!logLevels.length}
       />
       <SearchBar
         onChange={setSearchTerm}

--- a/static/app/views/replays/detail/domMutations/domFilters.tsx
+++ b/static/app/views/replays/detail/domMutations/domFilters.tsx
@@ -26,7 +26,7 @@ function DomFilters({
         size="sm"
         onChange={selected => setType(selected.map(_ => _.value))}
         value={type}
-        isDisabled={!mutationTypes.length}
+        disabled={!mutationTypes.length}
       />
       <SearchBar
         size="sm"

--- a/static/app/views/replays/detail/network/networkFilters.tsx
+++ b/static/app/views/replays/detail/network/networkFilters.tsx
@@ -32,7 +32,7 @@ function NetworkFilters({
         size="sm"
         onChange={selected => setStatus(selected.map(_ => _.value))}
         value={status}
-        isDisabled={!statusTypes.length}
+        disabled={!statusTypes.length}
       />
       <CompactSelect
         triggerProps={{prefix: t('Type')}}
@@ -42,7 +42,7 @@ function NetworkFilters({
         size="sm"
         onChange={selected => setType(selected.map(_ => _.value))}
         value={type}
-        isDisabled={!resourceTypes.length}
+        disabled={!resourceTypes.length}
       />
       <SearchBar
         size="sm"


### PR DESCRIPTION
Update `CompactSelect` prop names for better consistency with other components in our component system. The changes are as follows:
 - `isDisabled` —> `disabled` (as used by form inputs, `Button`, `AutoComplete`,…)
 - `placement` —> `position` (as used by `useOverlay`, `Tooltip`, `DropdownMenu`,…)
 - A few feature props:
   - Search:
     - `isSearchable` —> `searchable` (as used by `SelectControl`, consistent with our pattern of not using the `is` prefix)
     - `placeholder` —> `searchPlaceholder`  (more obvious that it's related to `searchable`)
     - `onInputChange` —> `onSearch` (more obvious that it's related to `searchable`)
   - Clear button:
     - `isClearable` —> `clearable` (as used by `SelectControl`, consistent with our pattern of not using the `is` prefix)
   - Loading indicator:
     - `isLoading` —> `loading` (more consistent with our pattern of not using the `is` prefix)