### PR TITLE
ref: normalize tuple vs. list in rule serialization

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -56,7 +56,9 @@ class ProjectOptionRuleStore:
     _option_name = "sentry:transaction_name_cluster_rules"
 
     def read_sorted(self, project: Project) -> List[Tuple[ReplacementRule, int]]:
-        return project.get_option(self._option_name, default=[])  # type: ignore
+        ret = project.get_option(self._option_name, default=[])
+        # normalize tuple vs. list (write_pickle vs. write_json)
+        return [tuple(lst) for lst in ret]  # type: ignore[misc]
 
     def read(self, project: Project) -> RuleSet:
         return {rule: last_seen for rule, last_seen in self.read_sorted(project)}

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -19,6 +19,7 @@ from sentry.ingest.transaction_clusterer.rules import (
 )
 from sentry.ingest.transaction_clusterer.tasks import cluster_projects, spawn_clusterers
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.relay.config import get_project_config
 from sentry.testutils.helpers import Feature
@@ -139,8 +140,16 @@ def test_sort_rules():
     ]
 
 
+@pytest.fixture(params=(True, False))
+def pickle_mode(request):
+    field = ProjectOption._meta.get_field("value")
+    with mock.patch.object(field, "write_json", request.param):
+        yield
+
+
 @mock.patch("sentry.ingest.transaction_clusterer.rules.CompositeRuleStore.MERGE_MAX_RULES", 2)
 @pytest.mark.django_db
+@pytest.mark.usefixtures("pickle_mode")
 def test_max_rule_threshold_merge_composite_store(default_project):
     assert len(get_sorted_rules(default_project)) == 0
 


### PR DESCRIPTION
we're looking to enable "write_json" mode for pickle fields -- this test fails depending on how it is written