### PR TITLE
fix(profiling): alternative import type

### DIFF
--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -120,9 +120,15 @@ export class Flamegraph {
         break;
       }
       case 'alphabetical':
+        if (this.profile.type === 'flamechart') {
+          throw new TypeError('Flamechart does not support alphabetical sorting');
+        }
         this.frames = this.buildSortedChart(profile, alphabeticTreeSort);
         break;
       case 'call order':
+        if (this.profile.type === 'flamegraph') {
+          throw new TypeError('Flamegraph does not support call order sorting');
+        }
         this.frames = this.buildCallOrderChart(profile);
         break;
       default:

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -120,15 +120,9 @@ export class Flamegraph {
         break;
       }
       case 'alphabetical':
-        if (this.profile.type === 'flamechart') {
-          throw new TypeError('Flamechart does not support alphabetical sorting');
-        }
         this.frames = this.buildSortedChart(profile, alphabeticTreeSort);
         break;
       case 'call order':
-        if (this.profile.type === 'flamegraph') {
-          throw new TypeError('Flamegraph does not support call order sorting');
-        }
         this.frames = this.buildCallOrderChart(profile);
         break;
       default:

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -98,12 +98,14 @@ export function memoizeByReference<Arguments, Value>(
   };
 }
 
-export function memoizeVariadicByReference<Arguments, Value>(
-  fn: (...args: ReadonlyArray<Arguments>) => Value
-): (...t: ReadonlyArray<Arguments>) => Value {
-  let cache: Cache<ReadonlyArray<Arguments>, Value> | null = null;
+type Arguments<F extends Function> = F extends (...args: infer A) => any ? A : never;
 
-  return function memoizeByReferenceCallback(...args: ReadonlyArray<Arguments>) {
+export function memoizeVariadicByReference<T extends (...args) => V, V = ReturnType<T>>(
+  fn: T
+): (...t: Arguments<T>) => V {
+  let cache: Cache<Arguments<T>, V> | null = null;
+
+  return function memoizeByReferenceCallback(...args: Arguments<T>): V {
     // If this is the first run then eval the fn and cache the result
     if (!cache) {
       cache = {args, value: fn(...args)};


### PR DESCRIPTION
~Alternative to https://github.com/getsentry/sentry/pull/44506, benefits of this approach is that we only re-import once and the state is synchronously propagated to the children.~

Why did I forget useMemo exists, I do not know, but we should use it here instead.