### PR TITLE
Revert "ref(file-io): Ignore certain ios files"

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
 import random
 import re
 from abc import ABC, abstractmethod
@@ -754,7 +753,6 @@ class FileIOMainThreadDetector(PerformanceDetector):
 
     __slots__ = ("spans_involved", "stored_problems")
 
-    IGNORED_EXTENSIONS = {".nib", ".plist", ".strings"}
     type: DetectorType = DetectorType.FILE_IO_MAIN_THREAD
     settings_key = DetectorType.FILE_IO_MAIN_THREAD
 
@@ -854,9 +852,6 @@ class FileIOMainThreadDetector(PerformanceDetector):
     def _is_file_io_on_main_thread(self, span: Span) -> bool:
         data = span.get("data", {})
         if data is None:
-            return False
-        _, fileext = os.path.splitext(data.get("file.path", ""))
-        if fileext in self.IGNORED_EXTENSIONS:
             return False
         # doing is True since the value can be any type
         return data.get("blocked_main_thread", False) is True

--- a/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/utils/performance_issues/test_file_io_on_main_thread_detector.py
@@ -71,12 +71,6 @@ class NPlusOneAPICallsDetectorTest(TestCase):
 
         assert self.find_problems(event) == []
 
-    def test_ignores_nib_files(self):
-        event = get_event("file-io-on-main-thread")
-        event["spans"][0]["data"]["file.path"] = "something/stuff.txt/blah/yup/ios.nib"
-
-        assert self.find_problems(event) == []
-
     def test_gives_problem_correct_title(self):
         event = get_event("file-io-on-main-thread")
         event["spans"][0]["data"]["blocked_main_thread"] = True


### PR DESCRIPTION
This reverts commit 74193e750e72226e1a55169c686cf15ae005f567.

- Reverting, based on additional feedback from mobile developers that the 16ms threshold is enough

slack: https://sentry.slack.com/archives/C04CYM5SQ67/p1676993763906789?thread_ts=1676552245.603249&cid=C04CYM5SQ67