### PR TITLE
ref(perf-for-sentry): Improve frontend measurements

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -6,10 +6,7 @@ import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
 
 import {SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import {Config} from 'sentry/types';
-import {
-  initializeMeasureAssetsTimeout,
-  LongTaskObserver,
-} from 'sentry/utils/performanceForSentry';
+import {addExtraMeasurements, LongTaskObserver} from 'sentry/utils/performanceForSentry';
 
 const SPA_MODE_ALLOW_URLS = [
   'localhost',
@@ -94,6 +91,8 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       return tracesSampleRate;
     },
     beforeSendTransaction(event) {
+      addExtraMeasurements(event);
+
       event.spans = event.spans?.filter(span => {
         // Filter analytic timeout spans.
         return ['reload.getsentry.net', 'amplitude.com'].every(
@@ -139,5 +138,4 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
   }
 
   LongTaskObserver.startPerformanceObserver();
-  initializeMeasureAssetsTimeout();
 }

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -5,6 +5,13 @@
     <meta name="robots" content="NONE,NOARCHIVE" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= htmlWebpackPlugin.options.title || 'Sentry Dev'%></title>
+    <script>
+      function __sentryMark(name) {
+        if (!window.performance || typeof window.performance.mark !== 'function') { return; }
+        window.performance.mark(name);
+      }
+      __sentryMark('head-start');
+    </script>
     <script type="text/javascript">
     try {
       var reg = new RegExp(/\/organizations\/(.+?(?=(\/|$)))(\/|$)/, 'i');


### PR DESCRIPTION
### Summary
This cleans up some of the asset timing measurements since we have a measurement limit now, on top of adding 'pre_bundle_load' to track the difference between index.html response and beginning the actual app (measuring entrypoint timings).


### Other
- Switched to `beforeSendTransaction` instead of .. a timeout
- The `index.ejs` for dev-ui didn't have `head-start`, which we use in gsapp, so just mimicking it here so dev works correctly when checking these values.
- Limited resource collection to `sentry-cdn`
- `pre_bundle_load` is `head-start` - `ttfb`