### PR TITLE
feat(alert previews): Support issue platform

### DIFF
--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from django import forms
 
 from sentry.eventstore.models import GroupEvent
-from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
+from sentry.issues.grouptype import GroupCategory
 from sentry.models import Group
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
@@ -27,9 +27,7 @@ class IssueCategoryFilter(EventFilter):
 
     def _passes(self, group: Group) -> bool:
         try:
-            value: GroupCategory = GroupCategory(
-                get_group_type_by_type_id(int(self.get_option("value"))).category
-            )
+            value: GroupCategory = GroupCategory(int(self.get_option("value")))
         except (TypeError, ValueError):
             return False
 

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from django import forms
 
 from sentry.eventstore.models import GroupEvent
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.models import Group
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
@@ -27,7 +27,9 @@ class IssueCategoryFilter(EventFilter):
 
     def _passes(self, group: Group) -> bool:
         try:
-            value: GroupCategory = GroupCategory(int(self.get_option("value")))
+            value: GroupCategory = GroupCategory(
+                get_group_type_by_type_id(int(self.get_option("value"))).category
+            )
         except (TypeError, ValueError):
             return False
 

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -276,8 +276,8 @@ def get_group_dataset(group_ids: Sequence[int]) -> Dict[int, Dataset]:
     """
     group_categories = Group.objects.filter(id__in=group_ids).values_list("id", "type")
     return {
-        group[0]: get_dataset_from_category(get_group_type_by_type_id(group[1]).category)
-        for group in group_categories
+        group_id: get_dataset_from_category(get_group_type_by_type_id(group_type).category)
+        for group_id, group_type in group_categories
     }
 
 

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -11,9 +11,9 @@ from sentry.models import Group, Project
 from sentry.rules import RuleBase, rules
 from sentry.rules.history.preview_strategy import (
     DATASET_TO_COLUMN_NAME,
-    GROUP_CATEGORY_TO_DATASET,
-    UPDATE_KWARGS_FOR_GROUP,
-    UPDATE_KWARGS_FOR_GROUPS,
+    get_dataset_from_category,
+    get_update_kwargs_for_group,
+    get_update_kwargs_for_groups,
 )
 from sentry.rules.processor import get_match_function
 from sentry.snuba.dataset import Dataset
@@ -104,7 +104,6 @@ def preview(
         group_fires = get_fired_groups(
             group_activity, filter_objects, filter_func, start, frequency, event_map
         )
-
         return group_fires
     except PreviewException:
         return None
@@ -236,10 +235,8 @@ def get_top_groups(
     # queries each dataset for top x groups and then gets top x overall
     query_params = []
     for dataset in datasets:
-        if dataset not in UPDATE_KWARGS_FOR_GROUPS:
-            continue
-
-        kwargs = UPDATE_KWARGS_FOR_GROUPS[dataset](
+        kwargs = get_update_kwargs_for_groups(
+            dataset,
             group_ids,
             {
                 "dataset": dataset,
@@ -279,7 +276,7 @@ def get_group_dataset(group_ids: Sequence[int]) -> Dict[int, Dataset]:
     """
     group_categories = Group.objects.filter(id__in=group_ids).values_list("id", "type")
     return {
-        group[0]: GROUP_CATEGORY_TO_DATASET.get(get_group_type_by_type_id(group[1]).category)
+        group[0]: get_dataset_from_category(get_group_type_by_type_id(group[1]).category)
         for group in group_categories
     }
 
