### PR TITLE
fix(ratelimit): make SystemHealthEndpoint use its own rate limit bucket

### DIFF
--- a/src/sentry/api/endpoints/system_health.py
+++ b/src/sentry/api/endpoints/system_health.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry import status_checks
 from sentry.api.base import Endpoint, pending_silo_endpoint
 from sentry.auth.superuser import is_active_superuser
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.status_checks import sort_by_severity
 from sentry.utils.hashlib import md5_text
 
@@ -14,6 +15,7 @@ from sentry.utils.hashlib import md5_text
 @pending_silo_endpoint
 class SystemHealthEndpoint(Endpoint):
     permission_classes = (IsAuthenticated,)
+    rate_limits = RateLimitConfig(group="INTERNAL")
 
     def get(self, request: Request) -> Response:
         if not is_active_superuser(request):

--- a/src/sentry/ratelimits/config.py
+++ b/src/sentry/ratelimits/config.py
@@ -38,6 +38,7 @@ SENTRY_RATELIMITER_GROUP_DEFAULTS: Mapping[GroupName, Mapping[RateLimitCategory,
             settings.SENTRY_CONCURRENT_RATE_LIMIT_GROUP_CLI,
         ),
     },
+    "INTERNAL": {category: DEFAULT_RATELIMIT for category in RateLimitCategory},
 }
 
 


### PR DESCRIPTION
the system should not be taking away quota from UI interactions. Put it in its own bucket. Use the defaults since I don't want to do a bunch of analysis right now to figure out the optimal number