### PR TITLE
meta(codeowners): Add ingest ownership to relay tasks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 /src/sentry/scripts/quotas/                              @getsentry/owners-ingest
 /src/sentry/scripts/tsdb/                                @getsentry/owners-ingest
 /src/sentry/tasks/store.py                               @getsentry/owners-ingest
+/src/sentry/tasks/relay.py                               @getsentry/owners-ingest
 /src/sentry/tasks/unmerge.py                             @getsentry/owners-ingest
 /tests/sentry/event_manager/                             @getsentry/owners-ingest
 /tests/sentry/ingest/                                    @getsentry/owners-ingest


### PR DESCRIPTION
`/src/sentry/tasks/relay.py` contains code for building and invalidating project configs, currently without a code owner assigned. This file is owned and maintained by Ingest, and ideally diffs on that file are also reviewed by Ingest. This PR adds the team as a code owner to that file.

#skip-changelog