### PR TITLE
ref(segmentedControl): Remove shadow around indicator when `priority="primary"`

### DIFF
--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -277,32 +277,31 @@ const SegmentSelectionIndicator = styled(motion.div)<{priority: Priority}>`
   bottom: 0;
   left: 0;
   right: 0;
-  background: ${p =>
-    p.priority === 'primary' ? p.theme.active : p.theme.backgroundElevated};
-  border-radius: ${p =>
-    p.priority === 'primary'
-      ? p.theme.borderRadius
-      : `calc(${p.theme.borderRadius} - 1px)`};
-  box-shadow: 0 0 2px rgba(43, 34, 51, 0.32);
-
-  input.focus-visible ~ & {
-    box-shadow: ${p =>
-      p.priority === 'primary'
-        ? `0 0 0 3px ${p.theme.focus}`
-        : `0 0 0 2px ${p.theme.focusBorder}`};
-  }
 
   ${p =>
-    p.priority === 'primary' &&
-    `
+    p.priority === 'primary'
+      ? `
+    background: ${p.theme.active};
+    border-radius: ${p.theme.borderRadius};
+    input.focus-visible ~ & {
+      box-shadow: 0 0 0 3px ${p.theme.focus};
+    }
+
     top: -1px;
     bottom: -1px;
-
     label:first-child > & {
       left: -1px;
     }
     label:last-child > & {
       right: -1px;
+    }
+  `
+      : `
+    background: ${p.theme.backgroundElevated};
+    border-radius: calc(${p.theme.borderRadius} - 1px);
+    box-shadow: 0 0 2px rgba(43, 34, 51, 0.32);
+    input.focus-visible ~ & {
+      box-shadow: 0 0 0 2px ${p.theme.focusBorder};
     }
   `}
 `;


### PR DESCRIPTION
**Before ——** heavy shadow looks jarring around a purple button
<img width="164" alt="Screenshot 2023-02-09 at 1 56 12 PM" src="https://user-images.githubusercontent.com/44172267/217948358-1a835ced-3665-49cd-b282-afd60209e32e.png">

**After ——**
<img width="164" alt="Screenshot 2023-02-09 at 1 56 29 PM" src="https://user-images.githubusercontent.com/44172267/217948414-90c1c01f-a1c1-4043-adfe-6a6cb1066bbb.png">
