### PR TITLE
feat(metrics): Automatically discard bad tags

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -137,8 +137,6 @@ class AuthIdentityHandler:
             "sso.login_attempt",
             tags={
                 "provider": self.provider.key,
-                "organization_id": self.organization.id,
-                "user_id": user.id,
             },
             sample_rate=1.0,
             skip_internal=False,
@@ -156,8 +154,6 @@ class AuthIdentityHandler:
             "sso.login_success",
             tags={
                 "provider": self.provider.key,
-                "organization_id": self.organization.id,
-                "user_id": user.id,
             },
             sample_rate=1.0,
             skip_internal=False,
@@ -880,8 +876,6 @@ class AuthHelper(Pipeline):
                 tags={
                     "flow": self.state.flow,
                     "provider": self.provider.key,
-                    "organization_id": self.organization.id,
-                    "user_id": self.request.user.id,
                 },
                 skip_internal=False,
                 sample_rate=1.0,
@@ -892,8 +886,6 @@ class AuthHelper(Pipeline):
                 tags={
                     "flow": self.state.flow,
                     "provider": self.provider.key,
-                    "organization_id": self.organization.id,
-                    "user_id": self.request.user.id,
                 },
                 skip_internal=False,
                 sample_rate=1.0,
@@ -905,8 +897,6 @@ class AuthHelper(Pipeline):
             extra={
                 "flow": self.state.flow,
                 "provider": self.provider.key,
-                "organization_id": self.organization.id,
-                "user_id": self.request.user.id,
                 "error_message": message,
             },
         )

--- a/src/sentry/auth/idpmigration.py
+++ b/src/sentry/auth/idpmigration.py
@@ -117,7 +117,7 @@ def get_verification_value_from_key(key: str) -> Dict[str, Any] | None:
     verification_value: Dict[str, Any] = json.loads(verification_str)
     metrics.incr(
         "idpmigration.confirmation_success",
-        tags={key: verification_value.get(key) for key in ("provider", "organization_id")},
+        tags={"provider": verification_value.get("provider")},
         sample_rate=1.0,
     )
     return verification_value

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1572,7 +1572,7 @@ SENTRY_METRICS_OPTIONS = {}
 SENTRY_METRICS_SAMPLE_RATE = 1.0
 SENTRY_METRICS_PREFIX = "sentry."
 SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefixes.
-SENTRY_METRICS_WARN_BAD_TAGS = IS_DEV
+SENTRY_METRICS_DISALLOW_BAD_TAGS = IS_DEV
 
 # Metrics product
 SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.postgres.postgres_v2.PostgresIndexer"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1572,6 +1572,7 @@ SENTRY_METRICS_OPTIONS = {}
 SENTRY_METRICS_SAMPLE_RATE = 1.0
 SENTRY_METRICS_PREFIX = "sentry."
 SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefixes.
+SENTRY_METRICS_WARN_BAD_TAGS = IS_DEV
 
 # Metrics product
 SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.postgres.postgres_v2.PostgresIndexer"

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -60,15 +60,18 @@ def _add_global_tags(_all_threads: bool = False, **tags: TagValue) -> List[Tags]
     return stack
 
 
+class BadMetricTags(RuntimeError):
+    pass
+
+
 def _filter_tags(tags: MutableTags) -> MutableTags:
     """Removes unwanted tags from the tag mapping and returns a filtered one."""
     discarded = frozenset(key for key in tags if key.endswith("_id") or key in BAD_TAGS)
     if not discarded:
         return tags
 
