### PR TITLE
fix(profiling): remove throw when switching

### DIFF
--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -120,15 +120,9 @@ export class Flamegraph {
         break;
       }
       case 'alphabetical':
-        if (this.profile.type === 'flamechart') {
-          throw new TypeError('Flamechart does not support alphabetical sorting');
-        }
         this.frames = this.buildSortedChart(profile, alphabeticTreeSort);
         break;
       case 'call order':
-        if (this.profile.type === 'flamegraph') {
-          throw new TypeError('Flamegraph does not support call order sorting');
-        }
         this.frames = this.buildCallOrderChart(profile);
         break;
       default:


### PR DESCRIPTION
Avoid throwing because profileGroup re-imports the profile group as a consequence of a useEffect. This means that for a brief moment we have an overlap between the types.