### PR TITLE
fix(perf): Transaction name search wildcard, parsing and metrics incompatible filters

### DIFF
--- a/static/app/components/performance/searchBar.spec.tsx
+++ b/static/app/components/performance/searchBar.spec.tsx
@@ -139,7 +139,7 @@ describe('SearchBar', () => {
     expect(onSearch).toHaveBeenCalledWith('transaction:clients.fetch');
   });
 
-  it('Submits wildcard searches', async () => {
+  it('Submits wildcard searches as raw text searches', async () => {
     const onSearch = jest.fn();
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -163,7 +163,7 @@ describe('SearchBar', () => {
 
     expect(screen.queryByTestId('smart-search-dropdown')).not.toBeInTheDocument();
     expect(onSearch).toHaveBeenCalledTimes(1);
-    expect(onSearch).toHaveBeenCalledWith('transaction:client*');
+    expect(onSearch).toHaveBeenCalledWith('client*');
   });
 
   it('closes the search dropdown when clicked outside of', () => {

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -193,7 +193,7 @@ function SearchBar(props: SearchBarProps) {
   const handleSearch = (query: string) => {
     setSearchResults([]);
     setSearchString(query);
-    onSearch(query ? `transaction:${wrapQueryInWildcards(query)}` : '');
+    onSearch(query || '');
     closeDropdown();
   };
 
@@ -254,7 +254,7 @@ interface DataItem {
   'count()'?: number;
 }
 
-const wrapQueryInWildcards = (query: string) => {
+export const wrapQueryInWildcards = (query: string) => {
   if (!query.startsWith('*')) {
     query = '*' + query;
   }

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -193,7 +193,7 @@ function SearchBar(props: SearchBarProps) {
   const handleSearch = (query: string) => {
     setSearchResults([]);
     setSearchString(query);
-    onSearch(query ? `transaction:${query}` : '');
+    onSearch(query ? `transaction:${wrapQueryInWildcards(query)}` : '');
     closeDropdown();
   };
 
@@ -255,7 +255,7 @@ interface DataItem {
 }
 
 const wrapQueryInWildcards = (query: string) => {
-  if (!query.startsWith('* ')) {
+  if (!query.startsWith('*')) {
     query = '*' + query;
   }
 

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -116,7 +116,7 @@ function SearchBar(props: SearchBarProps) {
       if (currentItem?.value) {
         handleChooseItem(currentItem.value);
       } else {
-        handleSearch(searchString);
+        handleSearch(searchString, true);
       }
     }
   };
@@ -182,7 +182,7 @@ function SearchBar(props: SearchBarProps) {
 
   const handleChooseItem = (value: string) => {
     const item = decodeValueToItem(value);
-    handleSearch(item.transaction);
+    handleSearch(item.transaction, false);
   };
 
   const handleClickItemIcon = (value: string) => {
@@ -190,10 +190,11 @@ function SearchBar(props: SearchBarProps) {
     navigateToItemTransactionSummary(item);
   };
 
-  const handleSearch = (query: string) => {
+  const handleSearch = (query: string, asRawText: boolean) => {
     setSearchResults([]);
     setSearchString(query);
-    onSearch(query || '');
+    const fullQuery = asRawText ? query : `transaction:${query}`;
+    onSearch(query ? fullQuery : '');
     closeDropdown();
   };
 

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -392,6 +392,30 @@ export function getTermHelp(
   return PERFORMANCE_TERMS[term](organization);
 }
 
+function prepareQueryForLandingPage(searchQuery, withStaticFilters) {
+  const conditions = new MutableSearch(searchQuery);
+
+  // If there is a bare text search, we want to treat it as a search
+  // on the transaction name.
+  if (conditions.freeText.length > 0) {
+    const parsedFreeText = conditions.freeText.join(' ');
+
+    // the query here is a user entered condition, no need to escape it
+    conditions.setFilterValues(
+      'transaction',
+      [wrapQueryInWildcards(parsedFreeText)],
+      false
+    );
+    conditions.freeText = [];
+  }
+  if (withStaticFilters) {
+    conditions.tokens = conditions.tokens.filter(
+      token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
+    );
+  }
+  return conditions.formatString();
+}
+
 function generateGenericPerformanceEventView(
   location: Location,
   withStaticFilters: boolean,
@@ -433,28 +457,7 @@ function generateGenericPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = new MutableSearch(searchQuery);
-
-  // If there is a bare text search, we want to treat it as a search
-  // on the transaction name.
-  if (conditions.freeText.length > 0) {
-    const parsedFreeText = conditions.freeText.join(' ');
-
-    // the query here is a user entered condition, no need to escape it
-    conditions.setFilterValues(
-      'transaction',
-      [wrapQueryInWildcards(parsedFreeText)],
-      false
-    );
-    conditions.freeText = [];
-  }
-
-  if (withStaticFilters) {
-    conditions.tokens = conditions.tokens.filter(
-      token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
-    );
-  }
-  savedQuery.query = conditions.formatString();
+  savedQuery.query = prepareQueryForLandingPage(searchQuery, withStaticFilters);
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
@@ -514,27 +517,7 @@ function generateBackendPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = new MutableSearch(searchQuery);
-
-  // If there is a bare text search, we want to treat it as a search
-  // on the transaction name.
-  if (conditions.freeText.length > 0) {
-    const parsedFreeText = conditions.freeText.join(' ');
-
-    // the query here is a user entered condition, no need to escape it
-    conditions.setFilterValues(
-      'transaction',
-      [wrapQueryInWildcards(parsedFreeText)],
-      false
-    );
-    conditions.freeText = [];
-  }
-  if (withStaticFilters) {
-    conditions.tokens = conditions.tokens.filter(
-      token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
-    );
-  }
-  savedQuery.query = conditions.formatString();
+  savedQuery.query = prepareQueryForLandingPage(searchQuery, withStaticFilters);
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
 
@@ -598,27 +581,7 @@ function generateMobilePerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = new MutableSearch(searchQuery);
-
-  // If there is a bare text search, we want to treat it as a search
-  // on the transaction name.
-  if (conditions.freeText.length > 0) {
-    const parsedFreeText = conditions.freeText.join(' ');
-
-    // the query here is a user entered condition, no need to escape it
-    conditions.setFilterValues(
-      'transaction',
-      [wrapQueryInWildcards(parsedFreeText)],
-      false
-    );
-    conditions.freeText = [];
-  }
-  if (withStaticFilters) {
-    conditions.tokens = conditions.tokens.filter(
-      token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
-    );
-  }
-  savedQuery.query = conditions.formatString();
+  savedQuery.query = prepareQueryForLandingPage(searchQuery, withStaticFilters);
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
 
@@ -668,27 +631,7 @@ function generateFrontendPageloadPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = new MutableSearch(searchQuery);
-
-  // If there is a bare text search, we want to treat it as a search
-  // on the transaction name.
-  if (conditions.freeText.length > 0) {
-    const parsedFreeText = conditions.freeText.join(' ');
-
-    // the query here is a user entered condition, no need to escape it
-    conditions.setFilterValues(
-      'transaction',
-      [wrapQueryInWildcards(parsedFreeText)],
-      false
-    );
-    conditions.freeText = [];
-  }
-  if (withStaticFilters) {
-    conditions.tokens = conditions.tokens.filter(
-      token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
-    );
-  }
-  savedQuery.query = conditions.formatString();
+  savedQuery.query = prepareQueryForLandingPage(searchQuery, withStaticFilters);
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
 
@@ -739,27 +682,7 @@ function generateFrontendOtherPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = new MutableSearch(searchQuery);
-
-  // If there is a bare text search, we want to treat it as a search
-  // on the transaction name.
-  if (conditions.freeText.length > 0) {
-    const parsedFreeText = conditions.freeText.join(' ');
-
-    // the query here is a user entered condition, no need to escape it
-    conditions.setFilterValues(
-      'transaction',
-      [wrapQueryInWildcards(parsedFreeText)],
-      false
-    );
-    conditions.freeText = [];
-  }
-  if (withStaticFilters) {
-    conditions.tokens = conditions.tokens.filter(
-      token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
-    );
-  }
-  savedQuery.query = conditions.formatString();
+  savedQuery.query = prepareQueryForLandingPage(searchQuery, withStaticFilters);
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
 
@@ -852,21 +775,7 @@ export function generatePerformanceVitalDetailView(
   savedQuery.orderby = decodeScalar(query.sort, '-count');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = new MutableSearch(searchQuery);
-
-  // If there is a bare text search, we want to treat it as a search
-  // on the transaction name.
-  if (conditions.freeText.length > 0) {
-    // the query here is a user entered condition, no need to escape it
-    conditions.setFilterValues(
-      'transaction',
-      [wrapQueryInWildcards(conditions.freeText.join(' '))],
-      false
-    );
-    conditions.freeText = [];
-  }
-  conditions.setFilterValues('event.type', ['transaction']);
-  savedQuery.query = conditions.formatString();
+  savedQuery.query = prepareQueryForLandingPage(searchQuery, false);
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
 

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -434,7 +434,6 @@ function generateGenericPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-  // const isLimitedSearch = isUsingLimitedSearch(location, withStaticFilters);
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -1,6 +1,7 @@
 import {Location} from 'history';
 
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
+import {wrapQueryInWildcards} from 'sentry/components/performance/searchBar';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import {NewQuery, Organization, Project, SelectValue} from 'sentry/types';
@@ -453,20 +454,18 @@ function generateGenericPerformanceEventView(
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.freeText.length > 0) {
-    const parsedFreeText = isLimitedSearch
-      ? decodeScalar(conditions.freeText, '')
-      : conditions.freeText.join(' ');
+    const parsedFreeText = conditions.freeText.join(' ');
 
-    if (isLimitedSearch) {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`${parsedFreeText}`], false);
-    } else {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`*${parsedFreeText}*`], false);
-    }
+    // the query here is a user entered condition, no need to escape it
+    conditions.setFilterValues(
+      'transaction',
+      [wrapQueryInWildcards(parsedFreeText)],
+      false
+    );
     conditions.freeText = [];
   }
   if (isLimitedSearch) {
+    // TODO fix transaction.duration  filter here
     conditions.tokens = conditions.tokens.filter(
       token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
     );
@@ -490,7 +489,6 @@ function generateGenericPerformanceEventView(
 
 function generateBackendPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
   organization: Organization
 ): EventView {
   const {query} = location;
@@ -532,22 +530,18 @@ function generateBackendPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-  const isLimitedSearch = isUsingLimitedSearch(location, withStaticFilters);
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.freeText.length > 0) {
-    const parsedFreeText = isLimitedSearch
-      ? decodeScalar(conditions.freeText, '')
-      : conditions.freeText.join(' ');
+    const parsedFreeText = conditions.freeText.join(' ');
 
-    if (isLimitedSearch) {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`${parsedFreeText}`], false);
-    } else {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`*${parsedFreeText}*`], false);
-    }
+    // the query here is a user entered condition, no need to escape it
+    conditions.setFilterValues(
+      'transaction',
+      [wrapQueryInWildcards(parsedFreeText)],
+      false
+    );
     conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
@@ -563,7 +557,6 @@ function generateMobilePerformanceEventView(
   location: Location,
   projects: Project[],
   genericEventView: EventView,
-  withStaticFilters: boolean,
   organization: Organization
 ): EventView {
   const {query} = location;
@@ -615,23 +608,18 @@ function generateMobilePerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-  const isLimitedSearch = isUsingLimitedSearch(location, withStaticFilters);
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.freeText.length > 0) {
-    const parsedFreeText = isLimitedSearch
-      ? // pick first element to search transactions by name
-        decodeScalar(conditions.freeText, '')
-      : conditions.freeText.join(' ');
+    const parsedFreeText = conditions.freeText.join(' ');
 
-    if (isLimitedSearch) {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`${parsedFreeText}`], false);
-    } else {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`*${parsedFreeText}*`], false);
-    }
+    // the query here is a user entered condition, no need to escape it
+    conditions.setFilterValues(
+      'transaction',
+      [wrapQueryInWildcards(parsedFreeText)],
+      false
+    );
     conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
@@ -645,7 +633,6 @@ function generateMobilePerformanceEventView(
 
 function generateFrontendPageloadPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
   organization: Organization
 ): EventView {
   const {query} = location;
@@ -685,23 +672,18 @@ function generateFrontendPageloadPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-  const isLimitedSearch = isUsingLimitedSearch(location, withStaticFilters);
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.freeText.length > 0) {
-    const parsedFreeText = isLimitedSearch
-      ? // pick first element to search transactions by name
-        decodeScalar(conditions.freeText, '')
-      : conditions.freeText.join(' ');
+    const parsedFreeText = conditions.freeText.join(' ');
 
-    if (isLimitedSearch) {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`${parsedFreeText}`], false);
-    } else {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`*${parsedFreeText}*`], false);
-    }
+    // the query here is a user entered condition, no need to escape it
+    conditions.setFilterValues(
+      'transaction',
+      [wrapQueryInWildcards(parsedFreeText)],
+      false
+    );
     conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
@@ -716,7 +698,6 @@ function generateFrontendPageloadPerformanceEventView(
 
 function generateFrontendOtherPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
   organization: Organization
 ): EventView {
   const {query} = location;
@@ -756,24 +737,18 @@ function generateFrontendOtherPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = new MutableSearch(searchQuery);
-  const isLimitedSearch = isUsingLimitedSearch(location, withStaticFilters);
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
-  if (conditions.freeText.length > 0 && !isLimitedSearch) {
-    const parsedFreeText = isLimitedSearch
-      ? // pick first element to search transactions by name
-        decodeScalar(conditions.freeText, '')
-      : conditions.freeText.join(' ');
+  if (conditions.freeText.length > 0) {
+    const parsedFreeText = conditions.freeText.join(' ');
 
-    if (isLimitedSearch) {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`${parsedFreeText}`], false);
-    } else {
-      // the query here is a user entered condition, no need to escape it
-      conditions.setFilterValues('transaction', [`*${parsedFreeText}*`], false);
-    }
-
+    // the query here is a user entered condition, no need to escape it
+    conditions.setFilterValues(
+      'transaction',
+      [wrapQueryInWildcards(parsedFreeText)],
+      false
+    );
     conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
@@ -803,29 +778,16 @@ export function generatePerformanceEventView(
   const display = getCurrentLandingDisplay(location, projects, eventView);
   switch (display?.field) {
     case LandingDisplayField.FRONTEND_PAGELOAD:
-      return generateFrontendPageloadPerformanceEventView(
-        location,
-        withStaticFilters,
-        organization
-      );
+      return generateFrontendPageloadPerformanceEventView(location, organization);
     case LandingDisplayField.FRONTEND_OTHER:
-      return generateFrontendOtherPerformanceEventView(
-        location,
-        withStaticFilters,
-        organization
-      );
+      return generateFrontendOtherPerformanceEventView(location, organization);
     case LandingDisplayField.BACKEND:
-      return generateBackendPerformanceEventView(
-        location,
-        withStaticFilters,
-        organization
-      );
+      return generateBackendPerformanceEventView(location, organization);
     case LandingDisplayField.MOBILE:
       return generateMobilePerformanceEventView(
         location,
         projects,
         eventView,
-        withStaticFilters,
         organization
       );
     default:
@@ -877,7 +839,7 @@ export function generatePerformanceVitalDetailView(
     // the query here is a user entered condition, no need to escape it
     conditions.setFilterValues(
       'transaction',
-      [`*${conditions.freeText.join(' ')}*`],
+      [wrapQueryInWildcards(conditions.freeText.join(' '))],
       false
     );
     conditions.freeText = [];

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -119,6 +119,11 @@ export function PerformanceLanding(props: Props) {
     if (transactionValues.length) {
       return transactionValues[0];
     }
+    if (conditions.freeText.length > 0) {
+      // raw text query will be wrapped in wildcards in generatePerformanceEventView
+      // so no need to wrap it here
+      return conditions.freeText.join(' ');
+    }
     return '';
   };
 


### PR DESCRIPTION
This PR fixes:
- Wildcard search. Previously, free text would get interpreted as a wildcard query. This PR brings that back
<img width="1191" alt="Screen Shot 2023-02-14 at 4 31 15 PM" src="https://user-images.githubusercontent.com/23648387/218895509-426992a7-ed94-43a9-9323-c535b704de8e.png">

- Previously, we'd only take a first element of the parsed query. This change now accounts for transaction names with a space in them so we correctly apply the transaction filter

- If any filters were applied in transaction summary, navigating back to the landing page wouldn't clear those filters correctly so the metrics query would fail. 
**Before:**
<img width="1743" alt="Screen Shot 2023-02-14 at 4 30 41 PM" src="https://user-images.githubusercontent.com/23648387/218895505-7f16298d-2fe9-4cbd-84b1-56c7cca1feeb.png">
<img width="1817" alt="Screen Shot 2023-02-14 at 4 30 31 PM" src="https://user-images.githubusercontent.com/23648387/218895500-ddd9123f-c739-44d4-8c8e-fd383408b24b.png">

**After:**
<img width="1202" alt="Screen Shot 2023-02-14 at 4 30 59 PM" src="https://user-images.githubusercontent.com/23648387/218895507-17a2ad44-e1e9-4d11-95d7-646f294cd9ee.png">

Fixes PERF-1960, PERF-1939
