### PR TITLE
fix(api): use the event.datetime field when comparing timestamps for a project's prev next events

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -30,15 +30,15 @@ logger = logging.getLogger(__name__)
 
 def get_before_event_condition(event):
     return [
-        [TIMESTAMP, "<=", event.timestamp],
-        [[TIMESTAMP, "<", event.timestamp], [EVENT_ID, "<", event.event_id]],
+        [TIMESTAMP, "<=", event.datetime],
+        [[TIMESTAMP, "<", event.datetime], [EVENT_ID, "<", event.event_id]],
     ]
 
 
 def get_after_event_condition(event):
     return [
-        [TIMESTAMP, ">=", event.timestamp],
-        [[TIMESTAMP, ">", event.timestamp], [EVENT_ID, ">", event.event_id]],
+        [TIMESTAMP, ">=", event.datetime],
+        [[TIMESTAMP, ">", event.datetime], [EVENT_ID, ">", event.event_id]],
     ]
 
 


### PR DESCRIPTION
The `timestamp` field value returns an unparselable datetime string that looks like `2023-02-15T23:45:11.577919+00:00`. This works for [snuba datasets](https://github.com/getsentry/snuba/blob/a8c0b5c10807ef981ed3e8deb58e924a575f6814/snuba/query/processors/logical/timeseries_processor.py#L156-L163) with `TimeSeriesProcessor` applied to the entity(discover, errors, transactions). Since that processor is not advised to be used, we have to pass in the datetime instead here when doing comparisons.

Resolves SENTRY-Z20