### PR TITLE
feat(hybrid-cloud): Add superUserUrl to the client config

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -257,9 +257,10 @@ def get_client_config(request=None):
                 org_context = organization_service.get_organization_by_id(
                     id=superuser.ORG_ID, user_id=None
                 )
-                context["links"]["superUserUrl"] = generate_organization_url(
-                    org_context.organization.slug
-                )
+                if org_context and org_context.organization:
+                    context["links"]["superUserUrl"] = generate_organization_url(
+                        org_context.organization.slug
+                    )
     else:
         context.update({"isAuthenticated": False, "user": None})
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -258,7 +258,7 @@ def get_client_config(request=None):
                     id=superuser.ORG_ID, user_id=None
                 )
                 if org_context and org_context.organization:
-                    context["links"]["superUserUrl"] = generate_organization_url(
+                    context["links"]["superuserUrl"] = generate_organization_url(
                         org_context.organization.slug
                     )
     else:

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -253,6 +253,13 @@ def get_client_config(request=None):
             # This is needed in the case where you access a different org and get denied, but the UI
             # can open the sudo dialog if you are an "inactive" superuser
             context["user"]["isSuperuser"] = request.user.is_superuser
+            if superuser.ORG_ID is not None:
+                org_context = organization_service.get_organization_by_id(
+                    id=superuser.ORG_ID, user_id=None
+                )
+                context["links"]["superUserUrl"] = generate_organization_url(
+                    org_context.organization.slug
+                )
     else:
         context.update({"isAuthenticated": False, "user": None})
 

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 from django.test import override_settings
@@ -9,6 +10,7 @@ from sentry.testutils import APITestCase
 from sentry.testutils.cases import AuthProviderTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import control_silo_test
+from sentry.utils.auth import SSO_EXPIRY_TIME, SsoSession
 
 
 @control_silo_test(stable=True)
@@ -190,6 +192,54 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                     )
                     assert response.status_code == 200
                     assert COOKIE_NAME in response.cookies
+
+    @with_feature("organizations:u2f-superuser-form")
+    @mock.patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
+    @mock.patch("sentry.auth.authenticators.U2fInterface.validate_response", return_value=False)
+    def test_superuser_expired_sso_user_no_password_saas_product(
+        self, validate_response, is_available
+    ):
+        from sentry.auth.superuser import COOKIE_NAME, Superuser
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            org_provider = AuthProvider.objects.create(
+                organization=self.organization, provider="dummy"
+            )
+
+            user = self.create_user("foo@example.com", is_superuser=True)
+
+            self.get_auth(user)
+
+            user.update(password="")
+
+            AuthIdentity.objects.create(user=user, auth_provider=org_provider)
+
+            with mock.patch.object(Superuser, "org_id", self.organization.id), override_settings(
+                SUPERUSER_ORG_ID=self.organization.id
+            ):
+                with self.settings(SENTRY_SELF_HOSTED=False):
+                    self.login_as(user, organization_id=self.organization.id)
+
+                    sso_session_expired = SsoSession(
+                        self.organization.id,
+                        datetime.now(tz=timezone.utc) - SSO_EXPIRY_TIME - timedelta(hours=1),
+                    )
+                    self.session[sso_session_expired.session_key] = sso_session_expired.to_dict()
+                    self.save_session()
+
+                    response = self.client.put(
+                        self.path,
+                        data={
+                            "isSuperuserModal": True,
+                            "challenge": """{"challenge":"challenge"}""",
+                            "response": """{"response":"response"}""",
+                            "superuserAccessCategory": "for_unit_test",
+                            "superuserReason": "for testing",
+                        },
+                    )
+                    # status code of 401 means invalid SSO session
+                    assert response.status_code == 401
+                    assert COOKIE_NAME not in response.cookies
 
     @with_feature("organizations:u2f-superuser-form")
     def test_superuser_sso_user_no_u2f_saas_product(self):

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -201,7 +201,7 @@ class ClientConfigViewTest(TestCase):
             "organizationUrl": None,
             "regionUrl": None,
             "sentryUrl": "http://testserver",
-            "superUserUrl": f"http://{self.organization.slug}.testserver",
+            "superuserUrl": f"http://{self.organization.slug}.testserver",
         }
         assert "activeorg" not in self.client.session
 

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -182,18 +182,11 @@ class ClientConfigViewTest(TestCase):
         assert data["customerDomain"] is None
 
     def test_superuser(self):
-        # Cannot set the superuser org id using override_settings().
-        # So we set them and restore them manually.
-        old_superuser_org_id = superuser.ORG_ID
-        superuser.ORG_ID = self.organization.id
-
         user = self.create_user("foo@example.com", is_superuser=True)
         self.login_as(user, superuser=True)
 
-        resp = self.client.get(self.path)
-
-        # Restore values
-        superuser.ORG_ID = old_superuser_org_id
+        with mock.patch("sentry.auth.superuser.ORG_ID", self.organization.id):
+            resp = self.client.get(self.path)
 
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"


### PR DESCRIPTION
This pull request adds the `superUserUrl` attribute to the client config. This attribute will only exist if and only if the current authenticated user is a _superuser_.

If a superuser needs to be re-authenticated, then we redirect them to `superUserUrl`.

I've also added a test case for the case when the SSO session has expired.