### PR TITLE
fix(discover): Use optional chaining on possibly undefined vars

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -704,7 +704,7 @@ export function parseArguments(functionText: string, columnText: string): string
   let i: number = 0;
   let j: number = 0;
 
-  while (j < columnText.length) {
+  while (j < columnText?.length) {
     if (i === j && columnText[j] === '"') {
       // when we see a quote at the beginning of
       // an argument, then this is a quoted string

--- a/static/app/views/discover/table/quickContext/releaseContext.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.tsx
@@ -44,7 +44,7 @@ function ReleaseContext(props: BaseContextProps) {
   const getCommitAuthorTitle = () => {
     const user = ConfigStore.get('user');
     const commitCount = data?.commitCount || 0;
-    let authorsCount = data?.authors.length || 0;
+    let authorsCount = data?.authors?.length || 0;
 
     const userInAuthors =
       data &&


### PR DESCRIPTION
These variables sometimes can be `undefined`, so use optional chaining to prevent an error from being thrown in these cases.

Fixes [JAVASCRIPT-2E18](https://sentry.sentry.io/issues/3929508818/?project=11276&referrer=slack) and [JAVASCRIPT-2E0R](https://sentry.sentry.io/issues/3929115362/events/f8c5cc260a3a4c6da3cb7d8e19481870/?project=11276&referrer=previous-event)