### PR TITLE
fix(api): Remove inclusion of CHECKIN_ID in monitor check-in POST

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -77,7 +77,6 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
         parameters=[
             GLOBAL_PARAMS.ORG_SLUG,
             MONITOR_PARAMS.MONITOR_ID,
-            MONITOR_PARAMS.CHECKIN_ID,
         ],
         request=MonitorCheckInValidator,
         responses={


### PR DESCRIPTION
This is not a parameter