### PR TITLE
feat(profile-issues): Add profile category/type to search autocomplete

### DIFF
--- a/static/app/stores/tagStore.spec.jsx
+++ b/static/app/stores/tagStore.spec.jsx
@@ -48,7 +48,7 @@ describe('TagStore', function () {
         },
       ]);
 
-      expect(TagStore.getIssueAttributes().has).toEqual({
+      expect(TagStore.getIssueAttributes(TestStubs.Organization()).has).toEqual({
         key: 'has',
         name: 'Has Tag',
         values: ['mytag', 'otherkey'],
@@ -64,7 +64,7 @@ describe('TagStore', function () {
         },
       ]);
 
-      const tags = TagStore.getIssueAttributes();
+      const tags = TagStore.getIssueAttributes(TestStubs.Organization());
       expect(tags.is).toBeTruthy();
       expect(tags.is.key).toBe('is');
       expect(tags.assigned).toBeTruthy();
@@ -80,7 +80,7 @@ describe('TagStore', function () {
         },
       ]);
 
-      const tags = TagStore.getIssueTags();
+      const tags = TagStore.getIssueTags(TestStubs.Organization());
 
       // state
       expect(tags.mytag).toBeTruthy();

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -1,6 +1,6 @@
 import {createStore} from 'reflux';
 
-import {Tag, TagCollection} from 'sentry/types';
+import {IssueCategory, IssueType, Tag, TagCollection} from 'sentry/types';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
 import {FieldKey, ISSUE_FIELDS} from 'sentry/utils/fields';
 
@@ -80,17 +80,18 @@ const storeConfig: TagStoreDefinition = {
       [FieldKey.ISSUE_CATEGORY]: {
         key: FieldKey.ISSUE_CATEGORY,
         name: 'Issue Category',
-        values: ['error', 'performance'],
+        values: [IssueCategory.ERROR, IssueCategory.PERFORMANCE, IssueCategory.PROFILE],
         predefined: true,
       },
       [FieldKey.ISSUE_TYPE]: {
         key: FieldKey.ISSUE_TYPE,
         name: 'Issue Type',
         values: [
-          'performance_n_plus_one_db_queries',
-          'performance_n_plus_one_api_calls',
-          'performance_consecutive_db_queries',
-          'performance_slow_db_query',
+          IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+          IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
+          IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES,
+          IssueType.PERFORMANCE_SLOW_DB_QUERY,
+          IssueType.PROFILE_BLOCKED_THREAD,
         ],
         predefined: true,
       },

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -1,6 +1,6 @@
 import {createStore} from 'reflux';
 
-import {IssueCategory, IssueType, Tag, TagCollection} from 'sentry/types';
+import {IssueCategory, IssueType, Organization, Tag, TagCollection} from 'sentry/types';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
 import {FieldKey, ISSUE_FIELDS} from 'sentry/utils/fields';
 
@@ -15,8 +15,8 @@ const BUILTIN_TAGS = ISSUE_FIELDS.reduce<TagCollection>((acc, tag) => {
 }, {});
 
 interface TagStoreDefinition extends CommonStoreDefinition<TagCollection> {
-  getIssueAttributes(): TagCollection;
-  getIssueTags(): TagCollection;
+  getIssueAttributes(org: Organization): TagCollection;
+  getIssueTags(org: Organization): TagCollection;
   loadTagsSuccess(data: Tag[]): void;
   reset(): void;
   state: TagCollection;
@@ -34,7 +34,7 @@ const storeConfig: TagStoreDefinition = {
   /**
    * Gets only predefined issue attributes
    */
-  getIssueAttributes() {
+  getIssueAttributes(org: Organization) {
     // TODO(mitsuhiko): what do we do with translations here?
     const isSuggestions = [
       'resolved',
@@ -80,7 +80,11 @@ const storeConfig: TagStoreDefinition = {
       [FieldKey.ISSUE_CATEGORY]: {
         key: FieldKey.ISSUE_CATEGORY,
         name: 'Issue Category',
-        values: [IssueCategory.ERROR, IssueCategory.PERFORMANCE, IssueCategory.PROFILE],
+        values: [
+          IssueCategory.ERROR,
+          IssueCategory.PERFORMANCE,
+          ...(org.features.includes('issue-platform') ? [IssueCategory.PROFILE] : []),
+        ],
         predefined: true,
       },
       [FieldKey.ISSUE_TYPE]: {
@@ -91,7 +95,9 @@ const storeConfig: TagStoreDefinition = {
           IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
           IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES,
           IssueType.PERFORMANCE_SLOW_DB_QUERY,
-          IssueType.PROFILE_BLOCKED_THREAD,
+          ...(org.features.includes('issue-platform')
+            ? [IssueType.PROFILE_BLOCKED_THREAD]
+            : []),
         ],
         predefined: true,
       },
@@ -150,14 +156,14 @@ const storeConfig: TagStoreDefinition = {
   /**
    * Get all tags including builtin issue tags and issue attributes
    */
-  getIssueTags() {
+  getIssueTags(org: Organization) {
     return {
       ...BUILTIN_TAGS,
       ...SEMVER_TAGS,
       // State tags should overwrite built ins.
       ...this.state,
       // We want issue attributes to overwrite any built in and state tags
-      ...this.getIssueAttributes(),
+      ...this.getIssueAttributes(org),
     };
   },
 

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -29,7 +29,7 @@ describe('withIssueTags HoC', function () {
 
   it('forwards loaded tags to the wrapped component', async function () {
     const Container = withIssueTags(MyComponent);
-    render(<Container forwardedValue="value" />);
+    render(<Container organization={TestStubs.Organization()} forwardedValue="value" />);
 
     // Should forward props.
     expect(await screen.findByText(/ForwardedValue: value/)).toBeInTheDocument();
@@ -54,7 +54,7 @@ describe('withIssueTags HoC', function () {
 
   it('updates the assigned tags with users and teams, and bookmark tags with users', function () {
     const Container = withIssueTags(MyComponent);
-    render(<Container forwardedValue="value" />);
+    render(<Container organization={TestStubs.Organization()} forwardedValue="value" />);
 
     act(() => {
       TagStore.loadTagsSuccess([


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/44429

Simple change, just adds some profile issue values to the searchbar autocomplete.

![CleanShot 2023-02-13 at 15 13 29](https://user-images.githubusercontent.com/10888943/218595481-7887e7c3-1b2b-444e-8391-59f535cbb94c.png)

![CleanShot 2023-02-13 at 15 13 16](https://user-images.githubusercontent.com/10888943/218595487-99703a96-5e68-45cb-a39f-4f0bce201322.png)
