### PR TITLE
fix(profiling): always use flamegraph config space

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -394,10 +394,7 @@ function Flamegraph(): ReactElement {
         minWidth: uiFrames.minFrameDuration,
         barHeight: 10,
         depthOffset: 0,
-        configSpaceTransform:
-          xAxis === 'transaction'
-            ? new Rect(-flamegraph.profile.startedAt, 0, 0, 0)
-            : undefined,
+        configSpaceTransform: xAxis === 'transaction' ? new Rect(0, 0, 0, 0) : undefined,
       },
     });
 

--- a/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
@@ -57,6 +57,7 @@ export function FlamegraphPreview({
     const canvasView = new CanvasView({
       canvas: flamegraphCanvas,
       model: flamegraph,
+      modelConfigSpace: flamegraph.configSpace,
       options: {barHeight: flamegraphTheme.SIZES.BAR_HEIGHT},
       mode: 'anchorBottom',
     });

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -135,8 +135,8 @@ export function FlamegraphSpans({
 
     const drawSpans = () => {
       spansRenderer.draw(
-        spansView.configView.transformRect(spansView.configSpaceTransform),
-        spansView.fromConfigView(spansCanvas.physicalSpace)
+        spansView.toOriginConfigView(spansView.configView),
+        spansView.fromTransformedConfigView(spansCanvas.physicalSpace)
       );
     };
 

--- a/static/app/utils/profiling/canvasView.spec.tsx
+++ b/static/app/utils/profiling/canvasView.spec.tsx
@@ -22,6 +22,7 @@ const makeCanvasAndView = (
   const canvasView = new CanvasView<Flamegraph>({
     canvas: flamegraphCanvas,
     model: flamegraph,
+    modelConfigSpace: flamegraph.configSpace,
     options: {
       inverted: flamegraph.inverted,
       minWidth: flamegraph.profile.minFrameDuration,

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -18,17 +18,21 @@ export class CanvasView<T extends {configSpace: Rect}> {
   barHeight: number;
 
   model: T;
+  modelConfigSpace: Readonly<Rect>;
+
   canvas: FlamegraphCanvas;
   mode: 'anchorTop' | 'anchorBottom' | 'stretchToFit' = 'anchorTop';
 
   constructor({
     canvas,
     options,
+    modelConfigSpace,
     model,
     mode,
   }: {
     canvas: FlamegraphCanvas;
     model: T;
+    modelConfigSpace: Readonly<Rect>;
     options: {
       barHeight: number;
       configSpaceTransform?: Rect;
@@ -38,13 +42,17 @@ export class CanvasView<T extends {configSpace: Rect}> {
     };
     mode?: CanvasView<T>['mode'];
   }) {
+    this.canvas = canvas;
+
     this.mode = mode || this.mode;
     this.inverted = !!options.inverted;
+
     this.minWidth = options.minWidth ?? 0;
-    this.model = model;
-    this.canvas = canvas;
     this.depthOffset = options.depthOffset ?? 0;
     this.barHeight = options.barHeight ? options.barHeight * window.devicePixelRatio : 0;
+
+    this.model = model;
+    this.modelConfigSpace = modelConfigSpace;
 
     // This is a transformation matrix that is applied to the configView, it allows us to
     // transform an entire view and render it without having to recompute the models.
@@ -79,8 +87,8 @@ export class CanvasView<T extends {configSpace: Rect}> {
         this.configSpace = new Rect(
           0,
           0,
-          this.model.configSpace.width,
-          this.model.configSpace.height + this.depthOffset
+          this.modelConfigSpace.width,
+          this.modelConfigSpace.height + this.depthOffset
         );
         return;
       }
@@ -90,9 +98,9 @@ export class CanvasView<T extends {configSpace: Rect}> {
         this.configSpace = new Rect(
           0,
           0,
-          this.model.configSpace.width,
+          this.modelConfigSpace.width,
           Math.max(
-            this.model.configSpace.height + this.depthOffset,
+            this.modelConfigSpace.height + this.depthOffset,
             canvas.physicalSpace.height / this.barHeight
           )
         );

--- a/static/app/utils/profiling/renderers/flamegraphRendererDOM.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRendererDOM.spec.tsx
@@ -41,6 +41,7 @@ describe('FlamegraphDomRenderer', () => {
     const flamegraphView = new CanvasView<Flamegraph>({
       canvas: flamegraphCanvas,
       model: flamegraph,
+      modelConfigSpace: flamegraph.configSpace,
       options: {
         inverted: flamegraph.inverted,
         minWidth: flamegraph.profile.minFrameDuration,

--- a/static/app/utils/profiling/renderers/flamegraphRendererWebGL.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRendererWebGL.spec.tsx
@@ -246,6 +246,7 @@ describe('flamegraphRendererWebGL', () => {
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
         model: flamegraph,
+        modelConfigSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,
@@ -307,6 +308,7 @@ describe('flamegraphRendererWebGL', () => {
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
         model: flamegraph,
+        modelConfigSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,


### PR DESCRIPTION
We want to always use flamegraph config space as it'll always be the largest it can ever get. Fixes a bug where a view was scrollable when it should not have been.