### PR TITLE
feat(perf-issues): respect span render blocking status in detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -485,13 +485,17 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
             self.fcp = None
 
     def _is_blocking_render(self, span):
+        data = span.get("data", None)
+        render_blocking_status = data and data.get("resource.render_blocking_status")
+        if render_blocking_status == "non-blocking":
+            return False
+
         span_end_timestamp = timedelta(seconds=span.get("timestamp", 0))
         fcp_timestamp = self.transaction_start + self.fcp
         if span_end_timestamp >= fcp_timestamp:
             return False
 
         minimum_size_bytes = self.settings.get("minimum_size_bytes")
-        data = span.get("data", None)
         encoded_body_size = data and data.get("Encoded Body Size", 0) or 0
         if encoded_body_size < minimum_size_bytes or encoded_body_size > self.MAX_SIZE_BYTES:
             return False


### PR DESCRIPTION
As of browser SDK 7.38.0, we now [log the render-blocking status](https://github.com/getsentry/sentry-javascript/pull/7127) reported by the browser in resource spans' `data` hash. (Background info: [MDN](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus)). If a value is present and that span is `non-blocking`, ignore our heuristics and treat the resource as non-blocking in the Large Render Blocking Asset detector.

This PR also updates each test case to start from a valid event and then minimally mutate it into an invalid one, because I was losing confidence that each test was really testing what it should.