### PR TITLE
fix(issue-platform): better error.handled and error.unhandled queries

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -227,22 +227,6 @@ SEARCH_STRATEGIES: Mapping[int, GroupSearchStrategy] = {
 }
 
 
-def _update_profiling_search_filters(
-    search_filters: Sequence[SearchFilter],
-) -> Sequence[SearchFilter]:
-    updated_filters = []
-
-    for sf in search_filters:
-        # XXX: we replace queries on these keys to something that should return nothing since
-        # profiling issues doesn't support have stacktraces
-        if sf.key.name in ("notHandled", "error.handled"):
-            updated_filters.append(SearchFilter(SearchKey("1"), "=", SearchValue("2")))
-        else:
-            updated_filters.append(sf)
-
-    return updated_filters
-
-
 SEARCH_FILTER_UPDATERS: Mapping[int, GroupSearchFilterUpdater] = {
     GroupCategory.PERFORMANCE.value: lambda search_filters: [
         # need to remove this search filter, so we don't constrain the returned transactions
@@ -250,7 +234,6 @@ SEARCH_FILTER_UPDATERS: Mapping[int, GroupSearchFilterUpdater] = {
         for sf in search_filters
         if sf.key.name != "message"
     ],
-    GroupCategory.PROFILE.value: _update_profiling_search_filters,
 }
 
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2491,6 +2491,18 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         assert list(results) == []
         assert results.hits == 2
 
+    def test_not_handled_function(self):
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile error.handled:0",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            assert list(results) == []
+
 
 class CdcEventsSnubaSearchTest(SharedSnubaTest):
     @property

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2491,18 +2491,6 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         assert list(results) == []
         assert results.hits == 2
 
-    def test_not_handled_function(self):
-        with self.feature("organizations:issue-platform"):
-            results = self.make_query(
-                projects=[self.project],
-                search_filter_query="issue.category:profile error.handled:0",
-                sort_by="date",
-                limit=1,
-                count_hits=True,
-            )
-
-            assert list(results) == []
-
 
 class CdcEventsSnubaSearchTest(SharedSnubaTest):
     @property

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2495,13 +2495,41 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         with self.feature("organizations:issue-platform"):
             results = self.make_query(
                 projects=[self.project],
+                search_filter_query="issue.category:profile error.unhandled:0",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            results2 = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile error.unhandled:1",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            assert list(results) == list(results2) == []
+
+    def test_is_handled_function(self):
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                projects=[self.project],
                 search_filter_query="issue.category:profile error.handled:0",
                 sort_by="date",
                 limit=1,
                 count_hits=True,
             )
 
-            assert list(results) == []
+            results2 = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile error.handled:1",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            assert list(results) == list(results2) == []
 
 
 class CdcEventsSnubaSearchTest(SharedSnubaTest):


### PR DESCRIPTION
Reverts https://github.com/getsentry/sentry/pull/44769

and, instead, relies on this https://github.com/getsentry/snuba/pull/3757 to return no data from the query.