### PR TITLE
fix(source-maps): fixes too many values to unpack error in ArtifactSource

### DIFF
--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -201,10 +201,8 @@ class ArtifactSource:
         return len(self.sorted_and_filtered_files)
 
     def __getitem__(self, range):
-        return [
-            pseudo_releasefile(url, info, self._dist)
-            for url, info in self.sorted_and_filtered_files[range]
-        ]
+        url, info = self.sorted_and_filtered_files[range]
+        return [pseudo_releasefile(url, info, self._dist)]
 
 
 def pseudo_releasefile(url, info, dist):

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -201,8 +201,10 @@ class ArtifactSource:
         return len(self.sorted_and_filtered_files)
 
     def __getitem__(self, range):
-        url, info = self.sorted_and_filtered_files[range]
-        return [pseudo_releasefile(url, info, self._dist)]
+        return [
+            pseudo_releasefile(url, info, self._dist)
+            for url, info in self.sorted_and_filtered_files[range]
+        ]
 
 
 def pseudo_releasefile(url, info, dist):

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -297,7 +297,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
             if artifact_index is not None:
                 files = artifact_index.get("files", {})
                 source = ArtifactSource(dist, files, [], [])
-                data_sources.extend([source[i][0] for i in range(len(source))])
+                data_sources.extend(source[:])
 
         return data_sources
 

--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -297,7 +297,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
             if artifact_index is not None:
                 files = artifact_index.get("files", {})
                 source = ArtifactSource(dist, files, [], [])
-                data_sources.extend([source[i] for i in range(len(source))])
+                data_sources.extend([source[i][0] for i in range(len(source))])
 
         return data_sources
 


### PR DESCRIPTION
this pr fixes the unpacking issue in `__getitem__` for the source maps debug endpoint. instead of trying to index in one by one, we will use the slice to get all the results at once, avoiding the unpacking issue which came from doing it one at a time. 
