### PR TITLE
fix(perf-issue): add project id to redis cache key for ignore limit

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2298,7 +2298,7 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
 
                     for new_grouphash in new_grouphashes:
                         group_type = performance_problems_by_hash[new_grouphash].type
-                        if not should_create_group(client, new_grouphash, group_type):
+                        if not should_create_group(client, new_grouphash, group_type, project):
                             groups_to_ignore.add(new_grouphash)
 
                     new_grouphashes = new_grouphashes - groups_to_ignore
@@ -2411,8 +2411,8 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
 
 
 @metrics.wraps("performance.performance_issue.should_create_group", sample_rate=1.0)
-def should_create_group(client: Any, grouphash: str, type: GroupType) -> bool:
-    times_seen = client.incr(f"grouphash:{grouphash}")
+def should_create_group(client: Any, grouphash: str, type: GroupType, project: Project) -> bool:
+    times_seen = client.incr(f"grouphash:{grouphash}:{project.id}")
     metrics.incr(
         "performance.performance_issue.grouphash_counted",
         tags={

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2412,7 +2412,8 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
 
 @metrics.wraps("performance.performance_issue.should_create_group", sample_rate=1.0)
 def should_create_group(client: Any, grouphash: str, type: GroupType, project: Project) -> bool:
-    times_seen = client.incr(f"grouphash:{grouphash}:{project.id}")
+    key = f"grouphash:{grouphash}:{project.id}"
+    times_seen = client.incr(key)
     metrics.incr(
         "performance.performance_issue.grouphash_counted",
         tags={
@@ -2432,7 +2433,7 @@ def should_create_group(client: Any, grouphash: str, type: GroupType, project: P
 
         return True
     else:
-        client.expire(grouphash, 60 * 60 * 24)  # 24 hour expiration from last seen
+        client.expire(key, 60 * 60 * 24)  # 24 hour expiration from last seen
         return False
 
 


### PR DESCRIPTION
This PR makes two changes
1. A fingerprint could be the same between projects, so we don't want to rely on the grouphash only to set the times_seen of a group. This adds the project id to the cache key.
2. Fixed incorrect cache key when setting expire time. (It was being set to -1, which I believe means no expiry, so our redis probably has more keys then it needs to)