### PR TITLE
ref(proj-config): Schedule project config invalidations after database transactions have finished

### DIFF
--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -109,11 +109,7 @@ class TeamKeyTransactionModelManager(BaseManager):
             )
             # invalidate project config only when the rule is enabled
             if RuleType.BOOST_KEY_TRANSACTIONS_RULE.value in enabled_biases:
-                transaction.on_commit(
-                    lambda: schedule_invalidate_project_config(
-                        project_id=project.id, trigger=trigger
-                    )
-                )
+                schedule_invalidate_project_config(project_id=project.id, trigger=trigger)
 
     def post_save(self, instance, **kwargs):
         # this hook may be called from model hooks during an

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
-from django.db import models, transaction
+from django.db import models
 
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.picklefield import PickledObjectField
@@ -69,10 +69,8 @@ class OrganizationOptionManager(OptionManager["Organization"]):
             # task.
             #
             # If there is no transaction open, on_commit should run immediately.
-            transaction.on_commit(
-                lambda: schedule_invalidate_project_config(
-                    organization_id=organization_id, trigger=update_reason
-                )
+            schedule_invalidate_project_config(
+                organization_id=organization_id, trigger=update_reason
             )
 
         cache_key = self._make_key(organization_id)

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -63,12 +63,6 @@ class OrganizationOptionManager(OptionManager["Organization"]):
 
     def reload_cache(self, organization_id: int, update_reason: str) -> Mapping[str, Value]:
         if update_reason != "organizationoption.get_all_values":
-            # this hook may be called from model hooks during an
-            # open transaction. In that case, wait until the current transaction has
-            # been committed or rolled back to ensure we don't read stale data in the
-            # task.
-            #
-            # If there is no transaction open, on_commit should run immediately.
             schedule_invalidate_project_config(
                 organization_id=organization_id, trigger=update_reason
             )

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -121,12 +121,6 @@ class ProjectOptionManager(OptionManager["Project"]):
 
     def reload_cache(self, project_id: int, update_reason: str) -> Mapping[str, Value]:
         if update_reason != "projectoption.get_all_values":
-            # this hook may be called from model hooks during an
-            # open transaction. In that case, wait until the current transaction has
-            # been committed or rolled back to ensure we don't read stale data in the
-            # task.
-            #
-            # If there is no transaction open, on_commit should run immediately.
             schedule_invalidate_project_config(project_id=project_id, trigger=update_reason)
         cache_key = self._make_key(project_id)
         result = {i.key: i.value for i in self.filter(project=project_id)}

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
-from django.db import models, transaction
+from django.db import models
 
 from sentry import projectoptions
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
@@ -127,11 +127,7 @@ class ProjectOptionManager(OptionManager["Project"]):
             # task.
             #
             # If there is no transaction open, on_commit should run immediately.
-            transaction.on_commit(
-                lambda: schedule_invalidate_project_config(
-                    project_id=project_id, trigger=update_reason
-                )
-            )
+            schedule_invalidate_project_config(project_id=project_id, trigger=update_reason)
         cache_key = self._make_key(project_id)
         result = {i.key: i.value for i in self.filter(project=project_id)}
         cache.set(cache_key, result)

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import petname
 from django.conf import settings
-from django.db import ProgrammingError, models, transaction
+from django.db import ProgrammingError, models
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -40,10 +40,8 @@ class ProjectKeyManager(BaseManager):
         # task.
         #
         # If there is no transaction open, on_commit should run immediately.
-        transaction.on_commit(
-            lambda: schedule_invalidate_project_config(
-                public_key=instance.public_key, trigger="projectkey.post_save"
-            )
+        schedule_invalidate_project_config(
+            public_key=instance.public_key, trigger="projectkey.post_save"
         )
 
     def post_delete(self, instance, **kwargs):
@@ -53,10 +51,8 @@ class ProjectKeyManager(BaseManager):
         # task.
         #
         # If there is no transaction open, on_commit should run immediately.
-        transaction.on_commit(
-            lambda: schedule_invalidate_project_config(
-                public_key=instance.public_key, trigger="projectkey.post_delete"
-            )
+        schedule_invalidate_project_config(
+            public_key=instance.public_key, trigger="projectkey.post_delete"
         )
 
 

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -34,23 +34,11 @@ class ProjectKeyStatus:
 
 class ProjectKeyManager(BaseManager):
     def post_save(self, instance, **kwargs):
-        # this hook may be called from model hooks during an
-        # open transaction. In that case, wait until the current transaction has
-        # been committed or rolled back to ensure we don't read stale data in the
-        # task.
-        #
-        # If there is no transaction open, on_commit should run immediately.
         schedule_invalidate_project_config(
             public_key=instance.public_key, trigger="projectkey.post_save"
         )
 
     def post_delete(self, instance, **kwargs):
-        # this hook may be called from model hooks during an
-        # open transaction. In that case, wait until the current transaction has
-        # been committed or rolled back to ensure we don't read stale data in the
-        # task.
-        #
-        # If there is no transaction open, on_commit should run immediately.
         schedule_invalidate_project_config(
             public_key=instance.public_key, trigger="projectkey.post_delete"
         )

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -8,7 +8,7 @@ from time import time
 from typing import List, Mapping, Optional, Sequence, Union
 
 import sentry_sdk
-from django.db import IntegrityError, models, router, transaction
+from django.db import IntegrityError, models, router
 from django.db.models import Case, F, Func, Q, Subquery, Sum, Value, When
 from django.db.models.signals import pre_save
 from django.utils import timezone
@@ -83,9 +83,7 @@ class ReleaseProjectModelManager(BaseManager):
             and options.get("dynamic-sampling:enabled-biases")
             and project_boosted_releases.has_boosted_releases
         ):
-            transaction.on_commit(
-                lambda: schedule_invalidate_project_config(project_id=project.id, trigger=trigger)
-            )
+            schedule_invalidate_project_config(project_id=project.id, trigger=trigger)
 
     def post_save(self, instance, **kwargs):
         self._on_post(project=instance.project, trigger="releaseproject.post_save")

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import sentry_sdk
+from django.db import transaction
 
 from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
@@ -241,6 +242,27 @@ def invalidate_project_config(
 
 
 def schedule_invalidate_project_config(
+    *,
+    trigger,
+    organization_id=None,
+    project_id=None,
+    public_key=None,
+    countdown=5,
+):
+    # TODO: add docstrings
+
+    transaction.on_commit(
+        lambda: _schedule_invalidate_project_config(
+            trigger=trigger,
+            organization_id=organization_id,
+            project_id=project_id,
+            public_key=public_key,
+            countdown=countdown,
+        )
+    )
+
+
+def _schedule_invalidate_project_config(
     *,
     trigger,
     organization_id=None,

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -249,8 +249,17 @@ def schedule_invalidate_project_config(
     public_key=None,
     countdown=5,
 ):
-    # TODO: add docstrings
+    """Enqueues :func:`_schedule_invalidate_project_config` to run after the
+    ongoing database transaction is committed. See
+    :func:`_schedule_invalidate_project_config`'s docstrings to learn how to use
+    it.
 
+    You should use this function instead of
+    :func:`_schedule_invalidate_project_config`. If not, it's possible the
+    project config invalidation job finishes before the database transaction is
+    completed, resulting in producing an stale project config that may cause a
+    production issue.
+    """
     transaction.on_commit(
         lambda: _schedule_invalidate_project_config(
             trigger=trigger,

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -250,7 +250,8 @@ def schedule_invalidate_project_config(
     countdown=5,
 ):
     """Enqueues :func:`_schedule_invalidate_project_config` to run after the
-    ongoing database transaction is committed. See
+    ongoing database transaction is committed (or run directly if there's no
+    database transaction ongoing). See
     :func:`_schedule_invalidate_project_config`'s docstrings to learn how to use
     it.
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -1,5 +1,5 @@
-import contextlib
-from unittest.mock import patch
+from unittest import mock
+from unittest.mock import call, patch
 
 import pytest
 from django.db import transaction
@@ -8,6 +8,7 @@ from sentry.models import Project, ProjectKey, ProjectKeyStatus, ProjectOption
 from sentry.relay.projectconfig_cache.redis import RedisProjectConfigCache
 from sentry.relay.projectconfig_debounce_cache.redis import RedisProjectConfigDebounceCache
 from sentry.tasks.relay import (
+    _schedule_invalidate_project_config,
     build_project_config,
     invalidate_project_config,
     schedule_build_project_config,
@@ -27,45 +28,6 @@ def _cache_keys_for_org(org):
     for proj in Project.objects.filter(organization_id=org.id):
         for key in ProjectKey.objects.filter(project_id=proj.id):
             yield key.public_key
-
-
-@pytest.fixture
-def emulate_transactions(burst_task_runner, django_capture_on_commit_callbacks):
-    # This contraption helps in testing the usage of `transaction.on_commit` in
-    # schedule_build_project_config. Normally tests involving transactions would
-    # require us to use the transactional testcase (or
-    # `pytest.mark.django_db(transaction=True)`), but that incurs a 2x slowdown
-    # in test speed and we're trying to keep our testcases fast.
-    @contextlib.contextmanager
-    def inner(assert_num_callbacks=1):
-        with burst_task_runner() as burst:
-            with django_capture_on_commit_callbacks(execute=True) as callbacks:
-                yield
-
-                # Assert there are no relay-related jobs in the queue yet, as we should have
-                # some on_commit callbacks instead. If we don't, then the model
-                # hook has scheduled the build_project_config task prematurely.
-                #
-                # Remove any other jobs from the queue that may have been triggered via model hooks
-                assert not any("relay" in task.__name__ for task, _, _ in burst.queue)
-                burst.queue.clear()
-
-            # for some reason, the callbacks array is only populated by
-            # pytest-django's implementation after the context manager has
-            # exited, not while they are being registered
-            assert len(callbacks) == assert_num_callbacks
-
-        # Callbacks have been executed, job(s) should've been scheduled now, so
-        # let's execute them.
-        #
-        # Note: We can't directly assert that the data race has not occured, as
-        # there are no real DB transactions available in this testcase. The
-        # entire test runs in one transaction because that's how pytest-django
-        # sets up things unless one uses
-        # pytest.mark.django_db(transaction=True).
-        burst(max_jobs=10)
-
-    return inner
 
 
 @pytest.fixture
@@ -150,12 +112,13 @@ def test_generate(
     default_project,
     default_organization,
     default_projectkey,
+    task_runner,
     redis_cache,
-    django_cache,
 ):
     assert not redis_cache.get(default_projectkey.public_key)
 
-    build_project_config(default_projectkey.public_key)
+    with task_runner():
+        build_project_config(default_projectkey.public_key)
 
     cfg = redis_cache.get(default_projectkey.public_key)
 
@@ -170,16 +133,14 @@ def test_generate(
     ]
 
 
-@pytest.mark.django_db
-def test_project_update_option(
-    default_projectkey, default_project, emulate_transactions, redis_cache, django_cache
-):
+@pytest.mark.django_db(transaction=True)
+def test_project_update_option(default_projectkey, default_project, task_runner, redis_cache):
     # Put something in the cache, otherwise triggers/the invalidation task won't compute
     # anything.
-    redis_cache.set_many({default_projectkey.public_key: "dummy"})
+    with task_runner():
+        redis_cache.set_many({default_projectkey.public_key: "dummy"})
 
-    # XXX: there should only be one hook triggered, regardless of debouncing
-    with emulate_transactions(assert_num_callbacks=4):
+    with task_runner():
         default_project.update_option(
             "sentry:relay_pii_config", '{"applications": {"$string": ["@creditcard:mask"]}}'
         )
@@ -188,8 +149,7 @@ def test_project_update_option(
         "applications": {"$string": ["@creditcard:mask"]}
     }
 
-    # XXX: there should only be one hook triggered, regardless of debouncing
-    with emulate_transactions(assert_num_callbacks=2):
+    with task_runner():
         default_project.organization.update_option(
             "sentry:relay_pii_config", '{"applications": {"$string": ["@creditcard:mask"]}}'
         )
@@ -203,27 +163,27 @@ def test_project_update_option(
         }
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_project_delete_option(
-    default_projectkey, default_project, emulate_transactions, redis_cache, django_cache
+    default_projectkey,
+    default_project,
+    task_runner,
+    redis_cache,
 ):
     # Put something in the cache, otherwise triggers/the invalidation task won't compute
     # anything.
     redis_cache.set_many({default_projectkey.public_key: "dummy"})
 
-    # XXX: there should only be one hook triggered, regardless of debouncing
-    with emulate_transactions(assert_num_callbacks=3):
+    with task_runner():
         default_project.delete_option("sentry:relay_pii_config")
 
     assert redis_cache.get(default_projectkey)["config"]["piiConfig"] == {}
 
 
 @pytest.mark.django_db
-def test_project_get_option_does_not_reload(
-    default_project, emulate_transactions, monkeypatch, django_cache
-):
+def test_project_get_option_does_not_reload(default_project, task_runner, monkeypatch):
     ProjectOption.objects._option_cache.clear()
-    with emulate_transactions(assert_num_callbacks=0):
+    with task_runner():
         with patch("sentry.utils.cache.cache.get", return_value=None):
             with patch("sentry.tasks.relay.schedule_build_project_config") as build_project_config:
                 default_project.get_option(
@@ -233,10 +193,8 @@ def test_project_get_option_does_not_reload(
     assert not build_project_config.called
 
 
-@pytest.mark.django_db
-def test_invalidation_project_deleted(
-    default_project, emulate_transactions, redis_cache, django_cache
-):
+@pytest.mark.django_db(transaction=True)
+def test_invalidation_project_deleted(default_project, task_runner, redis_cache, django_cache):
     # Ensure we have a ProjectKey
     project_key = next(_cache_keys_for_project(default_project))
     assert project_key
@@ -248,7 +206,7 @@ def test_invalidation_project_deleted(
     project_id = default_project.id
 
     # Delete the project normally, this will delete it from the cache
-    with emulate_transactions(assert_num_callbacks=5):
+    with task_runner():
         default_project.delete()
     assert redis_cache.get(project_key)["disabled"]
 
@@ -257,13 +215,12 @@ def test_invalidation_project_deleted(
     assert redis_cache.get(project_key)["disabled"]
 
 
-@pytest.mark.django_db
-def test_projectkeys(default_project, emulate_transactions, redis_cache, django_cache):
+@pytest.mark.django_db(transaction=True)
+def test_projectkeys(default_project, task_runner, redis_cache):
     # When a projectkey is deleted the invalidation task should be triggered and the project
     # should be cached as disabled.
 
-    # XXX: there should only be one hook triggered, regardless of debouncing
-    with emulate_transactions(assert_num_callbacks=2):
+    with task_runner():
         deleted_pks = list(ProjectKey.objects.filter(project=default_project))
         for key in deleted_pks:
             key.delete()
@@ -277,13 +234,13 @@ def test_projectkeys(default_project, emulate_transactions, redis_cache, django_
     (pk_json,) = redis_cache.get(pk.public_key)["publicKeys"]
     assert pk_json["publicKey"] == pk.public_key
 
-    with emulate_transactions():
+    with task_runner():
         pk.status = ProjectKeyStatus.INACTIVE
         pk.save()
 
     assert redis_cache.get(pk.public_key)["disabled"]
 
-    with emulate_transactions():
+    with task_runner():
         pk.delete()
 
     assert redis_cache.get(pk.public_key)["disabled"]
@@ -294,7 +251,10 @@ def test_projectkeys(default_project, emulate_transactions, redis_cache, django_
 
 @pytest.mark.django_db(transaction=True)
 def test_db_transaction(
-    default_project, default_projectkey, redis_cache, task_runner, django_cache
+    default_project,
+    default_projectkey,
+    redis_cache,
+    task_runner,
 ):
     # Put something in the cache, otherwise triggers/the invalidation task won't compute
     # anything.
@@ -330,15 +290,14 @@ def test_db_transaction(
     }
 
 
+@pytest.mark.django_db(transaction=True)
 class TestInvalidationTask:
-    @pytest.mark.django_db
     def test_debounce(
         self,
         monkeypatch,
         default_project,
         default_organization,
         invalidation_debounce_cache,
-        django_cache,
     ):
         tasks = []
 
@@ -375,7 +334,6 @@ class TestInvalidationTask:
             },
         ]
 
-    @pytest.mark.django_db
     def test_invalidate(
         self,
         monkeypatch,
@@ -384,7 +342,6 @@ class TestInvalidationTask:
         default_projectkey,
         task_runner,
         redis_cache,
-        django_cache,
     ):
         cfg = {"dummy-key": "val"}
         redis_cache.set_many({default_projectkey.public_key: cfg})
@@ -399,7 +356,6 @@ class TestInvalidationTask:
             assert cfg["disabled"] is False
             assert cfg["projectId"] == default_project.id
 
-    @pytest.mark.django_db
     def test_invalidate_org(
         self,
         monkeypatch,
@@ -408,7 +364,6 @@ class TestInvalidationTask:
         default_projectkey,
         redis_cache,
         task_runner,
-        django_cache,
     ):
         # Currently for org-wide we delete the config instead of computing it.
         cfg = {"dummy-key": "val"}
@@ -425,8 +380,30 @@ class TestInvalidationTask:
             assert new_cfg is not None
             assert new_cfg != cfg
 
+    @mock.patch(
+        "sentry.tasks.relay._schedule_invalidate_project_config",
+        wraps=_schedule_invalidate_project_config,
+    )
+    @mock.patch("django.db.transaction.on_commit", wraps=transaction.on_commit)
+    def test_project_config_invalidations_after_commit(
+        self, oncommit, schedule_inner, default_project
+    ):
+        schedule_invalidate_project_config(
+            trigger="test", project_id=default_project.id, countdown=2
+        )
 
-@pytest.mark.django_db
+        assert oncommit.call_count == 1
+        assert schedule_inner.call_count == 1
+        assert schedule_inner.call_args == call(
+            trigger="test",
+            organization_id=None,
+            project_id=default_project.id,
+            public_key=None,
+            countdown=2,
+        )
+
+
+@pytest.mark.django_db(transaction=True)
 def test_invalidate_hierarchy(
     monkeypatch,
     burst_task_runner,
@@ -435,7 +412,6 @@ def test_invalidate_hierarchy(
     redis_cache,
     debounce_cache,
     invalidation_debounce_cache,
-    django_cache,
 ):
     # Put something in the cache, otherwise the invalidation task won't compute anything.
     redis_cache.set_many({default_projectkey.public_key: "dummy"})


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/35523.

Scheduling a project config invalidation before the database transaction is completed is problematic -- the transaction may modify the project's config after the invalidation has completed execution. As a result, a stale project config is sent to relays, worst case causing serious issues in production.

In the past, some of the most problematic invalidation places have been hidden behind a call to `transaction.on_commit` to ensure this is not the case and it has worked fine. However, not all invalidation calls happen behind it, and there isn't anything built to ensure future calls are also safe. This PR moves the `transaction.on_commit` logic to be part of the scheduling so that callers don't have to take any responsibilities about how to use it, and make sure it's always called.

Although this is a refactor and shouldn't change the behavior and frequency of project config invalidations it's possible something may have slipped off, so deploying this PR is risky.

Resolves https://github.com/getsentry/team-ingest/issues/41.