### PR TITLE
fix: Put project transfer links back on root domain

### DIFF
--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -13,6 +13,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
 from sentry.models import OrganizationMember
 from sentry.utils.email import MessageBuilder
+from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
 
 delete_logger = logging.getLogger("sentry.deletions.api")
@@ -79,9 +80,7 @@ class ProjectTransferEndpoint(ProjectEndpoint):
             "from_org": project.organization.name,
             "project_name": project.slug,
             "request_time": timezone.now(),
-            "url": organization.absolute_url(
-                "/accept-transfer/", query=urlencode({"data": url_data})
-            ),
+            "url": absolute_uri(f"/accept-transfer/?{urlencode({'data': url_data})}"),
             "requester": request.user,
         }
         MessageBuilder(

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -41,7 +41,7 @@ class ProjectTransferTest(APITestCase):
 
             assert response.status_code == 204
             assert len(mail.outbox) == 1
-            assert organization.absolute_url("/accept-transfer/?") in mail.outbox[0].body
+            assert "http://testserver/accept-transfer/?" in mail.outbox[0].body
 
     def test_transfer_project_owner_from_team(self):
         project = self.create_project()


### PR DESCRIPTION
We can't use customer-domains for project transfers as the receiver may not be in the receiving org, and the reciever may have multiple organizations so we can't pre-select one either.

Longer term this will need to become a region based URL but we don't have those in use yet.

Fixes #44823