### PR TITLE
fix(profiling): cleanup state when switching views

### DIFF
--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences.tsx
@@ -48,6 +48,10 @@ export function flamegraphPreferencesReducer(
     case 'set type': {
       return {
         ...state,
+        // When a user switches from chart to graph, there is some
+        // cleanup that we need to do to the state as some of the views
+        // are not compatible with each other.
+        xAxis: action.payload === 'flamegraph' ? 'profile' : state.xAxis,
         type: action.payload,
       };
     }


### PR DESCRIPTION
We will need to do the same with call order/left heavy as call order no longer works, but we need to add an alphabetical sort to flamegraphs first