### PR TITLE
fix(api): Don't try and convert_args when http_method_not_allowed

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -285,9 +285,11 @@ class Endpoint(APIView):
                 self.initial(request, *args, **kwargs)
 
                 # Get the appropriate handler method
-                if request.method.lower() in self.http_method_names:
-                    handler = getattr(self, request.method.lower(), self.http_method_not_allowed)
+                method = request.method.lower()
+                if method in self.http_method_names and hasattr(self, method):
+                    handler = getattr(self, method)
 
+                    # Only convert args when using defined handlers
                     (args, kwargs) = self.convert_args(request, *args, **kwargs)
                     self.args = args
                     self.kwargs = kwargs

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -78,6 +78,6 @@ class SentryInternalAppTokenCreationTest(APITestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.client.post(url, format="json")
+        response = self.client.delete(url, format="json")
 
         assert response.status_code == 404

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -6,6 +6,7 @@ from sentry.testutils.silo import region_silo_test
 
 
 class BaseIncidentCommentDetailsTest(APITestCase):
+    method = "put"
     endpoint = "sentry-api-0-organization-incident-comment-details"
 
     def setUp(self):


### PR DESCRIPTION
Fixes SENTRY-XXT