### PR TITLE
Add suspect commit type to CommitSerialier

### DIFF
--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -55,7 +55,7 @@ class CommitSerializer(Serializer):
                 "repository": repository_objs.get(str(item.repository_id), {}),
                 "user": users_by_author.get(str(item.author_id), {}) if item.author_id else {},
                 "pull_request": pull_request_by_commit.get(item.key, None),
-                "type": self.type,
+                "suspect_commit_type": self.type,
             }
 
         return result
@@ -66,7 +66,7 @@ class CommitSerializer(Serializer):
             "message": obj.message,
             "dateCreated": obj.date_added,
             "pullRequest": attrs["pull_request"],
-            "type": attrs["type"],
+            "suspectCommitType": attrs["suspect_commit_type"],
         }
         if "repository" not in self.exclude:
             d["repository"] = attrs["repository"]

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -20,9 +20,10 @@ def get_users_for_commits(item_list, user=None) -> Mapping[str, Author]:
 
 @register(Commit)
 class CommitSerializer(Serializer):
-    def __init__(self, exclude=None, include=None, *args, **kwargs):
+    def __init__(self, exclude=None, include=None, type=None, *args, **kwargs):
         Serializer.__init__(self, *args, **kwargs)
         self.exclude = frozenset(exclude if exclude else ())
+        self.type = type or ""
 
     def get_attrs(self, item_list, user):
         if "author" not in self.exclude:
@@ -54,6 +55,7 @@ class CommitSerializer(Serializer):
                 "repository": repository_objs.get(str(item.repository_id), {}),
                 "user": users_by_author.get(str(item.author_id), {}) if item.author_id else {},
                 "pull_request": pull_request_by_commit.get(item.key, None),
+                "type": self.type,
             }
 
         return result
@@ -64,6 +66,7 @@ class CommitSerializer(Serializer):
             "message": obj.message,
             "dateCreated": obj.date_added,
             "pullRequest": attrs["pull_request"],
+            "type": attrs["type"],
         }
         if "repository" not in self.exclude:
             d["repository"] = attrs["repository"]

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -77,9 +77,10 @@ class CommitSerializer(Serializer):
 
 @register(Commit)
 class CommitWithReleaseSerializer(CommitSerializer):
-    def __init__(self, exclude=None, include=None, *args, **kwargs):
+    def __init__(self, exclude=None, include=None, type=None, *args, **kwargs):
         Serializer.__init__(self, *args, **kwargs)
         self.exclude = frozenset(exclude if exclude else ())
+        self.type = type or ""
 
     def get_attrs(self, item_list, user):
         from sentry.models import ReleaseCommit

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import operator
 from collections import defaultdict
