### PR TITLE
fix(view-hierarchy): Use absolute positions in Flutter

### DIFF
--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -166,6 +166,7 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
               hierarchy={hierarchy}
               selectedNode={userHasSelected ? selectedNode : undefined}
               onNodeSelect={onWireframeNodeSelect}
+              project={project}
             />
           </Right>
         )}

--- a/static/app/components/events/viewHierarchy/utils.spec.tsx
+++ b/static/app/components/events/viewHierarchy/utils.spec.tsx
@@ -58,7 +58,7 @@ describe('View Hierarchy Utils', function () {
     });
 
     it('does not shift children when specified', function () {
-      const actual = getHierarchyDimensions(MOCK_HIERARCHY, false);
+      const actual = getHierarchyDimensions(MOCK_HIERARCHY, true);
 
       // One array for each root
       expect(actual).toEqual({

--- a/static/app/components/events/viewHierarchy/utils.spec.tsx
+++ b/static/app/components/events/viewHierarchy/utils.spec.tsx
@@ -42,7 +42,7 @@ describe('View Hierarchy Utils', function () {
   });
 
   describe('getHierarchyDimensions', function () {
-    it('properly calculates coordinates', function () {
+    it('properly calculates coordinates and shifts children by default', function () {
       const actual = getHierarchyDimensions(MOCK_HIERARCHY);
 
       expect(actual).toEqual({
@@ -50,6 +50,22 @@ describe('View Hierarchy Utils', function () {
           {node: MOCK_HIERARCHY[0], rect: new Rect(0, 0, 10, 10)},
           {node: INTERMEDIATE_NODE, rect: new Rect(10, 5, 10, 10)},
           {node: LEAF_NODE, rect: new Rect(12, 7, 5, 5)},
+          {node: MOCK_HIERARCHY[1], rect: new Rect(10, 0, 20, 20)},
+        ],
+        maxWidth: 30,
+        maxHeight: 20,
+      });
+    });
+
+    it('does not shift children when specified', function () {
+      const actual = getHierarchyDimensions(MOCK_HIERARCHY, false);
+
+      // One array for each root
+      expect(actual).toEqual({
+        nodes: [
+          {node: MOCK_HIERARCHY[0], rect: new Rect(0, 0, 10, 10)},
+          {node: INTERMEDIATE_NODE, rect: new Rect(10, 5, 10, 10)},
+          {node: LEAF_NODE, rect: new Rect(2, 2, 5, 5)},
           {node: MOCK_HIERARCHY[1], rect: new Rect(10, 0, 20, 20)},
         ],
         maxWidth: 30,

--- a/static/app/components/events/viewHierarchy/utils.tsx
+++ b/static/app/components/events/viewHierarchy/utils.tsx
@@ -42,7 +42,7 @@ export function useResizeCanvasObserver(canvases: (HTMLCanvasElement | null)[]):
 
 export function getHierarchyDimensions(
   hierarchies: ViewHierarchyWindow[],
-  useAbsolutePosition: boolean = true
+  useAbsolutePosition: boolean = false
 ): {
   maxHeight: number;
   maxWidth: number;

--- a/static/app/components/events/viewHierarchy/utils.tsx
+++ b/static/app/components/events/viewHierarchy/utils.tsx
@@ -40,7 +40,10 @@ export function useResizeCanvasObserver(canvases: (HTMLCanvasElement | null)[]):
   return bounds;
 }
 
-export function getHierarchyDimensions(hierarchies: ViewHierarchyWindow[]): {
+export function getHierarchyDimensions(
+  hierarchies: ViewHierarchyWindow[],
+  useAbsolutePosition: boolean = true
+): {
   maxHeight: number;
   maxWidth: number;
   nodes: ViewNode[];
@@ -60,8 +63,8 @@ export function getHierarchyDimensions(hierarchies: ViewHierarchyWindow[]): {
     const node = {
       node: child,
       rect: new Rect(
-        (parent?.x ?? 0) + (child.x ?? 0),
-        (parent?.y ?? 0) + (child.y ?? 0),
+        useAbsolutePosition ? child.x ?? 0 : (parent?.x ?? 0) + (child.x ?? 0),
+        useAbsolutePosition ? child.y ?? 0 : (parent?.y ?? 0) + (child.y ?? 0),
         child.width ?? 0,
         child.height ?? 0
       ),

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -48,7 +48,11 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect, project}: WireframePr
   const canvasSize = useResizeCanvasObserver(canvases);
 
   const hierarchyData = useMemo(
-    () => getHierarchyDimensions(hierarchy, project.platform === 'flutter'),
+    () =>
+      getHierarchyDimensions(
+        hierarchy,
+        ['flutter', 'dart-flutter'].includes(project?.platform ?? '')
+      ),
     [hierarchy, project.platform]
   );
   const nodeLookupMap = useMemo(() => {

--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -14,6 +14,7 @@ import {
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Project} from 'sentry/types';
 import {
   getCenterScaleMatrixFromConfigPosition,
   Rect,
@@ -29,10 +30,11 @@ export interface ViewNode {
 type WireframeProps = {
   hierarchy: ViewHierarchyWindow[];
   onNodeSelect: (node?: ViewHierarchyWindow) => void;
+  project: Project;
   selectedNode?: ViewHierarchyWindow;
 };
 
-function Wireframe({hierarchy, selectedNode, onNodeSelect}: WireframeProps) {
+function Wireframe({hierarchy, selectedNode, onNodeSelect, project}: WireframeProps) {
   const theme = useTheme();
   const [canvasRef, setCanvasRef] = useState<HTMLCanvasElement | null>(null);
   const [overlayRef, setOverlayRef] = useState<HTMLCanvasElement | null>(null);
@@ -45,7 +47,10 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect}: WireframeProps) {
 
   const canvasSize = useResizeCanvasObserver(canvases);
 
-  const hierarchyData = useMemo(() => getHierarchyDimensions(hierarchy), [hierarchy]);
+  const hierarchyData = useMemo(
+    () => getHierarchyDimensions(hierarchy, project.platform === 'flutter'),
+    [hierarchy, project.platform]
+  );
   const nodeLookupMap = useMemo(() => {
     const map = new Map<ViewHierarchyWindow, ViewNode>();
     hierarchyData.nodes.forEach(node => {


### PR DESCRIPTION
A workaround for it being difficult to get relative positions in Flutter. We have access to the SDK name and version so down the road we can transition these view hierarchies smoothly when the relative position is fixed.

Closes #44590 