### PR TITLE
fix(profiling): half size row initial height

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
@@ -17,7 +17,7 @@ import {CollapsibleTimeline} from './collapsibleTimeline';
 // 664px is approximately the width where we start to scroll inside
 // 30px is the min height to where the drawer can still be resized
 const MIN_FLAMEGRAPH_DRAWER_DIMENSIONS: [number, number] = [680, 30];
-const FLAMEGRAPH_DRAWER_INITIAL_HEIGHT = 180;
+const FLAMEGRAPH_DRAWER_INITIAL_HEIGHT = 190;
 
 interface FlamegraphLayoutProps {
   flamegraph: React.ReactElement;


### PR DESCRIPTION
Make initial drawer height clip the final row - this gives a visual hint that the drawer is scrollable

Before
<img width="642" alt="CleanShot 2023-02-14 at 08 42 39@2x" src="https://user-images.githubusercontent.com/9317857/218755748-16d57904-32eb-464f-9615-71674bea3968.png">
After
<img width="1071" alt="CleanShot 2023-02-14 at 08 42 15@2x" src="https://user-images.githubusercontent.com/9317857/218755756-4704f540-683a-4a8a-ae9c-524211266230.png">
