### PR TITLE
fix(source-maps): fix titles and adds url prefix to error message

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
@@ -108,7 +108,11 @@ describe('SourceMapDebug', () => {
     const error: SourceMapDebugError = {
       type: SourceMapProcessingIssueType.PARTIAL_MATCH,
       message: '',
-      data: {absPath: 'insertPath', partialMatchPath: 'matchedSourcemapPath'},
+      data: {
+        absPath: 'insertPath',
+        partialMatchPath: 'matchedSourcemapPath',
+        urlPrefix: 'urlPrefix',
+      },
     };
     MockApiClient.addMockResponse({
       url,
@@ -126,10 +130,7 @@ describe('SourceMapDebug', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText(
-        'The abs_path of the stack frame is a partial match. The stack frame has the path insertPath which is a partial match to matchedSourcemapPath.',
-        {exact: false}
-      )
+      screen.getByText('Partial Absolute Path Match', {exact: false})
     ).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Read Guide'})).toHaveAttribute(
       'href',

--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -69,10 +69,14 @@ function getErrorMessage(
     case SourceMapProcessingIssueType.PARTIAL_MATCH:
       return [
         {
-          title: t(
-            'The abs_path of the stack frame is a partial match. The stack frame has the path %s which is a partial match to %s. You might need to modify the value of url-prefix.',
-            error.data.absPath,
-            error.data.partialMatchPath
+          title: t('Partial Absolute Path Match'),
+          desc: tct(
+            'The abs_path of the stack frame is a partial match. The stack frame has the path [absPath] which is a partial match to [partialMatchPath]. You need to update the value for the URL prefix argument or `includes` in your config options to include [urlPrefix]',
+            {
+              absPath: <code>{error.data.absPath}</code>,
+              partialMatchPath: <code>{error.data.partialMatchPath}</code>,
+              urlPrefix: <code>{error.data.urlPrefix}</code>,
+            }
           ),
           docsLink: getTroubleshootingLink(
             'verify-artifact-names-match-stack-trace-frames'
@@ -138,7 +142,7 @@ function getErrorMessage(
     case SourceMapProcessingIssueType.DIST_MISMATCH:
       return [
         {
-          title: t('Absolute Path Mismatch'),
+          title: t('Dist Mismatch'),
           desc: tct(
             "The distribution identifier you are providing doesn't match. The [literalDist] value of [dist] configured in your [init] must be the same as the one used during source map upload. Please refer to the instructions in our docs guide for help with troubleshooting the issue.",
             {

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
@@ -30,7 +30,7 @@ interface UrlNotValidDebugError extends BaseSourceMapDebugError {
   type: SourceMapProcessingIssueType.URL_NOT_VALID;
 }
 interface PartialMatchDebugError extends BaseSourceMapDebugError {
-  data: {absPath: string; partialMatchPath: string};
+  data: {absPath: string; partialMatchPath: string; urlPrefix: string};
   type: SourceMapProcessingIssueType.PARTIAL_MATCH;
 }
 interface DistMismatchDebugError extends BaseSourceMapDebugError {


### PR DESCRIPTION
this pr fixes 2 titles for the debugging source maps messages and adds in more context around how they can change their url-prefix or other settings if there is a partial match 