### PR TITLE
fix(stacktrace): Fix frame title formatting when there is a source map warning

### DIFF
--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -289,19 +289,21 @@ export class Line extends Component<Props, State> {
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : undefined}>
         <DefaultLine className="title" data-test-id="title">
-          <VertCenterWrapper>
-            <SourceMapWarning frame={data} debugFrames={debugFrames} />
-            <div>
-              {this.renderLeadHint()}
-              <DefaultTitle
-                frame={data}
-                platform={this.props.platform ?? 'other'}
-                isHoverPreviewed={isHoverPreviewed}
-                meta={this.props.frameMeta}
-              />
-            </div>
+          <DefaultLineTitleWrapper>
+            <VertCenterWrapper>
+              <SourceMapWarning frame={data} debugFrames={debugFrames} />
+              <div>
+                {this.renderLeadHint()}
+                <DefaultTitle
+                  frame={data}
+                  platform={this.props.platform ?? 'other'}
+                  isHoverPreviewed={isHoverPreviewed}
+                  meta={this.props.frameMeta}
+                />
+              </div>
+            </VertCenterWrapper>
             {this.renderRepeats()}
-          </VertCenterWrapper>
+          </DefaultLineTitleWrapper>
           {this.renderExpander()}
         </DefaultLine>
       </StrictClick>
@@ -440,10 +442,15 @@ const RepeatedFrames = styled('div')`
   display: inline-block;
 `;
 
-const VertCenterWrapper = styled('div')`
+const DefaultLineTitleWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
+`;
+
+const VertCenterWrapper = styled('div')`
+  display: flex;
+  align-items: center;
 `;
 
 const RepeatedContent = styled(VertCenterWrapper)`

--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -290,7 +290,7 @@ export class Line extends Component<Props, State> {
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : undefined}>
         <DefaultLine className="title" data-test-id="title">
           <DefaultLineTitleWrapper>
-            <VertCenterWrapper>
+            <LeftLineTitle>
               <SourceMapWarning frame={data} debugFrames={debugFrames} />
               <div>
                 {this.renderLeadHint()}
@@ -301,7 +301,7 @@ export class Line extends Component<Props, State> {
                   meta={this.props.frameMeta}
                 />
               </div>
-            </VertCenterWrapper>
+            </LeftLineTitle>
             {this.renderRepeats()}
           </DefaultLineTitleWrapper>
           {this.renderExpander()}
@@ -448,12 +448,12 @@ const DefaultLineTitleWrapper = styled('div')`
   justify-content: space-between;
 `;
 
-const VertCenterWrapper = styled('div')`
+const LeftLineTitle = styled('div')`
   display: flex;
   align-items: center;
 `;
 
-const RepeatedContent = styled(VertCenterWrapper)`
+const RepeatedContent = styled(LeftLineTitle)`
   justify-content: center;
 `;
 


### PR DESCRIPTION
Regression caused in https://github.com/getsentry/sentry/pull/44771, `justify-content: space-between` was added to push the repeat icon to the right, but this breaks down when there is an extra source map warning icon on the left.

Before:

![CleanShot 2023-02-21 at 15 46 13](https://user-images.githubusercontent.com/10888943/220484369-7b5bb9d6-2fc8-4ec0-aca5-264806fb84d6.png)

After:

![CleanShot 2023-02-21 at 15 44 36](https://user-images.githubusercontent.com/10888943/220484160-2ae3694d-17d0-48ec-b6fd-0db3a1727767.png)