### PR TITLE
ref: use non-root logger for exception logging

### DIFF
--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -17,6 +17,8 @@ from django.contrib.auth.models import AnonymousUser
 
 from sentry.utils.json import JSONData
 
+logger = logging.getLogger(__name__)
+
 K = TypeVar("K")
 
 registry: MutableMapping[Any, Any] = {}
@@ -113,7 +115,7 @@ class Serializer:
         try:
             return self.serialize(obj, attrs, user, **kwargs)
         except Exception:
-            logging.exception("Failed to serialize", extra={"instance": obj})
+            logger.exception("Failed to serialize", extra={"instance": obj})
             return None
 
     def serialize(


### PR DESCRIPTION
this error is the root cause of https://sentry.sentry.io/issues/3931343277/?project=1&query=is%3Aunresolved+is%3Afor_review&referrer=issue-stream&sort=freq&statsPeriod=14d -- but this doesn't show up as event because `logging.exception` is the root logger (and goes nowhere except breadcrumbs)

switching this to a named logger (`sentry.*` based on the module namespace) should allow it to show up as an event