### PR TITLE
chore(enterprise): Track number of spans per Python transaction

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -256,7 +256,11 @@ def traces_sampler(sampling_context):
 
 def before_send_transaction(event, _):
     # Occasionally the span limit is hit and we drop spans from transactions, this helps find transactions where this occurs.
-    event["tags"]["spans_over_limit"] = len(event["spans"]) >= 1000
+    num_of_spans = len(event["spans"])
+    event["tags"]["spans_over_limit"] = num_of_spans >= 1000
+    if not event["measurements"]:
+        event["measurements"] = {}
+    event["measurements"]["num_of_spans"] = {"value": num_of_spans}
     return event
 
 


### PR DESCRIPTION
Tracking this metric for the Enterprise sales side. DM me for more information.

Refs [ER-1392](https://getsentry.atlassian.net/browse/ER-1392)

[ER-1392]: https://getsentry.atlassian.net/browse/ER-1392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