### PR TITLE
chore(label): platform dotnet

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -317,6 +317,9 @@
   description: ''
 
 # Platforms
+- name: 'Platform: .NET'
+  color: '584774'
+  description: ''
 - name: 'Platform: Cocoa'
   color: '584774'
   description: ''


### PR DESCRIPTION
A change adding Replay removed .NET:

```
Validating provided labels
Fetching labels from GitHub
 > Added: the "Platform: .NET" label in the repo is not expected. It will be deleted.
 > Added: the "python" label in the repo is not expected. It will be deleted.
This is a dry run. No changes have been made on GitHub
```

Open issue to tag: https://github.com/getsentry/sentry/issues/44377