### PR TITLE
ref(project ownership): Handle owner not existing

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -15,7 +15,7 @@ from sentry.utils import metrics
 from sentry.utils.cache import cache
 
 if TYPE_CHECKING:
-    from sentry.models import ProjectCodeOwners, Team
+    from sentry.models import ProjectCodeOwners, Team, User
     from sentry.services.hybrid_cloud.user import APIUser
 
 READ_CACHE_DURATION = 3600
@@ -272,6 +272,14 @@ class ProjectOwnership(Model):
                 return
 
             owner = issue_owner.owner()
+            if not owner:
+                return
+
+            try:
+                owner = owner.resolve()
+            except (User.DoesNotExist, Team.DoesNotExist):
+                return
+
             details = (
                 {"integration": ActivityIntegration.SUSPECT_COMMITTER.value}
                 if issue_owner.type == GroupOwnerType.SUSPECT_COMMIT.value
@@ -285,23 +293,23 @@ class ProjectOwnership(Model):
                     "rule": (issue_owner.context or {}).get("rule", ""),
                 }
             )
-            if owner and owner.resolve():
-                assignment = GroupAssignee.objects.assign(
-                    event.group,
-                    owner.resolve(),
-                    create_only=True,
-                    extra=details,
-                )
 
-                if assignment["new_assignment"] or assignment["updated_assignment"]:
-                    analytics.record(
-                        "codeowners.assignment"
-                        if details.get("integration") == ActivityIntegration.CODEOWNERS.value
-                        else "issueowners.assignment",
-                        organization_id=ownership.project.organization_id,
-                        project_id=project_id,
-                        group_id=event.group.id,
-                    )
+            assignment = GroupAssignee.objects.assign(
+                event.group,
+                owner,
+                create_only=True,
+                extra=details,
+            )
+
+            if assignment["new_assignment"] or assignment["updated_assignment"]:
+                analytics.record(
+                    "codeowners.assignment"
+                    if details.get("integration") == ActivityIntegration.CODEOWNERS.value
+                    else "issueowners.assignment",
+                    organization_id=ownership.project.organization_id,
+                    project_id=project_id,
+                    group_id=event.group.id,
+                )
 
     @classmethod
     def _matching_ownership_rules(


### PR DESCRIPTION
We were getting a lot of `Team.DoesNotExist` exceptions raised from this code path - this moves things around slightly to return early if the user or team isn't found. 

Fixes [SENTRY-YDF](https://sentry.sentry.io/issues/3907792841/)