@@ -318,14 +315,11 @@ def get_events(
     query_params = []
     # query events by group_id (first event for each group)
     for dataset, ids in group_ids.items():
-        if (
-            dataset not in columns
-            or dataset not in UPDATE_KWARGS_FOR_GROUP
-            or dataset == Dataset.Transactions
-        ):
+        if dataset not in columns or dataset == Dataset.Transactions:
             # transaction query cannot be made until https://getsentry.atlassian.net/browse/SNS-1891 is fixed
             continue
-        kwargs = UPDATE_KWARGS_FOR_GROUPS[dataset](
+        kwargs = get_update_kwargs_for_groups(
+            dataset,
             ids,
             {
                 "dataset": dataset,
@@ -503,10 +497,8 @@ def get_frequency_buckets(
     """
     Puts the events of a group into buckets, and returns the bucket counts.
     """
-    if dataset not in UPDATE_KWARGS_FOR_GROUP:
-        return {}
-
-    kwargs = UPDATE_KWARGS_FOR_GROUP[dataset](
+    kwargs = get_update_kwargs_for_group(
+        dataset,
         group_id,
         {
             "dataset": dataset,

--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -76,7 +76,7 @@ def get_update_kwargs_for_groups(
     group_ids: Sequence[int],
     kwargs: Dict[str, Any],
     has_issue_state_condition: bool = True,
-):
+) -> Dict[str, Any]:
     if dataset == Dataset.Transactions:
         return _transactions_from_groups_kwargs(group_ids, kwargs, has_issue_state_condition)
     return _events_from_groups_kwargs(group_ids, kwargs, has_issue_state_condition)
@@ -97,7 +97,9 @@ Returns the rows that reference the group id without arrayjoining.
 """
 
 
-def get_update_kwargs_for_group(dataset: Dataset, group_id: int, kwargs: Dict[str, Any]):
+def get_update_kwargs_for_group(
+    dataset: Dataset, group_id: int, kwargs: Dict[str, Any]
+) -> Dict[str, Any]:
     if dataset == Dataset.Transactions:
         return _transactions_from_group_kwargs(group_id, kwargs)
     return _events_from_group_kwargs(group_id, kwargs)

--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -8,22 +8,26 @@ from sentry.snuba.events import Columns
 Issue category specific components to computing a preview for a set of rules.
 
 To add support for a new issue category/dataset:
-    1. Add mapping from GroupCategory to Dataset
+    1. Update get_dataset_from_category
     2. Add mapping from Dataset to snuba column name
         a. The column name should be a field in sentry.snuba.events.Column
-    3. Add category-specific query params for UPDATE_KWARGS_FOR_GROUPS and UPDATE_KWARGS_FOR_GROUP
+    3. Add category-specific query params for get_update_kwargs_for_groups and get_update_kwargs_for_group
 """
 
-# Maps group category to dataset
-GROUP_CATEGORY_TO_DATASET: Dict[int, Dataset] = {
-    GroupCategory.ERROR.value: Dataset.Events,
-    GroupCategory.PERFORMANCE.value: Dataset.Transactions,
-}
+
+def get_dataset_from_category(category: int) -> Dataset:
+    if category == GroupCategory.ERROR.value:
+        return Dataset.Events
+    elif category == GroupCategory.PERFORMANCE.value:
+        return Dataset.Transactions
+    return Dataset.IssuePlatform
+
 
 # Maps datasets to snuba column name
 DATASET_TO_COLUMN_NAME: Dict[Dataset, str] = {
     Dataset.Events: "event_name",
     Dataset.Transactions: "transaction_name",
+    Dataset.IssuePlatform: "issue_platform_name",
 }
 
 
@@ -65,10 +69,17 @@ Returns the rows that contain the group id.
 If there's a many-to-many relationship, the group id column should be arrayjoined.
 If there are no issue state changes (causes no group ids), then do not filter by group ids.
 """
-UPDATE_KWARGS_FOR_GROUPS = {
-    Dataset.Events: _events_from_groups_kwargs,
-    Dataset.Transactions: _transactions_from_groups_kwargs,
-}
+
+
+def get_update_kwargs_for_groups(
+    dataset: Dataset,
+    group_ids: Sequence[int],
+    kwargs: Dict[str, Any],
+    has_issue_state_condition: bool = True,
+):
+    if dataset == Dataset.Transactions:
+        return _transactions_from_groups_kwargs(group_ids, kwargs, has_issue_state_condition)
+    return _events_from_groups_kwargs(group_ids, kwargs, has_issue_state_condition)
 
 
 def _events_from_group_kwargs(group_id: int, kwargs: Dict[str, Any]) -> Dict[str, Any]:
@@ -84,7 +95,9 @@ def _transactions_from_group_kwargs(group_id: int, kwargs: Dict[str, Any]) -> Di
 """
 Returns the rows that reference the group id without arrayjoining.
 """
-UPDATE_KWARGS_FOR_GROUP = {
-    Dataset.Events: _events_from_group_kwargs,
-    Dataset.Transactions: _transactions_from_group_kwargs,
-}
+
+
+def get_update_kwargs_for_group(dataset: Dataset, group_id: int, kwargs: Dict[str, Any]):
+    if dataset == Dataset.Transactions:
+        return _transactions_from_group_kwargs(group_id, kwargs)
+    return _events_from_group_kwargs(group_id, kwargs)


### PR DESCRIPTION
Add support for issues using the issue platform in alert previews. I refactored some of the dictionaries to be functions instead so there is an easy fallback to the issue platform and less duplication. 

Fixes #44264