### PR TITLE
ref(devservices): Expose snuba admin on port 1219

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2110,8 +2110,9 @@ SENTRY_DEVSERVICES = {
         {
             "image": "ghcr.io/getsentry/snuba:latest",
             "pull": True,
-            "ports": {"1218/tcp": 1218},
-            "command": ["devserver"],
+            "ports": {"1218/tcp": 1218, "1219/tcp": 1219},
+            "command": ["devserver"]
+            + (["--no-workers"] if "snuba" in settings.SENTRY_EVENTSTREAM else []),
             "environment": {
                 "PYTHONUNBUFFERED": "1",
                 "SNUBA_SETTINGS": "docker",
@@ -2119,7 +2120,9 @@ SENTRY_DEVSERVICES = {
                 "CLICKHOUSE_HOST": "{containers[clickhouse][name]}",
                 "CLICKHOUSE_PORT": "9000",
                 "CLICKHOUSE_HTTP_PORT": "8123",
-                "DEFAULT_BROKERS": "{containers[kafka][name]}:9093",
+                "DEFAULT_BROKERS": ""
+                if "snuba" in settings.SENTRY_EVENTSTREAM
+                else "{containers[kafka][name]}:9093",
                 "REDIS_HOST": "{containers[redis][name]}",
                 "REDIS_PORT": "6379",
                 "REDIS_DB": "1",

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -341,19 +341,9 @@ def _start_service(
     fast: bool = False,
     always_start: bool = False,
 ) -> docker.models.containers.Container | None:
-    from django.conf import settings
-
     from docker.errors import NotFound
 
     options = containers[name]
-
-    # HACK(mattrobenolt): special handle snuba backend because it needs to
-    # handle different values based on the eventstream backend
-    # For snuba, we can't run the full suite of devserver, but can only
-    # run the api.
-    if name == "snuba" and "snuba" in settings.SENTRY_EVENTSTREAM:
-        options["environment"].pop("DEFAULT_BROKERS", None)
-        options["command"] = ["devserver", "--no-workers"]
 
     for key, value in list(options["environment"].items()):
         options["environment"][key] = value.format(containers=containers)


### PR DESCRIPTION
Needs https://github.com/getsentry/snuba/pull/3750

Also remove a snuba-specific hack because we can access settings in
SENTRY_DEVSERVICES now.

