### PR TITLE
feat(perf): show tpm and histograms as percentages for metrics

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -18,7 +18,10 @@ import EventView from 'sentry/utils/discover/eventView';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {
+  DISPLAY_MAP_DENY_LIST,
+  getTransactionMEPParamsIfApplicable,
+} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 import {TransactionsListOption} from 'sentry/views/releases/detail/overview';
 
@@ -161,6 +164,8 @@ function TransactionSummaryCharts({
     organization,
     location
   );
+  // For mep-incompatible displays hide event count
+  const hideTransactionCount = DISPLAY_MAP_DENY_LIST.includes(display as DisplayModes);
 
   return (
     <Panel>
@@ -254,9 +259,11 @@ function TransactionSummaryCharts({
 
       <ChartControls>
         <InlineContainer>
-          <SectionHeading key="total-heading">{t('Total Transactions')}</SectionHeading>
+          <SectionHeading key="total-heading">
+            {hideTransactionCount ? '' : t('Total Transactions')}
+          </SectionHeading>
           <SectionValue key="total-value">
-            {totalValues === null ? (
+            {totalValues === null || hideTransactionCount ? (
               <Placeholder height="24px" />
             ) : (
               totalValues.toLocaleString()

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -19,7 +19,10 @@ import {formatPercentage} from 'sentry/utils/formatters';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {
+  canUseMetricsInTransactionSummary,
+  getTransactionMEPParamsIfApplicable,
+} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 import {TransactionsListOption} from 'sentry/views/releases/detail/overview';
 
@@ -165,10 +168,12 @@ function TransactionSummaryCharts({
     location
   );
   // For mep-incompatible displays hide event count
-  const hideTransactionCount = display === DisplayModes.TREND;
+  const hideTransactionCount =
+    canUseMetricsInTransactionSummary(organization) && display === DisplayModes.TREND;
 
   // For partially-mep-compatible displays show event count as a %
-  const showTransactionCountAsPercentage = display === DisplayModes.LATENCY;
+  const showTransactionCountAsPercentage =
+    canUseMetricsInTransactionSummary(organization) && display === DisplayModes.LATENCY;
 
   function getTotalValue() {
     if (totalValue === null || hideTransactionCount) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -75,12 +75,12 @@ type Props = {
   eventView: EventView;
   location: Location;
   organization: Organization;
-  totalValues: number | null;
+  totalValue: number | null;
   withoutZerofill: boolean;
 };
 
 function TransactionSummaryCharts({
-  totalValues,
+  totalValue,
   eventView,
   organization,
   location,
@@ -182,6 +182,7 @@ function TransactionSummaryCharts({
             statsPeriod={eventView.statsPeriod}
             currentFilter={currentFilter}
             queryExtras={queryExtras}
+            totalCount={hideTransactionCount ? totalValue : null}
           />
         )}
         {display === DisplayModes.DURATION && (
@@ -263,10 +264,10 @@ function TransactionSummaryCharts({
             {hideTransactionCount ? '' : t('Total Transactions')}
           </SectionHeading>
           <SectionValue key="total-value">
-            {totalValues === null || hideTransactionCount ? (
+            {totalValue === null || hideTransactionCount ? (
               <Placeholder height="24px" />
             ) : (
-              totalValues.toLocaleString()
+              totalValue.toLocaleString()
             )}
           </SectionValue>
         </InlineContainer>

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -78,6 +78,7 @@ type Props = {
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
   totalValues: Record<string, number> | null;
   transactionName: string;
+  unfilteredTotalValues?: Record<string, number> | null;
 };
 
 function SummaryContent({
@@ -92,6 +93,7 @@ function SummaryContent({
   projectId,
   transactionName,
   onChangeFilter,
+  unfilteredTotalValues,
 }: Props) {
   const routes = useRoutes();
   function handleSearch(query: string) {
@@ -416,6 +418,7 @@ function SummaryContent({
           totals={totalValues}
           eventView={eventView}
           transactionName={transactionName}
+          unfilteredTotals={unfilteredTotalValues}
         />
         <SidebarSpacer />
         <Tags

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -212,6 +212,9 @@ function SummaryContent({
 
   const query = decodeScalar(location.query.query, '');
   const totalCount = totalValues === null ? null : totalValues['count()'];
+  const unfilteredTotalCount = unfilteredTotalValues
+    ? unfilteredTotalValues['count()']
+    : null;
 
   // NOTE: This is not a robust check for whether or not a transaction is a front end
   // transaction, however it will suffice for now.
@@ -336,6 +339,7 @@ function SummaryContent({
           totalValue={totalCount}
           currentFilter={spanOperationBreakdownFilter}
           withoutZerofill={hasPerformanceChartInterpolation}
+          unfilteredTotalValue={unfilteredTotalCount}
         />
         <TransactionsList
           location={location}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -333,7 +333,7 @@ function SummaryContent({
           organization={organization}
           location={location}
           eventView={eventView}
-          totalValues={totalCount}
+          totalValue={totalCount}
           currentFilter={spanOperationBreakdownFilter}
           withoutZerofill={hasPerformanceChartInterpolation}
         />

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -36,7 +36,10 @@ import withProjects from 'sentry/utils/withProjects';
 import {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import {TableColumn} from 'sentry/views/discover/table/types';
 import Tags from 'sentry/views/discover/tags';
-import {canUseTransactionMetricsData} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {
+  canUseMetricsInTransactionSummary,
+  canUseTransactionMetricsData,
+} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {
   PERCENTILE as VITAL_PERCENTILE,
   VITAL_GROUPS,
@@ -179,7 +182,7 @@ function SummaryContent({
   }
 
   function generateActionBarItems(_org: Organization, _location: Location) {
-    if (!_org.features.includes('performance-metrics-backed-transaction-summary')) {
+    if (!canUseMetricsInTransactionSummary(_org)) {
       return undefined;
     }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -251,6 +251,32 @@ describe('Performance > TransactionSummary', function () {
         },
       ],
     });
+    // Events Mock unfiltered totals for percentage calculations
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        meta: {
+          fields: {
+            'tpm()': 'number',
+            'count()': 'number',
+          },
+        },
+        data: [
+          {
+            'count()': 2,
+            'tpm()': 1,
+          },
+        ],
+      },
+      match: [
+        (_url, options) => {
+          return (
+            options.query?.field?.includes('tpm()') &&
+            !options.query?.field?.includes('p95()')
+          );
+        },
+      ],
+    });
     // Events Transaction list response
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -227,6 +227,10 @@ function getUnfilteredTotalsEventView(
       kind: 'function',
       function: ['tpm', '', undefined, undefined],
     },
+    {
+      kind: 'function',
+      function: ['count', '', undefined, undefined],
+    },
   ];
 
   // Use the user supplied query but remove any non transaction name

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -21,7 +21,10 @@ import useApi from 'sentry/utils/useApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
-import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
+import {
+  canUseMetricsInTransactionSummary,
+  getTransactionMEPParamsIfApplicable,
+} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 import {addRoutePerformanceContext} from '../../utils';
 import {
@@ -152,8 +155,11 @@ function OverviewContentWrapper(props: ChildProps) {
   const totals: TotalValues | null =
     (tableData?.data?.[0] as {[k: string]: number}) ?? null;
 
-  const unfilteredTotals: TotalValues | null =
-    (unfilteredTableData?.data?.[0] as {[k: string]: number}) ?? null;
+  const unfilteredTotals: TotalValues | null = canUseMetricsInTransactionSummary(
+    organization
+  )
+    ? (unfilteredTableData?.data?.[0] as {[k: string]: number}) ?? null
+    : null;
 
   return (
     <SummaryContent

--- a/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
@@ -9,6 +9,7 @@ import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
+import {formatPercentage} from 'sentry/utils/formatters';
 import Histogram from 'sentry/utils/performance/histogram';
 import HistogramQuery from 'sentry/utils/performance/histogram/histogramQuery';
 import {HistogramData} from 'sentry/utils/performance/histogram/types';
@@ -31,6 +32,7 @@ type Props = ViewProps & {
   location: Location;
   organization: OrganizationSummary;
   queryExtras?: Record<string, string>;
+  totalCount?: number | null;
 };
 
 /**
@@ -52,14 +54,24 @@ function Content({
   location,
   currentFilter,
   queryExtras,
+  totalCount,
 }: Props) {
   const [zoomError, setZoomError] = useState(false);
+  const displayCountAsPercentage = !!totalCount;
 
   function handleMouseOver() {
     // Hide the zoom error tooltip on the next hover.
     if (zoomError) {
       setZoomError(false);
     }
+  }
+
+  function parseHistogramData(data: HistogramData): HistogramData {
+    // display each bin's count as a % of total count
+    if (totalCount) {
+      return data.map(({bin, count}) => ({bin, count: count / totalCount}));
+    }
+    return data;
   }
 
   function renderChart(data: HistogramData) {
@@ -86,8 +98,11 @@ function Content({
         if (!zoomError) {
           // Replicate the necessary logic from sentry/components/charts/components/tooltip.jsx
           contents = seriesData.map(item => {
-            const label = item.seriesName;
-            const value = item.value[1].toLocaleString();
+            const label = displayCountAsPercentage ? t('Transactions') : item.seriesName;
+            const value = displayCountAsPercentage
+              ? formatPercentage(item.value[1])
+              : item.value[1].toLocaleString();
+
             return [
               '<div class="tooltip-series">',
               `<div><span class="tooltip-label">${item.marker} <strong>${label}</strong></span> ${value}</div>`,
@@ -108,9 +123,11 @@ function Content({
       },
     };
 
+    const parsedData = parseHistogramData(data);
+
     const series = {
       seriesName: t('Count'),
-      data: formatHistogramData(data, {type: 'duration'}),
+      data: formatHistogramData(parsedData, {type: 'duration'}),
     };
 
     return (

--- a/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/index.tsx
@@ -16,6 +16,7 @@ type Props = ViewProps & {
   location: Location;
   organization: OrganizationSummary;
   queryExtras?: Record<string, string>;
+  totalCount?: number | null;
 };
 
 function LatencyChart({currentFilter, ...props}: Props) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -23,7 +23,11 @@ import {tooltipFormatter} from 'sentry/utils/discover/charts';
 import EventView from 'sentry/utils/discover/eventView';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
-import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
+import {
+  formatAbbreviatedNumber,
+  formatFloat,
+  formatPercentage,
+} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import AnomaliesQuery from 'sentry/utils/performance/anomalies/anomaliesQuery';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -92,7 +96,7 @@ function SidebarCharts({
   function getValueFromTotals(field, totalValues, unfilteredTotalValues) {
     if (totalValues) {
       if (unfilteredTotalValues) {
-        return tct('[tpm] tpm', {
+        return tct('[tpm]', {
           tpm: formatPercentage(totalValues[field] / unfilteredTotalValues[field]),
         });
       }
@@ -343,7 +347,10 @@ function SidebarChartsContainer({
         gridIndex: 2,
         splitNumber: 4,
         axisLabel: {
-          formatter: value => formatPercentage(value, 0),
+          formatter: value =>
+            unfilteredTotals
+              ? formatPercentage(value, 0)
+              : formatAbbreviatedNumber(value),
           color: theme.chartLabel,
         },
         ...axisLineConfig,

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -59,3 +59,10 @@ export function getTransactionMEPParamsIfApplicable(
 
   return getMEPQueryParams(mepContext);
 }
+
+export function canUseMetricsInTransactionSummary(organization: Organization) {
+  return (
+    canUseMetricsData(organization) &&
+    organization.features.includes('performance-metrics-backed-transaction-summary')
+  );
+}

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -9,7 +9,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 import {DisplayModes} from 'sentry/views/performance/transactionSummary/utils';
 
-const DISPLAY_MAP_DENY_LIST = [DisplayModes.TREND, DisplayModes.LATENCY];
+export const DISPLAY_MAP_DENY_LIST = [DisplayModes.TREND, DisplayModes.LATENCY];
 
 export function canUseTransactionMetricsData(organization, location) {
   const isUsingMetrics = canUseMetricsData(organization);

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -46,13 +46,14 @@ export function canUseTransactionMetricsData(organization, location) {
 export function getTransactionMEPParamsIfApplicable(
   mepContext: MetricsEnhancedSettingContext,
   organization: Organization,
-  location: Location
+  location: Location,
+  unfiltered: boolean = false
 ) {
   if (!organization.features.includes('performance-metrics-backed-transaction-summary')) {
     return undefined;
   }
 
-  if (!canUseTransactionMetricsData(organization, location)) {
+  if (!unfiltered && !canUseTransactionMetricsData(organization, location)) {
     return undefined;
   }
 


### PR DESCRIPTION
- hide transaction event count for trends view [only when feature flag + mep]
<img width="795" alt="Screen Shot 2023-02-08 at 11 03 15 PM" src="https://user-images.githubusercontent.com/23648387/217661490-14ad4dbe-4a49-4c48-a5b9-57aec0b4f162.png">

- for histograms [only when feature flag + mep]
    - show event count as a % of processed event count
    - convert each bin's count into a % of total indexed event count
   
<img width="800" alt="Screen Shot 2023-02-08 at 11 02 52 PM" src="https://user-images.githubusercontent.com/23648387/217661679-f940bbf7-bccb-4268-9a75-90be11e29874.png">
<img width="785" alt="Screen Shot 2023-02-08 at 11 03 07 PM" src="https://user-images.githubusercontent.com/23648387/217661685-ec6bc801-f6bb-45c8-85cc-8f4d05eb39d7.png">

- for tpm [only when feature flag + mep]
   - rename tpm to "Total Transactions"
   - display `indexed_tpm()/processed_tpm()` when viewing indexed events and `processed_tpm()/processed_tpm()` when viewing processed events
   - convert each data point to `tpm()/processed_tpm()`
when showing processed events:
<img width="807" alt="Screen Shot 2023-02-08 at 11 06 52 PM" src="https://user-images.githubusercontent.com/23648387/217662173-95e515ba-3e5c-4a95-9f86-9d27f90df93b.png">
when dropping to indexed events:
<img width="811" alt="Screen Shot 2023-02-08 at 11 07 11 PM" src="https://user-images.githubusercontent.com/23648387/217662236-ac98a71e-30ff-4f75-a3a6-1b60abee3a15.png">

Tested for conditions:
- no feature flag + mep enabled
- feature flag + mep enabled
- feature-flag + no mep enabled

