### PR TITLE
feat(replays): Set the default date range for replay index to 7d

### DIFF
--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -5,6 +6,7 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
+import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {space} from 'sentry/styles/space';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -16,6 +18,18 @@ function ReplaysFilters() {
   const {selection} = usePageFilters();
   const {pathname, query} = useLocation();
   const organization = useOrganization();
+
+  useEffect(() => {
+    if (query[URL_PARAM.PERIOD] === undefined) {
+      browserHistory.replace({
+        pathname,
+        query: {
+          ...query,
+          [URL_PARAM.PERIOD]: '24h',
+        },
+      });
+    }
+  }, [pathname, query]);
 
   return (
     <FilterContainer>

--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -25,7 +25,7 @@ function ReplaysFilters() {
         pathname,
         query: {
           ...query,
-          [URL_PARAM.PERIOD]: '24h',
+          [URL_PARAM.PERIOD]: '7d',
         },
       });
     }


### PR DESCRIPTION
Lowering the default date range for the replays index page

Two reasons:
1) it's a really slow query when the org has lots of replays, because we fetch everything from the db before we paginate it. backend team knows about this
2) No one really pages through the data anyway, so we don't need to have a huge list of 90d or 14d or anything. Whatever's the most recent is what they'll see.