### PR TITLE
ref(checkbox): Update focus state

### DIFF
--- a/docs-ui/stories/components/checkbox.stories.js
+++ b/docs-ui/stories/components/checkbox.stories.js
@@ -1,5 +1,5 @@
-import {useState} from 'react';
 import styled from '@emotion/styled';
+import {useArgs} from '@storybook/client-api';
 
 import Checkbox from 'sentry/components/checkbox';
 
@@ -23,48 +23,29 @@ export default {
 };
 
 export const Default = props => {
-  const [checked, setChecked] = useState(true);
+  const [_, updateArgs] = useArgs();
 
   return (
     <div>
-      <Checkbox
-        {...props}
-        checked={checked}
-        onChange={e => setChecked(e.target.checked)}
-      />
+      <Checkbox {...props} onChange={e => updateArgs({checked: !!e.target.checked})} />
     </div>
   );
 };
 
 export const WithLabel = props => {
-  const [check1, setCheck1] = useState(true);
-  const [check2, setCheck2] = useState(false);
+  const [_, updateArgs] = useArgs();
 
   return (
-    <div>
-      <Label>
-        Label to left
-        <Checkbox
-          {...props}
-          checked={check1}
-          onChange={e => setCheck1(e.target.checked)}
-        />
-      </Label>
-      <Label>
-        <Checkbox
-          {...props}
-          checked={check2}
-          onChange={e => setCheck2(e.target.checked)}
-        />
-        Label to right
-      </Label>
-    </div>
+    <Label>
+      <Checkbox {...props} onChange={e => updateArgs({checked: !!e.target.checked})} />
+      Label
+    </Label>
   );
 };
 
 const Label = styled('label')`
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.5rem;
   margin-bottom: 2rem;
 `;

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -103,7 +103,15 @@ const HiddenInput = styled('input')`
   cursor: pointer;
 
   &.focus-visible + * {
-    box-shadow: ${p => p.theme.focusBorder} 0 0 0 2px;
+    ${p =>
+      p.checked
+        ? `
+        box-shadow: ${p.theme.focus} 0 0 0 3px;
+      `
+        : `
+        border-color: ${p.theme.focusBorder};
+        box-shadow: ${p.theme.focusBorder} 0 0 0 1px;
+      `}
   }
 
   &:disabled + * {


### PR DESCRIPTION
Make checkbox focus states more similar to those on our buttons.

**Before ——**
<img width="28" alt="Screenshot 2023-02-10 at 10 45 16 AM" src="https://user-images.githubusercontent.com/44172267/218172709-d0aad1b9-6166-4815-9e0d-0d3f44ce5b3d.png">
<img width="28" alt="Screenshot 2023-02-10 at 10 44 58 AM" src="https://user-images.githubusercontent.com/44172267/218172664-1c2356af-8dfa-4727-8cb7-8fa1ab01a4ec.png">

**After ——**
<img width="28" alt="Screenshot 2023-02-10 at 10 44 28 AM" src="https://user-images.githubusercontent.com/44172267/218172578-616a566e-d023-42bb-8a46-0196916d839a.png">
<img width="28" alt="Screenshot 2023-02-10 at 10 44 44 AM" src="https://user-images.githubusercontent.com/44172267/218172622-752cd509-c493-418b-ac0d-ce00d5f06d99.png">
