### PR TITLE
fix(issue-platform): Fix organization event details endpoint to return occurrence

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -6,6 +8,8 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
 from sentry.models.project import Project, ProjectStatus
+
+logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint
@@ -35,7 +39,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
 
-        data = serialize(event)
+        data = serialize(event.for_group(event.group))
         data["projectSlug"] = project_slug
 
         return Response(data)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -39,7 +39,10 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
 
-        data = serialize(event.for_group(event.group))
+        if event.group:
+            event = event.for_group(event.group)
+
+        data = serialize(event)
         data["projectSlug"] = project_slug
 
         return Response(data)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -1,5 +1,3 @@
-import logging
-
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,8 +6,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
 from sentry.models.project import Project, ProjectStatus
-
-logger = logging.getLogger(__name__)
 
 
 @region_silo_endpoint

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -738,7 +738,7 @@ class GroupEvent(BaseEvent):
         return group_event
 
     @property
-    def occurrence(self) -> IssueOccurrence:
+    def occurrence(self) -> Optional[IssueOccurrence]:
         if not self._occurrence and self.occurrence_id:
             self._occurrence = IssueOccurrence.fetch(self.occurrence_id, self.project_id)
             if self._occurrence is None:

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import logging
 import string
 from copy import deepcopy
 from datetime import datetime
@@ -27,6 +28,8 @@ from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyView
 from sentry.utils.safe import get_path, trim
 from sentry.utils.strings import truncatechars
+
+logger = logging.getLogger(__name__)
 
 # Keys in the event payload we do not want to send to the event stream / snuba.
 EVENTSTREAM_PRUNED_KEYS = ("debug_meta", "_meta")
@@ -736,6 +739,14 @@ class GroupEvent(BaseEvent):
 
     @property
     def occurrence(self) -> IssueOccurrence:
+        if not self._occurrence and self.occurrence_id:
+            self._occurrence = IssueOccurrence.fetch(self.occurrence_id, self.project_id)
+            if self._occurrence is None:
+                logger.error(
+                    "Failed to fetch occurrence for event",
+                    extra={"group_id": self.group_id, "occurrence_id": self.occurrence_id},
+                )
+
         return self._occurrence
 
     @occurrence.setter

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -755,7 +755,7 @@ class GroupEvent(BaseEvent):
 
     @property
     def occurrence_id(self) -> Optional[str]:
-        if self.occurrence:
+        if self._occurrence:
             return self.occurrence.id
 
         column = self._get_column_name(Columns.OCCURRENCE_ID)

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -251,6 +251,8 @@ class SnubaEventStorage(EventStorage):
                 return None
 
             event.group_id = result["data"][0]["group_id"]
+            # Inject the snuba data here to make sure any snuba columns are available
+            event._snuba_data = result["data"][0]
 
         return event
 

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -220,7 +220,7 @@ class SnubaEventStorage(EventStorage):
             try:
                 result = snuba.raw_query(
                     dataset=dataset,
-                    selected_columns=["group_id"],
+                    selected_columns=self.__get_columns(dataset),
                     start=event.datetime,
                     end=event.datetime + timedelta(seconds=1),
                     filter_keys={"project_id": [project_id], "event_id": [event_id]},

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -32,7 +32,6 @@ from sentry.db.models import (
 )
 from sentry.eventstore.models import GroupEvent
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_type_by_type_id
-from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.query import apply_performance_conditions
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.snuba.dataset import Dataset
@@ -217,16 +216,7 @@ def get_oldest_or_latest_event_for_environments(
     )
 
     if events:
-        group_event = events[0].for_group(group)
-        occurrence_id = group_event.occurrence_id
-        if occurrence_id:
-            group_event.occurrence = IssueOccurrence.fetch(occurrence_id, group.project_id)
-            if group_event.occurrence is None:
-                logger.error(
-                    "Failed to fetch occurrence for event",
-                    extra={"group_id": group.id, "occurrence_id": occurrence_id},
-                )
-        return group_event
+        return events[0].for_group(group)
 
     return None
 

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -1,4 +1,5 @@
 import pickle
+from unittest import mock
 
 import pytest
 
@@ -6,12 +7,15 @@ from sentry import eventstore, nodestore
 from sentry.db.models.fields.node import NodeData, NodeIntegrityFailure
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.grouping.enhancer import Enhancements
+from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models import Environment
 from sentry.snuba.dataset import Dataset
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import snuba
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test
@@ -553,6 +557,39 @@ class GroupEventFromEventTest(TestCase):
         # Make sure we don't make additional queries when accessing project here
         with self.assertNumQueries(0):
             group_event.project
+
+
+@region_silo_test
+class GroupEventOccurrenceTest(TestCase, OccurrenceTestMixin):
+    def test(self):
+        occurrence_data = self.build_occurrence_data(project_id=self.project.id)
+        occurrence, group_info = process_event_and_issue_occurrence(
+            occurrence_data,
+            event_data={
+                "event_id": occurrence_data["event_id"],
+                "project_id": occurrence_data["project_id"],
+                "level": "info",
+            },
+        )
+
+        event = Event(
+            occurrence_data["project_id"],
+            occurrence_data["event_id"],
+            group_info.group.id,
+            data={},
+            snuba_data={"occurrence_id": occurrence.id},
+        )
+        with mock.patch.object(IssueOccurrence, "fetch", wraps=IssueOccurrence.fetch) as fetch_mock:
+            group_event = event.for_group(event.group)
+            assert group_event.occurrence == occurrence
+            assert fetch_mock.call_count == 1
+            # Access the property again, call count shouldn't increase since we're cached
+            group_event.occurrence
+            assert fetch_mock.call_count == 1
+            # Call count should increase if we do it a second time
+            group_event.occurrence = None
+            assert group_event.occurrence == occurrence
+            assert fetch_mock.call_count == 2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This goes through a slightly different path than our oldest/latest event endpoints, and so the occurrence isn't returned. Moved fetching of the occurrence to inside `GroupEvent` so that we'll always have the occurrence available when we have a `GroupEvent`.
