### PR TITLE
test(search): add a negative test for search query="release.build:[<release-build>]"

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1561,6 +1561,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
             release_2_g_1,
         ]
 
+        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_BUILD_ALIAS}:[124]")
+        assert response.status_code == 400, response.content
+
     def test_aggregate_stats_regression_test(self):
         self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
Adds a testcase for when users uses the wrong value for `release.build` search term.

![Screen Shot 2023-02-16 at 2 16 15 PM](https://user-images.githubusercontent.com/101606877/219499560-76d95dd9-c4b4-44b5-9b48-b80552eb276d.png)

