### PR TITLE
test(metrics): Reenable extraction test

### DIFF
--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -1,19 +1,15 @@
 import uuid
 
 import confluent_kafka as kafka
-import pytest
 
 from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import Feature
-from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
 
 class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
-    @pytest.mark.skip("breaks in Relay for unknown reasons")
-    @override_options({"relay.transaction-names-client-based": 1.0})
     def test_all_transaction_metrics_emitted(self):
         with Feature(
             {


### PR DESCRIPTION
Reenable test that ensures that all new metrics strings are added to the string indexer. Do not merge until this test also passes in https://github.com/getsentry/relay/pull/1833.