### PR TITLE
fix(profiling): Clean up rendering around grid renderer

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -405,7 +405,7 @@ export function FlamegraphSpans({
 
 const Canvas = styled('canvas')<{cursor?: CSSProperties['cursor']}>`
   width: 100%;
-  height: 100%;
+  height: calc(100% - 20px);
   position: absolute;
   left: 0;
   top: 0;

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -165,7 +165,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
     FOCUSED_FRAME_BORDER_COLOR: lightTheme.focus,
     FRAME_GRAYSCALE_COLOR: [0.5, 0.5, 0.6, 0.1],
     SPAN_FALLBACK_COLOR: [0, 0, 0, 0.1],
-    GRID_FRAME_BACKGROUND_COLOR: 'rgba(255, 255, 255, 0.8)',
+    GRID_FRAME_BACKGROUND_COLOR: 'rgb(255, 255, 255)',
     GRID_LINE_COLOR: '#e5e7eb',
     HIGHLIGHTED_LABEL_COLOR: [240, 240, 0, 1],
     HOVERED_FRAME_BORDER_COLOR: 'rgba(0, 0, 0, 0.8)',

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -201,7 +201,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     FOCUSED_FRAME_BORDER_COLOR: darkTheme.focus,
     FRAME_GRAYSCALE_COLOR: [0.5, 0.5, 0.5, 0.4],
     SPAN_FALLBACK_COLOR: [1, 1, 1, 0.3],
-    GRID_FRAME_BACKGROUND_COLOR: 'rgba(0, 0, 0, 0.4)',
+    GRID_FRAME_BACKGROUND_COLOR: 'rgba(0, 0, 0)',
     GRID_LINE_COLOR: '#222227',
     HIGHLIGHTED_LABEL_COLOR: [136, 50, 0, 1],
     HOVERED_FRAME_BORDER_COLOR: 'rgba(255, 255, 255, 0.8)',

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -201,7 +201,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     FOCUSED_FRAME_BORDER_COLOR: darkTheme.focus,
     FRAME_GRAYSCALE_COLOR: [0.5, 0.5, 0.5, 0.4],
     SPAN_FALLBACK_COLOR: [1, 1, 1, 0.3],
-    GRID_FRAME_BACKGROUND_COLOR: 'rgba(0, 0, 0)',
+    GRID_FRAME_BACKGROUND_COLOR: 'rgb(0, 0, 0)',
     GRID_LINE_COLOR: '#222227',
     HIGHLIGHTED_LABEL_COLOR: [136, 50, 0, 1],
     HOVERED_FRAME_BORDER_COLOR: 'rgba(255, 255, 255, 0.8)',

--- a/static/app/utils/profiling/renderers/gridRenderer.tsx
+++ b/static/app/utils/profiling/renderers/gridRenderer.tsx
@@ -79,14 +79,7 @@ class GridRenderer {
 
     // Draw the background of the top timeline
     context.fillStyle = this.theme.COLORS.GRID_FRAME_BACKGROUND_COLOR;
-    context.fillRect(
-      0,
-      0,
-      physicalViewRect.width,
-      this.theme.SIZES.LABEL_FONT_SIZE * window.devicePixelRatio +
-        this.theme.SIZES.LABEL_FONT_PADDING * window.devicePixelRatio * 2 -
-        this.theme.SIZES.LABEL_FONT_PADDING
-    );
+    context.fillRect(0, 0, physicalViewRect.width, this.theme.SIZES.BAR_HEIGHT);
 
     // Draw top timeline lines
     context.fillStyle = this.theme.COLORS.GRID_LINE_COLOR;


### PR DESCRIPTION
The spans canvas had height 100% which was overlapping with the flamegraph canvas and the grid renderer had opacity on the background color so when the flamechart is scrolled, it was visible under the grid.

# Screenshots

## Light mode

### Before

![image](https://user-images.githubusercontent.com/10239353/217941540-3cfbe347-b9a4-431f-97f2-a3dbf33bf137.png)

### After

![image](https://user-images.githubusercontent.com/10239353/217941205-1b2aec14-1a07-4485-a1b0-b70df6fced2b.png)

## Dark mode

### Before

![image](https://user-images.githubusercontent.com/10239353/217941420-91631814-568c-42b7-9c5f-caaffe2a9b2a.png)

### After

![image](https://user-images.githubusercontent.com/10239353/217941345-aac1fbe4-7cf0-43bf-a1ae-9894d2162865.png)