### PR TITLE
feat(view-hierarchy): Add beta badge

### DIFF
--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -1,12 +1,13 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import * as Sentry from '@sentry/react';
 import isEmpty from 'lodash/isEmpty';
 
 import {useFetchEventAttachments} from 'sentry/actionCreators/events';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {getAttachmentUrl} from 'sentry/components/events/attachmentViewers/utils';
+import FeatureBadge from 'sentry/components/featureBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {tn} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {Event, IssueAttachment, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {useQuery} from 'sentry/utils/queryClient';
@@ -77,7 +78,13 @@ function EventViewHierarchyContent({event, project}: Props) {
   return (
     <EventDataSection
       type="view_hierarchy"
-      title={tn('View Hierarchy', 'View Hierarchies', viewHierarchies.length)}
+      title={
+        <Fragment>
+          {t('View Hierarchy')}
+
+          <FeatureBadge type="beta" />
+        </Fragment>
+      }
     >
       <ErrorBoundary mini>
         <ViewHierarchy viewHierarchy={hierarchy} project={project} />


### PR DESCRIPTION
Add a beta badge, as well as change the header title to just be "View Hierarchy". We'll only have one view hierarchy attachment.

![Screenshot 2023-02-09 at 12 27 14 PM](https://user-images.githubusercontent.com/22846452/217891048-7c41986c-c96a-4637-a16e-8be9b06e9834.png)
