### PR TITLE
feat(metric-alerts): Hide irrelevant fields from filter input

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {TagCollection} from 'sentry/types';
 
 // Don't forget to update https://docs.sentry.io/product/sentry-basics/search/searchable-properties/ for any changes made here
 
@@ -1241,3 +1242,16 @@ export const getFieldDefinition = (
       return EVENT_FIELD_DEFINITIONS[key] ?? null;
   }
 };
+
+export function makeTagCollection(fieldKeys: FieldKey[]): TagCollection {
+  return Object.fromEntries(
+    fieldKeys.map(fieldKey => [
+      fieldKey,
+      {
+        key: fieldKey,
+        name: fieldKey,
+        kind: getFieldDefinition(fieldKey)?.kind,
+      },
+    ])
+  );
+}

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -493,15 +493,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 <StyledSearchBar
                   searchSource="alert_builder"
                   defaultQuery={initialData?.query ?? ''}
-                  omitTags={[
-                    'event.type',
-                    'release.version',
-                    'release.stage',
-                    'release.package',
-                    'release.build',
-                    'project',
-                    ...DATASET_OMITTED_TAGS[dataset],
-                  ]}
+                  omitTags={DATASET_OMITTED_TAGS[dataset]}
                   includeSessionTagsValues={dataset === Dataset.SESSIONS}
                   disabled={disabled}
                   useFormWrapper={false}

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -28,7 +28,11 @@ import {
   DATA_SOURCE_LABELS,
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
 } from 'sentry/views/alerts/utils';
-import {AlertType, DATASET_OMITTED_TAGS} from 'sentry/views/alerts/wizard/options';
+import {
+  AlertType,
+  DATASET_OMITTED_TAGS,
+  DATASET_SUPPORTED_TAGS,
+} from 'sentry/views/alerts/wizard/options';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
 import {DEFAULT_AGGREGATE, DEFAULT_TRANSACTION_AGGREGATE} from './constants';
@@ -144,19 +148,6 @@ class RuleConditionsForm extends PureComponent<Props, State> {
       default:
         return t('Filter transactions by URL, tags, and other properties\u2026');
     }
-  }
-
-  get searchSupportedTags() {
-    if (isCrashFreeAlert(this.props.dataset)) {
-      return {
-        release: {
-          key: 'release',
-          name: 'release',
-        },
-      };
-    }
-
-    return undefined;
   }
 
   renderEventTypeFilter() {
@@ -494,6 +485,9 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                   searchSource="alert_builder"
                   defaultQuery={initialData?.query ?? ''}
                   omitTags={DATASET_OMITTED_TAGS[dataset]}
+                  {...(DATASET_SUPPORTED_TAGS[dataset]
+                    ? {supportedTags: DATASET_SUPPORTED_TAGS[dataset]}
+                    : {})}
                   includeSessionTagsValues={dataset === Dataset.SESSIONS}
                   disabled={disabled}
                   useFormWrapper={false}
@@ -521,9 +515,6 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                     onFilterSearch(query);
                     onChange(query, {});
                   }}
-                  {...(this.searchSupportedTags
-                    ? {supportedTags: this.searchSupportedTags}
-                    : {})}
                   hasRecentSearches={dataset !== Dataset.SESSIONS}
                 />
               </SearchContainer>

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -20,7 +20,6 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Environment, Organization, Project, SelectValue} from 'sentry/types';
 import {getDisplayName} from 'sentry/utils/environment';
-import {MobileVital, WebVital} from 'sentry/utils/fields';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import withProjects from 'sentry/utils/withProjects';
 import WizardField from 'sentry/views/alerts/rules/metric/wizardField';
@@ -29,7 +28,7 @@ import {
   DATA_SOURCE_LABELS,
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
 } from 'sentry/views/alerts/utils';
-import {AlertType} from 'sentry/views/alerts/wizard/options';
+import {AlertType, DATASET_OMITTED_TAGS} from 'sentry/views/alerts/wizard/options';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
 import {DEFAULT_AGGREGATE, DEFAULT_TRANSACTION_AGGREGATE} from './constants';
@@ -430,16 +429,6 @@ class RuleConditionsForm extends PureComponent<Props, State> {
         []),
     ];
 
