### PR TITLE
feat(issues): adds analytics to proguard misconfiguration banner display and click

### DIFF
--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -159,7 +159,18 @@ const useFetchProguardMappingFiles = ({
             'Some frames appear to be minified. Did you configure the [plugin]?',
             {
               plugin: (
-                <ExternalLink href="https://docs.sentry.io/platforms/android/proguard/#gradle">
+                <ExternalLink
+                  href="https://docs.sentry.io/platforms/android/proguard/#gradle"
+                  onClick={() => {
+                    trackAdvancedAnalyticsEvent(
+                      'issue_error_banner.proguard_misconfigured.clicked',
+                      {
+                        organization,
+                        group: event?.groupID,
+                      }
+                    );
+                  }}
+                >
                   Sentry Gradle Plugin
                 </ExternalLink>
               ),
@@ -226,6 +237,7 @@ const useRecordAnalyticsEvent = ({event, project}: {event: Event; project: Proje
 };
 
 export const EventErrors = ({event, project, isShare}: EventErrorsProps) => {
+  const organization = useOrganization();
   useRecordAnalyticsEvent({event, project});
   const releaseArtifacts = useFetchReleaseArtifacts({event, project});
   const {proguardErrorsLoading, proguardErrors} = useFetchProguardMappingFiles({
@@ -233,6 +245,21 @@ export const EventErrors = ({event, project, isShare}: EventErrorsProps) => {
     project,
     isShare,
   });
+
+  useEffect(() => {
+    if (
+      proguardErrors?.length &&
+      proguardErrors[0]?.type === 'proguard_potentially_misconfigured_plugin'
+    ) {
+      trackAdvancedAnalyticsEvent('issue_error_banner.proguard_misconfigured.displayed', {
+        organization,
+        group: event?.groupID,
+        platform: project.platform,
+      });
+    }
+    // Just for analytics, only track this once per visit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {dist: eventDistribution, errors: eventErrors = [], _meta} = event;
 

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -30,6 +30,14 @@ export type IssueEventParameters = {
   'issue.shared_publicly': {};
   'issue_details.performance.autogrouped_siblings_toggle': {};
   'issue_details.performance.hidden_spans_expanded': {};
+  'issue_error_banner.proguard_misconfigured.clicked': {
+    group?: string;
+    platform?: string;
+  };
+  'issue_error_banner.proguard_misconfigured.displayed': {
+    group?: string;
+    platform?: string;
+  };
   'issue_error_banner.viewed': {
     error_message: string[];
     error_type: string[];
@@ -146,6 +154,10 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'event_cause.snoozed': 'Event Cause Snoozed',
   'event_cause.dismissed': 'Event Cause Dismissed',
   'issue_error_banner.viewed': 'Issue Error Banner Viewed',
+  'issue_error_banner.proguard_misconfigured.displayed':
+    'Proguard Potentially Misconfigured Issue Error Banner Displayed',
+  'issue_error_banner.proguard_misconfigured.clicked':
+    'Proguard Potentially Misconfigured Issue Error Banner Link Clicked',
   'issues_tab.viewed': 'Viewed Issues Tab',
   'issue_search.failed': 'Issue Search: Failed',
   'issue_search.empty': 'Issue Search: Empty',


### PR DESCRIPTION
Adds analytics to track when the proguard potential misconfiguration banner is displayed and when a user clicks the link in the banner.