### PR TITLE
fix(tests): Fix `<Item>` `textValue` warnings

### DIFF
--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -47,7 +47,7 @@ function OptionSelector({
   const mappedOptions = useMemo(() => {
     return options.map(opt => ({
       ...opt,
-      textValue: opt.label,
+      textValue: String(opt.label),
       label: <Truncate value={String(opt.label)} maxLength={60} expandDirection="left" />,
     }));
   }, [options]);

--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -47,6 +47,7 @@ function OptionSelector({
   const mappedOptions = useMemo(() => {
     return options.map(opt => ({
       ...opt,
+      textValue: opt.label,
       label: <Truncate value={String(opt.label)} maxLength={60} expandDirection="left" />,
     }));
   }, [options]);

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -157,6 +157,7 @@ function BaseTabList({
           value: key,
           label: item.props.children,
           disabled: item.props.disabled,
+          textValue: item.textValue,
         };
       });
   }, [state.collection, overflowTabs]);


### PR DESCRIPTION
Fix all those `textValue` warnings we've been seeing a lot of lately:
<img width="798" alt="Screenshot 2023-02-14 at 12 19 10 PM" src="https://user-images.githubusercontent.com/44172267/218852541-3ad86f1a-0f7d-436c-a0ce-ea97d94b425e.png">

They all come from just two components: `Tabs` and charts' `OptionSelector`.