### PR TITLE
bug(replay): Fix <a> tag nesting in Replay ViewIssueLink

### DIFF
--- a/static/app/views/replays/detail/console/viewIssueLink.tsx
+++ b/static/app/views/replays/detail/console/viewIssueLink.tsx
@@ -1,7 +1,4 @@
-import styled from '@emotion/styled';
-
 import ShortId from 'sentry/components/shortId';
-import {space} from 'sentry/styles/space';
 import {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
 import useOrganization from 'sentry/utils/useOrganization';
 import {breadcrumbHasIssue} from 'sentry/views/replays/detail/console/utils';
@@ -21,17 +18,7 @@ function ViewIssueLink({breadcrumb}: Props) {
   const to = {
     pathname: `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/?referrer=replay-console`,
   };
-  return (
-    <ShortIdBreadrcumb>
-      <ShortId to={to} shortId={groupShortId} />
-    </ShortIdBreadrcumb>
-  );
+  return <ShortId to={to} shortId={groupShortId} />;
 }
-
-const ShortIdBreadrcumb = styled('div')`
-  display: flex;
-  gap: ${space(1)};
-  align-items: center;
-`;
 
 export default ViewIssueLink;

--- a/static/app/views/replays/detail/console/viewIssueLink.tsx
+++ b/static/app/views/replays/detail/console/viewIssueLink.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import Link from 'sentry/components/links/link';
 import ShortId from 'sentry/components/shortId';
 import {space} from 'sentry/styles/space';
 import {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
@@ -23,11 +22,9 @@ function ViewIssueLink({breadcrumb}: Props) {
     pathname: `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/?referrer=replay-console`,
   };
   return (
-    <Link to={to}>
-      <ShortIdBreadrcumb>
-        <ShortId to={to} shortId={groupShortId} />
-      </ShortIdBreadrcumb>
-    </Link>
+    <ShortIdBreadrcumb>
+      <ShortId to={to} shortId={groupShortId} />
+    </ShortIdBreadrcumb>
   );
 }
 


### PR DESCRIPTION
Before:
<img width="803" alt="SCR-20230213-n62" src="https://user-images.githubusercontent.com/187460/219440896-ae0e60d8-700f-43c0-8426-adacfe08404d.png">

After it's just fixed, and we've got less wrapping html too. Link works the same, same hit-target for mouse clicks.

Fixes #44766