### PR TITLE
fix(issues): Use tooltip skipWrapper to avoid styled tooltip

### DIFF
--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -32,7 +32,7 @@ function IssueReplayCount({groupId}: Props) {
     count
   );
   return (
-    <StyledTooltip title={count > 50 ? titleOver50 : title50OrLess}>
+    <Tooltip skipWrapper title={count > 50 ? titleOver50 : title50OrLess}>
       <ReplayCountLink
         to={`/organizations/${organization.slug}/issues/${groupId}/replays/`}
         aria-label="replay-count"
@@ -40,17 +40,13 @@ function IssueReplayCount({groupId}: Props) {
         <IconPlay size="xs" />
         {countDisplay}
       </ReplayCountLink>
-    </StyledTooltip>
+    </Tooltip>
   );
 }
 
-const StyledTooltip = styled(Tooltip)`
-  display: flex;
-  align-items: center;
-`;
-
 const ReplayCountLink = styled(Link)`
   display: inline-flex;
+  align-items: center;
   color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
   gap: 0 ${space(0.5)};

--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -46,7 +46,6 @@ function IssueReplayCount({groupId}: Props) {
 
 const ReplayCountLink = styled(Link)`
   display: inline-flex;
-  align-items: center;
   color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
   gap: 0 ${space(0.5)};


### PR DESCRIPTION
skipWrapper removes the span and puts the aria-describedby on the child element