### PR TITLE
ref(perf): Make the transaction summary sidebar charts less confusing

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -289,7 +289,7 @@ function SidebarChartsContainer({
   };
 
   const chartOptions: Omit<LineChartProps, 'series'> = {
-    height: 480,
+    height: 360,
     grid: [
       {
         top: '60px',
@@ -307,7 +307,7 @@ function SidebarChartsContainer({
         top: '380px',
         left: '10px',
         right: '10px',
-        height: '120px',
+        height: '0px',
       },
     ],
     axisPointer: {

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -145,7 +145,7 @@ function SidebarCharts({
 
       <ChartLabel top="320px">
         <ChartTitle>
-          {displayTPMAsPercentage ? t('Total Transactions') : t('TPM')}
+          {displayTPMAsPercentage ? t('Total Events') : t('TPM')}
           <QuestionTooltip
             position="top"
             title={
@@ -410,39 +410,18 @@ function SidebarChartsContainer({
       interval={getInterval(datetimeSelection)}
       showLoading={false}
       includePrevious={false}
-      yAxis={['apdex()', 'failure_rate()', 'epm()']}
+      yAxis={['apdex()', 'failure_rate()']}
       partial
       referrer="api.performance.transaction-summary.sidebar-chart"
       queryExtras={queryExtras}
     >
       {({results, errored, loading, reloading}) => {
         const series = results
-          ? results
-              .map(_values => {
-                if (_values.seriesName === 'epm()') {
-                  const unfilteredTotalTPM = unfilteredTotals
-                    ? unfilteredTotals['tpm()']
-                    : null;
-                  if (unfilteredTotalTPM) {
-                    return {
-                      ..._values,
-                      data: _values.data.map(point => {
-                        return {
-                          ...point,
-                          value: point.value / unfilteredTotalTPM,
-                        };
-                      }),
-                    };
-                  }
-                  return _values;
-                }
-                return _values;
-              })
-              .map((v, i: number) => ({
-                ...v,
-                yAxisIndex: i,
-                xAxisIndex: i,
-              }))
+          ? results.map((v, i: number) => ({
+              ...v,
+              yAxisIndex: i,
+              xAxisIndex: i,
+            }))
           : [];
 
         return (


### PR DESCRIPTION
The "Total Transactions" sidebar chart was confusing because it was meant to indicate to the user the percentage of events available for the transaction. To address this, for now we are renaming the title to "Total Events" and removing the line chart.

### Before
![image](https://user-images.githubusercontent.com/16740047/217969794-83663337-a9ca-4578-ac5d-4cc7da96a94c.png)

### After
![image](https://user-images.githubusercontent.com/16740047/217969824-e876db49-853c-469d-a94a-41f559f032a0.png)
