### PR TITLE
feat(profile-issues): Use issuePlatform dataset for discover queries

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -1,4 +1,5 @@
 import {AggregationOutputType} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 
 import type {Actor, Avatar, ObjectStatus, Scope} from './core';
 import type {OrgExperiments} from './experiments';
@@ -193,6 +194,7 @@ export interface NewQuery {
   projects: Readonly<number[]>;
   version: SavedQueryVersions;
   createdBy?: User;
+  dataset?: DiscoverDatasets;
   display?: string;
   end?: string;
   environment?: Readonly<string[]>;

--- a/static/app/utils/discover/eventView.spec.jsx
+++ b/static/app/utils/discover/eventView.spec.jsx
@@ -5,6 +5,7 @@ import EventView, {
 } from 'sentry/utils/discover/eventView';
 import {
   CHART_AXIS_OPTIONS,
+  DiscoverDatasets,
   DISPLAY_MODE_OPTIONS,
   DisplayModes,
 } from 'sentry/utils/discover/types';
@@ -59,6 +60,7 @@ describe('EventView.fromLocation()', function () {
         environment: ['staging'],
         yAxis: 'p95',
         display: 'previous',
+        dataset: DiscoverDatasets.DISCOVER,
       },
     };
 
@@ -81,6 +83,7 @@ describe('EventView.fromLocation()', function () {
       environment: ['staging'],
       yAxis: 'p95',
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
     });
   });
 
@@ -192,6 +195,7 @@ describe('EventView.fromSavedQuery()', function () {
       orderby: '-id',
       environment: ['staging'],
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
     };
     const eventView = EventView.fromSavedQuery(saved);
 
@@ -213,6 +217,7 @@ describe('EventView.fromSavedQuery()', function () {
       environment: ['staging'],
       yAxis: undefined,
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
     });
 
     const eventView2 = EventView.fromSavedQuery({
@@ -408,6 +413,7 @@ describe('EventView.fromSavedQuery()', function () {
       orderby: '-id',
       environment: ['staging'],
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
       yAxis: ['count()'],
     };
     const eventView = EventView.fromSavedQuery(saved);
@@ -428,6 +434,7 @@ describe('EventView.fromSavedQuery()', function () {
       statsPeriod: '14d',
       environment: ['staging'],
       yAxis: 'count()',
+      dataset: DiscoverDatasets.DISCOVER,
       display: 'previous',
     });
   });
@@ -627,6 +634,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       orderby: '-id',
       environment: ['staging'],
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     const location = {
@@ -657,6 +665,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       environment: ['staging'],
       yAxis: undefined,
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
     });
 
     const savedQuery2 = {...saved, range: undefined};
@@ -701,6 +710,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       orderby: '-id',
       environment: ['staging'],
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     const location = {
@@ -729,6 +739,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       environment: [],
       yAxis: undefined,
       display: 'previous',
+      dataset: DiscoverDatasets.DISCOVER,
     });
   });
 