+from enum import Enum
 from functools import reduce
 from typing import (
     Any,
@@ -148,6 +149,13 @@ class AuthorCommitsWithReleaseSerialized(TypedDict):
 class AnnotatedFrame(TypedDict):
     frame: str
     commits: Sequence[Tuple[Commit, int]]
+
+
+class SuspectCommitType(Enum):
+    """Used to distinguish old suspect commits from the newer commits obtained via the commit_context."""
+
+    RELEASE_COMMIT = "via commit in release"
+    INTEGRATION_COMMIT = "via SCM integration"
 
 
 def _get_committers(
@@ -325,7 +333,10 @@ def get_serialized_event_file_committers(
                 "commits": [
                     serialize(
                         commit,
-                        serializer=CommitSerializer(exclude=["author"], type="via SCM integration"),
+                        serializer=CommitSerializer(
+                            exclude=["author"],
+                            type=SuspectCommitType.INTEGRATION_COMMIT.value,
+                        ),
                     )
                 ],
             }
@@ -346,7 +357,10 @@ def get_serialized_event_file_committers(
         commits = [commit for committer in committers for commit in committer["commits"]]
         serialized_commits: Sequence[MutableMapping[str, Any]] = serialize(
             [c for (c, score) in commits],
-            serializer=CommitSerializer(exclude=["author"], type="via commit in release"),
+            serializer=CommitSerializer(
+                exclude=["author"],
+                type=SuspectCommitType.RELEASE_COMMIT.value,
+            ),
         )
 
         serialized_commits_by_id = {}

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -322,7 +322,12 @@ def get_serialized_event_file_committers(
         return [
             {
                 "author": author,
-                "commits": [serialize(commit, serializer=CommitSerializer(exclude=["author"]))],
+                "commits": [
+                    serialize(
+                        commit,
+                        serializer=CommitSerializer(exclude=["author"], type="via SCM integration"),
+                    )
+                ],
             }
         ]
 
@@ -340,7 +345,8 @@ def get_serialized_event_file_committers(
         )
         commits = [commit for committer in committers for commit in committer["commits"]]
         serialized_commits: Sequence[MutableMapping[str, Any]] = serialize(
-            [c for (c, score) in commits], serializer=CommitSerializer(exclude=["author"])
+            [c for (c, score) in commits],
+            serializer=CommitSerializer(exclude=["author"], type="via commit in release"),
         )
 
         serialized_commits_by_id = {}

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -186,11 +186,10 @@ class EventCommittersTest(APITestCase):
             assert response.status_code == 200, response.content
             assert len(response.data["committers"]) == 1
             assert response.data["committers"][0]["author"]["username"] == "admin@localhost"
-            assert len(response.data["committers"][0]["commits"]) == 1
-            assert (
-                response.data["committers"][0]["commits"][0]["message"]
-                == "placeholder commit message"
-            )
+            commits = response.data["committers"][0]["commits"]
+            assert len(commits) == 1
+            assert commits[0]["message"] == "placeholder commit message"
+            assert commits[0]["type"] == "scm"
 
     def test_with_commit_context_pull_request(self):
         with self.feature({"organizations:commit-context": True}):
@@ -246,9 +245,9 @@ class EventCommittersTest(APITestCase):
 
             response = self.client.get(url, format="json")
             assert response.status_code == 200, response.content
-            assert len(response.data["committers"][0]["commits"]) == 1
-            assert "pullRequest" in response.data["committers"][0]["commits"][0]
-            assert (
-                response.data["committers"][0]["commits"][0]["pullRequest"]["id"]
-                == pull_request.key
-            )
+
+            commits = response.data["committers"][0]["commits"]
+            assert len(commits) == 1
+            assert "pullRequest" in commits[0]
+            assert commits[0]["pullRequest"]["id"] == pull_request.key
+            assert commits[0]["type"] == "scm"

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -189,7 +189,7 @@ class EventCommittersTest(APITestCase):
             commits = response.data["committers"][0]["commits"]
             assert len(commits) == 1
             assert commits[0]["message"] == "placeholder commit message"
-            assert commits[0]["type"] == "scm"
+            assert commits[0]["suspectCommitType"] == "via SCM integration"
 
     def test_with_commit_context_pull_request(self):
         with self.feature({"organizations:commit-context": True}):
@@ -250,4 +250,4 @@ class EventCommittersTest(APITestCase):
             assert len(commits) == 1
             assert "pullRequest" in commits[0]
             assert commits[0]["pullRequest"]["id"] == pull_request.key
-            assert commits[0]["type"] == "scm"
+            assert commits[0]["suspectCommitType"] == "via SCM integration"

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -306,7 +306,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert "commits" in result[0]
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["type"] == "release"
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
     def test_kotlin_java_sdk_path_mangling(self):
         event = self.store_event(
@@ -482,7 +482,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] > 1
-        assert result[0]["commits"][0]["type"] == "release"
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
     def test_cocoa_swift_repo_relative_path(self):
         event = self.store_event(
@@ -543,7 +543,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] > 1
-        assert result[0]["commits"][0]["type"] == "release"
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
     def test_react_native_unchanged_frames(self):
         event = self.store_event(
@@ -613,7 +613,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] == 3
-        assert result[0]["commits"][0]["type"] == "release"
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
     def test_flutter_munged_frames(self):
         event = self.store_event(
@@ -667,7 +667,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] == 3
-        assert result[0]["commits"][0]["type"] == "release"
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
     def test_matching(self):
         event = self.store_event(
@@ -720,7 +720,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert "commits" in result[0]
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["type"] == "release"
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
     def test_matching_case_insensitive(self):
         event = self.store_event(
@@ -764,7 +764,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert "commits" in result[0]
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
-        assert result[0]["commits"][0]["type"] == "release"
+        assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
     def test_not_matching(self):
         event = self.store_event(

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -306,6 +306,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert "commits" in result[0]
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
+        assert result[0]["commits"][0]["type"] == "release"
 
     def test_kotlin_java_sdk_path_mangling(self):
         event = self.store_event(
@@ -481,6 +482,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] > 1
+        assert result[0]["commits"][0]["type"] == "release"
 
     def test_cocoa_swift_repo_relative_path(self):
         event = self.store_event(
@@ -541,6 +543,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] > 1
+        assert result[0]["commits"][0]["type"] == "release"
 
     def test_react_native_unchanged_frames(self):
         event = self.store_event(
@@ -610,6 +613,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] == 3
+        assert result[0]["commits"][0]["type"] == "release"
 
     def test_flutter_munged_frames(self):
         event = self.store_event(
@@ -663,6 +667,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["score"] == 3
+        assert result[0]["commits"][0]["type"] == "release"
 
     def test_matching(self):
         event = self.store_event(
@@ -715,6 +720,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert "commits" in result[0]
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
+        assert result[0]["commits"][0]["type"] == "release"
 
     def test_matching_case_insensitive(self):
         event = self.store_event(
@@ -758,6 +764,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert "commits" in result[0]
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
+        assert result[0]["commits"][0]["type"] == "release"
 
     def test_not_matching(self):
         event = self.store_event(


### PR DESCRIPTION
Adds `via commit in release` or `via SCM integration` to the serialized commit so we can indicate the source of suspect commits in the UI. 

[WOR-2717](https://getsentry.atlassian.net/browse/WOR-2717)

[WOR-2717]: https://getsentry.atlassian.net/browse/WOR-2717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