### PR TITLE
feat(crons): Allow users to download attachments

### DIFF
--- a/src/sentry/api/bases/monitor.py
+++ b/src/sentry/api/bases/monitor.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases.project import ProjectPermission
+from sentry.api.endpoints.event_attachment_details import EventAttachmentDetailsPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, Project, ProjectStatus
 from sentry.utils.sdk import bind_organization_context, configure_scope
@@ -32,6 +33,10 @@ class ProjectMonitorPermission(ProjectPermission):
         "PUT": ["project:read", "project:write", "project:admin"],
         "DELETE": ["project:read", "project:write", "project:admin"],
     }
+
+
+class MonitorCheckInAttachmentPermission(EventAttachmentDetailsPermission):
+    scope_map = ProjectMonitorPermission.scope_map
 
 
 class MonitorEndpoint(Endpoint):

--- a/src/sentry/api/endpoints/monitor_checkin_attachment.py
+++ b/src/sentry/api/endpoints/monitor_checkin_attachment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.http.response import FileResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -17,6 +18,23 @@ class MonitorCheckInAttachmentEndpoint(MonitorCheckInEndpoint):
     # TODO(davidenwang): Add documentation after uploading feature is complete
     private = True
     authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
+
+    def download(self, file_id):
+        file = File.objects.get(id=file_id)
+        fp = file.getfile()
+        response = FileResponse(
+            fp,
+            content_type=file.headers.get("Content-Type", "application/octet-stream"),
+        )
+        response["Content-Length"] = file.size
+        response["Content-Disposition"] = f"attachment; filename={file.name}"
+        return response
+
+    def get(self, request: Request, project, monitor, checkin) -> Response:
+        if checkin.attachment_id:
+            return self.download(checkin.attachment_id)
+        else:
+            return Response({"detail": "Check-in has no attachment"}, status=404)
 
     def post(self, request: Request, project, monitor, checkin) -> Response:
         """

--- a/src/sentry/api/endpoints/monitor_checkin_attachment.py
+++ b/src/sentry/api/endpoints/monitor_checkin_attachment.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.monitor import MonitorCheckInEndpoint
+from sentry.api.bases.monitor import MonitorCheckInAttachmentPermission, MonitorCheckInEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import File
 
@@ -18,6 +18,7 @@ class MonitorCheckInAttachmentEndpoint(MonitorCheckInEndpoint):
     # TODO(davidenwang): Add documentation after uploading feature is complete
     private = True
     authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
+    permission_classes = (MonitorCheckInAttachmentPermission,)
 
     def download(self, file_id):
         file = File.objects.get(id=file_id)


### PR DESCRIPTION
Adds a GET to `organizations/<org_id>/monitors/<monitor_id>/checkins/<checkin_id>/attachment/` which triggers a download for the attachment stored with the specified checkin. Returns a 404 if no attachment is there.