### PR TITLE
ref: Increase reprocessing TTL

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2804,8 +2804,11 @@ SENTRY_REPROCESSING_ATTACHMENT_CHUNK_SIZE = 2**20
 # for synchronization/progress report.
 SENTRY_REPROCESSING_SYNC_REDIS_CLUSTER = "default"
 
-# How long can reprocessing take before we start deleting its Redis keys?
-SENTRY_REPROCESSING_SYNC_TTL = 3600 * 24
+# How long tombstones from reprocessing will live.
+SENTRY_REPROCESSING_TOMBSTONES_TTL = 24 * 3600
+
+# How long reprocessing counters are kept in Redis before they expire.
+SENTRY_REPROCESSING_SYNC_TTL = 30 * 24 * 3600  # 30 days
 
 # How many events to query for at once while paginating through an entire
 # issue. Note that this needs to be kept in sync with the time-limits on


### PR DESCRIPTION
This increases (and refreshes) the main reprocessing counter/info in Redis. It also introduces a separate TTL for tombstones.

Reprocessing has been getting "stuck" quite a lot recently. Part of the problem is this counter which is responsible for calling `finish_reprocessing` in the end, and a missing counter value will also manifest itself as a progress bar stuck at 100% which is confusing to customers.

We have seen reprocessing jobs which are unreasonably slow, and can legitimately take >24h to complete. Increasing and refreshing the TTL reduces the likelihood of it breaking reprocessing, and also allows the team more time to investigate potential issues with reprocessing.