### PR TITLE
fix(profiling): Missing instrumentation always needs the context manager

### DIFF
--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -251,11 +251,11 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                     }}
                   >
                     <QuickTraceContext.Provider value={results}>
-                      {hasProfilingPreviewsFeature && profileId ? (
+                      {hasProfilingPreviewsFeature ? (
                         <ProfilesProvider
                           orgSlug={organization.slug}
                           projectSlug={this.projectId}
-                          profileId={profileId}
+                          profileId={profileId || ''}
                         >
                           <ProfileContext.Consumer>
                             {profiles => (
@@ -264,7 +264,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                                 input={
                                   profiles?.type === 'resolved' ? profiles.data : null
                                 }
-                                traceID={profileId}
+                                traceID={profileId || ''}
                               >
                                 <BorderlessEventEntries
                                   organization={organization}

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -232,11 +232,11 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                           }}
                         >
                           <QuickTraceContext.Provider value={results}>
-                            {hasProfilingPreviewsFeature && profileId ? (
+                            {hasProfilingPreviewsFeature ? (
                               <ProfilesProvider
                                 orgSlug={organization.slug}
                                 projectSlug={this.projectId}
-                                profileId={profileId}
+                                profileId={profileId || ''}
                               >
                                 <ProfileContext.Consumer>
                                   {profiles => (
@@ -247,7 +247,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                                           ? profiles.data
                                           : null
                                       }
-                                      traceID={profileId}
+                                      traceID={profileId || ''}
                                     >
                                       <BorderlessEventEntries
                                         organization={organization}


### PR DESCRIPTION
If the profile id doesnt exist, this was erroring because it was missing the context manager.
