### PR TITLE
feat(roles): only return orgs where user is owner for CloseAccount

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -134,7 +134,11 @@ class OrganizationManager(BaseManager):
         )
 
         # get owners from orgs
-        owner_role_orgs = orgs.filter(member_set__role=roles.get_top_dog().id)
+        owner_role_orgs = Organization.objects.filter(
+            member_set__user_id=user_id,
+            status=OrganizationStatus.VISIBLE,
+            member_set__role=roles.get_top_dog().id,
+        )
 
         # get owner teams
         owner_teams = Team.objects.filter(

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -44,6 +44,7 @@ class OrganizationsListTest(OrganizationIndexTest):
         user2 = self.create_user(email="user2@example.com")
         org3 = self.create_organization(name="C", owner=user2)
         org4 = self.create_organization(name="D", owner=user2)
+        org5 = self.create_organization(name="E", owner=user2)
 
         self.create_member(user=user2, organization=org2, role="owner")
         self.create_member(user=self.user, organization=org3, role="owner")
@@ -51,6 +52,7 @@ class OrganizationsListTest(OrganizationIndexTest):
         owner_team = self.create_team(organization=org4, org_role="owner")
         # org4 has 2 owners
         self.create_member(user=self.user, organization=org4, role="member", teams=[owner_team])
+        self.create_member(user=self.user, organization=org5, role="member")
 
         response = self.get_success_response(qs_params={"owner": 1})
         assert len(response.data) == 4


### PR DESCRIPTION
The close account page is currently showing all the orgs that a user is a part of, when it should be showing only the orgs where a user has the role of owner. The tests didn't catch this, this updates that and the logic for showing it.

The query had an extra inner join which wasn't filtering for the orgs where the user has an owner role properly.