### PR TITLE
feat(issue-platform): add a new post process forwarder for issue platform events

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -93,6 +93,7 @@ class EventStream(Service):
         queue: str,
         skip_consume: bool = False,
         group_states: Optional[GroupStates] = None,
+        occurrence_id: Optional[str] = None,
     ) -> None:
         if skip_consume:
             logger.info("post_process.skip.raw_event", extra={"event_id": event_id})
@@ -108,6 +109,8 @@ class EventStream(Service):
                     "cache_key": cache_key,
                     "group_id": group_id,
                     "group_states": group_states,
+                    "occurrence_id": occurrence_id,
+                    "project_id": project_id,
                 },
                 queue=queue,
             )
@@ -152,6 +155,7 @@ class EventStream(Service):
             self._get_queue_for_post_process(event),
             skip_consume,
             group_states,
+            occurrence_id=event.occurrence_id if isinstance(event, GroupEvent) else None,
         )
 
     def start_delete_groups(

--- a/src/sentry/eventstream/kafka/consumer_strategy.py
+++ b/src/sentry/eventstream/kafka/consumer_strategy.py
@@ -65,6 +65,7 @@ def dispatch_post_process_group_task(
                 "group_id": group_id,
                 "group_states": group_states,
                 "occurrence_id": occurrence_id,
+                "project_id": project_id,
             },
             queue=queue,
         )

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -471,4 +471,5 @@ class SnubaEventStream(SnubaProtocolEventStream):
             self._get_queue_for_post_process(event),
             skip_consume,
             group_states,
+            occurrence_id=event.occurrence_id if isinstance(event, GroupEvent) else None,
         )

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -52,7 +52,7 @@ _DEFAULT_DAEMONS = {
         "--synchronize-commit-group=transactions_group",
         "--no-strict-offset-reset",
     ],
