### PR TITLE
fix(perf): Fix web vitals labels in dark mode

### DIFF
--- a/static/app/components/events/interfaces/spans/measurementsPanel.tsx
+++ b/static/app/components/events/interfaces/spans/measurementsPanel.tsx
@@ -109,9 +109,9 @@ const Label = styled('div')<{
   font-size: ${p => p.theme.fontSizeExtraSmall};
   font-weight: 600;
   color: ${p => (p.failedThreshold ? `${p.theme.errorText}` : `${p.theme.textColor}`)};
-  background: ${p => p.theme.white};
+  background: ${p => p.theme.background};
   border: 1px solid;
-  border-color: ${p => (p.failedThreshold ? p.theme.red300 : p.theme.gray100)};
+  border-color: ${p => (p.failedThreshold ? p.theme.red300 : p.theme.gray200)};
   border-radius: ${p => p.theme.borderRadius};
   height: 75%;
   display: flex;


### PR DESCRIPTION
The web vitals labels in the span tree did not have the proper theme colours set, so they looked bad in dark mode.

### Before
![image](https://user-images.githubusercontent.com/16740047/218179691-ce9ec462-e1e7-4a3f-9dca-ab0e6aed8d84.png)

### After
![image](https://user-images.githubusercontent.com/16740047/218179719-786c6d12-4d07-4486-add8-b8aacb3a1139.png)

Fixes PERF-1934
