### PR TITLE
fix(dashboards): fixes misaligned widget menu icons

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -288,9 +288,11 @@ const ContextWrapper = styled('div')`
   align-items: center;
   height: ${space(3)};
   margin-left: ${space(1)};
+  gap: ${space(0.25)};
 `;
 
 const StyledDropdownMenuControl = styled(DropdownMenu)`
+  display: flex;
   & > button {
     z-index: auto;
   }


### PR DESCRIPTION
Fixed misaligned widget menu icons
![image](https://user-images.githubusercontent.com/83961295/219494789-4ae5fc54-4224-45ba-8dda-e4775fbd79d1.png)