### PR TITLE
fix(view-hierarchy): Navigating to out of view nodes

### DIFF
--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -192,4 +192,12 @@ describe('View Hierarchy', function () {
       screen.getByText('There is no view hierarchy data to visualize')
     ).toBeInTheDocument();
   });
+
+  it('renders with depth markers', function () {
+    const {container} = render(
+      <ViewHierarchy viewHierarchy={MOCK_DATA} project={project} />
+    );
+
+    expect(container).toSnapshot();
+  });
 });

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -12,12 +12,37 @@ import {
   useVirtualizedTree,
   UseVirtualizedTreeProps,
 } from 'sentry/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree';
+import {VirtualizedTreeRenderedRow} from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
 
 import {DetailsPanel} from './detailsPanel';
 import {RenderingSystem} from './renderingSystem';
 
 function getNodeLabel({identifier, type}: ViewHierarchyWindow) {
   return identifier ? `${type} - ${identifier}` : type;
+}
+
+function onScrollToNode(
+  node: VirtualizedTreeRenderedRow<ViewHierarchyWindow>,
+  scrollContainer: HTMLElement | null,
+  coordinates: {depth: number; top: number} | undefined
+) {
+  if (node) {
+    // When a user keyboard navigates to a node that's rendered in the "overscroll"
+    const lastCell = node.ref?.lastChild as HTMLElement | null | undefined;
+    if (lastCell) {
+      lastCell.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+      });
+    }
+  } else if (coordinates) {
+    // When a user clicks on a wireframe node that's not rendered in the "overscroll"
+    // we need to scroll to where the node would be rendered
+    const left = coordinates.depth * 16;
+    scrollContainer?.scrollBy({
+      left,
+    });
+  }
 }
 
 export type ViewHierarchyWindow = {
@@ -97,26 +122,6 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
       </TreeItem>
     );
   };
-
-  const onScrollToNode = useCallback((node, scrollContainer, coordinates) => {
-    if (node) {
-      // When a user keyboard navigates to a node that's rendered in the "overscroll"
-      const lastCell = node.ref?.lastChild as HTMLElement | null | undefined;
-      if (lastCell) {
-        lastCell.scrollIntoView({
-          block: 'nearest',
-          inline: 'nearest',
-        });
-      }
-    } else if (coordinates) {
-      // When a user clicks on a wireframe node that's not rendered in the "overscroll"
-      // we need to scroll to where the node would be rendered
-      const left = coordinates.depth * 16;
-      scrollContainer?.scrollBy({
-        left,
-      });
-    }
-  }, []);
 
   const {
     renderedItems,


### PR DESCRIPTION
We need to add custom code to handle horizontal scrolling when elements are out of view

e.g. when a user keyboard navigation up/down or when a wireframe node is clicked

Also replaces the divs I was using for depth markers for a single div with a repeating background. This improved performance significantly on deep trees.

Before:

https://user-images.githubusercontent.com/22846452/218544944-97a03273-e0fc-4ab9-8827-2573588a61f9.mov


After:

https://user-images.githubusercontent.com/22846452/218544993-7b0a714c-0f49-4294-917a-ddef5f3f0db5.mov

