### PR TITLE
chore(derived_code_mappings): Do not report known issues

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, List, Mapping, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Tuple
 
 from sentry_sdk import set_tag, set_user
 
@@ -27,6 +27,38 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sentry.integrations.base import IntegrationInstallation
+
+
+def process_error(error: ApiError, extra: Dict[str, str]) -> None:
+    """Log known issues and report unknown ones"""
+    msg = error.text
+    if error.json:
+        json_data: JSONData = error.json
+        msg = json_data.get("message")
+    extra["error"] = msg
+
+    if msg == "Not Found":
+        logger.warning("The org has uninstalled the Sentry App.", extra=extra)
+
+    if msg == "This installation has been suspended":
+        logger.warning("The org has suspended the Sentry App.", extra=extra)
+
+    if msg == "Server Error":
+        logger.warning("Github failed to respond.", extra=extra)
+
+    if msg.startswith("Although you appear to have the correct authorization credentials"):
+        # Although you appear to have the correct authorization credentials, the
+        # <github_org_here> organization has an IP allow list enabled, and
+        # <ip_address_here> is not permitted to access this resource.
+        logger.warning("The org has suspended the Sentry App. See code comment.", extra=extra)
+
+    # Logging the exception and returning is better than re-raising the error
+    # Otherwise, API errors would not group them since the HTTPError in the stack
+    # has unique URLs, thus, separating the errors
+    logger.exception(
+        "Unhandled ApiError occurred. Nothing is broken. Investigate. Multiple issues grouped.",
+        extra=extra,
+    )
 
 
 @instrumented_task(  # type: ignore
@@ -80,34 +112,7 @@ def derive_code_mappings(
             # This method is specific to the GithubIntegration
             trees = installation.get_trees_for_org()  # type: ignore
     except ApiError as error:
-        msg = error.text
-        if error.json:
-            json_data: JSONData = error.json
-            msg = json_data.get("message")
-        extra["error"] = msg
-
-        if msg == "Not Found":
-            logger.warning("The org has uninstalled the Sentry App.", extra=extra)
-            return
-
-        if msg == "This installation has been suspended":
-            logger.warning("The org has suspended the Sentry App.", extra=extra)
-            return
-
-        if msg.startswith("Although you appear to have the correct authorization credentials"):
-            # Although you appear to have the correct authorization credentials, the
-            # <github_org_here> organization has an IP allow list enabled, and
-            # <ip_address_here> is not permitted to access this resource.
-            logger.warning("The org has suspended the Sentry App. See code comment.", extra=extra)
-            return
-
-        # Logging the exception and returning is better than re-raising the error
-        # Otherwise, API errors would not group them since the HTTPError in the stack
-        # has unique URLs, thus, separating the errors
-        logger.exception(
-            "Unhandled ApiError occurred. Nothing is broken. Investigate. Multiple issues grouped.",
-            extra=extra,
-        )
+        process_error(error, extra)
         return
     except UnableToAcquireLock as error:
         extra["error"] = error

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -45,6 +45,7 @@ def process_error(error: ApiError, extra: Dict[str, str]) -> None:
         return
     elif msg == "Server Error":
         logger.warning("Github failed to respond.", extra=extra)
+        return
     elif msg.startswith("Although you appear to have the correct authorization credentials"):
         # Although you appear to have the correct authorization credentials, the
         # <github_org_here> organization has an IP allow list enabled, and

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -39,18 +39,21 @@ def process_error(error: ApiError, extra: Dict[str, str]) -> None:
 
     if msg == "Not Found":
         logger.warning("The org has uninstalled the Sentry App.", extra=extra)
-
-    if msg == "This installation has been suspended":
+        return
+    elif msg == "This installation has been suspended":
         logger.warning("The org has suspended the Sentry App.", extra=extra)
-
-    if msg == "Server Error":
+        return
+    elif msg == "Server Error":
         logger.warning("Github failed to respond.", extra=extra)
-
-    if msg.startswith("Although you appear to have the correct authorization credentials"):
+    elif msg.startswith("Although you appear to have the correct authorization credentials"):
         # Although you appear to have the correct authorization credentials, the
         # <github_org_here> organization has an IP allow list enabled, and
         # <ip_address_here> is not permitted to access this resource.
         logger.warning("The org has suspended the Sentry App. See code comment.", extra=extra)
+        return
+    elif msg.startswith("Due to U.S. trade controls law restrictions, this GitHub"):
+        logger.warning("Github has blocked this org. We will not continue.", extra=extra)
+        return
 
     # Logging the exception and returning is better than re-raising the error
     # Otherwise, API errors would not group them since the HTTPError in the stack


### PR DESCRIPTION
This change prevents Github's 5xx errors from being reported.

Fixes [SENTRY-Z2A](https://sentry.sentry.io/issues/3940568218) and [SENTRY-Z2E](https://sentry.sentry.io/issues/3940762300)