### PR TITLE
ref(tx-clusterer): Set max amount of rules to 50

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -73,7 +73,7 @@ class ProjectOptionRuleStore:
 
 class CompositeRuleStore:
     #: Maximum number (non-negative integer) of rules to write to stores.
-    MERGE_MAX_RULES: int = 25
+    MERGE_MAX_RULES: int = 30
 
     def __init__(self, stores: List[RuleStore]):
         self._stores = stores

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -73,7 +73,7 @@ class ProjectOptionRuleStore:
 
 class CompositeRuleStore:
     #: Maximum number (non-negative integer) of rules to write to stores.
-    MERGE_MAX_RULES: int = 30
+    MERGE_MAX_RULES: int = 50
 
     def __init__(self, stores: List[RuleStore]):
         self._stores = stores


### PR DESCRIPTION
Currently the maximum is 25, and we're seeing some cases with 26 rules and one being excluded. Excluded rules seem to make sense and their application should improve the quality of transaction names.  As far as we know, there aren't any issues with the size of the rules, and 25 was a magic number, so increasing it a bit shouldn't have big implications either.

50 is still a magic number. If 50 is still not enough, we'll think about how to approach that issue -- increasing the number if the size is not a problem and the rules have enough quality, or analyzing the rules and adjusting the algorithm if we need to exclude some.