### PR TITLE
feat(replays) on count endpoint return replay_ids instead of counts if passed parameter

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -68,19 +68,36 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
             replay_ids=list(replay_ids_mapping.keys()),
         )
 
-        counts: dict[int, int] = defaultdict(int)
+        if request.GET.get("returnIds"):
+            return self.respond(get_replay_ids(replay_results, replay_ids_mapping))
+        else:
+            return self.respond(get_counts(replay_results, replay_ids_mapping))
 
-        for row in replay_results["data"]:
-            identifiers = replay_ids_mapping[row["replay_id"]]
-            for identifier in identifiers:
-                counts[identifier] = min(counts[identifier] + 1, MAX_REPLAY_COUNT)
 
-        return self.respond(counts)
+def get_counts(replay_results: Any, replay_ids_mapping: dict[str, list[str]]) -> dict[str, int]:
+    ret: dict[str, int] = defaultdict(int)
+    for row in replay_results["data"]:
+        identifiers = replay_ids_mapping[row["replay_id"]]
+        for identifier in identifiers:
+            ret[identifier] = min(ret[identifier] + 1, MAX_REPLAY_COUNT)
+    return ret
+
+
+def get_replay_ids(
+    replay_results: Any, replay_ids_mapping: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    ret: dict[str, list[str]] = defaultdict(list)
+    for row in replay_results["data"]:
+        identifiers = replay_ids_mapping[row["replay_id"]]
+        for identifier in identifiers:
+            if len(ret[identifier]) < MAX_REPLAY_COUNT:
+                ret[identifier].append(row["replay_id"])
+    return ret
 
 
 def get_replay_id_mappings(
     request: Request, params: ParamsType, snuba_params: SnubaParams
-) -> dict[str, list[int]]:
+) -> dict[str, list[str]]:
 
     select_column, value = get_select_column(request.GET.get("query"))
 

--- a/tests/sentry/replays/test_organization_replay_count.py
+++ b/tests/sentry/replays/test_organization_replay_count.py
@@ -101,6 +101,89 @@ class OrganizationReplayCountEndpointTest(APITestCase, SnubaTestCase, ReplaysSnu
         assert response.status_code == 200, response.content
         assert response.data == expected
 
+    def test_simple_return_ids(self):
+        event_id_a = "a" * 32
+        event_id_b = "b" * 32
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
+        replay3_id = uuid.uuid4().hex
+
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay1_id,
+            )
+        )
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay2_id,
+            )
+        )
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay3_id,
+            )
+        )
+        event_a = self.store_event(
+            data={
+                "event_id": event_id_a,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": replay1_id},
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": replay2_id},
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": event_id_b,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": "z" * 32},  # a replay id that doesn't exist
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        event_c = self.store_event(
+            data={
+                "event_id": event_id_b,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": replay3_id},
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        )
+
+        query = {"query": f"issue.id:[{event_a.group.id}, {event_c.group.id}]", "returnIds": True}
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        expected = {
+            event_a.group.id: sorted([replay1_id, replay2_id]),
+            event_c.group.id: sorted([replay3_id]),
+        }
+        assert response.status_code == 200, response.content
+        self.assertCountEqual(
+            response.data[event_a.group.id],
+            expected[event_a.group.id],
+        )
+        self.assertCountEqual(
+            response.data[event_c.group.id],
+            expected[event_c.group.id],
+        )
+
     def test_one_replay_multiple_issues(self):
         event_id_a = "a" * 32
         event_id_b = "b" * 32


### PR DESCRIPTION
If passed the `returnIds` parameter, the endpoint will now return a list of replay_ids that are guaranteed to exist, instead of a count of them. this can be used on the issue details replay view to return a more accurate listing of replays.

In cases where there are many many events, and few replays, e.g. https://sentry.sentry.io/issues/3740335939/replays/?project=11276, inaccurate counts were seen. If the frontend uses this endpoint to query replay index instead, the counts should become accurate.

The counts will be non-deterministic, which is something that I will create a follow up ticket for as the fix is more involved. 

This can also be iterated on to handle pagination, brought up here: https://github.com/getsentry/replay-backend/issues/244

