### PR TITLE
fix(profiling): panels grid to use fr instead of pct

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -268,11 +268,11 @@ const ActionBar = styled('div')`
 // TODO: another simple primitive that can easily be <Grid columns={2} />
 const PanelsGrid = styled('div')`
   display: grid;
-  grid-template-columns: 50% 50%;
+  grid-template-columns: 1fr 1fr;
   gap: ${space(2)};
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 100%;
+    grid-template-columns: 1fr;
   }
 `;
 


### PR DESCRIPTION
## Summary

Fixes a small UI overflow bug where we were using pct values in `grid-template-columns` instead of `fr` ... TIL pct causes overflow w/ grid css props.


![image](https://user-images.githubusercontent.com/7349258/218127234-03ebef65-5769-43fe-a24b-32355d6d822c.png)
