### PR TITLE
feat(perf): Set default stats period to 7d

### DIFF
--- a/static/app/views/performance/data.spec.jsx
+++ b/static/app/views/performance/data.spec.jsx
@@ -2,7 +2,10 @@ import {
   MEPState,
   METRIC_SEARCH_SETTING_PARAM,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import {generatePerformanceEventView} from 'sentry/views/performance/data';
+import {
+  DEFAULT_STATS_PERIOD,
+  generatePerformanceEventView,
+} from 'sentry/views/performance/data';
 
 describe('generatePerformanceEventView()', function () {
   it('generates default values', function () {
@@ -16,7 +19,7 @@ describe('generatePerformanceEventView()', function () {
     expect(result.query).toEqual('');
     expect(result.getQueryWithAdditionalConditions()).toEqual('event.type:transaction');
     expect(result.sorts).toEqual([{kind: 'desc', field: 'tpm'}]);
-    expect(result.statsPeriod).toEqual('24h');
+    expect(result.statsPeriod).toEqual(DEFAULT_STATS_PERIOD);
   });
 
   it('applies sort from location', function () {
@@ -27,7 +30,7 @@ describe('generatePerformanceEventView()', function () {
     });
 
     expect(result.sorts).toEqual([{kind: 'desc', field: 'p50'}]);
-    expect(result.statsPeriod).toEqual('24h');
+    expect(result.statsPeriod).toEqual(DEFAULT_STATS_PERIOD);
   });
 
   it('does not override statsPeriod from location', function () {

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -18,7 +18,7 @@ import {
   vitalNameFromLocation,
 } from './vitalDetail/utils';
 
-export const DEFAULT_STATS_PERIOD = '24h';
+export const DEFAULT_STATS_PERIOD = '7d';
 export const DEFAULT_PROJECT_THRESHOLD_METRIC = 'duration';
 export const DEFAULT_PROJECT_THRESHOLD = 300;
 

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -241,12 +241,12 @@ describe('Performance > Landing > Index', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           environment: [],
-          interval: '15m',
+          interval: '1h',
           partial: '1',
           project: [],
           query: 'event.type:transaction',
           referrer: 'api.performance.generic-widget-chart.user-misery-area',
-          statsPeriod: '48h',
+          statsPeriod: '14d',
           yAxis: ['user_misery()', 'tpm()', 'failure_rate()'],
         }),
       })

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -8,6 +8,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {WebVital} from 'sentry/utils/fields';
 import {Browser} from 'sentry/utils/performance/vitals/constants';
+import {DEFAULT_STATS_PERIOD} from 'sentry/views/performance/data';
 import VitalDetail from 'sentry/views/performance/vitalDetail';
 import {vitalSupportedBrowsers} from 'sentry/views/performance/vitalDetail/utils';
 
@@ -305,7 +306,7 @@ describe('Performance > VitalDetail', function () {
         transaction: 'something',
         project: undefined,
         environment: [],
-        statsPeriod: '24h',
+        statsPeriod: DEFAULT_STATS_PERIOD,
         start: undefined,
         end: undefined,
         query: 'sometag:value has:measurements.lcp',
@@ -357,7 +358,7 @@ describe('Performance > VitalDetail', function () {
         transaction: 'something',
         project: undefined,
         environment: [],
-        statsPeriod: '24h',
+        statsPeriod: DEFAULT_STATS_PERIOD,
         start: undefined,
         end: undefined,
         query: 'anothertag:value has:measurements.cls',


### PR DESCRIPTION
Work on PERF-1833
First PR to get the feature flag to control `14 days` with the flag that previously controlled `7 days`
There will be 3 steps to this.

1. Merge change to set default stats period to `7 days` (this PR)
2. Set flag that controlled 7 days to 0% in flagr
3. Merge change to set the flag controlled stats period to `14 days` (#44895)
4. Use flagr to rollout.