### PR TITLE
test(flake): Fix UTC midnight issue

### DIFF
--- a/tests/sentry/api/endpoints/test_project_user_stats.py
+++ b/tests/sentry/api/endpoints/test_project_user_stats.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from freezegun import freeze_time
 
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -22,32 +23,37 @@ class ProjectUserDetailsTest(APITestCase):
         )
 
     def test_simple(self):
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(minutes=5)),
-                "tags": {"sentry:user": "user_1"},
-            },
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(minutes=5)),
-                "tags": {"sentry:user": "user_1"},
-            },
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(minutes=5)),
-                "tags": {"sentry:user": "user_2"},
-            },
-            project_id=self.project.id,
-        )
+        # Set the time to yesterday at 10am. This ensures the time is not
+        # in the future AND doesn't get affected by events and request being
+        # on seperate days, which can occur at midnight without freezing time.
+        now = before_now(hours=24).replace(hour=10)
+        with freeze_time(now):
+            self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(minutes=10)),
+                    "tags": {"sentry:user": "user_1"},
+                },
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(minutes=10)),
+                    "tags": {"sentry:user": "user_1"},
+                },
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(minutes=10)),
+                    "tags": {"sentry:user": "user_2"},
+                },
+                project_id=self.project.id,
+            )
 
-        response = self.client.get(self.path)
+            response = self.client.get(self.path)
 
-        assert response.status_code == 200, response.content
-        assert response.data[-1][1] == 2, response.data
-        for point in response.data[:-1]:
-            assert point[1] == 0
-        assert len(response.data) == 31
+            assert response.status_code == 200, response.content
+            assert response.data[-1][1] == 2, response.data
+            for point in response.data[:-1]:
+                assert point[1] == 0
+            assert len(response.data) == 31


### PR DESCRIPTION
The tests fail between 4 and 4.05pm PST (which is UTC midnight): https://sentry.sentry.io/issues/3873858998/events/?cursor=0%3A0%3A1&project=2423079&referrer=issue-stream&statsPeriod=14d

Freezing time should address this, setting time to fixed time and increasing minutes in events to 10 to ensure snuba caching doesn't cause any issues.