### PR TITLE
fix(perf-issues): consecutive db not checking starts with in query

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -181,7 +181,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         op: str = span.get("op", "") or ""
         description: str = span.get("description", "") or ""
         is_db_op = op == "db" or op.startswith("db.sql")
-        is_query = "SELECT" in description.upper()  # TODO - make this more elegant
+        is_query = description.upper().startswith("SELECT")
         return is_db_op and is_query
 
     def _fingerprint(self) -> str:

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -181,7 +181,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         op: str = span.get("op", "") or ""
         description: str = span.get("description", "") or ""
         is_db_op = op == "db" or op.startswith("db.sql")
-        is_query = description.upper().startswith("SELECT")
+        is_query = description.strip().upper().startswith("SELECT")
         return is_db_op and is_query
 
     def _fingerprint(self) -> str:


### PR DESCRIPTION
I've actually never ran into this, but this was pointed out, that we could have a SELECT nested within another query.
Say a SELECT within a delete.

We only want to consider SELECT queries.