### PR TITLE
chore: Remove deprecated structlog.threadlocal usage

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -240,9 +240,7 @@ def configure_structlog() -> None:
     from sentry import options
     from sentry.logging import LoggingFormat
 
-    WrappedDictClass = structlog.threadlocal.wrap_dict(dict)
     kwargs: dict[str, Any] = {
-        "context_class": WrappedDictClass,
         "wrapper_class": structlog.stdlib.BoundLogger,
         "cache_logger_on_first_use": True,
         "processors": [


### PR DESCRIPTION
This API is deprecated in structlog. It is recommended to use the `structlog.contextvars` module instead. Using that module requires further integration of logging into the request cycle.

I've not done that deeper integration as I've not been able to find any scenarios where we're binding context data into logging. Nor were we correctly using the clear_threadlocal() method so state would just accumulate.

This removes some noisy DeprecationWarnings that show up during the startup of every process we run in sentry.
