### PR TITLE
feat(profiling): Add profile id to trace view

### DIFF
--- a/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
@@ -186,7 +186,7 @@ function ProfilePreview({canvasView, event, organization}: ProfilePreviewProps) 
   function handleGoToProfile() {
     trackAdvancedAnalyticsEvent('profiling_views.go_to_flamegraph', {
       organization,
-      source: 'missing_instrumentation',
+      source: 'performance.missing_instrumentation',
     });
   }
 

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -1,7 +1,8 @@
 import {PlatformKey} from 'sentry/data/platformCategories';
 
 type ProfilingEventSource =
-  | 'missing_instrumentation'
+  | 'performance.missing_instrumentation'
+  | 'performance.trace_view'
   | 'slowest_transaction_panel'
   | 'transaction_details'
   | 'transaction_hovercard.trigger'

--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -65,6 +65,7 @@ export type TraceFullDetailed = Omit<TraceFull, 'children'> & {
   'transaction.op': string;
   'transaction.status': string;
   measurements?: Record<string, Measurement>;
+  profile_id?: string;
   tags?: EventTag[];
 };
 

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -140,8 +140,15 @@ class TransactionDetail extends Component<Props> {
       profileId: transaction.profile_id,
     });
 
+    function handleOnClick() {
+      trackAdvancedAnalyticsEvent('profiling_views.go_to_flamegraph', {
+        organization,
+        source: 'performance.trace_view',
+      });
+    }
+
     return (
-      <StyledButton size="xs" to={target}>
+      <StyledButton size="xs" to={target} onClick={handleOnClick}>
         {t('Go to Profile')}
       </StyledButton>
     );

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -30,6 +30,7 @@ import {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {CustomerProfiler} from 'sentry/utils/performanceForSentry';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 import {Row, Tags, TransactionDetails, TransactionDetailsContainer} from './styles';
@@ -126,6 +127,26 @@ class TransactionDetail extends Component<Props> {
     );
   }
 
+  renderGoToProfileButton() {
+    const {organization, transaction} = this.props;
+
+    if (!transaction.profile_id) {
+      return null;
+    }
+
+    const target = generateProfileFlamechartRoute({
+      orgSlug: organization.slug,
+      projectSlug: transaction.project_slug,
+      profileId: transaction.profile_id,
+    });
+
+    return (
+      <StyledButton size="xs" to={target}>
+        {t('Go to Profile')}
+      </StyledButton>
+    );
+  }
+
   renderMeasurements() {
     const {transaction} = this.props;
     const {measurements = {}} = transaction;
@@ -210,6 +231,11 @@ class TransactionDetail extends Component<Props> {
             </Row>
             <Row title="Transaction Status">{transaction['transaction.status']}</Row>
             <Row title="Span ID">{transaction.span_id}</Row>
+            {transaction.profile_id && (
+              <Row title="Profile ID" extra={this.renderGoToProfileButton()}>
+                {transaction.profile_id}
+              </Row>
+            )}
             <Row title="Project">{transaction.project_slug}</Row>
             <Row title="Start Date">
               {getDynamicText({


### PR DESCRIPTION
If a transaction has a profile associated with it, we should be be able to go the profile from the trace view directly.

Depends on #44385
Closes getsentry/team-profiling#181