### PR TITLE
ref(heroku): Handle null slug

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -68,7 +68,12 @@ class HerokuReleaseHook(ReleaseHook):
                     "email": email,
                 },
             )
-        commit = data.get("slug", {}).get("commit")
+        slug = data.get("slug")
+        if not slug:
+            logger.info("heroku.payload.missing-commit", extra={"project_id": self.project.id})
+            return HttpResponse(status=401)
+
+        commit = slug.get("commit")
         app_name = data.get("app", {}).get("name")
         if app_name:
             self.finish_release(


### PR DESCRIPTION
Handle the case where `slug` is null which is causing an AttributeError `'NoneType' object has no attribute 'get'` on the chained `.get()`. I'm not sure if Heroku sends differently shaped payloads in certain cases, but usually the commit data is in `data["slug"]["commit"]`. 

Fixes [SENTRY-YPR](https://sentry.sentry.io/issues/3920357271/), also see [this issue](https://getsentry.atlassian.net/browse/ISSUE-1646)