### PR TITLE
fix(indexer): Update join method of SimpleProduceStep

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
@@ -91,10 +91,16 @@ class SimpleProduceStep(ProcessingStep[KafkaPayload]):
         self.__closed = True
 
     def join(self, timeout: Optional[float] = None) -> None:
+        start_join = time.time()
+
         with metrics.timer("simple_produce_step.join_duration"):
             if not timeout:
-                timeout = 5.0
+                timeout = 2.0
             self.__producer.flush(timeout)
 
         self.__commit_function(self.__produced_message_offsets, force=True)
         self.__produced_message_offsets = {}
+
+        join_duration = time.time() - start_join()
+
+        logger.info("SimpleProduceStep.join: %s", join_duration)


### PR DESCRIPTION
[Arroyo 2.5.1](https://github.com/getsentry/arroyo/releases/tag/2.5.1) introduced a fix to Reduce causing this method to actually be called. join() was never being called from the previous step before 2.5.1.

When we initially deployed Arroyo 2.5.1 we noticed LeaveGroupRequestTimeouts as the timeout exceeded 5000 ms. (This caused [INC-311](https://getsentry.atlassian.net/browse/INC-311) at Sentry).

This change logs the time the produce step takes to close. It also reduces the timeout to try and prevent [INC-311](https://getsentry.atlassian.net/browse/INC-311) happening again.

We should merge it before trying Arroyo 2.5.1 again.


[INC-311]: https://getsentry.atlassian.net/browse/INC-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INC-311]: https://getsentry.atlassian.net/browse/INC-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