### PR TITLE
fix(issue-platform): include project_id in issue occurrence data

### DIFF
--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -29,6 +29,7 @@ class BasicEventSerializer(serializers.Serializer):
 class IssueOccurrenceSerializer(serializers.Serializer):
     id = serializers.CharField()
     event_id = serializers.CharField()
+    project_id = serializers.IntegerField()
     fingerprint = serializers.ListField()
     issue_title = serializers.CharField()
     subtitle = serializers.CharField()
@@ -89,6 +90,7 @@ class IssueOccurrenceEndpoint(Endpoint):
         if request.query_params.get("dummyOccurrence") == "True":
             occurrence = {
                 "id": "55f1419e73884cd2b45c79918f4b6dc5",
+                "project_id": 1,
                 "fingerprint": ["some-fingerprint"],
                 "issue_title": "something bad happened",
                 "subtitle": "it was bad",

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -90,7 +90,7 @@ class IssueOccurrenceEndpoint(Endpoint):
         if request.query_params.get("dummyOccurrence") == "True":
             occurrence = {
                 "id": "55f1419e73884cd2b45c79918f4b6dc5",
-                "project_id": 1,
+                "project_id": event["project_id"],
                 "fingerprint": ["some-fingerprint"],
                 "issue_title": "something bad happened",
                 "subtitle": "it was bad",

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -32,6 +32,7 @@ class IssueOccurrenceTest(APITestCase):
         }
         self.data = {
             "id": "55f1419e73884cd2b45c79918f4b6dc5",
+            "project_id": project.id,
             "fingerprint": ["some-fingerprint"],
             "issue_title": "something bad happened",
             "subtitle": "it was bad",


### PR DESCRIPTION
Forgot to include this field when we made `project_id` a mandatory field when processing issue occurrences.