### PR TITLE
feat(issue-owners): Setup caching to debounce Issue Owner evaluations

### DIFF
--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -15,6 +15,8 @@ from sentry.models.group import Group
 from sentry.utils.cache import cache
 
 READ_CACHE_DURATION = 3600
+ISSUE_OWNERS_DEBOUNCE_KEY = lambda group_id: f"owner_exists:1:{group_id}"
+ISSUE_OWNERS_DEBOUNCE_DURATION = 60 * 60 * 24
 
 
 class GroupOwnerType(Enum):
@@ -140,6 +142,24 @@ class GroupOwner(Model):
                 cls.get_autoassigned_owner_cache_key(group_id, project_id, autoassignment_types)
                 for group_id in group_ids
             ]
+            cache.delete_many(cache_keys)
+
+    @classmethod
+    def invalidate_debounce_issue_owners_evaluation_cache(cls, project_id):
+        # Get all the groups for a project that had an event within the ISSUE_OWNERS_DEBOUNCE_DURATION window.
+        # Any groups without events in that window would have expired their TTL in the cache.
+        queryset = Group.objects.filter(
+            project_id=project_id,
+            last_seen__gte=timezone.now() - timedelta(seconds=ISSUE_OWNERS_DEBOUNCE_DURATION),
+        ).values_list("id", flat=True)
+
+        # Run cache invalidation in batches
+        group_id_iter = queryset.iterator(chunk_size=1000)
+        while True:
+            group_ids = list(itertools.islice(group_id_iter, 1000))
+            if not group_ids:
+                break
+            cache_keys = [ISSUE_OWNERS_DEBOUNCE_KEY(group_id) for group_id in group_ids]
             cache.delete_many(cache_keys)
 
 

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -135,6 +135,7 @@ def process_resource_change(instance, change, **kwargs):
 
     autoassignment_types = ProjectOwnership._get_autoassignment_types(ownership)
     GroupOwner.invalidate_autoassigned_owner_cache(instance.project_id, autoassignment_types)
+    GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(instance.project_id)
 
 
 # Signals update the cached reads used in post_processing

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -332,6 +332,8 @@ def process_resource_change(instance, change, **kwargs):
     if len(autoassignment_types) > 0:
         GroupOwner.invalidate_autoassigned_owner_cache(instance.project_id, autoassignment_types)
 
+    GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(instance.project_id)
+
 
 # Signals update the cached reads used in post_processing
 post_save.connect(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -126,45 +126,59 @@ def handle_owner_assignment(job):
 
     with sentry_sdk.start_span(op="tasks.post_process_group.handle_owner_assignment"):
         try:
-            from sentry.models import GroupOwnerType, ProjectOwnership
+            from sentry.models import ProjectOwnership
 
             event = job["event"]
             project, group = event.project, event.group
-
+            basic_logging_details = {
+                "event": event.event_id,
+                "group": event.group_id,
+                "project": event.project_id,
+                "organization": event.project.organization_id,
+            }
+            # We want to debounce owner assignment when:
+            # - GroupOwner of type Ownership Rule || CodeOwner exist with TTL 1 day
+            # - we tried to calculate and could not find issue owners with TTL 1 day
+            # - an Assignee has been set with TTL of infinite
             with metrics.timer("post_process.handle_owner_assignment"):
-                with sentry_sdk.start_span(
-                    op="post_process.handle_owner_assignment.cache_set_owner"
-                ):
-                    issue_owner_key = f"owner_exists:1:{group.id}"
-                    issue_owners_exists = cache.get(issue_owner_key)
-                    if issue_owners_exists is None:
-                        # We don't care if a Suspect Commit groupowner exists
-                        issue_owners_exists = group.groupowner_set.filter(
-                            type__in=[
-                                GroupOwnerType.OWNERSHIP_RULE.value,
-                                GroupOwnerType.CODEOWNERS.value,
-                            ],
-                        ).exists()
-                        # Cache for an hour if it's assigned. We don't need to move that fast.
-                        cache.set(
-                            issue_owner_key,
-                            issue_owners_exists,
-                            3600 if issue_owners_exists else 60,
-                        )
-
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.cache_set_assignee"
                 ):
                     # Is the issue already assigned to a team or user?
-                    assignee_key = "assignee_exists:1:%s" % group.id
+                    assignee_key = f"assignee_exists:1:{group.id}"
                     assignees_exists = cache.get(assignee_key)
                     if assignees_exists is None:
                         assignees_exists = group.assignee_set.exists()
-                        # Cache for an hour if it's assigned. We don't need to move that fast.
-                        cache.set(assignee_key, assignees_exists, 3600 if assignees_exists else 60)
+                        # Cache for 1 day if it's assigned. We don't need to move that fast.
+                        cache.set(
+                            assignee_key, assignees_exists, 60 * 60 * 24 if assignees_exists else 60
+                        )
 
-                if issue_owners_exists and assignees_exists:
-                    return
+                    if assignees_exists:
+                        logger.info(
+                            "handle_owner_assignment.assignee_exists",
+                            extra={
+                                **basic_logging_details,
+                                "reason": "assignee_exists",
+                            },
+                        )
+                        return
+
+                with sentry_sdk.start_span(
+                    op="post_process.handle_owner_assignment.debounce_issue_owners"
+                ):
+                    issue_owners_key = f"owner_exists:1:{group.id}"
+                    debounce_issue_owners = cache.get(issue_owners_key)
+
+                    if debounce_issue_owners:
+                        logger.info(
+                            "handle_owner_assignment.issue_owners_exist",
+                            extra={
+                                **basic_logging_details,
+                                "reason": "issue_owners_exist",
+                            },
+                        )
+                        return
 
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.get_issue_owners"
@@ -181,10 +195,17 @@ def handle_owner_assignment(job):
 
                         issue_owners = ProjectOwnership.get_issue_owners(project.id, event.data)
 
+                        # Cache for 1 day after we calculated. We don't need to move that fast.
+                        cache.set(
+                            issue_owners_key,
+                            True,
+                            60 * 60 * 24,
+                        )
+
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.handle_group_owners"
                 ):
-                    if issue_owners and not issue_owners_exists:
+                    if issue_owners:
                         try:
                             handle_group_owners(project, group, issue_owners)
                         except Exception:


### PR DESCRIPTION
Currently we run this task on every event. Instead, we should debounce the task for groups that already have assignments and use a TTL of 1 day. For groups that we could not find an issue owner, we should debounce for 1 day. For groups that have an assignee, we should debounce indefinitely.

When Ownership Rules/Codeowners are changed, it should clear this debounce cache