### PR TITLE
chore(profiling): Add profiling icon to all go to profile buttons

### DIFF
--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -2,6 +2,7 @@ import Feature from 'sentry/components/acl/feature';
 import {Button} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {IconProfiling} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {Event, ProfileContext, ProfileContextKey} from 'sentry/types/event';
@@ -96,6 +97,7 @@ function getProfileKnownDataDetails({
                 source: 'events.profile_event_context',
               })
             }
+            icon={<IconProfiling size="xs" />}
           >
             {t('Go to Profile')}
           </Button>

--- a/static/app/components/profiling/transactionToProfileButton.tsx
+++ b/static/app/components/profiling/transactionToProfileButton.tsx
@@ -1,6 +1,7 @@
 import {Location} from 'history';
 
 import {Button, ButtonProps} from 'sentry/components/button';
+import {IconProfiling} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
@@ -43,7 +44,12 @@ function TransactionToProfileButton({
   });
 
   return (
-    <Button size={size} onClick={handleGoToProfile} to={target}>
+    <Button
+      size={size}
+      onClick={handleGoToProfile}
+      to={target}
+      icon={<IconProfiling size="xs" />}
+    >
       {children}
     </Button>
   );

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -19,7 +19,7 @@ import {
 } from 'sentry/components/performance/waterfall/rowDetails';
 import {generateIssueEventTarget} from 'sentry/components/quickTrace/utils';
 import {PAGE_URL_PARAM} from 'sentry/constants/pageFilters';
-import {IconLink} from 'sentry/icons';
+import {IconLink, IconProfiling} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -148,7 +148,12 @@ class TransactionDetail extends Component<Props> {
     }
 
     return (
-      <StyledButton size="xs" to={target} onClick={handleOnClick}>
+      <StyledButton
+        size="xs"
+        to={target}
+        onClick={handleOnClick}
+        icon={<IconProfiling size="xs" />}
+      >
         {t('Go to Profile')}
       </StyledButton>
     );


### PR DESCRIPTION
We want to be consistent in how the go to profile button is show and render the profiling icon every time.