### PR TITLE
Revert "ref(js): Small template usage improvement"

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -33,7 +33,7 @@ import {Panel, PanelBody} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import Truncate from 'sentry/components/truncate';
 import {IconCheckmark, IconFire, IconWarning} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import {DateString, Organization, Project} from 'sentry/types';
@@ -302,10 +302,8 @@ class MetricChart extends PureComponent<Props, State> {
       ...getRuleChangeSeries(rule, timeseriesData),
     ];
 
-    const queryFilter = tct('[filters] over [duration]', {
-      filters: filter?.join(' '),
-      duration: getDuration(rule.timeWindow * 60),
-    });
+    const queryFilter =
+      filter?.join(' ') + t(' over ') + getDuration(rule.timeWindow * 60);
 
     const percentOfWidth =
       width >= 1151


### PR DESCRIPTION
Reverts getsentry/sentry#44475

the text becomes a react element and overflows
![image](https://user-images.githubusercontent.com/1400464/218821489-b905f759-f738-4e74-b1a5-81ae022d5d65.png)
