### PR TITLE
feat(view-hierarchy): Add empty state

### DIFF
--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -179,4 +179,17 @@ describe('View Hierarchy', function () {
     // The overlay should not have rendered anything before any interactions
     expect(context.fillRect).not.toHaveBeenCalled();
   });
+
+  it('renders an empty state if there is no data in windows to visualize', function () {
+    render(
+      <ViewHierarchy
+        viewHierarchy={{rendering_system: 'This can be anything', windows: []}}
+        project={project}
+      />
+    );
+
+    expect(
+      screen.getByText('There is no view hierarchy data to visualize')
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -1,8 +1,10 @@
 import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {Node} from 'sentry/components/events/viewHierarchy/node';
 import {Wireframe} from 'sentry/components/events/viewHierarchy/wireframe';
+import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -128,6 +130,16 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
 
   const showWireframe = project?.platform !== 'unity';
 
+  if (!hierarchy.length) {
+    return (
+      <EmptyStateContainer>
+        <EmptyStateWarning small>
+          {t('There is no view hierarchy data to visualize')}
+        </EmptyStateWarning>
+      </EmptyStateContainer>
+    );
+  }
+
   return (
     <Fragment>
       <RenderingSystem system={viewHierarchy.rendering_system} />
@@ -227,4 +239,9 @@ const DepthMarker = styled('div')`
 
 const GhostRow = styled('div')`
   top: ${space(1.5)};
+`;
+
+const EmptyStateContainer = styled('div')`
+  border: 1px solid ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
 `;


### PR DESCRIPTION
Seems like we can get `windows: []` in the attachment. In that case there's nothing useful to visualize so show an empty state.

Current:
![Screenshot 2023-02-09 at 11 38 18 AM](https://user-images.githubusercontent.com/22846452/217882106-e7e659da-49d1-4833-8c56-62702db0efe7.png)

After:
![Screenshot 2023-02-09 at 11 50 30 AM](https://user-images.githubusercontent.com/22846452/217882344-55cb514f-c5b3-4071-ae93-a235507d7f26.png)

Closes #44300 
