### PR TITLE
fix(ui): Remove set z-indexes for bar chart series

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -2,7 +2,12 @@ import {Component, Fragment} from 'react';
 import {Theme, withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import Color from 'color';
-import type {LegendComponentOption, SeriesOption, TooltipComponentOption} from 'echarts';
+import type {
+  BarSeriesOption,
+  LegendComponentOption,
+  SeriesOption,
+  TooltipComponentOption,
+} from 'echarts';
 
 import BaseChart from 'sentry/components/charts/baseChart';
 import Legend from 'sentry/components/charts/components/legend';
@@ -172,10 +177,10 @@ type State = {
 };
 
 export type ChartStats = {
-  accepted: NonNullable<SeriesOption['data']>;
-  dropped: NonNullable<SeriesOption['data']>;
-  projected: NonNullable<SeriesOption['data']>;
-  filtered?: NonNullable<SeriesOption['data']>;
+  accepted: NonNullable<BarSeriesOption['data']>;
+  dropped: NonNullable<BarSeriesOption['data']>;
+  projected: NonNullable<BarSeriesOption['data']>;
+  filtered?: NonNullable<BarSeriesOption['data']>;
 };
 
 export class UsageChart extends Component<UsageChartProps, State> {
@@ -333,34 +338,30 @@ export class UsageChart extends Component<UsageChartProps, State> {
     let series: SeriesOption[] = [
       barSeries({
         name: SeriesTypes.ACCEPTED,
-        data: chartData.accepted as any, // TODO(ts)
+        data: chartData.accepted,
         barMinHeight: 1,
         stack: 'usage',
         legendHoverLink: false,
-        zlevel: 10,
       }),
       barSeries({
         name: SeriesTypes.FILTERED,
-        data: chartData.filtered as any, // TODO(ts)
+        data: chartData.filtered,
         barMinHeight: 1,
         stack: 'usage',
         legendHoverLink: false,
-        zlevel: 10,
       }),
       barSeries({
         name: SeriesTypes.DROPPED,
-        data: chartData.dropped as any, // TODO(ts)
+        data: chartData.dropped,
         stack: 'usage',
         legendHoverLink: false,
-        zlevel: 10,
       }),
       barSeries({
         name: SeriesTypes.PROJECTED,
-        data: chartData.projected as any, // TODO(ts)
+        data: chartData.projected,
         barMinHeight: 1,
         stack: 'usage',
         legendHoverLink: false,
-        zlevel: 10,
       }),
     ];
 
@@ -381,19 +382,19 @@ export class UsageChart extends Component<UsageChartProps, State> {
       },
     ];
 
-    if (chartData.filtered && (chartData.filtered as any[]).length > 0) {
+    if (chartData.filtered && chartData.filtered.length > 0) {
       legend.push({
         name: SeriesTypes.FILTERED,
       });
     }
 
-    if ((chartData.dropped as any[]).length > 0) {
+    if (chartData.dropped.length > 0) {
       legend.push({
         name: SeriesTypes.DROPPED,
       });
     }
 
-    if ((chartData.projected as any[]).length > 0) {
+    if (chartData.projected.length > 0) {
       legend.push({
         name: SeriesTypes.PROJECTED,
       });


### PR DESCRIPTION
This PR removes the set z-indexes for the usage chart bar series. I initially did this while working on the spike protection chart, but it turns out it wasn't necessary. Additionally, since markLine components seem to ignore the zLevel setting, the reserved usage chart was having issues.

### spike protection chart

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/35509934/220442075-e1baab1f-2d40-447e-ae63-d84d9f82ce94.png">

### super mocked fake data reserved usage screenshot

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/35509934/220442510-635e1a7b-d6d2-4712-bb1f-20a2b8e4e8ac.png">

