### PR TITLE
feat(issues): adds analytics tracking for when the missing proguard mapping banner is displayed

### DIFF
--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -247,15 +247,26 @@ export const EventErrors = ({event, project, isShare}: EventErrorsProps) => {
   });
 
   useEffect(() => {
-    if (
-      proguardErrors?.length &&
-      proguardErrors[0]?.type === 'proguard_potentially_misconfigured_plugin'
-    ) {
-      trackAdvancedAnalyticsEvent('issue_error_banner.proguard_misconfigured.displayed', {
-        organization,
-        group: event?.groupID,
-        platform: project.platform,
-      });
+    if (proguardErrors?.length) {
+      if (proguardErrors[0]?.type === 'proguard_potentially_misconfigured_plugin') {
+        trackAdvancedAnalyticsEvent(
+          'issue_error_banner.proguard_misconfigured.displayed',
+          {
+            organization,
+            group: event?.groupID,
+            platform: project.platform,
+          }
+        );
+      } else if (proguardErrors[0]?.type === 'proguard_missing_mapping') {
+        trackAdvancedAnalyticsEvent(
+          'issue_error_banner.proguard_missing_mapping.displayed',
+          {
+            organization,
+            group: event?.groupID,
+            platform: project.platform,
+          }
+        );
+      }
     }
     // Just for analytics, only track this once per visit
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -38,6 +38,10 @@ export type IssueEventParameters = {
     group?: string;
     platform?: string;
   };
+  'issue_error_banner.proguard_missing_mapping.displayed': {
+    group?: string;
+    platform?: string;
+  };
   'issue_error_banner.viewed': {
     error_message: string[];
     error_type: string[];
@@ -156,6 +160,8 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_error_banner.viewed': 'Issue Error Banner Viewed',
   'issue_error_banner.proguard_misconfigured.displayed':
     'Proguard Potentially Misconfigured Issue Error Banner Displayed',
+  'issue_error_banner.proguard_missing_mapping.displayed':
+    'Proguard Missing Mapping Issue Error Banner Displayed',
   'issue_error_banner.proguard_misconfigured.clicked':
     'Proguard Potentially Misconfigured Issue Error Banner Link Clicked',
   'issues_tab.viewed': 'Viewed Issues Tab',


### PR DESCRIPTION
Adds analytics tracking for when the missing proguard mapping banner is displayed
![image](https://user-images.githubusercontent.com/83961295/218589966-4c93dcbc-f626-4877-87a5-11a31d8d66aa.png)
