### PR TITLE
feat(metric-alerts): Forbid saving metric alerts that fall back to indexed events

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -495,6 +495,11 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                   placeholder={this.searchPlaceholder}
                   onChange={onChange}
                   query={initialData.query}
+                  // We only need strict validation for Transaction queries, everything else is fine
+                  highlightUnsupportedTags={[
+                    Dataset.GENERIC_METRICS,
+                    Dataset.TRANSACTIONS,
+                  ].includes(dataset)}
                   onKeyDown={e => {
                     /**
                      * Do not allow enter key to submit the alerts form since it is unlikely

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -431,7 +431,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
           <AlertContainer>
             <Alert type="info" showIcon>
               {tct(
-                'Filtering by these conditions automatically switch you to indexed events. [link:Learn more].',
+                'Based on your search criteria and sample rate, the events available may be limited. [link:Learn more].',
                 {
                   link: (
                     <ExternalLink href="https://docs.sentry.io/product/alerts/create-alerts/metric-alert-config/#filters" />

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -434,7 +434,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 'Filtering by these conditions automatically switch you to indexed events. [link:Learn more].',
                 {
                   link: (
-                    <ExternalLink href="https://docs.sentry.io/product/sentry-basics/search/searchable-properties/#processed-event-properties" />
+                    <ExternalLink href="https://docs.sentry.io/product/alerts/create-alerts/metric-alert-config/#filters" />
                   ),
                 }
               )}

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -57,7 +57,7 @@ type Props = {
   dataset: Dataset;
   disabled: boolean;
   onComparisonDeltaChange: (value: number) => void;
-  onFilterSearch: (query: string) => void;
+  onFilterSearch: (query: string, isQueryValid) => void;
   onTimeWindowChange: (value: number) => void;
   organization: Organization;
   project: Project;
@@ -507,12 +507,12 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
                     onKeyDown?.(e);
                   }}
-                  onClose={query => {
-                    onFilterSearch(query);
+                  onClose={(query, {validSearch}) => {
+                    onFilterSearch(query, validSearch);
                     onBlur(query);
                   }}
                   onSearch={query => {
-                    onFilterSearch(query);
+                    onFilterSearch(query, true);
                     onChange(query, {});
                   }}
                   hasRecentSearches={dataset !== Dataset.SESSIONS}

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -103,6 +103,7 @@ type State = {
   dataset: Dataset;
   environment: string | null;
   eventTypes: EventTypes[];
+  isQueryValid: boolean;
   project: Project;
   query: string;
   resolveThreshold: UnsavedMetricRule['resolveThreshold'];
@@ -172,6 +173,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       dataset,
       eventTypes: eventTypes ?? rule.eventTypes ?? [],
       query: rule.query ?? '',
+      isQueryValid: true, // Assume valid until input is changed
       timeWindow: rule.timeWindow,
       environment: rule.environment || null,
       triggerErrors: new Map(),
@@ -489,7 +491,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   // We handle the filter update outside of the fieldChange handler since we
   // don't want to update the filter on every input change, just on blurs and
   // searches.
-  handleFilterUpdate = (query: string) => {
+  handleFilterUpdate = (query: string, isQueryValid: boolean) => {
     const {organization, sessionId} = this.props;
 
     trackAdvancedAnalyticsEvent('alert_builder.filter', {
@@ -498,7 +500,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       query,
     });
 
-    this.setState({query});
+    this.setState({query, isQueryValid});
   };
 
   handleSubmit = async (

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -866,7 +866,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     return (
       <Access access={['alerts:write']}>
         {({hasAccess}) => {
-          const disabled = loading || !(isActiveSuperuser() || hasAccess);
+          const formDisabled = loading || !(isActiveSuperuser() || hasAccess);
+          const submitDisabled = formDisabled || !this.state.isQueryValid;
 
           return (
             <Fragment>
@@ -883,7 +884,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                   apiEndpoint={`/organizations/${organization.slug}/alert-rules/${
                     ruleId ? `${ruleId}/` : ''
                   }`}
-                  submitDisabled={disabled}
+                  submitDisabled={submitDisabled}
                   initialData={{
                     name,
                     dataset,
@@ -904,7 +905,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                   extraButton={
                     rule.id ? (
                       <Confirm
-                        disabled={disabled}
+                        disabled={formDisabled}
                         message={t('Are you sure you want to delete this alert rule?')}
                         header={t('Delete Alert Rule?')}
                         priority="danger"
@@ -923,7 +924,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       project={project}
                       organization={organization}
                       router={router}
-                      disabled={disabled}
+                      disabled={formDisabled}
                       thresholdChart={wizardBuilderChart}
                       onFilterSearch={this.handleFilterUpdate}
                       allowChangeEventTypes={
@@ -944,9 +945,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       showMEPAlertBanner={showMEPAlertBanner}
                     />
                     <AlertListItem>{t('Set thresholds')}</AlertListItem>
-                    {thresholdTypeForm(disabled)}
-                    {triggerForm(disabled)}
-                    {ruleNameOwnerForm(disabled)}
+                    {thresholdTypeForm(formDisabled)}
+                    {triggerForm(formDisabled)}
+                    {ruleNameOwnerForm(formDisabled)}
                   </List>
                 </Form>
               </Main>


### PR DESCRIPTION
Closes PERF-1969. We do not want people to make alerts that rely on indexed data, we only want them to make alerts that rely on _processed_ data. Right now people get a _warning_ that they're falling down to indexed events. This PR makes that much harder. This PR does this by:

1. Telling `SmartSearchBar` to validate that only the supported tags are allowed in case of metrics datasets. Other datasets can do whatever they want. This shows a red validation message when typing
2. Rigging up the form to disable the "Save Rule" button if the search input is not valid. This only happens on dropdown close, which should be good enough for now. I might update `SmartSearchBar` to report its validation state more often in the future
3. Updating the validation error message with a better explanation, and a link to the relevant documentation

**e.g.,**
![Screenshot 2023-02-09 at 3 36 40 PM](https://user-images.githubusercontent.com/989898/217934772-4acf966f-6e4c-4147-a45f-0ffa09b809ac.png)

