### PR TITLE
fix(issues): Select text before copying in share modal

### DIFF
--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -131,8 +131,8 @@ function ShareIssueModal({
                 borderless
                 size="sm"
                 onClick={() => {
-                  copy(shareUrl);
                   urlRef.current?.selectText();
+                  copy(shareUrl);
                 }}
                 icon={<IconCopy />}
                 aria-label={t('Copy to clipboard')}
@@ -155,6 +155,7 @@ function ShareIssueModal({
           <Button
             priority="primary"
             onClick={() => {
+              urlRef.current?.selectText();
               copy(shareUrl);
               closeModal();
             }}


### PR DESCRIPTION
copying doesn't always work in this modal when the text is selected after