### PR TITLE
chore(suspect commits): Correctly pluralize suspect commits title

### DIFF
--- a/static/app/components/events/eventCause.spec.jsx
+++ b/static/app/components/events/eventCause.spec.jsx
@@ -12,6 +12,42 @@ describe('EventCause', function () {
   const event = TestStubs.Event();
   const group = TestStubs.Group({firstRelease: {}});
 
+  const committers = [
+    {
+      author: {name: 'Max Bittker', id: '1'},
+      commits: [
+        {
+          message:
+            'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
+          score: 4,
+          id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+          repository: TestStubs.Repository(),
+          dateCreated: '2018-03-02T18:30:26Z',
+        },
+        {
+          message:
+            'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
+          score: 4,
+          id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+          repository: TestStubs.Repository(),
+          dateCreated: '2018-03-02T18:30:26Z',
+        },
+      ],
+    },
+    {
+      author: {name: 'Somebody else', id: '2'},
+      commits: [
+        {
+          message: 'fix: Make things less broken',
+          score: 2,
+          id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
+          repository: TestStubs.Repository(),
+          dateCreated: '2018-03-02T16:30:26Z',
+        },
+      ],
+    },
+  ];
+
   afterEach(function () {
     Client.clearMockResponses();
   });
@@ -21,41 +57,7 @@ describe('EventCause', function () {
       method: 'GET',
       url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
       body: {
-        committers: [
-          {
-            author: {name: 'Max Bittker', id: '1'},
-            commits: [
-              {
-                message:
-                  'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
-                score: 4,
-                id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-                repository: TestStubs.Repository(),
-                dateCreated: '2018-03-02T18:30:26Z',
-              },
-              {
-                message:
-                  'feat: Enhance suggested commits and add to alerts\n\n- Refactor components to use new shared CommitRow\n- Add Suspect Commits to alert emails\n- Refactor committers scanning code to handle various edge cases.',
-                score: 4,
-                id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-                repository: TestStubs.Repository(),
-                dateCreated: '2018-03-02T18:30:26Z',
-              },
-            ],
-          },
-          {
-            author: {name: 'Somebody else', id: '2'},
-            commits: [
-              {
-                message: 'fix: Make things less broken',
-                score: 2,
-                id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
-                repository: TestStubs.Repository(),
-                dateCreated: '2018-03-02T16:30:26Z',
-              },
-            ],
-          },
-        ],
+        committers,
       },
     });
   });
