### PR TITLE
feat(post_process): instrument pipeline_steps

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -489,7 +489,7 @@ def run_post_process_job(job: PostProcessJob):
 
     for pipeline_step in pipeline:
         try:
-            with sentry_sdk.start_span(op=f"tasks.post_process_group.{pipeline_step}"):
+            with sentry_sdk.start_span(op=f"tasks.post_process_group.{pipeline_step.__name__}"):
                 pipeline_step(job)
         except Exception:
             issue_category_metric = issue_category.name.lower() if issue_category else None

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -489,7 +489,8 @@ def run_post_process_job(job: PostProcessJob):
 
     for pipeline_step in pipeline:
         try:
-            pipeline_step(job)
+            with sentry_sdk.start_span(op=f"tasks.post_process_group.{pipeline_step}"):
+                pipeline_step(job)
         except Exception:
             issue_category_metric = issue_category.name.lower() if issue_category else None
             metrics.incr(


### PR DESCRIPTION
While troubleshooting a queue backlog, Ops noticed there's several steps in our post-process pipeline which are missing instrumentation. This PR adds instrumentation to all `pipeline_steps` in `GROUP_CATEGORY_POST_PROCESS_PIPELINE`.