### PR TITLE
fix(dynamic-sampling): Show rules v2 in config

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -383,7 +383,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
             include_rules = request.GET.get("includeDynamicSamplingRules") == "1"
             if include_rules and is_active_superuser(request):
-                data["dynamicSamplingRules"] = generate_rules(project)
+                data["dynamicSamplingRules"] = {
+                    "rules": generate_rules(project),
+                    "rulesV2": generate_rules(project, True),
+                }
         else:
             data["dynamicSamplingBiases"] = None
             data["dynamicSamplingRules"] = None

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1230,11 +1230,14 @@ class TestProjectDetailsDynamicSamplingRules(TestProjectDetailsDynamicSamplingBa
                 includeDynamicSamplingRules=1,
             )
             # we expect 2 rules 1 for boostEnvironments and uniform rule
-            assert len(response.data["dynamicSamplingRules"]) == 2
+            assert len(response.data["dynamicSamplingRules"]["rules"]) == 2
+            assert len(response.data["dynamicSamplingRules"]["rulesV2"]) == 2
             # 1001 is dev bias rule id
-            assert response.data["dynamicSamplingRules"][0]["id"] == 1001
+            assert response.data["dynamicSamplingRules"]["rules"][0]["id"] == 1001
+            assert response.data["dynamicSamplingRules"]["rulesV2"][0]["id"] == 1001
             # 1000 uniform rule id
-            assert response.data["dynamicSamplingRules"][1]["id"] == 1000
+            assert response.data["dynamicSamplingRules"]["rules"][1]["id"] == 1000
+            assert response.data["dynamicSamplingRules"]["rulesV2"][1]["id"] == 1000
 
     def test_get_dynamic_sampling_rules_disabled_if_no_feature_flag(self):
         with Feature(


### PR DESCRIPTION
This PR aims at adding the `rulesV2` to the project details endpoint.