### PR TITLE
feat(consumers) Add logging to all arroyo based consumers

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -911,6 +911,7 @@ LOGGING = {
             "propagate": False,
         },
         "celery.worker.job": {"handlers": ["console"], "propagate": False},
+        "arroyo": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "static_compiler": {"level": "INFO"},
         "django.request": {
             "level": "WARNING",


### PR DESCRIPTION
Currently our arroyo consumers don't log any of their topic assignments or revocations. This change will make that information available.

