### PR TITLE
meta: Define sentry_metrics ownership in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 /src/sentry/tsdb/redissnuba.py                           @getsentry/owners-snuba
 /src/sentry/search/snuba/                                @getsentry/owners-snuba
 /src/sentry/tagstore/snuba/                              @getsentry/owners-snuba
+/src/sentry/sentry_metrics/                              @getsentry/owners-snuba
 
 ## Event Ingestion
 /src/sentry/attachments/                                 @getsentry/owners-ingest

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,7 @@
 /src/sentry/search/snuba/                                @getsentry/owners-snuba
 /src/sentry/tagstore/snuba/                              @getsentry/owners-snuba
 /src/sentry/sentry_metrics/                              @getsentry/owners-snuba
+/tests/sentry/sentry_metrics/
 
 ## Event Ingestion
 /src/sentry/attachments/                                 @getsentry/owners-ingest


### PR DESCRIPTION
Search and storage is responsible for the metrics/indexer implementation in Sentry