### PR TITLE
fix(issue-platform): Fix project event details endpoint to return occurrence

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -35,7 +35,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
 
-        if event.group:
+        if hasattr(event, "for_group") and event.group:
             event = event.for_group(event.group)
 
         data = serialize(event)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -35,6 +35,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
 
+        # TODO: Remove `for_group` check once performance issues are moved to the issue platform
         if hasattr(event, "for_group") and event.group:
             event = event.for_group(event.group)
 

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -85,6 +85,9 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         environments = set(request.GET.getlist("environment"))
 
+        if hasattr(event, "for_group") and event.group:
+            event = event.for_group(event.group)
+
         data = wrap_event_response(request.user, event, project, environments)
         return Response(data)
 

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -85,6 +85,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         environments = set(request.GET.getlist("environment"))
 
+        # TODO: Remove `for_group` check once performance issues are moved to the issue platform
         if hasattr(event, "for_group") and event.group:
             event = event.for_group(event.group)
 

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -196,7 +196,7 @@ class SnubaEventStorage(EventStorage):
         if len(event.data) == 0:
             return None
 
-        if group_id is not None:
+        if group_id is not None and event.get_event_type() != "generic":
             # Set passed group_id if not a transaction
             if event.get_event_type() == "transaction":
                 logger.warning("eventstore.passed-group-id-for-transaction")

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -185,6 +185,22 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
             },
         )[0]
 
+    def test_generic_event_with_occurrence(self):
+        url = reverse(
+            "sentry-api-0-project-event-details",
+            kwargs={
+                "event_id": self.cur_event.event_id,
+                "project_slug": self.project.slug,
+                "organization_slug": self.project.organization.slug,
+            },
+        )
+        response = self.client.get(url, format="json", data={"group_id": self.cur_group.id})
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == self.cur_event.event_id
+        assert response.data["occurrence"] is not None
+        assert response.data["occurrence"]["id"] == self.cur_event.id
+
 
 @region_silo_test
 class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/44906

Turns out the endpoint we use is
`<org_slug>/<project_slug>/events/<event_id>/`
instead of
`<org_slug>/events/<project_slug>/<event_id>/`

