### PR TITLE
fix(notes): Sort group notes by reverse chronological order

### DIFF
--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
+from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
@@ -27,8 +28,8 @@ class GroupNotesEndpoint(GroupEndpoint):
         return self.paginate(
             request=request,
             queryset=notes,
-            # TODO(dcramer): we want to sort by datetime
-            order_by="-id",
+            paginator_cls=DateTimePaginator,
+            order_by="-datetime",
             on_results=lambda x: serialize(x, request.user),
         )
 

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -1,5 +1,8 @@
-from sentry.models import Activity, ExternalIssue, GroupLink, GroupSubscription
+import datetime
+
+from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
+from sentry.tasks.merge import merge_groups
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.types.activity import ActivityType
@@ -25,6 +28,71 @@ class GroupNoteTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(activity.id)
+
+    def test_note_merge(self):
+        """Test that when 2 (or more) issues with comments are merged, the chronological order of the comments are preserved."""
+        now = datetime.datetime.now()
+
+        project1 = self.create_project()
+        event1 = self.store_event(data={}, project_id=project1.id)
+        group1 = event1.group
+        note1 = Activity.objects.create(
+            group=group1,
+            project=project1,
+            type=ActivityType.NOTE.value,
+            user=self.user,
+            data={"text": "This looks bad :)"},
+            datetime=now - datetime.timedelta(days=70),
+        )
+        note2 = Activity.objects.create(
+            group=group1,
+            project=project1,
+            type=ActivityType.NOTE.value,
+            user=self.user,
+            data={"text": "Yeah we should probably look into this"},
+            datetime=now - datetime.timedelta(days=66),
+        )
+
+        project2 = self.create_project()
+        group2 = self.create_group(project2)
+
+        note3 = Activity.objects.create(
+            group=group2,
+            project=project2,
+            type=ActivityType.NOTE.value,
+            user=self.user,
+            data={"text": "I have been a good Sentry :)"},
+            datetime=now - datetime.timedelta(days=90),
+        )
+        note4 = Activity.objects.create(
+            group=group2,
+            project=project2,
+            type=ActivityType.NOTE.value,
+            user=self.user,
+            data={"text": "You have been a bad user :)"},
+            datetime=now - datetime.timedelta(days=88),
+        )
+
+        with self.tasks():
+            merge_groups([group1.id], group2.id)
+
+        assert not Group.objects.filter(id=group1.id).exists()
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{group2.id}/comments/"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 4
+
+        assert response.data[0]["id"] == str(note2.id)
+        assert response.data[0]["data"]["text"] == note2.data["text"]
+        assert response.data[1]["id"] == str(note1.id)
+        assert response.data[1]["data"]["text"] == note1.data["text"]
+        assert response.data[2]["id"] == str(note4.id)
+        assert response.data[2]["data"]["text"] == note4.data["text"]
+        assert response.data[3]["id"] == str(note3.id)
+        assert response.data[3]["data"]["text"] == note3.data["text"]
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
If there are comments on issues that are merged together, the reverse chronological order wasn't preserved as we were sorting by the ID. This uses the `DateTimePaginator` to return comments in the expected order. 

Fixes https://getsentry.atlassian.net/browse/ISSUE-929