### PR TITLE
chore(hybrid-cloud): Api* => Rpc*

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -45,7 +45,7 @@ __all__ = [
     "pending_silo_endpoint",
 ]
 
-from ..services.hybrid_cloud.auth import ApiAuthentication, ApiAuthenticatorType
+from ..services.hybrid_cloud.auth import RpcAuthentication, RpcAuthenticatorType
 from ..utils.pagination_factory import (
     annotate_span_with_pagination_args,
     clamp_pagination_per_page,
@@ -138,16 +138,16 @@ class Endpoint(APIView):
         if SiloMode.get_current_mode() == SiloMode.MONOLITH:
             return super().get_authenticators()
 
-        last_api_authenticator = ApiAuthentication([])
+        last_api_authenticator = RpcAuthentication([])
         result: List[BaseAuthentication] = []
         for authenticator_cls in self.authentication_classes:
-            auth_type = ApiAuthenticatorType.from_authenticator(authenticator_cls)
+            auth_type = RpcAuthenticatorType.from_authenticator(authenticator_cls)
             if auth_type:
                 last_api_authenticator.types.append(auth_type)
             else:
                 if last_api_authenticator.types:
                     result.append(last_api_authenticator)
-                    last_api_authenticator = ApiAuthentication([])
+                    last_api_authenticator = RpcAuthentication([])
                 result.append(authenticator_cls())
 
         if last_api_authenticator.types:

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -17,7 +17,7 @@ from sentry.api.validators.external_actor import (
 from sentry.api.validators.integrations import validate_provider
 from sentry.models import ExternalActor, Organization, Team
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.types.integrations import ExternalProviders, get_provider_choices
 
 AVAILABLE_PROVIDERS = {
@@ -98,7 +98,7 @@ class ExternalUserSerializer(ExternalActorSerializerBase):
 
     user_id = serializers.IntegerField(required=True)
 
-    def validate_user_id(self, user_id: int) -> APIUser:
+    def validate_user_id(self, user_id: int) -> RpcUser:
         """Ensure that this user exists and that they belong to the organization."""
         if (
             organization_service.check_membership_by_id(

--- a/src/sentry/api/bases/organization_integrations.py
+++ b/src/sentry/api/bases/organization_integrations.py
@@ -4,8 +4,8 @@ from rest_framework.request import Request
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.api.bases.organization import OrganizationIntegrationsPermission
 from sentry.services.hybrid_cloud.integration import (
-    APIIntegration,
-    APIOrganizationIntegration,
+    RpcIntegration,
+    RpcOrganizationIntegration,
     integration_service,
 )
 
@@ -35,7 +35,7 @@ class OrganizationIntegrationBaseEndpoint(IntegrationEndpoint):
             raise Http404
 
     @staticmethod
-    def get_organization_integration(organization, integration_id) -> APIOrganizationIntegration:
+    def get_organization_integration(organization, integration_id) -> RpcOrganizationIntegration:
         """
         Get just the cross table entry.
         Note: This will still return organization integrations that are pending deletion.
@@ -52,7 +52,7 @@ class OrganizationIntegrationBaseEndpoint(IntegrationEndpoint):
         return org_integration
 
     @staticmethod
-    def get_integration(organization, integration_id) -> APIIntegration:
+    def get_integration(organization, integration_id) -> RpcIntegration:
         """
         Note: The integration may still exist even when the
         OrganizationIntegration cross table entry has been deleted.

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -13,7 +13,7 @@ from sentry.integrations import IntegrationFeatures
 from sentry.models import Activity, ExternalIssue, GroupLink
 from sentry.models.group import Group
 from sentry.models.user import User
-from sentry.services.hybrid_cloud.integration import APIIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationFormError
 from sentry.signals import integration_issue_created, integration_issue_linked
 from sentry.types.activity import ActivityType
@@ -34,7 +34,7 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
         self.config = config
 
     def serialize(
-        self, obj: APIIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
+        self, obj: RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
     ) -> MutableMapping[str, JSONData]:
         data = super().serialize(obj, attrs, user)
 
@@ -59,7 +59,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
 
         return has_issue_sync or has_issue_basic
 
-    def _has_issue_feature_on_integration(self, integration: APIIntegration):
+    def _has_issue_feature_on_integration(self, integration: RpcIntegration):
         return integration_service.has_feature(
             provider=integration.provider, feature=IntegrationFeatures.ISSUE_BASIC
         ) or integration_service.has_feature(

--- a/src/sentry/api/endpoints/group_integrations.py
+++ b/src/sentry/api/endpoints/group_integrations.py
@@ -16,7 +16,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.user import User
 from sentry.services.hybrid_cloud import ApiPaginationArgs
-from sentry.services.hybrid_cloud.integration import APIIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.utils.json import JSONData
 
 
@@ -25,8 +25,8 @@ class IntegrationIssueSerializer(IntegrationSerializer):
         self.group = group
 
     def get_attrs(
-        self, item_list: List[APIIntegration], user: User, **kwargs: Any
-    ) -> MutableMapping[APIIntegration, MutableMapping[str, Any]]:
+        self, item_list: List[RpcIntegration], user: User, **kwargs: Any
+    ) -> MutableMapping[RpcIntegration, MutableMapping[str, Any]]:
         external_issues = ExternalIssue.objects.filter(
             id__in=GroupLink.objects.get_group_issues(self.group).values_list(
                 "linked_id", flat=True
@@ -62,7 +62,7 @@ class IntegrationIssueSerializer(IntegrationSerializer):
         }
 
     def serialize(
-        self, obj: APIIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
+        self, obj: RpcIntegration, attrs: Mapping[str, Any], user: User, **kwargs: Any
     ) -> MutableMapping[str, JSONData]:
         data = super().serialize(obj, attrs, user)
         data["externalIssues"] = attrs.get("external_issues", [])

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -11,7 +11,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.integration import OrganizationIntegrationSerializer
 from sentry.models import ObjectStatus, Organization, OrganizationIntegration
 from sentry.services.hybrid_cloud import ApiPaginationArgs
-from sentry.services.hybrid_cloud.integration import APIIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 
 
 def prepare_feature_filters(features_raw: Sequence[str]) -> set[str]:
@@ -20,7 +20,7 @@ def prepare_feature_filters(features_raw: Sequence[str]) -> set[str]:
 
 
 def prepare_features(
-    integration: APIIntegration,
+    integration: RpcIntegration,
 ) -> set[str]:
     """Normalize feature names Integration provider feature lists."""
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -40,7 +40,7 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.services.hybrid_cloud.organization_mapping import (
-    ApiOrganizationMappingUpdate,
+    RpcOrganizationMappingUpdate,
     organization_mapping_service,
 )
 from sentry.utils.cache import memoize
@@ -516,7 +516,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         )
                     elif "name" in changed_data:
                         organization_mapping_service.update(
-                            ApiOrganizationMappingUpdate(
+                            RpcOrganizationMappingUpdate(
                                 organization_id=organization.id,
                                 name=organization.name,
                             )

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -7,7 +7,7 @@ from rest_framework import serializers
 from sentry.models import ActorTuple, OrganizationMember, Team, User
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 class ActorField(serializers.Field):
@@ -25,7 +25,7 @@ class ActorField(serializers.Field):
                 "Could not parse actor. Format should be `type:id` where type is `team` or `user`."
             )
         try:
-            obj: APIUser | Team = actor.resolve()
+            obj: RpcUser | Team = actor.resolve()
         except (Team.DoesNotExist, User.DoesNotExist):
             raise serializers.ValidationError(f"{actor.type.__name__} does not exist")
 

--- a/src/sentry/api/fields/user.py
+++ b/src/sentry/api/fields/user.py
@@ -4,20 +4,20 @@ from typing import Any
 
 from rest_framework import serializers
 
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.utils.auth import find_users
 
 
 class UserField(serializers.Field):
-    def to_representation(self, value: APIUser):
+    def to_representation(self, value: RpcUser):
         return value.username
 
-    def to_internal_value(self, data: Any) -> APIUser | None:
+    def to_internal_value(self, data: Any) -> RpcUser | None:
         if not data:
             return None
 
         if isinstance(data, int) or data.isdigit():
-            user: APIUser = user_service.get_user(user_id=data)
+            user: RpcUser = user_service.get_user(user_id=data)
             if user is not None:
                 return user
 

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -49,7 +49,7 @@ from sentry.models.group import STATUS_UPDATE_CHOICES
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.models.groupinbox import GroupInboxRemoveAction, add_group_to_inbox
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import (
     issue_ignored,
     issue_mark_reviewed,
@@ -112,7 +112,7 @@ def handle_discard(
 
 
 def self_subscribe_and_assign_issue(
-    acting_user: User | APIUser | None, group: Group
+    acting_user: User | RpcUser | None, group: Group
 ) -> ActorTuple | None:
     # Used during issue resolution to assign to acting user
     # returns None if the user didn't elect to self assign on resolution
@@ -694,7 +694,7 @@ def update_groups(
         )
         if assigned_actor:
             for group in group_list:
-                resolved_actor: APIUser | Team = assigned_actor.resolve()
+                resolved_actor: RpcUser | Team = assigned_actor.resolve()
 
                 assignment = GroupAssignee.objects.assign(
                     group, resolved_actor, acting_user, extra=extra

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -100,20 +100,20 @@ class SentryPermission(ScopedPermission):
         if request.user and request.user.is_authenticated and request.auth:
             request.access = access.from_request_org_and_scopes(
                 request=request,
-                api_user_org_context=org_context,
+                rpc_user_org_context=org_context,
                 scopes=request.auth.get_scopes(),
             )
             return
 
         if request.auth:
             request.access = access.from_api_auth(
-                auth=request.auth, api_user_org_context=org_context
+                auth=request.auth, rpc_user_org_context=org_context
             )
             return
 
         request.access = access.from_request_org_and_scopes(
             request=request,
-            api_user_org_context=org_context,
+            rpc_user_org_context=org_context,
         )
 
         extra = {"organization_id": organization.id, "user_id": request.user.id}

--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -8,14 +8,14 @@ from sentry.api.serializers import Serializer, register
 from sentry.models import AuthProvider, Organization, OrganizationMember
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.auth import ApiAuthProvider
+    from sentry.services.hybrid_cloud.auth import RpcAuthProvider
 
 
 @register(AuthProvider)
 class AuthProviderSerializer(Serializer):
     def serialize(
         self,
-        obj: AuthProvider | ApiAuthProvider,
+        obj: AuthProvider | RpcAuthProvider,
         attrs,
         user,
         organization: Organization | None = None,

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -51,7 +51,7 @@ from sentry.models import (
     TeamStatus,
 )
 from sentry.models.user import User
-from sentry.services.hybrid_cloud.auth import ApiOrganizationAuthConfig, auth_service
+from sentry.services.hybrid_cloud.auth import RpcOrganizationAuthConfig, auth_service
 from sentry.services.hybrid_cloud.user import user_service
 from sentry.utils.http import is_using_customer_domain
 
@@ -190,7 +190,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
             for a in OrganizationAvatar.objects.filter(organization__in=item_list)
         }
 
-        configs_by_org_id: Mapping[int, ApiOrganizationAuthConfig] = {
+        configs_by_org_id: Mapping[int, RpcOrganizationAuthConfig] = {
             config.organization_id: config
             for config in auth_service.get_org_auth_config(
                 organization_ids=[o.id for o in item_list]
@@ -209,7 +209,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
 
     def _serialize_auth_providers(
         self,
-        configs_by_org_id: Mapping[int, ApiOrganizationAuthConfig],
+        configs_by_org_id: Mapping[int, RpcOrganizationAuthConfig],
         item_list: Sequence[Organization],
         user: User,
     ) -> Mapping[int, Any]:

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -25,7 +25,7 @@ from sentry.app import env
 from sentry.auth.access import (
     Access,
     SingularApiAccessOrgOptimization,
-    maybe_singular_api_access_org_context,
+    maybe_singular_rpc_access_org_context,
 )
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
@@ -106,7 +106,7 @@ def get_org_roles(
     if optimization:
         if optimization.access.roles is not None:
             return {
-                optimization.access.api_user_organization_context.organization.id: list(
+                optimization.access.rpc_user_organization_context.organization.id: list(
                     optimization.access.roles
                 )
             }
@@ -189,7 +189,7 @@ class TeamSerializer(Serializer):  # type: ignore
         request = env.request
         org_ids = {t.organization_id for t in item_list}
         optimization = (
-            maybe_singular_api_access_org_context(self.access, org_ids) if self.access else None
+            maybe_singular_rpc_access_org_context(self.access, org_ids) if self.access else None
         )
 
         all_org_roles = get_org_roles(org_ids, user, optimization=optimization)

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -39,8 +39,8 @@ from sentry.models import (
     UserPermission,
     UserRoleUser,
 )
-from sentry.services.hybrid_cloud.organization import ApiOrganizationSummary, organization_service
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary, organization_service
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils.avatar import get_gravatar_url
 
 
@@ -119,10 +119,10 @@ class UserSerializerResponseSelf(UserSerializerResponse):
 
 @register(User)
 class UserSerializer(Serializer):  # type: ignore
-    def _user_is_requester(self, obj: User, requester: User | AnonymousUser | APIUser) -> bool:
+    def _user_is_requester(self, obj: User, requester: User | AnonymousUser | RpcUser) -> bool:
         if isinstance(requester, User):
             return bool(requester == obj)
-        if isinstance(requester, APIUser):
+        if isinstance(requester, RpcUser):
             return bool(requester.id == obj.id)
         return False
 
@@ -130,7 +130,7 @@ class UserSerializer(Serializer):  # type: ignore
         self, item_list: Sequence[User], user: User
     ) -> Dict[int, List[AuthIdentity]]:
         if not (env.request and is_active_superuser(env.request)):
-            is_user = isinstance(user, User) or isinstance(user, APIUser)
+            is_user = isinstance(user, User) or isinstance(user, RpcUser)
             item_list = [x for x in item_list if is_user and x.id == user.id]
 
         queryset = AuthIdentity.objects.filter(
@@ -163,7 +163,7 @@ class UserSerializer(Serializer):  # type: ignore
         return data
 
     def serialize(
-        self, obj: User, attrs: MutableMapping[User, Any], user: User | AnonymousUser | APIUser
+        self, obj: User, attrs: MutableMapping[User, Any], user: User | AnonymousUser | RpcUser
     ) -> Union[UserSerializerResponse, UserSerializerResponseSelf]:
         experiment_assignments = experiments.all(user=user)
 
@@ -225,7 +225,7 @@ class UserSerializer(Serializer):  # type: ignore
                 only_visible=False,
                 organization_ids=list(organization_ids),
             )
-            orgs_by_id: Mapping[int, ApiOrganizationSummary] = {
+            orgs_by_id: Mapping[int, RpcOrganizationSummary] = {
                 o.id: o for o in auth_identity_organizations
             }
 

--- a/src/sentry/api/serializers/rest_framework/mentions.py
+++ b/src/sentry/api/serializers/rest_framework/mentions.py
@@ -5,7 +5,7 @@ from typing import Sequence
 from rest_framework import serializers
 
 from sentry.models import ActorTuple, Team, User
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 
 
 def extract_user_ids_from_mentions(organization_id, mentions):
@@ -16,7 +16,7 @@ def extract_user_ids_from_mentions(organization_id, mentions):
     is all user ids from explicitly mentioned teams, excluding any already
     mentioned users.
     """
-    actors: Sequence[APIUser | Team] = ActorTuple.resolve_many(mentions)
+    actors: Sequence[RpcUser | Team] = ActorTuple.resolve_many(mentions)
     actor_mentions = separate_resolved_actors(actors)
 
     team_users = user_service.get_many(
@@ -40,7 +40,7 @@ def separate_actors(actors):
     return {"users": users, "teams": teams}
 
 
-def separate_resolved_actors(actors: Sequence[APIUser | Team]):
+def separate_resolved_actors(actors: Sequence[RpcUser | Team]):
     users = [actor for actor in actors if actor.class_name() == "User"]
     teams = [actor for actor in actors if isinstance(actor, Team)]
 

--- a/src/sentry/api/validators/project_codeowners.py
+++ b/src/sentry/api/validators/project_codeowners.py
@@ -16,7 +16,7 @@ from sentry.ownership.grammar import parse_code_owners
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 def validate_association(
@@ -61,7 +61,7 @@ def validate_codeowners_associations(
     for external_actor in external_actors:
         type = actor_type_to_string(external_actor.actor.type)
         if type == "user":
-            user: APIUser = external_actor.actor.resolve()
+            user: RpcUser = external_actor.actor.resolve()
             organization_members_ids = OrganizationMember.objects.filter(
                 user_id=user.id, organization_id=project.organization_id
             ).values_list("id", flat=True)

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -6,6 +6,8 @@ __all__ = [
     "DEFAULT",
     "from_user_and_api_user_org_context",
     "from_api_member",
+    "from_user_and_rpc_user_org_context",
+    "from_rpc_member",
 ]
 
 import abc
@@ -35,13 +37,13 @@ from sentry.models import (
 from sentry.roles import organization_roles
 from sentry.roles.manager import OrganizationRole, TeamRole
 from sentry.services.hybrid_cloud.app import app_service
-from sentry.services.hybrid_cloud.auth import ApiAuthState, ApiMemberSsoState, auth_service
+from sentry.services.hybrid_cloud.auth import RpcAuthState, RpcMemberSsoState, auth_service
 from sentry.services.hybrid_cloud.organization import (
-    ApiTeamMember,
-    ApiUserOrganizationContext,
+    RpcTeamMember,
+    RpcUserOrganizationContext,
     organization_service,
 )
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.utils import metrics
 from sentry.utils.request_cache import request_cache
 
@@ -54,7 +56,7 @@ def get_cached_organization_member(user_id: int, organization_id: int) -> Organi
 def get_permissions_for_user(user_id: int) -> FrozenSet[str]:
     user = user_service.get_user(user_id)
     if user is None:
-        return FrozenSet()
+        return frozenset()
     return user.roles | user.permissions
 
 
@@ -391,23 +393,30 @@ class SingularApiAccessOrgOptimization:
     access: ApiBackedAccess
 
 
-def maybe_singular_api_access_org_context(
+def maybe_singular_rpc_access_org_context(
     access: Access, org_ids: Set[int]
 ) -> SingularApiAccessOrgOptimization | None:
     if (
         isinstance(access, ApiBackedAccess)
         and len(org_ids) == 1
-        and access.api_user_organization_context.organization.id in org_ids
+        and access.rpc_user_organization_context.organization.id in org_ids
     ):
         return SingularApiAccessOrgOptimization(access)
     return None
 
 
+maybe_singular_api_access_org_context = maybe_singular_rpc_access_org_context
+
+
 @dataclass
 class ApiBackedAccess(Access):
-    api_user_organization_context: ApiUserOrganizationContext
+    rpc_user_organization_context: RpcUserOrganizationContext
     requested_scopes: Iterable[str] | None
-    auth_state: ApiAuthState
+    auth_state: RpcAuthState
+
+    @property
+    def api_user_organization_context(self) -> RpcUserOrganizationContext:
+        return self.rpc_user_organization_context
 
     @cached_property
     def permissions(self) -> FrozenSet[str]:
@@ -423,12 +432,12 @@ class ApiBackedAccess(Access):
 
     @property
     def has_global_access(self) -> bool:
-        if self.api_user_organization_context.organization.flags.allow_joinleave:
+        if self.rpc_user_organization_context.organization.flags.allow_joinleave:
             return True
 
         if (
-            self.api_user_organization_context.member
-            and roles.get(self.api_user_organization_context.member.role).is_global
+            self.rpc_user_organization_context.member
+            and roles.get(self.rpc_user_organization_context.member.role).is_global
         ):
             return True
 
@@ -436,33 +445,33 @@ class ApiBackedAccess(Access):
 
     @cached_property
     def scopes(self) -> FrozenSet[str]:
-        if self.api_user_organization_context.member is None:
+        if self.rpc_user_organization_context.member is None:
             return frozenset(self.requested_scopes or [])
 
         if self.requested_scopes is None:
-            return frozenset(self.api_user_organization_context.member.scopes)
+            return frozenset(self.rpc_user_organization_context.member.scopes)
 
-        return frozenset(self.api_user_organization_context.member.scopes) & frozenset(
+        return frozenset(self.rpc_user_organization_context.member.scopes) & frozenset(
             self.requested_scopes
         )
 
     # TODO(cathy): remove this
     @property
     def role(self) -> str | None:
-        if self.api_user_organization_context.member is None:
+        if self.rpc_user_organization_context.member is None:
             return None
-        return self.api_user_organization_context.member.role
+        return self.rpc_user_organization_context.member.role
 
     @property
     def roles(self) -> Iterable[str] | None:
-        if self.api_user_organization_context.member is None:
+        if self.rpc_user_organization_context.member is None:
             return None
-        return organization_service.get_all_org_roles(self.api_user_organization_context.member)
+        return organization_service.get_all_org_roles(self.rpc_user_organization_context.member)
 
     def has_role_in_organization(
         self, role: str, organization: Organization, user_id: int | None
     ) -> bool:
-        member = self.api_user_organization_context.member
+        member = self.rpc_user_organization_context.member
         if member and member.user_id:
             return has_role_in_organization(
                 role=role, organization=organization, user_id=member.user_id
@@ -471,10 +480,10 @@ class ApiBackedAccess(Access):
 
     @cached_property
     def team_ids_with_membership(self) -> FrozenSet[int]:
-        if self.api_user_organization_context.member is None:
+        if self.rpc_user_organization_context.member is None:
             return frozenset()
         return frozenset(
-            mt.team_id for mt in self.api_user_organization_context.member.member_teams
+            mt.team_id for mt in self.rpc_user_organization_context.member.member_teams
         )
 
     @cached_property
@@ -483,9 +492,9 @@ class ApiBackedAccess(Access):
 
     @cached_property
     def project_ids_with_team_membership(self) -> FrozenSet[int]:
-        if self.api_user_organization_context.member is None:
+        if self.rpc_user_organization_context.member is None:
             return frozenset()
-        return frozenset(self.api_user_organization_context.member.project_ids)
+        return frozenset(self.rpc_user_organization_context.member.project_ids)
 
     @cached_property
     def accessible_project_ids(self) -> FrozenSet[int]:
@@ -496,16 +505,16 @@ class ApiBackedAccess(Access):
             return False
         if (
             self.has_global_access
-            and self.api_user_organization_context.organization.id == team.organization_id
+            and self.rpc_user_organization_context.organization.id == team.organization_id
         ):
             return True
         return team.id in self.team_ids_with_membership
 
-    def get_team_membership(self, team_id: int) -> ApiTeamMember | None:
-        if self.api_user_organization_context.member is None:
+    def get_team_membership(self, team_id: int) -> RpcTeamMember | None:
+        if self.rpc_user_organization_context.member is None:
             return None
 
-        for team_membership in self.api_user_organization_context.member.member_teams:
+        for team_membership in self.rpc_user_organization_context.member.member_teams:
             if team_membership.team_id == team_id:
                 return team_membership
         return None
@@ -516,7 +525,7 @@ class ApiBackedAccess(Access):
         if self.has_scope(scope):
             return True
 
-        if self.api_user_organization_context.member is None:
+        if self.rpc_user_organization_context.member is None:
             return False
 
         team_membership = self.get_team_membership(team.id)
@@ -541,8 +550,8 @@ class ApiBackedAccess(Access):
             return False
         if (
             self.has_global_access
-            and self.api_user_organization_context.member
-            and self.api_user_organization_context.organization.id == project.organization_id
+            and self.rpc_user_organization_context.member
+            and self.rpc_user_organization_context.organization.id == project.organization_id
         ):
             return True
         return project.id in self.project_ids_with_team_membership
@@ -554,10 +563,10 @@ class ApiBackedAccess(Access):
         if any(self.has_scope(scope) for scope in scopes):
             return True
 
-        if self.api_user_organization_context.member and features.has(
-            "organizations:team-roles", self.api_user_organization_context.organization.id
+        if self.rpc_user_organization_context.member and features.has(
+            "organizations:team-roles", self.rpc_user_organization_context.organization.id
         ):
-            memberships = self.api_user_organization_context.member.member_teams
+            memberships = self.rpc_user_organization_context.member.member_teams
             for membership in memberships:
                 team_scopes = membership.scopes
                 for scope in scopes:
@@ -654,12 +663,12 @@ class ApiBackedOrganizationGlobalAccess(ApiBackedAccess):
     def __init__(
         self,
         *,
-        api_user_organization_context: ApiUserOrganizationContext,
-        auth_state: ApiAuthState,
+        rpc_user_organization_context: RpcUserOrganizationContext,
+        auth_state: RpcAuthState,
         scopes: Iterable[str] | None,
     ):
         super().__init__(
-            api_user_organization_context=api_user_organization_context,
+            rpc_user_organization_context=rpc_user_organization_context,
             auth_state=auth_state,
             requested_scopes=scopes,
         )
@@ -674,13 +683,13 @@ class ApiBackedOrganizationGlobalAccess(ApiBackedAccess):
 
     def has_team_access(self, team: Team) -> bool:
         return bool(
-            team.organization_id == self.api_user_organization_context.organization.id
+            team.organization_id == self.rpc_user_organization_context.organization.id
             and team.status == TeamStatus.VISIBLE
         )
 
     def has_project_access(self, project: Project) -> bool:
         return bool(
-            project.organization_id == self.api_user_organization_context.organization.id
+            project.organization_id == self.rpc_user_organization_context.organization.id
             and project.status == ProjectStatus.VISIBLE
         )
 
@@ -688,7 +697,7 @@ class ApiBackedOrganizationGlobalAccess(ApiBackedAccess):
     def accessible_team_ids(self) -> FrozenSet[int]:
         return frozenset(
             t.id
-            for t in self.api_user_organization_context.organization.teams
+            for t in self.rpc_user_organization_context.organization.teams
             if t.status == TeamStatus.VISIBLE
         )
 
@@ -696,7 +705,7 @@ class ApiBackedOrganizationGlobalAccess(ApiBackedAccess):
     def accessible_project_ids(self) -> FrozenSet[int]:
         return frozenset(
             p.id
-            for p in self.api_user_organization_context.organization.projects
+            for p in self.rpc_user_organization_context.organization.projects
             if p.status == ProjectStatus.VISIBLE
         )
 
@@ -739,7 +748,7 @@ class ApiOrganizationGlobalMembership(ApiBackedOrganizationGlobalAccess):
 
 @dataclass
 class OrganizationlessAccess(Access):
-    auth_state: ApiAuthState
+    auth_state: RpcAuthState
 
     @cached_property
     def permissions(self) -> FrozenSet[str]:
@@ -815,8 +824,8 @@ class OrganizationlessAccess(Access):
 class SystemAccess(OrganizationlessAccess):
     def __init__(self) -> None:
         super().__init__(
-            auth_state=ApiAuthState(
-                sso_state=ApiMemberSsoState(False, False),
+            auth_state=RpcAuthState(
+                sso_state=RpcMemberSsoState(False, False),
                 permissions=[],
             ),
         )
@@ -851,8 +860,8 @@ class SystemAccess(OrganizationlessAccess):
 class NoAccess(OrganizationlessAccess):
     def __init__(self) -> None:
         super().__init__(
-            auth_state=ApiAuthState(
-                sso_state=ApiMemberSsoState(is_required=False, is_valid=True),
+            auth_state=RpcAuthState(
+                sso_state=RpcMemberSsoState(is_required=False, is_valid=True),
                 permissions=[],
             ),
         )
@@ -861,48 +870,48 @@ class NoAccess(OrganizationlessAccess):
 def from_request_org_and_scopes(
     *,
     request: Any,
-    api_user_org_context: ApiUserOrganizationContext | None = None,
+    rpc_user_org_context: RpcUserOrganizationContext | None = None,
     scopes: Iterable[str] | None = None,
 ) -> Access:
     is_superuser = is_active_superuser(request)
-    if not api_user_org_context:
-        return from_user_and_api_user_org_context(
+    if not rpc_user_org_context:
+        return from_user_and_rpc_user_org_context(
             user=request.user,
-            api_user_org_context=api_user_org_context,
+            rpc_user_org_context=rpc_user_org_context,
             is_superuser=is_superuser,
             scopes=scopes,
         )
 
     if getattr(request.user, "is_sentry_app", False):
-        return _from_api_sentry_app(api_user_org_context)
+        return _from_api_sentry_app(rpc_user_org_context)
 
     if is_superuser:
-        member = api_user_org_context.member
+        member = rpc_user_org_context.member
         auth_state = auth_service.get_user_auth_state(
             user_id=request.user.id,
-            organization_id=api_user_org_context.organization.id,
+            organization_id=rpc_user_org_context.organization.id,
             is_superuser=is_superuser,
             org_member=member,
         )
 
         return ApiBackedOrganizationGlobalAccess(
-            api_user_organization_context=api_user_org_context,
+            rpc_user_organization_context=rpc_user_org_context,
             auth_state=auth_state,
             scopes=scopes if scopes is not None else settings.SENTRY_SCOPES,
         )
 
     if hasattr(request, "auth") and not request.user.is_authenticated:
-        return from_api_auth(request.auth, api_user_org_context)
+        return from_api_auth(request.auth, rpc_user_org_context)
 
-    return from_user_and_api_user_org_context(
+    return from_user_and_rpc_user_org_context(
         user=request.user,
-        api_user_org_context=api_user_org_context,
+        rpc_user_org_context=rpc_user_org_context,
         is_superuser=False,
         scopes=scopes,
     )
 
 
-def organizationless_access(user: User | APIUser | AnonymousUser, is_superuser: bool) -> Access:
+def organizationless_access(user: User | RpcUser | AnonymousUser, is_superuser: bool) -> Access:
     return OrganizationlessAccess(
         auth_state=auth_service.get_user_auth_state(
             user_id=user.id,
@@ -913,32 +922,35 @@ def organizationless_access(user: User | APIUser | AnonymousUser, is_superuser: 
     )
 
 
-def normalize_valid_user(user: User | APIUser | AnonymousUser | None) -> User | APIUser | None:
+def normalize_valid_user(user: User | RpcUser | AnonymousUser | None) -> User | RpcUser | None:
     if not user or user.is_anonymous or not user.is_active:
         return None
     return user
 
 
-def from_user_and_api_user_org_context(
+def from_user_and_rpc_user_org_context(
     *,
-    user: User | APIUser | None,
-    api_user_org_context: ApiUserOrganizationContext | None = None,
+    user: User | RpcUser | None,
+    rpc_user_org_context: RpcUserOrganizationContext | None = None,
     is_superuser: bool = False,
     scopes: Iterable[str] | None = None,
-    auth_state: ApiAuthState | None = None,
+    auth_state: RpcAuthState | None = None,
 ) -> Access:
     if (user := normalize_valid_user(user)) is None:
         return DEFAULT
 
-    if not api_user_org_context or not api_user_org_context.member:
+    if not rpc_user_org_context or not rpc_user_org_context.member:
         return organizationless_access(user, is_superuser)
 
-    return from_api_member(
-        api_user_organization_context=api_user_org_context,
+    return from_rpc_member(
+        rpc_user_organization_context=rpc_user_org_context,
         scopes=scopes,
         is_superuser=is_superuser,
         auth_state=auth_state,
     )
+
+
+from_user_and_api_user_org_context = from_user_and_rpc_user_org_context
 
 
 def from_request(
@@ -1002,7 +1014,7 @@ def _from_sentry_app(
     return OrganizationGlobalMembership(organization, sentry_app.scope_list, sso_is_valid=True)
 
 
-def _from_api_sentry_app(context: ApiUserOrganizationContext | None = None) -> Access:
+def _from_api_sentry_app(context: RpcUserOrganizationContext | None = None) -> Access:
     if not context or context.user_id is None:
         return NoAccess()
 
@@ -1013,9 +1025,9 @@ def _from_api_sentry_app(context: ApiUserOrganizationContext | None = None) -> A
         return NoAccess()
 
     return ApiOrganizationGlobalMembership(
-        api_user_organization_context=context,
-        auth_state=ApiAuthState(
-            sso_state=ApiMemberSsoState(
+        rpc_user_organization_context=context,
+        auth_state=RpcAuthState(
+            sso_state=RpcMemberSsoState(
                 is_valid=True,
                 is_required=False,
             ),
@@ -1026,7 +1038,7 @@ def _from_api_sentry_app(context: ApiUserOrganizationContext | None = None) -> A
 
 
 def from_user(
-    user: User | APIUser | AnonymousUser | None,
+    user: User | RpcUser | AnonymousUser | None,
     organization: Organization | None = None,
     scopes: Iterable[str] | None = None,
     is_superuser: bool = False,
@@ -1063,26 +1075,29 @@ def from_member(
     return OrganizationMemberAccess(member, scope_intersection, permissions)
 
 
-def from_api_member(
-    api_user_organization_context: ApiUserOrganizationContext,
+def from_rpc_member(
+    rpc_user_organization_context: RpcUserOrganizationContext,
     scopes: Iterable[str] | None = None,
     is_superuser: bool = False,
-    auth_state: ApiAuthState | None = None,
+    auth_state: RpcAuthState | None = None,
 ) -> Access:
-    if api_user_organization_context.user_id is None:
+    if rpc_user_organization_context.user_id is None:
         return DEFAULT
 
     return ApiBackedAccess(
-        api_user_organization_context=api_user_organization_context,
+        rpc_user_organization_context=rpc_user_organization_context,
         requested_scopes=scopes,
         auth_state=auth_state
         or auth_service.get_user_auth_state(
-            user_id=api_user_organization_context.user_id,
-            organization_id=api_user_organization_context.organization.id,
+            user_id=rpc_user_organization_context.user_id,
+            organization_id=rpc_user_organization_context.organization.id,
             is_superuser=is_superuser,
-            org_member=api_user_organization_context.member,
+            org_member=rpc_user_organization_context.member,
         ),
     )
+
+
+from_api_member = from_rpc_member
 
 
 def from_auth(auth: ApiKey | SystemToken, organization: Organization) -> Access:
@@ -1098,16 +1113,16 @@ def from_auth(auth: ApiKey | SystemToken, organization: Organization) -> Access:
 
 
 def from_api_auth(
-    auth: ApiKey | SystemToken, api_user_org_context: ApiUserOrganizationContext
+    auth: ApiKey | SystemToken, rpc_user_org_context: RpcUserOrganizationContext
 ) -> Access:
     if is_system_auth(auth):
         return SystemAccess()
-    if auth.organization_id == api_user_org_context.organization.id:
+    if auth.organization_id == rpc_user_org_context.organization.id:
         return ApiBackedOrganizationGlobalAccess(
-            api_user_organization_context=api_user_org_context,
-            auth_state=ApiAuthState(
+            rpc_user_organization_context=rpc_user_org_context,
+            auth_state=RpcAuthState(
                 permissions=[],
-                sso_state=ApiMemberSsoState(
+                sso_state=RpcMemberSsoState(
                     is_valid=True,
                     is_required=False,
                 ),

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -35,10 +35,10 @@ from sentry.locks import locks
 from sentry.models import AuditLogEntry, AuthIdentity, AuthProvider, Organization, User
 from sentry.pipeline import Pipeline, PipelineSessionStore
 from sentry.pipeline.provider import PipelineProvider
-from sentry.services.hybrid_cloud.auth import ApiAuthIdentity, auth_service
+from sentry.services.hybrid_cloud.auth import RpcAuthIdentity, auth_service
 from sentry.services.hybrid_cloud.organization import (
-    ApiOrganization,
-    ApiOrganizationMember,
+    RpcOrganization,
+    RpcOrganizationMember,
     organization_service,
 )
 from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
@@ -98,13 +98,13 @@ class AuthIdentityHandler:
 
     auth_provider: AuthProvider
     provider: Provider
-    organization: ApiOrganization
+    organization: RpcOrganization
     request: HttpRequest
     identity: Mapping[str, Any]
 
     def __post_init__(self) -> None:
         # For debugging. TODO: Remove when tests are stable
-        if not isinstance(self.organization, ApiOrganization):
+        if not isinstance(self.organization, RpcOrganization):
             raise TypeError
 
     @cached_property
@@ -160,7 +160,7 @@ class AuthIdentityHandler:
         )
 
     @staticmethod
-    def _set_linked_flag(member: ApiOrganizationMember) -> None:
+    def _set_linked_flag(member: RpcOrganizationMember) -> None:
         if member.flags.sso__invalid or not member.flags.sso__linked:
             member.flags.sso__invalid = False
             member.flags.sso__linked = True
@@ -223,7 +223,7 @@ class AuthIdentityHandler:
             login_redirect_url = absolute_uri(login_redirect_url, url_prefix=url_prefix)
         return login_redirect_url
 
-    def _handle_new_membership(self, auth_identity: ApiAuthIdentity) -> ApiOrganizationMember:
+    def _handle_new_membership(self, auth_identity: RpcAuthIdentity) -> RpcOrganizationMember:
         user, om = auth_service.handle_new_membership(
             self.request, self.organization, auth_identity, self.auth_provider
         )
@@ -252,7 +252,7 @@ class AuthIdentityHandler:
             return None
 
     @transaction.atomic  # type: ignore
-    def handle_attach_identity(self, member: ApiOrganizationMember | None = None) -> AuthIdentity:
+    def handle_attach_identity(self, member: RpcOrganizationMember | None = None) -> AuthIdentity:
         """
         Given an already authenticated user, attach or re-attach an identity.
         """
@@ -355,7 +355,7 @@ class AuthIdentityHandler:
 
         return deletion_result
 
-    def _get_organization_member(self, auth_identity: AuthIdentity) -> ApiOrganizationMember:
+    def _get_organization_member(self, auth_identity: AuthIdentity) -> RpcOrganizationMember:
         """
         Check to see if the user has a member associated, if not, create a new membership
         based on the auth_identity email.

--- a/src/sentry/auth/idpmigration.py
+++ b/src/sentry/auth/idpmigration.py
@@ -9,7 +9,7 @@ from rb.clients import LocalClient
 
 from sentry import options
 from sentry.models import AuthProvider, User
-from sentry.services.hybrid_cloud.organization import ApiOrganization, organization_service
+from sentry.services.hybrid_cloud.organization import RpcOrganization, organization_service
 from sentry.utils import json, metrics, redis
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
@@ -22,7 +22,7 @@ SSO_VERIFICATION_KEY = "confirm_account_verification_key"
 
 def send_one_time_account_confirm_link(
     user: User,
-    org: ApiOrganization,
+    org: RpcOrganization,
     provider: AuthProvider,
     email: str,
     identity_id: str,
@@ -53,7 +53,7 @@ def get_redis_cluster() -> LocalClient:
 @dataclass
 class AccountConfirmLink:
     user: User
-    organization: ApiOrganization
+    organization: RpcOrganization
     provider: AuthProvider
     email: str
     identity_id: str

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -11,7 +11,7 @@ from sentry.eventstore.models import Event
 from sentry.models import Group, Project, ProjectOwnership, Rule, Team
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.notifications.utils.participants import get_send_to
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 
 
@@ -65,13 +65,13 @@ def get_digest_as_context(digest: Digest) -> Mapping[str, Any]:
 
 def get_events_by_participant(
     participants_by_provider_by_event: Mapping[
-        Event, Mapping[ExternalProviders, set[Team | APIUser]]
+        Event, Mapping[ExternalProviders, set[Team | RpcUser]]
     ]
-) -> Mapping[Team | APIUser, set[Event]]:
+) -> Mapping[Team | RpcUser, set[Event]]:
     """Invert a mapping of events to participants to a mapping of participants to events."""
     output = defaultdict(set)
     for event, participants_by_provider in participants_by_provider_by_event.items():
-        participants: set[Team | APIUser]
+        participants: set[Team | RpcUser]
         for participants in participants_by_provider.values():
             for participant in participants:
                 output[participant].add(event)
@@ -81,7 +81,7 @@ def get_events_by_participant(
 def get_personalized_digests(
     digest: Digest,
     participants_by_provider_by_event: Mapping[
-        Event, Mapping[ExternalProviders, set[Team | APIUser]]
+        Event, Mapping[ExternalProviders, set[Team | RpcUser]]
     ],
 ) -> Mapping[int, Digest]:
     events_by_participant = get_events_by_participant(participants_by_provider_by_event)
@@ -122,7 +122,7 @@ def get_participants_by_event(
     target_type: ActionTargetType = ActionTargetType.ISSUE_OWNERS,
     target_identifier: int | None = None,
     fallthrough_choice: FallthroughChoiceType | None = None,
-) -> Mapping[Event, Mapping[ExternalProviders, set[Team | APIUser]]]:
+) -> Mapping[Event, Mapping[ExternalProviders, set[Team | RpcUser]]]:
     """
     This is probably the slowest part in sending digests because we do a lot of
     DB calls while we iterate over every event. It would be great if we could

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -14,7 +14,7 @@ from sentry.exceptions import InvalidIdentity
 from sentry.models import ExternalActor, Identity, Integration, Organization, Team
 from sentry.pipeline import PipelineProvider
 from sentry.pipeline.views.base import PipelineView
-from sentry.services.hybrid_cloud.integration import APIOrganizationIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcOrganizationIntegration, integration_service
 from sentry.shared_integrations.constants import (
     ERR_INTERNAL,
     ERR_UNAUTHORIZED,
@@ -264,10 +264,10 @@ class IntegrationInstallation:
     def __init__(self, model: M, organization_id: int) -> None:
         self.model = model
         self.organization_id = organization_id
-        self._org_integration: APIOrganizationIntegration | None
+        self._org_integration: RpcOrganizationIntegration | None
 
     @property
-    def org_integration(self) -> APIOrganizationIntegration | None:
+    def org_integration(self) -> RpcOrganizationIntegration | None:
         if not hasattr(self, "_org_integration"):
             self._org_integration = integration_service.get_organization_integration(
                 integration_id=self.model.id,
@@ -276,7 +276,7 @@ class IntegrationInstallation:
         return self._org_integration
 
     @org_integration.setter
-    def org_integration(self, org_integration: APIOrganizationIntegration) -> None:
+    def org_integration(self, org_integration: RpcOrganizationIntegration) -> None:
         self._org_integration = org_integration
 
     def get_organization_config(self) -> Sequence[Any]:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -10,7 +10,7 @@ from sentry.integrations.client import ApiClient
 from sentry.integrations.github.utils import get_jwt, get_next_link
 from sentry.integrations.utils.code_mapping import Repo, RepoTree, filter_source_code_files
 from sentry.models import Integration, Repository
-from sentry.services.hybrid_cloud.integration import APIIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.utils import jwt
 from sentry.utils.cache import cache
@@ -384,7 +384,7 @@ class GitHubClientMixin(ApiClient):  # type: ignore
         Should the token have expired, a new token will be generated and
         automatically persisted into the integration.
         """
-        self.integration: APIIntegration
+        self.integration: RpcIntegration
 
         token: str | None = self.integration.metadata.get("access_token")
         expires_at: str | None = self.integration.metadata.get("expires_at")

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -28,7 +28,7 @@ from sentry.models import (
     User,
 )
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
@@ -880,7 +880,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
     def sync_assignee_outbound(
         self,
         external_issue: ExternalIssue,
-        user: Optional[APIUser],
+        user: Optional[RpcUser],
         assign: bool = True,
         **kwargs: Any,
     ) -> None:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -35,7 +35,7 @@ from sentry.models import (
 )
 from sentry.pipeline import PipelineView
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
@@ -964,7 +964,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
     def sync_assignee_outbound(
         self,
         external_issue: ExternalIssue,
-        user: Optional[APIUser],
+        user: Optional[RpcUser],
         assign: bool = True,
         **kwargs: Any,
     ) -> None:

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -9,7 +9,7 @@ from sentry.issues.grouptype import GroupCategory
 from sentry.models import Group, Project, Rule, Team
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.utils import get_matched_problem, get_span_evidence_value_problem
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils.http import absolute_uri
 
@@ -18,13 +18,13 @@ class AbstractMessageBuilder(ABC):
     pass
 
 
-def format_actor_options(actors: Sequence[Team | APIUser]) -> Sequence[Mapping[str, str]]:
+def format_actor_options(actors: Sequence[Team | RpcUser]) -> Sequence[Mapping[str, str]]:
     sort_func: Callable[[Mapping[str, str]], Any] = lambda actor: actor["text"]
     return sorted((format_actor_option(actor) for actor in actors), key=sort_func)
 
 
-def format_actor_option(actor: Team | APIUser) -> Mapping[str, str]:
-    if isinstance(actor, APIUser):
+def format_actor_option(actor: Team | RpcUser) -> Mapping[str, str]:
+    if isinstance(actor, RpcUser):
         return {"text": actor.get_display_name(), "value": f"user:{actor.id}"}
     if isinstance(actor, Team):
         return {"text": f"#{actor.slug}", "value": f"team:{actor.id}"}

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -17,7 +17,7 @@ from sentry.notifications.utils import (
     get_span_evidence_value_problem,
 )
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user_option import get_option_from_list, user_option_service
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.tasks.integrations import sync_status_inbound as sync_status_inbound_task
@@ -164,7 +164,7 @@ class IssueBasicMixin:
         """
         return []
 
-    def store_issue_last_defaults(self, project: Project, user: APIUser, data):
+    def store_issue_last_defaults(self, project: Project, user: RpcUser, data):
         """
         Stores the last used field defaults on a per-project basis. This
         accepts a dict of values that will be filtered to keys returned by

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -6,15 +6,15 @@ from typing import Any, Iterable, Mapping, MutableMapping
 from sentry.constants import ObjectStatus
 from sentry.models import ExternalActor, Integration, Organization, Team, User
 from sentry.notifications.notifications.base import BaseNotification
-from sentry.services.hybrid_cloud.identity import APIIdentity, APIIdentityProvider, identity_service
-from sentry.services.hybrid_cloud.integration import APIIntegration, integration_service
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.identity import RpcIdentity, RpcIdentityProvider, identity_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 
 
 def get_context(
     notification: BaseNotification,
-    recipient: Team | APIUser,
+    recipient: Team | RpcUser,
     shared_context: Mapping[str, Any],
     extra_context: Mapping[str, Any],
 ) -> Mapping[str, Any]:
@@ -29,7 +29,7 @@ def get_channel_and_integration_by_user(
     user: User,
     organization: Organization,
     provider: ExternalProviders,
-) -> Mapping[str, APIIntegration]:
+) -> Mapping[str, RpcIntegration]:
 
     identities = identity_service.get_user_identities_by_provider_type(
         user_id=user.id,
@@ -43,7 +43,7 @@ def get_channel_and_integration_by_user(
         # recipients.
         return {}
 
-    identity_id_to_idp: Mapping[APIIdentity.id, APIIdentityProvider | None] = {
+    identity_id_to_idp: Mapping[RpcIdentity.id, RpcIdentityProvider | None] = {
         identity.id: identity_service.get_provider(provider_id=identity.idp_id)
         for identity in identities
     }
@@ -94,8 +94,8 @@ def get_channel_and_integration_by_team(
 
 def get_integrations_by_channel_by_recipient(
     organization: Organization, recipients: Iterable[Team | User], provider: ExternalProviders
-) -> MutableMapping[Team | User, Mapping[str, APIIntegration | Integration]]:
-    output: MutableMapping[Team | User, Mapping[str, APIIntegration | Integration]] = defaultdict(
+) -> MutableMapping[Team | User, Mapping[str, RpcIntegration | Integration]]:
+    output: MutableMapping[Team | User, Mapping[str, RpcIntegration | Integration]] = defaultdict(
         dict
     )
     for recipient in recipients:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -20,7 +20,7 @@ from sentry.models import ActorTuple, Group, GroupStatus, Project, ReleaseProjec
 from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.actions import MessageAction
-from sentry.services.hybrid_cloud.identity import APIIdentity, identity_service
+from sentry.services.hybrid_cloud.identity import RpcIdentity, identity_service
 from sentry.services.hybrid_cloud.user import user_service
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -29,7 +29,7 @@ from sentry.utils.dates import to_timestamp
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
 
 
-def build_assigned_text(identity: APIIdentity, assignee: str) -> str | None:
+def build_assigned_text(identity: RpcIdentity, assignee: str) -> str | None:
     actor = ActorTuple.from_actor_identifier(assignee)
 
     try:
@@ -55,7 +55,7 @@ def build_assigned_text(identity: APIIdentity, assignee: str) -> str | None:
     return f"*Issue assigned to {assignee_text} by <@{identity.external_id}>*"
 
 
-def build_action_text(identity: APIIdentity, action: MessageAction) -> str | None:
+def build_action_text(identity: RpcIdentity, action: MessageAction) -> str | None:
     if action.name == "assign":
         selected_options = action.selected_options or []
         if not len(selected_options):
@@ -125,7 +125,7 @@ def has_releases(project: Project) -> bool:
 def get_action_text(
     text: str,
     actions: Sequence[Any],
-    identity: APIIdentity,
+    identity: RpcIdentity,
 ) -> str:
     return (
         text
@@ -146,7 +146,7 @@ def build_actions(
     text: str,
     color: str,
     actions: Sequence[MessageAction] | None = None,
-    identity: APIIdentity | None = None,
+    identity: RpcIdentity | None = None,
 ) -> tuple[Sequence[MessageAction], str, str]:
     """Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign."""
     if actions and identity:
@@ -237,7 +237,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
         group: Group,
         event: GroupEvent | None = None,
         tags: set[str] | None = None,
-        identity: APIIdentity | None = None,
+        identity: RpcIdentity | None = None,
         actions: Sequence[MessageAction] | None = None,
         rules: list[Rule] | None = None,
         link_to_event: bool = False,
@@ -303,7 +303,7 @@ def build_group_attachment(
     group: Group,
     event: GroupEvent | None = None,
     tags: set[str] | None = None,
-    identity: APIIdentity | None = None,
+    identity: RpcIdentity | None = None,
     actions: Sequence[MessageAction] | None = None,
     rules: list[Rule] | None = None,
     link_to_event: bool = False,

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -7,9 +7,9 @@ from rest_framework import status as status_
 from rest_framework.request import Request
 
 from sentry import options
-from sentry.services.hybrid_cloud.identity import APIIdentity, identity_service
-from sentry.services.hybrid_cloud.integration import APIIntegration, integration_service
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.identity import RpcIdentity, identity_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 
 from ..utils import check_signing_secret, logger
 
@@ -55,8 +55,8 @@ class SlackRequest:
 
     def __init__(self, request: Request) -> None:
         self.request = request
-        self._integration: APIIntegration | None = None
-        self._identity: APIIdentity | None
+        self._integration: RpcIntegration | None = None
+        self._identity: RpcIdentity | None
         self._data: MutableMapping[str, Any] = {}
 
     def validate(self) -> None:
@@ -79,7 +79,7 @@ class SlackRequest:
         return False
 
     @property
-    def integration(self) -> APIIntegration:
+    def integration(self) -> RpcIntegration:
         if not self._integration:
             raise RuntimeError
         return self._integration
@@ -123,7 +123,7 @@ class SlackRequest:
 
         return {k: v for k, v in data.items() if v}
 
-    def get_identity(self) -> APIIdentity | None:
+    def get_identity(self) -> RpcIdentity | None:
         if not hasattr(self, "_identity"):
             provider = identity_service.get_provider(
                 provider_type="slack", provider_ext_id=self.team_id
@@ -135,7 +135,7 @@ class SlackRequest:
             )
         return self._identity
 
-    def get_identity_user(self) -> APIUser | None:
+    def get_identity_user(self) -> RpcUser | None:
         identity = self.get_identity()
         if not identity:
             return None
@@ -198,7 +198,7 @@ class SlackRequest:
 class SlackDMRequest(SlackRequest):
     def __init__(self, request: Request) -> None:
         super().__init__(request)
-        self.user: APIUser | None = None
+        self.user: RpcUser | None = None
 
     @property
     def has_identity(self) -> bool:

--- a/src/sentry/integrations/slack/unfurl/issues.py
+++ b/src/sentry/integrations/slack/unfurl/issues.py
@@ -8,7 +8,7 @@ from django.http.request import HttpRequest
 from sentry import eventstore
 from sentry.integrations.slack.message_builder.issues import build_group_attachment
 from sentry.models import Group, Project, User
-from sentry.services.hybrid_cloud.integration import APIIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 
 from . import Handler, UnfurlableUrl, UnfurledUrl, make_type_coercer
 
@@ -22,7 +22,7 @@ map_issue_args = make_type_coercer(
 
 def unfurl_issues(
     request: HttpRequest,
-    integration: APIIntegration,
+    integration: RpcIntegration,
     links: List[UnfurlableUrl],
     user: Optional[User] = None,
 ) -> UnfurledUrl:

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -25,7 +25,7 @@ from sentry.models import Group, InviteStatus, NotificationSetting, Organization
 from sentry.models.activity import ActivityIntegration
 from sentry.notifications.utils.actions import MessageAction
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -69,7 +69,7 @@ RESOLVE_SELECTOR = {
 
 def update_group(
     group: Group,
-    user: APIUser,
+    user: RpcUser,
     data: Mapping[str, str],
     request: Request,
 ) -> Response:
@@ -130,7 +130,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
         self,
         slack_request: SlackActionRequest,
         group: Group,
-        user: APIUser,
+        user: RpcUser,
         error: ApiClient.ApiError,
         action_type: str,
     ) -> Response:
@@ -179,7 +179,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
         return self.respond_ephemeral(text)
 
     def on_assign(
-        self, request: Request, user: APIUser, group: Group, action: MessageAction
+        self, request: Request, user: RpcUser, group: Group, action: MessageAction
     ) -> None:
         if not (action.selected_options and len(action.selected_options)):
             # Short-circuit if action is invalid
@@ -202,7 +202,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
     def on_status(
         self,
         request: Request,
-        user: APIUser,
+        user: RpcUser,
         group: Group,
         action: MessageAction,
     ) -> None:

--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -10,11 +10,11 @@ from sentry.services.hybrid_cloud.user import user_service
 from sentry.tasks.integrations import sync_assignee_outbound
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.integration import APIIntegration
+    from sentry.services.hybrid_cloud.integration import RpcIntegration
 
 
 def where_should_sync(
-    integration: APIIntegration,
+    integration: RpcIntegration,
     key: str,
     organization_id: int | None = None,
 ) -> Sequence[Organization]:
@@ -53,7 +53,7 @@ def get_user_id(projects_by_user: Mapping[int, Sequence[int]], group: Group) -> 
 
 
 def sync_group_assignee_inbound(
-    integration: APIIntegration,
+    integration: RpcIntegration,
     email: str | None,
     external_issue_key: str,
     assign: bool = True,

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -35,7 +35,7 @@ from sentry.models import (
     generate_token,
 )
 from sentry.pipeline import NestedPipelineView, Pipeline, PipelineView
-from sentry.services.hybrid_cloud.integration import APIOrganizationIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcOrganizationIntegration, integration_service
 from sentry.shared_integrations.exceptions import (
     ApiError,
     IntegrationError,
@@ -118,7 +118,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.org_integration: APIOrganizationIntegration | None
+        self.org_integration: RpcOrganizationIntegration | None
         self.default_identity: Identity | None = None
 
     def reinstall(self) -> None:

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -18,7 +18,7 @@ from sentry.utils.linksign import generate_signed_link
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 def get_headers(notification: BaseNotification) -> Mapping[str, Any]:
@@ -71,14 +71,14 @@ def get_unsubscribe_link(
     return signed_link
 
 
-def log_message(notification: BaseNotification, recipient: Team | APIUser) -> None:
+def log_message(notification: BaseNotification, recipient: Team | RpcUser) -> None:
     extra = notification.get_log_params(recipient)
     logger.info("mail.adapter.notify.mail_user", extra={**extra})
 
 
 def get_context(
     notification: BaseNotification,
-    recipient: Team | APIUser,
+    recipient: Team | RpcUser,
     shared_context: Mapping[str, Any],
     extra_context: Mapping[str, Any],
 ) -> Mapping[str, Any]:
@@ -106,7 +106,7 @@ def get_context(
 @register_notification_provider(ExternalProviders.EMAIL)
 def send_notification_as_email(
     notification: BaseNotification,
-    recipients: Iterable[Team | APIUser],
+    recipients: Iterable[Team | RpcUser],
     shared_context: Mapping[str, Any],
     extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None,
 ) -> None:
@@ -136,7 +136,7 @@ def send_notification_as_email(
 
 def get_builder_args(
     notification: BaseNotification,
-    recipient: APIUser,
+    recipient: RpcUser,
     shared_context: Mapping[str, Any] | None = None,
     extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None = None,
 ) -> Mapping[str, Any]:

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -5,7 +5,7 @@ from sentry.utils.cache import memoize
 
 
 class AlertRuleActionCreator(Mediator):
-    install = Param("sentry.services.hybrid_cloud.app.ApiSentryAppInstallation")
+    install = Param("sentry.services.hybrid_cloud.app.RpcSentryAppInstallation")
     fields = Param(object, default=[])  # array of dicts
 
     def call(self) -> AlertRuleActionResult:

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -28,7 +28,7 @@ class AlertRuleActionRequester(Mediator):
     AlertRuleAction settings schema
     """
 
-    install = Param("sentry.services.hybrid_cloud.app.ApiSentryAppInstallation")
+    install = Param("sentry.services.hybrid_cloud.app.RpcSentryAppInstallation")
     uri = Param((str,))
     fields = Param(list, required=False, default=[])
     http_method = Param(str, required=False, default="POST")

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -9,7 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from django.urls import ResolverMatch, resolve
 
 from sentry.models.integrations import Integration, OrganizationIntegration
-from sentry.services.hybrid_cloud.organization import ApiOrganizationSummary, organization_service
+from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary, organization_service
 from sentry.silo import SiloLimit, SiloMode
 from sentry.silo.client import RegionSiloClient
 from sentry.types.region import Region, get_region_for_organization
@@ -106,7 +106,7 @@ class BaseRequestParser(abc.ABC):
 
     def get_organizations(
         self, integration: Integration = None
-    ) -> Sequence[ApiOrganizationSummary]:
+    ) -> Sequence[RpcOrganizationSummary]:
         """
         Use the get_integration() method to identify organizations associated with
         the integration request.
@@ -130,7 +130,7 @@ class BaseRequestParser(abc.ABC):
         )
 
     def get_regions(
-        self, organizations: Sequence[ApiOrganizationSummary] = None
+        self, organizations: Sequence[RpcOrganizationSummary] = None
     ) -> Sequence[Region]:
         """
         Use the get_organizations() method to identify forwarding regions.

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -22,7 +22,7 @@ from sentry.types.activity import CHOICES, ActivityType
 
 if TYPE_CHECKING:
     from sentry.models import Group, User
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 class ActivityManager(BaseManager):
@@ -60,7 +60,7 @@ class ActivityManager(BaseManager):
         self,
         group: Group,
         type: ActivityType,
-        user: Optional[User | APIUser] = None,
+        user: Optional[User | RpcUser] = None,
         data: Optional[Mapping[str, Any]] = None,
         send_notification: bool = True,
     ) -> Activity:

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -6,7 +6,7 @@ from django.db.models.signals import pre_save
 from rest_framework import serializers
 
 from sentry.db.models import Model, region_silo_only_model
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 
 if TYPE_CHECKING:
     from sentry.models import Team
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 ACTOR_TYPES = {"team": 0, "user": 1}
 
 
-def actor_type_to_class(type: int) -> Type[Union["Team", "APIUser"]]:
+def actor_type_to_class(type: int) -> Type[Union["Team", "RpcUser"]]:
     # type will be 0 or 1 and we want to get Team or User
     from sentry.models import Team, User
 
@@ -23,14 +23,14 @@ def actor_type_to_class(type: int) -> Type[Union["Team", "APIUser"]]:
     return ACTOR_TYPE_TO_CLASS[type]
 
 
-def fetch_actor_by_actor_id(cls, actor_id: int) -> Union["Team", "APIUser"]:
+def fetch_actor_by_actor_id(cls, actor_id: int) -> Union["Team", "RpcUser"]:
     results = fetch_actors_by_actor_ids(cls, [actor_id])
     if len(results) == 0:
         raise cls.DoesNotExist()
     return results[0]
 
 
-def fetch_actors_by_actor_ids(cls, actor_ids: List[int]) -> Union[List["Team"], List["APIUser"]]:
+def fetch_actors_by_actor_ids(cls, actor_ids: List[int]) -> Union[List["Team"], List["RpcUser"]]:
     from sentry.models import Team, User
 
     if cls is User:
@@ -41,7 +41,7 @@ def fetch_actors_by_actor_ids(cls, actor_ids: List[int]) -> Union[List["Team"], 
     raise ValueError(f"Cls {cls} is not a valid actor type.")
 
 
-def fetch_actor_by_id(cls, id: int) -> Union["Team", "APIUser"]:
+def fetch_actor_by_id(cls, id: int) -> Union["Team", "RpcUser"]:
     from sentry.models import Team, User
 
     if cls is Team:
@@ -78,7 +78,7 @@ class Actor(Model):
         app_label = "sentry"
         db_table = "sentry_actor"
 
-    def resolve(self) -> Union["Team", "APIUser"]:
+    def resolve(self) -> Union["Team", "RpcUser"]:
         # Returns User/Team model object
         return fetch_actor_by_actor_id(actor_type_to_class(self.type), self.id)
 
@@ -144,14 +144,14 @@ class ActorTuple(namedtuple("Actor", "id type")):
         except IndexError as e:
             raise serializers.ValidationError(f"Unable to resolve actor identifier: {e}")
 
-    def resolve(self) -> Union["Team", "APIUser"]:
+    def resolve(self) -> Union["Team", "RpcUser"]:
         return fetch_actor_by_id(self.type, self.id)
 
     def resolve_to_actor(self) -> Actor:
         return Actor.objects.get(id=self.resolve().actor_id)
 
     @classmethod
-    def resolve_many(cls, actors: Sequence["ActorTuple"]) -> Sequence[Union["Team", "APIUser"]]:
+    def resolve_many(cls, actors: Sequence["ActorTuple"]) -> Sequence[Union["Team", "RpcUser"]]:
         """
         Resolve multiple actors at the same time. Returns the result in the same order
         as the input, minus any actors we couldn't resolve.

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
 from sentry.db.models.manager import BaseManager
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 
 
 class CommitAuthorManager(BaseManager):
@@ -35,7 +35,7 @@ class CommitAuthor(Model):
 
     __repr__ = sane_repr("organization_id", "email", "name")
 
-    def find_users(self) -> List["APIUser"]:
+    def find_users(self) -> List["RpcUser"]:
         from sentry.models import OrganizationMember
 
         users = user_service.get_many_by_email([self.email])

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -42,8 +42,8 @@ from sentry.utils.strings import strip, truncatechars
 
 if TYPE_CHECKING:
     from sentry.models import Organization, Team
-    from sentry.services.hybrid_cloud.integration import APIIntegration
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.integration import RpcIntegration
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 logger = logging.getLogger(__name__)
 
@@ -314,7 +314,7 @@ class GroupManager(BaseManager):
 
     def get_groups_by_external_issue(
         self,
-        integration: APIIntegration,
+        integration: RpcIntegration,
         organizations: Sequence[Organization],
         external_issue_key: str,
     ) -> QuerySet:
@@ -644,7 +644,7 @@ class Group(Model):
     def calculate_score(cls, times_seen, last_seen):
         return math.log(float(times_seen or 1)) * 600 + float(last_seen.strftime("%s"))
 
-    def get_assignee(self) -> Team | APIUser | None:
+    def get_assignee(self) -> Team | RpcUser | None:
         from sentry.models import GroupAssignee
 
         try:

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -22,14 +22,14 @@ from sentry.utils import metrics
 
 if TYPE_CHECKING:
     from sentry.models import ActorTuple, Group, Team, User
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 class GroupAssigneeManager(BaseManager):
     def assign(
         self,
         group: Group,
-        assigned_to: Team | APIUser,
+        assigned_to: Team | RpcUser,
         acting_user: User | None = None,
         create_only: bool = False,
         extra: Dict[str, str] | None = None,
@@ -99,7 +99,7 @@ class GroupAssigneeManager(BaseManager):
 
         return {"new_assignment": created, "updated_assignment": bool(not created and affected)}
 
-    def deassign(self, group: Group, acting_user: User | APIUser | None = None) -> None:
+    def deassign(self, group: Group, acting_user: User | RpcUser | None = None) -> None:
         from sentry import features
         from sentry.integrations.utils import sync_group_assignee_outbound
         from sentry.models import Activity

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -17,7 +17,7 @@ from sentry.types.activity import ActivityType
 
 if TYPE_CHECKING:
     from sentry.models import Group, Release, Team, User
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 class GroupHistoryStatus:
@@ -211,7 +211,7 @@ def record_group_history_from_activity_type(
 def record_group_history(
     group: "Group",
     status: int,
-    actor: Optional[Union["APIUser", "Team"]] = None,
+    actor: Optional[Union["RpcUser", "Team"]] = None,
     release: Optional["Release"] = None,
 ):
     prev_history = get_prev_history(group, status)

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -20,7 +20,7 @@ from sentry.notifications.helpers import (
 )
 from sentry.notifications.types import GroupSubscriptionReason, NotificationSettingTypes
 from sentry.services.hybrid_cloud.notifications import notifications_service
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class GroupSubscriptionManager(BaseManager):  # type: ignore
     def subscribe(
         self,
         group: "Group",
-        user: "APIUser",
+        user: "RpcUser",
         reason: int = GroupSubscriptionReason.unknown,
     ) -> bool:
         """
@@ -54,12 +54,12 @@ class GroupSubscriptionManager(BaseManager):  # type: ignore
     def subscribe_actor(
         self,
         group: "Group",
-        actor: Union["Team", "User", "APIUser"],
+        actor: Union["Team", "User", "RpcUser"],
         reason: int = GroupSubscriptionReason.unknown,
     ) -> Optional[bool]:
         from sentry.models import Team, User
 
-        if isinstance(actor, APIUser) or isinstance(actor, User):
+        if isinstance(actor, RpcUser) or isinstance(actor, User):
             return self.subscribe(group, actor, reason)
         if isinstance(actor, Team):
             # subscribe the members of the team
@@ -114,7 +114,7 @@ class GroupSubscriptionManager(BaseManager):  # type: ignore
 
     def get_participants(
         self, group: "Group"
-    ) -> Mapping[ExternalProviders, Mapping["APIUser", int]]:
+    ) -> Mapping[ExternalProviders, Mapping["RpcUser", int]]:
         """
         Identify all users who are participating with a given issue.
         :param group: Group object
@@ -137,7 +137,7 @@ class GroupSubscriptionManager(BaseManager):  # type: ignore
             notification_settings, all_possible_users
         )
 
-        result: MutableMapping[ExternalProviders, MutableMapping["APIUser", int]] = defaultdict(
+        result: MutableMapping[ExternalProviders, MutableMapping["RpcUser", int]] = defaultdict(
             dict
         )
         for user in all_possible_users:

--- a/src/sentry/models/integrations/external_issue.py
+++ b/src/sentry/models/integrations/external_issue.py
@@ -17,12 +17,12 @@ from sentry.db.models import (
 from sentry.eventstore.models import Event
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.integration import APIIntegration
+    from sentry.services.hybrid_cloud.integration import RpcIntegration
 
 
 class ExternalIssueManager(BaseManager):
     def get_for_integration(
-        self, integration: APIIntegration, external_issue_key: str | None = None
+        self, integration: RpcIntegration, external_issue_key: str | None = None
     ) -> QuerySet:
         kwargs = dict(
             integration_id=integration.id,
@@ -35,7 +35,7 @@ class ExternalIssueManager(BaseManager):
         return self.filter(**kwargs)
 
     def get_linked_issues(
-        self, event: Event, integration: APIIntegration
+        self, event: Event, integration: RpcIntegration
     ) -> QuerySet[ExternalIssue]:
         from sentry.models import GroupLink
 
@@ -48,10 +48,10 @@ class ExternalIssueManager(BaseManager):
             integration_id=integration.id,
         )
 
-    def get_linked_issue_ids(self, event: Event, integration: APIIntegration) -> Sequence[str]:
+    def get_linked_issue_ids(self, event: Event, integration: RpcIntegration) -> Sequence[str]:
         return self.get_linked_issues(event, integration).values_list("key", flat=True)
 
-    def has_linked_issue(self, event: Event, integration: APIIntegration) -> bool:
+    def has_linked_issue(self, event: Event, integration: RpcIntegration) -> bool:
         return self.get_linked_issues(event, integration).exists()
 
 

--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -11,7 +11,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.security import get_secure_token
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.lost_password_hash import APILostPasswordHash
+    from sentry.services.hybrid_cloud.lost_password_hash import RpcLostPasswordHash
 
 
 @control_silo_only_model
@@ -64,7 +64,7 @@ class LostPasswordHash(Model):
         )
         msg.send_async([user.email])
 
-    # Duplicated from APILostPasswordHash
+    # Duplicated from RpcLostPasswordHash
     def get_absolute_url(self, mode: str = "recover") -> str:
         return LostPasswordHash.get_lostpassword_url(self.user_id, self.hash, mode)
 
@@ -77,7 +77,7 @@ class LostPasswordHash(Model):
         return absolute_uri(reverse(url_key, args=[user_id, hash]))
 
     @classmethod
-    def for_user(cls, user) -> "APILostPasswordHash":
+    def for_user(cls, user) -> "RpcLostPasswordHash":
         from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
 
         password_hash = lost_password_hash_service.get_or_create(user.id)

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -11,7 +11,7 @@ from sentry.db.models.manager import OptionManager, Value
 
 if TYPE_CHECKING:
     from sentry.models import Organization, Project, User
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 option_scope_error = "this is not a supported use case, scope to project OR organization"
 
@@ -19,7 +19,7 @@ option_scope_error = "this is not a supported use case, scope to project OR orga
 class UserOptionManager(OptionManager["User"]):
     def _make_key(
         self,
-        user: User | APIUser | int,
+        user: User | RpcUser | int,
         project: Project | None = None,
         organization: Organization | None = None,
     ) -> str:
@@ -36,7 +36,7 @@ class UserOptionManager(OptionManager["User"]):
         return key
 
     def get_value(
-        self, user: User | APIUser, key: str, default: Value | None = None, **kwargs: Any
+        self, user: User | RpcUser, key: str, default: Value | None = None, **kwargs: Any
     ) -> Value:
         project = kwargs.get("project")
         organization = kwargs.get("organization")
@@ -95,7 +95,7 @@ class UserOptionManager(OptionManager["User"]):
 
     def get_all_values(
         self,
-        user: User | APIUser | int,
+        user: User | RpcUser | int,
         project: Project | None = None,
         organization: Organization | None = None,
         force_reload: bool = False,

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -36,7 +36,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
 from sentry.models.team import Team
 from sentry.roles.manager import Role
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.utils.http import is_using_customer_domain
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import SnowflakeIdMixin, generate_snowflake_id
@@ -298,7 +298,7 @@ class Organization(Model, SnowflakeIdMixin):
 
         return self == type(self).get_default()
 
-    def has_access(self, user: APIUser, access=None):
+    def has_access(self, user: RpcUser, access=None):
         queryset = self.member_set.filter(user_id=user.id)
         if access is not None:
             queryset = queryset.filter(type__lte=access)
@@ -315,14 +315,14 @@ class Organization(Model, SnowflakeIdMixin):
             "default_role": self.default_role,
         }
 
-    def get_owners(self) -> Sequence[APIUser]:
+    def get_owners(self) -> Sequence[RpcUser]:
 
         owner_memberships = OrganizationMember.objects.filter(
             role=roles.get_top_dog().id, organization=self
         ).values_list("user_id", flat=True)
         return user_service.get_many(filter={"user_ids": owner_memberships})
 
-    def get_default_owner(self) -> APIUser:
+    def get_default_owner(self) -> RpcUser:
         if not hasattr(self, "_default_owner"):
             self._default_owner = self.get_owners()[0]
         return self._default_owner

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -37,8 +37,8 @@ from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
-    from sentry.services.hybrid_cloud.integration import APIIntegration
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.integration import RpcIntegration
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 INVITE_DAYS_VALID = 30
 
@@ -79,7 +79,7 @@ class OrganizationMemberManager(BaseManager):
             email__exact=None
         ).exclude(organization_id__in=orgs_with_scim).delete()
 
-    def get_for_integration(self, integration: APIIntegration, actor: APIUser) -> QuerySet:
+    def get_for_integration(self, integration: RpcIntegration, actor: RpcUser) -> QuerySet:
         return self.filter(
             user_id=actor.id,
             organization__organizationintegration__integration_id=integration.id,

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -16,7 +16,7 @@ from sentry.utils.cache import cache
 
 if TYPE_CHECKING:
     from sentry.models import ProjectCodeOwners, Team
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 READ_CACHE_DURATION = 3600
 
@@ -168,7 +168,7 @@ class ProjectOwnership(Model):
     ) -> Sequence[
         Tuple[
             "Rule",
-            Sequence[Union["Team", "APIUser"]],
+            Sequence[Union["Team", "RpcUser"]],
             Union[OwnerRuleType.OWNERSHIP_RULE.value, OwnerRuleType.CODEOWNERS.value],
         ]
     ]:

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -14,7 +14,7 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import pending_delete
 
 
@@ -94,7 +94,7 @@ class Repository(Model, PendingDeletionMixin):
         return super().reset_pending_deletion_field_names(["config"])
 
 
-def on_delete(instance, actor: APIUser | None = None, **kwargs):
+def on_delete(instance, actor: RpcUser | None = None, **kwargs):
     """
     Remove webhooks for repository providers that use repository level webhooks.
     This is called from sentry.tasks.deletion.run_deletion()

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -16,7 +16,7 @@ from sentry.db.models import (
     control_silo_only_model,
     region_silo_only_model,
 )
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.silo import SiloMode
 
 delete_logger = logging.getLogger("sentry.deletions.api")
@@ -121,7 +121,7 @@ class BaseScheduledDeletion(Model):
     def get_instance(self):
         return self.get_model().objects.get(pk=self.object_id)
 
-    def get_actor(self) -> APIUser | None:
+    def get_actor(self) -> RpcUser | None:
         if not self.actor_id:
             return None
 

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -25,7 +25,7 @@ from sentry.db.models import (
 from sentry.db.postgres.roles import test_psql_role_override
 from sentry.models import LostPasswordHash
 from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, find_regions_for_user
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils.http import absolute_uri
 
@@ -442,7 +442,7 @@ def refresh_user_nonce(sender, request, user, **kwargs):
     user.save(update_fields=["session_nonce"])
 
 
-@receiver(user_logged_out, sender=APIUser)
+@receiver(user_logged_out, sender=RpcUser)
 def refresh_api_user_nonce(sender, request, user, **kwargs):
     if user is None:
         return

--- a/src/sentry/models/userip.py
+++ b/src/sentry/models/userip.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model, sane_repr
 from sentry.models import User
 from sentry.services.hybrid_cloud.log import UserIpEvent, log_service
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils.geo import geo_by_addr
 
 
@@ -31,7 +31,7 @@ class UserIP(Model):
     __repr__ = sane_repr("user_id", "ip_address")
 
     @classmethod
-    def log(cls, user: User | APIUser, ip_address: str):
+    def log(cls, user: User | RpcUser, ip_address: str):
         # Only log once every 5 minutes for the same user/ip_address pair
         # since this is hit pretty frequently by all API calls in the UI, etc.
         cache_key = f"userip.log:{user.id}:{ip_address}"
@@ -40,7 +40,7 @@ class UserIP(Model):
             cache.set(cache_key, 1, 300)
 
 
-def _perform_log(user: User | APIUser, ip_address: str):
+def _perform_log(user: User | RpcUser, ip_address: str):
     try:
         geo = geo_by_addr(ip_address)
     except Exception:

--- a/src/sentry/notifications/additional_attachment_manager.py
+++ b/src/sentry/notifications/additional_attachment_manager.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, MutableMapping
 from sentry.api.validators.integrations import validate_provider
 from sentry.integrations.slack.message_builder import SlackAttachment
 from sentry.models import Integration, Organization
-from sentry.services.hybrid_cloud.integration import APIIntegration
+from sentry.services.hybrid_cloud.integration import RpcIntegration
 from sentry.types.integrations import ExternalProviders
 
 # TODO(Steve): Fix types
@@ -23,7 +23,7 @@ class AdditionalAttachmentManager:
     # need to update types for additional providers
     def get_additional_attachment(
         self,
-        integration: Integration | APIIntegration,
+        integration: Integration | RpcIntegration,
         organization: Organization,
     ) -> SlackAttachment | None:
         # look up the generator by the provider but only accepting slack for now

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -15,7 +15,7 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.services.hybrid_cloud.notifications import ApiNotificationSetting
+from sentry.services.hybrid_cloud.notifications import RpcNotificationSetting
 from sentry.types.integrations import (
     EXTERNAL_PROVIDERS,
     ExternalProviders,
@@ -26,13 +26,13 @@ from sentry.types.integrations import (
 
 if TYPE_CHECKING:
     from sentry.models import Group, GroupSubscription, Organization, Project, Team, User
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 def _get_notification_setting_default(
     provider: ExternalProviders,
     type: NotificationSettingTypes,
-    recipient: Team | APIUser | None = None,  # not needed right now
+    recipient: Team | RpcUser | None = None,  # not needed right now
 ) -> NotificationSettingOptionValues:
     """
     In order to increase engagement, we automatically opt users into receiving
@@ -49,7 +49,7 @@ def _get_notification_setting_default(
 
 def _get_default_value_by_provider(
     type: NotificationSettingTypes,
-    recipient: Team | APIUser | None = None,
+    recipient: Team | RpcUser | None = None,
 ) -> Mapping[ExternalProviders, NotificationSettingOptionValues]:
     return {
         provider: _get_notification_setting_default(provider, type, recipient)
@@ -59,10 +59,10 @@ def _get_default_value_by_provider(
 
 def _get_setting_mapping_from_mapping(
     notification_settings_by_recipient: Mapping[
-        Team | APIUser,
+        Team | RpcUser,
         Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
-    recipient: Team | APIUser,
+    recipient: Team | RpcUser,
     type: NotificationSettingTypes,
 ) -> Mapping[ExternalProviders, NotificationSettingOptionValues]:
     """
@@ -121,7 +121,7 @@ def should_be_participating(
 
 
 def where_should_be_participating(
-    recipient: Team | APIUser,
+    recipient: Team | RpcUser,
     subscription: GroupSubscription | None,
     notification_settings_by_recipient: Mapping[
         Team | User,
@@ -180,10 +180,10 @@ def get_values_by_provider_by_type(
 
 
 def transform_to_notification_settings_by_recipient(
-    notification_settings: Iterable[ApiNotificationSetting],
-    recipients: Iterable[Team | APIUser],
+    notification_settings: Iterable[RpcNotificationSetting],
+    recipients: Iterable[Team | RpcUser],
 ) -> Mapping[
-    Team | APIUser,
+    Team | RpcUser,
     Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
 ]:
     """
@@ -192,7 +192,7 @@ def transform_to_notification_settings_by_recipient(
     """
     actor_mapping = {recipient.actor_id: recipient for recipient in recipients}
     notification_settings_by_recipient: MutableMapping[
-        Team | APIUser,
+        Team | RpcUser,
         MutableMapping[
             NotificationScopeType,
             MutableMapping[ExternalProviders, NotificationSettingOptionValues],
@@ -208,7 +208,7 @@ def transform_to_notification_settings_by_recipient(
 
 
 def transform_to_notification_settings_by_scope(
-    notification_settings: Iterable[ApiNotificationSetting],
+    notification_settings: Iterable[RpcNotificationSetting],
 ) -> Mapping[
     NotificationScopeType,
     Mapping[int, Mapping[ExternalProviders, NotificationSettingOptionValues]],

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -29,7 +29,7 @@ from sentry.utils.sdk import configure_scope
 
 if TYPE_CHECKING:
     from sentry.models import NotificationSetting, Organization, Project, Team, User
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 REMOVE_SETTING_BATCH_SIZE = 1000
 
@@ -249,7 +249,7 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         self,
         type_: NotificationSettingTypes,
         parent: Organization | Project,
-        recipients: Iterable[Team | User | APIUser],
+        recipients: Iterable[Team | User | RpcUser],
     ) -> QuerySet:
         from sentry.models import Team
 
@@ -294,9 +294,9 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
     def filter_to_accepting_recipients(
         self,
         parent: Union[Organization, Project],
-        recipients: Iterable[Team | APIUser],
+        recipients: Iterable[Team | RpcUser],
         type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
-    ) -> Mapping[ExternalProviders, Iterable[Team | APIUser]]:
+    ) -> Mapping[ExternalProviders, Iterable[Team | RpcUser]]:
         """
         Filters a list of teams or users down to the recipients by provider who
         are subscribed to alerts. We check both the project level settings and

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, MutableMapping
 
 from sentry.models import Activity, NotificationSetting, Organization, Team, User
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 
 from .base import GroupActivityNotification
@@ -78,7 +78,7 @@ class AssignedActivityNotification(GroupActivityNotification):
 
     def get_participants_with_group_subscription_reason(
         self,
-    ) -> Mapping[ExternalProviders, Mapping[Team | APIUser, int]]:
+    ) -> Mapping[ExternalProviders, Mapping[Team | RpcUser, int]]:
         """Hack to tack on the assigned team to the list of users subscribed to the group."""
         users_by_provider = super().get_participants_with_group_subscription_reason()
         if is_team_assignee(self.activity):
@@ -93,7 +93,7 @@ class AssignedActivityNotification(GroupActivityNotification):
                 )
                 actors_by_provider: MutableMapping[
                     ExternalProviders,
-                    MutableMapping[Team | APIUser, int],
+                    MutableMapping[Team | RpcUser, int],
                 ] = defaultdict(dict)
                 actors_by_provider.update({**users_by_provider})
                 for provider, teams in teams_by_provider.items():

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -14,7 +14,7 @@ from sentry.notifications.types import NotificationSettingTypes
 from sentry.notifications.utils import send_activity_notification
 from sentry.notifications.utils.avatar import avatar_as_html
 from sentry.notifications.utils.participants import get_participants_for_group
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
@@ -64,7 +64,7 @@ class ActivityNotification(ProjectNotification, abc.ABC):
     @abc.abstractmethod
     def get_participants_with_group_subscription_reason(
         self,
-    ) -> Mapping[ExternalProviders, Mapping[Team | APIUser, int]]:
+    ) -> Mapping[ExternalProviders, Mapping[Team | RpcUser, int]]:
         pass
 
     def send(self) -> None:
@@ -92,7 +92,7 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
 
     def get_participants_with_group_subscription_reason(
         self,
-    ) -> Mapping[ExternalProviders, Mapping[Team | APIUser, int]]:
+    ) -> Mapping[ExternalProviders, Mapping[Team | RpcUser, int]]:
         """This is overridden by the activity subclasses."""
         user = user_service.get_user(self.activity.user_id)
         return get_participants_for_group(self.group, user)

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -10,7 +10,7 @@ from sentry.db.models import Model
 from sentry.models import Environment, NotificationSetting, Team, User
 from sentry.notifications.types import NotificationSettingTypes, get_notification_setting_type_name
 from sentry.notifications.utils.actions import MessageAction
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils.safe import safe_execute
 
@@ -84,7 +84,7 @@ class BaseNotification(abc.ABC):
         pass
 
     def get_recipient_context(
-        self, recipient: Team | APIUser, extra_context: Mapping[str, Any]
+        self, recipient: Team | RpcUser, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         # Basically a noop.
         return {**extra_context}
@@ -111,7 +111,7 @@ class BaseNotification(abc.ABC):
     def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
         return None
 
-    def get_log_params(self, recipient: Team | APIUser) -> Mapping[str, Any]:
+    def get_log_params(self, recipient: Team | RpcUser) -> Mapping[str, Any]:
         group = getattr(self, "group", None)
         params = {
             "organization_id": self.organization.id,
@@ -122,7 +122,7 @@ class BaseNotification(abc.ABC):
             params["user_id"] = recipient.id
         return params
 
-    def get_custom_analytics_params(self, recipient: Team | APIUser) -> Mapping[str, Any]:
+    def get_custom_analytics_params(self, recipient: Team | RpcUser) -> Mapping[str, Any]:
         """
         Returns a mapping of params used to record the event associated with self.analytics_event.
         By default, use the log params.
@@ -165,7 +165,7 @@ class BaseNotification(abc.ABC):
                 )
 
     def get_referrer(
-        self, provider: ExternalProviders, recipient: Optional[Team | APIUser] = None
+        self, provider: ExternalProviders, recipient: Optional[Team | RpcUser] = None
     ) -> str:
         # referrer needs the provider and recipient
         referrer = f"{self.metrics_key}-{EXTERNAL_PROVIDERS[provider]}"
@@ -174,7 +174,7 @@ class BaseNotification(abc.ABC):
         return referrer
 
     def get_sentry_query_params(
-        self, provider: ExternalProviders, recipient: Optional[Team | APIUser] = None
+        self, provider: ExternalProviders, recipient: Optional[Team | RpcUser] = None
     ) -> str:
         """
         Returns the query params that allow us to track clicks into Sentry links.
@@ -183,7 +183,7 @@ class BaseNotification(abc.ABC):
         """
         return f"?referrer={self.get_referrer(provider, recipient)}"
 
-    def get_settings_url(self, recipient: Team | APIUser, provider: ExternalProviders) -> str:
+    def get_settings_url(self, recipient: Team | RpcUser, provider: ExternalProviders) -> str:
         # Settings url is dependant on the provider so we know which provider is sending them into Sentry.
         if isinstance(recipient, Team):
             url_str = f"/settings/{self.organization.slug}/teams/{recipient.slug}/notifications/"
@@ -200,7 +200,7 @@ class BaseNotification(abc.ABC):
             )
         )
 
-    def determine_recipients(self) -> Iterable[Team | APIUser]:
+    def determine_recipients(self) -> Iterable[Team | RpcUser]:
         raise NotImplementedError
 
     def get_notification_providers(self) -> Iterable[ExternalProviders]:
@@ -210,16 +210,16 @@ class BaseNotification(abc.ABC):
         return notification_providers()
 
     def filter_to_accepting_recipients(
-        self, recipients: Iterable[Team | APIUser]
-    ) -> Mapping[ExternalProviders, Iterable[Team | APIUser]]:
+        self, recipients: Iterable[Team | RpcUser]
+    ) -> Mapping[ExternalProviders, Iterable[Team | RpcUser]]:
         accepting_recipients: Mapping[
-            ExternalProviders, Iterable[Team | APIUser]
+            ExternalProviders, Iterable[Team | RpcUser]
         ] = NotificationSetting.objects.filter_to_accepting_recipients(
             self.organization, recipients, self.notification_setting_type
         )
         return accepting_recipients
 
-    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | APIUser]]:
+    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | RpcUser]]:
         # need a notification_setting_type to call this function
         if not self.notification_setting_type:
             raise NotImplementedError

--- a/src/sentry/notifications/notifications/codeowners_auto_sync.py
+++ b/src/sentry/notifications/notifications/codeowners_auto_sync.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
 
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import NotificationSettingTypes
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ class AutoSyncNotification(ProjectNotification):
     notification_setting_type = NotificationSettingTypes.DEPLOY
     template_path = "sentry/emails/codeowners-auto-sync-failure"
 
-    def determine_recipients(self) -> Iterable[Team | APIUser]:
+    def determine_recipients(self) -> Iterable[Team | RpcUser]:
         return self.organization.get_owners()  # type: ignore
 
     @property

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -11,7 +11,7 @@ from sentry.notifications.notifications.strategies.role_based_recipient_strategy
     RoleBasedRecipientStrategy,
 )
 from sentry.notifications.types import NotificationSettingTypes
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
     def get_context(self) -> MutableMapping[str, Any]:
         return {}
 
-    def determine_recipients(self) -> Iterable[Team | APIUser]:
+    def determine_recipients(self) -> Iterable[Team | RpcUser]:
         return self.role_based_recipient_strategy.determine_recipients()
 
     def get_notification_title(

--- a/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable, MutableMapping
 
 from sentry import roles
 from sentry.models import OrganizationMember
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 
 if TYPE_CHECKING:
     from sentry.models import Organization, User
@@ -17,7 +17,7 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
     def __init__(self, organization: Organization):
         self.organization = organization
 
-    def get_member(self, user: APIUser) -> OrganizationMember:
+    def get_member(self, user: RpcUser) -> OrganizationMember:
         # cache the result
         if user.class_name() != "User":
             raise OrganizationMember.DoesNotExist()
@@ -35,7 +35,7 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
 
     def determine_recipients(
         self,
-    ) -> Iterable[APIUser]:
+    ) -> Iterable[RpcUser]:
         members = self.determine_member_recipients()
         # store the members in our cache
         for member in members:

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -10,7 +10,7 @@ from sentry.models import Group, GroupSubscription
 from sentry.notifications.helpers import get_reason_context
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.utils import send_activity_notification
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class UserReportNotification(ProjectNotification):
 
     def get_participants_with_group_subscription_reason(
         self,
-    ) -> Mapping[ExternalProviders, Mapping[Team | APIUser, int]]:
+    ) -> Mapping[ExternalProviders, Mapping[Team | RpcUser, int]]:
         data_by_provider = GroupSubscription.objects.get_participants(group=self.group)
         return {
             provider: data

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, MutableMappi
 
 from sentry.models import User
 from sentry.notifications.notifications.base import BaseNotification
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo.base import SiloMode
 from sentry.types.integrations import ExternalProviders
 
@@ -49,25 +49,25 @@ def register_notification_provider(
 def notify(
     provider: ExternalProviders,
     notification: Any,
-    recipients: Iterable[Team | APIUser],
+    recipients: Iterable[Team | RpcUser],
     shared_context: Mapping[str, Any],
     extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None = None,
 ) -> None:
     """Send notifications to these users or team."""
 
     """ ###################### Begin Hack ######################
-    # Temporary Hybrid Cloud hack that isolates the notification subsystem from APIUser
+    # Temporary Hybrid Cloud hack that isolates the notification subsystem from RpcUser
     # type changes. With this in place, we can assert that changes so far don't affect
     # Notification system behavior (only possibly who receives notifications).
     # This will be removed in future work.
 
-    # Create a new list of recipients that are full Team and User objects (as opposed to APIUser)
+    # Create a new list of recipients that are full Team and User objects (as opposed to RpcUser)
     """
     if SiloMode.get_current_mode() == SiloMode.MONOLITH:
         user_ids = []
         new_recipients = []
         for r in recipients:
-            if isinstance(r, APIUser):
+            if isinstance(r, RpcUser):
                 user_ids.append(r.id)
             else:
                 new_recipients.append(r)

--- a/src/sentry/plugins/providers/base.py
+++ b/src/sentry/plugins/providers/base.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from sentry.exceptions import InvalidIdentity, PluginError
 from sentry.models import Integration, OrganizationIntegration
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from social_auth.models import UserSocialAuth
 
 
@@ -87,7 +87,7 @@ class ProviderMixin:
 
         return not UserSocialAuth.objects.filter(user=user, provider=self.auth_provider).exists()
 
-    def get_auth(self, user: APIUser, **kwargs):
+    def get_auth(self, user: RpcUser, **kwargs):
         if self.auth_provider is None:
             return None
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -16,7 +16,7 @@ from sentry.models import (
     Project,
 )
 from sentry.plugins.bases import IssueTrackingPlugin, IssueTrackingPlugin2
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import (
     alert_rule_created,
     event_processed,
@@ -149,7 +149,7 @@ def record_first_event(project, event, **kwargs):
     )
 
     try:
-        user: APIUser = Organization.objects.get(id=project.organization_id).get_default_owner()
+        user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
     except IndexError:
         logger.warning(
             "Cannot record first event for organization (%s) due to missing owners",
@@ -340,7 +340,7 @@ def record_release_received(project, event, **kwargs):
     )
     if success:
         try:
-            user: APIUser = Organization.objects.get(id=project.organization_id).get_default_owner()
+            user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
         except IndexError:
             logger.warning(
                 "Cannot record release received for organization (%s) due to missing owners",
@@ -377,7 +377,7 @@ def record_user_context_received(project, event, **kwargs):
         )
         if success:
             try:
-                user: APIUser = Organization.objects.get(
+                user: RpcUser = Organization.objects.get(
                     id=project.organization_id
                 ).get_default_owner()
             except IndexError:
@@ -402,7 +402,7 @@ event_processed.connect(record_user_context_received, weak=False)
 @first_event_with_minified_stack_trace_received.connect(weak=False)
 def record_event_with_first_minified_stack_trace_for_project(project, event, **kwargs):
     try:
-        user: APIUser = Organization.objects.get(id=project.organization_id).get_default_owner()
+        user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
     except IndexError:
         logger.warning(
             "Cannot record first event for organization (%s) due to missing owners",
@@ -450,7 +450,7 @@ def record_sourcemaps_received(project, event, **kwargs):
     )
     if success:
         try:
-            user: APIUser = Organization.objects.get(id=project.organization_id).get_default_owner()
+            user: RpcUser = Organization.objects.get(id=project.organization_id).get_default_owner()
         except IndexError:
             logger.warning(
                 "Cannot record sourcemaps received for organization (%s) due to missing owners",

--- a/src/sentry/receivers/outbox/__init__.py
+++ b/src/sentry/receivers/outbox/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, Type, TypeVar
 
-from sentry.services.hybrid_cloud.tombstone import ApiTombstone, tombstone_service
+from sentry.services.hybrid_cloud.tombstone import RpcTombstone, tombstone_service
 
 
 class ModelLike(Protocol):
@@ -17,6 +17,6 @@ def maybe_process_tombstone(model: Type[T], object_identifier: int) -> T | None:
         return instance
 
     tombstone_service.record_remote_tombstone(
-        ApiTombstone(table_name=model._meta.db_table, identifier=object_identifier)
+        RpcTombstone(table_name=model._meta.db_table, identifier=object_identifier)
     )
     return None

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -9,7 +9,7 @@ from sentry.receivers.outbox import maybe_process_tombstone
 from sentry.services.hybrid_cloud.log import AuditLogEvent, UserIpEvent
 from sentry.services.hybrid_cloud.log.impl import DatabaseBackedLogService
 from sentry.services.hybrid_cloud.organization_mapping import (
-    ApiOrganizationMappingUpdate,
+    RpcOrganizationMappingUpdate,
     organization_mapping_service,
 )
 
@@ -48,5 +48,5 @@ def process_organization_updates(object_identifier: int, **kwds: Any):
     if (org := maybe_process_tombstone(Organization, object_identifier)) is None:
         return
 
-    update = ApiOrganizationMappingUpdate.from_instance(org)
+    update = RpcOrganizationMappingUpdate.from_instance(org)
     organization_mapping_service.update(update)

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -27,7 +27,7 @@ from sentry.models.grouphistory import (
     record_group_history_from_activity_type,
 )
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user_option import get_option_from_list, user_option_service
 from sentry.signals import buffer_incr_complete, issue_resolved
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
@@ -111,7 +111,7 @@ def resolved_in_commit(instance, created, **kwargs):
                 acting_user = None
 
                 if user_list:
-                    acting_user: APIUser = user_list[0]
+                    acting_user: RpcUser = user_list[0]
                     self_assign_issue: str = get_option_from_list(
                         user_option_service.get_many(
                             filter={"user_ids": [acting_user.id], "keys": ["self_assign_issue"]}
@@ -215,7 +215,7 @@ def resolved_in_pull_request(instance, created, **kwargs):
                     user_list = ()
                 acting_user = None
                 if user_list:
-                    acting_user: APIUser = user_list[0]
+                    acting_user: RpcUser = user_list[0]
                     GroupAssignee.objects.assign(
                         group=group, assigned_to=acting_user, acting_user=acting_user
                     )

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -6,8 +6,8 @@ from sentry import features
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.models import Group, GroupAssignee, Organization, SentryFunction, Team, User
-from sentry.services.hybrid_cloud.app import ApiSentryAppInstallation, app_service
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation, app_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.signals import (
     comment_created,
     comment_deleted,
@@ -24,7 +24,7 @@ from sentry.tasks.sentry_functions import send_sentry_function_webhook
 def send_issue_assigned_webhook(project, group, user, **kwargs):
     assignee = GroupAssignee.objects.get(group_id=group.id).assigned_actor()
 
-    actor: APIUser | Team = assignee.resolve()
+    actor: RpcUser | Team = assignee.resolve()
 
     data = {
         "assignee": {"type": assignee.type.__name__.lower(), "name": actor.name, "id": actor.id}
@@ -91,7 +91,7 @@ def send_comment_webhooks(organization, issue, user, event, data=None):
 def send_workflow_webhooks(
     organization: Organization,
     issue: Group,
-    user: User | APIUser,
+    user: User | RpcUser,
     event: str,
     data: Mapping[str, Any] | None = None,
 ) -> None:
@@ -115,6 +115,6 @@ def send_workflow_webhooks(
             send_sentry_function_webhook.delay(fn.external_id, event, issue.id, data)
 
 
-def installations_to_notify(organization, event) -> List[ApiSentryAppInstallation]:
+def installations_to_notify(organization, event) -> List[RpcSentryAppInstallation]:
     installations = app_service.get_installed_for_organization(organization_id=organization.id)
     return [i for i in installations if event in i.sentry_app.events]

--- a/src/sentry/services/hybrid_cloud/app/__init__.py
+++ b/src/sentry/services/hybrid_cloud/app/__init__.py
@@ -23,26 +23,32 @@ class SentryAppInstallationFilterArgs(TypedDict, total=False):
 
 
 @dataclass
-class ApiSentryAppInstallation:
+class RpcSentryAppInstallation:
     id: int = -1
     organization_id: int = -1
     status: int = SentryAppInstallationStatus.PENDING
     uuid: str = ""
-    sentry_app: ApiSentryApp = field(default_factory=lambda: ApiSentryApp())
+    sentry_app: RpcSentryApp = field(default_factory=lambda: RpcSentryApp())
+
+
+ApiSentryAppInstallation = RpcSentryAppInstallation
 
 
 @dataclass
-class ApiApiApplication:
+class RpcApiApplication:
     id: int = -1
     client_id: str = ""
     client_secret: str = ""
 
 
+ApiApiApplication = RpcApiApplication
+
+
 @dataclass
-class ApiSentryApp:
+class RpcSentryApp:
     id: int = -1
     scope_list: List[str] = field(default_factory=list)
-    application: ApiApiApplication = field(default_factory=ApiApiApplication)
+    application: RpcApiApplication = field(default_factory=RpcApiApplication)
     proxy_user_id: int | None = None  # can be null on deletion.
     owner_id: int = -1  # relation to an organization
     name: str = ""
@@ -51,12 +57,12 @@ class ApiSentryApp:
     status: str = ""
     events: List[str] = field(default_factory=list)
     is_alertable: bool = False
-    components: List[ApiSentryAppComponent] = field(default_factory=list)
+    components: List[RpcSentryAppComponent] = field(default_factory=list)
     webhook_url: str = ""
     is_internal: bool = True
     is_unpublished: bool = True
 
-    def get_component(self, type: str) -> Optional[ApiSentryAppComponent]:
+    def get_component(self, type: str) -> Optional[RpcSentryAppComponent]:
         for c in self.components:
             if c.type == type:
                 return c
@@ -77,21 +83,27 @@ class ApiSentryApp:
         return self.slug
 
 
+ApiSentryApp = RpcSentryApp
+
+
 @dataclass
-class ApiSentryAppComponent:
+class RpcSentryAppComponent:
     uuid: str = ""
     type: str = ""
     schema: JSONField = None
 
 
+ApiSentryAppComponent = RpcSentryAppComponent
+
+
 class AppService(
-    FilterQueryInterface[SentryAppInstallationFilterArgs, ApiSentryAppInstallation, None],
+    FilterQueryInterface[SentryAppInstallationFilterArgs, RpcSentryAppInstallation, None],
     InterfaceWithLifecycle,
 ):
     @abc.abstractmethod
     def find_installation_by_proxy_user(
         self, *, proxy_user_id: int, organization_id: int
-    ) -> ApiSentryAppInstallation | None:
+    ) -> RpcSentryAppInstallation | None:
         pass
 
     @abc.abstractmethod
@@ -112,7 +124,7 @@ class AppService(
         *,
         organization_id: int,
         sentry_app_id: Optional[int] = None,
-    ) -> List[ApiSentryAppInstallation]:
+    ) -> List[RpcSentryAppInstallation]:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -11,11 +11,11 @@ from sentry.models import SentryApp, SentryAppInstallation
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.integrations.sentry_app_component import SentryAppComponent
 from sentry.services.hybrid_cloud.app import (
-    ApiApiApplication,
-    ApiSentryApp,
-    ApiSentryAppComponent,
-    ApiSentryAppInstallation,
     AppService,
+    RpcApiApplication,
+    RpcSentryApp,
+    RpcSentryAppComponent,
+    RpcSentryAppInstallation,
     SentryAppInstallationFilterArgs,
 )
 from sentry.services.hybrid_cloud.filter_query import FilterQueryDatabaseImpl
@@ -23,7 +23,7 @@ from sentry.services.hybrid_cloud.filter_query import FilterQueryDatabaseImpl
 
 class DatabaseBackedAppService(
     FilterQueryDatabaseImpl[
-        SentryAppInstallation, SentryAppInstallationFilterArgs, ApiSentryAppInstallation, None
+        SentryAppInstallation, SentryAppInstallationFilterArgs, RpcSentryAppInstallation, None
     ],
     AppService,
 ):
@@ -95,7 +95,7 @@ class DatabaseBackedAppService(
         *,
         organization_id: int,
         sentry_app_id: Optional[int] = None,
-    ) -> List[ApiSentryAppInstallation]:
+    ) -> List[RpcSentryAppInstallation]:
         installations = SentryAppInstallation.objects.get_installed_for_organization(
             organization_id
         )
@@ -108,7 +108,7 @@ class DatabaseBackedAppService(
 
     def find_installation_by_proxy_user(
         self, *, proxy_user_id: int, organization_id: int
-    ) -> ApiSentryAppInstallation | None:
+    ) -> RpcSentryAppInstallation | None:
         try:
             sentry_app = SentryApp.objects.get(proxy_user_id=proxy_user_id)
         except SentryApp.DoesNotExist:
@@ -123,8 +123,8 @@ class DatabaseBackedAppService(
 
         return self._serialize_rpc(installation)
 
-    def _serialize_sentry_app(self, app: SentryApp) -> ApiSentryApp:
-        return ApiSentryApp(
+    def _serialize_sentry_app(self, app: SentryApp) -> RpcSentryApp:
+        return RpcSentryApp(
             id=app.id,
             scope_list=app.scope_list,
             application=self._serialize_api_application(app.application),
@@ -144,24 +144,24 @@ class DatabaseBackedAppService(
 
     def _serialize_sentry_app_component(
         self, component: SentryAppComponent
-    ) -> ApiSentryAppComponent:
-        return ApiSentryAppComponent(
+    ) -> RpcSentryAppComponent:
+        return RpcSentryAppComponent(
             uuid=component.uuid,
             type=component.type,
             schema=component.schema,
         )
 
-    def _serialize_api_application(self, api_app: ApiApplication) -> ApiApiApplication:
-        return ApiApiApplication(
+    def _serialize_api_application(self, api_app: ApiApplication) -> RpcApiApplication:
+        return RpcApiApplication(
             id=api_app.id,
             client_id=api_app.client_id,
             client_secret=api_app.client_secret,
         )
 
-    def _serialize_rpc(self, installation: SentryAppInstallation) -> ApiSentryAppInstallation:
+    def _serialize_rpc(self, installation: SentryAppInstallation) -> RpcSentryAppInstallation:
         app = installation.sentry_app
 
-        return ApiSentryAppInstallation(
+        return RpcSentryAppInstallation(
             id=installation.id,
             organization_id=installation.organization_id,
             status=installation.status,

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -23,34 +23,34 @@ from sentry.models import (
     User,
 )
 from sentry.services.hybrid_cloud.auth import (
-    ApiAuthenticatorType,
-    ApiAuthIdentity,
-    ApiAuthProvider,
-    ApiAuthProviderFlags,
-    ApiAuthState,
-    ApiMemberSsoState,
-    ApiOrganizationAuthConfig,
     AuthenticatedToken,
     AuthenticationContext,
     AuthenticationRequest,
     AuthService,
     MiddlewareAuthenticationResponse,
+    RpcAuthenticatorType,
+    RpcAuthIdentity,
+    RpcAuthProvider,
+    RpcAuthProviderFlags,
+    RpcAuthState,
+    RpcMemberSsoState,
+    RpcOrganizationAuthConfig,
 )
 from sentry.services.hybrid_cloud.organization import (
-    ApiOrganization,
-    ApiOrganizationMember,
-    ApiOrganizationMemberFlags,
+    RpcOrganization,
+    RpcOrganizationMember,
+    RpcOrganizationMemberFlags,
     organization_service,
 )
 from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.impl import serialize_rpc_user
 from sentry.silo import SiloMode
 from sentry.utils.auth import AuthUserPasswordExpired
 from sentry.utils.types import Any
 
-_SSO_BYPASS = ApiMemberSsoState(False, True)
-_SSO_NONMEMBER = ApiMemberSsoState(False, False)
+_SSO_BYPASS = RpcMemberSsoState(False, True)
+_SSO_NONMEMBER = RpcMemberSsoState(False, False)
 
 
 # When OrgMemberMapping table is created for the control silo, org_member_class will use that rather
@@ -58,9 +58,9 @@ _SSO_NONMEMBER = ApiMemberSsoState(False, False)
 def query_sso_state(
     organization_id: int | None,
     is_super_user: bool,
-    member: ApiOrganizationMember | OrganizationMember | None,
+    member: RpcOrganizationMember | OrganizationMember | None,
     org_member_class: Any = OrganizationMember,
-) -> ApiMemberSsoState:
+) -> RpcMemberSsoState:
     """
     Check whether SSO is required and valid for a given member.
     This should generally be accessed from the `request.access` object.
@@ -130,18 +130,18 @@ def query_sso_state(
         else:
             sso_is_valid = auth_identity.is_valid(member)
 
-    return ApiMemberSsoState(is_required=requires_sso, is_valid=sso_is_valid)
+    return RpcMemberSsoState(is_required=requires_sso, is_valid=sso_is_valid)
 
 
 class DatabaseBackedAuthService(AuthService):
-    def _serialize_auth_provider_flags(self, ap: AuthProvider) -> ApiAuthProviderFlags:
+    def _serialize_auth_provider_flags(self, ap: AuthProvider) -> RpcAuthProviderFlags:
         d: dict[str, bool] = {}
-        for f in dataclasses.fields(ApiAuthProviderFlags):
+        for f in dataclasses.fields(RpcAuthProviderFlags):
             d[f.name] = bool(ap.flags[f.name])
-        return ApiAuthProviderFlags(**d)
+        return RpcAuthProviderFlags(**d)
 
-    def _serialize_auth_provider(self, ap: AuthProvider) -> ApiAuthProvider:
-        return ApiAuthProvider(
+    def _serialize_auth_provider(self, ap: AuthProvider) -> RpcAuthProvider:
+        return RpcAuthProvider(
             id=ap.id,
             organization_id=ap.organization_id,
             provider=ap.provider,
@@ -150,7 +150,7 @@ class DatabaseBackedAuthService(AuthService):
 
     def get_org_auth_config(
         self, *, organization_ids: List[int]
-    ) -> List[ApiOrganizationAuthConfig]:
+    ) -> List[RpcOrganizationAuthConfig]:
         aps: Mapping[int, AuthProvider] = {
             ap.organization_id: ap
             for ap in AuthProvider.objects.filter(organization_id__in=organization_ids)
@@ -162,7 +162,7 @@ class DatabaseBackedAuthService(AuthService):
             .annotate(Count("id"))
         }
         return [
-            ApiOrganizationAuthConfig(
+            RpcOrganizationAuthConfig(
                 organization_id=oid,
                 auth_provider=self._serialize_auth_provider(aps[oid]) if oid in aps else None,
                 has_api_key=qs.get(oid, 0) > 0,
@@ -171,7 +171,7 @@ class DatabaseBackedAuthService(AuthService):
         ]
 
     def authenticate_with(
-        self, *, request: AuthenticationRequest, authenticator_types: List[ApiAuthenticatorType]
+        self, *, request: AuthenticationRequest, authenticator_types: List[RpcAuthenticatorType]
     ) -> AuthenticationContext:
         fake_request = FakeAuthenticationRequest(request)
         user: User | None = None
@@ -229,8 +229,8 @@ class DatabaseBackedAuthService(AuthService):
         user_id: int,
         is_superuser: bool,
         organization_id: int | None,
-        org_member: ApiOrganizationMember | OrganizationMember | None,
-    ) -> ApiAuthState:
+        org_member: RpcOrganizationMember | OrganizationMember | None,
+    ) -> RpcAuthState:
         sso_state = query_sso_state(
             organization_id=organization_id,
             is_super_user=is_superuser,
@@ -243,7 +243,7 @@ class DatabaseBackedAuthService(AuthService):
         if is_superuser:
             permissions.extend(get_permissions_for_user(user_id))
 
-        return ApiAuthState(
+        return RpcAuthState(
             sso_state=sso_state,
             permissions=permissions,
         )
@@ -260,18 +260,18 @@ class DatabaseBackedAuthService(AuthService):
             ).values_list("organization_id", flat=True)
         )
 
-    def get_auth_providers(self, organization_id: int) -> List[ApiAuthProvider]:
+    def get_auth_providers(self, organization_id: int) -> List[RpcAuthProvider]:
         return list(AuthProvider.objects.filter(organization_id=organization_id))
 
     def handle_new_membership(
         self,
         request: Request,
-        organization: ApiOrganization,
-        auth_identity: ApiAuthIdentity,
-        auth_provider: ApiAuthProvider,
-    ) -> Tuple[APIUser, ApiOrganizationMember]:
-        # TODO: Might be able to keep hold of the APIUser object whose ID was
-        #  originally passed to construct the ApiAuthIdentity object
+        organization: RpcOrganization,
+        auth_identity: RpcAuthIdentity,
+        auth_provider: RpcAuthProvider,
+    ) -> Tuple[RpcUser, RpcOrganizationMember]:
+        # TODO: Might be able to keep hold of the RpcUser object whose ID was
+        #  originally passed to construct the RpcAuthIdentity object
         user = User.objects.get(id=auth_identity.user_id)
         serial_user = serialize_rpc_user(user)
 
@@ -298,7 +298,7 @@ class DatabaseBackedAuthService(AuthService):
             # In that case, delete the invite request and create a new membership.
             invite_helper.handle_invite_not_approved()
 
-        flags = ApiOrganizationMemberFlags(sso__linked=True)
+        flags = RpcOrganizationMemberFlags(sso__linked=True)
         # if the org doesn't have the ability to add members then anyone who got added
         # this way should be disabled until the org upgrades
         if not features.has("organizations:invite-members", orm_org):

--- a/src/sentry/services/hybrid_cloud/filter_query.py
+++ b/src/sentry/services/hybrid_cloud/filter_query.py
@@ -8,7 +8,7 @@ from django.db.models import QuerySet
 if TYPE_CHECKING:
     from sentry.api.serializers import Serializer
     from sentry.services.hybrid_cloud.auth import AuthenticationContext
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 FILTER_ARGS = TypeVar("FILTER_ARGS")  # A typedict
@@ -31,7 +31,7 @@ OpaqueSerializedResponse = Any
 
 # This class should be inherited from to add this functionality to the public interface for a service.
 # E.g. class UserService(FilterQueryInterface[
-#        UserQueryArgs, APIUser, Union[UserSerializerResponse, UserSerializerResponseSelf]
+#        UserQueryArgs, RpcUser, Union[UserSerializerResponse, UserSerializerResponseSelf]
 #      ], InterfaceWithLifecycle):
 #         ...
 class FilterQueryInterface(Generic[FILTER_ARGS, RPC_RESPONSE, SERIALIZER_ENUM], abc.ABC):
@@ -40,7 +40,7 @@ class FilterQueryInterface(Generic[FILTER_ARGS, RPC_RESPONSE, SERIALIZER_ENUM], 
         self,
         *,
         filter: FILTER_ARGS,
-        as_user: Optional[APIUser] = None,
+        as_user: Optional[RpcUser] = None,
         auth_context: Optional[AuthenticationContext] = None,
         serializer: Optional[SERIALIZER_ENUM] = None,
     ) -> List[OpaqueSerializedResponse]:
@@ -53,7 +53,7 @@ class FilterQueryInterface(Generic[FILTER_ARGS, RPC_RESPONSE, SERIALIZER_ENUM], 
 
 # This class should be inherited from to add this functionality to the database implementation for a service.
 # E.g. class DatabaseBackedUserService(
-#         FilterQueryDatabaseImpl[User, UserFilterArgs, APIUser, UserSerializeType],
+#         FilterQueryDatabaseImpl[User, UserFilterArgs, RpcUser, UserSerializeType],
 #         UserService,
 #      ):
 #       ...
@@ -118,7 +118,7 @@ class FilterQueryDatabaseImpl(
         self,
         *,
         filter: FILTER_ARGS,
-        as_user: Optional[APIUser] = None,
+        as_user: Optional[RpcUser] = None,
         auth_context: Optional[AuthenticationContext] = None,
         serializer: Optional[SERIALIZER_ENUM] = None,
     ) -> List[OpaqueSerializedResponse]:

--- a/src/sentry/services/hybrid_cloud/identity/__init__.py
+++ b/src/sentry/services/hybrid_cloud/identity/__init__.py
@@ -12,32 +12,38 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class APIIdentityProvider:
+class RpcIdentityProvider:
     id: int
     type: str
     external_id: str
 
 
+APIIdentityProvider = RpcIdentityProvider
+
+
 @dataclass(frozen=True)
-class APIIdentity:
+class RpcIdentity:
     id: int
     idp_id: int
     user_id: int
     external_id: str
 
 
+APIIdentity = RpcIdentity
+
+
 class IdentityService(InterfaceWithLifecycle):
     def _serialize_identity_provider(
         self, identity_provider: IdentityProvider
-    ) -> APIIdentityProvider:
-        return APIIdentityProvider(
+    ) -> RpcIdentityProvider:
+        return RpcIdentityProvider(
             id=identity_provider.id,
             type=identity_provider.type,
             external_id=identity_provider.external_id,
         )
 
-    def _serialize_identity(self, identity: Identity) -> APIIdentity:
-        return APIIdentity(
+    def _serialize_identity(self, identity: Identity) -> RpcIdentity:
+        return RpcIdentity(
             id=identity.id,
             idp_id=identity.idp_id,
             user_id=identity.user_id,
@@ -51,9 +57,9 @@ class IdentityService(InterfaceWithLifecycle):
         provider_id: int | None = None,
         provider_type: str | None = None,
         provider_ext_id: str | None = None,
-    ) -> APIIdentityProvider | None:
+    ) -> RpcIdentityProvider | None:
         """
-        Returns an APIIdentityProvider either by using the idp.id (provider_id), or a combination
+        Returns an RpcIdentityProvider either by using the idp.id (provider_id), or a combination
         of idp.type (provider_type) and idp.external_id (provider_ext_id)
         """
         pass
@@ -65,9 +71,9 @@ class IdentityService(InterfaceWithLifecycle):
         provider_id: int,
         user_id: int | None = None,
         identity_ext_id: str | None = None,
-    ) -> APIIdentity | None:
+    ) -> RpcIdentity | None:
         """
-        Returns an APIIdentity using the idp.id (provider_id) and either the user.id (user_id)
+        Returns an RpcIdentity using the idp.id (provider_id) and either the user.id (user_id)
         or identity.external_id (identity_ext_id)
         """
         pass
@@ -79,7 +85,7 @@ class IdentityService(InterfaceWithLifecycle):
         user_id: int,
         provider_type: str,
         exclude_matching_external_ids: bool = False,
-    ) -> List[APIIdentity]:
+    ) -> List[RpcIdentity]:
         """
         Returns a list of APIIdentities for a given user based on idp.type (provider_type).
         If exclude_matching_external_ids is True, excludes entries with

--- a/src/sentry/services/hybrid_cloud/identity/impl.py
+++ b/src/sentry/services/hybrid_cloud/identity/impl.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, List
 
-from sentry.services.hybrid_cloud.identity import APIIdentity, APIIdentityProvider, IdentityService
+from sentry.services.hybrid_cloud.identity import IdentityService, RpcIdentity, RpcIdentityProvider
 
 
 class DatabaseBackedIdentityService(IdentityService):
@@ -15,7 +15,7 @@ class DatabaseBackedIdentityService(IdentityService):
         provider_id: int | None = None,
         provider_type: str | None = None,
         provider_ext_id: str | None = None,
-    ) -> APIIdentityProvider | None:
+    ) -> RpcIdentityProvider | None:
         from sentry.models.identity import IdentityProvider
 
         # If an id is provided, use that -- otherwise, use the type and external_id
@@ -35,7 +35,7 @@ class DatabaseBackedIdentityService(IdentityService):
         provider_id: int,
         user_id: int | None = None,
         identity_ext_id: str | None = None,
-    ) -> APIIdentity | None:
+    ) -> RpcIdentity | None:
         from sentry.models.identity import Identity
 
         # If an user_id is provided, use that -- otherwise, use the external_id
@@ -51,7 +51,7 @@ class DatabaseBackedIdentityService(IdentityService):
         user_id: int,
         provider_type: str,
         exclude_matching_external_ids: bool = False,
-    ) -> List[APIIdentity]:
+    ) -> List[RpcIdentity]:
         from django.db.models import F
 
         from sentry.models.identity import Identity

--- a/src/sentry/services/hybrid_cloud/integration/__init__.py
+++ b/src/sentry/services/hybrid_cloud/integration/__init__.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, eq=True)
-class APIIntegration:
+class RpcIntegration:
     id: int
     provider: str
     external_id: str
@@ -48,8 +48,11 @@ class APIIntegration:
         return "disabled"
 
 
+APIIntegration = RpcIntegration
+
+
 @dataclass(frozen=True, eq=True)
-class APIOrganizationIntegration:
+class RpcOrganizationIntegration:
     id: int
     default_auth_id: int
     organization_id: int
@@ -68,9 +71,12 @@ class APIOrganizationIntegration:
         return "disabled"
 
 
+APIOrganizationIntegration = RpcOrganizationIntegration
+
+
 class IntegrationService(InterfaceWithLifecycle):
-    def _serialize_integration(self, integration: Integration) -> APIIntegration:
-        return APIIntegration(
+    def _serialize_integration(self, integration: Integration) -> RpcIntegration:
+        return RpcIntegration(
             id=integration.id,
             provider=integration.provider,
             external_id=integration.external_id,
@@ -81,8 +87,8 @@ class IntegrationService(InterfaceWithLifecycle):
 
     def _serialize_organization_integration(
         self, oi: OrganizationIntegration
-    ) -> APIOrganizationIntegration:
-        return APIOrganizationIntegration(
+    ) -> RpcOrganizationIntegration:
+        return RpcOrganizationIntegration(
             id=oi.id,
             default_auth_id=oi.default_auth_id,
             organization_id=oi.organization_id,
@@ -123,7 +129,7 @@ class IntegrationService(InterfaceWithLifecycle):
         providers: List[str] | None = None,
         org_integration_status: int | None = None,
         limit: int | None = None,
-    ) -> List[APIIntegration]:
+    ) -> List[RpcIntegration]:
         """
         Returns all APIIntegrations matching the provided kwargs.
         """
@@ -136,9 +142,9 @@ class IntegrationService(InterfaceWithLifecycle):
         integration_id: int | None = None,
         provider: str | None = None,
         external_id: str | None = None,
-    ) -> APIIntegration | None:
+    ) -> RpcIntegration | None:
         """
-        Returns an APIIntegration using either the id or a combination of the provider and external_id
+        Returns an RpcIntegration using either the id or a combination of the provider and external_id
         """
         pass
 
@@ -153,7 +159,7 @@ class IntegrationService(InterfaceWithLifecycle):
         providers: List[str] | None = None,
         has_grace_period: bool | None = None,
         limit: int | None = None,
-    ) -> List[APIOrganizationIntegration]:
+    ) -> List[RpcOrganizationIntegration]:
         """
         Returns all APIOrganizationIntegrations from the matching kwargs.
         If providers is set, it will also be filtered by the integration providers set in the list.
@@ -163,9 +169,9 @@ class IntegrationService(InterfaceWithLifecycle):
 
     def get_organization_integration(
         self, *, integration_id: int, organization_id: int
-    ) -> APIOrganizationIntegration | None:
+    ) -> RpcOrganizationIntegration | None:
         """
-        Returns an APIOrganizationIntegration from the integration and organization ids.
+        Returns an RpcOrganizationIntegration from the integration and organization ids.
         """
         ois = self.get_organization_integrations(
             integration_id=integration_id, organization_id=organization_id, limit=1
@@ -180,9 +186,9 @@ class IntegrationService(InterfaceWithLifecycle):
         integration_id: int | None = None,
         provider: str | None = None,
         external_id: str | None = None,
-    ) -> Tuple[APIIntegration | None, APIOrganizationIntegration | None]:
+    ) -> Tuple[RpcIntegration | None, RpcOrganizationIntegration | None]:
         """
-        Returns a tuple of APIIntegration and APIOrganizationIntegration. The integration is selected
+        Returns a tuple of RpcIntegration and RpcOrganizationIntegration. The integration is selected
         by either integration_id, or a combination of provider and external_id.
         """
         pass
@@ -195,7 +201,7 @@ class IntegrationService(InterfaceWithLifecycle):
         name: str | None = None,
         metadata: Dict[str, Any] | None = None,
         status: int | None = None,
-    ) -> List[APIIntegration]:
+    ) -> List[RpcIntegration]:
         """
         Returns a list of APIIntegrations after updating the fields provided.
         To set a field as null, use the `set_{FIELD}_null` keyword argument.
@@ -210,9 +216,9 @@ class IntegrationService(InterfaceWithLifecycle):
         name: str | None = None,
         metadata: Dict[str, Any] | None = None,
         status: int | None = None,
-    ) -> APIIntegration | None:
+    ) -> RpcIntegration | None:
         """
-        Returns an APIIntegration after updating the fields provided.
+        Returns an RpcIntegration after updating the fields provided.
         To set a field as null, use the `set_{FIELD}_null` keyword argument.
         """
         pass
@@ -226,7 +232,7 @@ class IntegrationService(InterfaceWithLifecycle):
         status: int | None = None,
         grace_period_end: datetime | None = None,
         set_grace_period_end_null: bool | None = None,
-    ) -> List[APIOrganizationIntegration]:
+    ) -> List[RpcOrganizationIntegration]:
         """
         Returns a list of APIOrganizationIntegrations after updating the fields provided.
         To set a field as null, use the `set_{FIELD}_null` keyword argument.
@@ -242,9 +248,9 @@ class IntegrationService(InterfaceWithLifecycle):
         status: int | None = None,
         grace_period_end: datetime | None = None,
         set_grace_period_end_null: bool | None = None,
-    ) -> APIOrganizationIntegration | None:
+    ) -> RpcOrganizationIntegration | None:
         """
-        Returns an APIOrganizationIntegration after updating the fields provided.
+        Returns an RpcOrganizationIntegration after updating the fields provided.
         To set a field as null, use the `set_{FIELD}_null` keyword argument.
         """
         pass
@@ -254,7 +260,7 @@ class IntegrationService(InterfaceWithLifecycle):
     def get_installation(
         self,
         *,
-        integration: APIIntegration | Integration,
+        integration: RpcIntegration | Integration,
         organization_id: int,
     ) -> IntegrationInstallation:
         """

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -7,9 +7,9 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.models.integrations import Integration, OrganizationIntegration
 from sentry.services.hybrid_cloud import ApiPaginationArgs, ApiPaginationResult
 from sentry.services.hybrid_cloud.integration import (
-    APIIntegration,
-    APIOrganizationIntegration,
     IntegrationService,
+    RpcIntegration,
+    RpcOrganizationIntegration,
 )
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         providers: List[str] | None = None,
         org_integration_status: int | None = None,
         limit: int | None = None,
-    ) -> List[APIIntegration]:
+    ) -> List[RpcIntegration]:
         integration_kwargs: Dict[str, Any] = {}
         if integration_ids is not None:
             integration_kwargs["id__in"] = integration_ids
@@ -102,7 +102,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         provider: str | None = None,
         external_id: str | None = None,
         organization_id: int | None = None,
-    ) -> APIIntegration | None:
+    ) -> RpcIntegration | None:
         integration_kwargs: Dict[str, Any] = {}
         if integration_id is not None:
             integration_kwargs["id"] = integration_id
@@ -129,7 +129,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         providers: List[str] | None = None,
         has_grace_period: bool | None = None,
         limit: int | None = None,
-    ) -> List[APIOrganizationIntegration]:
+    ) -> List[RpcOrganizationIntegration]:
         oi_kwargs: Dict[str, Any] = {}
 
         if org_integration_ids is not None:
@@ -157,7 +157,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
 
     def get_organization_integration(
         self, *, integration_id: int, organization_id: int
-    ) -> APIOrganizationIntegration | None:
+    ) -> RpcOrganizationIntegration | None:
         organization_integration = OrganizationIntegration.objects.filter(
             integration_id=integration_id, organization_id=organization_id
         ).first()
@@ -175,7 +175,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         integration_id: int | None = None,
         provider: str | None = None,
         external_id: str | None = None,
-    ) -> Tuple[APIIntegration | None, APIOrganizationIntegration | None]:
+    ) -> Tuple[RpcIntegration | None, RpcOrganizationIntegration | None]:
         integration = self.get_integration(
             organization_id=organization_id,
             integration_id=integration_id,
@@ -202,7 +202,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         name: str | None = None,
         metadata: Dict[str, Any] | None = None,
         status: int | None = None,
-    ) -> List[APIIntegration]:
+    ) -> List[RpcIntegration]:
         integrations = Integration.objects.filter(id__in=integration_ids)
         if not integrations.exists():
             return []
@@ -229,7 +229,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         name: str | None = None,
         metadata: Dict[str, Any] | None = None,
         status: int | None = None,
-    ) -> APIIntegration | None:
+    ) -> RpcIntegration | None:
         integrations = self.update_integrations(
             integration_ids=[integration_id],
             name=name,
@@ -246,7 +246,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         status: int | None = None,
         grace_period_end: datetime | None = None,
         set_grace_period_end_null: bool | None = None,
-    ) -> List[APIOrganizationIntegration]:
+    ) -> List[RpcOrganizationIntegration]:
         ois = OrganizationIntegration.objects.filter(id__in=org_integration_ids)
         if not ois.exists():
             return []
@@ -276,7 +276,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         status: int | None = None,
         grace_period_end: datetime | None = None,
         set_grace_period_end_null: bool | None = None,
-    ) -> APIOrganizationIntegration | None:
+    ) -> RpcOrganizationIntegration | None:
         ois = self.update_organization_integrations(
             org_integration_ids=[org_integration_id],
             config=config,

--- a/src/sentry/services/hybrid_cloud/lost_password_hash/__init__.py
+++ b/src/sentry/services/hybrid_cloud/lost_password_hash/__init__.py
@@ -15,25 +15,25 @@ class LostPasswordHashService(InterfaceWithLifecycle):
     def get_or_create(
         self,
         user_id: int,
-    ) -> "APILostPasswordHash":
+    ) -> "RpcLostPasswordHash":
         """
-        This method returns a valid APILostPasswordHash for a user
+        This method returns a valid RpcLostPasswordHash for a user
         :return:
         """
         pass
 
     @classmethod
-    def serialize_lostpasswordhash(cls, lph: LostPasswordHash) -> "APILostPasswordHash":
+    def serialize_lostpasswordhash(cls, lph: LostPasswordHash) -> "RpcLostPasswordHash":
         args = {
             field.name: getattr(lph, field.name)
-            for field in fields(APILostPasswordHash)
+            for field in fields(RpcLostPasswordHash)
             if hasattr(lph, field.name)
         }
-        return APILostPasswordHash(**args)
+        return RpcLostPasswordHash(**args)
 
 
 @dataclass(frozen=True)
-class APILostPasswordHash:
+class RpcLostPasswordHash:
     id: int = -1
     user_id: int = -1
     hash: str = ""
@@ -41,6 +41,9 @@ class APILostPasswordHash:
 
     def get_absolute_url(self, mode: str = "recover") -> str:
         return cast(str, LostPasswordHash.get_lostpassword_url(self.user_id, self.hash, mode))
+
+
+APILostPasswordHash = RpcLostPasswordHash
 
 
 def impl_with_db() -> LostPasswordHashService:

--- a/src/sentry/services/hybrid_cloud/lost_password_hash/impl.py
+++ b/src/sentry/services/hybrid_cloud/lost_password_hash/impl.py
@@ -2,8 +2,8 @@ import datetime
 
 from sentry.models import LostPasswordHash
 from sentry.services.hybrid_cloud.lost_password_hash import (
-    APILostPasswordHash,
     LostPasswordHashService,
+    RpcLostPasswordHash,
 )
 
 
@@ -11,7 +11,7 @@ class DatabaseLostPasswordHashService(LostPasswordHashService):
     def get_or_create(
         self,
         user_id: int,
-    ) -> APILostPasswordHash:
+    ) -> RpcLostPasswordHash:
         # NOTE(mattrobenolt): Some security people suggest we invalidate
         # existing password hashes, but this opens up the possibility
         # of a DoS vector where then password resets are continually

--- a/src/sentry/services/hybrid_cloud/notifications/__init__.py
+++ b/src/sentry/services/hybrid_cloud/notifications/__init__.py
@@ -10,7 +10,7 @@ from sentry.notifications.types import (
     NotificationSettingTypes,
 )
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
 from sentry.types.integrations import ExternalProviders
 
@@ -19,13 +19,16 @@ if TYPE_CHECKING:
 
 
 @dataclasses.dataclass
-class ApiNotificationSetting:
+class RpcNotificationSetting:
     scope_type: NotificationScopeType = NotificationScopeType.USER
     scope_identifier: int = -1
     target_id: int = -1
     provider: ExternalProviders = ExternalProviders.EMAIL
     type: NotificationSettingTypes = NotificationSettingTypes.WORKFLOW
     value: NotificationSettingOptionValues = NotificationSettingOptionValues.DEFAULT
+
+
+ApiNotificationSetting = RpcNotificationSetting
 
 
 class MayHaveActor(Protocol):
@@ -49,7 +52,7 @@ class NotificationsService(InterfaceWithLifecycle):
         type: NotificationSettingTypes,
         parent_id: int,
         recipients: Sequence[MayHaveActor],
-    ) -> List[ApiNotificationSetting]:
+    ) -> List[RpcNotificationSetting]:
         pass
 
     @abstractmethod
@@ -57,21 +60,21 @@ class NotificationsService(InterfaceWithLifecycle):
         self,
         *,
         types: List[NotificationSettingTypes],
-        users: List[APIUser],
+        users: List[RpcUser],
         value: NotificationSettingOptionValues,
-    ) -> List[ApiNotificationSetting]:
+    ) -> List[RpcNotificationSetting]:
         pass
 
     @abstractmethod
     def get_settings_for_user_by_projects(
         self, *, type: NotificationSettingTypes, user_id: int, parent_ids: List[int]
-    ) -> List[ApiNotificationSetting]:
+    ) -> List[RpcNotificationSetting]:
         pass
 
     def _serialize_notification_settings(
         self, setting: NotificationSetting
-    ) -> ApiNotificationSetting:
-        return ApiNotificationSetting(
+    ) -> RpcNotificationSetting:
+        return RpcNotificationSetting(
             scope_type=setting.scope_type,
             scope_identifier=setting.scope_identifier,
             target_id=setting.target_id,

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -12,11 +12,11 @@ from sentry.notifications.types import (
     NotificationSettingTypes,
 )
 from sentry.services.hybrid_cloud.notifications import (
-    ApiNotificationSetting,
     MayHaveActor,
     NotificationsService,
+    RpcNotificationSetting,
 )
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 
 
 class DatabaseBackedNotificationsService(NotificationsService):
@@ -24,9 +24,9 @@ class DatabaseBackedNotificationsService(NotificationsService):
         self,
         *,
         types: List[NotificationSettingTypes],
-        users: List[APIUser],
+        users: List[RpcUser],
         value: NotificationSettingOptionValues,
-    ) -> List[ApiNotificationSetting]:
+    ) -> List[RpcNotificationSetting]:
         settings = NotificationSetting.objects.filter(
             target__in=[u.actor_id for u in users],
             type__in=types,
@@ -37,7 +37,7 @@ class DatabaseBackedNotificationsService(NotificationsService):
 
     def get_settings_for_recipient_by_parent(
         self, *, type: NotificationSettingTypes, parent_id: int, recipients: Sequence[MayHaveActor]
-    ) -> List[ApiNotificationSetting]:
+    ) -> List[RpcNotificationSetting]:
         team_ids = [r.id for r in recipients if r.class_name() == "Team"]
         user_ids = [r.id for r in recipients if r.class_name() == "User"]
         actor_ids: List[int] = [r.actor_id for r in recipients if r.actor_id is not None]
@@ -64,7 +64,7 @@ class DatabaseBackedNotificationsService(NotificationsService):
 
     def get_settings_for_user_by_projects(
         self, *, type: NotificationSettingTypes, user_id: int, parent_ids: List[int]
-    ) -> List[ApiNotificationSetting]:
+    ) -> List[RpcNotificationSetting]:
         try:
             user = User.objects.get(id=user_id)
         except User.DoesNotExist:

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, List, Mapping, Optional
 
 from sentry.models.organization import OrganizationStatus
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
 
 if TYPE_CHECKING:
@@ -17,15 +17,15 @@ class OrganizationService(InterfaceWithLifecycle):
     @abstractmethod
     def get_organization_by_id(
         self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
-    ) -> Optional[ApiUserOrganizationContext]:
+    ) -> Optional[RpcUserOrganizationContext]:
         """
         Fetches the organization, team, and project data given by an organization id, regardless of its visibility
         status.  When user_id is provided, membership data related to that user from the organization
-        is also given in the response.  See ApiUserOrganizationContext for more info.
+        is also given in the response.  See RpcUserOrganizationContext for more info.
         """
         pass
 
-    # TODO: This should return ApiOrganizationSummary objects, since we cannot realistically span out requests and
+    # TODO: This should return RpcOrganizationSummary objects, since we cannot realistically span out requests and
     #  capture full org objects / teams / permissions.  But we can gather basic summary data from the control silo.
     @abstractmethod
     def get_organizations(
@@ -34,7 +34,7 @@ class OrganizationService(InterfaceWithLifecycle):
         scope: Optional[str],
         only_visible: bool,
         organization_ids: Optional[List[int]] = None,
-    ) -> List[ApiOrganizationSummary]:
+    ) -> List[RpcOrganizationSummary]:
         """
         When user_id is set, returns all organizations associated with that user id given
         a scope and visibility requirement.  When user_id is not set, but organization_ids is, provides the
@@ -52,7 +52,7 @@ class OrganizationService(InterfaceWithLifecycle):
     @abstractmethod
     def check_membership_by_email(
         self, organization_id: int, email: str
-    ) -> Optional[ApiOrganizationMember]:
+    ) -> Optional[RpcOrganizationMember]:
         """
         Used to look up an organization membership by an email
         """
@@ -61,7 +61,7 @@ class OrganizationService(InterfaceWithLifecycle):
     @abstractmethod
     def check_membership_by_id(
         self, organization_id: int, user_id: int
-    ) -> Optional[ApiOrganizationMember]:
+    ) -> Optional[RpcOrganizationMember]:
         """
         Used to look up an organization membership by a user id
         """
@@ -76,7 +76,7 @@ class OrganizationService(InterfaceWithLifecycle):
 
     def get_organization_by_slug(
         self, *, user_id: Optional[int], slug: str, only_visible: bool
-    ) -> Optional[ApiUserOrganizationContext]:
+    ) -> Optional[RpcUserOrganizationContext]:
         """
         Defers to check_organization_by_slug -> get_organization_by_id
         """
@@ -90,25 +90,25 @@ class OrganizationService(InterfaceWithLifecycle):
     def add_organization_member(
         self,
         *,
-        organization: ApiOrganization,
-        user: APIUser,
-        flags: ApiOrganizationMemberFlags | None,
+        organization: RpcOrganization,
+        user: RpcUser,
+        flags: RpcOrganizationMemberFlags | None,
         role: str | None,
-    ) -> ApiOrganizationMember:
+    ) -> RpcOrganizationMember:
         pass
 
     @abstractmethod
-    def add_team_member(self, *, team_id: int, organization_member: ApiOrganizationMember) -> None:
+    def add_team_member(self, *, team_id: int, organization_member: RpcOrganizationMember) -> None:
         pass
 
     @abstractmethod
-    def update_membership_flags(self, *, organization_member: ApiOrganizationMember) -> None:
+    def update_membership_flags(self, *, organization_member: RpcOrganizationMember) -> None:
         pass
 
     @abstractmethod
     def get_all_org_roles(
         self,
-        organization_member: Optional[ApiOrganizationMember] = None,
+        organization_member: Optional[RpcOrganizationMember] = None,
         member_id: Optional[int] = None,
     ) -> List[str]:
         pass
@@ -140,7 +140,7 @@ def team_status_visible() -> int:
 
 
 @dataclass
-class ApiTeam:
+class RpcTeam:
     id: int = -1
     status: int = field(default_factory=team_status_visible)
     organization_id: int = -1
@@ -152,14 +152,20 @@ class ApiTeam:
         return "Team"
 
 
+ApiTeam = RpcTeam
+
+
 @dataclass
-class ApiTeamMember:
+class RpcTeamMember:
     id: int = -1
     is_active: bool = False
     role: Optional[TeamRole] = None
     project_ids: List[int] = field(default_factory=list)
     scopes: List[str] = field(default_factory=list)
     team_id: int = -1
+
+
+ApiTeamMember = RpcTeamMember
 
 
 def project_status_visible() -> int:
@@ -169,7 +175,7 @@ def project_status_visible() -> int:
 
 
 @dataclass
-class ApiProject:
+class RpcProject:
     id: int = -1
     slug: str = ""
     name: str = ""
@@ -177,8 +183,11 @@ class ApiProject:
     status: int = field(default_factory=project_status_visible)
 
 
+ApiProject = RpcProject
+
+
 @dataclass
-class ApiOrganizationMemberFlags:
+class RpcOrganizationMemberFlags:
     sso__linked: bool = False
     sso__invalid: bool = False
     member_limit__restricted: bool = False
@@ -193,18 +202,21 @@ class ApiOrganizationMemberFlags:
         return bool(getattr(self, item))
 
 
+ApiOrganizationMemberFlags = RpcOrganizationMemberFlags
+
+
 @dataclass
-class ApiOrganizationMember:
+class RpcOrganizationMember:
     id: int = -1
     organization_id: int = -1
     # This can be null when the user is deleted.
     user_id: Optional[int] = None
-    member_teams: List[ApiTeamMember] = field(default_factory=list)
+    member_teams: List[RpcTeamMember] = field(default_factory=list)
     role: str = ""
     has_global_access: bool = False
     project_ids: List[int] = field(default_factory=list)
     scopes: List[str] = field(default_factory=list)
-    flags: ApiOrganizationMemberFlags = field(default_factory=lambda: ApiOrganizationMemberFlags())
+    flags: RpcOrganizationMemberFlags = field(default_factory=lambda: RpcOrganizationMemberFlags())
 
     def get_audit_log_metadata(self, user_email: str) -> Mapping[str, Any]:
         team_ids = [mt.team_id for mt in self.member_teams]
@@ -218,8 +230,11 @@ class ApiOrganizationMember:
         }
 
 
+ApiOrganizationMember = RpcOrganizationMember
+
+
 @dataclass
-class ApiOrganizationFlags:
+class RpcOrganizationFlags:
     allow_joinleave: bool = False
     enhanced_privacy: bool = False
     disable_shared_issues: bool = False
@@ -229,15 +244,21 @@ class ApiOrganizationFlags:
     require_email_verification: bool = False
 
 
+ApiOrganizationFlags = RpcOrganizationFlags
+
+
 @dataclass
-class ApiOrganizationInvite:
+class RpcOrganizationInvite:
     id: int = -1
     token: str = ""
     email: str = ""
 
 
+ApiOrganizationInvite = RpcOrganizationInvite
+
+
 @dataclass
-class ApiOrganizationSummary:
+class RpcOrganizationSummary:
     """
     The subset of organization metadata available from the control silo specifically.
     """
@@ -247,21 +268,27 @@ class ApiOrganizationSummary:
     name: str = ""
 
 
+ApiOrganizationSummary = RpcOrganizationSummary
+
+
 @dataclass
-class ApiOrganization(ApiOrganizationSummary):
+class RpcOrganization(RpcOrganizationSummary):
     # Represents the full set of teams and projects associated with the org.  Note that these are not filtered by
     # visibility, but you can apply a manual filter on the status attribute.
-    teams: List[ApiTeam] = field(default_factory=list)
-    projects: List[ApiProject] = field(default_factory=list)
+    teams: List[RpcTeam] = field(default_factory=list)
+    projects: List[RpcProject] = field(default_factory=list)
 
-    flags: ApiOrganizationFlags = field(default_factory=lambda: ApiOrganizationFlags())
+    flags: RpcOrganizationFlags = field(default_factory=lambda: RpcOrganizationFlags())
     status: OrganizationStatus = OrganizationStatus.VISIBLE
 
     default_role: str = ""
 
 
+ApiOrganization = RpcOrganization
+
+
 @dataclass
-class ApiUserOrganizationContext:
+class RpcUserOrganizationContext:
     """
     This object wraps an organization result inside of its membership context in terms of an (optional) user id.
     This is due to the large number of callsites that require an organization and a user's membership at the
@@ -272,13 +299,16 @@ class ApiUserOrganizationContext:
     # user_id is None iff the get_organization_by_id call is not provided a user_id context.
     user_id: Optional[int] = None
     # The organization is always non-null because the null wrapping is around this object instead.
-    # A None organization => a None ApiUserOrganizationContext
-    organization: ApiOrganization = field(default_factory=lambda: ApiOrganization())
+    # A None organization => a None RpcUserOrganizationContext
+    organization: RpcOrganization = field(default_factory=lambda: RpcOrganization())
     # member can be None when the given user_id does not have membership with the given organization.
     # Note that all related fields of this organization member are filtered by visibility and is_active=True.
-    member: Optional[ApiOrganizationMember] = None
+    member: Optional[RpcOrganizationMember] = None
 
     def __post_init__(self) -> None:
         # Ensures that outer user_id always agrees with the inner member object.
         if self.user_id is not None and self.member is not None:
             assert self.user_id == self.member.user_id
+
+
+ApiUserOrganizationContext = RpcUserOrganizationContext

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -18,22 +18,22 @@ from sentry.models import (
 )
 from sentry.services.hybrid_cloud import logger
 from sentry.services.hybrid_cloud.organization import (
-    ApiOrganization,
-    ApiOrganizationFlags,
-    ApiOrganizationInvite,
-    ApiOrganizationMember,
-    ApiOrganizationMemberFlags,
-    ApiOrganizationSummary,
-    ApiProject,
-    ApiTeam,
-    ApiTeamMember,
-    ApiUserOrganizationContext,
     OrganizationService,
+    RpcOrganization,
+    RpcOrganizationFlags,
+    RpcOrganizationInvite,
+    RpcOrganizationMember,
+    RpcOrganizationMemberFlags,
+    RpcOrganizationSummary,
+    RpcProject,
+    RpcTeam,
+    RpcTeamMember,
+    RpcUserOrganizationContext,
 )
 from sentry.services.hybrid_cloud.util import flags_to_bits
 
 if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 def escape_flag_name(flag_name: str) -> str:
@@ -46,9 +46,9 @@ def unescape_flag_name(flag_name: str) -> str:
 
 class DatabaseBackedOrganizationService(OrganizationService):
     @classmethod
-    def _serialize_member_flags(cls, member: OrganizationMember) -> ApiOrganizationMemberFlags:
-        result = ApiOrganizationMemberFlags()
-        for f in dataclasses.fields(ApiOrganizationMemberFlags):
+    def _serialize_member_flags(cls, member: OrganizationMember) -> RpcOrganizationMemberFlags:
+        result = RpcOrganizationMemberFlags()
+        for f in dataclasses.fields(RpcOrganizationMemberFlags):
             setattr(result, f.name, bool(getattr(member.flags, unescape_flag_name(f.name))))
         return result
 
@@ -56,8 +56,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def serialize_member(
         cls,
         member: OrganizationMember,
-    ) -> ApiOrganizationMember:
-        api_member = ApiOrganizationMember(
+    ) -> RpcOrganizationMember:
+        api_member = RpcOrganizationMember(
             id=member.id,
             organization_id=member.organization_id,
             user_id=member.user.id if member.user is not None else None,
@@ -89,15 +89,15 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return api_member
 
     @classmethod
-    def _serialize_flags(cls, org: Organization) -> ApiOrganizationFlags:
-        result = ApiOrganizationFlags()
+    def _serialize_flags(cls, org: Organization) -> RpcOrganizationFlags:
+        result = RpcOrganizationFlags()
         for f in dataclasses.fields(result):
             setattr(result, f.name, getattr(org.flags, f.name))
         return result
 
     @classmethod
-    def _serialize_team(cls, team: Team) -> ApiTeam:
-        return ApiTeam(
+    def _serialize_team(cls, team: Team) -> RpcTeam:
+        return RpcTeam(
             id=team.id,
             status=team.status,
             organization_id=team.organization_id,
@@ -108,8 +108,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
     @classmethod
     def _serialize_team_member(
         cls, team_member: OrganizationMemberTeam, project_ids: Iterable[int]
-    ) -> ApiTeamMember:
-        result = ApiTeamMember(
+    ) -> RpcTeamMember:
+        result = RpcTeamMember(
             id=team_member.id,
             is_active=team_member.is_active,
             role=team_member.get_team_role(),
@@ -121,8 +121,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return result
 
     @classmethod
-    def _serialize_project(cls, project: Project) -> ApiProject:
-        return ApiProject(
+    def _serialize_project(cls, project: Project) -> RpcProject:
+        return RpcProject(
             id=project.id,
             slug=project.slug,
             name=project.name,
@@ -130,16 +130,16 @@ class DatabaseBackedOrganizationService(OrganizationService):
             status=project.status,
         )
 
-    def _serialize_organization_summary(self, org: Organization) -> ApiOrganizationSummary:
-        return ApiOrganizationSummary(
+    def _serialize_organization_summary(self, org: Organization) -> RpcOrganizationSummary:
+        return RpcOrganizationSummary(
             slug=org.slug,
             id=org.id,
             name=org.name,
         )
 
     @classmethod
-    def serialize_organization(cls, org: Organization) -> ApiOrganization:
-        api_org: ApiOrganization = ApiOrganization(
+    def serialize_organization(cls, org: Organization) -> RpcOrganization:
+        api_org: RpcOrganization = RpcOrganization(
             slug=org.slug,
             id=org.id,
             flags=cls._serialize_flags(org),
@@ -156,7 +156,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
     def check_membership_by_id(
         self, organization_id: int, user_id: int
-    ) -> Optional[ApiOrganizationMember]:
+    ) -> Optional[RpcOrganizationMember]:
         try:
             member = OrganizationMember.objects.get(
                 organization_id=organization_id, user_id=user_id
@@ -168,8 +168,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
     def get_organization_by_id(
         self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
-    ) -> Optional[ApiUserOrganizationContext]:
-        membership: Optional[ApiOrganizationMember] = None
+    ) -> Optional[RpcUserOrganizationContext]:
+        membership: Optional[RpcOrganizationMember] = None
         if user_id is not None:
             try:
                 om = OrganizationMember.objects.get(organization_id=id, user_id=user_id)
@@ -185,13 +185,13 @@ class DatabaseBackedOrganizationService(OrganizationService):
         except Organization.DoesNotExist:
             return None
 
-        return ApiUserOrganizationContext(
+        return RpcUserOrganizationContext(
             user_id=user_id, organization=self.serialize_organization(org), member=membership
         )
 
     def check_membership_by_email(
         self, organization_id: int, email: str
-    ) -> Optional[ApiOrganizationMember]:
+    ) -> Optional[RpcOrganizationMember]:
         try:
             member = OrganizationMember.objects.get(organization_id=organization_id, email=email)
         except OrganizationMember.DoesNotExist:
@@ -219,7 +219,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         scope: Optional[str],
         only_visible: bool,
         organization_ids: Optional[List[int]] = None,
-    ) -> List[ApiOrganizationSummary]:
+    ) -> List[RpcOrganizationSummary]:
         # This needs to query the control tables for organization data and not the region ones, because spanning out
         # would be very expansive.
         if user_id is not None:
@@ -258,17 +258,17 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return [r.organization for r in results]
 
     @staticmethod
-    def _deserialize_member_flags(flags: ApiOrganizationMemberFlags) -> int:
+    def _deserialize_member_flags(flags: RpcOrganizationMemberFlags) -> int:
         return flags_to_bits(flags.sso__linked, flags.sso__invalid, flags.member_limit__restricted)
 
     def add_organization_member(
         self,
         *,
-        organization: ApiOrganization,
-        user: APIUser,
-        flags: ApiOrganizationMemberFlags | None,
+        organization: RpcOrganization,
+        user: RpcUser,
+        flags: RpcOrganizationMemberFlags | None,
         role: str | None,
-    ) -> ApiOrganizationMember:
+    ) -> RpcOrganizationMember:
         member = OrganizationMember.objects.create(
             organization_id=organization.id,
             user_id=user.id,
@@ -277,26 +277,26 @@ class DatabaseBackedOrganizationService(OrganizationService):
         )
         return self.serialize_member(member)
 
-    def add_team_member(self, *, team_id: int, organization_member: ApiOrganizationMember) -> None:
+    def add_team_member(self, *, team_id: int, organization_member: RpcOrganizationMember) -> None:
         OrganizationMemberTeam.objects.create(
             team_id=team_id, organizationmember_id=organization_member.id
         )
-        # It might be nice to return an ApiTeamMember to represent what we just
+        # It might be nice to return an RpcTeamMember to represent what we just
         # created, but doing so would require a list of project IDs. We can implement
         # that if a return value is needed in the future.
 
-    def update_membership_flags(self, *, organization_member: ApiOrganizationMember) -> None:
+    def update_membership_flags(self, *, organization_member: RpcOrganizationMember) -> None:
         model = OrganizationMember.objects.get(id=organization_member.id)
         model.flags = self._deserialize_member_flags(organization_member.flags)
         model.save()
 
     @classmethod
-    def _serialize_invite(cls, om: OrganizationMember) -> ApiOrganizationInvite:
-        return ApiOrganizationInvite(om.id, om.token, om.email)
+    def _serialize_invite(cls, om: OrganizationMember) -> RpcOrganizationInvite:
+        return RpcOrganizationInvite(om.id, om.token, om.email)
 
     def get_all_org_roles(
         self,
-        organization_member: Optional[ApiOrganizationMember] = None,
+        organization_member: Optional[RpcOrganizationMember] = None,
         member_id: Optional[int] = None,
     ) -> List[str]:
         if member_id:

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, eq=True)
-class APIOrganizationMapping:
+class RpcOrganizationMapping:
     organization_id: int = -1
     slug: str = ""
     name: str = ""
@@ -33,15 +33,21 @@ class APIOrganizationMapping:
     customer_id: Optional[str] = None
 
 
+APIOrganizationMapping = RpcOrganizationMapping
+
+
 @dataclass
-class ApiOrganizationMappingUpdate(PatchableMixin["Organization"]):
+class RpcOrganizationMappingUpdate(PatchableMixin["Organization"]):
     organization_id: int = -1
     name: Unset[str] = UnsetVal
     customer_id: Unset[str] = UnsetVal
 
     @classmethod
-    def from_instance(cls, inst: Organization) -> ApiOrganizationMappingUpdate:
+    def from_instance(cls, inst: Organization) -> RpcOrganizationMappingUpdate:
         return cls(**cls.params_from_instance(inst), organization_id=inst.id)
+
+
+ApiOrganizationMappingUpdate = RpcOrganizationMappingUpdate
 
 
 class OrganizationMappingService(InterfaceWithLifecycle):
@@ -56,7 +62,7 @@ class OrganizationMappingService(InterfaceWithLifecycle):
         region_name: str,
         idempotency_key: Optional[str] = "",
         customer_id: Optional[str],
-    ) -> APIOrganizationMapping:
+    ) -> RpcOrganizationMapping:
         """
         This method returns a new or recreated OrganizationMapping object.
         If a record already exists with the same slug, the organization_id can only be
@@ -77,7 +83,7 @@ class OrganizationMappingService(InterfaceWithLifecycle):
         pass
 
     @abstractmethod
-    def update(self, update: ApiOrganizationMappingUpdate) -> None:
+    def update(self, update: RpcOrganizationMappingUpdate) -> None:
         pass
 
     @abstractmethod

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -6,9 +6,9 @@ from django.db import transaction
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.organization_mapping import (
-    APIOrganizationMapping,
-    ApiOrganizationMappingUpdate,
     OrganizationMappingService,
+    RpcOrganizationMapping,
+    RpcOrganizationMappingUpdate,
 )
 
 
@@ -24,7 +24,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
         idempotency_key: Optional[str] = "",
         # There's only a customer_id when updating an org slug
         customer_id: Optional[str] = None,
-    ) -> APIOrganizationMapping:
+    ) -> RpcOrganizationMapping:
 
         if idempotency_key:
             org_mapping, _created = OrganizationMapping.objects.update_or_create(
@@ -51,15 +51,15 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
 
     def serialize_organization_mapping(
         self, org_mapping: OrganizationMapping
-    ) -> APIOrganizationMapping:
+    ) -> RpcOrganizationMapping:
         args = {
             field.name: getattr(org_mapping, field.name)
-            for field in fields(APIOrganizationMapping)
+            for field in fields(RpcOrganizationMapping)
             if hasattr(org_mapping, field.name)
         }
-        return APIOrganizationMapping(**args)
+        return RpcOrganizationMapping(**args)
 
-    def update(self, update: ApiOrganizationMappingUpdate) -> None:
+    def update(self, update: RpcOrganizationMappingUpdate) -> None:
         with transaction.atomic():
             (
                 OrganizationMapping.objects.filter(organization_id=update.organization_id)

--- a/src/sentry/services/hybrid_cloud/project_key/__init__.py
+++ b/src/sentry/services/hybrid_cloud/project_key/__init__.py
@@ -23,13 +23,16 @@ class ProjectKeyRole(Enum):
 
 
 @dataclass
-class ApiProjectKey:
+class RpcProjectKey:
     dsn_public: str = ""
+
+
+ApiProjectKey = RpcProjectKey
 
 
 class ProjectKeyService(InterfaceWithLifecycle):
     @abstractmethod
-    def get_project_key(self, project_id: str, role: ProjectKeyRole) -> Optional[ApiProjectKey]:
+    def get_project_key(self, project_id: str, role: ProjectKeyRole) -> Optional[RpcProjectKey]:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/project_key/impl.py
+++ b/src/sentry/services/hybrid_cloud/project_key/impl.py
@@ -3,9 +3,9 @@ from typing import Optional
 from django.db.models import F
 
 from sentry.services.hybrid_cloud.project_key import (
-    ApiProjectKey,
     ProjectKeyRole,
     ProjectKeyService,
+    RpcProjectKey,
 )
 
 
@@ -13,7 +13,7 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
     def close(self) -> None:
         pass
 
-    def get_project_key(self, project_id: str, role: ProjectKeyRole) -> Optional[ApiProjectKey]:
+    def get_project_key(self, project_id: str, role: ProjectKeyRole) -> Optional[RpcProjectKey]:
         from sentry.models import ProjectKey
 
         project_keys = ProjectKey.objects.filter(
@@ -21,6 +21,6 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
         )
 
         if project_keys:
-            return ApiProjectKey(dsn_public=project_keys[0].dsn_public)
+            return RpcProjectKey(dsn_public=project_keys[0].dsn_public)
 
         return None

--- a/src/sentry/services/hybrid_cloud/tombstone/__init__.py
+++ b/src/sentry/services/hybrid_cloud/tombstone/__init__.py
@@ -6,9 +6,12 @@ from sentry.silo import SiloMode
 
 
 @dataclass
-class ApiTombstone:
+class RpcTombstone:
     table_name: str = ""
     identifier: int = -1
+
+
+ApiTombstone = RpcTombstone
 
 
 # the tombstone service itself is unaware of model mapping, that is the responsibility of the caller and the outbox
@@ -17,7 +20,7 @@ class ApiTombstone:
 # of who owns what models changes independent of the rollout of logic.
 class TombstoneService(InterfaceWithLifecycle):
     @abstractmethod
-    def record_remote_tombstone(self, tombstone: ApiTombstone) -> None:
+    def record_remote_tombstone(self, tombstone: RpcTombstone) -> None:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/tombstone/impl.py
+++ b/src/sentry/services/hybrid_cloud/tombstone/impl.py
@@ -1,12 +1,12 @@
 from typing import Any, MutableMapping
 
 from sentry.models import ControlTombstone, RegionTombstone
-from sentry.services.hybrid_cloud.tombstone import ApiTombstone, TombstoneService
+from sentry.services.hybrid_cloud.tombstone import RpcTombstone, TombstoneService
 from sentry.silo import SiloMode
 
 
 class RegionTombstoneService(TombstoneService):
-    def record_remote_tombstone(self, tombstone: ApiTombstone) -> None:
+    def record_remote_tombstone(self, tombstone: RpcTombstone) -> None:
         RegionTombstone.record_delete(tombstone.table_name, tombstone.identifier)
 
     def close(self) -> None:
@@ -14,7 +14,7 @@ class RegionTombstoneService(TombstoneService):
 
 
 class ControlTombstoneService(TombstoneService):
-    def record_remote_tombstone(self, tombstone: ApiTombstone) -> None:
+    def record_remote_tombstone(self, tombstone: RpcTombstone) -> None:
         ControlTombstone.record_delete(tombstone.table_name, tombstone.identifier)
 
     def close(self) -> None:
@@ -45,7 +45,7 @@ class MonolithTombstoneService(TombstoneService):
                         return model
         raise ValueError(f"Could not find model by table name {table_name}")
 
-    def record_remote_tombstone(self, tombstone: ApiTombstone) -> None:
+    def record_remote_tombstone(self, tombstone: RpcTombstone) -> None:
         model = self._get_model(tombstone.table_name)
         if SiloMode.CONTROL in model._meta.silo_limit.modes:
             RegionTombstone.record_delete(tombstone.table_name, tombstone.identifier)

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, eq=True)
-class APIUser:
+class RpcUser:
     id: int = -1
     pk: int = -1
     name: str = ""
@@ -38,8 +38,8 @@ class APIUser:
 
     roles: FrozenSet[str] = frozenset()
     permissions: FrozenSet[str] = frozenset()
-    avatar: Optional[APIAvatar] = None
-    useremails: FrozenSet[APIUserEmail] = frozenset()
+    avatar: Optional[RpcAvatar] = None
+    useremails: FrozenSet[RpcUserEmail] = frozenset()
 
     def has_usable_password(self) -> bool:
         return self.password_usable
@@ -65,19 +65,28 @@ class APIUser:
         return "User"
 
 
+APIUser = RpcUser
+
+
 @dataclass(frozen=True, eq=True)
-class APIAvatar:
+class RpcAvatar:
     id: int = 0
     file_id: int = 0
     ident: str = ""
     avatar_type: str = "letter_avatar"
 
 
+APIAvatar = RpcAvatar
+
+
 @dataclass(frozen=True, eq=True)
-class APIUserEmail:
+class RpcUserEmail:
     id: int = 0
     email: str = ""
     is_verified: bool = False
+
+
+APIUserEmail = RpcUserEmail
 
 
 class UserSerializeType(IntEnum):  # annoying
@@ -98,12 +107,12 @@ class UserFilterArgs(TypedDict, total=False):
 
 
 class UserService(
-    FilterQueryInterface[UserFilterArgs, APIUser, UserSerializeType], InterfaceWithLifecycle
+    FilterQueryInterface[UserFilterArgs, RpcUser, UserSerializeType], InterfaceWithLifecycle
 ):
     @abstractmethod
     def get_many_by_email(
         self, emails: List[str], is_active: bool = True, is_verified: bool = True
-    ) -> List[APIUser]:
+    ) -> List[RpcUser]:
         """
         Return a list of users matching the filters
         :param email:
@@ -115,7 +124,7 @@ class UserService(
     @abstractmethod
     def get_by_username(
         self, username: str, with_valid_password: bool = True, is_active: bool | None = None
-    ) -> List[APIUser]:
+    ) -> List[RpcUser]:
         """
         Return a list of users that match a username and falling back to email
         :param username:
@@ -129,15 +138,15 @@ class UserService(
         pass
 
     @abstractmethod
-    def get_from_group(self, group: Group) -> List[APIUser]:
+    def get_from_group(self, group: Group) -> List[RpcUser]:
         """Get all users in all teams in a given Group's project."""
         pass
 
     @abstractmethod
-    def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[APIUser]:
+    def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[RpcUser]:
         pass
 
-    def get_user(self, user_id: int) -> Optional[APIUser]:
+    def get_user(self, user_id: int) -> Optional[RpcUser]:
         """
         This method returns a User object given an ID
         :param user_id:

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -17,9 +17,9 @@ from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.filter_query import FilterQueryDatabaseImpl
 from sentry.services.hybrid_cloud.user import (
-    APIAvatar,
-    APIUser,
-    APIUserEmail,
+    RpcAvatar,
+    RpcUser,
+    RpcUserEmail,
     UserFilterArgs,
     UserSerializeType,
     UserService,
@@ -27,12 +27,12 @@ from sentry.services.hybrid_cloud.user import (
 
 
 class DatabaseBackedUserService(
-    FilterQueryDatabaseImpl[User, UserFilterArgs, APIUser, UserSerializeType],
+    FilterQueryDatabaseImpl[User, UserFilterArgs, RpcUser, UserSerializeType],
     UserService,
 ):
     def get_many_by_email(
         self, emails: List[str], is_active: bool = True, is_verified: bool = True
-    ) -> List[APIUser]:
+    ) -> List[RpcUser]:
         query = self._base_query()
         if is_verified:
             query = query.filter(emails__is_verified=is_verified)
@@ -44,7 +44,7 @@ class DatabaseBackedUserService(
 
     def get_by_username(
         self, username: str, with_valid_password: bool = True, is_active: bool | None = None
-    ) -> List[APIUser]:
+    ) -> List[RpcUser]:
         qs = User.objects
 
         if is_active is not None:
@@ -99,7 +99,7 @@ class DatabaseBackedUserService(
 
         return list(query)
 
-    def get_from_group(self, group: Group) -> List[APIUser]:
+    def get_from_group(self, group: Group) -> List[RpcUser]:
         return [
             self._serialize_rpc(u)
             for u in self._base_query().filter(
@@ -109,7 +109,7 @@ class DatabaseBackedUserService(
             )
         ]
 
-    def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[APIUser]:
+    def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[RpcUser]:
         return [self._serialize_rpc(u) for u in self._base_query().filter(actor_id__in=actor_ids)]
 
     def close(self) -> None:
@@ -142,14 +142,14 @@ class DatabaseBackedUserService(
             serializer = DetailedSelfUserSerializer()
         return serializer
 
-    def _serialize_rpc(self, user: User) -> APIUser:
+    def _serialize_rpc(self, user: User) -> RpcUser:
         return serialize_rpc_user(user)
 
 
-def serialize_rpc_user(user: User) -> APIUser:
+def serialize_rpc_user(user: User) -> RpcUser:
     args = {
         field.name: getattr(user, field.name)
-        for field in fields(APIUser)
+        for field in fields(RpcUser)
         if hasattr(user, field.name)
     }
     args["pk"] = user.pk
@@ -171,11 +171,11 @@ def serialize_rpc_user(user: User) -> APIUser:
         roles = frozenset(flatten(user.roles))
     args["roles"] = roles
 
-    useremails: FrozenSet[APIUserEmail] = frozenset({})
+    useremails: FrozenSet[RpcUserEmail] = frozenset({})
     if hasattr(user, "useremails") and user.useremails is not None:
         useremails = frozenset(
             {
-                APIUserEmail(
+                RpcUserEmail(
                     id=e["id"],
                     email=e["email"],
                     is_verified=e["is_verified"],
@@ -186,14 +186,14 @@ def serialize_rpc_user(user: User) -> APIUser:
     args["useremails"] = useremails
     avatar = user.avatar.first()
     if avatar is not None:
-        avatar = APIAvatar(
+        avatar = RpcAvatar(
             id=avatar.id,
             file_id=avatar.file_id,
             ident=avatar.ident,
             avatar_type=avatar.avatar_type,
         )
     args["avatar"] = avatar
-    return APIUser(**args)
+    return RpcUser(**args)
 
 
 def flatten(iter: Iterable[Any]) -> List[Any]:

--- a/src/sentry/services/hybrid_cloud/user_option/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user_option/__init__.py
@@ -10,7 +10,7 @@ from sentry.silo import SiloMode
 
 
 @dataclass
-class ApiUserOption:
+class RpcUserOption:
     id: int = -1
     user_id: int = -1
     value: Any = None
@@ -19,8 +19,11 @@ class ApiUserOption:
     organization_id: int | None = None
 
 
+ApiUserOption = RpcUserOption
+
+
 def get_option_from_list(
-    options: List[ApiUserOption],
+    options: List[RpcUserOption],
     *,
     key: str | None = None,
     user_id: int | None = None,
@@ -44,7 +47,7 @@ class UserOptionFilterArgs(TypedDict, total=False):
 
 
 class UserOptionService(
-    FilterQueryInterface[UserOptionFilterArgs, ApiUserOption, None], InterfaceWithLifecycle
+    FilterQueryInterface[UserOptionFilterArgs, RpcUserOption, None], InterfaceWithLifecycle
 ):
     @abstractmethod
     def delete_options(self, *, option_ids: List[int]) -> None:

--- a/src/sentry/services/hybrid_cloud/user_option/impl.py
+++ b/src/sentry/services/hybrid_cloud/user_option/impl.py
@@ -8,14 +8,14 @@ from sentry.api.serializers.base import Serializer
 from sentry.models.options.user_option import UserOption
 from sentry.services.hybrid_cloud.filter_query import FilterQueryDatabaseImpl
 from sentry.services.hybrid_cloud.user_option import (
-    ApiUserOption,
+    RpcUserOption,
     UserOptionFilterArgs,
     UserOptionService,
 )
 
 
 class DatabaseBackedUserOptionService(
-    FilterQueryDatabaseImpl[UserOption, UserOptionFilterArgs, ApiUserOption, None],
+    FilterQueryDatabaseImpl[UserOption, UserOptionFilterArgs, RpcUserOption, None],
     UserOptionService,
 ):
     def delete_options(self, *, option_ids: List[int]) -> None:
@@ -74,8 +74,8 @@ class DatabaseBackedUserOptionService(
             )
         return query
 
-    def _serialize_rpc(self, op: UserOption) -> ApiUserOption:
-        return ApiUserOption(
+    def _serialize_rpc(self, op: UserOption) -> RpcUserOption:
+        return RpcUserOption(
             id=op.id,
             user_id=op.user_id,
             value=op.value,

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -14,7 +14,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
-from sentry.services.hybrid_cloud.integration import APIOrganizationIntegration, integration_service
+from sentry.services.hybrid_cloud.integration import RpcOrganizationIntegration, integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.tasks.base import instrumented_task
 from sentry.utils.json import JSONData
@@ -144,7 +144,7 @@ def get_stacktrace(data: NodeData) -> List[Mapping[str, Any]]:
 
 def get_installation(
     organization: Organization,
-) -> Tuple[IntegrationInstallation | None, APIOrganizationIntegration | None]:
+) -> Tuple[IntegrationInstallation | None, RpcOrganizationIntegration | None]:
     integration, organization_integration = integration_service.get_organization_context(
         organization_id=organization.id, provider="github"
     )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -202,7 +202,7 @@ def handle_group_owners(project, group, issue_owners):
     from sentry.models.groupowner import GroupOwner, GroupOwnerType, OwnerRuleType
     from sentry.models.team import Team
     from sentry.models.user import User
-    from sentry.services.hybrid_cloud.user import APIUser
+    from sentry.services.hybrid_cloud.user import RpcUser
 
     lock = locks.get(f"groupowner-bulk:{group.id}", duration=10, name="groupowner_bulk")
     try:
@@ -214,7 +214,7 @@ def handle_group_owners(project, group, issue_owners):
                 type__in=[GroupOwnerType.OWNERSHIP_RULE.value, GroupOwnerType.CODEOWNERS.value],
             )
             new_owners = {}
-            owners: Union[List[APIUser], List[Team]]
+            owners: Union[List[RpcUser], List[Team]]
             for rule, owners, source in issue_owners:
                 for owner in owners:
                     # Can potentially have multiple rules pointing to the same owner
@@ -260,7 +260,7 @@ def handle_group_owners(project, group, issue_owners):
                     )
                     user_id = None
                     team_id = None
-                    if owner_type is APIUser:
+                    if owner_type is RpcUser:
                         user_id = owner_id
                     if owner_type is Team:
                         team_id = owner_id

--- a/src/sentry/templatetags/sentry_avatars.py
+++ b/src/sentry/templatetags/sentry_avatars.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from sentry.models import User, UserAvatar
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils.avatar import get_email_avatar, get_gravatar_url, get_letter_avatar
 from sentry.utils.http import absolute_uri
 
@@ -68,7 +68,7 @@ def avatar(user, size=36):
 @register.inclusion_tag("sentry/partial/avatar.html")
 def avatar_for_email(user, size=36):
     # user can be User or OrganizationMember
-    if isinstance(user, User) or isinstance(user, APIUser):
+    if isinstance(user, User) or isinstance(user, RpcUser):
         user_id = user.id
         email = user.email
     else:

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -14,7 +14,7 @@ from sentry.models import (
     OrganizationMember,
     OrganizationMemberTeam,
 )
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import exempt_from_silo_limits
@@ -396,7 +396,7 @@ class Fixtures:
         self,
         organization: Organization,
         external_id: str = "TXXXXXXX1",
-        user: APIUser = None,
+        user: RpcUser = None,
         identity_external_id: str = "UXXXXXXX1",
         **kwargs: Any,
     ):

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -14,7 +14,7 @@ from sentry.features.base import OrganizationFeature, ProjectFeature
 from sentry.features.exceptions import FeatureNotRegistered
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.services.hybrid_cloud.organization import ApiOrganization
+from sentry.services.hybrid_cloud.organization import RpcOrganization
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ def Feature(names):
 
             if isinstance(feature, OrganizationFeature):
                 org = args[0] if len(args) > 0 else kwargs.get("organization", None)
-                if not isinstance(org, Organization) and not isinstance(org, ApiOrganization):
+                if not isinstance(org, Organization) and not isinstance(org, RpcOrganization):
                     raise ValueError("Must provide organization to check feature")
                 return resolve_feature_name_value_for_org(org, names[name])
 

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -8,7 +8,7 @@ from sentry.issues.grouptype import ProfileBlockedThreadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.models import Team, User
 from sentry.notifications.notifications.base import BaseNotification
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.dates import ensure_aware
 
@@ -21,7 +21,7 @@ class DummyNotification(BaseNotification):
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         pass
 
-    def determine_recipients(self) -> Iterable[Team | APIUser]:
+    def determine_recipients(self) -> Iterable[Team | RpcUser]:
         return []
 
     def build_attachment_title(self, *args):

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -15,7 +15,7 @@ from django.urls import resolve, reverse
 from django.utils.http import is_safe_url
 
 from sentry.models import Authenticator, Organization, User
-from sentry.services.hybrid_cloud.organization import ApiOrganization
+from sentry.services.hybrid_cloud.organization import RpcOrganization
 from sentry.services.hybrid_cloud.user import user_service
 from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
@@ -139,7 +139,7 @@ def initiate_login(request: HttpRequest, next_url: str | None = None) -> None:
         request.session["_next"] = next_url
 
 
-def get_org_redirect_url(request: HttpRequest, active_organization: ApiOrganization | None) -> str:
+def get_org_redirect_url(request: HttpRequest, active_organization: RpcOrganization | None) -> str:
     from sentry import features
 
     # TODO(dcramer): deal with case when the user cannot create orgs

--- a/src/sentry/utils/email/manager.py
+++ b/src/sentry/utils/email/manager.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Mapping
 from sentry.models import Project, UserEmail
 
 from ...services.hybrid_cloud.user import user_service
-from ...services.hybrid_cloud.user_option import ApiUserOption, user_option_service
+from ...services.hybrid_cloud.user_option import RpcUserOption, user_option_service
 from .faker import is_fake_email
 
 logger = logging.getLogger("sentry.mail")
@@ -23,7 +23,7 @@ def get_email_addresses(
     results = {}
 
     if project:
-        to_delete: List[ApiUserOption] = []
+        to_delete: List[RpcUserOption] = []
         options = user_option_service.get_many(
             filter={"user_ids": pending, "project_id": project.id, "keys": ["mail:email"]}
         )

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -12,7 +12,7 @@ from sentry.locks import locks
 from sentry.models import Integration, Organization, OrganizationOption, Repository
 from sentry.plugins.bases.issue2 import IssueGroupActionEndpoint, IssuePlugin2
 from sentry.plugins.providers import RepositoryProvider
-from sentry.services.hybrid_cloud.user import APIUser
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
@@ -48,7 +48,7 @@ class GitHubMixin(CorePluginMixin):
         else:
             return ERR_INTERNAL
 
-    def get_client(self, user: APIUser):
+    def get_client(self, user: RpcUser):
         auth = self.get_auth(user=user)
         if auth is None:
             raise PluginError(API_ERRORS[401])

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -28,27 +28,27 @@ def silo_from_user(
     scopes=None,
     is_superuser=False,
 ) -> Access:
-    api_user_org_context = None
+    rpc_user_org_context = None
     if organization:
-        api_user_org_context = organization_service.get_organization_by_id(
+        rpc_user_org_context = organization_service.get_organization_by_id(
             id=organization.id, user_id=user.id
         )
-    return access.from_user_and_api_user_org_context(
+    return access.from_user_and_rpc_user_org_context(
         user=user,
-        api_user_org_context=api_user_org_context,
+        rpc_user_org_context=rpc_user_org_context,
         is_superuser=is_superuser,
         scopes=scopes,
     )
 
 
 def silo_from_request(request, organization: Organization = None, scopes=None) -> Access:
-    api_user_org_context = None
+    rpc_user_org_context = None
     if organization:
-        api_user_org_context = organization_service.get_organization_by_id(
+        rpc_user_org_context = organization_service.get_organization_by_id(
             id=organization.id, user_id=request.user.id
         )
     return access.from_request_org_and_scopes(
-        request=request, api_user_org_context=api_user_org_context, scopes=scopes
+        request=request, rpc_user_org_context=rpc_user_org_context, scopes=scopes
     )
 
 

--- a/tests/sentry/hybrid_cloud/test_auth.py
+++ b/tests/sentry/hybrid_cloud/test_auth.py
@@ -2,9 +2,9 @@ import pytest
 
 from sentry.models import ApiKey, AuthProvider
 from sentry.services.hybrid_cloud.auth import (
-    ApiAuthProvider,
-    ApiAuthProviderFlags,
-    ApiOrganizationAuthConfig,
+    RpcAuthProvider,
+    RpcAuthProviderFlags,
+    RpcOrganizationAuthConfig,
     auth_service,
 )
 from sentry.testutils.factories import Factories
@@ -34,16 +34,16 @@ def test_get_org_auth_config():
     )
 
     assert sorted(result, key=lambda v: v.organization_id) == [
-        ApiOrganizationAuthConfig(
+        RpcOrganizationAuthConfig(
             organization_id=org_with_many_api_keys.id, auth_provider=None, has_api_key=True
         ),
-        ApiOrganizationAuthConfig(
+        RpcOrganizationAuthConfig(
             organization_id=org_without_api_keys.id,
-            auth_provider=ApiAuthProvider(
+            auth_provider=RpcAuthProvider(
                 id=ap.id,
                 organization_id=org_without_api_keys.id,
                 provider="dummy",
-                flags=ApiAuthProviderFlags(
+                flags=RpcAuthProviderFlags(
                     allow_unlinked=True,
                     scim_enabled=False,
                 ),

--- a/tests/sentry/hybrid_cloud/test_integration.py
+++ b/tests/sentry/hybrid_cloud/test_integration.py
@@ -10,8 +10,8 @@ from sentry.integrations.base import IntegrationFeatures
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration import (
-    APIIntegration,
-    APIOrganizationIntegration,
+    RpcIntegration,
+    RpcOrganizationIntegration,
     integration_service,
 )
 from sentry.testutils import TestCase
@@ -62,7 +62,7 @@ class BaseIntegrationServiceTest(TestCase):
 
     def verify_result(
         self,
-        result: List[APIIntegration | APIOrganizationIntegration],
+        result: List[RpcIntegration | RpcOrganizationIntegration],
         expected: List[Integration | OrganizationIntegration],
     ):
         """Ensures APIModels in result, match the Models in expected"""
@@ -70,12 +70,12 @@ class BaseIntegrationServiceTest(TestCase):
         result_ids = [api_item.id for api_item in result]
         assert all([item.id in result_ids for item in expected])
 
-    def verify_integration_result(self, result: APIIntegration, expected: Integration):
+    def verify_integration_result(self, result: RpcIntegration, expected: Integration):
         serialized_fields = ["id", "provider", "external_id", "name", "metadata", "status"]
         for field in serialized_fields:
             assert getattr(result, field) == getattr(expected, field)
 
-    def verify_org_integration_result(self, result: APIIntegration, expected: Integration):
+    def verify_org_integration_result(self, result: RpcIntegration, expected: Integration):
         serialized_fields = [
             "id",
             "default_auth_id",

--- a/tests/sentry/hybrid_cloud/test_organization.py
+++ b/tests/sentry/hybrid_cloud/test_organization.py
@@ -14,11 +14,11 @@ from sentry.models import (
     User,
 )
 from sentry.services.hybrid_cloud.organization import (
-    ApiOrganization,
-    ApiOrganizationMember,
-    ApiProject,
-    ApiTeam,
-    ApiTeamMember,
+    RpcOrganization,
+    RpcOrganizationMember,
+    RpcProject,
+    RpcTeam,
+    RpcTeamMember,
     organization_service,
 )
 from sentry.services.hybrid_cloud.organization.impl import unescape_flag_name
@@ -94,7 +94,7 @@ def assert_for_list(a: List[Any], b: List[Any], assertion: Callable) -> None:
         assertion(a_thing, b_thing)
 
 
-def assert_team_equals(orm_team: Team, team: ApiTeam):
+def assert_team_equals(orm_team: Team, team: RpcTeam):
     assert team.id == orm_team.id
     assert team.slug == orm_team.slug
     assert team.status == orm_team.status
@@ -102,7 +102,7 @@ def assert_team_equals(orm_team: Team, team: ApiTeam):
     assert team.org_role == orm_team.org_role
 
 
-def assert_project_equals(orm_project: Project, project: ApiProject):
+def assert_project_equals(orm_project: Project, project: RpcProject):
     assert project.id == orm_project.id
     assert project.status == orm_project.status
     assert project.slug == orm_project.slug
@@ -110,7 +110,7 @@ def assert_project_equals(orm_project: Project, project: ApiProject):
     assert project.name == orm_project.name
 
 
-def assert_team_member_equals(orm_team_member: OrganizationMemberTeam, team_member: ApiTeamMember):
+def assert_team_member_equals(orm_team_member: OrganizationMemberTeam, team_member: RpcTeamMember):
     assert team_member.id == orm_team_member.id
     assert team_member.team_id == orm_team_member.team_id
     assert team_member.role == orm_team_member.get_team_role()
@@ -122,7 +122,7 @@ def assert_team_member_equals(orm_team_member: OrganizationMemberTeam, team_memb
 
 
 def assert_organization_member_equals(
-    orm_organization_member: OrganizationMember, organization_member: ApiOrganizationMember
+    orm_organization_member: OrganizationMember, organization_member: RpcOrganizationMember
 ):
     assert organization_member.organization_id == orm_organization_member.organization_id
     assert organization_member.id == orm_organization_member.id
@@ -153,7 +153,7 @@ def assert_organization_member_equals(
         )
 
 
-def assert_orgs_equal(orm_org: Organization, org: ApiOrganization) -> None:
+def assert_orgs_equal(orm_org: Organization, org: RpcOrganization) -> None:
     assert org.id == orm_org.id
     assert org.name == orm_org.name
     assert org.slug == orm_org.slug

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -3,7 +3,7 @@ from django.db import IntegrityError
 
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
-    ApiOrganizationMappingUpdate,
+    RpcOrganizationMappingUpdate,
     organization_mapping_service,
 )
 from sentry.testutils import TransactionTestCase
@@ -82,7 +82,7 @@ class OrganizationMappingTest(TransactionTestCase):
         assert api_org_mapping.customer_id is None
 
         organization_mapping_service.update(
-            ApiOrganizationMappingUpdate(
+            RpcOrganizationMappingUpdate(
                 organization_id=self.organization.id,
                 customer_id="test",
             )
@@ -91,14 +91,14 @@ class OrganizationMappingTest(TransactionTestCase):
         assert org_mapping.customer_id == "test"
 
         organization_mapping_service.update(
-            ApiOrganizationMappingUpdate(organization_id=self.organization.id, name="new name!")
+            RpcOrganizationMappingUpdate(organization_id=self.organization.id, name="new name!")
         )
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         assert org_mapping.customer_id == "test"
         assert org_mapping.name == "new name!"
 
         organization_mapping_service.update(
-            ApiOrganizationMappingUpdate(organization_id=self.organization.id)
+            RpcOrganizationMappingUpdate(organization_id=self.organization.id)
         )
         # Does not overwrite with empty value.
         assert org_mapping.name == "new name!"

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -23,7 +23,7 @@ from sentry.notifications.utils.participants import (
 )
 from sentry.ownership import grammar
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
-from sentry.services.hybrid_cloud.user import APIUser, user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
@@ -601,7 +601,7 @@ class GetOwnersCase(TestCase):
         )
 
     def assert_recipients(
-        self, expected: Iterable[Union[Team, User]], received: Iterable[Union[Team, APIUser]]
+        self, expected: Iterable[Union[Team, User]], received: Iterable[Union[Team, RpcUser]]
     ) -> None:
         assert len(expected) == len(received)
         for recipient in expected:

--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -1,5 +1,5 @@
 from sentry import features
-from sentry.services.hybrid_cloud.organization import ApiOrganization, organization_service
+from sentry.services.hybrid_cloud.organization import RpcOrganization, organization_service
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import region_silo_test
@@ -25,7 +25,7 @@ class TestTestUtilsFeatureHelper(TestCase):
             )
             assert org_context
             assert org_context.organization
-            assert isinstance(org_context.organization, ApiOrganization)
+            assert isinstance(org_context.organization, RpcOrganization)
 
             assert features.has("organizations:customer-domains", org_context.organization) is False
 
@@ -35,7 +35,7 @@ class TestTestUtilsFeatureHelper(TestCase):
             )
             assert org_context
             assert org_context.organization
-            assert isinstance(org_context.organization, ApiOrganization)
+            assert isinstance(org_context.organization, RpcOrganization)
 
             assert features.has("organizations:customer-domains", org_context.organization)
 
@@ -47,7 +47,7 @@ class TestTestUtilsFeatureHelper(TestCase):
             )
             assert org_context
             assert org_context.organization
-            assert isinstance(org_context.organization, ApiOrganization)
+            assert isinstance(org_context.organization, RpcOrganization)
 
             assert features.has("organizations:customer-domains", org_context.organization) is False
 
@@ -57,6 +57,6 @@ class TestTestUtilsFeatureHelper(TestCase):
             )
             assert org_context
             assert org_context.organization
-            assert isinstance(org_context.organization, ApiOrganization)
+            assert isinstance(org_context.organization, RpcOrganization)
 
             assert features.has("organizations:customer-domains", org_context.organization)


### PR DESCRIPTION
Renaming Api* dataclasses to Rpc*.  Retaining old names for now for compatibility, will clean up in followup.