### PR TITLE
feat(issue-platform): support event lookup by event_id when processing an issue occurrence

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -121,9 +121,9 @@ def process_event_and_issue_occurrence(
 
 
 def lookup_event_and_process_issue_occurrence(
-    occurrence_data: IssueOccurrenceData, project_id: int, event_id: str
+    occurrence_data: IssueOccurrenceData,
 ) -> Optional[Tuple[IssueOccurrence, Optional[GroupInfo]]]:
-    event = lookup_event(project_id, event_id)
+    event = lookup_event(occurrence_data["project_id"], occurrence_data["event_id"])
     if event is None:
         return None
 
@@ -146,6 +146,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
                 "evidence_display": payload.get("evidence_display"),
                 "type": payload["type"],
                 "detection_time": payload["detection_time"],
+                # TODO: need to parse level
             }
 
             if "event" in payload:
@@ -233,13 +234,9 @@ def _process_message(
         return None
 
     if "event_data" in kwargs:
-        return process_event_and_issue_occurrence(**kwargs)  # returning for easier testing, for now
+        return process_event_and_issue_occurrence(kwargs["occurrence_data"], kwargs["event_data"])
     else:
-        return lookup_event_and_process_issue_occurrence(
-            occurrence_data=kwargs["occurrence_data"],
-            project_id=kwargs["occurrence_data"]["project_id"],
-            event_id=kwargs["occurrence_data"]["event_id"],
-        )
+        return lookup_event_and_process_issue_occurrence(kwargs["occurrence_data"])
 
 
 class OccurrenceStrategy(ProcessingStrategy[KafkaPayload]):

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -221,11 +221,16 @@ def _process_message(message: Mapping[str, Any]) -> Tuple[IssueOccurrence, Optio
     """
     metrics.incr("occurrence_ingest.messages", sample_rate=1.0)
 
-    kwargs = _get_kwargs(message)
-    if "event_data" in kwargs:
-        return process_event_and_issue_occurrence(kwargs["occurrence_data"], kwargs["event_data"])
-    else:
-        return lookup_event_and_process_issue_occurrence(kwargs["occurrence_data"])
+    try:
+        kwargs = _get_kwargs(message)
+        if "event_data" in kwargs:
+            return process_event_and_issue_occurrence(
+                kwargs["occurrence_data"], kwargs["event_data"]
+            )
+        else:
+            return lookup_event_and_process_issue_occurrence(kwargs["occurrence_data"])
+    except (ValueError, KeyError) as e:
+        raise InvalidEventPayloadError(e)
 
 
 class OccurrenceStrategy(ProcessingStrategy[KafkaPayload]):

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -21,7 +21,6 @@ from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
 from sentry.utils import json, metrics
 from sentry.utils.batching_kafka_consumer import create_topics
-from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.kafka_config import get_kafka_consumer_cluster_options
 
 logger = logging.getLogger(__name__)
@@ -78,7 +77,6 @@ def save_event_from_occurrence(
     data["type"] = "generic"
 
     project_id = data.pop("project_id")
-    data = CanonicalKeyDict(data)
 
     with metrics.timer("occurrence_consumer.save_event_occurrence.event_manager.save"):
         manager = EventManager(data)

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -115,8 +115,6 @@ def lookup_event_and_process_issue_occurrence(
     event_id = occurrence_data["event_id"]
     try:
         event = lookup_event(project_id, event_id)
-    except EventLookupError:
-        raise
     except Exception:
         raise EventLookupError(f"Failed to lookup event({event_id}) for project_id({project_id})")
 

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -248,10 +248,8 @@ class OccurrenceStrategy(ProcessingStrategy[KafkaPayload]):
         try:
             payload = json.loads(message.payload.value, use_rapid_json=True)
             _process_message(payload)
-        except rapidjson.JSONDecodeError as je:
-            logger.error(je)
-        except ValueError as ve:
-            logger.error(ve)
+        except (rapidjson.JSONDecodeError, InvalidEventPayloadError, EventLookupError) as ee:
+            logger.error(ee)
         except Exception as e:
             logger.exception(e)
 

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -214,9 +214,7 @@ def _validate_event_data(event_data: Mapping[str, Any]) -> None:
         raise InvalidEventPayloadError("Event payload does not match schema")
 
 
-def _process_message(
-    message: Mapping[str, Any]
-) -> Optional[Tuple[IssueOccurrence, Optional[GroupInfo]]]:
+def _process_message(message: Mapping[str, Any]) -> Tuple[IssueOccurrence, Optional[GroupInfo]]:
     """
     :raises InvalidEventPayloadError: when the message is invalid
     :raises EventLookupError: when the provided event_id in the message couldn't be found.

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -155,7 +155,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 if not payload.get("event_id") and not event_payload.get("event_id"):
                     raise InvalidEventPayloadError("Payload must contain an event_id")
 
-                if not payload.get("event_id") and event_payload.get("event_id"):
+                if not payload.get("event_id"):
                     occurrence_data["event_id"] = event_payload.get("event_id")
 
                 event_data = {
@@ -244,10 +244,8 @@ class OccurrenceStrategy(ProcessingStrategy[KafkaPayload]):
         try:
             payload = json.loads(message.payload.value, use_rapid_json=True)
             _process_message(payload)
-        except (rapidjson.JSONDecodeError, InvalidEventPayloadError, EventLookupError) as ee:
-            logger.error(ee)
-        except Exception as e:
-            logger.exception(e)
+        except (rapidjson.JSONDecodeError, InvalidEventPayloadError, EventLookupError, Exception):
+            logger.exception("failed to process message payload")
 
     def close(self) -> None:
         pass

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -214,10 +214,13 @@ def make_performance_event(project, sample_name: str):
 
 
 def make_generic_event(project):
+    event_id = uuid.uuid4().hex
+    occurrence_data = TEST_ISSUE_OCCURRENCE.to_dict()
+    occurrence_data["event_id"] = event_id
     occurrence, group_info = process_event_and_issue_occurrence(
-        TEST_ISSUE_OCCURRENCE.to_dict(),
+        occurrence_data,
         {
-            "event_id": uuid.uuid4().hex,
+            "event_id": event_id,
             "project_id": project.id,
             "timestamp": before_now(minutes=1).isoformat(),
         },

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 from copy import deepcopy
 from typing import Any, Dict, Optional, Sequence
+from unittest import mock
 
 import pytest
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -120,7 +120,7 @@ class IssueOccurrenceProcessMessageTest(OccurrenceTestMixin, TestCase, SnubaTest
 
 
 class IssueOccurrenceLookupEventIdTest(IssueOccurrenceProcessMessageTest):
-    def test_lookup_event_doesnt_exist(self):
+    def test_lookup_event_doesnt_exist(self) -> None:
         message = get_test_message(self.project.id, include_event=False)
         with pytest.raises(EventLookupError):
             _process_message(message)
@@ -145,8 +145,9 @@ class IssueOccurrenceLookupEventIdTest(IssueOccurrenceProcessMessageTest):
             event_id=event1.event_id,
             type=PerformanceSlowDBQueryGroupType.type_id,
         )
-        occurrence, group_info = _process_message(message)
-        assert occurrence is not None
+        processed = _process_message(message)
+        assert processed is not None
+        occurrence, _ = processed[0], processed[1]
 
         fetched_event = self.eventstore.get_event_by_id(self.project.id, occurrence.event_id)
         assert fetched_event is not None

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -117,14 +117,14 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
 
     def test_invalid_occurrence_payload(self) -> None:
         message = get_test_message(self.project.id, type=300)
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidEventPayloadError):
             _process_message(message)
 
     def test_mismatch_event_ids(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
         message["event_id"] = "id1"
         message["event"]["event_id"] = "id2"
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidEventPayloadError):
             _process_message(message)
 
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -3,7 +3,6 @@ import logging
 import uuid
 from copy import deepcopy
 from typing import Any, Dict, Optional, Sequence
-from unittest import mock
 
 import pytest
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional, Sequence
 import pytest
 
 from sentry.eventstore.snuba.backend import SnubaEventStorage
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType, PerformanceSlowDBQueryGroupType
+from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType, ProfileBlockedThreadGroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.occurrence_consumer import (
     EventLookupError,

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -363,8 +363,8 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
         assert group_event.occurrence is None
 
     def test_get_latest_event_occurrence(self):
-        occurrence_data = self.build_occurrence_data(project_id=self.project.id)
         event_id = uuid.uuid4().hex
+        occurrence_data = self.build_occurrence_data(event_id=event_id, project_id=self.project.id)
         occurrence = process_event_and_issue_occurrence(
             occurrence_data,
             {

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -28,8 +28,10 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         if event_type == "performance":
             event = self.create_performance_issue()
         elif event_type == "generic":
-            occurrence_data = self.build_occurrence_data(project_id=self.project.id)
             event_id = uuid.uuid4().hex
+            occurrence_data = self.build_occurrence_data(
+                event_id=event_id, project_id=self.project.id
+            )
             occurrence, group_info = process_event_and_issue_occurrence(
                 occurrence_data,
                 {

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2322,10 +2322,11 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         super().setUp()
         self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
 
+        event_id_1 = uuid.uuid4().hex
         _, group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(),
+            self.build_occurrence_data(event_id=event_id_1),
             {
-                "event_id": uuid.uuid4().hex,
+                "event_id": event_id_1,
                 "project_id": self.project.id,
                 "title": "some problem",
                 "platform": "python",
@@ -2336,10 +2337,11 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         )
         self.profile_group_1 = group_info.group
 
+        event_id_2 = uuid.uuid4().hex
         _, group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(fingerprint=["put-me-in-group-2"]),
+            self.build_occurrence_data(event_id=event_id_2, fingerprint=["put-me-in-group-2"]),
             {
-                "event_id": uuid.uuid4().hex,
+                "event_id": event_id_2,
                 "project_id": self.project.id,
                 "title": "some other problem",
                 "platform": "python",
@@ -2350,10 +2352,11 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         )
         self.profile_group_2 = group_info.group
 
+        event_id_3 = uuid.uuid4().hex
         process_event_and_issue_occurrence(
-            self.build_occurrence_data(fingerprint=["put-me-in-group-3"]),
+            self.build_occurrence_data(event_id=event_id_3, fingerprint=["put-me-in-group-3"]),
             {
-                "event_id": uuid.uuid4().hex,
+                "event_id": event_id_3,
                 "project_id": self.project.id,
                 "title": "some other problem",
                 "platform": "python",


### PR DESCRIPTION
Current implementation of issue occurrence processing assumes the `event` dict is populated with the event data. This works for Profiling issues since they will always send the event payload with the occurrence. 

To support migrating over Performance issues creation to the issue platform, we need to support event lookup by ID since Performance issues occurrences won't have the event payload.


Resolves sentry#43983