### PR TITLE
Remove Type: Epic label entirely

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -69,8 +69,6 @@
 - name: 'Type: Design'
   color: '584774'
   description: ''
-- name: 'Type: Epic'
-  color: '584774'
 - name: 'Type: Feature Request'
   color: '584774'
   description: ''


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/44832, for https://github.com/getsentry/team-ospo/issues/106.