### PR TITLE
feat(heartbeart): Add signals to sessionStorage - [TET-693]

### DIFF
--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -4,7 +4,7 @@ import sessionStorageWrapper from 'sentry/utils/sessionStorage';
 
 const isBrowser = typeof window !== 'undefined';
 
-function readStorageValue<T>(key, initialValue: T) {
+function readStorageValue<T>(key: string, initialValue: T) {
   const value = sessionStorage.getItem(key);
 
   // We check for 'undefined' because the value may have
@@ -23,13 +23,11 @@ function readStorageValue<T>(key, initialValue: T) {
   }
 }
 
-function useSessionStorage<T>(
+export function useSessionStorage<T>(
   key: string,
-  initialValue?: T
-): [T | undefined, (value: T | undefined) => void, () => void] {
-  const [state, setState] = useState<T | undefined>(() =>
-    readStorageValue(key, initialValue)
-  );
+  initialValue: T
+): [T, (value: T) => void, () => void] {
+  const [state, setState] = useState<T>(() => readStorageValue(key, initialValue));
 
   useEffect(() => {
     setState(readStorageValue(key, initialValue));
@@ -38,7 +36,7 @@ function useSessionStorage<T>(
   }, [key]);
 
   const wrappedSetState = useCallback(
-    (value: T | undefined) => {
+    (value: T) => {
       setState(value);
 
       try {
@@ -51,9 +49,9 @@ function useSessionStorage<T>(
   );
 
   const removeItem = useCallback(() => {
-    setState(undefined);
+    setState(initialValue);
     sessionStorageWrapper.removeItem(key);
-  }, [key]);
+  }, [key, initialValue]);
 
   if (!isBrowser) {
     return [initialValue, () => {}, () => {}];
@@ -61,5 +59,3 @@ function useSessionStorage<T>(
 
   return [state, wrappedSetState, removeItem];
 }
-
-export default useSessionStorage;

--- a/static/app/views/onboarding/components/heartbeatFooter/useHeartbeat.tsx
+++ b/static/app/views/onboarding/components/heartbeatFooter/useHeartbeat.tsx
@@ -67,19 +67,23 @@ export function useHeartbeat(
   // *not* include sample events, while just looking at the issues list will.
   // We will wait until the project.firstEvent is set and then locate the
   // event given that event datetime
-  useQuery<Group[]>([`/projects/${organization.slug}/${projectSlug}/issues/`], {
-    staleTime: 0,
-    enabled: !!firstError && !firstIssue, // Only fetch if an error event is received and we have not yet located the first issue,
-    onSuccess: data => {
-      setFirstIssue(data.find((issue: Group) => issue.firstSeen === firstError));
-    },
-  });
+  const {isLoading: issuesLoading} = useQuery<Group[]>(
+    [`/projects/${organization.slug}/${projectSlug}/issues/`],
+    {
+      staleTime: 0,
+      enabled: !!firstError && !firstIssue, // Only fetch if an error event is received and we have not yet located the first issue,
+      onSuccess: data => {
+        setFirstIssue(data.find((issue: Group) => issue.firstSeen === firstError));
+      },
+    }
+  );
 
   const firstErrorReceived = firstIssue ?? !!firstError;
   const loading = eventIsLoading || sessionIsLoading;
 
   return {
     loading,
+    issuesLoading,
     serverConnected,
     firstErrorReceived,
     firstTransactionReceived,


### PR DESCRIPTION
## Problem

In the heartbeat solution, we display toasters when Sentry detects an "SDK connection" and when Sentry received a "First Error". The issue is that always when a page is freshly loaded, all requests are again fired to grab the data again and if a user has already gone through everything and the project is completely configured, the toaster is regardless displayed again. This behaviour is annoying.

## Solution

We are now making use of `sessionStorage`, so as soon as Sentry detects for the very first time an "SDK connection" and a "First error", this information is saved in the session of the tab. As a result, toasters won't be again displayed if the user refreshed the page or go back to the same page after navigating elsewhere. The only downside is that this only lasts until the tab is closed, but I don't think that users would open different tabs for the same page at the same time.


