### PR TITLE
feat(ecosystem): Rename issue owners to ownership rules

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -459,7 +459,7 @@ function buildRoutes() {
       />
       <Route
         path="ownership/"
-        name={t('Issue Owners')}
+        name={t('Ownership Rules')}
         component={make(() => import('sentry/views/settings/project/projectOwnership'))}
       />
       <Route

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -48,8 +48,10 @@ export default function getConfiguration({
         },
         {
           path: `${pathPrefix}/ownership/`,
-          title: t('Issue Owners'),
-          description: t('Manage issue ownership rules for a project'),
+          title: organization?.features?.includes('streamline-targeting-context')
+            ? t('Ownership Rules')
+            : t('Issue Owners'),
+          description: t('Manage ownership rules for a project'),
         },
         {
           path: `${pathPrefix}/data-forwarding/`,

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -32,9 +32,17 @@ type State = {
 } & AsyncView['state'];
 
 class ProjectOwnership extends AsyncView<Props, State> {
+  // TODO: Remove with `streamline-targeting-context`
+  getOwnershipTitle() {
+    const {organization} = this.props;
+    return organization.features?.includes('streamline-targeting-context')
+      ? t('Ownership Rules')
+      : t('Issue Owners');
+  }
+
   getTitle() {
     const {project} = this.props;
-    return routeTitleGen(t('Issue Owners'), project.slug, false);
+    return routeTitleGen(this.getOwnershipTitle(), project.slug, false);
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
@@ -242,7 +250,7 @@ tags.sku_class:enterprise #enterprise`;
     return (
       <Fragment>
         <SettingsPageHeader
-          title={t('Issue Owners')}
+          title={this.getOwnershipTitle()}
           action={
             <Fragment>
               <Button


### PR DESCRIPTION
behind the `streamline-targeting-context` flag.

![image](https://user-images.githubusercontent.com/1400464/218892668-264b1611-77f9-4c8b-9fdb-6f7b98634bab.png)

[WOR-2611](https://getsentry.atlassian.net/browse/WOR-2611)

[WOR-2611]: https://getsentry.atlassian.net/browse/WOR-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