### PR TITLE
feat(wizard): adds organizations to context for setup wizard

### DIFF
--- a/src/sentry/templates/sentry/setup-wizard.html
+++ b/src/sentry/templates/sentry/setup-wizard.html
@@ -24,6 +24,7 @@
       container: '#setup-wizard-container',
       props: {
         hash: {{ hash|to_json|safe }},
+        organizations: {{ organizations|to_json|safe }},
       },
     });
   </script>

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -106,4 +106,5 @@ class SetupWizardView(BaseView):
         key = f"{SETUP_WIZARD_CACHE_KEY}{wizard_hash}"
         default_cache.set(key, result, SETUP_WIZARD_CACHE_TIMEOUT)
 
+        context["organizations"] = serialize(list(orgs))
         return render_to_response("sentry/setup-wizard.html", context, request)


### PR DESCRIPTION
This PR adds the list of organizations associated with the user to the UI for the setup wizard. The goal of this is so we can start recording analytics on the front end. Note we will only associate the wizard with an organization if the user is part of one organization. This is because we don't know which organization to use.