### PR TITLE
feat(profiling): Link missing instrumentation to setup profiling

### DIFF
--- a/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
@@ -1,19 +1,24 @@
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {FlamegraphPreview} from 'sentry/components/profiling/flamegraph/flamegraphPreview';
+import {getDocsPlatformSDKForPlatform} from 'sentry/components/profiling/ProfilingOnboarding/util';
+import {PlatformKey} from 'sentry/data/platformCategories';
 import {IconProfiling} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {Organization} from 'sentry/types';
 import {EventTransaction} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useProfiles} from 'sentry/views/profiling/profilesProvider';
+import useProjects from 'sentry/utils/useProjects';
+import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
 import InlineDocs from './inlineDocs';
 import {GapSpanType} from './types';
@@ -29,11 +34,51 @@ export function GapSpanDetails({
   resetCellMeasureCache,
   span,
 }: GapSpanDetailsProps) {
+  const {projects} = useProjects({slugs: event.projectSlug ? [event.projectSlug] : []});
+  const projectHasProfile = false && projects?.[0]?.hasProfiles;
+
   const organization = useOrganization();
-  const profiles = useProfiles();
   const [canvasView, setCanvasView] = useState<CanvasView<FlamegraphModel> | null>(null);
 
-  if (profiles?.type !== 'resolved') {
+  const profileGroup = useProfileGroup();
+
+  const threadId = useMemo(
+    () => profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId,
+    [profileGroup]
+  );
+
+  const profile = useMemo(() => {
+    if (!defined(threadId)) {
+      return null;
+    }
+    return profileGroup.profiles.find(p => p.threadId === threadId) ?? null;
+  }, [profileGroup.profiles, threadId]);
+
+  const hasProfile = defined(threadId) && defined(profile);
+
+  const flamegraph = useMemo(() => {
+    if (!hasProfile) {
+      return FlamegraphModel.Example();
+    }
+
+    return new FlamegraphModel(profile, threadId, {});
+  }, [hasProfile, profile, threadId]);
+
+  const relativeStartTimestamp = hasProfile
+    ? span.start_timestamp - event.startTimestamp
+    : 0;
+  const relativeStopTimestamp = hasProfile
+    ? span.timestamp - event.startTimestamp
+    : flamegraph.configSpace.width;
+
+  const docsPlatform = getDocsPlatformSDKForPlatform(event.platform);
+
+  if (
+    // profiling isn't supported for this platform
+    !docsPlatform ||
+    // the project already sent a profile but this transaction doesnt have a profile
+    (projectHasProfile && !hasProfile)
+  ) {
     return (
       <InlineDocs
         orgSlug={organization.slug}
@@ -44,6 +89,79 @@ export function GapSpanDetails({
     );
   }
 
+  return (
+    <Container>
+      {!projectHasProfile && <SetupProfilingInstructions docsPlatform={docsPlatform} />}
+      {projectHasProfile && hasProfile && (
+        <ProfilePreview
+          canvasView={canvasView}
+          event={event}
+          organization={organization}
+        />
+      )}
+      <FlamegraphContainer>
+        <FlamegraphPreview
+          flamegraph={flamegraph}
+          relativeStartTimestamp={relativeStartTimestamp}
+          relativeStopTimestamp={relativeStopTimestamp}
+          renderText={hasProfile}
+          updateFlamegraphView={setCanvasView}
+        />
+      </FlamegraphContainer>
+    </Container>
+  );
+}
+
+interface SetupProfilingInstructionsProps {
+  docsPlatform: PlatformKey;
+}
+
+function SetupProfilingInstructions({docsPlatform}: SetupProfilingInstructionsProps) {
+  // ios is the only supported apple platform right now
+  const docsLink =
+    docsPlatform === 'apple-ios'
+      ? 'https://docs.sentry.io/platforms/apple/guides/ios/profiling/'
+      : `https://docs.sentry.io/platforms/${docsPlatform}/profiling/`;
+
+  return (
+    <InstructionsContainer>
+      <Heading>{t('Requires Manual Instrumentation')}</Heading>
+      <p>
+        {tct(
+          `To manually instrument certain regions of your code, view [docLink:our documentation].`,
+          {
+            docLink: (
+              <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />
+            ),
+          }
+        )}
+      </p>
+      <Heading>{t('With Profiling, we could paint a better picture')}</Heading>
+      <p>
+        {t(
+          'Profiles can give you additional context on which functions are sampled at the same time of these spans.'
+        )}
+      </p>
+      <Button
+        icon={<IconProfiling />}
+        size="sm"
+        priority="primary"
+        href={docsLink}
+        external
+      >
+        {t('Set Up Profiling')}
+      </Button>
+    </InstructionsContainer>
+  );
+}
+
+interface ProfilePreviewProps {
+  canvasView: CanvasView<FlamegraphModel> | null;
+  event: Readonly<EventTransaction>;
+  organization: Organization;
+}
+
+function ProfilePreview({canvasView, event, organization}: ProfilePreviewProps) {
   const profileId = event.contexts.profile?.profile_id || '';
 
   // we want to try to go straight to the same config view as the preview
@@ -73,42 +191,28 @@ export function GapSpanDetails({
   }
 
   return (
-    <Container>
-      <InstructionsContainer>
-        <Heading>{t('Requires Manual Instrumentation')}</Heading>
-        <p>
-          {tct(
-            `To manually instrument certain regions of your code, view [docLink:our documentation].`,
-            {
-              docLink: (
-                <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />
-              ),
-            }
-          )}
-        </p>
-        <Heading>{t('A Profile is available for this transaction!')}</Heading>
-        <p>
-          {t(
-            'We have a profile that can give you some additional context on which functions were sampled during this span.'
-          )}
-        </p>
-        <Button
-          icon={<IconProfiling />}
-          size="sm"
-          onClick={handleGoToProfile}
-          to={target}
-        >
-          {t('Go to Profile')}
-        </Button>
-      </InstructionsContainer>
-      <FlamegraphContainer>
-        <FlamegraphPreview
-          relativeStartTimestamp={span.start_timestamp - event.startTimestamp}
-          relativeStopTimestamp={span.timestamp - event.startTimestamp}
-          updateFlamegraphView={setCanvasView}
-        />
-      </FlamegraphContainer>
-    </Container>
+    <InstructionsContainer>
+      <Heading>{t('Requires Manual Instrumentation')}</Heading>
+      <p>
+        {tct(
+          `To manually instrument certain regions of your code, view [docLink:our documentation].`,
+          {
+            docLink: (
+              <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />
+            ),
+          }
+        )}
+      </p>
+      <Heading>{t('A Profile is available for this transaction!')}</Heading>
+      <p>
+        {t(
+          'We have a profile that can give you some additional context on which functions were sampled during this span.'
+        )}
+      </p>
+      <Button icon={<IconProfiling />} size="sm" onClick={handleGoToProfile} to={target}>
+        {t('Go to Profile')}
+      </Button>
+    </InstructionsContainer>
   );
 }
 

--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -15,7 +15,9 @@ export type SupportedProfilingPlatform = (typeof supportedProfilingPlatforms)[nu
 export type SupportedProfilingPlatformSDK =
   (typeof supportedProfilingPlatformSDKs)[number];
 
-function getDocsPlatformSDKForPlatform(platform): PlatformKey | null {
+export function getDocsPlatformSDKForPlatform(
+  platform
+): SupportedProfilingPlatform | null {
   if (platform === 'android') {
     return 'android';
   }

--- a/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
@@ -21,17 +21,20 @@ import {Rect, useResizeCanvasObserver} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer2D} from 'sentry/utils/profiling/renderers/flamegraphRenderer2D';
 import {FlamegraphTextRenderer} from 'sentry/utils/profiling/renderers/flamegraphTextRenderer';
 import {formatTo} from 'sentry/utils/profiling/units/units';
-import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
 interface FlamegraphPreviewProps {
+  flamegraph: FlamegraphModel;
   relativeStartTimestamp: number;
   relativeStopTimestamp: number;
+  renderText?: boolean;
   updateFlamegraphView?: (canvasView: CanvasView<FlamegraphModel> | null) => void;
 }
 
 export function FlamegraphPreview({
+  flamegraph,
   relativeStartTimestamp,
   relativeStopTimestamp,
+  renderText = true,
   updateFlamegraphView,
 }: FlamegraphPreviewProps) {
   const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);
@@ -39,27 +42,6 @@ export function FlamegraphPreview({
 
   const {theme} = useLegacyStore(ConfigStore);
   const flamegraphTheme = theme === 'light' ? LightFlamegraphTheme : DarkFlamegraphTheme;
-  const profileGroup = useProfileGroup();
-
-  const threadId = useMemo(
-    () => profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId,
-    [profileGroup]
-  );
-
-  const profile = useMemo(() => {
-    if (!defined(threadId)) {
-      return null;
-    }
-    return profileGroup.profiles.find(p => p.threadId === threadId) ?? null;
-  }, [profileGroup.profiles, threadId]);
-
-  const flamegraph = useMemo(() => {
-    if (!defined(threadId) || !defined(profile)) {
-      return FlamegraphModel.Empty();
-    }
-
-    return new FlamegraphModel(profile, threadId, {});
-  }, [profile, threadId]);
 
   const [flamegraphCanvasRef, setFlamegraphCanvasRef] =
     useState<HTMLCanvasElement | null>(null);
@@ -152,25 +134,38 @@ export function FlamegraphPreview({
       );
     };
 
-    const drawText = () => {
-      textRenderer.draw(
-        flamegraphView.toOriginConfigView(flamegraphView.configView),
-        flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace)
-      );
-    };
+    const drawText = renderText
+      ? () => {
+          textRenderer.draw(
+            flamegraphView.toOriginConfigView(flamegraphView.configView),
+            flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace)
+          );
+        }
+      : null;
 
     scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
     scheduler.registerBeforeFrameCallback(drawRectangles);
-    scheduler.registerBeforeFrameCallback(drawText);
+    if (drawText) {
+      scheduler.registerBeforeFrameCallback(drawText);
+    }
 
     scheduler.draw();
 
     return () => {
       scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
       scheduler.unregisterBeforeFrameCallback(drawRectangles);
-      scheduler.unregisterBeforeFrameCallback(drawText);
+      if (drawText) {
+        scheduler.unregisterBeforeFrameCallback(drawText);
+      }
     };
-  }, [flamegraphRenderer, flamegraphView, flamegraphCanvas, scheduler, textRenderer]);
+  }, [
+    flamegraphRenderer,
+    flamegraphView,
+    flamegraphCanvas,
+    renderText,
+    scheduler,
+    textRenderer,
+  ]);
 
   return (
     <CanvasContainer>

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -3,6 +3,7 @@ import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 
 import {Rect} from './gl/utils';
 import {Profile} from './profile/profile';
+import {SampledProfile} from './profile/sampledProfile';
 import {makeFormatter, makeTimelineFormatter} from './units/units';
 import {CallTreeNode} from './callTreeNode';
 import {Frame} from './frame';
@@ -37,6 +38,13 @@ export class Flamegraph {
 
   static Empty(): Flamegraph {
     return new Flamegraph(Profile.Empty, 0, {
+      inverted: false,
+      leftHeavy: false,
+    });
+  }
+
+  static Example(): Flamegraph {
+    return new Flamegraph(SampledProfile.Example, 0, {
       inverted: false,
       leftHeavy: false,
     });

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -143,6 +143,34 @@ export class SampledProfile extends Profile {
     return profile.build();
   }
 
+  static Example = SampledProfile.FromProfile(
+    {
+      startValue: 0,
+      endValue: 1000,
+      name: 'Example sampled profile',
+      threadID: 0,
+      unit: 'millisecond',
+      weights: [200, 200, 200, 200, 200],
+      samples: [
+        [0, 1, 2],
+        [0, 1, 2, 3, 4, 5],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3, 4],
+        [0, 1],
+      ],
+      type: 'sampled',
+    },
+    {
+      0: new Frame({key: 0, name: 'f0'}),
+      1: new Frame({key: 1, name: 'f1'}),
+      2: new Frame({key: 2, name: 'f2'}),
+      3: new Frame({key: 3, name: 'f3'}),
+      4: new Frame({key: 4, name: 'f4'}),
+      5: new Frame({key: 5, name: 'f5'}),
+    },
+    {type: 'flamechart'}
+  );
+
   appendSampleWithWeight(stack: Frame[], weight: number, end: number): void {
     // Keep track of discarded samples and ones that may have negative weights
     this.trackSampleStats(weight);


### PR DESCRIPTION
This adds an empty state for when the project supports profiling but does not currently send profiles to link to the profiling setup page for that platform.

![image](https://user-images.githubusercontent.com/10239353/217914232-305f84db-65eb-4045-9ef7-614ed5836ecb.png)
