### PR TITLE
feat(issue-platform): Retrive prev/next event for platform events

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -269,11 +269,12 @@ class SnubaEventStorage(EventStorage):
         filter.conditions.extend(get_after_event_condition(event))
         filter.start = event.datetime
 
-        dataset = (
-            snuba.Dataset.Transactions
-            if event.get_event_type() == "transaction"
-            else snuba.Dataset.Discover
-        )
+        if event.get_event_type() == "transaction":
+            dataset = snuba.Dataset.Transactions
+        elif event.get_event_type() == "generic":
+            dataset = snuba.Dataset.IssuePlatform
+        else:
+            dataset = snuba.Dataset.Discover
 
         return self.__get_event_id_from_filter(filter=filter, orderby=ASC_ORDERING, dataset=dataset)
 
@@ -294,11 +295,12 @@ class SnubaEventStorage(EventStorage):
         # to the end condition since it uses a less than condition
         filter.end = event.datetime + timedelta(seconds=1)
 
-        dataset = (
-            snuba.Dataset.Transactions
-            if event.get_event_type() == "transaction"
-            else snuba.Dataset.Discover
-        )
+        if event.get_event_type() == "transaction":
+            dataset = snuba.Dataset.Transactions
+        elif event.get_event_type() == "generic":
+            dataset = snuba.Dataset.IssuePlatform
+        else:
+            dataset = snuba.Dataset.Discover
 
         return self.__get_event_id_from_filter(
             filter=filter, orderby=DESC_ORDERING, dataset=dataset

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -254,6 +254,14 @@ class SnubaEventStorage(EventStorage):
 
         return event
 
+    def _get_dataset_for_event(self, event):
+        if event.get_event_type() == "transaction":
+            return snuba.Dataset.Transactions
+        elif event.get_event_type() == "generic":
+            return snuba.Dataset.IssuePlatform
+        else:
+            return snuba.Dataset.Discover
+
     def get_next_event_id(self, event, filter):
         """
         Returns (project_id, event_id) of a next event given a current event
@@ -268,14 +276,7 @@ class SnubaEventStorage(EventStorage):
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_after_event_condition(event))
         filter.start = event.datetime
-
-        if event.get_event_type() == "transaction":
-            dataset = snuba.Dataset.Transactions
-        elif event.get_event_type() == "generic":
-            dataset = snuba.Dataset.IssuePlatform
-        else:
-            dataset = snuba.Dataset.Discover
-
+        dataset = self._get_dataset_for_event(event)
         return self.__get_event_id_from_filter(filter=filter, orderby=ASC_ORDERING, dataset=dataset)
 
     def get_prev_event_id(self, event, filter):
@@ -294,14 +295,7 @@ class SnubaEventStorage(EventStorage):
         # the previous event can have the same timestamp, add 1 second
         # to the end condition since it uses a less than condition
         filter.end = event.datetime + timedelta(seconds=1)
-
-        if event.get_event_type() == "transaction":
-            dataset = snuba.Dataset.Transactions
-        elif event.get_event_type() == "generic":
-            dataset = snuba.Dataset.IssuePlatform
-        else:
-            dataset = snuba.Dataset.Discover
-
+        dataset = self._get_dataset_for_event(event)
         return self.__get_event_id_from_filter(
             filter=filter, orderby=DESC_ORDERING, dataset=dataset
         )

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -417,11 +417,12 @@ def reset_snuba(call_snuba):
         "/tests/sessions/drop",
         "/tests/metrics/drop",
         "/tests/generic_metrics/drop",
+        "/tests/search_issues/drop",
     ]
 
     assert all(
         response.status_code == 200
-        for response in ThreadPoolExecutor(4).map(call_snuba, init_endpoints)
+        for response in ThreadPoolExecutor(len(init_endpoints)).map(call_snuba, init_endpoints)
     )
 
 

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -1,9 +1,11 @@
 from django.urls import reverse
 
 from sentry.issues.grouptype import PerformanceRenderBlockingAssetSpanGroupType
+from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test
@@ -11,8 +13,9 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        project = self.create_project()
+        self.setup_data()
 
+    def setup_data(self):
         one_min_ago = iso_format(before_now(minutes=1))
         two_min_ago = iso_format(before_now(minutes=2))
         three_min_ago = iso_format(before_now(minutes=3))
@@ -20,11 +23,11 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
 
         self.prev_event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": four_min_ago, "fingerprint": ["group-1"]},
-            project_id=project.id,
+            project_id=self.project.id,
         )
         self.cur_event = self.store_event(
             data={"event_id": "b" * 32, "timestamp": three_min_ago, "fingerprint": ["group-1"]},
-            project_id=project.id,
+            project_id=self.project.id,
         )
         self.next_event = self.store_event(
             data={
@@ -34,8 +37,9 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
                 "environment": "production",
                 "tags": {"environment": "production"},
             },
-            project_id=project.id,
+            project_id=self.project.id,
         )
+        self.cur_group = self.next_event.group
 
         # Event in different group
         self.store_event(
@@ -46,7 +50,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
                 "environment": "production",
                 "tags": {"environment": "production"},
             },
-            project_id=project.id,
+            project_id=self.project.id,
         )
 
     def test_simple(self):
@@ -54,8 +58,8 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
             "sentry-api-0-project-event-details",
             kwargs={
                 "event_id": self.cur_event.event_id,
-                "project_slug": self.cur_event.project.slug,
-                "organization_slug": self.cur_event.project.organization.slug,
+                "project_slug": self.project.slug,
+                "organization_slug": self.project.organization.slug,
             },
         )
         response = self.client.get(url, format="json")
@@ -64,15 +68,15 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["id"] == str(self.cur_event.event_id)
         assert response.data["nextEventID"] == str(self.next_event.event_id)
         assert response.data["previousEventID"] == str(self.prev_event.event_id)
-        assert response.data["groupID"] == str(self.cur_event.group.id)
+        assert response.data["groupID"] == str(self.cur_group.id)
 
     def test_snuba_no_prev(self):
         url = reverse(
             "sentry-api-0-project-event-details",
             kwargs={
                 "event_id": self.prev_event.event_id,
-                "project_slug": self.prev_event.project.slug,
-                "organization_slug": self.prev_event.project.organization.slug,
+                "project_slug": self.project.slug,
+                "organization_slug": self.project.organization.slug,
             },
         )
         response = self.client.get(url, format="json")
@@ -81,15 +85,15 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["id"] == str(self.prev_event.event_id)
         assert response.data["previousEventID"] is None
         assert response.data["nextEventID"] == self.cur_event.event_id
-        assert response.data["groupID"] == str(self.prev_event.group.id)
+        assert response.data["groupID"] == str(self.cur_group.id)
 
     def test_snuba_with_environment(self):
         url = reverse(
             "sentry-api-0-project-event-details",
             kwargs={
                 "event_id": self.cur_event.event_id,
-                "project_slug": self.cur_event.project.slug,
-                "organization_slug": self.cur_event.project.organization.slug,
+                "project_slug": self.project.slug,
+                "organization_slug": self.project.organization.slug,
             },
         )
         response = self.client.get(
@@ -100,15 +104,15 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["id"] == str(self.cur_event.event_id)
         assert response.data["previousEventID"] is None
         assert response.data["nextEventID"] == self.next_event.event_id
-        assert response.data["groupID"] == str(self.prev_event.group.id)
+        assert response.data["groupID"] == str(self.cur_group.id)
 
     def test_ignores_different_group(self):
         url = reverse(
             "sentry-api-0-project-event-details",
             kwargs={
                 "event_id": self.next_event.event_id,
-                "project_slug": self.next_event.project.slug,
-                "organization_slug": self.next_event.project.organization.slug,
+                "project_slug": self.project.slug,
+                "organization_slug": self.project.organization.slug,
             },
         )
         response = self.client.get(url, format="json")
@@ -116,6 +120,70 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(self.next_event.event_id)
         assert response.data["nextEventID"] is None
+
+
+@region_silo_test
+class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTest):
+    def setup_data(self):
+        one_min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
+        three_min_ago = iso_format(before_now(minutes=3))
+        four_min_ago = iso_format(before_now(minutes=4))
+
+        prev_event_id = "a" * 32
+        self.prev_event, prev_group_info = process_event_and_issue_occurrence(
+            self.build_occurrence_data(
+                event_id=prev_event_id, project_id=self.project.id, fingerprint=["group-1"]
+            ),
+            {
+                "event_id": prev_event_id,
+                "project_id": self.project.id,
+                "timestamp": four_min_ago,
+                "message_timestamp": four_min_ago,
+            },
+        )
+
+        cur_event_id = "b" * 32
+        self.cur_event, cur_group_info = process_event_and_issue_occurrence(
+            self.build_occurrence_data(
+                event_id=cur_event_id, project_id=self.project.id, fingerprint=["group-1"]
+            ),
+            {
+                "event_id": cur_event_id,
+                "project_id": self.project.id,
+                "timestamp": three_min_ago,
+                "message_timestamp": three_min_ago,
+            },
+        )
+        self.cur_group = cur_group_info.group
+
+        next_event_id = "c" * 32
+        self.next_event, next_group_info = process_event_and_issue_occurrence(
+            self.build_occurrence_data(
+                event_id=next_event_id, project_id=self.project.id, fingerprint=["group-1"]
+            ),
+            {
+                "event_id": next_event_id,
+                "project_id": self.project.id,
+                "timestamp": two_min_ago,
+                "message_timestamp": two_min_ago,
+                "tags": {"environment": "production"},
+            },
+        )
+
+        unrelated_event_id = "d" * 32
+        process_event_and_issue_occurrence(
+            self.build_occurrence_data(
+                event_id=unrelated_event_id, project_id=self.project.id, fingerprint=["group-2"]
+            ),
+            {
+                "event_id": unrelated_event_id,
+                "project_id": self.project.id,
+                "timestamp": one_min_ago,
+                "message_timestamp": one_min_ago,
+                "tags": {"environment": "production"},
+            },
+        )[0]
 
 
 @region_silo_test


### PR DESCRIPTION
Adds support for fetching next/prev event for the issue platform. I also noticed that we're not properly resetting our dataset in snuba after tests, which was causing test instability.

Resolves https://github.com/getsentry/sentry/issues/42278


