### PR TITLE
ref(profile): avoid unshift

### DIFF
--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -123,15 +123,15 @@ export class Profile {
       let node: CallTreeNode | null = stackTop;
 
       while (node && !node.isRoot() && node !== top) {
-        toOpen.unshift(node);
+        toOpen.push(node);
         node = node.parent;
       }
 
-      for (const toOpenNode of toOpen) {
-        openFrame(toOpenNode, value);
+      for (let i = toOpen.length - 1; i >= 0; i--) {
+        openFrame(toOpen[i], value);
       }
 
-      prevStack = prevStack.concat(toOpen);
+      prevStack = prevStack.concat(toOpen.reverse());
       value += this.weights[sampleIndex++];
     }
 

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -101,7 +101,7 @@ export class Profile {
     openFrame: (node: CallTreeNode, value: number) => void,
     closeFrame: (node: CallTreeNode, value: number) => void
   ): void {
-    let prevStack: CallTreeNode[] = [];
+    const prevStack: CallTreeNode[] = [];
     let value = 0;
 
     let sampleIndex = 0;
@@ -129,12 +129,13 @@ export class Profile {
 
       for (let i = toOpen.length - 1; i >= 0; i--) {
         openFrame(toOpen[i], value);
+        prevStack.push(toOpen[i]);
       }
 
-      prevStack = prevStack.concat(toOpen.reverse());
       value += this.weights[sampleIndex++];
     }
 
+    // Close any remaining frames
     for (let i = prevStack.length - 1; i >= 0; i--) {
       closeFrame(prevStack[i], value);
     }


### PR DESCRIPTION
Unshift causes this to run in On^2 - we can do better by pushing to the array and iterating in reverse order. We can also get rid of the stack concatenation that way.