### PR TITLE
fix(replay): LCP breadcrumbs link to wrong tab

### DIFF
--- a/static/app/utils/replays/hooks/useCrumbHandlers.tsx
+++ b/static/app/utils/replays/hooks/useCrumbHandlers.tsx
@@ -49,6 +49,15 @@ function useCrumbHandlers(startTimestampMs: number = 0) {
         setCurrentTime(relativeTimeInMs(crumb.timestamp, startTimestampMs));
       }
 
+      if (
+        crumb.data &&
+        'action' in crumb.data &&
+        crumb.data.action === 'largest-contentful-paint'
+      ) {
+        setActiveTab('dom');
+        return;
+      }
+
       if ('type' in crumb) {
         switch (crumb.type) {
           case BreadcrumbType.NAVIGATION:


### PR DESCRIPTION
Fix to open DOM Events tab instead of Console

Closes https://github.com/getsentry/sentry/issues/44416
