### PR TITLE
fix(dev): Allow dockerized relay to connect to dev server

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -526,7 +526,13 @@ if (
       'Access-Control-Allow-Credentials': 'true',
     },
     // Cover the various environments we use (vercel, getsentry-dev, localhost)
-    allowedHosts: ['.sentry.dev', '.dev.getsentry.net', '.localhost', '127.0.0.1'],
+    allowedHosts: [
+      '.sentry.dev',
+      '.dev.getsentry.net',
+      '.localhost',
+      '127.0.0.1',
+      '.docker.internal',
+    ],
     static: {
       directory: './src/sentry/static/sentry',
       watch: true,


### PR DESCRIPTION
The change to `devServer.allowedHost` made in https://github.com/getsentry/sentry/pull/44625 caused Relay to fail authentication in our dev setup:

```
relay   2023-02-16T15:42:01Z [relay_server::actors::upstream] INFO: registering with upstream (http://host.docker.internal:8000/)
relay   2023-02-16T15:42:01Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request
relay     caused by: failed to parse JSON response
relay     caused by: expected value at line 1 column 1
```

because the dev server responded with the string `Invalid Host header`.

I'm not sure why webpack is even in the loop for API requests, but adding the `.docker.internal` suffix to `allowedHosts` seems to fix the problem.