### PR TITLE
fix(dashboards): Display an error message when widget validation fails on clicking add widget

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -7,7 +7,7 @@ import omit from 'lodash/omit';
 import set from 'lodash/set';
 
 import {validateWidget} from 'sentry/actionCreators/dashboards';
-import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -811,6 +811,7 @@ function WidgetBuilder({
         loading: false,
         errors: {...state.errors, ...mapErrors(error?.responseJSON ?? {}, {})},
       });
+      addErrorMessage(t('Unable to save widget'));
       return false;
     }
   }


### PR DESCRIPTION
Displays an error message when a widget fails validation on clicking add/update widget.
![image](https://user-images.githubusercontent.com/83961295/217943395-893c6382-73aa-4900-93d3-59b30edd904a.png)