### PR TITLE
ref(indexer): Simplify indexer by using built-in Arroyo strategies

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/common.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/common.py
@@ -1,17 +1,13 @@
 import logging
-import time
-from typing import Any, List, MutableMapping, MutableSequence, Optional, Union
+from typing import Any, List, MutableMapping, MutableSequence, Union
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
-from arroyo.processing.strategies import MessageRejected
-from arroyo.processing.strategies import ProcessingStrategy
-from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
-from arroyo.types import Message, Value
+from arroyo.types import Message
 from django.conf import settings
 
 from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingPayload
-from sentry.utils import kafka_config, metrics
+from sentry.utils import kafka_config
 
 MessageBatch = List[Message[KafkaPayload]]
 IndexerOutputMessageBatch = MutableSequence[Message[Union[RoutingPayload, KafkaPayload]]]
@@ -37,123 +33,3 @@ def get_config(
         queued_min_messages=DEFAULT_QUEUED_MIN_MESSAGES,
     )
     return consumer_config
-
-
-class MetricsBatchBuilder:
-    """
-    Batches up individual messages - type: Message[KafkaPayload] - into a
-    list, which will later be the payload for the big outer message
-    that gets passed through to the ParallelTransformStep.
-
-    See `__flush` method of BatchMessages for when that happens.
-    """
-
-    def __init__(self, max_batch_size: int, max_batch_time: float) -> None:
-        self.__messages: MessageBatch = []
-        self.__max_batch_size = max_batch_size
-        self.__deadline = time.time() + max_batch_time / 1000.0
-
-    def __len__(self) -> int:
-        return len(self.__messages)
-
-    @property
-    def messages(self) -> MessageBatch:
-        return self.__messages
-
-    def append(self, message: Message[KafkaPayload]) -> None:
-        self.__messages.append(message)
-
-    def ready(self) -> bool:
-        if len(self.messages) >= self.__max_batch_size:
-            return True
-        elif time.time() >= self.__deadline:
-            return True
-        else:
-            return False
-
-
-class BatchMessages(ProcessingStep[KafkaPayload]):
-    """
-    First processing step in the MetricsConsumerStrategyFactory.
-    Keeps track of a batch of messages (using the MetricsBatchBuilder)
-    and then when at capacity, either max_batch_time or max_batch_size,
-    flushes the batch.
-
-    Flushing the batch here means wrapping the batch in a Message, the batch
-    itself being the payload. This is what the ParallelTransformStep will
-    process in the process_message function.
-    """
-
-    def __init__(
-        self,
-        next_step: ProcessingStrategy[MessageBatch],
-        max_batch_time: float,
-        max_batch_size: int,
-    ):
-        self.__max_batch_size = max_batch_size
-        self.__max_batch_time = max_batch_time
-
-        self.__next_step = next_step
-        self.__batch: Optional[MetricsBatchBuilder] = None
-        self.__closed = False
-        self.__batch_start: Optional[float] = None
-        # If we received MessageRejected from subsequent steps, this is set to true.
-        # It is reset to false upon the next successful submit.
-        self.__apply_backpressure = False
-
-    def poll(self) -> None:
-        assert not self.__closed
-
-        self.__next_step.poll()
-
-        if self.__batch and self.__batch.ready():
-            self.__flush()
-
-    def submit(self, message: Message[KafkaPayload]) -> None:
-        if self.__apply_backpressure is True:
-            raise MessageRejected
-
-        if self.__batch is None:
-            self.__batch_start = time.time()
-            self.__batch = MetricsBatchBuilder(self.__max_batch_size, self.__max_batch_time)
-
-        self.__batch.append(message)
-
-        if self.__batch and self.__batch.ready():
-            self.__flush()
-
-    def __flush(self) -> None:
-        if not self.__batch:
-            return
-        last = self.__batch.messages[-1]
-
-        new_message = Message(Value(self.__batch.messages, last.committable))
-        if self.__batch_start is not None:
-            elapsed_time = time.time() - self.__batch_start
-            metrics.timing("batch_messages.build_time", elapsed_time)
-
-        try:
-            self.__next_step.submit(new_message)
-            if self.__apply_backpressure is True:
-                self.__apply_backpressure = False
-            self.__batch_start = None
-            self.__batch = None
-        except MessageRejected:
-            self.__apply_backpressure = True
-
-    def terminate(self) -> None:
-        self.__closed = True
-        self.__next_step.terminate()
-
-    def close(self) -> None:
-        self.__closed = True
-
-    def join(self, timeout: Optional[float] = None) -> None:
-        if self.__batch:
-            last = self.__batch.messages[-1]
-            logger.debug(
-                f"Abandoning batch of {len(self.__batch)} messages...latest offset: {last.committable}"
-            )
-
-        self.__next_step.close()
-        self.__next_step.join(timeout)

