### PR TITLE
feat(attachment): recognize .log files as text/plain mimetype

### DIFF
--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -109,6 +109,7 @@ def configure(ctx, py, yaml, skip_service_validation=False):
         ("application/x-font-ttf", "ttc"),
         ("font/opentype", "otf"),
         ("image/svg+xml", "svg"),
+        ("text/plain", "log"),
     ):
         mimetypes.add_type(type, "." + ext)
 


### PR DESCRIPTION
Should fix #38189

As I understand the guess of mimetype occurs here: https://github.com/getsentry/sentry/blob/184fa3bfd28266e7bd91abe4b2b3bdf6d11825a2/src/sentry/models/eventattachment.py#L53-L61

And by default `mimetypes.guess_type("test.log")` would return `(None, None)` instead of `('text/plain', None)`, ending up with `application/octet-stream` as the MIME type for `.log` files in the API.

And then right here the `.log` file would have been previously guessed as non-previewable in the UI:
https://github.com/getsentry/sentry/blob/184fa3bfd28266e7bd91abe4b2b3bdf6d11825a2/static/app/components/events/eventAttachments.tsx#L38-L56

So this change should let `mimetypes` detect this file type properly and fix the aforementioned issue (that is assuming the `Content-Type` header, wherever it comes from, wouldn't override it either...).

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
