### PR TITLE
ref(ui): Show commit message prominently in CommitRow

### DIFF
--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -93,9 +93,14 @@ function CommitRow({
       )}
 
       <CommitMessage>
-        <Message>
-          {tct('[author] committed [commitLink]', {
-            author: isUser ? t('You') : commit.author?.name ?? t('Unknown author'),
+        <Message>{formatCommitMessage(commit.message)}</Message>
+        <Meta>
+          {tct('[author] committed [commitLink] \u2022 [date]', {
+            author: (
+              <strong>
+                {isUser ? t('You') : commit.author?.name ?? t('Unknown author')}
+              </strong>
+            ),
             commitLink: (
               <CommitLink
                 inline
@@ -105,11 +110,13 @@ function CommitRow({
                 onClick={onCommitClick ? () => onCommitClick(commit) : undefined}
               />
             ),
+            date: (
+              <TimeSince
+                tooltipSuffix={commit.suspectCommitType}
+                date={commit.dateCreated}
+              />
+            ),
           })}
-        </Message>
-        <Meta>
-          {formatCommitMessage(commit.message)} &bull;{' '}
-          <TimeSince tooltipSuffix={commit.suspectCommitType} date={commit.dateCreated} />
         </Meta>
       </CommitMessage>
 


### PR DESCRIPTION
Before
<img alt="clipboard.png"  src="https://i.imgur.com/boVoFED.png" />

After
<img alt="clipboard.png"  src="https://i.imgur.com/RDYwNFu.png" />