### PR TITLE
feat(perf-issues): Span Evidence support for MN+1

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -33,10 +33,10 @@ describe('SpanEvidenceKeyValueList', () => {
     });
 
     parentSpan.addChild({
-      startTimestamp: 0.01,
-      endTimestamp: 2.1,
+      startTimestamp: 2.1,
+      endTimestamp: 4.0,
       op: 'db',
-      description: 'SELECT * FROM books WHERE id = %s',
+      description: 'SELECT * FROM books',
       problemSpan: ProblemSpan.OFFENDER,
     });
 
@@ -59,6 +59,65 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId(/span-evidence-key-value-list.repeating-spans/)
       ).toHaveTextContent('db - SELECT * FROM books');
+      expect(
+        screen.queryByTestId('span-evidence-key-value-list.')
+      ).not.toBeInTheDocument();
+
+      expect(screen.queryByRole('cell', {name: 'Parameter'})).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('span-evidence-key-value-list.problem-parameters')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('MN+1 Database Queries', () => {
+    const builder = new TransactionEventBuilder('a1', '/');
+
+    const parentSpan = new MockSpan({
+      startTimestamp: 0,
+      endTimestamp: 0.2,
+      op: 'http.server',
+      problemSpan: ProblemSpan.PARENT,
+    });
+
+    parentSpan.addChild({
+      startTimestamp: 0.01,
+      endTimestamp: 2.1,
+      op: 'db',
+      description: 'SELECT * FROM books',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+
+    parentSpan.addChild({
+      startTimestamp: 2.1,
+      endTimestamp: 4.0,
+      op: 'db',
+      description: 'SELECT * FROM books WHERE id = %s',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+
+    builder.addSpan(parentSpan);
+
+    it('Renders relevant fields', () => {
+      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+
+      expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction')
+      ).toHaveTextContent('/');
+
+      expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.parent-span')
+      ).toHaveTextContent('http.server');
+
+      expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.repeating-spans-2')
+      ).toHaveTextContent('db - SELECT * FROM books');
+      expect(screen.getByTestId('span-evidence-key-value-list.')).toHaveTextContent(
+        'db - SELECT * FROM books WHERE id = %s'
+      );
 
       expect(screen.queryByRole('cell', {name: 'Parameter'})).not.toBeInTheDocument();
       expect(

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -96,15 +96,14 @@ const NPlusOneDBQueriesSpanEvidence = ({
   offendingSpans,
 }: SpanEvidenceKeyValueListProps) => {
   const dbSpans = offendingSpans.filter(span => span.op === 'db');
-  const uniqueDbSpans = dbSpans.filter(span => {
-    return offendingSpans.find(s => s.description === span.description) === span;
-  });
-  const repeatingSpanRows = uniqueDbSpans.map((span, i) => {
-    return makeRow(
-      i === 0 ? t('Repeating Spans (%s)', dbSpans.length) : '',
-      getSpanEvidenceValue(span)
+  const repeatingSpanRows = dbSpans
+    .filter(span => offendingSpans.find(s => s.description === span.description) === span)
+    .map((span, i) =>
+      makeRow(
+        i === 0 ? t('Repeating Spans (%s)', dbSpans.length) : '',
+        getSpanEvidenceValue(span)
+      )
     );
-  });
 
   return (
     <PresortedKeyValueList

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -94,20 +94,30 @@ const NPlusOneDBQueriesSpanEvidence = ({
   event,
   parentSpan,
   offendingSpans,
-}: SpanEvidenceKeyValueListProps) => (
-  <PresortedKeyValueList
-    data={
-      [
-        makeTransactionNameRow(event),
-        parentSpan ? makeRow(t('Parent Span'), getSpanEvidenceValue(parentSpan)) : null,
-        makeRow(
-          t('Repeating Spans (%s)', offendingSpans.length),
-          getSpanEvidenceValue(offendingSpans[0])
-        ),
-      ].filter(Boolean) as KeyValueListData
-    }
-  />
-);
+}: SpanEvidenceKeyValueListProps) => {
+  const dbSpans = offendingSpans.filter(span => span.op === 'db');
+  const uniqueDbSpans = dbSpans.filter(span => {
+    return offendingSpans.find(s => s.description === span.description) === span;
+  });
+  const repeatingSpanRows = uniqueDbSpans.map((span, i) => {
+    return makeRow(
+      i === 0 ? t('Repeating Spans (%s)', dbSpans.length) : '',
+      getSpanEvidenceValue(span)
+    );
+  });
+
+  return (
+    <PresortedKeyValueList
+      data={
+        [
+          makeTransactionNameRow(event),
+          parentSpan ? makeRow(t('Parent Span'), getSpanEvidenceValue(parentSpan)) : null,
+          ...repeatingSpanRows,
+        ].filter(Boolean) as KeyValueListData
+      }
+    />
+  );
+};
 
 const NPlusOneAPICallsSpanEvidence = ({
   event,


### PR DESCRIPTION
Display all repeating queries as span evidence, and not just the first. For regular N+1s, all offending spans will match, so they will still have just one repeating spans row (no change).
