### PR TITLE
fix(widget-builder): filters bar

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Button} from 'sentry/components/button';
-import ButtonBar from 'sentry/components/buttonBar';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
@@ -117,8 +116,6 @@ export function FilterResultsStep({
         <ProjectPageFilter disabled />
         <EnvironmentPageFilter disabled />
         <DatePageFilter alignDropdown="left" disabled />
-      </StyledPageFilterBar>
-      <FilterButtons>
         <ReleasesProvider organization={organization} selection={selection}>
           <StyledReleasesSelectControl
             selectedReleases={
@@ -130,7 +127,7 @@ export function FilterResultsStep({
             className="widget-release-select"
           />
         </ReleasesProvider>
-      </FilterButtons>
+      </StyledPageFilterBar>
       <div>
         {queries.map((query, queryIndex) => {
           return (
@@ -199,18 +196,16 @@ const QueryField = styled(FieldGroup)`
 const StyledPageFilterBar = styled(PageFilterBar)`
   margin-bottom: ${space(1)};
   margin-right: ${space(2)};
-`;
 
-const FilterButtons = styled(ButtonBar)`
-  grid-template-columns: 1fr;
-
-  margin-bottom: ${space(1)};
-  margin-right: ${space(2)};
-
-  justify-content: space-between;
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    flex-direction: column;
+    height: auto;
+  }
 `;
 
 const StyledReleasesSelectControl = styled(ReleasesSelectControl)`
+  width: 100%;
+
   button {
     width: 100%;
   }


### PR DESCRIPTION
- Integrated releases into pagefilters
- Deal with responsiveness

**Before:**
![Screenshot 2023-02-17 at 10 57 05 AM](https://user-images.githubusercontent.com/4830259/219760589-51f1d87a-426e-48c7-a652-a992b3b5458d.png)
![Screenshot 2023-02-17 at 10 58 10 AM](https://user-images.githubusercontent.com/4830259/219761348-86ecea67-ad4d-4276-b746-54bf474a1ff1.png)

**After:**
![Screenshot 2023-02-17 at 10 53 21 AM](https://user-images.githubusercontent.com/4830259/219759994-7e0b9d9a-10b4-41e6-9f98-73bda08161cb.png)
![Screenshot 2023-02-17 at 10 53 35 AM](https://user-images.githubusercontent.com/4830259/219761386-6ed96b7e-76db-43d3-976c-b7291bb101fb.png)