### PR TITLE
fix(crons): Rate limit how many checkins per minute we allow for crons

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -29,7 +29,7 @@ from sentry.signals import first_cron_checkin_received, first_cron_monitor_creat
 from sentry.utils import metrics
 
 CHECKIN_QUOTA_LIMIT = 5
-CHECKING_QUOTA_WINDOW = 60
+CHECKIN_QUOTA_WINDOW = 60
 
 
 @region_silo_endpoint
@@ -127,7 +127,7 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
         if ratelimits.is_limited(
             f"monitor-checkins:{monitor.id}",
             limit=CHECKIN_QUOTA_LIMIT,
-            window=CHECKING_QUOTA_WINDOW,
+            window=CHECKIN_QUOTA_WINDOW,
         ):
             metrics.incr("monitors.checkin.dropped.ratelimited")
             raise Throttled(

--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import List
 
-from django.conf import settings
 from django.db import transaction
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import Throttled
@@ -26,13 +25,9 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.parameters import GLOBAL_PARAMS, MONITOR_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, Project, ProjectKey
-from sentry.ratelimits.sliding_windows import RedisSlidingWindowRateLimiter
 from sentry.signals import first_cron_checkin_received, first_cron_monitor_created
 from sentry.utils import metrics
 
-checkin_ratelimiter = RedisSlidingWindowRateLimiter(
-    cluster=getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
-)
 CHECKIN_QUOTA_LIMIT = 5
 CHECKING_QUOTA_WINDOW = 60
 

--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -30,7 +30,7 @@ from sentry.signals import first_cron_checkin_received, first_cron_monitor_creat
 from sentry.utils import metrics
 
 checkin_ratelimiter = RedisSlidingWindowRateLimiter(
-    cluster=settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER
+    cluster=getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
 )
 CHECKIN_QUOTA = Quota(60, 60, 5)
 

--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import Throttled
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import ratelimits
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.monitor import MonitorEndpoint
@@ -25,14 +26,15 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.parameters import GLOBAL_PARAMS, MONITOR_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, Project, ProjectKey
-from sentry.ratelimits.sliding_windows import Quota, RedisSlidingWindowRateLimiter, RequestedQuota
+from sentry.ratelimits.sliding_windows import RedisSlidingWindowRateLimiter
 from sentry.signals import first_cron_checkin_received, first_cron_monitor_created
 from sentry.utils import metrics
 
 checkin_ratelimiter = RedisSlidingWindowRateLimiter(
     cluster=getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
 )
-CHECKIN_QUOTA = Quota(60, 60, 5)
+CHECKIN_QUOTA_LIMIT = 5
+CHECKING_QUOTA_WINDOW = 60
 
 
 @region_silo_endpoint
@@ -127,11 +129,11 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
         if not serializer.is_valid():
             return self.respond(serializer.errors, status=400)
 
-        granted_quota = checkin_ratelimiter.check_and_use_quotas(
-            [RequestedQuota(f"monitor-checkins:{monitor.id}", 1, [CHECKIN_QUOTA])]
-        )[0]
-
-        if not granted_quota.granted:
+        if ratelimits.is_limited(
+            f"monitor-checkins:{monitor.id}",
+            limit=CHECKIN_QUOTA_LIMIT,
+            window=CHECKING_QUOTA_WINDOW,
+        ):
             metrics.incr("monitors.checkin.dropped.ratelimited")
             raise Throttled(
                 detail="Rate limited, please send no more than 5 checkins per minute per monitor"

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -8,7 +8,6 @@ from django.utils.http import urlquote
 from freezegun import freeze_time
 
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, MonitorType
-from sentry.ratelimits.sliding_windows import Quota
 from sentry.testutils import MonitorTestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -208,9 +207,7 @@ class CreateMonitorCheckInTest(MonitorTestCase):
 
             path = path_func(monitor)
 
-            with mock.patch(
-                "sentry.api.endpoints.monitor_checkins.CHECKIN_QUOTA", Quota(60, 60, 1)
-            ):
+            with mock.patch("sentry.api.endpoints.monitor_checkins.CHECKIN_QUOTA_LIMIT", 1):
                 resp = self.client.post(path, {"status": "ok"})
                 assert resp.status_code == 201, resp.content
                 resp = self.client.post(path, {"status": "ok"})


### PR DESCRIPTION
Some users are creating checkins every second, which is unnecessary and causing a lot of extra rows in postgres. As a stopgap, rate limit users to 5 checkins per minute per cron.
