### PR TITLE
feat(roles): refactor get_top_dogs for Organization + AcceptProjectTransfer 2

### DIFF
--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -12,7 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
     DetailedOrganizationSerializerWithProjectsAndTeams,
 )
-from sentry.models import Organization, OrganizationMember, OrganizationStatus, Project
+from sentry.models import Organization, OrganizationMember, Project
 from sentry.utils import metrics
 from sentry.utils.signing import unsign
 
@@ -58,11 +58,8 @@ class AcceptProjectTransferEndpoint(Endpoint):
         except InvalidPayload as e:
             return Response({"detail": str(e)}, status=400)
 
-        organizations = Organization.objects.filter(
-            status=OrganizationStatus.ACTIVE,
-            id__in=OrganizationMember.objects.filter(
-                user=request.user, role=roles.get_top_dog().id
-            ).values_list("organization_id", flat=True),
+        organizations = Organization.objects.get_member_top_dog_organizations(
+            user_id=request.user.id
         )
 
         return Response(

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -58,7 +58,7 @@ class AcceptProjectTransferEndpoint(Endpoint):
         except InvalidPayload as e:
             return Response({"detail": str(e)}, status=400)
 
-        organizations = Organization.objects.get_member_top_dog_organizations(
+        organizations = Organization.objects.get_organizations_where_user_is_owner(
             user_id=request.user.id
         )
 
@@ -102,7 +102,7 @@ class AcceptProjectTransferEndpoint(Endpoint):
             return Response({"detail": "Invalid organization"}, status=400)
 
         # check if user is an owner of the organization
-        is_org_owner = request.access.has_organization_role(
+        is_org_owner = request.access.has_role_in_organization(
             role=roles.get_top_dog().id, organization=organization, user_id=request.user.id
         )
 

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -12,8 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
     DetailedOrganizationSerializerWithProjectsAndTeams,
 )
-from sentry.models import Organization, OrganizationMember, Project
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.models import Organization, Project
 from sentry.utils import metrics
 from sentry.utils.signing import unsign
 
@@ -103,17 +102,8 @@ class AcceptProjectTransferEndpoint(Endpoint):
             return Response({"detail": "Invalid organization"}, status=400)
 
         # check if user is an owner of the organization
-        query = OrganizationMember.objects.filter(
-            user__is_active=True,
-            user=request.user,
-            organization_id=organization.id,
-        )
-        is_org_owner = (
-            query.filter(role=roles.get_top_dog().id).exists()
-            or OrganizationMemberTeam.objects.filter(
-                team__in=organization.get_teams_with_org_role(roles.get_top_dog().id),
-                organizationmember_id__in=list(query.values_list("id", flat=True)),
-            ).exists()
+        is_org_owner = request.access.has_organization_role(
+            role=roles.get_top_dog().id, organization=organization, user_id=request.user.id
         )
 
         if not is_org_owner:

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -78,7 +78,7 @@ class OrganizationIndexEndpoint(Endpoint):
             # This is used when closing an account
 
             # also fetches organizations in which you are a member of an owner team
-            queryset = Organization.objects.get_member_top_dog_organizations(
+            queryset = Organization.objects.get_organizations_where_user_is_owner(
                 user_id=request.user.id, queryset=queryset
             )
             org_results = []

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -76,10 +76,10 @@ class OrganizationIndexEndpoint(Endpoint):
 
         elif owner_only:
             # This is used when closing an account
-            queryset = queryset.filter(
-                member_set__role=roles.get_top_dog().id,
-                member_set__user_id=request.user.id,
-                status=OrganizationStatus.VISIBLE,
+
+            # also fetches organizations in which you are a member of an owner team
+            queryset = Organization.objects.get_member_top_dog_organizations(
+                user_id=request.user.id, queryset=queryset
             )
             org_results = []
             for org in sorted(queryset, key=lambda x: x.name):

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -66,7 +66,7 @@ class OrganizationIndexEndpoint(Endpoint):
         """
         owner_only = request.GET.get("owner") in ("1", "true")
 
-        queryset = Organization.objects.all()
+        queryset = Organization.objects.distinct()
 
         if request.auth and not request.user.is_authenticated:
             if hasattr(request.auth, "project"):
@@ -79,7 +79,7 @@ class OrganizationIndexEndpoint(Endpoint):
 
             # also fetches organizations in which you are a member of an owner team
             queryset = Organization.objects.get_organizations_where_user_is_owner(
-                user_id=request.user.id, queryset=queryset
+                user_id=request.user.id
             )
             org_results = []
             for org in sorted(queryset, key=lambda x: x.name):

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -66,7 +66,7 @@ class OrganizationIndexEndpoint(Endpoint):
         """
         owner_only = request.GET.get("owner") in ("1", "true")
 
-        queryset = Organization.objects.distinct()
+        queryset = Organization.objects.all()
 
         if request.auth and not request.user.is_authenticated:
             if hasattr(request.auth, "project"):

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -64,10 +64,11 @@ def has_role_in_organization(role: str, organization: Organization, user_id: int
         user=user_id,
         organization_id=organization.id,
     )
+    teams_with_org_role = organization.get_teams_with_org_roles([role])
     return bool(
         query.filter(role=role).exists()
         or OrganizationMemberTeam.objects.filter(
-            team__in=organization.get_teams_with_org_role(role),
+            team__in=teams_with_org_role,
             organizationmember_id__in=list(query.values_list("id", flat=True)),
         ).exists()
     )

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -35,7 +35,6 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
 from sentry.models.team import Team
-from sentry.roles import organization_roles
 from sentry.roles.manager import Role
 from sentry.services.hybrid_cloud.user import APIUser, user_service
 from sentry.utils.http import is_using_customer_domain
@@ -368,9 +367,7 @@ class Organization(Model, SnowflakeIdMixin):
             user__is_active=True,
         )
         members_on_teams_with_role = (
-            OrganizationMemberTeam.objects.filter(
-                team__in=self.get_teams_with_org_role(organization_roles.get_top_dog().id)
-            )
+            OrganizationMemberTeam.objects.filter(team__in=self.get_teams_with_org_role(role))
             .exclude(organizationmember_id__in=list(members_with_role.values_list("id", flat=True)))
             .values_list("organizationmember__id", flat=True)
         )

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -374,7 +374,7 @@ class Organization(Model, SnowflakeIdMixin):
             .exclude(organizationmember_id__in=owners)
             .values_list("id", flat=True)
         )
-        return len(owners[:2]) == 1
+        return len(owners) == 1
 
     def merge_to(from_org, to_org):
         from sentry.models import (

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -130,41 +130,31 @@ class OrganizationManager(BaseManager):
         The default top priority role in Sentry is owner.
         """
 
-        # get orgs and orgmemberIDs for the user
-        query = OrganizationMember.objects.filter(user_id=user_id)
         if queryset:  # queryset is a QuerySet of valid orgs
-            orgs_and_members = query.filter(organization__in=queryset)
-        orgs_and_members = query.values_list("organization_id", "id")
+            orgs = queryset.filter(
+                member_set__user_id=user_id,
+                status=OrganizationStatus.VISIBLE,
+            )
+        else:
+            orgs = Organization.objects.distinct().filter(
+                member_set__user_id=user_id,
+                status=OrganizationStatus.VISIBLE,
+            )
 
-        organizations, org_members = zip(*orgs_and_members)
-        organizations = list(organizations)
-        org_members = list(org_members)
+        # get owners from orgs
+        owner_role_orgs = orgs.filter(member_set__role=roles.get_top_dog().id)
 
         # get owner teams
         owner_teams = Team.objects.filter(
-            organization_id__in=organizations, org_role=roles.get_top_dog().id
+            organization_id__in=orgs, org_role=roles.get_top_dog().id
         ).values_list("id", flat=True)
 
-        # get owners from owner teams
-        owners = list(
-            OrganizationMemberTeam.objects.filter(
-                team_id__in=owner_teams,
-                organizationmember_id__in=org_members,
-            ).values_list("organizationmember_id", flat=True)
-        )
+        # get the orgs in which the user is a member of an owner team
+        owner_team_member_orgs = OrganizationMemberTeam.objects.filter(
+            team__in=owner_teams
+        ).values_list("organizationmember__organization_id", flat=True)
 
-        # get corresponding orgs from org list
-        members_to_org = {m: organizations[i] for (i, m) in enumerate(org_members)}
-        orgs = {members_to_org[m] for m in owners if m in members_to_org}
-
-        # get owners from orgs
-        owner_role_orgs = set(
-            OrganizationMember.objects.filter(
-                role=roles.get_top_dog().id, user_id=user_id
-            ).values_list("organization_id", flat=True)
-        )
-
-        return self.filter(id__in=orgs.union(owner_role_orgs), status=OrganizationStatus.ACTIVE)
+        return self.filter(id__in=owner_team_member_orgs).union(owner_role_orgs)
 
 
 @region_silo_only_model

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -122,24 +122,16 @@ class OrganizationManager(BaseManager):
             return [r.organization for r in results if scope in r.get_scopes()]
         return [r.organization for r in results]
 
-    def get_organizations_where_user_is_owner(
-        self, user_id: int, queryset: QuerySet = None
-    ) -> QuerySet:
+    def get_organizations_where_user_is_owner(self, user_id: int) -> QuerySet:
         """
         Returns a QuerySet of all organizations where a user has the top priority role.
         The default top priority role in Sentry is owner.
         """
 
-        if queryset:  # queryset is a QuerySet of valid orgs
-            orgs = queryset.filter(
-                member_set__user_id=user_id,
-                status=OrganizationStatus.VISIBLE,
-            )
-        else:
-            orgs = Organization.objects.distinct().filter(
-                member_set__user_id=user_id,
-                status=OrganizationStatus.VISIBLE,
-            )
+        orgs = Organization.objects.filter(
+            member_set__user_id=user_id,
+            status=OrganizationStatus.VISIBLE,
+        )
 
         # get owners from orgs
         owner_role_orgs = orgs.filter(member_set__role=roles.get_top_dog().id)

--- a/tests/sentry/api/endpoints/test_accept_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_accept_project_transfer.py
@@ -77,6 +77,41 @@ class AcceptTransferProjectTest(APITestCase):
         assert self.from_organization.slug in org_slugs
         assert self.to_organization.slug in org_slugs
 
+    def test_returns_org_options_with_signed_link__owner_through_team(self):
+        user = self.create_user("bar@example.com")
+        owner_team_from = self.create_team(organization=self.from_organization, org_role="owner")
+        owner_team_to = self.create_team(organization=self.to_organization, org_role="owner")
+        from_member = self.create_member(
+            organization=self.from_organization,
+            user=user,
+            teams=[owner_team_from, self.from_team],
+            role="member",
+        )
+        self.create_member(
+            organization=self.to_organization,
+            user=user,
+            teams=[owner_team_to],
+            role="member",
+        )
+
+        self.login_as(user)
+        url_data = sign(
+            actor_id=from_member.user_id,
+            from_organization_id=self.from_organization.id,
+            project_id=self.project.id,
+            user_id=user.id,
+            transaction_id=self.transaction_id,
+        )
+
+        resp = self.client.get(self.path + "?" + urlencode({"data": url_data}))
+        assert resp.status_code == 200
+        assert resp.data["project"]["slug"] == self.project.slug
+        assert resp.data["project"]["id"] == self.project.id
+        assert len(resp.data["organizations"]) == 2
+        org_slugs = {o["slug"] for o in resp.data["organizations"]}
+        assert self.from_organization.slug in org_slugs
+        assert self.to_organization.slug in org_slugs
+
     def test_transfers_project_to_team_deprecated(self):
         self.login_as(self.owner)
         url_data = sign(

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -43,19 +43,25 @@ class OrganizationsListTest(OrganizationIndexTest):
 
         user2 = self.create_user(email="user2@example.com")
         org3 = self.create_organization(name="C", owner=user2)
-        self.create_organization(name="D", owner=user2)
+        org4 = self.create_organization(name="D", owner=user2)
 
         self.create_member(user=user2, organization=org2, role="owner")
         self.create_member(user=self.user, organization=org3, role="owner")
 
+        owner_team = self.create_team(organization=org4, org_role="owner")
+        # org4 has 2 owners
+        self.create_member(user=self.user, organization=org4, role="member", teams=[owner_team])
+
         response = self.get_success_response(qs_params={"owner": 1})
-        assert len(response.data) == 3
+        assert len(response.data) == 4
         assert response.data[0]["organization"]["id"] == str(org.id)
         assert response.data[0]["singleOwner"] is True
         assert response.data[1]["organization"]["id"] == str(org2.id)
         assert response.data[1]["singleOwner"] is False
         assert response.data[2]["organization"]["id"] == str(org3.id)
         assert response.data[2]["singleOwner"] is False
+        assert response.data[3]["organization"]["id"] == str(org4.id)
+        assert response.data[3]["singleOwner"] is False
 
     def test_status_query(self):
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)


### PR DESCRIPTION
MOVED TO #44554

Fixing #44182 (reverted)

Store the results of the queries in Python whenever possible so Django is forced to evaluate them and there are multiple queries as opposite to one giant one.