-    if settings.SENTRY_METRICS_WARN_BAD_TAGS:
-        logger = logging.getLogger("sentry.metrics")
-        logger.warning("discarded illegal metric tags: %s", sorted(discarded))
+    if settings.SENTRY_METRICS_DISALLOW_BAD_TAGS:
+        raise BadMetricTags("discarded illegal metric tags: %s" % sorted(discarded))
     return {k: v for k, v in tags.items() if k not in discarded}
 
 

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -29,7 +29,14 @@ metrics_skip_all_internal = getattr(settings, "SENTRY_METRICS_SKIP_ALL_INTERNAL"
 metrics_skip_internal_prefixes = tuple(settings.SENTRY_METRICS_SKIP_INTERNAL_PREFIXES)
 
 _BAD_TAGS = frozenset(["event", "project", "group"])
-_METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(["process_message"])
+_METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(
+    [
+        # snuba related tags
+        "process_message",
+        "commit_log_msg_latency",
+        "process_message.normalized",
+    ]
+)
 
 T = TypeVar("T")
 F = TypeVar("F", bound=Callable[..., Any])

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -36,6 +36,8 @@ _METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(
         "commit_log_msg_latency",
         "process_message.normalized",
         "batching_consumer.batch.size",
+        "batching_consumer.batch.flush",
+        "batching_consumer.batch.flush.normalized",
     ]
 )
 

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -34,6 +34,7 @@ _METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(
         # snuba related tags
         "process_message",
         "commit_log_msg_latency",
+        "commit_log_latency",
         "process_message.normalized",
         "batching_consumer.batch.size",
         "batching_consumer.batch.flush",

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -35,6 +35,7 @@ _METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(
         "process_message",
         "commit_log_msg_latency",
         "process_message.normalized",
+        "batching_consumer.batch.size",
     ]
 )
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -119,6 +119,7 @@ def pytest_configure(config):
     settings.CELERY_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE = True
     settings.PICKLED_OBJECT_FIELD_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE = True
     settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+    settings.SENTRY_METRICS_DISALLOW_BAD_TAGS = True
 
     settings.DEBUG_VIEWS = True
     settings.SERVE_UPLOADED_FILES = True

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -60,7 +60,7 @@ def test_global():
     assert metrics._get_current_global_tags() == {}
 
 
-def test_filter_tags(caplog):
+def test_filter_tags_dev(caplog):
     with override_settings(SENTRY_METRICS_WARN_BAD_TAGS=True), caplog.at_level(
         logging.WARNING, logger="sentry.metrics"
     ):
@@ -75,3 +75,14 @@ def test_filter_tags(caplog):
                 "discarded illegal metric tags: ['event', 'foo_id', 'group', 'project']",
             )
         ]
+
+
+def test_filter_tags_prod(caplog):
+    with override_settings(SENTRY_METRICS_WARN_BAD_TAGS=False), caplog.at_level(
+        logging.WARNING, logger="sentry.metrics"
+    ):
+        assert metrics._filter_tags({"foo": "bar"}) == {"foo": "bar"}
+        assert metrics._filter_tags(
+            {"foo": "bar", "foo_id": 42, "project": 42, "group": 99, "event": 22}
+        ) == {"foo": "bar"}
+        assert caplog.record_tuples == []

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -61,19 +61,17 @@ def test_global():
 
 def test_filter_tags_dev():
     with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=True):
-        metrics._filter_tags({"foo": "bar"})
+        metrics._filter_tags("x", {"foo": "bar"})
         with pytest.raises(
             metrics.BadMetricTags,
-            match=r"discarded illegal metric tags: \['event', 'foo_id', 'group', 'project'\]",
+            match=r"discarded illegal metric tags: \['event', 'foo_id', 'project'\] for metric 'x'",
         ):
-            metrics._filter_tags(
-                {"foo": "bar", "foo_id": 42, "project": 42, "group": 99, "event": 22}
-            )
+            metrics._filter_tags("x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22})
 
 
 def test_filter_tags_prod():
     with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=False):
-        assert metrics._filter_tags({"foo": "bar"}) == {"foo": "bar"}
+        assert metrics._filter_tags("x", {"foo": "bar"}) == {"foo": "bar"}
         assert metrics._filter_tags(
-            {"foo": "bar", "foo_id": 42, "project": 42, "group": 99, "event": 22}
+            "x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22}
         ) == {"foo": "bar"}


### PR DESCRIPTION
This PR changes our internal metrics emission to error during development and CI if you are trying to emit tag keys on the internal metrics interface that are commonly associated with high cardinality. Anything ending in `_id` will be rejected, same with the obvious issues of `project` and `event`.

The goal here is to ensure that developers are more cautious about introducing such metrics as the conditionality impact of this can quickly create a high datadog bill.

This also passes on getsentry: https://github.com/getsentry/getsentry/pull/9507