### PR TITLE
feat(issue-owners): Ratelimit issue ownership evaluations

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS))
 
-ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 1000
+ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 30
 
 
 class PostProcessJob(TypedDict, total=False):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -123,8 +123,12 @@ def _capture_group_stats(job: PostProcessJob) -> None:
 
 
 def should_issue_owners_ratelimit(
-    cache_key,
+    project_id,
 ):
+    """
+    Make sure that we do not make more requests than ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT at the project level.
+    """
+    cache_key = f"issue_owner_assignment_ratelimit:{project_id}"
     data = cache.get(cache_key)
     if data is None:
         requests = 1
@@ -168,9 +172,7 @@ def handle_owner_assignment(job):
 
                 with sentry_sdk.start_span(op="post_process.handle_owner_assignment.ratelimited"):
 
-                    ratelimit_key = f"issue_owner_assignment_ratelimit:{project.id}"
-
-                    if should_issue_owners_ratelimit(ratelimit_key):
+                    if should_issue_owners_ratelimit(project.id):
                         logger.info(
                             "handle_owner_assignment.ratelimited",
                             extra={

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -993,7 +993,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
     def test_issue_owners_should_ratelimit(self, logger):
         cache.set(
             f"issue_owner_assignment_ratelimit:{self.project.id}",
-            (ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT + 1, datetime.now()),
+            (ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT, datetime.now()),
         )
         event = self.create_event(
             data={

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Dict
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -39,7 +39,11 @@ from sentry.rules import init_registry
 from sentry.services.hybrid_cloud.user import user_service
 from sentry.tasks.derive_code_mappings import SUPPORTED_LANGUAGES
 from sentry.tasks.merge import merge_groups
-from sentry.tasks.post_process import post_process_group, process_event
+from sentry.tasks.post_process import (
+    ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
+    post_process_group,
+    process_event,
+)
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import BaseTestCase
 from sentry.testutils.helpers import apply_feature_flag_on_cls, with_feature
@@ -982,6 +986,38 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
                 "project": event.project_id,
                 "organization": event.project.organization_id,
                 "reason": "issue_owners_exist",
+            },
+        )
+
+    @patch("sentry.tasks.post_process.logger")
+    def test_issue_owners_should_ratelimit(self, logger):
+        cache.set(
+            f"issue_owner_assignment_ratelimit:{self.project.id}",
+            (ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT + 1, datetime.now()),
+        )
+        event = self.create_event(
+            data={
+                "message": "oh no",
+                "platform": "python",
+                "stacktrace": {"frames": [{"filename": "src/app.py"}]},
+            },
+            project_id=self.project.id,
+        )
+
+        self.call_post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+        logger.info.assert_any_call(
+            "handle_owner_assignment.ratelimited",
+            extra={
+                "event": event.event_id,
+                "group": event.group_id,
+                "project": event.project_id,
+                "organization": event.project.organization_id,
+                "reason": "ratelimited",
             },
         )
 


### PR DESCRIPTION
## Objective:
Customers can create new groups for the same issue and potentially overload the queue. We should set a project-wide ratelimit. The value of the ratelimit is based on the p99 of the current new issue creation per project per min across all orgs.
