### PR TITLE
feat(view-hierarchy): Improve Rendering System UI

### DIFF
--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -200,4 +200,12 @@ describe('View Hierarchy', function () {
 
     expect(container).toSnapshot();
   });
+
+  it('renders an icon with a tooltip for the rendering system', async function () {
+    MOCK_DATA.rendering_system = 'flutter';
+    render(<ViewHierarchy viewHierarchy={MOCK_DATA} project={project} />);
+
+    userEvent.hover(screen.getByTestId('rendering-system-icon'));
+    expect(await screen.findByText('Rendering System: flutter')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -165,7 +165,10 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
 
   return (
     <Fragment>
-      <RenderingSystem system={viewHierarchy.rendering_system} />
+      <RenderingSystem
+        platform={project?.platform}
+        system={viewHierarchy.rendering_system}
+      />
       <Content>
         <Left hasRight={showWireframe}>
           <TreeContainer>
@@ -228,6 +231,7 @@ const TreeContainer = styled('div')`
   background-color: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.gray100};
   border-radius: ${p => p.theme.borderRadius};
+  border-top-left-radius: 0;
 `;
 
 const DetailsContainer = styled('div')`
@@ -238,7 +242,7 @@ const DetailsContainer = styled('div')`
 `;
 
 const ScrollContainer = styled('div')`
-  padding: ${space(1.5)};
+  padding: 0 ${space(1.5)} ${space(1.5)} ${space(1.5)};
 `;
 
 const RenderedItemsContainer = styled('div')`
@@ -269,7 +273,7 @@ const DepthMarker = styled('div')<{depth: number}>`
 `;
 
 const GhostRow = styled('div')`
-  top: ${space(1.5)};
+  top: 0;
 `;
 
 const EmptyStateContainer = styled('div')`

--- a/static/app/components/events/viewHierarchy/renderingSystem.tsx
+++ b/static/app/components/events/viewHierarchy/renderingSystem.tsx
@@ -1,18 +1,39 @@
 import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
 
-import Pill from 'sentry/components/pill';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 
 type RenderingSystemProps = {
+  platform?: string;
   system?: string;
 };
 
-function RenderingSystem({system}: RenderingSystemProps) {
-  return <StyledPill name={t('Rendering System')} value={system ?? t('Unknown')} />;
+function RenderingSystem({platform, system}: RenderingSystemProps) {
+  return (
+    <Container>
+      <Tooltip title={t('Rendering System: %s', system ?? t('Unknown'))}>
+        <PlatformIcon
+          data-test-id="rendering-system-icon"
+          platform={platform ?? 'generic'}
+          size={21}
+          radius={null}
+        />
+      </Tooltip>
+    </Container>
+  );
 }
 
 export {RenderingSystem};
 
-const StyledPill = styled(Pill)`
-  width: max-content;
+const Container = styled('div')`
+  position: absolute;
+  top: -0.5px;
+  left: -${space(3)};
+  z-index: 1;
+
+  img {
+    border-radius: 4px 0 0 4px;
+  }
 `;


### PR DESCRIPTION
Going with a hoverable icon that matches the platform. When hovered, the icon should show "Rendering System: X"

<img width="665" alt="Screenshot 2023-02-17 at 4 14 40 PM" src="https://user-images.githubusercontent.com/22846452/219796107-8a6092e5-9b22-47b2-af88-97167a288b3d.png">
<img width="706" alt="Screenshot 2023-02-17 at 4 13 54 PM" src="https://user-images.githubusercontent.com/22846452/219796109-be0cc960-0713-44a3-97ce-ae19bf64d050.png">

Closes #42997 