### PR TITLE
fix(codecov): Fix git blame for multi repo projects

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -206,7 +206,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
             git_blame_list.sort(key=lambda blame: blame["commit"]["committedDate"])
             commit_sha = git_blame_list[-1]["commit"]["oid"]
         if not commit_sha:
-            logger.warning(
+            # Report to Sentry so we can investigate
+            logger.error(
                 "Failed to get commit from git blame.",
                 extra={
                     "git_blame_response": git_blame_list,
@@ -219,7 +220,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
 
     def fetch_codecov_data(
         self,
-        has_error_commit: bool,
         ref: Optional[str],
         integrations: BaseQuerySet,
         org: Organization,
@@ -238,8 +238,9 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
         )
         # Get commit sha from Git blame if valid
         gh_integrations = integrations.filter(provider="github")
-        should_get_commit_sha = fetch_commit_sha and gh_integrations and not has_error_commit
+        should_get_commit_sha = fetch_commit_sha and gh_integrations
 
+        ref_source = "from_release"
         if should_get_commit_sha:
             try:
                 integration_installation = gh_integrations[0].get_installation(
@@ -252,10 +253,14 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
                     repo,
                     branch,
                 )
+                ref_source = "from_git_blame"
             except Exception:
                 logger.exception(
                     "Failed to get commit sha from git blame, pending investigation. Continuing execution."
                 )
+
+        with configure_scope() as scope:
+            scope.set_tag("codecov.ref_source", ref_source)
 
         # Call codecov API if codecov-commit-sha-from-git-blame flag is not enabled
         # or getting ref from git blame was successful
@@ -267,7 +272,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
                 ref=ref if ref else branch,
                 ref_type="sha" if ref else "branch",
                 path=path,
-                has_error_commit=has_error_commit,
             )
             if lineCoverage and codecovUrl:
                 codecov_data = {
@@ -374,8 +378,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
                     try:
                         line_no = ctx.get("line_no")
                         codecov_data = self.fetch_codecov_data(
-                            has_error_commit := bool(ctx.get("commit_id")),
-                            ref=ctx["commit_id"] if has_error_commit else None,
+                            ref=ctx.get("commit_id"),
                             integrations=integrations,
                             org=project.organization,
                             user=request.user,

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -11,7 +11,7 @@ REF_TYPE = Literal["branch", "sha"]
 
 
 def get_codecov_data(
-    repo: str, service: str, ref: str, ref_type: REF_TYPE, path: str, has_error_commit: bool
+    repo: str, service: str, ref: str, ref_type: REF_TYPE, path: str
 ) -> Tuple[Optional[LineCoverage], Optional[str]]:
     codecov_token = options.get("codecov.client-secret")
     line_coverage = None
@@ -34,7 +34,6 @@ def get_codecov_data(
                 "codecov.request_path": path,
                 "codecov.request_ref": ref,
                 "codecov.http_code": response.status_code,
-                "codecov.ref_source": "from_release" if has_error_commit else "from_git_blame",
             }
 
             response_json = response.json()

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -369,10 +369,10 @@ class ProjectStracktraceLinkTestCodecov(BaseProjectStacktraceLink):
     @mock.patch("sentry.integrations.mixins.repositories.RepositoryMixin.get_stacktrace_link")
     @mock.patch("sentry.integrations.github.client.GitHubClientMixin.get_blame_for_file")
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
-    def test_get_commit_sha_from_blame_logger_warning(
+    def test_get_commit_sha_from_blame_failed_to_get_commit(
         self, get_jwt, mock_blame, mock_get_stacktrace_link
     ):
-        self._caplog.set_level(logging.WARNING, logger="sentry")
+        self._caplog.set_level(logging.ERROR, logger="sentry")
         self.organization.flags.codecov_access = True
         self.organization.save()
         self.integration.provider = "github"
@@ -389,10 +389,11 @@ class ProjectStracktraceLinkTestCodecov(BaseProjectStacktraceLink):
             qs_params={"file": self.filepath, "lineNo": 26},
         )
 
+        # Error logging means an error is sent to Sentry
         assert self._caplog.record_tuples == [
             (
                 "sentry.api.endpoints.project_stacktrace_link",
-                logging.WARNING,
+                logging.ERROR,
                 "Failed to get commit from git blame.",
             )
         ]


### PR DESCRIPTION
In some projects where there are more than one repository associated to a project, we get a commit that comes from the release. For instance, in the case of the sentry project, we get the commit from the getsentry repo, thus, we can't use that commit with the sentry repo.

Fixes:

* Even if a commit is set, run the git blame experiment
  * As mentioned above, the commit may not even be for the right repo
* Report an error if we fail to git blame

Fixes [WOR-2718](https://getsentry.atlassian.net/browse/WOR-2718)

[WOR-2718]: https://getsentry.atlassian.net/browse/WOR-2718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