### PR TITLE
fix(issue-platform): Support issue platform post process forwarder

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 class PostProcessForwarderType(str, Enum):
     ERRORS = "errors"
     TRANSACTIONS = "transactions"
-    ISSUE_PLATFORM = "issue_platform"
+    ISSUE_PLATFORM = "search_issues"
 
 
 class KafkaEventStream(SnubaProtocolEventStream):


### PR DESCRIPTION
The post process forwarder supports an entity named "search_issues". There is no such option called "issue_platform". Since the post process forwarder is matching the entity to this enum, it was impossible to ever run the post process forwarder for issue platform.

