### PR TITLE
chore(view-hierarchy): Expose option in /manage/settings

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -50,6 +50,7 @@ const optionsAvailable = [
   'profile.issues.blocked_main_thread-ingest.la-rollout',
   'profile.issues.blocked_main_thread-ingest.ea-rollout',
   'profile.issues.blocked_main_thread-ingest.ga-rollout',
+  'processing.view-hierarchies-deobfuscation-general-availability',
 ];
 
 type Field = ReturnType<typeof getOption>;


### PR DESCRIPTION
Created an options flag here: https://github.com/getsentry/sentry/pull/44960/
but I didn't realize I needed to add it to this available options array.