### PR TITLE
feat(loader): Add `JS_SDK_DYNAMIC_LOADER_SDK_VERSION` to config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2529,6 +2529,8 @@ GEOIP_PATH_MMDB = None
 JS_SDK_LOADER_CDN_URL = ""
 # Version of the SDK - Used in header Surrogate-Key sdk/JS_SDK_LOADER_SDK_VERSION
 JS_SDK_LOADER_SDK_VERSION = ""
+# Version of the Dynamic Loader - Used in header Surrogate-Key sdk/JS_SDK_DYNAMIC_LOADER_SDK_VERSION
+JS_SDK_DYNAMIC_LOADER_SDK_VERSION = ""
 # This should be the url pointing to the JS SDK. It may contain up to two "%s".
 # The first "%s" will be replaced with the SDK version, the second one is used
 # to inject a bundle modifier in the JS SDK CDN loader. e.g:


### PR DESCRIPTION
Add `JS_SDK_DYNAMIC_LOADER_SDK_VERSION`, which matches the `JS_SDK_LOADER_SDK_VERSION` set. This will be used to set the `Surrogate-Key` for fastly caches (meaning we can on demand purge the cache for the dynamic sdk loader template)

ref https://github.com/getsentry/sentry/issues/44225