@@ -1521,6 +1532,7 @@ describe('EventView.toNewQuery()', function () {
     statsPeriod: '14d',
     environment: ['staging'],
     display: 'releases',
+    dataset: DiscoverDatasets.DISCOVER,
   };
 
   it('outputs the right fields', function () {
@@ -1542,6 +1554,7 @@ describe('EventView.toNewQuery()', function () {
       range: '14d',
       environment: ['staging'],
       display: 'releases',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     expect(output).toEqual(expected);
@@ -1571,6 +1584,7 @@ describe('EventView.toNewQuery()', function () {
       range: '14d',
       environment: ['staging'],
       display: 'releases',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     expect(output).toEqual(expected);
@@ -1600,6 +1614,7 @@ describe('EventView.toNewQuery()', function () {
       range: '14d',
       environment: ['staging'],
       display: 'releases',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     expect(output).toEqual(expected);
@@ -1737,6 +1752,7 @@ describe('EventView.clone()', function () {
       environment: ['staging'],
       interval: '5m',
       display: 'releases',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     const eventView = new EventView(state);
@@ -2673,6 +2689,7 @@ describe('EventView.isEqualTo()', function () {
       environment: ['staging'],
       yAxis: 'fam',
       display: 'releases',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     const eventView = new EventView(state);
@@ -2725,6 +2742,7 @@ describe('EventView.isEqualTo()', function () {
       environment: ['staging'],
       yAxis: 'fam',
       display: 'releases',
+      dataset: DiscoverDatasets.DISCOVER,
     };
 
     const differences = {
@@ -2740,6 +2758,7 @@ describe('EventView.isEqualTo()', function () {
       environment: [],
       yAxis: 'ok boomer',
       display: 'previous',
+      dataset: DiscoverDatasets.ISSUE_PLATFORM,
     };
     const eventView = new EventView(state);
 
@@ -2798,6 +2817,7 @@ describe('EventView.getResultsViewUrlTarget()', function () {
     statsPeriod: '14d',
     environment: ['staging'],
     display: 'previous',
+    dataset: DiscoverDatasets.DISCOVER,
   };
   const organization = TestStubs.Organization();
 
@@ -2850,6 +2870,7 @@ describe('EventView.getResultsViewShortUrlTarget()', function () {
     statsPeriod: '14d',
     environment: ['staging'],
     display: 'previous',
+    dataset: DiscoverDatasets.DISCOVER,
   };
   const organization = TestStubs.Organization();
 
@@ -2910,6 +2931,7 @@ describe('EventView.getPerformanceTransactionEventsViewUrlTarget()', function ()
     statsPeriod: '14d',
     environment: ['staging'],
     display: 'previous',
+    dataset: DiscoverDatasets.DISCOVER,
   };
   const organization = TestStubs.Organization();
   const showTransactions = 'p99';

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -37,6 +37,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import {
   CHART_AXIS_OPTIONS,
+  DiscoverDatasets,
   DISPLAY_MODE_FALLBACK_OPTIONS,
   DISPLAY_MODE_OPTIONS,
   DisplayModes,
@@ -298,6 +299,7 @@ class EventView {
   expired?: boolean;
   createdBy: User | undefined;
   additionalConditions: MutableSearch; // This allows views to always add additional conditions to the query to get specific data. It should not show up in the UI unless explicitly called.
+  dataset?: DiscoverDatasets;
 
   constructor(props: {
     additionalConditions: MutableSearch;
@@ -316,6 +318,7 @@ class EventView {
     team: Readonly<('myteams' | number)[]>;
     topEvents: string | undefined;
     yAxis: string | undefined;
+    dataset?: DiscoverDatasets;
     expired?: boolean;
     interval?: string;
     utc?: string | boolean | undefined;
@@ -361,6 +364,7 @@ class EventView {
     this.utc = props.utc;
     this.environment = environment;
     this.yAxis = props.yAxis;
+    this.dataset = props.dataset;
     this.display = props.display;
     this.topEvents = props.topEvents;
     this.interval = props.interval;
@@ -392,6 +396,7 @@ class EventView {
       interval: decodeScalar(location.query.interval),
       createdBy: undefined,
       additionalConditions: new MutableSearch([]),
+      dataset: decodeScalar(location.query.dataset) as DiscoverDatasets,
     });
   }
 
@@ -469,6 +474,7 @@ class EventView {
       createdBy: saved.createdBy,
       expired: saved.expired,
       additionalConditions: new MutableSearch([]),
+      dataset: saved.dataset,
     });
   }
 
@@ -535,6 +541,8 @@ class EventView {
         end: decodeScalar(end),
         statsPeriod: decodeScalar(statsPeriod),
         utc,
+        dataset:
+          (decodeScalar(location.query.dataset) as DiscoverDatasets) ?? saved.dataset,
       });
     }
     return EventView.fromLocation(location);
@@ -554,6 +562,7 @@ class EventView {
       yAxis: 'count()',
       display: DisplayModes.DEFAULT,
       topEvents: '5',
+      dataset: DiscoverDatasets.DISCOVER,
     };
     const keys = Object.keys(defaults).filter(key => !omitList.includes(key));
     for (const key of keys) {
@@ -603,6 +612,7 @@ class EventView {
       range: this.statsPeriod,
       environment: this.environment,
       yAxis: this.yAxis ? [this.yAxis] : undefined,
+      dataset: this.dataset,
       display: this.display,
       topEvents: this.topEvents,
       interval: this.interval,
@@ -688,6 +698,7 @@ class EventView {
       project: this.project,
       query: this.query,
       yAxis: this.yAxis || this.getYAxis(),
+      dataset: this.dataset,
       display: this.display,
       topEvents: this.topEvents,
       interval: this.interval,
@@ -778,6 +789,7 @@ class EventView {
       statsPeriod: this.statsPeriod,
       environment: this.environment,
       yAxis: this.yAxis,
+      dataset: this.dataset,
       display: this.display,
       topEvents: this.topEvents,
       interval: this.interval,
@@ -1172,6 +1184,7 @@ class EventView {
         sort,
         per_page: DEFAULT_PER_PAGE,
         query: queryString,
+        dataset: this.dataset,
       }
     ) as EventQuery & LocationQuery;
 

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -17,6 +17,7 @@ export enum DiscoverDatasets {
   DISCOVER = 'discover',
   METRICS = 'metrics',
   METRICS_ENHANCED = 'metricsEnhanced',
+  ISSUE_PLATFORM = 'issuePlatform',
 }
 
 export const TOP_EVENT_MODES: string[] = [DisplayModes.TOP5, DisplayModes.DAILYTOP5];

--- a/static/app/utils/issueTypeConfig/errorConfig.tsx
+++ b/static/app/utils/issueTypeConfig/errorConfig.tsx
@@ -15,6 +15,7 @@ const errorConfig: IssueCategoryConfigMapping = {
     replays: {enabled: true},
     similarIssues: {enabled: true},
     userFeedback: {enabled: true},
+    usesIssuePlatform: false,
   },
 };
 

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -26,6 +26,7 @@ const BASE_CONFIG: IssueTypeConfig = {
   userFeedback: {enabled: false},
   evidence: {title: t('Evidence')},
   resources: null,
+  usesIssuePlatform: true,
 };
 
 const issueTypeConfig: Config = {

--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -28,6 +28,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
     userFeedback: {enabled: false},
     // Performance issues render a custom SpanEvidence component
     evidence: null,
+    usesIssuePlatform: false,
   },
   [IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES]: {
     resources: {

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -67,6 +67,10 @@ export type IssueTypeConfig = {
    * Is the User Feedback tab shown for this issue
    */
   userFeedback: DisabledWithReasonConfig;
+  /**
+   * Whether or not the issue type is using the issue platform
+   */
+  usesIssuePlatform: boolean;
 };
 
 export interface IssueCategoryConfigMapping

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -43,6 +43,7 @@ import {analytics} from 'sentry/utils/analytics';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {uniqueId} from 'sentry/utils/guid';
@@ -79,6 +80,8 @@ class Actions extends Component<Props> {
     const {group, project, organization} = this.props;
     const {title, type, shortId} = group;
 
+    const config = getConfigForIssueType(group);
+
     const discoverQuery = {
       id: undefined,
       name: title || type,
@@ -88,6 +91,7 @@ class Actions extends Component<Props> {
       projects: [Number(project.id)],
       version: 2 as SavedQueryVersions,
       range: '90d',
+      dataset: config.usesIssuePlatform ? DiscoverDatasets.ISSUE_PLATFORM : undefined,
     };
 
     const discoverView = EventView.fromSavedQuery(discoverQuery);

--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -6,6 +6,8 @@ import {PlatformCategory, PlatformKey} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
 import {Group, IssueCategory, Organization} from 'sentry/types';
 import EventView, {decodeSorts} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {platformToCategory} from 'sentry/utils/platform';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import EventsTable from 'sentry/views/performance/transactionSummary/transactionEvents/eventsTable';
@@ -20,11 +22,15 @@ export interface Props {
 
 const AllEventsTable = (props: Props) => {
   const {location, organization, issueId, excludedTags, group} = props;
+  const config = getConfigForIssueType(props.group);
   const [error, setError] = useState<string>('');
   const routes = useRoutes();
   const {fields, columnTitles} = getColumns(group, organization);
 
   const eventView: EventView = EventView.fromLocation(props.location);
+  if (config.usesIssuePlatform) {
+    eventView.dataset = DiscoverDatasets.ISSUE_PLATFORM;
+  }
   eventView.fields = fields.map(fieldName => ({field: fieldName}));
 
   eventView.sorts = decodeSorts(location).filter(sort => fields.includes(sort.field));


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/43413, https://github.com/getsentry/sentry/issues/44357

Currently, the "All Events" tab on issue details and the "Open in Discover" button don't show the correct results for profile issues because we are not querying the `issuePlatform` dataset.

- Adds optional `dataset` option to `EventView`
- Updates "All Events" and "Open in Discover" to use `dataset: 'issuePlatform'` for profile issues