### PR TITLE
ref(tagsstore): cap tags store size

### DIFF
--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -28,7 +28,6 @@ const storeConfig: TagStoreDefinition = {
   init() {
     // XXX: Do not use `this.listenTo` in this store. We avoid usage of reflux
     // listeners due to their leaky nature in tests.
-
     this.state = {};
   },
 
@@ -171,17 +170,48 @@ const storeConfig: TagStoreDefinition = {
   },
 
   loadTagsSuccess(data) {
-    const newTags = data.reduce<TagCollection>((acc, tag) => {
-      acc[tag.key] = {
+    // Note: We could probably stop cloning the data here and just
+    // assign to this.state directly, but there is a change someone may
+    // be relying on referential equality somewhere in the codebase and
+    // we dont want to risk breaking that.
+    const newState = {};
+
+    for (let i = 0; i < data.length; i++) {
+      const tag = data[i];
+      newState[tag.key] = {
         values: [],
         ...tag,
       };
+    }
 
-      return acc;
-    }, {});
+    // We will iterate through the previous tags in reverse so that previously
+    // added tags are carried over first. We rely on browser implementation
+    // of Object.keys() to return keys in insertion order.
+    const previousTagKeys = Object.keys(this.state);
 
-    this.state = {...this.state, ...newTags};
-    this.trigger(this.state);
+    const MAX_STORE_SIZE = 2000;
+    // We will carry over the previous tags until we reach the max store size
+    const toCarryOver = Math.max(0, MAX_STORE_SIZE - data.length);
+
+    let carriedOver = 0;
+    while (previousTagKeys.length > 0 && carriedOver < toCarryOver) {
+      const tagKey = previousTagKeys.pop();
+      if (tagKey === undefined) {
+        // Should be unreachable, but just in case
+        break;
+      }
+      // If the new state already has a previous tag then we will not carry it over
+      // and use the latest tag in the store instead.
+      if (newState[tagKey]) {
+        continue;
+      }
+      // Else override the tag with the previous tag
+      newState[tagKey] = this.state[tagKey];
+      carriedOver++;
+    }
+
+    this.state = newState;
+    this.trigger(newState);
   },
 };
 

--- a/static/app/utils/useTags.spec.tsx
+++ b/static/app/utils/useTags.spec.tsx
@@ -14,7 +14,7 @@ describe('useTags', function () {
     );
 
     const {result} = reactHooks.renderHook(useTags);
-    const {tags} = result.current;
+    const tags = result.current;
 
     const expected = {mechanism: {name: 'Mechanism', key: 'mechanism', values: []}};
     expect(tags).toEqual(expected);

--- a/static/app/utils/useTags.tsx
+++ b/static/app/utils/useTags.tsx
@@ -2,16 +2,8 @@ import TagStore from 'sentry/stores/tagStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {TagCollection} from 'sentry/types';
 
-type Result = {
-  tags: TagCollection;
-};
-
-function useTags(): Result {
-  const tags = useLegacyStore(TagStore);
-
-  return {
-    tags,
-  };
+function useTags(): TagCollection {
+  return useLegacyStore(TagStore);
 }
 
 export default useTags;

--- a/static/app/views/discover/table/columnEditModal.tsx
+++ b/static/app/views/discover/table/columnEditModal.tsx
@@ -52,8 +52,8 @@ function ColumnEditModal(props: Props) {
     });
   }, [organization.id]);
 
-  const {tags} = useTags();
-  const tagKeys = Object.values(tags).map(({key}) => key);
+  const tags = useTags();
+  const tagKeys = Object.keys(tags);
 
   const [columns, setColumns] = useState<Column[]>(props.columns);
 


### PR DESCRIPTION
The tags store can grow unbounded as we always carry over all tags between projects. This PR introduces a cap and a max carry over mechanism.

This means that if you switch between projects that have many tags, the store grows so large that an interaction on the searchbox (focus) will cause jank as all the tags are pulled out of the store and processed. I set the max number to some arbitrary number I think we should comfortably be able to process without jank, but I'm open to updating this. If there is a max tags per project limit somewhere, we should probably use that.

Screenshot from the SearchBar.getTagList transaction I added a while back - [link to discover query](https://sentry.sentry.io/discover/results/?field=p75%28transaction.duration%29&field=p99%28transaction.duration%29&field=p100%28transaction.duration%29&name=SearchBox.getTagList&project=-1&query=title%3ASearchBar.getTagList&statsPeriod=90d&yAxis=p75%28transaction.duration%29&yAxis=p99%28transaction.duration%29&yAxis=p100%28transaction.duration%29)

<img width="1020" alt="CleanShot 2023-02-10 at 10 26 01@2x" src="https://user-images.githubusercontent.com/9317857/218129592-13a46cdc-1d3c-48b4-9706-5e060ac3163c.png">
