### PR TITLE
chore(derived_code_mappings): Group various Api errors

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -161,15 +161,11 @@ class GitHubClientMixin(ApiClient):  # type: ignore
         trees: Dict[str, RepoTree] = {}
         extra = {"gh_org": gh_org}
         repositories = self._populate_repositories(gh_org, cache_seconds)
-        extra.update({"repos_num": str(len(repositories))})
         trees = self._populate_trees(repositories)
-        logger.info("Using cached trees for Github org.", extra=extra)
 
-        try:
-            rate_limit = self.get_rate_limit()
-            extra.update({"remaining": str(rate_limit.remaining)})
-        except ApiError:
-            logger.warning("Failed to get latest rate limit info. Let's keep going.")
+        rate_limit = self.get_rate_limit()
+        extra.update({"remaining": str(rate_limit.remaining), "repos_num": str(len(repositories))})
+        logger.info("Using cached trees for Github org.", extra=extra)
 
         return trees
 
@@ -183,11 +179,8 @@ class GitHubClientMixin(ApiClient):  # type: ignore
                 {"full_name": repo["full_name"], "default_branch": repo["default_branch"]}
                 for repo in self.get_repositories(fetch_max_pages=True)
             ]
-            if not repositories:
-                logger.warning("Fetching repositories returned an empty list.")
-            else:
-                cache.set(cache_key, repositories, cache_seconds)
-                logger.info("Cached repositories.", extra={"repos_count": len(repositories)})
+            cache.set(cache_key, repositories, cache_seconds)
+            logger.info("Cached repositories.")
 
         return repositories
 

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -91,10 +91,11 @@ def derive_code_mappings(
             return
 
         # Logging the exception and returning is better than re-raising the error
-        # Otherwise, the API errors would be grouped based on the HTTPError that the
-        # requests library raises and create more issues than necessary
+        # Otherwise, API errors would not group them since the HTTPError in the stack
+        # has unique URLs, thus, separating the errors
         logger.exception(
-            "Unhandled ApiError occurred. Nothing is broken. Investigate. Multiple issues grouped."
+            "Unhandled ApiError occurred. Nothing is broken. Investigate. Multiple issues grouped.",
+            extra=extra,
         )
         return
     except UnableToAcquireLock as error:

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -90,7 +90,13 @@ def derive_code_mappings(
             logger.warning("The org has uninstalled the Sentry App.", extra=extra)
             return
 
-        raise error  # Let's report the issue
+        # Logging the exception and returning is better than re-raising the error
+        # Otherwise, the API errors would be grouped based on the HTTPError that the
+        # requests library raises and create more issues than necessary
+        logger.exception(
+            "Unhandled ApiError occurred. Nothing is broken. Investigate. Multiple issues grouped."
+        )
+        return
     except UnableToAcquireLock as error:
         extra["error"] = error
         logger.warning("derive_code_mappings.getting_lock_failed", extra=extra)

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -56,13 +56,14 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
         ):
             assert derive_code_mappings(self.project.id, self.event_data) is None
 
-    def test_raises_other_api_errors(self):
+    @patch("sentry.tasks.derive_code_mappings.logger")
+    def test_raises_other_api_errors(self, mock_logger):
         with patch(
             "sentry.integrations.github.client.GitHubClientMixin.get_trees_for_org",
             side_effect=ApiError("foo"),
         ):
-            with pytest.raises(ApiError):
-                derive_code_mappings(self.project.id, self.event_data)
+            derive_code_mappings(self.project.id, self.event_data)
+            assert mock_logger.exception.call_count == 1
 
     def test_unable_to_get_lock(self):
         with patch(


### PR DESCRIPTION
It seems that unhandled errors tend not to group together because the originating error starts with an HTTPError that can be any URL.

Logging them in a unique line will group them together rather than based on the initial unique URL.