### PR TITLE
fix(profiling): Auto create profiles kafka topic for dev

### DIFF
--- a/src/sentry/profiles/consumers/__init__.py
+++ b/src/sentry/profiles/consumers/__init__.py
@@ -11,6 +11,7 @@ from django.conf import settings
 
 from sentry.profiles.consumers.process.factory import ProcessProfileStrategyFactory
 from sentry.utils import kafka_config
+from sentry.utils.batching_kafka_consumer import create_topics
 
 
 def get_profiles_process_consumer(
@@ -47,6 +48,7 @@ def get_config(
     force_cluster: str | None,
 ) -> MutableMapping[str, Any]:
     cluster_name: str = force_cluster or settings.KAFKA_TOPICS[topic]["cluster"]
+    create_topics(cluster_name, [topic])
     return build_kafka_consumer_configuration(
         kafka_config.get_kafka_consumer_cluster_options(
             cluster_name,


### PR DESCRIPTION
The BatchingKafkaConsumer used to do this automatically, when moving to arroyo, this was not implemented. Basing this off the occurrence_consumer.