### PR TITLE
fix(perf-issues): (M)N+1 DB span evidence should include all db* spans

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -91,7 +91,7 @@ describe('SpanEvidenceKeyValueList', () => {
     parentSpan.addChild({
       startTimestamp: 2.1,
       endTimestamp: 4.0,
-      op: 'db',
+      op: 'db.sql.active_record',
       description: 'SELECT * FROM books WHERE id = %s',
       problemSpan: ProblemSpan.OFFENDER,
     });
@@ -116,7 +116,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.repeating-spans-2')
       ).toHaveTextContent('db - SELECT * FROM books');
       expect(screen.getByTestId('span-evidence-key-value-list.')).toHaveTextContent(
-        'db - SELECT * FROM books WHERE id = %s'
+        'db.sql.active_record - SELECT * FROM books WHERE id = %s'
       );
 
       expect(screen.queryByRole('cell', {name: 'Parameter'})).not.toBeInTheDocument();

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -95,7 +95,7 @@ const NPlusOneDBQueriesSpanEvidence = ({
   parentSpan,
   offendingSpans,
 }: SpanEvidenceKeyValueListProps) => {
-  const dbSpans = offendingSpans.filter(span => span.op === 'db');
+  const dbSpans = offendingSpans.filter(span => (span.op || '').startsWith('db'));
   const repeatingSpanRows = dbSpans
     .filter(span => offendingSpans.find(s => s.description === span.description) === span)
     .map((span, i) =>


### PR DESCRIPTION
Previously we were only considering `db` spans, but any offending spans that starts with `db` should be considered.
