### PR TITLE
ref(stack-trace-filter): Update copy for js events - [TET-706]

### DIFF
--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -151,6 +151,22 @@ export function TraceEventDataSection({
       ];
     }
 
+    // This logic might be incomplete, but according to the SDK folks, this is 99.9% of the cases
+    if (platform.startsWith('javascript')) {
+      return [
+        {
+          label: t('Minified'),
+          value: 'minified',
+          disabled: !hasMinified,
+          tooltip: !hasMinified ? t('Minified version not available') : undefined,
+        },
+        {
+          label: displayOptions['raw-stack-trace'],
+          value: 'raw-stack-trace',
+        },
+      ];
+    }
+
     return [
       {
         label: displayOptions.minified,


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/29228205/218761851-533451c5-1034-4d7a-b712-9aecc76c731e.png)


**After:**

![Screenshot 2023-02-14 at 15 05 25](https://user-images.githubusercontent.com/29228205/218761707-0584607d-8040-40fc-bb23-e7e9522aedc2.png)
