### PR TITLE
fix(perf): Add margin below the anomalies chart

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
@@ -295,7 +295,10 @@ function AnomaliesContent(props: Props) {
       >
         {queryData => (
           <Fragment>
-            <Anomalies {...props} queryData={queryData} />
+            <AnomaliesWrapper>
+              <Anomalies {...props} queryData={queryData} />
+            </AnomaliesWrapper>
+
             <AnomaliesTable
               anomalies={queryData.data?.anomalies}
               {...props}
@@ -316,6 +319,10 @@ const FilterActions = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: auto 1fr;
   }
+`;
+
+const AnomaliesWrapper = styled('div')`
+  margin-bottom: ${space(2)};
 `;
 
 export default AnomaliesContent;


### PR DESCRIPTION
There was previously no margin separating the anomalies chart and the table, making it look weird

### Before
![image](https://user-images.githubusercontent.com/16740047/217918311-ae8cfa7e-d0e8-4039-bb62-74296f47ffb9.png)

### After
![image](https://user-images.githubusercontent.com/16740047/217918376-9d95e81a-74e3-49d1-bc24-5531523a5285.png)
