### PR TITLE
fix(default_cache): Move is_default_cache to options so that ServiceDelegator can be used

### DIFF
--- a/src/sentry/cache/__init__.py
+++ b/src/sentry/cache/__init__.py
@@ -8,6 +8,4 @@ from sentry.utils.imports import import_string
 if not settings.SENTRY_CACHE:
     raise ImproperlyConfigured("You must configure ``cache.backend``.")
 
-default_cache = import_string(settings.SENTRY_CACHE)(
-    is_default_cache=True, **settings.SENTRY_CACHE_OPTIONS
-)
+default_cache = import_string(settings.SENTRY_CACHE)(**settings.SENTRY_CACHE_OPTIONS)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1457,7 +1457,7 @@ SENTRY_BUFFER_OPTIONS = {}
 # XXX: We explicitly require the cache to be configured as its not optional
 # and causes serious confusion with the default django cache
 SENTRY_CACHE = None
-SENTRY_CACHE_OPTIONS = {}
+SENTRY_CACHE_OPTIONS = {"is_default_cache": True}
 
 # Attachment blob cache backend
 SENTRY_ATTACHMENTS = "sentry.attachments.default.DefaultAttachmentCache"


### PR DESCRIPTION
`ServiceDelegator`'s constructor does not accept additional keyword arguments and therefore it's failing when `default_cache` is configured to use it.

```
  File "/usr/src/sentry/src/sentry/attachments/redis.py", line 5, in <module>
    from sentry.cache.redis import RbCache, RedisClusterCache
  File "/usr/src/sentry/src/sentry/cache/__init__.py", line 11, in <module>
    default_cache = import_string(settings.SENTRY_CACHE)(
TypeError: __init__() got an unexpected keyword argument 'is_default_cache'
```