### PR TITLE
bump(dynamic-sampling): Bump sentry-relay to 0.8.18

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.5.0
-sentry-relay>=0.8.17
+sentry-relay>=0.8.18
 sentry-sdk>=1.14.0
 snuba-sdk>=1.0.3
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -155,7 +155,7 @@ rsa==4.8
 s3transfer==0.5.2
 selenium==4.3.0
 sentry-arroyo==2.5.0
-sentry-relay==0.8.17
+sentry-relay==0.8.18
 sentry-sdk==1.14.0
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -108,7 +108,7 @@ rsa==4.8
 s3transfer==0.5.2
 selenium==4.3.0
 sentry-arroyo==2.5.0
-sentry-relay==0.8.17
+sentry-relay==0.8.18
 sentry-sdk==1.14.0
 simplejson==3.17.6
 six==1.16.0

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -747,5 +747,5 @@ def test_generate_rules_with_old_format(get_blended_sample_rate, default_project
     ]
 
     assert generate_rules(default_project) == expected
-    config_str = json.dumps({"rules": generate_rules(default_project)})
+    config_str = json.dumps({"rules": generate_rules(default_project), "rulesV2": []})
     validate_sampling_configuration(config_str)

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -257,7 +257,7 @@ def test_scrubbing_after_processing(
         def get_event_preprocessors(self, data):
             # Right now we do not scrub data from event preprocessors
             def more_extra(data):
-                data["extra"]["aaa2"] = "event preprocessor"
+                data["extra"]["ooo2"] = "event preprocessor"
                 return data
 
             return [more_extra]
@@ -268,11 +268,11 @@ def test_scrubbing_after_processing(
     register_plugin(globals(), TestPlugin)
 
     if setting_method == "datascrubbers":
-        options_model.update_option("sentry:sensitive_fields", ["a"])
+        options_model.update_option("sentry:sensitive_fields", ["o"])
         options_model.update_option("sentry:scrub_data", True)
     elif setting_method == "piiconfig":
         options_model.update_option(
-            "sentry:relay_pii_config", '{"applications": {"extra.aaa": ["@anything:replace"]}}'
+            "sentry:relay_pii_config", '{"applications": {"extra.ooo": ["@anything:replace"]}}'
         )
     else:
         raise ValueError(setting_method)
@@ -282,7 +282,7 @@ def test_scrubbing_after_processing(
         "platform": "python",
         "logentry": {"formatted": "test"},
         "event_id": EVENT_ID,
-        "extra": {"aaa": "remove me"},
+        "extra": {"ooo": "remove me"},
     }
 
     mock_event_processing_store.get.return_value = data
@@ -293,7 +293,7 @@ def test_scrubbing_after_processing(
     process_event(cache_key="e:1", start_time=1, data_has_changed=True)
 
     ((_, (event,), _),) = mock_event_processing_store.store.mock_calls
-    assert event["extra"] == {"aaa": "[Filtered]", "aaa2": "event preprocessor"}
+    assert event["extra"] == {"ooo": "[Filtered]", "ooo2": "event preprocessor"}
 
     mock_save_event.delay.assert_called_once_with(
         cache_key="e:1", data=None, start_time=1, event_id=EVENT_ID, project_id=default_project.id

--- a/tests/sentry/test_datascrubbing.py
+++ b/tests/sentry/test_datascrubbing.py
@@ -17,7 +17,7 @@ def merge_pii_configs(prefixes_and_configs):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("field", ["aaa", "aää", "a a", "a\na", "a'a"])
+@pytest.mark.parametrize("field", ["ooo", "oöö", "o o", "o\no", "o'o"])
 def test_scrub_data(field, default_project):
     project = default_project
     organization = project.organization
@@ -34,7 +34,7 @@ def test_scrub_data(field, default_project):
     """,
     )
     organization.update_option("sentry:safe_fields", [])
-    organization.update_option("sentry:sensitive_fields", ["a"])
+    organization.update_option("sentry:sensitive_fields", ["o"])
     organization.update_option("sentry:scrub_ip_address", False)
     organization.update_option("sentry:require_scrub_data", True)
 
@@ -46,7 +46,6 @@ def test_scrub_data(field, default_project):
             ]
         },
     }
-
     new_event = scrub_data(project, event)
 
     assert new_event == (


### PR DESCRIPTION
This PR bumps the sentry-relay library to the latest version that supports `rulesV2`.