### PR TITLE
ref(perf-issues): Change copy for resources section of slow DB issues

### DIFF
--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -113,7 +113,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
   [IssueType.PERFORMANCE_SLOW_DB_QUERY]: {
     resources: {
       description: t(
-        'Slow DB Queries are SELECT query spans that take longer than 1s. A quick method to understand why this may be the case is running an EXPLAIN command on the query itself. To learn more about how to fix slow DB queries, check out these resources:'
+        'Slow DB Queries are SELECT query spans that are consistently taking longer than 1s. A quick method to understand why this may be the case is running an EXPLAIN command on the query itself. To learn more about how to fix slow DB queries, check out these resources:'
       ),
       links: [],
       linksByPlatform: {},


### PR DESCRIPTION
Slight adjustment to the copy so it is more specific; we create issues when queries are *consistently* taking longer than 1s