### PR TITLE
feat(roles): refactor get_top_dogs 2

### DIFF
--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -12,7 +12,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
 from sentry.models import OrganizationMember
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.utils.email import MessageBuilder
 from sentry.utils.signing import sign
 
@@ -56,25 +55,14 @@ class ProjectTransferEndpoint(ProjectEndpoint):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         try:
-            owner = OrganizationMember.objects.filter(
-                user__email__iexact=email, role=roles.get_top_dog().id, user__is_active=True
+            owner = OrganizationMember.objects.get_members_by_email_and_role(
+                email=email, role=roles.get_top_dog().id
             )[0]
         except IndexError:
-            try:
-                org_members = list(
-                    OrganizationMember.objects.filter(
-                        user__email__iexact=email, user__is_active=True
-                    ).values_list("id", flat=True)
-                )
-                org_member_id = OrganizationMemberTeam.objects.filter(
-                    team_id__org_role=roles.get_top_dog().id, organizationmember_id__in=org_members
-                )[0].organizationmember_id
-                owner = OrganizationMember.objects.filter(id=org_member_id)[0]
-            except IndexError:
-                return Response(
-                    {"detail": "Could not find an organization owner with that email"},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
+            return Response(
+                {"detail": "Could not find an organization owner with that email"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         organization = project.organization
         transaction_id = uuid4().hex

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -7,7 +7,7 @@ from typing import FrozenSet, Optional, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.db.models.signals import post_delete
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
@@ -283,11 +283,22 @@ class Organization(Model, SnowflakeIdMixin):
         }
 
     def get_owners(self) -> Sequence[APIUser]:
+        # get owner teams
+        owner_teams = self.get_teams_with_org_role(role=roles.get_top_dog().id)
 
-        owner_memberships = OrganizationMember.objects.filter(
-            role=roles.get_top_dog().id, organization=self
+        # get owners from owner teams
+        owner_team_members = list(
+            OrganizationMemberTeam.objects.filter(
+                team_id__in=owner_teams,
+            ).values_list("organizationmember_id", flat=True)
+        )
+
+        # get owners from org role
+        owners = self.member_set.filter(
+            Q(role=roles.get_top_dog().id) | Q(id__in=owner_team_members)
         ).values_list("user_id", flat=True)
-        return user_service.get_many(filter={"user_ids": owner_memberships})
+
+        return user_service.get_many(filter={"user_ids": owners})
 
     def get_default_owner(self) -> APIUser:
         if not hasattr(self, "_default_owner"):

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -284,7 +284,7 @@ class Organization(Model, SnowflakeIdMixin):
 
     def get_owners(self) -> Sequence[APIUser]:
         # get owner teams
-        owner_teams = self.get_teams_with_org_role(role=roles.get_top_dog().id)
+        owner_teams = self.get_teams_with_org_role(roles=[roles.get_top_dog().id])
 
         # get owners from owner teams
         owner_team_members = list(
@@ -634,11 +634,11 @@ class Organization(Model, SnowflakeIdMixin):
             scopes.discard("alerts:write")
         return frozenset(scopes)
 
-    def get_teams_with_org_role(self, role):
+    def get_teams_with_org_role(self, roles):
         from sentry.models.team import Team
 
-        if role:
-            return Team.objects.filter(org_role=role, organization=self)
+        if roles:
+            return Team.objects.filter(org_role__in=roles, organization=self)
 
         return Team.objects.filter(organization=self).exclude(org_role=None)
 

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -32,7 +32,9 @@ from sentry.db.models import (
 from sentry.db.models.utils import slugify_instance
 from sentry.locks import locks
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
+from sentry.models.team import Team
 from sentry.roles.manager import Role
 from sentry.services.hybrid_cloud.user import APIUser, user_service
 from sentry.utils.http import is_using_customer_domain

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from enum import IntEnum
-from typing import FrozenSet, Iterable, Optional, Sequence
+from typing import Collection, FrozenSet, Optional, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
@@ -344,14 +344,9 @@ class Organization(Model, SnowflakeIdMixin):
         return self._default_owner_id
 
     def has_single_owner(self):
-        owners = list(
-            self.get_members_with_org_roles(roles=[roles.get_top_dog().id]).values_list(
-                "id", flat=True
-            )
-        )
-        return len(owners[:2]) == 1
+        return self.get_members_with_org_roles(roles=[roles.get_top_dog().id]).count() == 1
 
-    def get_members_with_org_roles(self, roles: Iterable[str]) -> QuerySet:
+    def get_members_with_org_roles(self, roles: Collection[str]) -> QuerySet:
         members_with_role = OrganizationMember.objects.filter(
             organization=self,
             role__in=roles,
@@ -677,10 +672,10 @@ class Organization(Model, SnowflakeIdMixin):
             scopes.discard("alerts:write")
         return frozenset(scopes)
 
-    def get_teams_with_org_roles(self, roles: Optional[Iterable[str]] = None):
+    def get_teams_with_org_roles(self, roles: Optional[Collection[str]] = None):
         from sentry.models.team import Team
 
-        if roles:
+        if roles is not None:
             return Team.objects.filter(org_role__in=roles, organization=self)
 
         return Team.objects.filter(organization=self).exclude(org_role=None)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -348,18 +348,18 @@ class Organization(Model, SnowflakeIdMixin):
 
     def get_members_with_org_roles(self, roles: Collection[str]) -> QuerySet:
         members_with_role = set(
-            OrganizationMember.objects.filter(
-                organization=self,
+            self.member_set.filter(
                 role__in=roles,
                 user__isnull=False,
                 user__is_active=True,
             ).values_list("id", flat=True)
         )
 
+        teams_with_org_role = self.get_teams_with_org_roles(roles).values_list("id", flat=True)
         members_on_teams_with_role = set(
-            OrganizationMemberTeam.objects.filter(
-                team__in=self.get_teams_with_org_roles(roles)
-            ).values_list("organizationmember__id", flat=True)
+            OrganizationMemberTeam.objects.filter(team_id__in=teams_with_org_role).values_list(
+                "organizationmember__id", flat=True
+            )
         )
 
         return OrganizationMember.objects.filter(

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from enum import IntEnum
-from typing import FrozenSet, Optional, Sequence
+from typing import FrozenSet, Iterable, Optional, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 from django.db.models.signals import post_delete
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
@@ -283,20 +283,9 @@ class Organization(Model, SnowflakeIdMixin):
         }
 
     def get_owners(self) -> Sequence[APIUser]:
-        # get owner teams
-        owner_teams = self.get_teams_with_org_role(roles=[roles.get_top_dog().id])
-
-        # get owners from owner teams
-        owner_team_members = list(
-            OrganizationMemberTeam.objects.filter(
-                team_id__in=owner_teams,
-            ).values_list("organizationmember_id", flat=True)
+        owners = self.get_members_with_org_roles(roles=[roles.get_top_dog().id]).values_list(
+            "user_id", flat=True
         )
-
-        # get owners from org role
-        owners = self.member_set.filter(
-            Q(role=roles.get_top_dog().id) | Q(id__in=owner_team_members)
-        ).values_list("user_id", flat=True)
 
         return user_service.get_many(filter={"user_ids": owners})
 
@@ -319,12 +308,30 @@ class Organization(Model, SnowflakeIdMixin):
         return self._default_owner_id
 
     def has_single_owner(self):
-        from sentry.models import OrganizationMember
+        owners = list(
+            self.get_members_with_org_roles(roles=[roles.get_top_dog().id]).values_list(
+                "id", flat=True
+            )
+        )
+        return len(owners[:2]) == 1
 
-        count = OrganizationMember.objects.filter(
-            organization=self, role=roles.get_top_dog().id, user__isnull=False, user__is_active=True
-        )[:2].count()
-        return count == 1
+    def get_members_with_org_roles(self, roles: Iterable[str]) -> QuerySet:
+        members_with_role = OrganizationMember.objects.filter(
+            organization=self,
+            role__in=roles,
+            user__isnull=False,
+            user__is_active=True,
+        )
+        members_on_teams_with_role = (
+            OrganizationMemberTeam.objects.filter(team__in=self.get_teams_with_org_roles(roles))
+            .exclude(organizationmember_id__in=list(members_with_role.values_list("id", flat=True)))
+            .values_list("organizationmember__id", flat=True)
+        )
+
+        # union of querysets, is distinct
+        return members_with_role | OrganizationMember.objects.filter(
+            id__in=members_on_teams_with_role
+        )
 
     def merge_to(from_org, to_org):
         from sentry.models import (
@@ -634,7 +641,7 @@ class Organization(Model, SnowflakeIdMixin):
             scopes.discard("alerts:write")
         return frozenset(scopes)
 
-    def get_teams_with_org_role(self, roles):
+    def get_teams_with_org_roles(self, roles: Optional[Iterable[str]] = None):
         from sentry.models.team import Team
 
         if roles:

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -539,7 +539,9 @@ class OrganizationMember(Model):
             .exclude(id=self.id)
             .exists()
         ) and not OrganizationMemberTeam.objects.filter(
-            team__in=self.organization.get_teams_with_org_role(organization_roles.get_top_dog().id)
+            team__in=self.organization.get_teams_with_org_role(
+                roles=[organization_roles.get_top_dog().id]
+            )
         ).exclude(
             organizationmember_id=self.id
         ).exists()

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
@@ -18,7 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 from structlog import get_logger
 
 from bitfield import BitField
-from sentry import features
+from sentry import features, roles
 from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -101,6 +101,20 @@ class OrganizationMemberManager(BaseManager):
         for user_id, team_id in queryset:
             user_teams[user_id].append(team_id)
         return user_teams
+
+    def get_members_by_email_and_role(self, email: str, role: str) -> QuerySet:
+        from sentry.models import OrganizationMemberTeam
+
+        org_members = list(
+            self.filter(user__email__iexact=email, user__is_active=True).values_list(
+                "id", flat=True
+            )
+        )
+        team_members = OrganizationMemberTeam.objects.filter(
+            team_id__org_role=role, organizationmember_id__in=org_members
+        ).values_list("organizationmember_id")
+
+        return self.filter(Q(role=role, id__in=org_members) | Q(id__in=team_members))
 
 
 @region_silo_only_model
@@ -526,23 +540,10 @@ class OrganizationMember(Model):
         if organization_roles.get_top_dog().id not in self.get_all_org_roles():
             return False
 
-        from sentry.models import OrganizationMemberTeam
-
-        # check if any other member has the owner role, including through a team
-        is_only_owner = (
-            not OrganizationMember.objects.filter(
-                organization=self.organization_id,
-                role=organization_roles.get_top_dog().id,
-                user__isnull=False,
-                user__is_active=True,
-            )
+        # check if any other member has the owner role, including through a team\-
+        is_only_owner = not (
+            self.organization.get_members_with_org_roles(roles=[roles.get_top_dog().id])
             .exclude(id=self.id)
             .exists()
-        ) and not OrganizationMemberTeam.objects.filter(
-            team__in=self.organization.get_teams_with_org_role(
-                roles=[organization_roles.get_top_dog().id]
-            )
-        ).exclude(
-            organizationmember_id=self.id
-        ).exists()
+        )
         return is_only_owner

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -110,7 +110,7 @@ class OrganizationMemberManager(BaseManager):
         )
         team_members = OrganizationMemberTeam.objects.filter(
             team_id__org_role=role, organizationmember__in=org_members
-        ).values_list("organizationmember_id")
+        ).values_list("organizationmember_id", flat=True)
 
         return self.filter(Q(role=role, id__in=org_members) | Q(id__in=team_members))
 

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -105,18 +105,16 @@ class OrganizationMemberManager(BaseManager):
     def get_members_by_email_and_role(self, email: str, role: str) -> QuerySet:
         from sentry.models import OrganizationMemberTeam
 
-        org_members = set(
-            self.filter(user__email__iexact=email, user__is_active=True).values_list(
-                "id", flat=True
-            )
-        )
+        org_members = self.filter(user__email__iexact=email, user__is_active=True)
         team_members = set(
             OrganizationMemberTeam.objects.filter(
-                team_id__org_role=role, organizationmember__in=org_members
+                team_id__org_role=role,
+                organizationmember_id__in=org_members.values_list("id", flat=True),
             ).values_list("organizationmember_id", flat=True)
         )
 
-        return self.filter(org_members.union(team_members))
+        org_members = set(org_members.filter(role=role).values_list("id", flat=True))
+        return self.filter(id__in=org_members.union(team_members))
 
 
 @region_silo_only_model

--- a/src/sentry/notifications/notifications/strategies/owner_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/owner_recipient_strategy.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from django.db.models import Q
-
 from sentry import roles
 from sentry.models import OrganizationMember
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 
 from .role_based_recipient_strategy import RoleBasedRecipientStrategy
 
@@ -14,17 +11,9 @@ from .role_based_recipient_strategy import RoleBasedRecipientStrategy
 class OwnerRecipientStrategy(RoleBasedRecipientStrategy):
     def determine_member_recipients(self) -> Iterable[OrganizationMember]:
         # Explicitly typing to satisfy mypy.
-        # get owner teams
-        owner_teams = self.organization.get_teams_with_org_role(role=roles.get_top_dog().id)
-
-        # get owners from owner teams
-        owner_team_members = list(
-            OrganizationMemberTeam.objects.filter(
-                team_id__in=owner_teams,
-            ).values_list("organizationmember_id", flat=True)
+        members: Iterable[
+            OrganizationMember
+        ] = OrganizationMember.objects.get_contactable_members_for_org(self.organization.id).filter(
+            role=roles.get_top_dog().id,
         )
-
-        members: Iterable[OrganizationMember] = OrganizationMember.get_contactable_members_for_org(
-            self.organization.id
-        ).filter(Q(role=roles.get_top_dog().id) | Q(id__in=owner_team_members))
         return members

--- a/src/sentry/notifications/notifications/strategies/owner_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/owner_recipient_strategy.py
@@ -15,7 +15,7 @@ class OwnerRecipientStrategy(RoleBasedRecipientStrategy):
     def determine_member_recipients(self) -> Iterable[OrganizationMember]:
         # Explicitly typing to satisfy mypy.
         # get owner teams
-        owner_teams = self.get_teams_with_org_role(role=roles.get_top_dog().id)
+        owner_teams = self.organization.get_teams_with_org_role(role=roles.get_top_dog().id)
 
         # get owners from owner teams
         owner_team_members = list(

--- a/src/sentry/notifications/notifications/strategies/owner_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/owner_recipient_strategy.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import Iterable
 
+from django.db.models import Q
+
 from sentry import roles
 from sentry.models import OrganizationMember
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
 
 from .role_based_recipient_strategy import RoleBasedRecipientStrategy
 
@@ -11,9 +14,17 @@ from .role_based_recipient_strategy import RoleBasedRecipientStrategy
 class OwnerRecipientStrategy(RoleBasedRecipientStrategy):
     def determine_member_recipients(self) -> Iterable[OrganizationMember]:
         # Explicitly typing to satisfy mypy.
-        members: Iterable[
-            OrganizationMember
-        ] = OrganizationMember.objects.get_contactable_members_for_org(self.organization.id).filter(
-            role=roles.get_top_dog().id,
+        # get owner teams
+        owner_teams = self.get_teams_with_org_role(role=roles.get_top_dog().id)
+
+        # get owners from owner teams
+        owner_team_members = list(
+            OrganizationMemberTeam.objects.filter(
+                team_id__in=owner_teams,
+            ).values_list("organizationmember_id", flat=True)
         )
+
+        members: Iterable[OrganizationMember] = OrganizationMember.get_contactable_members_for_org(
+            self.organization.id
+        ).filter(Q(role=roles.get_top_dog().id) | Q(id__in=owner_team_members))
         return members

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -43,6 +43,29 @@ class ProjectTransferTest(APITestCase):
             assert len(mail.outbox) == 1
             assert organization.absolute_url("/accept-transfer/?") in mail.outbox[0].body
 
+    def test_transfer_project_owner_from_team(self):
+        project = self.create_project()
+        organization = project.organization
+
+        new_user = self.create_user("b@example.com")
+        org = self.create_organization(name="New Org")
+        owner_team = self.create_team(organization=org, org_role="owner")
+        self.create_member(organization=org, user=new_user, teams=[owner_team])
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-transfer",
+            kwargs={"organization_slug": organization.slug, "project_slug": project.slug},
+        )
+
+        with self.tasks():
+            response = self.client.post(url, {"email": new_user.email})
+
+            assert response.status_code == 204
+            assert len(mail.outbox) == 1
+            assert organization.absolute_url("/accept-transfer/?") in mail.outbox[0].body
+
     def test_transfer_project_to_invalid_user(self):
         project = self.create_project()
         # new user is not an owner of anything


### PR DESCRIPTION
Fixing #44248 (reverted)

Replace the Queryset unions using | with set unions. This removes the OR from the SQL query, which is slow because the result also needs to be sorted and the org member table is huge.