### PR TITLE
fix(hybrid-cloud): Update is_valid_redirect to support customer domains relative to base hostname

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 from time import time
-from typing import Any, Collection, Container, Dict, Mapping, Sequence, cast
+from typing import Any, Collection, Dict, Iterable, Mapping, Sequence, cast
 from urllib.parse import urlencode, urlparse
 
 from django.conf import settings
@@ -187,7 +187,7 @@ def get_login_redirect(request: HttpRequest, default: str | None = None) -> str:
     return login_redirect
 
 
-def is_valid_redirect(url: str, allowed_hosts: Container[str] | None = None) -> bool:
+def is_valid_redirect(url: str, allowed_hosts: Iterable[str] | None = None) -> bool:
     if not url:
         return False
     if url.startswith(get_login_url()):

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from time import time
 from typing import Any, Collection, Container, Dict, Mapping, Sequence, cast
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -14,6 +14,7 @@ from django.http.request import HttpRequest
 from django.urls import resolve, reverse
 from django.utils.http import is_safe_url
 
+from sentry import options
 from sentry.models import Authenticator, Organization, User
 from sentry.services.hybrid_cloud.organization import RpcOrganization
 from sentry.services.hybrid_cloud.user import user_service
@@ -191,6 +192,15 @@ def is_valid_redirect(url: str, allowed_hosts: Container[str] | None = None) -> 
         return False
     if url.startswith(get_login_url()):
         return False
+    parsed_url = urlparse(url)
+    url_host = parsed_url.netloc
+    base_hostname = options.get("system.base-hostname")
+    if url_host.endswith(f".{base_hostname}"):
+        if allowed_hosts is None:
+            allowed_hosts = {url_host}
+        else:
+            allowed_hosts = set(allowed_hosts)
+            allowed_hosts.add(url_host)
     return cast(bool, is_safe_url(url, allowed_hosts=allowed_hosts))
 
 


### PR DESCRIPTION
This addresses the customer domain redirect urls not being respected after successful authentication (e.g. `?next=orgslug.sentry.io/path/`)