### PR TITLE
codeql(config): set codeql to only scan when code files are changed

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,9 +1,9 @@
 name: 'Sentry CodeQL Config'
 
 paths:
-  - '**.js'
-  - '**.ejs'
-  - '**.tsx'
-  - '**.ts'
-  - '**.py'
+  - '**/*.js'
+  - '**/*.ejs'
+  - '**/*.tsx'
+  - '**/*.ts'
+  - '**/*.py'
   - '!**/tests/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,9 +1,4 @@
 name: 'Sentry CodeQL Config'
 
-paths:
-  - '**/*.js'
-  - '**/*.ejs'
-  - '**/*.tsx'
-  - '**/*.ts'
-  - '**/*.py'
-  - '!**/tests/**'
+paths-ignore:
+  - '**/tests/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,9 @@
-name: "Sentry CodeQL Config"
+name: 'Sentry CodeQL Config'
 
-paths-ignore:
-  - '**/tests/**'
+paths:
+  - '**.js'
+  - '**.ejs'
+  - '**.tsx'
+  - '**.ts'
+  - '**.py'
+  - '!**/tests/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,14 +9,21 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ['master']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: ['master']
+    paths:
+      - '**.js'
+      - '**.ejs'
+      - '**.tsx'
+      - '**.ts'
+      - '**.py'
+      - '!tests/**'
   schedule:
     - cron: '44 12 * * 1'
 
@@ -32,42 +39,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python' ]
+        language: ['javascript', 'python']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@3e7e3b32d0fb8283594bb0a76cc60a00918b0969  # v2
-      with:
-        config-file: ./.github/codeql/codeql-config.yml
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: security-extended
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@3e7e3b32d0fb8283594bb0a76cc60a00918b0969 # v2
+        with:
+          config-file: ./.github/codeql/codeql-config.yml
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: security-extended
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@3e7e3b32d0fb8283594bb0a76cc60a00918b0969  # v2
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@3e7e3b32d0fb8283594bb0a76cc60a00918b0969 # v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3e7e3b32d0fb8283594bb0a76cc60a00918b0969  # v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@3e7e3b32d0fb8283594bb0a76cc60a00918b0969 # v2
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
CodeQL was running on every PR, regardless of whether there were changes to any JavaScript/Python files. This is an extra 5-6 minutes that was being introduced to CI where it was unnecessary. 
