### PR TITLE
feat(stack-trace): Add amplitude analytics code - [TET-724]

### DIFF
--- a/static/app/utils/analytics/stackTraceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/stackTraceAnalyticsEvents.tsx
@@ -1,0 +1,85 @@
+export type StackTraceEventParameters = {
+  'stack-trace.display_option_absolute_addresses_clicked': {
+    checked: boolean;
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.display_option_absolute_file_paths_clicked': {
+    checked: boolean;
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.display_option_minified_clicked': {
+    checked: boolean;
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.display_option_raw_stack_trace_clicked': {
+    checked: boolean;
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.display_option_unsymbolicated_clicked': {
+    checked: boolean;
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.display_option_verbose_function_names_clicked': {
+    checked: boolean;
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.download_clicked': {
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.full_stack_trace_clicked': {
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.most_relevant_clicked': {
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.sort_option_recent_first_clicked': {
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+  'stack-trace.sort_option_recent_last_clicked': {
+    is_mobile: boolean;
+    project_slug: string;
+    platform?: string;
+  };
+};
+
+export const stackTraceEventMap: Record<keyof StackTraceEventParameters, string> = {
+  'stack-trace.display_option_absolute_addresses_clicked':
+    'Stack Trace: Display Option - Absolute Addresses - Clicked',
+  'stack-trace.display_option_absolute_file_paths_clicked':
+    'Stack Trace: Display Option - Absolute File Paths - Clicked',
+  'stack-trace.display_option_minified_clicked':
+    'Stack Trace: Display Option - Minified - Clicked',
+  'stack-trace.display_option_raw_stack_trace_clicked':
+    'Stack Trace: Display Option - Raw Stack Trace - Clicked',
+  'stack-trace.display_option_unsymbolicated_clicked':
+    'Stack Trace: Display Option - Unsymbolicated - Clicked',
+  'stack-trace.display_option_verbose_function_names_clicked':
+    'Stack Trace: Display Option - Verbose Function Names - Clicked',
+  'stack-trace.download_clicked': 'Stack Trace: Download - Clicked',
+  'stack-trace.full_stack_trace_clicked': 'Stack Trace: Full Stack Trace - Clicked',
+  'stack-trace.most_relevant_clicked': 'Stack Trace: Most Relevant - Clicked',
+  'stack-trace.sort_option_recent_first_clicked':
+    'Stack Trace: Sort Option - Recent First - Clicked',
+  'stack-trace.sort_option_recent_last_clicked':
+    'Stack Trace: Sort Option - Recent Last - Clicked',
+};

--- a/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
@@ -19,6 +19,7 @@ import {releasesEventMap, ReleasesEventParameters} from './releasesAnalyticsEven
 import {replayEventMap, ReplayEventParameters} from './replayAnalyticsEvents';
 import {searchEventMap, SearchEventParameters} from './searchAnalyticsEvents';
 import {settingsEventMap, SettingsEventParameters} from './settingsAnalyticsEvents';
+import {stackTraceEventMap, StackTraceEventParameters} from './stackTraceAnalyticsEvents';
 import {TeamInsightsEventParameters, workflowEventMap} from './workflowAnalyticsEvents';
 
 type EventParameters = GrowthEventParameters &
@@ -35,7 +36,8 @@ type EventParameters = GrowthEventParameters &
   SettingsEventParameters &
   TeamInsightsEventParameters &
   DynamicSamplingEventParameters &
-  HeartbeatEventParameters;
+  HeartbeatEventParameters &
+  StackTraceEventParameters;
 
 const allEventMap: Record<string, string | null> = {
   ...coreUIEventMap,
@@ -53,6 +55,7 @@ const allEventMap: Record<string, string | null> = {
   ...workflowEventMap,
   ...dynamicSamplingEventMap,
   ...heartbeatEventMap,
+  ...stackTraceEventMap,
 };
 
 /**


### PR DESCRIPTION
Add amplitude analytics code to the actions we display on the top of stack traces so we can track what is being used.

![image](https://user-images.githubusercontent.com/29228205/220643369-d9b66537-b014-4ae7-8efb-ca44b5095f9b.png)
