### PR TITLE
fix(loading): fix white loading screen flash in dark mode

### DIFF
--- a/static/less/base.less
+++ b/static/less/base.less
@@ -30,6 +30,13 @@ body {
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
   min-height: 100vh;
+
+  @media (prefers-color-scheme: dark) {
+    // surface100
+    background-color: #18121c;
+    // gray400
+    color: #d6d0dc;
+  }
 }
 
 h1,

--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -393,23 +393,6 @@ table.table.key-value {
   margin: 6em auto;
   position: relative;
 
-  &.overlay {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(255, 255, 255, 0.8);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0;
-
-    &.dark {
-      background-color: rgba(0, 0, 0, 0.6);
-    }
-  }
-
   .loading-indicator {
     position: relative;
     border: 6px solid @white-darkest;


### PR DESCRIPTION
I noticed that if user sets their system mode to dark and tries loading sentry, we still show the white loading screen.

I'm not sure if this is the correct fix for two reasons, first, I may have missed a less variable that would map to our dark mode colors and secondly, adding styles to the body may break some text somewhere on Sentry that has never been styled (though we probably dont care unless it was on a white background which seems unlikely for dark mode anyways)

prod vs fixed version

https://user-images.githubusercontent.com/9317857/218775056-f3ec8da8-8310-43bc-ad7b-20d3393ac98e.mp4

I have also removed that layout.overlay class from our stylesheed because I could not find it's usage anywhere.

One thing to note is that if the user is using a light mode as their system preference, but has set their Sentry mode to dark mode, the same problem occurs (as we currently only rely on prefers css query and not user preferences). In that case we would need to apply a classname to toggle that from the start (leaving that part out as I'm not sure whats the best way to solve it nor if it's even doable)

