### PR TITLE
feat(roles): ref Organization and AcceptProjectTransfer

### DIFF
--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -12,7 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
     DetailedOrganizationSerializerWithProjectsAndTeams,
 )
-from sentry.models import Organization, OrganizationMember, OrganizationStatus, Project
+from sentry.models import Organization, Project
 from sentry.utils import metrics
 from sentry.utils.signing import unsign
 
@@ -58,11 +58,8 @@ class AcceptProjectTransferEndpoint(Endpoint):
         except InvalidPayload as e:
             return Response({"detail": str(e)}, status=400)
 
-        organizations = Organization.objects.filter(
-            status=OrganizationStatus.ACTIVE,
-            id__in=OrganizationMember.objects.filter(
-                user=request.user, role=roles.get_top_dog().id
-            ).values_list("organization_id", flat=True),
+        organizations = Organization.objects.get_organizations_where_user_is_owner(
+            user_id=request.user.id
         )
 
         return Response(
@@ -105,12 +102,9 @@ class AcceptProjectTransferEndpoint(Endpoint):
             return Response({"detail": "Invalid organization"}, status=400)
 
         # check if user is an owner of the organization
-        is_org_owner = OrganizationMember.objects.filter(
-            user__is_active=True,
-            user=request.user,
-            role=roles.get_top_dog().id,
-            organization_id=organization.id,
-        ).exists()
+        is_org_owner = request.access.has_role_in_organization(
+            role=roles.get_top_dog().id, organization=organization, user_id=request.user.id
+        )
 
         if not is_org_owner:
             return Response({"detail": "Invalid organization"}, status=400)

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -76,10 +76,10 @@ class OrganizationIndexEndpoint(Endpoint):
 
         elif owner_only:
             # This is used when closing an account
-            queryset = queryset.filter(
-                member_set__role=roles.get_top_dog().id,
-                member_set__user_id=request.user.id,
-                status=OrganizationStatus.VISIBLE,
+
+            # also fetches organizations in which you are a member of an owner team
+            queryset = Organization.objects.get_organizations_where_user_is_owner(
+                user_id=request.user.id, queryset=queryset
             )
             org_results = []
             for org in sorted(queryset, key=lambda x: x.name):

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -79,7 +79,7 @@ class OrganizationIndexEndpoint(Endpoint):
 
             # also fetches organizations in which you are a member of an owner team
             queryset = Organization.objects.get_organizations_where_user_is_owner(
-                user_id=request.user.id, queryset=queryset
+                user_id=request.user.id
             )
             org_results = []
             for org in sorted(queryset, key=lambda x: x.name):

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -58,6 +58,21 @@ def get_permissions_for_user(user_id: int) -> FrozenSet[str]:
     return user.roles | user.permissions
 
 
+def has_role_in_organization(role: str, organization: Organization, user_id: int) -> bool:
+    query = OrganizationMember.objects.filter(
+        user__is_active=True,
+        user=user_id,
+        organization_id=organization.id,
+    )
+    return bool(
+        query.filter(role=role).exists()
+        or OrganizationMemberTeam.objects.filter(
+            team__in=organization.get_teams_with_org_role(role),
+            organizationmember_id__in=list(query.values_list("id", flat=True)),
+        ).exists()
+    )
+
+
 class Access(abc.ABC):
     @property
     @abc.abstractmethod
@@ -139,6 +154,12 @@ class Access(abc.ABC):
         if self.roles is not None:
             return [cast(OrganizationRole, organization_roles.get(r)) for r in self.roles]
         return []
+
+    @abc.abstractmethod
+    def has_role_in_organization(
+        self, role: str, organization: Organization, user_id: int | None
+    ) -> bool:
+        pass
 
     @abc.abstractmethod
     def has_team_access(self, team: Team) -> bool:
@@ -293,6 +314,15 @@ class DbAccess(Access):
         """
         return self.project_ids_with_team_membership
 
+    def has_role_in_organization(
+        self, role: str, organization: Organization, user_id: int | None
+    ) -> bool:
+        if self._member:
+            return has_role_in_organization(
+                role=role, organization=organization, user_id=self._member.user_id
+            )
+        return False
+
     def has_team_scope(self, team: Team, scope: str) -> bool:
         """
         Return bool representing if a user should have access with the given scope to information
@@ -427,6 +457,16 @@ class ApiBackedAccess(Access):
         if self.api_user_organization_context.member is None:
             return None
         return organization_service.get_all_org_roles(self.api_user_organization_context.member)
+
+    def has_role_in_organization(
+        self, role: str, organization: Organization, user_id: int | None
+    ) -> bool:
+        member = self.api_user_organization_context.member
+        if member and member.user_id:
+            return has_role_in_organization(
+                role=role, organization=organization, user_id=member.user_id
+            )
+        return False
 
     @cached_property
     def team_ids_with_membership(self) -> FrozenSet[int]:
@@ -734,6 +774,13 @@ class OrganizationlessAccess(Access):
     @property
     def roles(self) -> Iterable[str] | None:
         return None
+
+    def has_role_in_organization(
+        self, role: str, organization: Organization, user_id: int | None
+    ) -> bool:
+        if user_id:
+            return has_role_in_organization(role=role, organization=organization, user_id=user_id)
+        return False
 
     @property
     def team_ids_with_membership(self) -> FrozenSet[int]:

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -64,10 +64,11 @@ def has_role_in_organization(role: str, organization: Organization, user_id: int
         user=user_id,
         organization_id=organization.id,
     )
+    teams_with_org_role = organization.get_teams_with_org_roles([role])
     return bool(
         query.filter(role=role).exists()
         or OrganizationMemberTeam.objects.filter(
-            team__in=organization.get_teams_with_org_role(role),
+            team__in=teams_with_org_role,
             organizationmember_id__in=list(query.values_list("id", flat=True)),
         ).exists()
     )

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -32,7 +32,9 @@ from sentry.db.models import (
 from sentry.db.models.utils import slugify_instance
 from sentry.locks import locks
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
+from sentry.models.team import Team
 from sentry.roles.manager import Role
 from sentry.services.hybrid_cloud.user import APIUser, user_service
 from sentry.utils.http import is_using_customer_domain
@@ -119,6 +121,50 @@ class OrganizationManager(BaseManager):
         if scope is not None:
             return [r.organization for r in results if scope in r.get_scopes()]
         return [r.organization for r in results]
+
+    def get_organizations_where_user_is_owner(
+        self, user_id: int, queryset: QuerySet = None
+    ) -> QuerySet:
+        """
+        Returns a QuerySet of all organizations where a user has the top priority role.
+        The default top priority role in Sentry is owner.
+        """
+
+        # get orgs and orgmemberIDs for the user
+        query = OrganizationMember.objects.filter(user_id=user_id)
+        if queryset:  # queryset is a QuerySet of valid orgs
+            orgs_and_members = query.filter(organization__in=queryset)
+        orgs_and_members = query.values_list("organization_id", "id")
+
+        organizations, org_members = zip(*orgs_and_members)
+        organizations = list(organizations)
+        org_members = list(org_members)
+
+        # get owner teams
+        owner_teams = Team.objects.filter(
+            organization_id__in=organizations, org_role=roles.get_top_dog().id
+        ).values_list("id", flat=True)
+
+        # get owners from owner teams
+        owners = list(
+            OrganizationMemberTeam.objects.filter(
+                team_id__in=owner_teams,
+                organizationmember_id__in=org_members,
+            ).values_list("organizationmember_id", flat=True)
+        )
+
+        # get corresponding orgs from org list
+        members_to_org = {m: organizations[i] for (i, m) in enumerate(org_members)}
+        orgs = {members_to_org[m] for m in owners if m in members_to_org}
+
+        # get owners from orgs
+        owner_role_orgs = set(
+            OrganizationMember.objects.filter(
+                role=roles.get_top_dog().id, user_id=user_id
+            ).values_list("organization_id", flat=True)
+        )
+
+        return self.filter(id__in=orgs.union(owner_role_orgs), status=OrganizationStatus.ACTIVE)
 
 
 @region_silo_only_model
@@ -308,12 +354,26 @@ class Organization(Model, SnowflakeIdMixin):
         return self._default_owner_id
 
     def has_single_owner(self):
-        from sentry.models import OrganizationMember
+        owners = list(
+            self.get_members_with_org_role(roles.get_top_dog().id).values_list("id", flat=True)
+        )
+        return len(owners[:2]) == 1
 
-        count = OrganizationMember.objects.filter(
-            organization=self, role=roles.get_top_dog().id, user__isnull=False, user__is_active=True
-        )[:2].count()
-        return count == 1
+    def get_members_with_org_role(self, role: str):
+        members_with_role = OrganizationMember.objects.filter(
+            organization=self,
+            role=role,
+            user__isnull=False,
+            user__is_active=True,
+        )
+        members_on_teams_with_role = (
+            OrganizationMemberTeam.objects.filter(team__in=self.get_teams_with_org_role(role))
+            .exclude(organizationmember_id__in=list(members_with_role.values_list("id", flat=True)))
+            .values_list("organizationmember__id", flat=True)
+        )
+        return members_with_role | OrganizationMember.objects.filter(
+            id__in=members_on_teams_with_role
+        )
 
     def merge_to(from_org, to_org):
         from sentry.models import (

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from enum import IntEnum
-from typing import FrozenSet, Optional, Sequence
+from typing import Collection, FrozenSet, Optional, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
@@ -122,49 +122,31 @@ class OrganizationManager(BaseManager):
             return [r.organization for r in results if scope in r.get_scopes()]
         return [r.organization for r in results]
 
-    def get_organizations_where_user_is_owner(
-        self, user_id: int, queryset: QuerySet = None
-    ) -> QuerySet:
+    def get_organizations_where_user_is_owner(self, user_id: int) -> QuerySet:
         """
         Returns a QuerySet of all organizations where a user has the top priority role.
         The default top priority role in Sentry is owner.
         """
 
-        # get orgs and orgmemberIDs for the user
-        query = OrganizationMember.objects.filter(user_id=user_id)
-        if queryset:  # queryset is a QuerySet of valid orgs
-            orgs_and_members = query.filter(organization__in=queryset)
-        orgs_and_members = query.values_list("organization_id", "id")
+        orgs = Organization.objects.filter(
+            member_set__user_id=user_id,
+            status=OrganizationStatus.VISIBLE,
+        )
 
-        organizations, org_members = zip(*orgs_and_members)
-        organizations = list(organizations)
-        org_members = list(org_members)
+        # get owners from orgs
+        owner_role_orgs = orgs.filter(member_set__role=roles.get_top_dog().id)
 
         # get owner teams
         owner_teams = Team.objects.filter(
-            organization_id__in=organizations, org_role=roles.get_top_dog().id
+            organization__in=orgs, org_role=roles.get_top_dog().id
         ).values_list("id", flat=True)
 
-        # get owners from owner teams
-        owners = list(
-            OrganizationMemberTeam.objects.filter(
-                team_id__in=owner_teams,
-                organizationmember_id__in=org_members,
-            ).values_list("organizationmember_id", flat=True)
-        )
+        # get the orgs in which the user is a member of an owner team
+        owner_team_member_orgs = OrganizationMemberTeam.objects.filter(
+            team_id__in=owner_teams
+        ).values_list("organizationmember__organization_id", flat=True)
 
-        # get corresponding orgs from org list
-        members_to_org = {m: organizations[i] for (i, m) in enumerate(org_members)}
-        orgs = {members_to_org[m] for m in owners if m in members_to_org}
-
-        # get owners from orgs
-        owner_role_orgs = set(
-            OrganizationMember.objects.filter(
-                role=roles.get_top_dog().id, user_id=user_id
-            ).values_list("organization_id", flat=True)
-        )
-
-        return self.filter(id__in=orgs.union(owner_role_orgs), status=OrganizationStatus.ACTIVE)
+        return self.filter(id__in=owner_team_member_orgs).union(owner_role_orgs)
 
 
 @region_silo_only_model
@@ -355,24 +337,28 @@ class Organization(Model, SnowflakeIdMixin):
 
     def has_single_owner(self):
         owners = list(
-            self.get_members_with_org_role(roles.get_top_dog().id).values_list("id", flat=True)
+            self.get_members_with_org_roles([roles.get_top_dog().id]).values_list("id", flat=True)
         )
         return len(owners[:2]) == 1
 
-    def get_members_with_org_role(self, role: str):
-        members_with_role = OrganizationMember.objects.filter(
-            organization=self,
-            role=role,
-            user__isnull=False,
-            user__is_active=True,
+    def get_members_with_org_roles(self, roles: Collection[str]):
+        members_with_role = set(
+            self.member_set.filter(
+                role__in=roles,
+                user__isnull=False,
+                user__is_active=True,
+            ).values_list("id", flat=True)
         )
-        members_on_teams_with_role = (
-            OrganizationMemberTeam.objects.filter(team__in=self.get_teams_with_org_role(role))
-            .exclude(organizationmember_id__in=list(members_with_role.values_list("id", flat=True)))
-            .values_list("organizationmember__id", flat=True)
+
+        teams_with_org_role = self.get_teams_with_org_roles(roles).values_list("id", flat=True)
+        members_on_teams_with_role = set(
+            OrganizationMemberTeam.objects.filter(team_id__in=teams_with_org_role).values_list(
+                "organizationmember__id", flat=True
+            )
         )
-        return members_with_role | OrganizationMember.objects.filter(
-            id__in=members_on_teams_with_role
+
+        return OrganizationMember.objects.filter(
+            id__in=members_with_role.union(members_on_teams_with_role)
         )
 
     def merge_to(from_org, to_org):
@@ -683,11 +669,11 @@ class Organization(Model, SnowflakeIdMixin):
             scopes.discard("alerts:write")
         return frozenset(scopes)
 
-    def get_teams_with_org_role(self, role):
+    def get_teams_with_org_roles(self, roles: Optional[Collection[str]]) -> QuerySet:
         from sentry.models.team import Team
 
-        if role:
-            return Team.objects.filter(org_role=role, organization=self)
+        if roles is not None:
+            return Team.objects.filter(org_role__in=roles, organization=self)
 
         return Team.objects.filter(organization=self).exclude(org_role=None)
 

--- a/tests/sentry/api/endpoints/test_accept_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_accept_project_transfer.py
@@ -77,6 +77,41 @@ class AcceptTransferProjectTest(APITestCase):
         assert self.from_organization.slug in org_slugs
         assert self.to_organization.slug in org_slugs
 
+    def test_returns_org_options_with_signed_link__owner_through_team(self):
+        user = self.create_user("bar@example.com")
+        owner_team_from = self.create_team(organization=self.from_organization, org_role="owner")
+        owner_team_to = self.create_team(organization=self.to_organization, org_role="owner")
+        from_member = self.create_member(
+            organization=self.from_organization,
+            user=user,
+            teams=[owner_team_from, self.from_team],
+            role="member",
+        )
+        self.create_member(
+            organization=self.to_organization,
+            user=user,
+            teams=[owner_team_to],
+            role="member",
+        )
+
+        self.login_as(user)
+        url_data = sign(
+            actor_id=from_member.user_id,
+            from_organization_id=self.from_organization.id,
+            project_id=self.project.id,
+            user_id=user.id,
+            transaction_id=self.transaction_id,
+        )
+
+        resp = self.client.get(self.path + "?" + urlencode({"data": url_data}))
+        assert resp.status_code == 200
+        assert resp.data["project"]["slug"] == self.project.slug
+        assert resp.data["project"]["id"] == self.project.id
+        assert len(resp.data["organizations"]) == 2
+        org_slugs = {o["slug"] for o in resp.data["organizations"]}
+        assert self.from_organization.slug in org_slugs
+        assert self.to_organization.slug in org_slugs
+
     def test_transfers_project_to_team_deprecated(self):
         self.login_as(self.owner)
         url_data = sign(
@@ -96,6 +131,31 @@ class AcceptTransferProjectTest(APITestCase):
     def test_non_owner_cannot_transfer_project(self):
         rando_user = self.create_user(email="blipp@bloop.com", is_superuser=False)
         rando_org = self.create_organization(name="supreme beans")
+
+        self.login_as(rando_user)
+        url_data = sign(
+            actor_id=self.member.user_id,
+            from_organization_id=rando_org.id,
+            project_id=self.project.id,
+            user_id=rando_user.id,
+            transaction_id=self.transaction_id,
+        )
+
+        resp = self.client.post(
+            self.path, data={"organization": self.to_organization.slug, "data": url_data}
+        )
+        assert resp.status_code == 400
+        p = Project.objects.get(id=self.project.id)
+        assert p.organization_id == self.from_organization.id
+        assert p.organization_id != rando_org.id
+
+    def test_non_owner_on_owner_team_can_transfer_project(self):
+        rando_user = self.create_user(email="blipp@bloop.com", is_superuser=False)
+        rando_org = self.create_organization(name="supreme beans")
+        owner_team = self.create_team(organization=rando_org, org_role="owner")
+        self.create_member(
+            organization=rando_org, user=rando_user, teams=[owner_team], role="member"
+        )
 
         self.login_as(rando_user)
         url_data = sign(

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -43,19 +43,25 @@ class OrganizationsListTest(OrganizationIndexTest):
 
         user2 = self.create_user(email="user2@example.com")
         org3 = self.create_organization(name="C", owner=user2)
-        self.create_organization(name="D", owner=user2)
+        org4 = self.create_organization(name="D", owner=user2)
 
         self.create_member(user=user2, organization=org2, role="owner")
         self.create_member(user=self.user, organization=org3, role="owner")
 
+        owner_team = self.create_team(organization=org4, org_role="owner")
+        # org4 has 2 owners
+        self.create_member(user=self.user, organization=org4, role="member", teams=[owner_team])
+
         response = self.get_success_response(qs_params={"owner": 1})
-        assert len(response.data) == 3
+        assert len(response.data) == 4
         assert response.data[0]["organization"]["id"] == str(org.id)
         assert response.data[0]["singleOwner"] is True
         assert response.data[1]["organization"]["id"] == str(org2.id)
         assert response.data[1]["singleOwner"] is False
         assert response.data[2]["organization"]["id"] == str(org3.id)
         assert response.data[2]["singleOwner"] is False
+        assert response.data[3]["organization"]["id"] == str(org4.id)
+        assert response.data[3]["singleOwner"] is False
 
     def test_status_query(self):
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)


### PR DESCRIPTION
Git acrobatics: squashes the revert into one commit and the changes into another commit (from #44541)

Fixing https://github.com/getsentry/sentry/pull/44182 (reverted)

Store the results of the queries in Python whenever possible so Django is forced to evaluate them and there are multiple queries as opposite to one giant one. Use .union() for sets or QuerySets as opposed to | (OR) for QuerySets which is much slower.