### PR TITLE
fix(replay): `crumb.data` can be a primitive

### DIFF
--- a/static/app/components/replays/breadcrumbs/utils.tsx
+++ b/static/app/components/replays/breadcrumbs/utils.tsx
@@ -4,7 +4,7 @@ import {BreadcrumbType, Crumb} from 'sentry/types/breadcrumbs';
  * Generate breadcrumb descriptions based on type
  */
 export function getDescription(crumb: Crumb, startTimestampMs?: number) {
-  if (crumb.data && 'action' in crumb.data) {
+  if (typeof crumb.data === 'object' && crumb.data !== null && 'action' in crumb.data) {
     switch (crumb.data.action) {
       case 'largest-contentful-paint':
         if (crumb.timestamp && startTimestampMs) {
@@ -31,7 +31,12 @@ export function getDescription(crumb: Crumb, startTimestampMs?: number) {
  */
 export function getTitle(crumb: Crumb) {
   // Supports replay specific breadcrumbs
-  if (crumb.data && 'label' in crumb.data && crumb.data.label) {
+  if (
+    typeof crumb.data === 'object' &&
+    crumb.data !== null &&
+    'label' in crumb.data &&
+    crumb.data.label
+  ) {
     return crumb.data.label;
   }
 


### PR DESCRIPTION
Quick fix for `getTitle` throwing when `crumb.data` is a primitive (e.g. boolean).

We should update the typing to be `unknown` since custom breadcrumbs can have `data` be anything.

Fixes JAVASCRIPT-2DAP
