### PR TITLE
test(js): Provide a default legacy context in RTL render

### DIFF
--- a/static/app/views/onboarding/createSampleEventButton.spec.jsx
+++ b/static/app/views/onboarding/createSampleEventButton.spec.jsx
@@ -22,7 +22,8 @@ describe('CreateSampleEventButton', function () {
         project={{...project, platform: 'javascript'}}
       >
         {createSampleText}
-      </CreateSampleEventButton>
+      </CreateSampleEventButton>,
+      {organization: org}
     );
   }
 

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Component} from 'react';
 import {InjectedRouter} from 'react-router';
 import {cache} from '@emotion/css'; // eslint-disable-line @emotion/no-vanilla
 import {CacheProvider, ThemeProvider} from '@emotion/react';
@@ -44,9 +44,12 @@ function createProvider(contextDefs: Record<string, any>) {
 }
 
 function makeAllTheProviders({context, ...initializeOrgOptions}: ProviderOptions) {
-  const ContextProvider = context ? createProvider(context) : Fragment;
-
-  const {organization, router} = initializeOrg(initializeOrgOptions as any);
+  const {organization, router, routerContext} = initializeOrg(
+    initializeOrgOptions as any
+  );
+  const ContextProvider = context
+    ? createProvider(context)
+    : createProvider(routerContext);
 
   return function ({children}: {children?: React.ReactNode}) {
     return (


### PR DESCRIPTION
There are unfortunately multiple consumers of legacy context still in the app, such as `withOrganization` and react-router. Tests are sometimes broken without passing in `context` to the RTL `render` function because of this, which can be incredibly confusing. For example, `Link`s render without an href.  

This change simply provides a default so tests are simpler to write.