### PR TITLE
ref(grouptype): Handle invalid issue.type search better

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -54,7 +54,7 @@ def get_group_types_by_category(category: int) -> Set[int]:
 
 def get_group_type_by_slug(slug: str) -> Type[GroupType]:
     if slug not in _slug_lookup:
-        raise ValueError(f"No group type with the slug {slug} is registered.")
+        return None
     return _slug_lookup[slug]
 
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Set, Type
+from typing import Any, Dict, Optional, Set, Type
 
 
 class GroupCategory(Enum):
@@ -52,7 +52,7 @@ def get_group_types_by_category(category: int) -> Set[int]:
     return _category_lookup[category]
 
 
-def get_group_type_by_slug(slug: str) -> Type[GroupType]:
+def get_group_type_by_slug(slug: str) -> Optional[Type[GroupType]]:
     if slug not in _slug_lookup:
         return None
     return _slug_lookup[slug]

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -310,5 +310,5 @@ class ConvertTypeValueTest(TestCase):
         assert convert_type_value(
             ["error", "performance_n_plus_one_db_queries"], [self.project], self.user, None
         ) == [1, 1006]
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidSearchQuery):
             convert_type_value(["hellboy"], [self.project], self.user, None)

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -59,11 +59,7 @@ class GroupTypeTest(TestCase):  # type: ignore
 
             assert get_group_type_by_slug(TestGroupType.slug) == TestGroupType
 
-            nonexistent_slug = "meow"
-            with self.assertRaisesMessage(
-                ValueError, f"No group type with the slug {nonexistent_slug} is registered."
-            ):
-                get_group_type_by_slug(nonexistent_slug)
+            assert get_group_type_by_slug("meow") is None
 
     def test_category_validation(self) -> None:
         with patch.dict(_group_type_registry, {}, clear=True):

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -470,7 +470,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         )
         assert set(results) == {self.group1, self.group2, group_3, group_4}
 
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidSearchQuery):
             self.make_query(search_filter_query="issue.type:performance_i_dont_exist")
 
     def test_status_with_environment(self):


### PR DESCRIPTION
If a user searches for an invalid value using the search term `issue.type`, we currently show an "Internal Error" banner and it causes [this issue](https://sentry.sentry.io/issues/3930558254/). Handle this better so the user can see that it's an invalid search query. 

Fixes SENTRY-YYB and #44817 