### PR TITLE
chore(heroku): Remove legacy code

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -43,13 +43,17 @@ class HerokuReleaseHook(ReleaseHook):
 
         return hmac.compare_digest(heroku_hmac, computed_hmac)
 
-    def handle_legacy(self, request: Request) -> Response:
-        """Code path to handle deploy hooks. Delete after Feb 17th 2023 - https://blog.heroku.com/deployhooks-sunset"""
-        email = None
-        if "user" in request.POST:
-            email = request.POST["user"]
-        elif "actor" in request.POST:
-            email = request.POST["actor"].get("email")
+    def handle(self, request: Request) -> Response:
+        heroku_hmac = request.headers.get("Heroku-Webhook-Hmac-SHA256")
+
+        if not self.is_valid_signature(request.body.decode("utf-8"), heroku_hmac):
+            logger.info("heroku.webhook.invalid-signature", extra={"project_id": self.project.id})
+            return HttpResponse(status=401)
+
+        body = json.loads(request.body)
+        data = body.get("data")
+        email = data.get("user", {}).get("email") or data.get("actor", {}).get("email")
+
         try:
             user = User.objects.get(
                 email__iexact=email, sentry_orgmember_set__organization__project=self.project
@@ -64,53 +68,16 @@ class HerokuReleaseHook(ReleaseHook):
                     "email": email,
                 },
             )
-        self.finish_release(
-            version=request.POST.get("head_long"),
-            url=request.POST.get("url"),
-            owner_id=user.id if user else None,
-        )
-
-    def handle(self, request: Request) -> Response:
-        heroku_hmac = request.headers.get("Heroku-Webhook-Hmac-SHA256")
-
-        if heroku_hmac:
-            if not self.is_valid_signature(request.body.decode("utf-8"), heroku_hmac):
-                logger.info(
-                    "heroku.webhook.invalid-signature", extra={"project_id": self.project.id}
-                )
-                return HttpResponse(status=401)
-
-            body = json.loads(request.body)
-            data = body.get("data")
-            email = data.get("user", {}).get("email") or data.get("actor", {}).get("email")
-
-            try:
-                user = User.objects.get(
-                    email__iexact=email, sentry_orgmember_set__organization__project=self.project
-                )
-            except (User.DoesNotExist, User.MultipleObjectsReturned):
-                user = None
-                logger.info(
-                    "owner.missing",
-                    extra={
-                        "organization_id": self.project.organization_id,
-                        "project_id": self.project.id,
-                        "email": email,
-                    },
-                )
-            commit = data.get("slug", {}).get("commit")
-            app_name = data.get("app", {}).get("name")
-            if app_name:
-                self.finish_release(
-                    version=commit,
-                    url=f"http://{app_name}.herokuapp.com",
-                    owner_id=user.id if user else None,
-                )
-            else:
-                self.finish_release(version=commit, owner_id=user.id if user else None)
-
+        commit = data.get("slug", {}).get("commit")
+        app_name = data.get("app", {}).get("name")
+        if app_name:
+            self.finish_release(
+                version=commit,
+                url=f"http://{app_name}.herokuapp.com",
+                owner_id=user.id if user else None,
+            )
         else:
-            self.handle_legacy(request)  # TODO delete this else after Feb 17th 2023
+            self.finish_release(version=commit, owner_id=user.id if user else None)
 
     def set_refs(self, release, **values):
         if not values.get("owner_id", None):


### PR DESCRIPTION
Remove the code path in the Heroku plugin that uses the now deprecated deploy hooks. https://blog.heroku.com/deployhooks-sunset