### PR TITLE
test(issue platform): Add test for issue:shortId search

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -1,3 +1,4 @@
+from sentry.issues.grouptype import ProfileBlockedThreadGroupType
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -71,6 +72,8 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         )
         event_group = event.for_group(event.group)
         event_group.occurrence = self.build_occurrence()
+        event.group.type = ProfileBlockedThreadGroupType.type_id
+
         self.login_as(user=self.user)
         response = self.get_response(
             query=f"issue:{event.group.qualified_short_id}", groups=[event.group.id]

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -2,10 +2,11 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test
-class GroupListTest(APITestCase, SnubaTestCase):
+class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     endpoint = "sentry-api-0-organization-group-index-stats"
 
     def setUp(self):
@@ -53,6 +54,33 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response_data) == 2
         assert int(response_data[0]["id"]) == group_a.id
         assert int(response_data[1]["id"]) == group_c.id
+        assert "title" not in response_data[0]
+        assert "hasSeen" not in response_data[0]
+        assert "stats" in response_data[0]
+        assert "firstSeen" in response_data[0]
+        assert "lastSeen" in response_data[0]
+        assert "count" in response_data[0]
+        assert "userCount" in response_data[0]
+        assert "lifetime" in response_data[0]
+        assert "filtered" in response_data[0]
+
+    def test_issue_platform_issue(self):
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=1)), "fingerprint": ["group-a"]},
+            project_id=self.project.id,
+        )
+        event_group = event.for_group(event.group)
+        event_group.occurrence = self.build_occurrence()
+        self.login_as(user=self.user)
+        response = self.get_response(
+            query=f"issue:{event.group.qualified_short_id}", groups=[event.group.id]
+        )
+
+        response_data = sorted(response.data, key=lambda x: x["firstSeen"], reverse=True)
+
+        assert response.status_code == 200
+        assert len(response_data) == 1
+        assert int(response_data[0]["id"]) == event.group.id
         assert "title" not in response_data[0]
         assert "hasSeen" not in response_data[0]
         assert "stats" in response_data[0]


### PR DESCRIPTION
We support the search syntax `issue:shortId` but didn't have tests specifically around this for the issue platform when you search in the issue stream.

Closes #44539