### PR TITLE
feat(onboarding): Add feature flag to control project deletion - [TET-689]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1234,6 +1234,9 @@ SENTRY_FEATURES = {
     "organizations:mobile-view-hierarchies": False,
     # Enable the onboarding heartbeat footer on the sdk setup page
     "organizations:onboarding-heartbeat-footer": False,
+    # Enable a new behavior for deleting the freshly created project,
+    # if the user clicks on the back button in the onboarding for new orgs
+    "organizations:onboarding-project-deletion-on-back-click": False,
     # Disables multiselect platform in the onboarding flow
     "organizations:onboarding-remove-multiselect-platform": False,
     # Enable ANR rates in project details page

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -209,6 +209,7 @@ default_manager.add("organizations:integrations-issue-sync", OrganizationFeature
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature)
 default_manager.add("organizations:onboarding-heartbeat-footer", OrganizationFeature, True)
+default_manager.add("organizations:onboarding-project-deletion-on-back-click", OrganizationFeature, True)
 default_manager.add("organizations:onboarding-remove-multiselect-platform", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add("organizations:profile-blocked-main-thread-ingest", OrganizationFeature)


### PR DESCRIPTION
Create a feature flag that, when active, enables deletion of a project if the user clicks on the back button while on the page 'set up docs' - onboarding.

 