### PR TITLE
ref(hybrid-cloud): More test annotations

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -133,11 +133,6 @@ class UserService(
         pass
 
     @abstractmethod
-    def get_from_project(self, project_id: int) -> List[Group]:
-        """Get all users associated with a project identifier"""
-        pass
-
-    @abstractmethod
     def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[APIUser]:
         pass
 

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -13,7 +13,6 @@ from sentry.api.serializers import (
 from sentry.api.serializers.base import Serializer
 from sentry.db.models import BaseQuerySet
 from sentry.db.models.query import in_iexact
-from sentry.models import Project
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.filter_query import FilterQueryDatabaseImpl
@@ -107,15 +106,6 @@ class DatabaseBackedUserService(
                 is_active=True,
             )
         ]
-
-    def get_from_project(self, project_id: int) -> List[APIUser]:
-        try:
-            project = Project.objects.get(id=project_id)
-        except Project.DoesNotExist:
-            return []
-        return self.get_many(
-            filter=dict(user_ids=project.member_set.values_list("user_id", flat=True))
-        )
 
     def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[APIUser]:
         return [self._serialize_rpc(u) for u in self._base_query().filter(actor_id__in=actor_ids)]

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -22,6 +22,7 @@ from sentry.rules.conditions import EventCondition
 from sentry.rules.filters.base import EventFilter
 from sentry.rules.processor import RuleProcessor
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 
 EMAIL_ACTION_DATA = {
     "id": "sentry.mail.actions.NotifyEmailAction",
@@ -40,6 +41,7 @@ class MockConditionTrue(EventCondition):
         return True
 
 
+@region_silo_test(stable=True)
 class RuleProcessorTest(TestCase):
     def setUp(self):
         self.group_event = self.store_event(data={}, project_id=self.project.id)
@@ -240,6 +242,7 @@ class MockFilterFalse(EventFilter):
         return False
 
 
+@region_silo_test(stable=True)
 class RuleProcessorTestFilters(TestCase):
     MOCK_SENTRY_RULES_WITH_FILTERS = (
         "sentry.mail.actions.NotifyEmailAction",
@@ -446,6 +449,7 @@ class RuleProcessorTestFilters(TestCase):
         assert futures[0].kwargs == {}
 
 
+@region_silo_test(stable=True)
 class RuleProcessorActiveReleaseTest(TestCase):
     def setUp(self):
         self.group_event = self.store_event(

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -16,7 +16,7 @@ from sentry.search.utils import (
     tokenize_query,
 )
 from sentry.testutils import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import control_silo_test, region_silo_test
 
 
 def test_get_numeric_field_value():
@@ -130,6 +130,7 @@ def test_get_numeric_field_value_invalid():
         get_numeric_field_value("foo", ">=1k")
 
 
+@region_silo_test(stable=True)
 class ParseQueryTest(TestCase):
     def parse_query(self, query):
         return parse_query([self.project], query, self.user, None)
@@ -622,6 +623,7 @@ class ParseQueryTest(TestCase):
         assert result["assigned_or_suggested"].id == 0
 
 
+@region_silo_test(stable=True)
 class GetLatestReleaseTest(TestCase):
     def test(self):
         with pytest.raises(Release.DoesNotExist):

--- a/tests/sentry/tasks/integrations/test_kickoff_vsts_subscription_check.py
+++ b/tests/sentry/tasks/integrations/test_kickoff_vsts_subscription_check.py
@@ -6,6 +6,7 @@ import responses
 from sentry.models import Identity, IdentityProvider, Integration
 from sentry.tasks.integrations import kickoff_vsts_subscription_check
 from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
 
 PROVIDER = "vsts"
 
@@ -36,6 +37,7 @@ def assert_subscription(
         assert check_time == subscription_data["check"]
 
 
+@control_silo_test(stable=True)
 class VstsSubscriptionCheckTest(TestCase):
     def setUp(self):
         responses.add(

--- a/tests/sentry/utils/suspect_resolutions/test_commit_correlation.py
+++ b/tests/sentry/utils/suspect_resolutions/test_commit_correlation.py
@@ -11,6 +11,7 @@ from sentry.models import (
     ReleaseCommit,
 )
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.utils.suspect_resolutions.commit_correlation import (
     get_files_changed_in_releases,
@@ -18,6 +19,7 @@ from sentry.utils.suspect_resolutions.commit_correlation import (
 )
 
 
+@region_silo_test(stable=True)
 class CommitCorrelationTest(TestCase):
     def setup(self, status=GroupStatus.RESOLVED):
         project = self.create_project()

--- a/tests/sentry/utils/suspect_resolutions/test_get_suspect_resolutions.py
+++ b/tests/sentry/utils/suspect_resolutions/test_get_suspect_resolutions.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from sentry.models import Activity, Group, GroupStatus
 from sentry.signals import issue_resolved
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.utils.suspect_resolutions.commit_correlation import CommitCorrelatedResult
 from sentry.utils.suspect_resolutions.get_suspect_resolutions import (
@@ -18,6 +19,7 @@ from sentry.utils.suspect_resolutions.metric_correlation import (
 )
 
 
+@region_silo_test(stable=True)
 class GetSuspectResolutionsTest(TestCase):
     @mock.patch(
         "sentry.utils.suspect_resolutions.get_suspect_resolutions.is_issue_commit_correlated",

--- a/tests/sentry/utils/suspect_resolutions/test_metric_correlation.py
+++ b/tests/sentry/utils/suspect_resolutions/test_metric_correlation.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from sentry.models import GroupStatus
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.utils.suspect_resolutions.metric_correlation import (
     CandidateMetricCorrResult,
     calculate_pearson_correlation_coefficient,
@@ -15,6 +16,7 @@ from sentry.utils.suspect_resolutions.metric_correlation import (
 WINDOW = 60
 
 
+@region_silo_test(stable=True)
 class MetricCorrelationTest(TestCase):
     def generate_timestamps(self):
         now = datetime.datetime.now()

--- a/tests/sentry/utils/suspect_resolutions/test_resolved_in_active_release.py
+++ b/tests/sentry/utils/suspect_resolutions/test_resolved_in_active_release.py
@@ -4,11 +4,13 @@ from django.utils import timezone
 
 from sentry.models import Deploy, Group, GroupRelease, GroupStatus
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.utils.suspect_resolutions.resolved_in_active_release import (
     is_resolved_issue_within_active_release,
 )
 
 
+@region_silo_test(stable=True)
 class ResolvedInActiveReleaseTest(TestCase):
     def test_unresolved_issue_in_active_release(self):
         project = self.create_project()

--- a/tests/sentry/utils/suspect_resolutions_releases/test_get_suspect_resolutions_releases.py
+++ b/tests/sentry/utils/suspect_resolutions_releases/test_get_suspect_resolutions_releases.py
@@ -6,11 +6,13 @@ from django.utils import timezone
 from sentry.models import GroupRelease, GroupStatus, ReleaseProject
 from sentry.signals import release_created
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.utils.suspect_resolutions_releases.get_suspect_resolutions_releases import (
     get_suspect_resolutions_releases,
 )
 
 
+@region_silo_test(stable=True)
 class GetSuspectResolutionsReleasesTest(TestCase):
     @mock.patch("sentry.analytics.record")
     def test_get_suspect_resolutions_releases(self, record):


### PR DESCRIPTION
Fairly vanilla test annotations. Replacing some query callsites with tidied FilterQueryInterface methods on the user service.