### PR TITLE
dependabot(config): configure for docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,12 @@ updates:
       - dependency-name: 'reflux'
       - dependency-name: 'sprintf-js'
       - dependency-name: 'u2f-api'
+  - package-ecosystem: 'docker'
+    directory: 'docker/'
+    schedule:
+      interval: 'daily'
+    reviewers:
+      - '@getsentry/owners-python-build'
+      - '@getsentry/security'
+    # security only updates
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,7 +65,7 @@ updates:
     schedule:
       interval: 'daily'
     reviewers:
-      - '@getsentry/owners-python-build'
+      - '@getsentry/open-source'
       - '@getsentry/security'
     # security only updates
     open-pull-requests-limit: 0


### PR DESCRIPTION
Configures Dependabot to also open security updates for Docker image updates. Let me know if I got the reviewers incorrect, I can adjust them.