### PR TITLE
fix(api): validate user_id as an int before trying to query

### DIFF
--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -12,6 +12,11 @@ class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (MemberPermission,)
 
     def get(self, request: Request, organization, user_id) -> Response:
+        try:
+            int(user_id)
+        except ValueError:
+            return Response({"detail": "user_id must be an integer"}, status=400)
+
         users = user_service.serialize_many(
             filter={"user_ids": [user_id], "organization_id": organization.id}, as_user=request.user
         )

--- a/src/sentry/api/endpoints/organization_user_details.py
+++ b/src/sentry/api/endpoints/organization_user_details.py
@@ -1,3 +1,4 @@
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,7 +16,7 @@ class OrganizationUserDetailsEndpoint(OrganizationEndpoint):
         try:
             int(user_id)
         except ValueError:
-            return Response({"detail": "user_id must be an integer"}, status=400)
+            raise ValidationError(f"user_id({user_id}) must be an integer")
 
         users = user_service.serialize_many(
             filter={"user_ids": [user_id], "organization_id": organization.id}, as_user=request.user

--- a/tests/sentry/api/endpoints/test_organization_user_details.py
+++ b/tests/sentry/api/endpoints/test_organization_user_details.py
@@ -25,3 +25,7 @@ class OrganizationUserDetailsTest(APITestCase):
         user = self.create_user("meep@localhost", username="meep")
 
         self.get_error_response(self.org.slug, user.id, status_code=404)
+
+    def test_bad_user_id(self):
+        self.get_error_response(self.org.slug, 123, status_code=404)
+        self.get_error_response(self.org.slug, "not_valid", status_code=400)


### PR DESCRIPTION
Some users seems to be passing in random strings to this endpoint causing errors. Validate it before trying to query for it.

Fixes SENTRY-YN0