### PR TITLE
chore(scim): Update ops field to be case insensitive for SCIM endpoints

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -81,9 +81,15 @@ class OperationValue(Field):
 
 
 class SCIMPatchOperationSerializer(serializers.Serializer):
-    op = serializers.ChoiceField(choices=("replace",), required=True)
+    op = serializers.CharField(required=True)
     value = OperationValue()
     path = serializers.CharField(required=False)
+
+    def validate_op(self, value: str) -> str:
+        value = value.lower()
+        if value in [MemberPatchOps.REPLACE]:
+            return value
+        raise serializers.ValidationError(f'"{value}" is not a valid choice')
 
 
 class SCIMPatchRequestSerializer(serializers.Serializer):

--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -51,6 +51,28 @@ class SCIMTeamDetailsTests(SCIMTestCase):
             "meta": {"resourceType": "Group"},
         }
 
+    def test_scim_team_details_invalid_patch_op(self):
+        team = self.create_team(organization=self.organization)
+        url = reverse(
+            "sentry-api-0-organization-scim-team-details", args=[self.organization.slug, team.id]
+        )
+        response = self.client.patch(
+            url,
+            {
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [
+                    {
+                        "op": "invalid",
+                        "value": {
+                            "id": str(team.id),
+                            "displayName": "newName",
+                        },
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 400, response.content
+
     def test_scim_team_details_patch_replace_rename_team(self):
         team = self.create_team(organization=self.organization)
         url = reverse(
@@ -237,7 +259,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
             url,
             {
                 "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-                "Operations": [{}] * 101,
+                "Operations": [{"op": "replace"}] * 101,
             },
         )
 
@@ -280,7 +302,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
             url,
             {
                 "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-                "Operations": [{"op": "replace", "path": "displayName", "value": "theNewName"}],
+                "Operations": [{"op": "Replace", "path": "displayName", "value": "theNewName"}],
             },
         )
         assert response.status_code == 204, response.content


### PR DESCRIPTION
Update `PATCH` method for both SCIM team and user endpoints to support case insensitive `op` fields. 

We'll need to do this since some IdPs like Azure will send values such as `Replace`, which will be rejected. This pull request addresses that. 