### PR TITLE
ref(backup/restore): Export Environment and EnvironmentProject for backup/restore

### DIFF
--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -34,7 +34,7 @@ class EnvironmentProject(Model):
 
 @region_silo_only_model
 class Environment(Model):
-    __include_in_export__ = False
+    __include_in_export__ = True
 
     organization_id = BoundedBigIntegerField()
     projects = models.ManyToManyField("sentry.Project", through=EnvironmentProject)

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -20,7 +20,7 @@ OK_NAME_PATTERN = re.compile(ENVIRONMENT_NAME_PATTERN)
 
 @region_silo_only_model
 class EnvironmentProject(Model):
-    __include_in_export__ = False
+    __include_in_export__ = True
 
     project = FlexibleForeignKey("sentry.Project")
     environment = FlexibleForeignKey("sentry.Environment")


### PR DESCRIPTION
Adding `sentry_environment` and `sentry_environmentproject` to backup/restore workflow as an ask since it's breaking the workflow for self-hosted.
https://github.com/getsentry/self-hosted/issues/1965

Asked in #discuss-backend and it isn't super high volume so seems to be fine