### PR TITLE
fix(stateLayer): Prevent hover/press effect if an ancestor is disabled

### DIFF
--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -71,7 +71,8 @@ const InteractionStateLayer = styled(
         `
       : ''}
 
-  *:disabled > && {
+  *:disabled &&,
+  *[aria-disabled="true"] && {
     opacity: 0;
   }
 `;


### PR DESCRIPTION
There are some cases where `InteractionStateLayer` will transition into a hover/press state even when one of its ancestors is disabled:
<img width="164" alt="Screenshot 2023-02-09 at 9 39 00 AM" src="https://user-images.githubusercontent.com/44172267/217894052-351e4a45-88f6-4960-b828-66e3a55392b5.png">

This happens because with the way it's currently implemented, `InteractionStateLayer` is only disabled when its immediate parent is disabled. In certain components such as `MenuListItem`, that's not the case:
```jsx
<MenuItemWrap disabled>
    <InnerWrap>
        <InteractionStateLayer />
        …
    </InnerWrap>
</MenuItemWrap>
```

This PR disables `InteractionStateLayer` when any of its ancestors, regardless of depth, is disabled. The original issue is fixed:
<img width="164" alt="Screenshot 2023-02-09 at 9 39 50 AM" src="https://user-images.githubusercontent.com/44172267/217894200-eac42391-0019-49a7-8626-ff17fb13b0c2.png">
