### PR TITLE
None guard around user.

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -65,7 +65,9 @@ class HerokuReleaseHook(ReleaseHook):
                 },
             )
         self.finish_release(
-            version=request.POST.get("head_long"), url=request.POST.get("url"), owner_id=user.id
+            version=request.POST.get("head_long"),
+            url=request.POST.get("url"),
+            owner_id=user.id if user else None,
         )
 
     def handle(self, request: Request) -> Response:


### PR DESCRIPTION
I added None guards in other places, but missed this one.  Validated with code search that no other calls to finish_release need this change.

https://sentry.my.sentry.io/organizations/sentry/issues/392546/?project=2&referrer=slack