### PR TITLE
test(grouping): Escape chars in fingerprint matcher

### DIFF
--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-escape-chars.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-escape-chars.json
@@ -1,0 +1,19 @@
+{
+    "_fingerprinting_rules": [
+        {
+            "matchers": [
+                [
+                    "message",
+                    "\\{\\[\\*\\?\\]\\}"
+                ]
+            ],
+            "fingerprint": [
+                "escaped",
+                "{{ message }}"
+            ]
+        }
+    ],
+    "logentry": {
+        "formatted": "{[*?]}"
+    }
+}

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_escape_chars.pysnap
@@ -1,0 +1,9 @@
+---
+created: '2023-02-10T15:02:32.115736Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:fingerprint:ident-shingle: "escaped"
+similarity:2020-07-23:fingerprint:ident-shingle: "{[*?]}"
+similarity:2020-07-23:message:character-5-shingle: "[*?]}"
+similarity:2020-07-23:message:character-5-shingle: "{[*?]"

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -1,0 +1,32 @@
+---
+created: '2023-02-10T13:31:47.690454Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - attributes: {}
+    fingerprint:
+    - escaped
+    - '{{ message }}'
+    matchers:
+    - - message
+      - \{\[\*\?\]\}
+  version: 1
+fingerprint:
+- escaped
+- '{{ message }}'
+title: '{[*?]}'
+variants:
+  custom-fingerprint:
+    matched_rule: message:"\{\[\*\?\]\}" -> "escaped{{ message }}"
+    type: custom-fingerprint
+    values:
+    - escaped
+    - '{[*?]}'
+  default:
+    component:
+      contributes: false
+      contributes_to_similarity: true
+      hint: custom fingerprint takes precedence
+    type: component


### PR DESCRIPTION
It seems that in addition to `*` and `[`, also `{` needs to be escaped. This PR adds a test to verify this.