### PR TITLE
feat(roles): add feature flag for org roles for teams

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1262,6 +1262,8 @@ SENTRY_FEATURES = {
     "organizations:scim-orgmember-roles": False,
     # Enable team member role provisioning through scim
     "organizations:scim-team-roles": False,
+    # Enable the setting of org roles for team
+    "organizations:org-roles-for-teams": False,
     # Enable the in-app source map debugging feature
     "organizations:fix-source-map-cta": False,
     # Enable new JS SDK Dynamic Loader

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -154,6 +154,7 @@ default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, Tr
 default_manager.add("organizations:scaleable-codeowners-search", OrganizationFeature)
 default_manager.add("organizations:scim-orgmember-roles", OrganizationFeature, True)
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, True)
+default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, True)
 default_manager.add("organizations:sentry-functions", OrganizationFeature, False)
 default_manager.add("organizations:session-replay", OrganizationFeature)
 default_manager.add("organizations:session-replay-beta-grace", OrganizationFeature, True)


### PR DESCRIPTION
Adds a flag for org roles for teams. This will be used to flag the frontend feature changes and the logic to set the role in the first place.