### PR TITLE
fix(search): remove warning when searching by issue short

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -974,7 +974,7 @@ export const ISSUE_FIELDS = [
   FieldKey.HTTP_URL,
   FieldKey.ID,
   FieldKey.IS,
-  // FieldKey.ISSUE,
+  FieldKey.ISSUE,
   FieldKey.ISSUE_CATEGORY,
   FieldKey.ISSUE_TYPE,
   FieldKey.LAST_SEEN,


### PR DESCRIPTION
Related to this PR https://github.com/getsentry/sentry/pull/44521

but merged in the part where we actually remove the warning when searching on `issue:<issue-short-id>`.