### PR TITLE
fix(hybrid-cloud): Update re-authentication logic for superuser/sudo modal forms

### DIFF
--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -176,9 +176,9 @@ class SudoModal extends Component<Props, State> {
       // ignore errors
     }
     const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
-    const {superUserUrl} = window.__initialData.links;
-    if (window.__initialData?.customerDomain && superUserUrl) {
-      const redirectURL = `${trimEnd(superUserUrl, '/')}${authLoginPath}`;
+    const {superuserUrl} = window.__initialData.links;
+    if (window.__initialData?.customerDomain && superuserUrl) {
+      const redirectURL = `${trimEnd(superuserUrl, '/')}${authLoginPath}`;
       window.location.assign(redirectURL);
       return;
     }

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -1,6 +1,7 @@
 import {Component, Fragment} from 'react';
 import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
+import trimEnd from 'lodash/trimEnd';
 
 import {logout} from 'sentry/actionCreators/account';
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -174,7 +175,14 @@ class SudoModal extends Component<Props, State> {
     } catch {
       // ignore errors
     }
-    window.location.assign(`/auth/login/?next=${encodeURIComponent(location.pathname)}`);
+    const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
+    const {superUserUrl} = window.__initialData.links;
+    if (window.__initialData?.customerDomain && superUserUrl) {
+      const redirectURL = `${trimEnd(superUserUrl, '/')}${authLoginPath}`;
+      window.location.assign(redirectURL);
+      return;
+    }
+    window.location.assign(authLoginPath);
   };
 
   async getAuthenticators() {

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -134,9 +134,9 @@ class SuperuserAccessForm extends Component<Props, State> {
       // ignore errors
     }
     const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
-    const {superUserUrl} = window.__initialData.links;
-    if (window.__initialData?.customerDomain && superUserUrl) {
-      const redirectURL = `${trimEnd(superUserUrl, '/')}${authLoginPath}`;
+    const {superuserUrl} = window.__initialData.links;
+    if (window.__initialData?.customerDomain && superuserUrl) {
+      const redirectURL = `${trimEnd(superuserUrl, '/')}${authLoginPath}`;
       window.location.assign(redirectURL);
       return;
     }

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -1,5 +1,6 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
+import trimEnd from 'lodash/trimEnd';
 
 import {logout} from 'sentry/actionCreators/account';
 import {Client} from 'sentry/api';
@@ -132,7 +133,14 @@ class SuperuserAccessForm extends Component<Props, State> {
     } catch {
       // ignore errors
     }
-    window.location.assign('/auth/login/');
+    const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
+    const {superUserUrl} = window.__initialData.links;
+    if (window.__initialData?.customerDomain && superUserUrl) {
+      const redirectURL = `${trimEnd(superUserUrl, '/')}${authLoginPath}`;
+      window.location.assign(redirectURL);
+      return;
+    }
+    window.location.assign(authLoginPath);
   };
 
   async getAuthenticators() {

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -142,6 +142,7 @@ export interface Config {
     organizationUrl: string | undefined;
     regionUrl: string | undefined;
     sentryUrl: string;
+    superUserUrl?: string;
   };
   /**
    * This comes from django (django.contrib.messages)

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -142,7 +142,7 @@ export interface Config {
     organizationUrl: string | undefined;
     regionUrl: string | undefined;
     sentryUrl: string;
-    superUserUrl?: string;
+    superuserUrl?: string;
   };
   /**
    * This comes from django (django.contrib.messages)


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/44915.

This pull request:

- Adds `superUserUrl` typescript type. This attribute will only exist if and only if the current authenticated user is a _superuser_.
- Updates the re-authentication logic for superuser/sudo modal forms such that `superUserUrl` is consumed in the customer domain world. In addition, we properly add `?next=...` to redirect users back to the original URL that they originated from when the superuser/sudo modal appeared.