### PR TITLE
fix(hybrid-cloud): Remove redundant self._base_query() call in _apply_filters

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -69,7 +69,6 @@ class DatabaseBackedUserService(
         query: BaseQuerySet,
         filters: UserFilterArgs,
     ) -> List[User]:
-        query = self._base_query()
         if "user_ids" in filters:
             query = query.filter(id__in=filters["user_ids"])
         if "is_active" in filters:


### PR DESCRIPTION
The call to `self._base_query()` in `_apply_filters()` is redundant as we already make this call in `_query_many()` here: https://github.com/getsentry/sentry/blob/fc99b7b231638855effd8b02341db3084ae281f4/src/sentry/services/hybrid_cloud/filter_query.py#L105-L113