### PR TITLE
fix(python-tests): Fix symbolicator flaky tests - [TET-707]

### DIFF
--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2022-07-28T11:40:27.313975Z'
-creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
 contexts:
@@ -25,7 +23,7 @@ debug_meta:
           has_symbols: true
           has_unwind_info: true
         status: ok
-      location: sentry://project_debug_file/5
+      location: sentry://project_debug_file/x
       source: sentry:project
       source_name: Sentry
     code_file: C:\projects\breakpad-tools\windows\Release\crash.exe

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2022-07-28T11:40:41.659077Z'
-creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
 contexts: null
@@ -17,7 +15,7 @@ debug_meta:
           has_symbols: true
           has_unwind_info: false
         status: ok
-      location: sentry://project_debug_file/6
+      location: sentry://project_debug_file/x
       source: sentry:project
       source_name: Sentry
     code_file: Foo.app/Contents/Foo

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -77,7 +77,6 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
     def get_event(self, event_id):
         return eventstore.get_event_by_id(self.project.id, event_id)
 
-    @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44459")
     def test_real_resolving(self):
         url = reverse(
             "sentry-api-0-dsym-files",
@@ -108,9 +107,13 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
 
         event = self.post_and_retrieve_event(REAL_RESOLVING_EVENT_DATA)
         assert event.data["culprit"] == "main"
+
+        candidates = event.data["debug_meta"]["images"][0]["candidates"]
+        redact_location(candidates)
+        event.data["debug_meta"]["images"][0]["candidates"] = candidates
+
         insta_snapshot_stacktrace_data(self, event.data)
 
-    @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44459")
     def test_debug_id_resolving(self):
         file = File.objects.create(
             name="crash.pdb", type="default", headers={"Content-Type": "text/x-breakpad"}
@@ -167,6 +170,11 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
 
         event = self.post_and_retrieve_event(event_data)
         assert event.data["culprit"] == "main"
+
+        candidates = event.data["debug_meta"]["images"][0]["candidates"]
+        redact_location(candidates)
+        event.data["debug_meta"]["images"][0]["candidates"] = candidates
+
         insta_snapshot_stacktrace_data(self, event.data)
 
     def test_missing_dsym(self):


### PR DESCRIPTION
**What this PR does:**

Fix symbolicator flakiness in tests present in the file `tests/symbolicator/test_payload_full.py `

This issue is well explained in the issue https://github.com/getsentry/sentry/issues/44459

**Solution:**

Reuse the function 

https://github.com/getsentry/sentry/blob/bc987db8d76669cea17328f61649cd848030e00e/tests/symbolicator/test_payload_full.py#L248 

to always generate the same sentry location URI `sentry://project_debug_file/x`