### PR TITLE
fix(perf): Fix event detail header layout

### DIFF
--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -171,14 +171,17 @@ class EventMetas extends Component<Props, State> {
                   subtext={httpStatus}
                 />
               )}
-              {isTransaction(event) && event.contexts.browser && (
-                <MetaData
-                  headingText={t('Browser')}
-                  tooltipText={t('The browser used in this transaction.')}
-                  bodyText={<BrowserDisplay event={event} />}
-                  subtext={event.contexts.browser?.version}
-                />
-              )}
+              {isTransaction(event) &&
+                (event.contexts.browser ? (
+                  <MetaData
+                    headingText={t('Browser')}
+                    tooltipText={t('The browser used in this transaction.')}
+                    bodyText={<BrowserDisplay event={event} />}
+                    subtext={event.contexts.browser?.version}
+                  />
+                ) : (
+                  <span />
+                ))}
               {hasReplay && (
                 <ReplayButtonContainer>
                   <Button href="#breadcrumbs" size="sm" icon={<IconPlay size="xs" />}>


### PR DESCRIPTION
### Summary
The flex layout needs a placeholder for transaction events when browser isn't in contexts so that trace nav doesn't enter a layout cell before it.

Fixes #44728

### Screenshot (after)
![Screenshot 2023-02-16 at 10 02 56 AM](https://user-images.githubusercontent.com/6111995/219402316-6ae1b7b9-1de1-4321-9f1a-4dea3b26e2b6.png)