--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -1,12 +1,13 @@
 import logging
-from typing import Callable, Mapping
+from typing import Callable, Mapping, MutableSequence
 
-from arroyo.types import Message
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import BaseValue, Message
 
 from sentry import options
 from sentry.sentry_metrics.configuration import IndexerStorage, MetricsIngestConfiguration
 from sentry.sentry_metrics.consumers.indexer.batch import IndexerBatch
-from sentry.sentry_metrics.consumers.indexer.common import IndexerOutputMessageBatch, MessageBatch
+from sentry.sentry_metrics.consumers.indexer.common import IndexerOutputMessageBatch
 from sentry.sentry_metrics.indexer.base import StringIndexer
 from sentry.sentry_metrics.indexer.cloudspanner.cloudspanner import CloudSpannerIndexer
 from sentry.sentry_metrics.indexer.limiters.cardinality import cardinality_limiter_factory
@@ -44,16 +45,14 @@ class MessageProcessor:
 
     def process_messages(
         self,
-        outer_message: Message[MessageBatch],
+        outer_message: Message[MutableSequence[BaseValue[KafkaPayload]]],
     ) -> IndexerOutputMessageBatch:
         """
-        We have an outer_message Message() whose payload is a batch of Message() objects.
+        We have an outer message Message() whose payload is a batch of Value() objects.
 
             Message(
-                partition=...,
-                offset=...
-                timestamp=...
                 payload=[Message(...), Message(...), etc]
+                commitable=...
             )
 
         The inner messages payloads are KafkaPayload's that have:

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import MutableMapping
 from datetime import datetime, timezone
+from typing import Sequence
 
 import pytest
 from arroyo.backends.kafka import KafkaPayload
@@ -70,17 +71,15 @@ extracted_string_output = {
 }
 
 
-def _construct_messages(payloads):
+def _construct_messages(payloads) -> Sequence[BrokerValue]:
     message_batch = []
     for i, (payload, headers) in enumerate(payloads):
         message_batch.append(
-            Message(
-                BrokerValue(
-                    KafkaPayload(None, json.dumps(payload).encode("utf-8"), headers or []),
-                    Partition(Topic("topic"), 0),
-                    i,
-                    datetime.now(),
-                )
+            BrokerValue(
+                KafkaPayload(None, json.dumps(payload).encode("utf-8"), headers or []),
+                Partition(Topic("topic"), 0),
+                i,
+                datetime.now(),
             )
         )
 

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -144,17 +144,15 @@ def test_process_messages() -> None:
 
     new_batch = MESSAGE_PROCESSOR.process_messages(outer_message=outer_message)
     expected_new_batch = [
-        Message(
-            BrokerValue(
-                KafkaPayload(
-                    None,
-                    json.dumps(__translated_payload(message_payloads[i])).encode("utf-8"),
-                    [("metric_type", message_payloads[i]["type"])],
-                ),
-                m.value.partition,
-                m.value.offset,
-                m.value.timestamp,
-            )
+        BrokerValue(
+            KafkaPayload(
+                None,
+                json.dumps(__translated_payload(message_payloads[i])).encode("utf-8"),
+                [("metric_type", message_payloads[i]["type"])],
+            ),
+            m.partition,
+            m.offset,
+            m.timestamp,
         )
         for i, m in enumerate(message_batch)
     ]
@@ -224,21 +222,17 @@ def test_process_messages_invalid_messages(
         json.dumps(invalid_payload).encode("utf-8") if format_payload else invalid_payload
     )
     message_batch = [
-        Message(
-            BrokerValue(
-                KafkaPayload(None, json.dumps(counter_payload).encode("utf-8"), []),
-                Partition(Topic("topic"), 0),
-                0,
-                datetime.now(),
-            )
+        BrokerValue(
+            KafkaPayload(None, json.dumps(counter_payload).encode("utf-8"), []),
+            Partition(Topic("topic"), 0),
+            0,
+            datetime.now(),
         ),
-        Message(
-            BrokerValue(
-                KafkaPayload(None, formatted_payload, []),
-                Partition(Topic("topic"), 0),
-                1,
-                datetime.now(),
-            )
+        BrokerValue(
+            KafkaPayload(None, formatted_payload, []),
+            Partition(Topic("topic"), 0),
+            1,
+            datetime.now(),
         ),
     ]
     # the outer message uses the last message's partition, offset, and timestamp
@@ -252,15 +246,13 @@ def test_process_messages_invalid_messages(
     # we expect just the valid counter_payload msg to be left
     expected_msg = message_batch[0]
     expected_new_batch = [
-        Message(
-            Value(
-                KafkaPayload(
-                    None,
-                    json.dumps(__translated_payload(counter_payload)).encode("utf-8"),
-                    [("metric_type", "c")],
-                ),
-                expected_msg.committable,
-            )
+        Value(
+            KafkaPayload(
+                None,
+                json.dumps(__translated_payload(counter_payload)).encode("utf-8"),
+                [("metric_type", "c")],
+            ),
+            expected_msg.committable,
         )
     ]
     compare_message_batches_ignoring_metadata(new_batch, expected_new_batch)
@@ -280,29 +272,23 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
     rate_limited_payload2["name"] = "rate_limited_test"
 
     message_batch = [
-        Message(
-            BrokerValue(
-                KafkaPayload(None, json.dumps(counter_payload).encode("utf-8"), []),
-                Partition(Topic("topic"), 0),
-                0,
-                datetime.now(),
-            )
+        BrokerValue(
+            KafkaPayload(None, json.dumps(counter_payload).encode("utf-8"), []),
+            Partition(Topic("topic"), 0),
+            0,
+            datetime.now(),
         ),
-        Message(
-            BrokerValue(
-                KafkaPayload(None, json.dumps(rate_limited_payload).encode("utf-8"), []),
-                Partition(Topic("topic"), 0),
-                1,
-                datetime.now(),
-            )
+        BrokerValue(
+            KafkaPayload(None, json.dumps(rate_limited_payload).encode("utf-8"), []),
+            Partition(Topic("topic"), 0),
+            1,
+            datetime.now(),
         ),
-        Message(
-            BrokerValue(
-                KafkaPayload(None, json.dumps(rate_limited_payload2).encode("utf-8"), []),
-                Partition(Topic("topic"), 0),
-                2,
-                datetime.now(),
-            )
+        BrokerValue(
+            KafkaPayload(None, json.dumps(rate_limited_payload2).encode("utf-8"), []),
+            Partition(Topic("topic"), 0),
+            2,
+            datetime.now(),
         ),
     ]
     # the outer message uses the last message's partition, offset, and timestamp
@@ -322,17 +308,15 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
     # cause/depend on string writes that have been rate limited
     expected_msg = message_batch[0]
     expected_new_batch = [
-        Message(
-            BrokerValue(
-                KafkaPayload(
-                    None,
-                    json.dumps(__translated_payload(counter_payload)).encode("utf-8"),
-                    [("metric_type", "c")],
-                ),
-                expected_msg.value.partition,
-                expected_msg.value.offset,
-                expected_msg.value.timestamp,
-            )
+        BrokerValue(
+            KafkaPayload(
+                None,
+                json.dumps(__translated_payload(counter_payload)).encode("utf-8"),
+                [("metric_type", "c")],
+            ),
+            expected_msg.partition,
+            expected_msg.offset,
+            expected_msg.timestamp,
         )
     ]
     compare_message_batches_ignoring_metadata(new_batch, expected_new_batch)
@@ -369,13 +353,11 @@ def test_process_messages_cardinality_limited(
 
         message_payloads = [counter_payload, distribution_payload, set_payload]
         message_batch = [
-            Message(
-                BrokerValue(
-                    KafkaPayload(None, json.dumps(payload).encode("utf-8"), []),
-                    Partition(Topic("topic"), 0),
-                    i + 1,
-                    datetime.now(),
-                )
+            BrokerValue(
+                KafkaPayload(None, json.dumps(payload).encode("utf-8"), []),
+                Partition(Topic("topic"), 0),
+                i + 1,
+                datetime.now(),
             )
             for i, payload in enumerate(message_payloads)
         ]

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -1,19 +1,15 @@
 import logging
-import time
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Dict, List, MutableMapping, Sequence, Union
-from unittest.mock import Mock, call
 
 import pytest
 from arroyo.backends.kafka import KafkaPayload
-from arroyo.processing.strategies import MessageRejected
 from arroyo.types import BrokerValue, Message, Partition, Topic, Value
 
 from sentry.ratelimits.cardinality import CardinalityLimiter
 from sentry.sentry_metrics.configuration import IndexerStorage, UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.consumers.indexer.batch import invalid_metric_tags, valid_metric_name
-from sentry.sentry_metrics.consumers.indexer.common import BatchMessages, MetricsBatchBuilder
 from sentry.sentry_metrics.consumers.indexer.processing import MessageProcessor
 from sentry.sentry_metrics.indexer.limiters.cardinality import (
     TimeseriesCardinalityLimiter,
@@ -58,156 +54,6 @@ def compare_message_batches_ignoring_metadata(
     assert len(actual) == len(expected)
     for (a, e) in zip(actual, expected):
         compare_messages_ignoring_mapping_metadata(a, e)
-
-
-def _batch_message_set_up(next_step: Mock, max_batch_time: float = 100.0, max_batch_size: int = 2):
-    # batch time is in seconds
-    batch_messages_step = BatchMessages(
-        next_step=next_step, max_batch_time=max_batch_time, max_batch_size=max_batch_size
-    )
-
-    message1 = Message(
-        BrokerValue(
-            KafkaPayload(None, b"some value", []), Partition(Topic("topic"), 0), 1, datetime.now()
-        )
-    )
-    message2 = Message(
-        BrokerValue(
-            KafkaPayload(None, b"another value", []),
-            Partition(Topic("topic"), 0),
-            2,
-            datetime.now(),
-        )
-    )
-    return (batch_messages_step, message1, message2)
-
-
-def test_batch_messages() -> None:
-    next_step = Mock()
-
-    batch_messages_step, message1, message2 = _batch_message_set_up(next_step)
-
-    # submit the first message, batch builder should should be created
-    # and the messaged added to the batch
-    batch_messages_step.submit(message=message1)
-
-    assert len(batch_messages_step._BatchMessages__batch) == 1
-
-    # neither batch_size or batch_time as been met so poll shouldn't
-    # do anything yet (aka shouldn't flush and call next_step.submit)
-    batch_messages_step.poll()
-
-    assert len(batch_messages_step._BatchMessages__batch) == 1
-    assert not next_step.submit.called
-
-    # submit the second message, message should be added to the batch
-    # which will now saturate the batch_size (2). This will trigger
-    # __flush which in turn calls next.submit and reset the batch to None
-    batch_messages_step.submit(message=message2)
-
-    assert next_step.submit.call_args == call(
-        Message(Value([message1, message2], message2.committable)),
-    )
-
-    assert batch_messages_step._BatchMessages__batch is None
-
-
-def test_batch_messages_rejected_message():
-    next_step = Mock()
-    next_step.submit.side_effect = MessageRejected()
-
-    batch_messages_step, message1, message2 = _batch_message_set_up(next_step)
-
-    batch_messages_step.poll()
-    batch_messages_step.submit(message=message1)
-
-    # if we try to submit a batch when the next step is
-    # not ready to accept more messages we'll get a
-    # MessageRejected error. This will be reraised for
-    # to the stream processor on the subsequent call to submit
-    batch_messages_step.submit(message=message2)
-
-    with pytest.raises(MessageRejected):
-        batch_messages_step.submit(message=message2)
-
-    # when poll is called, we still try to flush the batch
-    # caust its full but we handled the MessageRejected error
-    batch_messages_step.poll()
-    assert next_step.submit.called
-
-
-def test_batch_messages_join():
-    next_step = Mock()
-
-    batch_messages_step, message1, _ = _batch_message_set_up(next_step)
-
-    batch_messages_step.poll()
-    batch_messages_step.submit(message=message1)
-    # A rebalance, restart, scale up or any other event
-    # that causes partitions to be revoked will call join
-    batch_messages_step.join(timeout=3)
-    # we don't flush the batch
-    assert not next_step.submit.called
-
-
-def test_metrics_batch_builder():
-    max_batch_time = 3.0  # seconds
-    max_batch_size = 2
-
-    # 1. Ready when max_batch_size is reached
-    batch_builder_size = MetricsBatchBuilder(
-        max_batch_size=max_batch_size, max_batch_time=max_batch_time
-    )
-
-    assert not batch_builder_size.ready()
-
-    message1 = Message(
-        BrokerValue(
-            KafkaPayload(None, b"some value", []), Partition(Topic("topic"), 0), 1, datetime.now()
-        )
-    )
-    batch_builder_size.append(message1)
-    assert not batch_builder_size.ready()
-
-    message2 = Message(
-        BrokerValue(
-            KafkaPayload(None, b"another value", []),
-            Partition(Topic("topic"), 0),
-            2,
-            datetime.now(),
-        )
-    )
-    batch_builder_size.append(message2)
-    assert batch_builder_size.ready()
-
-    # 2. Ready when max_batch_time is reached
-    batch_builder_time = MetricsBatchBuilder(
-        max_batch_size=max_batch_size, max_batch_time=max_batch_time
-    )
-
-    assert not batch_builder_time.ready()
-
-    message1 = Message(
-        BrokerValue(
-            KafkaPayload(None, b"some value", []), Partition(Topic("topic"), 0), 1, datetime.now()
-        )
-    )
-    batch_builder_time.append(message1)
-    assert not batch_builder_time.ready()
-
-    time.sleep(3)
-    assert batch_builder_time.ready()
-
-    # 3. Adding the same message twice to the same batch
-    batch_builder_time = MetricsBatchBuilder(
-        max_batch_size=max_batch_size, max_batch_time=max_batch_time
-    )
-    message1 = Message(
-        BrokerValue(
-            KafkaPayload(None, b"some value", []), Partition(Topic("topic"), 0), 1, datetime.now()
-        )
-    )
-    batch_builder_time.append(message1)
 
 
 ts = int(datetime.now(tz=timezone.utc).timestamp())

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -129,13 +129,11 @@ def __translated_payload(
 def test_process_messages() -> None:
     message_payloads = [counter_payload, distribution_payload, set_payload]
     message_batch = [
-        Message(
-            BrokerValue(
-                KafkaPayload(None, json.dumps(payload).encode("utf-8"), []),
-                Partition(Topic("topic"), 0),
-                i + 1,
-                datetime.now(),
-            )
+        BrokerValue(
+            KafkaPayload(None, json.dumps(payload).encode("utf-8"), []),
+            Partition(Topic("topic"), 0),
+            i + 1,
+            datetime.now(),
         )
         for i, payload in enumerate(message_payloads)
     ]


### PR DESCRIPTION
This replaces a custom batching implementation with the one provided by Arroyo. The unbatching step can also be replaced as a follow up.