### PR TITLE
feat(crons): More columns on the monitors list

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "copy-text-to-clipboard": "3.0.1",
     "copy-webpack-plugin": "^11.0.0",
     "core-js": "^3.27.1",
+    "cronstrue": "^2.23.0",
     "crypto-browserify": "^3.12.0",
     "crypto-js": "4.0.0",
     "css-loader": "^5.2.6",

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -8,9 +8,7 @@ import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
 import {Button, ButtonProps} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeatureBadge from 'sentry/components/featureBadge';
-import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
-import Link from 'sentry/components/links/link';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
@@ -18,7 +16,6 @@ import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SearchBar from 'sentry/components/searchBar';
-import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -33,8 +30,8 @@ import withSentryRouter from 'sentry/utils/withSentryRouter';
 import AsyncView from 'sentry/views/asyncView';
 
 import CronsFeedbackButton from './cronsFeedbackButton';
-import {MonitorBadge} from './monitorBadge';
-import {Monitor, MonitorStatus} from './types';
+import {MonitorRow} from './row';
+import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
   WithRouteAnalyticsProps &
@@ -138,35 +135,20 @@ class Monitors extends AsyncView<Props, State> {
             {monitorList?.length ? (
               <Fragment>
                 <StyledPanelTable
-                  headers={[t('Monitor Name'), t('Next Checkin'), t('Project')]}
+                  headers={[
+                    t('Monitor Name'),
+                    t('Status'),
+                    t('Schedule'),
+                    t('Next Checkin'),
+                    t('Project'),
+                  ]}
                 >
                   {monitorList?.map(monitor => (
-                    <Fragment key={monitor.id}>
-                      <MonitorName>
-                        <MonitorBadge status={monitor.status} />
-                        <Link
-                          to={`/organizations/${organization.slug}/crons/${monitor.id}/`}
-                        >
-                          {monitor.name}
-                        </Link>
-                      </MonitorName>
-                      <NextCheckin>
-                        {monitor.nextCheckIn &&
-                        monitor.status !== MonitorStatus.DISABLED &&
-                        monitor.status !== MonitorStatus.ACTIVE ? (
-                          <TimeSince date={monitor.nextCheckIn} />
-                        ) : (
-                          '\u2014'
-                        )}
-                      </NextCheckin>
-                      <ProjectColumn>
-                        <IdBadge
-                          project={monitor.project}
-                          avatarSize={18}
-                          avatarProps={{hasTooltip: true, tooltip: monitor.project.slug}}
-                        />
-                      </ProjectColumn>
-                    </Fragment>
+                    <MonitorRow
+                      key={monitor.id}
+                      monitor={monitor}
+                      organization={organization}
+                    />
                   ))}
                 </StyledPanelTable>
                 {monitorListPageLinks && (
@@ -203,25 +185,8 @@ const Filters = styled('div')`
   margin-bottom: ${space(2)};
 `;
 
-const MonitorName = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(2)};
-  font-size: ${p => p.theme.fontSizeLarge};
-`;
-
-const NextCheckin = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-const ProjectColumn = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: 1fr max-content max-content;
+  grid-template-columns: 1fr max-content max-content max-content max-content;
 `;
 
 const ButtonList = styled(ButtonBar)`

--- a/static/app/views/monitors/row.tsx
+++ b/static/app/views/monitors/row.tsx
@@ -1,0 +1,134 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import cronstrue from 'cronstrue';
+
+import IdBadge from 'sentry/components/idBadge';
+import Link from 'sentry/components/links/link';
+import TextOverflow from 'sentry/components/textOverflow';
+import TimeSince from 'sentry/components/timeSince';
+import {t, tct, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import {shouldUse24Hours} from 'sentry/utils/dates';
+
+import {MonitorBadge} from './monitorBadge';
+import {Monitor, MonitorConfig, MonitorStatus, ScheduleType} from './types';
+
+interface MonitorRowProps {
+  monitor: Monitor;
+  organization: Organization;
+}
+
+function scheduleAsText(config: MonitorConfig) {
+  // Crontab format uses cronstrue
+  if (config.schedule_type === ScheduleType.CRONTAB) {
+    return cronstrue.toString(config.schedule, {
+      verbose: true,
+      throwExceptionOnParseError: false,
+      use24HourTimeFormat: shouldUse24Hours(),
+    });
+  }
+
+  // Interval format is simpler
+  const [value, timeUnit] = config.schedule;
+
+  if (timeUnit === 'minute') {
+    return tn('Every minute', 'Every %s minutes', value);
+  }
+
+  if (timeUnit === 'hour') {
+    return tn('Every hour', 'Every %s hours', value);
+  }
+
+  if (timeUnit === 'day') {
+    return tn('Every day', 'Every %s days', value);
+  }
+
+  if (timeUnit === 'week') {
+    return tn('Every week', 'Every %s weeks', value);
+  }
+
+  if (timeUnit === 'month') {
+    return tn('Every month', 'Every %s months', value);
+  }
+
+  return t('Unknown schedule');
+}
+
+function MonitorRow({monitor, organization}: MonitorRowProps) {
+  const lastCheckin = <TimeSince unitStyle="regular" date={monitor.lastCheckIn} />;
+
+  return (
+    <Fragment>
+      <MonitorName>
+        <MonitorBadge status={monitor.status} />
+        <Link to={`/organizations/${organization.slug}/crons/${monitor.id}/`}>
+          {monitor.name}
+        </Link>
+      </MonitorName>
+      <StatusColumn>
+        <TextOverflow>
+          {monitor.status === MonitorStatus.DISABLED
+            ? t('Paused')
+            : monitor.status === MonitorStatus.ACTIVE
+            ? t('Waiting for first check-in')
+            : monitor.status === MonitorStatus.OK
+            ? tct('Check-in [lastCheckin]', {lastCheckin})
+            : monitor.status === MonitorStatus.MISSED_CHECKIN
+            ? tct('Missed [lastCheckin]', {lastCheckin})
+            : monitor.status === MonitorStatus.ERROR
+            ? tct('Failed [lastCheckin]', {lastCheckin})
+            : null}
+        </TextOverflow>
+      </StatusColumn>
+      <ScheduleColumn>
+        <TextOverflow>{scheduleAsText(monitor.config)}</TextOverflow>
+      </ScheduleColumn>
+      <NextCheckin>
+        {monitor.nextCheckIn &&
+        monitor.status !== MonitorStatus.DISABLED &&
+        monitor.status !== MonitorStatus.ACTIVE ? (
+          <TimeSince unitStyle="regular" date={monitor.nextCheckIn} />
+        ) : (
+          '\u2014'
+        )}
+      </NextCheckin>
+      <ProjectColumn>
+        <IdBadge
+          project={monitor.project}
+          avatarSize={18}
+          avatarProps={{hasTooltip: true, tooltip: monitor.project.slug}}
+        />
+      </ProjectColumn>
+    </Fragment>
+  );
+}
+
+export {MonitorRow};
+
+const MonitorName = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(2)};
+  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const StatusColumn = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const ScheduleColumn = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const NextCheckin = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const ProjectColumn = styled('div')`
+  display: flex;
+  align-items: center;
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,6 +6320,11 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cronstrue@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-2.23.0.tgz#8f000f62c0034a0efae820b6b4f86052836c3d38"
+  integrity sha512-iPoWUQbCwUmrBf1w9W+9YQs8FowWp/teC2XGz3zAmt0Aja+HWGjyjUkWASWcsdzxSuL0EIIdvlfGEVBljvTbSQ==
+
 cross-fetch@^3.0.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"


### PR DESCRIPTION
* Adds a "Schedule" column for the cron schedule. This is powered by https://github.com/bradymholt/cRonstrue/

* Adds a "Status". We will improve this later, since right now it
  doesn't indicate in-progress and other statuses very well.

![image](https://user-images.githubusercontent.com/1421724/219229394-74a46267-4b2f-4c42-ba86-5de787d59959.png)

