### PR TITLE
ref(heroku): Don't create an issue for user misconfig

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -73,7 +73,7 @@ class HerokuReleaseHook(ReleaseHook):
 
         if heroku_hmac:
             if not self.is_valid_signature(request.body.decode("utf-8"), heroku_hmac):
-                logger.error(
+                logger.info(
                     "heroku.webhook.invalid-signature", extra={"project_id": self.project.id}
                 )
                 return HttpResponse(status=401)


### PR DESCRIPTION
Change `logger.error` to `logger.info` to not create an issue in Sentry for poor user configuration. 

Fixes [SENTRY-YJM](https://sentry.sentry.io/issues/3913203710/events/72f17ad589d548169fda855f726ddab8/?project=1)