-    "post-process-forwarder-generic": [
+    "post-process-forwarder-issue-platform": [
         "sentry",
         "run",
         "post-process-forwarder",
@@ -301,7 +301,7 @@ and run `sentry devservices up kafka zookeeper`.
         if eventstream.requires_post_process_forwarder():
             daemons += [_get_daemon("post-process-forwarder")]
             daemons += [_get_daemon("post-process-forwarder-transactions")]
-            daemons += [_get_daemon("post-process-forwarder-generic")]
+            daemons += [_get_daemon("post-process-forwarder-issue-platform")]
 
         if settings.SENTRY_EXTRA_WORKERS:
             daemons.extend([_get_daemon(name) for name in settings.SENTRY_EXTRA_WORKERS])

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -52,6 +52,18 @@ _DEFAULT_DAEMONS = {
         "--synchronize-commit-group=transactions_group",
         "--no-strict-offset-reset",
     ],
+    "post-process-forwarder-generic": [
+        "sentry",
+        "run",
+        "post-process-forwarder",
+        "--entity=search_issues",
+        "--loglevel=debug",
+        "--commit-batch-size=100",
+        "--commit-batch-timeout-ms=1000",
+        "--commit-log-topic=snuba-generic-events-commit-log",
+        "--synchronize-commit-group=generic_events_group",
+        "--no-strict-offset-reset",
+    ],
     "ingest": ["sentry", "run", "ingest-consumer", "--all-consumer-types"],
     "occurrences": ["sentry", "run", "occurrences-ingest-consumer", "--no-strict-offset-reset"],
     "region_to_control": [
@@ -289,6 +301,7 @@ and run `sentry devservices up kafka zookeeper`.
         if eventstream.requires_post_process_forwarder():
             daemons += [_get_daemon("post-process-forwarder")]
             daemons += [_get_daemon("post-process-forwarder-transactions")]
+            daemons += [_get_daemon("post-process-forwarder-generic")]
 
         if settings.SENTRY_EXTRA_WORKERS:
             daemons.extend([_get_daemon(name) for name in settings.SENTRY_EXTRA_WORKERS])

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -366,8 +366,8 @@ def cron(**options):
 @strict_offset_reset_option()
 @click.option(
     "--entity",
-    type=click.Choice(["errors", "transactions"]),
-    help="The type of entity to process (errors, transactions).",
+    type=click.Choice(["errors", "transactions", "search_issues"]),
+    help="The type of entity to process (errors, transactions, search_issues).",
 )
 @log_options()
 @configuration

--- a/tests/sentry/eventstream/kafka/test_consumer_strategy.py
+++ b/tests/sentry/eventstream/kafka/test_consumer_strategy.py
@@ -100,8 +100,8 @@ def test_dispatch_task(mock_dispatch: Mock) -> None:
 
 
 @pytest.mark.django_db
-@patch("sentry.eventstream.kafka.consumer_strategy.dispatch_post_process_group_task")
-def test_dispatch_task_with_occurrence(mock_dispatch: Mock) -> None:
+@patch("sentry.tasks.post_process.post_process_group.apply_async")
+def test_dispatch_task_with_occurrence(mock_post_process_group: Mock) -> None:
     commit = Mock()
     partition = Partition(Topic("test-occurrence"), 0)
     factory = PostProcessForwarderStrategyFactory(concurrency=2, max_pending_futures=10)
@@ -114,22 +114,25 @@ def test_dispatch_task_with_occurrence(mock_dispatch: Mock) -> None:
 
     # Dispatch can take a while
     for _i in range(0, 5):
-        if mock_dispatch.call_count:
+        if mock_post_process_group.call_count:
             break
         time.sleep(0.1)
 
-    mock_dispatch.assert_called_once_with(
-        event_id="066f15fe1cd2406aaa7c6a07471d7aef",
-        project_id=2,
-        group_id=44,
-        primary_hash="2ec9f0faba66dc0b356aebf1621fd25e",
-        is_new=False,
-        is_regression=None,
-        is_new_group_environment=False,
-        queue="post_process_issue_platform",
-        group_states=None,
-        occurrence_id="0c6d75ac396941e0bc4b33c2ff7f3657",
-    )
+    assert mock_post_process_group.call_count == 1
+    assert mock_post_process_group.call_args.kwargs == {
+        "kwargs": {
+            "cache_key": "e:066f15fe1cd2406aaa7c6a07471d7aef:2",
+            "group_id": 44,
+            "group_states": None,
+            "is_new": False,
+            "is_new_group_environment": False,
+            "is_regression": None,
+            "occurrence_id": "0c6d75ac396941e0bc4b33c2ff7f3657",
+            "primary_hash": "2ec9f0faba66dc0b356aebf1621fd25e",
+            "project_id": 2,
+        },
+        "queue": "post_process_issue_platform",
+    }
 
     strategy.join()
     strategy.close()

--- a/tests/sentry/eventstream/kafka/test_consumer_strategy.py
+++ b/tests/sentry/eventstream/kafka/test_consumer_strategy.py
@@ -37,6 +37,34 @@ def get_kafka_payload() -> KafkaPayload:
     )
 
 
+def get_occurrence_kafka_payload() -> KafkaPayload:
+    return KafkaPayload(
+        key=None,
+        value=json.dumps(
+            [
+                2,
+                "insert",
+                {
+                    "group_id": 44,
+                    "event_id": "066f15fe1cd2406aaa7c6a07471d7aef",
+                    "organization_id": 2,
+                    "project_id": 2,
+                    "primary_hash": "2ec9f0faba66dc0b356aebf1621fd25e",
+                    "occurrence_id": "0c6d75ac396941e0bc4b33c2ff7f3657",
+                },
+                {
+                    "is_new": False,
+                    "is_regression": None,
+                    "is_new_group_environment": False,
+                    "queue": "post_process_issue_platform",
+                    "skip_consume": False,
+                },
+            ]
+        ).encode(),
+        headers=[],
+    )
+
+
 @pytest.mark.django_db
 @patch("sentry.eventstream.kafka.consumer_strategy.dispatch_post_process_group_task")
 def test_dispatch_task(mock_dispatch: Mock) -> None:
@@ -65,6 +93,42 @@ def test_dispatch_task(mock_dispatch: Mock) -> None:
         queue="post_process_errors",
         group_states=None,
         occurrence_id=None,
+    )
+
+    strategy.join()
+    strategy.close()
+
+
+@pytest.mark.django_db
+@patch("sentry.eventstream.kafka.consumer_strategy.dispatch_post_process_group_task")
+def test_dispatch_task_with_occurrence(mock_dispatch: Mock) -> None:
+    commit = Mock()
+    partition = Partition(Topic("test-occurrence"), 0)
+    factory = PostProcessForwarderStrategyFactory(concurrency=2, max_pending_futures=10)
+    strategy = factory.create_with_partitions(commit, {partition: 0})
+
+    strategy.submit(
+        Message(BrokerValue(get_occurrence_kafka_payload(), partition, 1, datetime.now()))
+    )
+    strategy.poll()
+
+    # Dispatch can take a while
+    for _i in range(0, 5):
+        if mock_dispatch.call_count:
+            break
+        time.sleep(0.1)
+
+    mock_dispatch.assert_called_once_with(
+        event_id="066f15fe1cd2406aaa7c6a07471d7aef",
+        project_id=2,
+        group_id=44,
+        primary_hash="2ec9f0faba66dc0b356aebf1621fd25e",
+        is_new=False,
+        is_regression=None,
+        is_new_group_environment=False,
+        queue="post_process_issue_platform",
+        group_states=None,
+        occurrence_id="0c6d75ac396941e0bc4b33c2ff7f3657",
     )
 
     strategy.join()

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -219,6 +219,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
 
     @patch("sentry.eventstream.insert", autospec=True)
     def test_groupevent_occurrence_passed(self, mock_eventstream_insert):
+
         now = datetime.utcnow()
         event = self.__build_transaction_event()
         event.group_id = self.group.id
@@ -238,7 +239,6 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         self.__produce_event(*insert_args, **insert_kwargs)
         producer = self.producer_mock
         produce_args, produce_kwargs = list(producer.produce.call_args)
-
         version, type_, payload1, payload2 = json.loads(produce_kwargs["value"])
         assert produce_kwargs["topic"] == settings.KAFKA_EVENTSTREAM_GENERIC
         assert produce_kwargs["key"] is None


### PR DESCRIPTION
Adds a new post process forwarder to handle issue occurrence events going through the event stream.

Tested this locally by calling our `issue-occurrence/$` dummy endpoint to produce an issue occurrence event from `occurrence-ingest-consumer` -> `eventstream` -> `post_process_group`. 

It seems testing locally doesn't really go through post-process-forwarder (see https://github.com/getsentry/sentry/blob/404ab7b70ed70e3da27343197e44d6f42ceccfb5/src/sentry/eventstream/snuba.py#L452-L475). But I added a test to verify passing the correct args to the `KafkaEventstream` does properly call `consumer_strategy.dispatch_post_process_group_task`.