### PR TITLE
fix(issue-platform): re-write error.handled/notHandled search query for issue platform dat…

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -233,6 +233,8 @@ def _update_profiling_search_filters(
     updated_filters = []
 
     for sf in search_filters:
+        # XXX: we replace queries on these keys to something that should return nothing since
+        # profiling issues doesn't support have stacktraces
         if sf.key.name in ("notHandled", "error.handled"):
             updated_filters.append(SearchFilter(SearchKey("1"), "=", SearchValue("2")))
         else:

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -227,6 +227,20 @@ SEARCH_STRATEGIES: Mapping[int, GroupSearchStrategy] = {
 }
 
 
+def _update_profiling_search_filters(
+    search_filters: Sequence[SearchFilter],
+) -> Sequence[SearchFilter]:
+    updated_filters = []
+
+    for sf in search_filters:
+        if sf.key.name in ("notHandled", "error.handled"):
+            updated_filters.append(SearchFilter(SearchKey("1"), "=", SearchValue("2")))
+        else:
+            updated_filters.append(sf)
+
+    return updated_filters
+
+
 SEARCH_FILTER_UPDATERS: Mapping[int, GroupSearchFilterUpdater] = {
     GroupCategory.PERFORMANCE.value: lambda search_filters: [
         # need to remove this search filter, so we don't constrain the returned transactions
@@ -234,6 +248,7 @@ SEARCH_FILTER_UPDATERS: Mapping[int, GroupSearchFilterUpdater] = {
         for sf in search_filters
         if sf.key.name != "message"
     ],
+    GroupCategory.PROFILE.value: _update_profiling_search_filters,
 }
 
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2491,6 +2491,18 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         assert list(results) == []
         assert results.hits == 2
 
+    def test_not_handled_function(self):
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile error.handled:0",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            assert list(results) == []
+
 
 class CdcEventsSnubaSearchTest(SharedSnubaTest):
     @property


### PR DESCRIPTION
Issue counts in the release details page queries the counts of 'Unhandled' events. In the case of Profiling issues, I'm not sure there's an equivalent to an unhandled issue since there's no stacktrace. 

![Screen Shot 2023-02-16 at 9 34 04 AM](https://user-images.githubusercontent.com/101606877/219444120-50f2626e-ae2a-4830-b8f2-270675b028be.png)


This PR modifies the issue count query when searching on the generic dataset to return a count of zero.

Fixes SENTRY-Z21