### PR TITLE
fix(replay): Fix duration due to incorrect LCP endtimestamp

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -163,7 +163,7 @@ export function breadcrumbFactory(
       label: error['error.type'].join(''),
       eventId: error.id,
       groupId: error['issue.id'] || 1,
-      groupShortId: error.issue || 'POKEDEX-4NN',
+      groupShortId: error.issue,
       project: error['project.name'],
     },
     timestamp: error.timestamp,
@@ -263,8 +263,11 @@ export function replayTimestamps(
   )
     .map(timestamp => +new Date(timestamp * 1000))
     .filter(Boolean);
-  const spanStartTimestamps = rawSpanData.map(span => span.startTimestamp * 1000);
-  const spanEndTimestamps = rawSpanData.map(span => span.endTimestamp * 1000);
+  const rawSpanDataFiltered = rawSpanData.filter(
+    ({op}) => op !== 'largest-contentful-paint'
+  );
+  const spanStartTimestamps = rawSpanDataFiltered.map(span => span.startTimestamp * 1000);
+  const spanEndTimestamps = rawSpanDataFiltered.map(span => span.endTimestamp * 1000);
 
   return {
     startTimestampMs: Math.min(


### PR DESCRIPTION
Due to 7.38.0 (https://github.com/getsentry/sentry-javascript/pull/7187) LCP endtimestamp was being incorrectly recorded. The end timestamp is used in our UI to calculate duration at the moment, so LCP with high values are causing our calculated duration to be incorrect. Ignore LCP in the duration calculation as a temporary fix. Ideally we would get SDK timestamps correct so that we only have the event duration as the source of truth for duration.
