### PR TITLE
fix(view-hierarchy): Clicking on the right of overflown row labels not selecting

### DIFF
--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -93,8 +93,8 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
     const key = `view-hierarchy-node-${r.key}`;
 
     if (selectedNodeIndex === r.key && selectedNode !== r.item.node) {
-      // Workaround because rows don't take up the whole width of the scroll container.
-      // The onClick handler won't fire
+      // Workaround because rows don't take up the whole width of the scroll container
+      // so the onClick handler won't fire
       setSelectedNode(r.item.node);
       r.ref?.focus({preventScroll: true});
       setUserHasSelected(true);

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -93,7 +93,11 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
     const key = `view-hierarchy-node-${r.key}`;
 
     if (selectedNodeIndex === r.key && selectedNode !== r.item.node) {
+      // Workaround because rows don't take up the whole width of the scroll container.
+      // The onClick handler won't fire
       setSelectedNode(r.item.node);
+      r.ref?.focus({preventScroll: true});
+      setUserHasSelected(true);
     }
 
     return (
@@ -108,7 +112,6 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
         onKeyDown={handleRowKeyDown}
         onClick={e => {
           handleRowClick(e);
-          setUserHasSelected(true);
         }}
       >
         {r.item.depth !== 0 && <DepthMarker depth={r.item.depth} />}

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -91,6 +91,11 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
     }
   ) => {
     const key = `view-hierarchy-node-${r.key}`;
+
+    if (selectedNodeIndex === r.key && selectedNode !== r.item.node) {
+      setSelectedNode(r.item.node);
+    }
+
     return (
       <TreeItem
         key={key}
@@ -101,12 +106,8 @@ function ViewHierarchy({viewHierarchy, project}: ViewHierarchyProps) {
         tabIndex={selectedNodeIndex === r.key ? 0 : 1}
         onMouseEnter={handleRowMouseEnter}
         onKeyDown={handleRowKeyDown}
-        onFocus={() => {
-          setSelectedNode(r.item.node);
-        }}
         onClick={e => {
           handleRowClick(e);
-          setSelectedNode(r.item.node);
           setUserHasSelected(true);
         }}
       >

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -268,6 +268,12 @@ export function useVirtualizedTree<T extends TreeLike>(
       const element = latestItemsRef.current.find(item => item.key === index);
       if (element?.ref) {
         element.ref.dataset.hovered = 'true';
+        markRowAsHovered(index, latestItemsRef.current, {
+          ghostRowRef: hoveredGhostRowRef.current,
+          rowHeight: props.rowHeight,
+          scrollTop: latestStateRef.current.scrollTop,
+          theme,
+        });
       }
     };
 


### PR DESCRIPTION
The rows don't extend the full width if they require scrolling to the right. This means the onClick handler doesn't trigger when clicking in the whitespace after the row labels end for elements that need to be scrolled horizontally into view. The hook still calculates a click in the whitespace as a selection so we can hook into this for a workaround to set the selected node when we detect a change.

Also updates the hook to mark rows as hovered when the mouse moves. There was a case in profiling where hovers weren't being picked up. I figured if we were setting the `data-hovered` attribute, we'd likewise want to style the ghost row.

e.g. in prod:

https://user-images.githubusercontent.com/22846452/220445396-08ee2ee7-2891-4af8-b5a6-d3ad7bcb78c0.mov

after:

https://user-images.githubusercontent.com/22846452/220445438-f88e0867-408e-42c7-8069-57933e9ea2e5.mov

This is the effect in view hierarchies:


https://user-images.githubusercontent.com/22846452/220446428-ef7799d3-165f-48a4-ae08-abbee7c475cb.mov

Closes #44754 