### PR TITLE
test(symbolicator): skipping flakey tests

### DIFF
--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -69,6 +69,7 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
         "organizations:custom-symbol-sources": False,
     }
 
+    @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44459")
     def test_full_minidump(self):
         self.project.update_option("sentry:store_crash_reports", STORE_CRASH_REPORTS_ALL)
         self.upload_symbols()
@@ -142,6 +143,7 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
         insta_snapshot_stacktrace_data(self, event.data)
         assert not EventAttachment.objects.filter(event_id=event.event_id)
 
+    @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44459")
     def test_reprocessing(self):
         # NOTE:
         # When running this test against a local symbolicator instance,

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -77,6 +77,7 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
     def get_event(self, event_id):
         return eventstore.get_event_by_id(self.project.id, event_id)
 
+    @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44459")
     def test_real_resolving(self):
         url = reverse(
             "sentry-api-0-dsym-files",
@@ -109,6 +110,7 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
         assert event.data["culprit"] == "main"
         insta_snapshot_stacktrace_data(self, event.data)
 
+    @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44459")
     def test_debug_id_resolving(self):
         file = File.objects.create(
             name="crash.pdb", type="default", headers={"Content-Type": "text/x-breakpad"}


### PR DESCRIPTION
These tests seem to be flakey to the point where it can fail CI on master.

Please see https://github.com/getsentry/sentry/issues/44459