### PR TITLE
feat(analytics): Add SDK name + version to frontend analytics

### DIFF
--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -135,6 +135,8 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
       organization_id: parseInt(organization.id, 10),
       project_platforms: getSelectedProjectPlatforms(location, projects),
       has_otel: event?.contexts?.otel !== undefined,
+      sdk_name: event?.sdk?.name,
+      sdk_version: event?.sdk?.version,
     });
 
     const {isSidebarVisible} = this.state;


### PR DESCRIPTION
Similar to what we do for event details at https://github.com/getsentry/sentry/blob/ce1cfca996ad60324701af03c3265b0516994629/static/app/utils/events.tsx#L304-L305

add sdk name and version to events when transaction detail page is viewed.