### PR TITLE
ref(js): Improve TimeSince props

### DIFF
--- a/docs-ui/stories/components/timeSince.stories.js
+++ b/docs-ui/stories/components/timeSince.stories.js
@@ -12,12 +12,10 @@ export const _TimeSince = args => {
 
 _TimeSince.args = {
   date: new Date('Oct 31, 2020 9:00:00 PM UTC'),
-  disabledAbsoluteTooltip: false,
-  extraShort: false,
-  shorten: false,
   suffix: '',
+  disabledAbsoluteTooltip: false,
   tooltipShowSeconds: false,
-  tooltipTitle: null,
+  tooltipPrefix: null,
   tooltipUnderlineColor: 'black',
 };
 _TimeSince.argTypes = {

--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -30,7 +30,7 @@ const EVENT_ROUND_LIMIT = 1000;
 function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
   const {reason, reason_details: reasonDetails, date_added: dateAdded} = inbox;
   const relativeDateAdded = getDynamicText({
-    value: dateAdded && getRelativeDate(dateAdded, 'ago', true),
+    value: dateAdded && getRelativeDate(dateAdded, 'ago', 'short'),
     fixed: '3s ago',
   });
 
@@ -171,7 +171,12 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
       {showDateAdded && dateAdded && (
         <Fragment>
           <Separator type={tagType ?? 'default'}>{' | '}</Separator>
-          <TimeSince date={dateAdded} suffix="" extraShort disabledAbsoluteTooltip />
+          <TimeSince
+            date={dateAdded}
+            suffix=""
+            unitStyle="extraShort"
+            disabledAbsoluteTooltip
+          />
         </Fragment>
       )}
     </StyledTag>

--- a/static/app/components/group/inboxBadges/timesTag.tsx
+++ b/static/app/components/group/inboxBadges/timesTag.tsx
@@ -25,10 +25,10 @@ const TimesTag = ({lastSeen, firstSeen}: Props) => {
         getDynamicText({
           value: (
             <TimeSince
-              tooltipTitle={t('Last Seen')}
+              tooltipPrefix={t('Last Seen')}
               date={lastSeen}
               suffix={t('ago')}
-              shorten
+              unitStyle="short"
             />
           ),
           fixed: '10s ago',
@@ -40,11 +40,11 @@ const TimesTag = ({lastSeen, firstSeen}: Props) => {
         getDynamicText({
           value: (
             <TimeSince
-              tooltipTitle={t('First Seen')}
+              tooltipPrefix={t('First Seen')}
               date={firstSeen}
               suffix={t('old')}
               className="hidden-xs hidden-sm"
-              shorten
+              unitStyle="short"
             />
           ),
           fixed: '10s old',

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -395,10 +395,10 @@ function BaseGroupRow({
     <Placeholder height="18px" />
   ) : (
     <TimeSince
-      tooltipTitle={t('Last Triggered')}
+      tooltipPrefix={t('Last Triggered')}
       date={lastTriggeredDate}
       suffix={t('ago')}
-      shorten
+      unitStyle="short"
     />
   );
 

--- a/static/app/components/timeSince.spec.tsx
+++ b/static/app/components/timeSince.spec.tsx
@@ -19,12 +19,12 @@ describe('TimeSince', function () {
   });
 
   it('renders a shortened date', () => {
-    render(<TimeSince shorten date={tenMinAgo} />);
+    render(<TimeSince unitStyle="short" date={tenMinAgo} />);
     expect(screen.getByText('10min ago')).toBeInTheDocument();
   });
 
   it('renders a extrashort date', () => {
-    render(<TimeSince shorten extraShort date={tenMinAgo} />);
+    render(<TimeSince unitStyle="extraShort" date={tenMinAgo} />);
     expect(screen.getByText('10m ago')).toBeInTheDocument();
   });
 
@@ -34,7 +34,7 @@ describe('TimeSince', function () {
   });
 
   it('renders a spanish suffix with shortened', () => {
-    render(<TimeSince shorten extraShort date={tenMinAgo} suffix="atrás" />);
+    render(<TimeSince unitStyle="extraShort" date={tenMinAgo} suffix="atrás" />);
     expect(screen.getByText('10m atrás')).toBeInTheDocument();
   });
 });

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -18,6 +18,8 @@ function getDateObj(date: RelaxedDateType): Date {
 
 type RelaxedDateType = string | number | Date;
 
+type UnitStyle = 'default' | 'short' | 'extraShort';
+
 interface Props extends React.TimeHTMLAttributes<HTMLTimeElement> {
   /**
    * The date value, can be string, number (e.g. timestamp), or instance of Date
@@ -29,23 +31,35 @@ interface Props extends React.TimeHTMLAttributes<HTMLTimeElement> {
    */
   disabledAbsoluteTooltip?: boolean;
   /**
-   * Shortens the shortened relative time
-   * min to m, hr to h
-   */
-  extraShort?: boolean;
-  /**
-   * For relative time shortens minutes to min, hour to hr etc.
-   */
-  shorten?: boolean;
-  /**
    * Suffix after elapsed time e.g. "ago" in "5 minutes ago"
    */
   suffix?: string;
-
+  /**
+   * Customize the tooltip content. This replaces the long form of the timestamp
+   * completely.
+   */
   tooltipBody?: React.ReactNode;
+  /**
+   * Prefix content to add to the tooltip. Useful to indicate what the relative
+   * time is for
+   */
+  tooltipPrefix?: React.ReactNode;
+  /**
+   * Include seconds in the tooltip
+   */
   tooltipShowSeconds?: boolean;
-  tooltipTitle?: React.ReactNode;
+  /**
+   * Change the color of the underline
+   */
   tooltipUnderlineColor?: ColorOrAlias;
+  /**
+   * How much text should be used for the relative sufixx:
+   *
+   * default:    hour, minute, second
+   * short:      hr, min, sec
+   * extraShort: h, m, s
+   */
+  unitStyle?: UnitStyle;
 }
 
 function TimeSince({
@@ -53,18 +67,17 @@ function TimeSince({
   suffix = t('ago'),
   disabledAbsoluteTooltip,
   tooltipShowSeconds,
-  tooltipTitle,
+  tooltipPrefix: tooltipTitle,
   tooltipBody,
   tooltipUnderlineColor,
-  shorten,
-  extraShort,
+  unitStyle,
   ...props
 }: Props) {
   const tickerRef = useRef<number | undefined>();
 
   const computeRelativeDate = useCallback(
-    () => getRelativeDate(date, suffix, shorten, extraShort),
-    [date, suffix, shorten, extraShort]
+    () => getRelativeDate(date, suffix, unitStyle),
+    [date, suffix, unitStyle]
   );
 
   const [relative, setRelative] = useState<string>(computeRelativeDate());
@@ -122,18 +135,20 @@ export default TimeSince;
 export function getRelativeDate(
   currentDateTime: RelaxedDateType,
   suffix?: string,
-  shorten?: boolean,
-  extraShort?: boolean
+  unitStyle: UnitStyle = 'default'
 ): string {
   const date = getDateObj(currentDateTime);
 
-  if ((shorten || extraShort) && suffix) {
+  const shorten = unitStyle === 'short';
+  const extraShort = unitStyle === 'extraShort';
+
+  if (unitStyle !== 'default' && suffix) {
     return t('%(time)s %(suffix)s', {
       time: getDuration(moment().diff(moment(date), 'seconds'), 0, shorten, extraShort),
       suffix,
     });
   }
-  if ((shorten || extraShort) && !suffix) {
+  if (unitStyle !== 'default' && !suffix) {
     return getDuration(moment().diff(moment(date), 'seconds'), 0, shorten, extraShort);
   }
   if (!suffix) {

--- a/static/app/views/alerts/list/incidents/row.tsx
+++ b/static/app/views/alerts/list/incidents/row.tsx
@@ -54,7 +54,7 @@ function AlertListRow({incident, projectsLoaded, projects, organization}: Props)
 
       <NoWrapNumeric>
         {getDynamicText({
-          value: <TimeSince date={incident.dateStarted} extraShort />,
+          value: <TimeSince date={incident.dateStarted} unitStyle="extraShort" />,
           fixed: '1w ago',
         })}
       </NoWrapNumeric>

--- a/static/app/views/projectsDashboard/deploys.tsx
+++ b/static/app/views/projectsDashboard/deploys.tsx
@@ -73,7 +73,10 @@ const Deploy = ({deploy, project, shorten}: DeployProps) => (
       {getDynamicText({
         fixed: '3 hours ago',
         value: (
-          <TimeSince date={deploy.dateFinished} shorten={shorten ? shorten : false} />
+          <TimeSince
+            date={deploy.dateFinished}
+            unitStyle={shorten ? 'short' : 'default'}
+          />
         ),
       })}
     </DeployTime>

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -50,7 +50,7 @@ function ReplayMetaData({replayRecord}: Props) {
         {replayRecord ? (
           <Fragment>
             <IconCalendar color="gray300" />
-            <TimeSince date={replayRecord.started_at} shorten />
+            <TimeSince date={replayRecord.started_at} unitStyle="short" />
           </Fragment>
         ) : (
           <HeaderPlaceholder />


### PR DESCRIPTION
* Consolidates `shorten` and `extraShort` to `unitStyle`
* Renames `tooltipTitle` to `tooltipPrefix` to make it more clear
* Adds comments to all the props