-    const transactionTags = [
-      'transaction',
-      'transaction.duration',
-      'transaction.op',
-      'transaction.status',
-    ];
-    const measurementTags = Object.values({...WebVital, ...MobileVital});
-    const eventOmitTags =
-      dataset === 'events' ? [...measurementTags, ...transactionTags] : [];
-
     const hasMetricDataset = organization.features.includes('mep-rollout-flag');
 
     return (
@@ -511,7 +500,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                     'release.package',
                     'release.build',
                     'project',
-                    ...eventOmitTags,
+                    ...DATASET_OMITTED_TAGS[dataset],
                   ]}
                   includeSessionTagsValues={dataset === Dataset.SESSIONS}
                   disabled={disabled}

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -188,24 +188,32 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'cls',
 ]);
 
-const TRANSACTION_SUPPORTED_TAGS = makeTagCollection([
+const TRANSACTION_SUPPORTED_TAGS = [
   FieldKey.RELEASE,
   FieldKey.TRANSACTION,
   FieldKey.TRANSACTION_OP,
   FieldKey.TRANSACTION_STATUS,
   FieldKey.HTTP_METHOD,
-]);
-const SESSION_SUPPORTED_TAGS = makeTagCollection([FieldKey.RELEASE]);
+];
+const SESSION_SUPPORTED_TAGS = [FieldKey.RELEASE];
+
+import mapValues from 'lodash/mapValues';
 
 // Some data sets support a very limited number of tags. For these cases,
 // define all supported tags explicitly
-export const DATASET_SUPPORTED_TAGS: Record<Dataset, TagCollection | undefined> = {
-  [Dataset.ERRORS]: undefined,
-  [Dataset.TRANSACTIONS]: TRANSACTION_SUPPORTED_TAGS,
-  [Dataset.METRICS]: SESSION_SUPPORTED_TAGS,
-  [Dataset.GENERIC_METRICS]: TRANSACTION_SUPPORTED_TAGS,
-  [Dataset.SESSIONS]: SESSION_SUPPORTED_TAGS,
-};
+export const DATASET_SUPPORTED_TAGS: Record<Dataset, TagCollection | undefined> =
+  mapValues(
+    {
+      [Dataset.ERRORS]: undefined,
+      [Dataset.TRANSACTIONS]: TRANSACTION_SUPPORTED_TAGS,
+      [Dataset.METRICS]: SESSION_SUPPORTED_TAGS,
+      [Dataset.GENERIC_METRICS]: TRANSACTION_SUPPORTED_TAGS,
+      [Dataset.SESSIONS]: SESSION_SUPPORTED_TAGS,
+    },
+    value => {
+      return value ? makeTagCollection(value) : undefined;
+    }
+  );
 
 // Some data sets support all tags except some. For these cases, define the
 // omissions only

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -188,11 +188,22 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'cls',
 ]);
 
+// Some data sets support all tags except some. For these cases, define the
+// omissions only
+const ALWAYS_OMITTED_TAGS = [
+  FieldKey.EVENT_TYPE,
+  FieldKey.RELEASE_VERSION,
+  FieldKey.RELEASE_STAGE,
+  FieldKey.RELEASE_BUILD,
+  FieldKey.PROJECT,
+];
+
 export const DATASET_OMITTED_TAGS: Record<
   Dataset,
   Array<FieldKey | WebVital | MobileVital>
 > = {
   [Dataset.ERRORS]: [
+    ...ALWAYS_OMITTED_TAGS,
     ...Object.values(WebVital),
     ...Object.values(MobileVital),
     FieldKey.TRANSACTION,
@@ -200,10 +211,10 @@ export const DATASET_OMITTED_TAGS: Record<
     FieldKey.TRANSACTION_OP,
     FieldKey.TRANSACTION_STATUS,
   ],
-  [Dataset.TRANSACTIONS]: [],
-  [Dataset.METRICS]: [],
-  [Dataset.GENERIC_METRICS]: [],
-  [Dataset.SESSIONS]: [],
+  [Dataset.TRANSACTIONS]: [...ALWAYS_OMITTED_TAGS],
+  [Dataset.METRICS]: [...ALWAYS_OMITTED_TAGS],
+  [Dataset.GENERIC_METRICS]: [...ALWAYS_OMITTED_TAGS],
+  [Dataset.SESSIONS]: [...ALWAYS_OMITTED_TAGS],
 };
 
 export function getMEPAlertsDataset(

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
+import {FieldKey, MobileVital, WebVital} from 'sentry/utils/fields';
 import {
   Dataset,
   EventTypes,
@@ -186,6 +187,24 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'fid',
   'cls',
 ]);
