### PR TITLE
feat(issue-platform): introduce project_id as a required top-level field in occurrence payload

### DIFF
--- a/src/sentry/data/samples/generic-event-profiling.json
+++ b/src/sentry/data/samples/generic-event-profiling.json
@@ -364,5 +364,6 @@
     "id": "0c6d75ac-3969-41e0-bc4b-33c2ff7f3657",
     "issue_title": "File I/O function called on main thread",
     "subtitle": "Some Transaction",
-    "type": 2000
+    "type": 2000,
+    "project_id": 1
 }

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -43,7 +43,7 @@ def save_issue_occurrence(
         raise ValueError("IssueOccurrence must have the same event_id as the passed Event")
     # Note: For now we trust the project id passed along with the event. Later on we should make
     # sure that this is somehow validated.
-    occurrence.save(event.project_id)
+    occurrence.save()
 
     # TODO: Pass release here
     group_info = save_issue_from_occurrence(occurrence, event, None)

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -20,6 +20,7 @@ class IssueEvidenceData(TypedDict):
 
 class IssueOccurrenceData(TypedDict):
     id: str
+    project_id: int
     event_id: str
     fingerprint: Sequence[str]
     issue_title: str
@@ -62,6 +63,7 @@ class IssueOccurrence:
     """
 
     id: str
+    project_id: int
     # Event id pointing to an event in nodestore
     event_id: str
     fingerprint: Sequence[str]
@@ -89,6 +91,7 @@ class IssueOccurrence:
     ) -> IssueOccurrenceData:
         return {
             "id": self.id,
+            "project_id": self.project_id,
             "event_id": self.event_id,
             "fingerprint": self.fingerprint,
             "issue_title": self.issue_title,
@@ -105,6 +108,7 @@ class IssueOccurrence:
     def from_dict(cls, data: IssueOccurrenceData) -> IssueOccurrence:
         return cls(
             data["id"],
+            data["project_id"],
             # We'll always have an event id when loading an issue occurrence
             data["event_id"],
             data["fingerprint"],
@@ -145,8 +149,8 @@ class IssueOccurrence:
         identifier = hashlib.md5(f"{id_}::{project_id}".encode()).hexdigest()
         return f"i-o:{identifier}"
 
-    def save(self, project_id: int) -> None:
-        nodestore.set(self.build_storage_identifier(self.id, project_id), self.to_dict())
+    def save(self) -> None:
+        nodestore.set(self.build_storage_identifier(self.id, self.project_id), self.to_dict())
 
     @classmethod
     def fetch(cls, id_: str, project_id: int) -> Optional[IssueOccurrence]:

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -125,7 +125,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
             if "event" in payload:
                 event_payload = payload["event"]
                 if payload["project_id"] != event_payload.get("project_id"):
-                    raise ValueError(
+                    raise InvalidEventPayloadError(
                         f"project_id in occurrence ({payload['project_id']}) is different from project_id in event ({event_payload.get('project_id')})"
                     )
 

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -108,6 +108,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
             kwargs = {
                 "occurrence_data": {
                     "id": payload["id"],
+                    "project_id": payload["project_id"],
                     "fingerprint": payload["fingerprint"],
                     "issue_title": payload["issue_title"],
                     "subtitle": payload["subtitle"],
@@ -123,6 +124,11 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
 
             if "event" in payload:
                 event_payload = payload["event"]
+                if payload["project_id"] != event_payload.get("project_id"):
+                    raise ValueError(
+                        f"project_id in occurrence ({payload['project_id']}) is different from project_id in event ({event_payload.get('project_id')})"
+                    )
+
                 kwargs["event_data"] = {
                     "event_id": event_payload.get("event_id"),
                     "project_id": event_payload.get("project_id"),

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -72,6 +72,7 @@ class DummyNotificationWithMoreFields(DummyNotification):
 
 TEST_ISSUE_OCCURRENCE = IssueOccurrence(
     uuid.uuid4().hex,
+    1,
     uuid.uuid4().hex,
     ["some-fingerprint"],
     "something bad happened",

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -170,7 +170,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         event = event.for_group(event.groups[0])
         occurrence = self.build_occurrence(level="info")
-        occurrence.save(project_id=self.project.id)
+        occurrence.save()
         event.occurrence = occurrence
 
         event.group.type = GroupType.PROFILE_BLOCKED_THREAD

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -17,8 +17,8 @@ class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):  # type: ignor
 class IssueOccurenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):  # type: ignore
     def test(self) -> None:
         occurrence = self.build_occurrence()
-        occurrence.save(self.project.id)
-        fetched_occurrence = IssueOccurrence.fetch(occurrence.id, self.project.id)
+        occurrence.save()
+        fetched_occurrence = IssueOccurrence.fetch(occurrence.id, occurrence.project_id)
         assert fetched_occurrence is not None
         self.assert_occurrences_identical(occurrence, fetched_occurrence)
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -157,10 +157,10 @@ class ParseEventPayloadTest(IssueOccurrenceTestMessage):
         message["event"]["tags"]["nan-tag"] = float("nan")
         self.run_test(message)
 
-    @mock.patch("sentry.issues.occurrence_consumer.logger")
-    def test_project_ids_mismatch(self, mock_logger):
+    def test_project_ids_mismatch(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
         message["project_id"] = 1
         message["event"]["project_id"] = 2
-        assert _get_kwargs(message) is None
-        assert mock_logger.exception.call_count == 1
+        with mock.patch("sentry.issues.occurrence_consumer.logger") as mock_logger:
+            assert _get_kwargs(message) is None
+            assert mock_logger.exception.call_count == 1

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -3,7 +3,6 @@ import logging
 import uuid
 from copy import deepcopy
 from typing import Any, Dict, Optional, Sequence
-from unittest import mock
 
 import pytest
 
@@ -161,6 +160,5 @@ class ParseEventPayloadTest(IssueOccurrenceTestMessage):
         message = deepcopy(get_test_message(self.project.id))
         message["project_id"] = 1
         message["event"]["project_id"] = 2
-        with mock.patch("sentry.issues.occurrence_consumer.logger") as mock_logger:
-            assert _get_kwargs(message) is None
-            assert mock_logger.exception.call_count == 1
+        with pytest.raises(InvalidEventPayloadError):
+            _get_kwargs(message)

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -32,6 +32,7 @@ class OccurrenceTestMixin:
     def build_occurrence_data(self, **overrides: Any) -> IssueOccurrenceData:
         kwargs: IssueOccurrenceData = {
             "id": uuid.uuid4().hex,
+            "project_id": 1,
             "event_id": uuid.uuid4().hex,
             "fingerprint": ["some-fingerprint"],
             "issue_title": "something bad happened",

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -189,6 +189,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         )
         event = event.for_group(event.groups[0])
         occurrence = IssueOccurrence(
+            self.project.id,
             uuid.uuid4().hex,
             uuid.uuid4().hex,
             ["some-fingerprint"],
@@ -204,7 +205,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             GroupType.PROFILE_BLOCKED_THREAD,
             ensure_aware(datetime.now()),
         )
-        occurrence.save(self.project.id)
+        occurrence.save()
         event.occurrence = occurrence
 
         event.group.type = GroupType.PROFILE_BLOCKED_THREAD
@@ -241,6 +242,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         event = event.for_group(event.groups[0])
         occurrence = IssueOccurrence(
             uuid.uuid4().hex,
+            self.project.id,
             uuid.uuid4().hex,
             ["some-fingerprint"],
             "something bad happened",
@@ -251,7 +253,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             GroupType.PROFILE_BLOCKED_THREAD,
             ensure_aware(datetime.now()),
         )
-        occurrence.save(self.project.id)
+        occurrence.save()
         event.occurrence = occurrence
 
         event.group.type = GroupType.PROFILE_BLOCKED_THREAD

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -363,7 +363,7 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
         assert group_event.occurrence is None
 
     def test_get_latest_event_occurrence(self):
-        occurrence_data = self.build_occurrence_data()
+        occurrence_data = self.build_occurrence_data(project_id=self.project.id)
         event_id = uuid.uuid4().hex
         occurrence = process_event_and_issue_occurrence(
             occurrence_data,

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -28,7 +28,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         if event_type == "performance":
             event = self.create_performance_issue()
         elif event_type == "generic":
-            occurrence_data = self.build_occurrence_data()
+            occurrence_data = self.build_occurrence_data(project_id=self.project.id)
             event_id = uuid.uuid4().hex
             occurrence, group_info = process_event_and_issue_occurrence(
                 occurrence_data,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1306,7 +1306,7 @@ class PostProcessGroupGenericTest(
             data=data, project_id=project_id, assert_no_errors=assert_no_errors
         )
 
-        occurrence_data = self.build_occurrence_data(event_id=event.event_id)
+        occurrence_data = self.build_occurrence_data(event_id=event.event_id, project_id=project_id)
         occurrence, group_info = save_issue_occurrence(occurrence_data, event)
         assert group_info is not None
 


### PR DESCRIPTION
This is needed for cases when we process Issue occurrences without an `event` in the payload, e.g. Performance issues.