### PR TITLE
fix(plugins) Fix URL used to connect to social auth

### DIFF
--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -18,6 +18,7 @@ from sentry.api.serializers.models.plugin import (
 from sentry.exceptions import InvalidIdentity, PluginError, PluginIdentityRequired
 from sentry.plugins.base import plugins
 from sentry.signals import plugin_enabled
+from sentry.utils.http import absolute_uri
 
 ERR_ALWAYS_ENABLED = "This plugin is always enabled."
 ERR_FIELD_REQUIRED = "This field is required."
@@ -41,7 +42,8 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
         except PluginIdentityRequired as e:
             context = serialize(plugin, request.user, PluginSerializer(project))
             context["config_error"] = str(e)
-            context["auth_url"] = reverse("socialauth_associate", args=[plugin.slug])
+            # Use an absolute URI so that oauth redirects work.
+            context["auth_url"] = absolute_uri(reverse("socialauth_associate", args=[plugin.slug]))
 
         if context["isDeprecated"]:
             raise Http404

--- a/static/app/plugins/components/settings.tsx
+++ b/static/app/plugins/components/settings.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
+import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import Form from 'sentry/components/deprecatedforms/form';
 import FormState from 'sentry/components/forms/state';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -174,21 +176,21 @@ class PluginSettings<
       }
       return (
         <div className="m-b-1">
-          <div className="alert alert-warning m-b-1">{data.config_error}</div>
-          <a className="btn btn-primary" href={authUrl}>
+          <Alert type="warning">{data.config_error}</Alert>
+          <Button priority="primary" href={authUrl}>
             {t('Associate Identity')}
-          </a>
+          </Button>
         </div>
       );
     }
 
     if (this.state.state === FormState.ERROR && !this.state.fieldList) {
       return (
-        <div className="alert alert-error m-b-1">
+        <Alert type="error">
           {tct('An unknown error occurred. Need help with this? [link:Contact support]', {
             link: <a href="https://sentry.io/support/" />,
           })}
-        </div>
+        </Alert>
       );
     }
 

--- a/tests/sentry/api/endpoints/test_project_plugin_details.py
+++ b/tests/sentry/api/endpoints/test_project_plugin_details.py
@@ -41,6 +41,14 @@ class ProjectPluginDetailsTest(ProjectPluginDetailsTestBase):
             }
         ]
 
+    def test_auth_url_absolute(self):
+        response = self.get_success_response(
+            self.project.organization.slug, self.project.slug, "asana"
+        )
+        assert response.data["id"] == "asana"
+        assert "http://testserver" in response.data["auth_url"]
+        assert "social/associate/asana" in response.data["auth_url"]
+
 
 @region_silo_test
 class UpdateProjectPluginTest(ProjectPluginDetailsTestBase):


### PR DESCRIPTION
Social Auth based plugins need to base their URLs on the root domain and not a customer domain. This ensures that existing Oauth client configuration continues to work. This is relevant for the asana plugin.

I've also updated the UI components used in plugin warnings as they were using bootstrap based styles.

Refs HC-663
