### PR TITLE
fix(onboarding): Fix sympony not appering under server - [TET-708]

### DIFF
--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -67,9 +67,23 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
       platform.name.toLowerCase().includes(filter) ||
       filterAliases[platform.id as PlatformKey]?.some(alias => alias.includes(filter));
 
-    const categoryMatch = (platform: PlatformIntegration) =>
-      category === 'all' ||
-      (currentCategory?.platforms as undefined | string[])?.includes(platform.id);
+    const categoryMatch = (platform: PlatformIntegration) => {
+      if (category === 'all') {
+        return true;
+      }
+
+      // Symfony was no appering under the server category
+      // because the php-symfony entry in src/sentry/integration-docs/_platforms.json
+      // does not contain the suffix 2.
+      // This is a temporary fix until we can update that file or completly remove the php-symfony2 occurrences
+      if (
+        (platform.id as any) === 'php-symfony' &&
+        (currentCategory?.platforms as undefined | string[])?.includes('php-symfony2')
+      ) {
+        return true;
+      }
+      return (currentCategory?.platforms as undefined | string[])?.includes(platform.id);
+    };
 
     const filtered = platforms
       .filter(this.state.filter ? subsetMatch : categoryMatch)


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/29228205/218780262-63436797-c791-4ded-8702-f8bc4b67a080.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/218780156-50409336-1700-4a51-87e2-2186bf895dc0.png)


The Symfony platform was not appearing under the tab "server" because the file "src/sentry/integration-docs/_platforms.json" doesn't contain a symphony entry with the number/suffix "2" and the backend list on the frontend  we contains symfony with the suffix `2`

https://github.com/getsentry/sentry/blob/765a9bf2b4da53a9c43cc20ac7a90316f7ada906/static/app/data/platformCategories.tsx#L106


Still have to check deeper how the `_platforms.json` file is generated because locally it does not contain the entry mentioned above but in production it does https://github.com/getsentry/sentry/blob/765a9bf2b4da53a9c43cc20ac7a90316f7ada906/fixtures/integration-docs/_platforms.json#L278 

Strange 🤔 

In any case, this is a temp fix that solves the issue 