### PR TITLE
fix(discover): Remove the quick context timeout

### DIFF
--- a/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
@@ -167,7 +167,6 @@ export function QuickContextHoverWrapper(props: ContextProps) {
     <HoverWrapper>
       <StyledHovercard
         showUnderline
-        displayTimeout={600}
         delay={HOVER_DELAY}
         header={getHoverHeader(dataRow, contextType, organization)}
         body={getHoverBody(


### PR DESCRIPTION
- Based on feedback its sorta annoying how long it takes for the hovercard to disappear
- Looking at other hovercards we don't really set a timeout on other cards so i'm just going to remove it