### PR TITLE
fix(sdk): Fix sentry transactions w/ customer domains

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -7,6 +7,7 @@ import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
 import {SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import {Config} from 'sentry/types';
 import {addExtraMeasurements, LongTaskObserver} from 'sentry/utils/performanceForSentry';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 const SPA_MODE_ALLOW_URLS = [
   'localhost',
@@ -99,6 +100,9 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
           partialDesc => !span.description?.includes(partialDesc)
         );
       });
+      if (event.transaction) {
+        event.transaction = normalizeUrl(event.transaction, {forceCustomerDomain: true});
+      }
       return event;
     },
     /**


### PR DESCRIPTION
### Summary
We started splitting our transactions after introducing customer domains as they are separate routes within the router. This normalizes transaction names against the new routes for customer domains.

eg. /organizations/:orgId/performance/ becomes /performance/

