### PR TITLE
fix(saved-searches): Fix search bar overflowing at specific viewport size

### DIFF
--- a/static/app/views/issueList/issueSearchWithSavedSearches.tsx
+++ b/static/app/views/issueList/issueSearchWithSavedSearches.tsx
@@ -58,11 +58,7 @@ const SearchBarWithButtonContainer = styled('div')`
   width: 100%;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    min-width: 30rem;
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
-    min-width: 35rem;
+    flex-basis: 35rem;
   }
 `;
 


### PR DESCRIPTION
Before:

![CleanShot 2023-02-09 at 11 46 24](https://user-images.githubusercontent.com/10888943/217921261-0a658573-f16b-44fa-a157-74414b0632ed.png)

After:
 
![CleanShot 2023-02-09 at 11 45 52](https://user-images.githubusercontent.com/10888943/217921160-5c7c9eca-38de-439d-9e82-e2f013628c52.png)