+
+export const DATASET_OMITTED_TAGS: Record<
+  Dataset,
+  Array<FieldKey | WebVital | MobileVital>
+> = {
+  [Dataset.ERRORS]: [
+    ...Object.values(WebVital),
+    ...Object.values(MobileVital),
+    FieldKey.TRANSACTION,
+    FieldKey.TRANSACTION_DURATION,
+    FieldKey.TRANSACTION_OP,
+    FieldKey.TRANSACTION_STATUS,
+  ],
+  [Dataset.TRANSACTIONS]: [],
+  [Dataset.METRICS]: [],
+  [Dataset.GENERIC_METRICS]: [],
+  [Dataset.SESSIONS]: [],
+};
 
 export function getMEPAlertsDataset(
   dataset: Dataset,

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -1,3 +1,5 @@
+import mapValues from 'lodash/mapValues';
+
 import {t} from 'sentry/locale';
 import {Organization, TagCollection} from 'sentry/types';
 import {
@@ -202,8 +204,6 @@ const TRANSACTION_SUPPORTED_TAGS = [
   FieldKey.HTTP_METHOD,
 ];
 const SESSION_SUPPORTED_TAGS = [FieldKey.RELEASE];
-
-import mapValues from 'lodash/mapValues';
 
 // Some data sets support a very limited number of tags. For these cases,
 // define all supported tags explicitly

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -1,6 +1,12 @@
 import {t} from 'sentry/locale';
 import {Organization, TagCollection} from 'sentry/types';
-import {FieldKey, makeTagCollection, MobileVital, WebVital} from 'sentry/utils/fields';
+import {
+  FieldKey,
+  makeTagCollection,
+  MobileVital,
+  SpanOpBreakdown,
+  WebVital,
+} from 'sentry/utils/fields';
 import {
   Dataset,
   EventTypes,
@@ -219,7 +225,7 @@ export const DATASET_SUPPORTED_TAGS: Record<Dataset, TagCollection | undefined> 
 // omissions only
 export const DATASET_OMITTED_TAGS: Record<
   Dataset,
-  Array<FieldKey | WebVital | MobileVital> | undefined
+  Array<FieldKey | WebVital | MobileVital | SpanOpBreakdown> | undefined
 > = {
   [Dataset.ERRORS]: [
     FieldKey.EVENT_TYPE,
@@ -229,6 +235,7 @@ export const DATASET_OMITTED_TAGS: Record<
     FieldKey.PROJECT,
     ...Object.values(WebVital),
     ...Object.values(MobileVital),
+    ...Object.values(SpanOpBreakdown),
     FieldKey.TRANSACTION,
     FieldKey.TRANSACTION_DURATION,
     FieldKey.TRANSACTION_OP,


### PR DESCRIPTION
Closes PERF-1966. This improves an existing behaviour where the filter bar only shows the fields that are relevant to the current dataset. This expands it.

![Screenshot 2023-02-09 at 12 56 58 PM](https://user-images.githubusercontent.com/989898/217900065-98f93114-1419-4dc4-b5f8-951c8d686e74.png)

- hide transaction and span fields from error alerts filtering
- hide all non-metric fields from transaction alert filtering

For example, hide `spans.http` when filtering errors, which never make sense. Also hides `resolved:true` when searching for transactions. Most importantly, for transaction filtering only _metrics-supported_ fields are now suggested. Users can still type in the other fields, and they'll work, but the dropdown doesn't recommend them anymore.

## Changes

- Add `makeTagCollection` helper. This code is already all over the place, I put it somewhere central
- Create `DATASET_OMITTED_TAGS` constant. Use it to replace the current dataset comparison conditional
- Create `DATASET_SUPPORTED_TAGS`. Use it to replace the current `searchSupportedTags` logic
- Expand the omitted/supported lists a little bit to make them more strict
