### PR TITLE
ref(analytics): Add project platform

### DIFF
--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -12,6 +12,7 @@ class FirstEventSentEvent(analytics.Event):
         analytics.Attribute("platform", required=False),
         analytics.Attribute("url", required=False),
         analytics.Attribute("has_minified_stack_trace", required=False),
+        analytics.Attribute("project_platform", required=False),
     )
 
 
@@ -19,11 +20,9 @@ class FirstEventSentEvent(analytics.Event):
 class FirstEventSentEventForProject(FirstEventSentEvent):
     type = "first_event_for_project.sent"
 
-    attributes = FirstEventSentEvent.attributes + (analytics.Attribute("project_platform"),)
-
 
 # first error with minified stack trace for a project
-class FirstEventSentEventWithMinifiedStackTraceForProject(FirstEventSentEventForProject):
+class FirstEventSentEventWithMinifiedStackTraceForProject(FirstEventSentEvent):
     type = "first_event_with_minified_stack_trace_for_project.sent"
 
 

--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -19,9 +19,11 @@ class FirstEventSentEvent(analytics.Event):
 class FirstEventSentEventForProject(FirstEventSentEvent):
     type = "first_event_for_project.sent"
 
+    attributes = FirstEventSentEvent.attributes + (analytics.Attribute("project_platform"),)
+
 
 # first error with minified stack trace for a project
-class FirstEventSentEventWithMinifiedStackTraceForProject(FirstEventSentEvent):
+class FirstEventSentEventWithMinifiedStackTraceForProject(FirstEventSentEventForProject):
     type = "first_event_with_minified_stack_trace_for_project.sent"
 
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -177,6 +177,7 @@ def record_first_event(project, event, **kwargs):
             organization_id=project.organization_id,
             project_id=project.id,
             platform=event.platform,
+            project_platform=project.platform,
         )
         return
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -164,6 +164,7 @@ def record_first_event(project, event, **kwargs):
         organization_id=project.organization_id,
         project_id=project.id,
         platform=event.platform,
+        project_platform=project.platform,
         url=dict(event.tags).get("url", None),
         has_minified_stack_trace=has_event_minified_stack_trace(event),
     )
@@ -430,6 +431,7 @@ def record_event_with_first_minified_stack_trace_for_project(project, event, **k
                 organization_id=project.organization_id,
                 project_id=project.id,
                 platform=event.platform,
+                project_platform=project.platform,
                 url=dict(event.tags).get("url", None),
             )
 

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -520,7 +520,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         a first event with minified stack trace is received
         """
         now = timezone.now()
-        project = self.create_project(first_event=now)
+        project = self.create_project(first_event=now, platform="VueJS")
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
         event = load_data("javascript")
@@ -563,6 +563,7 @@ class OrganizationOnboardingTaskTest(TestCase):
             organization_id=project.organization_id,
             project_id=project.id,
             platform=event["platform"],
+            project_platform="VueJS",
             url=url,
         )
 


### PR DESCRIPTION
Add the project platform to analytic events for `first_event_for_project.sent` so we can know more specific data about what's being used. If we're recording "Javascript" for the `platform` attribute, this would record (for example) "VueJS" as the `project_platform` value. 

Closes #44908 