### PR TITLE
fix(profiling): use minmax on profiling landing panelsgrid

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -268,11 +268,10 @@ const ActionBar = styled('div')`
 // TODO: another simple primitive that can easily be <Grid columns={2} />
 const PanelsGrid = styled('div')`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) 1fr;
   gap: ${space(2)};
-
   @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 `;
 


### PR DESCRIPTION
## Summary
This fixes overflow behaviour of the current panelgrid when dealing with long text.
![image](https://user-images.githubusercontent.com/7349258/218527780-9c635b2e-63c1-43c5-896d-fbf0ca145a01.png)
![image](https://user-images.githubusercontent.com/7349258/218527820-58535f6b-bee5-4989-bbc7-abfc131ac967.png)
![image](https://user-images.githubusercontent.com/7349258/218527861-62d4f84d-509b-4056-8826-bdb7549c07f9.png)