@@ -93,6 +95,50 @@ describe('EventCause', function () {
 
     expect(await screen.findByTestId('quick-context-commit-row')).toBeInTheDocument();
     expect(screen.queryByTestId('commit-row')).not.toBeInTheDocument();
+  });
+
+  it('renders correct heading for single commit', async () => {
+    // For this one test, undo the `beforeEach` so that we can respond with just a single commit
+    Client.clearMockResponses();
+    Client.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
+      body: {
+        committers: [committers[0]],
+      },
+    });
+
+    render(
+      <EventCause
+        project={project}
+        commitRow={CommitRow}
+        eventId={event.id}
+        group={group}
+      />,
+      {
+        organization,
+      }
+    );
+
+    expect(await screen.findByText(/Suspect Commit/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Suspect Commits/i)).not.toBeInTheDocument();
+  });
+
+  it('renders correct heading for multiple commits (and filters to unique commits)', async () => {
+    render(
+      <EventCause
+        project={project}
+        commitRow={CommitRow}
+        eventId={event.id}
+        group={group}
+      />,
+      {
+        organization,
+      }
+    );
+
+    // There are two commits rather than three because two of the mock commits above are the same
+    expect(await screen.findByText(/Suspect Commits \(2\)/i)).toBeInTheDocument();
   });
 
   it('expands', async function () {

--- a/static/app/components/events/eventCause.tsx
+++ b/static/app/components/events/eventCause.tsx
@@ -72,14 +72,21 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
   };
 
   const commits = getUniqueCommitsWithAuthors();
+
+  const commitHeading =
+    commits.length > 1
+      ? `${t('Suspect Commits')} (${commits.length})`
+      : t('Suspect Commit');
+
   return (
     <DataSection>
       <CauseHeader>
-        <h3 data-test-id="event-cause">
-          {t('Suspect Commits')} ({commits.length})
-        </h3>
+        <h3 data-test-id="event-cause">{commitHeading}</h3>
         {commits.length > 1 && (
-          <ExpandButton onClick={() => setIsExpanded(!isExpanded)}>
+          <ExpandButton
+            onClick={() => setIsExpanded(!isExpanded)}
+            data-test-id="expand-commit-list"
+          >
             {isExpanded ? (
               <Fragment>
                 {t('Show less')} <IconSubtract isCircled size="md" />

--- a/static/app/components/events/eventCause.tsx
+++ b/static/app/components/events/eventCause.tsx
@@ -7,7 +7,7 @@ import {CommitRowProps} from 'sentry/components/commitRow';
 import {CauseHeader, DataSection} from 'sentry/components/events/styles';
 import {Panel} from 'sentry/components/panels';
 import {IconAdd, IconSubtract} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {AvatarProject, Commit, Group} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -73,10 +73,7 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
 
   const commits = getUniqueCommitsWithAuthors();
 
-  const commitHeading =
-    commits.length > 1
-      ? `${t('Suspect Commits')} (${commits.length})`
-      : t('Suspect Commit');
+  const commitHeading = tn('Suspect Commit', 'Suspect Commits (%s)', commits.length);
 
   return (
     <DataSection>

--- a/static/app/views/discover/table/quickContext/issueContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.spec.tsx
@@ -1,6 +1,6 @@
 import {QueryClientProvider} from '@tanstack/react-query';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {EventData} from 'sentry/utils/discover/eventView';
 import {QueryClient} from 'sentry/utils/queryClient';
@@ -188,9 +188,9 @@ describe('Quick Context Content Issue Column', function () {
 
       // Ensure all commit data is present
       expect(screen.getByText(/MD/i)).toBeInTheDocument();
-      expect(screen.getByText(/View commit/i)).toBeInTheDocument();
-      expect(screen.getByText(/by/i)).toBeInTheDocument();
-      expect(screen.getByText(/Maisey the Dog/i)).toBeInTheDocument();
+      expect(screen.getByTestId('quick-context-commit-row')).toHaveTextContent(
+        /View commit ab27092 by Maisey the Dog/
+      );
     });
 
     it('Renders multiple suspect commits', async () => {
@@ -213,14 +213,12 @@ describe('Quick Context Content Issue Column', function () {
       // Check that they're both there
       expect(screen.getByText(/MD/i)).toBeInTheDocument();
       expect(screen.getByText(/CB/i)).toBeInTheDocument();
-
-      // Ensure each row has the right contents
-      const maiseyCommitRow = within(
-        screen.getAllByTestId('quick-context-commit-row')[0]
+      expect(screen.getAllByTestId('quick-context-commit-row')[0]).toHaveTextContent(
+        /View commit ab27092 by Maisey the Dog/
       );
-      expect(maiseyCommitRow.getByText(/View commit/i)).toBeInTheDocument();
-      expect(maiseyCommitRow.getByText(/by/i)).toBeInTheDocument();
-      expect(maiseyCommitRow.getByText(/Maisey the Dog/i)).toBeInTheDocument();
+      expect(screen.getAllByTestId('quick-context-commit-row')[1]).toHaveTextContent(
+        /View commit fe29668 by Charlie Bear/
+      );
     });
   });
 });

--- a/static/app/views/discover/table/quickContext/issueContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.spec.tsx
@@ -134,7 +134,31 @@ describe('Quick Context Content Issue Column', function () {
   });
 
   describe('Suspect commits', () => {
-    it('Renders a single suspect commit', async () => {
+    const maiseyCommitter = {
+      author: {name: 'Maisey the Dog', id: '1231'},
+      commits: [
+        {
+          message: 'feat(simulator): Add option for multiple squirrels (#1121)',
+          id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+          dateCreated: '2012-09-08T04:15:12',
+          repository: TestStubs.Repository(),
+        },
+      ],
+    };
+    const charlieCommitter = {
+      author: {name: 'Charlie Bear', id: '1121'},
+      commits: [
+        {
+          message:
+            'ref(simulator): Split leaderboard calculations into separate functions (#1231)',
+          id: 'fe29668b24cea6faad8afb8f6d9417f402ef9c18',
+          dateCreated: '2012-04-15T09:09:12',
+          repository: TestStubs.Repository(),
+        },
+      ],
+    };
+
+    beforeEach(() => {
       MockApiClient.addMockResponse({
         url: '/issues/3512441874/events/oldest/',
         method: 'GET',
@@ -142,23 +166,18 @@ describe('Quick Context Content Issue Column', function () {
           eventID: '6b43e285de834ec5b5fe30d62d549b20',
         },
       });
+    });
 
+    afterEach(() => {
+      MockApiClient.clearMockResponses();
+    });
+
+    it('Renders a single suspect commit', async () => {
       MockApiClient.addMockResponse({
         method: 'GET',
         url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
         body: {
-          committers: [
-            {
-              author: {name: 'Maisey the Dog', id: '1231'},
-              commits: [
-                {
-                  message: 'feat(simulator): Add option for multiple squirrels',
-                  id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-                  dateCreated: '2012-09-08T04:15:12',
-                },
-              ],
-            },
-          ],
+          committers: [maiseyCommitter],
         },
       });
       renderIssueContext();
@@ -176,40 +195,10 @@ describe('Quick Context Content Issue Column', function () {
 
     it('Renders multiple suspect commits', async () => {
       MockApiClient.addMockResponse({
-        url: '/issues/3512441874/events/oldest/',
-        method: 'GET',
-        body: {
-          eventID: '6b43e285de834ec5b5fe30d62d549b20',
-        },
-      });
-
-      MockApiClient.addMockResponse({
         method: 'GET',
         url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
         body: {
-          committers: [
-            {
-              author: {name: 'Maisey the Dog', id: '1231'},
-              commits: [
-                {
-                  message: 'feat(simulator): Add option for multiple squirrels (#1121)',
-                  id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-                  dateCreated: '2012-09-08T04:15:12',
-                },
-              ],
-            },
-            {
-              author: {name: 'Charlie Bear', id: '1121'},
-              commits: [
-                {
-                  message:
-                    'ref(simulator): Split leaderboard calculations into separate functions (#1231)',
-                  id: 'fe29668b24cea6faad8afb8f6d9417f402ef9c18',
-                  dateCreated: '2012-04-15T09:09:12',
-                },
-              ],
-            },
-          ],
+          committers: [maiseyCommitter, charlieCommitter],
         },
       });
       renderIssueContext();

--- a/static/app/views/discover/table/quickContext/issueContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.spec.tsx
@@ -1,6 +1,6 @@
 import {QueryClientProvider} from '@tanstack/react-query';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {EventData} from 'sentry/utils/discover/eventView';
 import {QueryClient} from 'sentry/utils/queryClient';
@@ -133,44 +133,105 @@ describe('Quick Context Content Issue Column', function () {
     expect(screen.getByText(/typeError: error description/i)).toBeInTheDocument();
   });
 
-  it('Renders Suspect Commits', async () => {
-    MockApiClient.addMockResponse({
-      url: '/issues/3512441874/events/oldest/',
-      method: 'GET',
-      body: {
-        eventID: '6b43e285de834ec5b5fe30d62d549b20',
-      },
-    });
+  describe('Suspect commits', () => {
+    it('Renders a single suspect commit', async () => {
+      MockApiClient.addMockResponse({
+        url: '/issues/3512441874/events/oldest/',
+        method: 'GET',
+        body: {
+          eventID: '6b43e285de834ec5b5fe30d62d549b20',
+        },
+      });
 
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
-      body: {
-        committers: [
-          {
-            author: {name: 'Max Bittker', id: '1'},
-            commits: [
-              {
-                message: 'feat: Added new feature',
-                score: 4,
-                id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
-                repository: TestStubs.Repository(),
-                dateCreated: '2018-03-02T18:30:26Z',
-                pullRequest: {
-                  externalUrl: 'url',
+      MockApiClient.addMockResponse({
+        method: 'GET',
+        url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
+        body: {
+          committers: [
+            {
+              author: {name: 'Maisey the Dog', id: '1231'},
+              commits: [
+                {
+                  message: 'feat(simulator): Add option for multiple squirrels',
+                  id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+                  dateCreated: '2012-09-08T04:15:12',
                 },
-              },
-            ],
-          },
-        ],
-      },
-    });
-    renderIssueContext();
+              ],
+            },
+          ],
+        },
+      });
+      renderIssueContext();
 
-    expect(await screen.findByText(/Suspect Commits/i)).toBeInTheDocument();
-    expect(screen.getByText(/MB/i)).toBeInTheDocument();
-    expect(screen.getByText(/View commit/i)).toBeInTheDocument();
-    expect(screen.getByText(/by/i)).toBeInTheDocument();
-    expect(screen.getByText(/You/i)).toBeInTheDocument();
+      // Make sure the title renders in the singular, since there's only one commit
+      expect(await screen.findByText(/Suspect Commit/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Suspect Commits/i)).not.toBeInTheDocument();
+
+      // Ensure all commit data is present
+      expect(screen.getByText(/MD/i)).toBeInTheDocument();
+      expect(screen.getByText(/View commit/i)).toBeInTheDocument();
+      expect(screen.getByText(/by/i)).toBeInTheDocument();
+      expect(screen.getByText(/Maisey the Dog/i)).toBeInTheDocument();
+    });
+
+    it('Renders multiple suspect commits', async () => {
+      MockApiClient.addMockResponse({
+        url: '/issues/3512441874/events/oldest/',
+        method: 'GET',
+        body: {
+          eventID: '6b43e285de834ec5b5fe30d62d549b20',
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        method: 'GET',
+        url: '/projects/org-slug/cool-team/events/6b43e285de834ec5b5fe30d62d549b20/committers/',
+        body: {
+          committers: [
+            {
+              author: {name: 'Maisey the Dog', id: '1231'},
+              commits: [
+                {
+                  message: 'feat(simulator): Add option for multiple squirrels (#1121)',
+                  id: 'ab2709293d0c9000829084ac7b1c9221fb18437c',
+                  dateCreated: '2012-09-08T04:15:12',
+                },
+              ],
+            },
+            {
+              author: {name: 'Charlie Bear', id: '1121'},
+              commits: [
+                {
+                  message:
+                    'ref(simulator): Split leaderboard calculations into separate functions (#1231)',
+                  id: 'fe29668b24cea6faad8afb8f6d9417f402ef9c18',
+                  dateCreated: '2012-04-15T09:09:12',
+                },
+              ],
+            },
+          ],
+        },
+      });
+      renderIssueContext();
+
+      // Make sure the title renders in the plural
+      expect(await screen.findByText(/Suspect Commits \(2\)/i)).toBeInTheDocument();
+
+      // When there's more than one commit, any past the first start out hidden
+      const expandButton = await screen.findByTestId('expand-commit-list');
+      userEvent.click(expandButton);
+
+      // Check that they're both there
+      expect(screen.getByText(/MD/i)).toBeInTheDocument();
+      expect(screen.getByText(/CB/i)).toBeInTheDocument();
+
+      // Ensure each row has the right contents
+      const maiseyCommitRow = within(
+        screen.getAllByTestId('quick-context-commit-row')[0]
+      );
+      expect(maiseyCommitRow.getByText(/View commit/i)).toBeInTheDocument();
+      expect(maiseyCommitRow.getByText(/by/i)).toBeInTheDocument();
+      expect(maiseyCommitRow.getByText(/Maisey the Dog/i)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
This fixes the heading for suspect commits so that it's only pluralized if there's more than one commit.

Ref: WOR-2706

One commit:
![Screenshot 2023-02-21 at 9 36 30 AM](https://user-images.githubusercontent.com/14812505/220472525-84e70d2f-f16e-4e4a-843d-daf37368e05e.jpg)

Two commits:
![Screenshot 2023-02-21 at 9 35 45 AM](https://user-images.githubusercontent.com/14812505/220472571-061e8ac4-5701-40bd-a0b4-a40b4cdb050a.jpg)
