### PR TITLE
feat(profiling): double click reset zoom

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -352,9 +352,27 @@ function FlamegraphZoomViewMinimap({
     setLastDragVector(null);
   }, []);
 
-  const onMinimapCanvasDoubleClick = useCallback(() => {
-    canvasPoolManager.dispatch('reset zoom', []);
-  }, [canvasPoolManager]);
+  const onMinimapCanvasDoubleClick = useCallback(
+    (evt: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!flamegraphMiniMapCanvas || !flamegraphMiniMapView || !canvasPoolManager) {
+        return;
+      }
+
+      const configSpaceMouse = flamegraphMiniMapView.getTransformedConfigSpaceCursor(
+        vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
+        flamegraphMiniMapCanvas
+      );
+
+      const view = new Rect(
+        0,
+        configSpaceMouse[1] - flamegraphMiniMapView.configView.height / 2,
+        flamegraphMiniMapView.configSpace.width,
+        flamegraphMiniMapView.configView.height
+      );
+      canvasPoolManager.dispatch('set config view', [view, flamegraphMiniMapView]);
+    },
+    [canvasPoolManager, flamegraphMiniMapCanvas, flamegraphMiniMapView]
+  );
 
   useEffect(() => {
     window.addEventListener('mouseup', onMinimapCanvasMouseUp);

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -352,6 +352,10 @@ function FlamegraphZoomViewMinimap({
     setLastDragVector(null);
   }, []);
 
+  const onMinimapCanvasDoubleClick = useCallback(() => {
+    canvasPoolManager.dispatch('reset zoom', []);
+  }, [canvasPoolManager]);
+
   useEffect(() => {
     window.addEventListener('mouseup', onMinimapCanvasMouseUp);
 
@@ -367,6 +371,7 @@ function FlamegraphZoomViewMinimap({
         onMouseDown={onMinimapCanvasMouseDown}
         onMouseMove={onMinimapCanvasMouseMove}
         onMouseLeave={onMinimapCanvasMouseUp}
+        onDoubleClick={onMinimapCanvasDoubleClick}
         cursor={getMinimapCanvasCursor(
           flamegraphMiniMapView?.configView,
           configSpaceCursor,


### PR DESCRIPTION

It seems like double clicking to reset zoom is somewhat of a common pattern. Not sure if we should extend it to the main flamechart view as well?

https://user-images.githubusercontent.com/9317857/218758241-04aa796a-dc23-4c8f-867b-541e524de2d4.mp4

