### PR TITLE
feat(saved-searches): Add feature flag to control button location experiment

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1138,6 +1138,7 @@ SENTRY_FEATURES = {
     "organizations:issue-alert-fallback-targeting": False,
     # Enable removing issue from issue list if action taken.
     "organizations:issue-list-removal-action": False,
+    "organizations:issue-list-saved-searches-button-location": False,
     # Prefix host with organization ID when giving users DSNs (can be
     # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)
     "organizations:org-subdomains": False,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1138,6 +1138,7 @@ SENTRY_FEATURES = {
     "organizations:issue-alert-fallback-targeting": False,
     # Enable removing issue from issue list if action taken.
     "organizations:issue-list-removal-action": False,
+    # Moves the saved searches button location next to the search bar
     "organizations:issue-list-saved-searches-button-location": False,
     # Prefix host with organization ID when giving users DSNs (can be
     # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -87,6 +87,7 @@ default_manager.add("organizations:issue-alert-preview", OrganizationFeature, Tr
 default_manager.add("organizations:issue-alert-test-notifications", OrganizationFeature, True)
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, True)
 default_manager.add("organizations:issue-list-removal-action", OrganizationFeature, True)
+default_manager.add("organizations:issue-list-saved-searches-button-location", OrganizationFeature, True)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, True)
 default_manager.add("organizations:issue-platform", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, True)


### PR DESCRIPTION
Needed for https://github.com/getsentry/getsentry/pull/9541 so we can control which orgs see the experiment.