### PR TITLE
chore(derived_code_mappings): Correctly print rate limit info

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -34,6 +34,9 @@ class GithubRateLimitInfo:
     def next_window(self) -> str:
         return datetime.utcfromtimestamp(self.reset).strftime("%H:%M:%S")
 
+    def __repr__(self) -> str:
+        return f"GithubRateLimit(limit={self.limit},rem={self.remaining},reset={self.reset})"
+
 
 class GitHubClientMixin(ApiClient):  # type: ignore
     allow_redirects = True


### PR DESCRIPTION
It currently prints like this:
```
{rate_limit: <sentry.integrations.github.client.GithubRateLimitInfo object at 0x7f0c2b290760>}
```