### PR TITLE
fix(profiling): Account for device pixel ratio in grid renderer

### DIFF
--- a/static/app/utils/profiling/renderers/gridRenderer.tsx
+++ b/static/app/utils/profiling/renderers/gridRenderer.tsx
@@ -79,7 +79,12 @@ class GridRenderer {
 
     // Draw the background of the top timeline
     context.fillStyle = this.theme.COLORS.GRID_FRAME_BACKGROUND_COLOR;
-    context.fillRect(0, 0, physicalViewRect.width, this.theme.SIZES.BAR_HEIGHT);
+    context.fillRect(
+      0,
+      0,
+      physicalViewRect.width,
+      this.theme.SIZES.TIMELINE_HEIGHT * window.devicePixelRatio
+    );
 
     // Draw top timeline lines
     context.fillStyle = this.theme.COLORS.GRID_LINE_COLOR;


### PR DESCRIPTION
On retina screens, the device pixel ratio means that we need to adjust the timeline height accordingly.