### PR TITLE
fix(issue-platform): Make sure generic events have a title

### DIFF
--- a/src/sentry/issues/json_schemas.py
+++ b/src/sentry/issues/json_schemas.py
@@ -10,7 +10,7 @@ EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
         "tags": {"type": "object"},
         "timestamp": {"type": "string", "format": "date-time"},
         "received": {"type": "string", "format": "date-time"},
-        # "title": {"type": "string", "minLength": 1}, leaving this out, for now
+        "title": {"type": "string", "minLength": 1},
         # non-required properties
         "breadcrumbs": {
             "type": ["array", "null"],
@@ -136,6 +136,7 @@ EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
         "project_id",
         "tags",
         "timestamp",
-    ],  # title will be required, if enabled
+        "title",
+    ],
     "additionalProperties": False,
 }

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -183,6 +183,8 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "tags": event_payload.get("tags"),
                     "timestamp": event_payload.get("timestamp"),
                     "received": event_payload.get("received", timezone.now()),
+                    # This allows us to show the title consistently in discover
+                    "title": occurrence_data["issue_title"],
                 }
 
                 optional_params = [

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -281,3 +281,8 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
             message = deepcopy(get_test_message(self.project.id))
             message["event"]["event_id"] = "hi"
             _get_kwargs(message)
+
+    def test_occurrence_title_on_event(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["issue_title"] == kwargs["event_data"]["title"]


### PR DESCRIPTION
This uses the `issue_title` from the occurrence as the default title on the event. This allows events in discover to display a useful title.

I don't think we have a case where we'll want to allow users to pass an event title that's different to the occurrence title, but we can add that if someone wants it later.

Note that for perf issues, they'll be using existing transactions and so these events will just be transactions and have their original title.




<!-- Describe your PR here. -->