### PR TITLE
fix(perf-issues): (M)N+1 span evidence should group db spans by hash

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -29,6 +29,7 @@ describe('SpanEvidenceKeyValueList', () => {
       endTimestamp: 2.1,
       op: 'db',
       description: 'SELECT * FROM books',
+      hash: 'aaa',
       problemSpan: ProblemSpan.OFFENDER,
     });
 
@@ -37,6 +38,7 @@ describe('SpanEvidenceKeyValueList', () => {
       endTimestamp: 4.0,
       op: 'db',
       description: 'SELECT * FROM books',
+      hash: 'aaa',
       problemSpan: ProblemSpan.OFFENDER,
     });
 
@@ -85,6 +87,7 @@ describe('SpanEvidenceKeyValueList', () => {
       endTimestamp: 2.1,
       op: 'db',
       description: 'SELECT * FROM books',
+      hash: 'aaa',
       problemSpan: ProblemSpan.OFFENDER,
     });
 
@@ -93,6 +96,7 @@ describe('SpanEvidenceKeyValueList', () => {
       endTimestamp: 4.0,
       op: 'db.sql.active_record',
       description: 'SELECT * FROM books WHERE id = %s',
+      hash: 'bbb',
       problemSpan: ProblemSpan.OFFENDER,
     });
 

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -97,7 +97,7 @@ const NPlusOneDBQueriesSpanEvidence = ({
 }: SpanEvidenceKeyValueListProps) => {
   const dbSpans = offendingSpans.filter(span => (span.op || '').startsWith('db'));
   const repeatingSpanRows = dbSpans
-    .filter(span => offendingSpans.find(s => s.description === span.description) === span)
+    .filter(span => offendingSpans.find(s => s.hash === span.hash) === span)
     .map((span, i) =>
       makeRow(
         i === 0 ? t('Repeating Spans (%s)', dbSpans.length) : '',

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -14,6 +14,7 @@ type AddSpanOpts = {
   startTimestamp: number;
   data?: Record<string, any>;
   description?: string;
+  hash?: string;
   op?: string;
   problemSpan?: ProblemSpan | ProblemSpan[];
   status?: string;
@@ -180,13 +181,15 @@ export class MockSpan {
    * this will be handled automatically and you do not need to provide an ID. Defaults to the root span's ID.
    */
   constructor(opts: AddSpanOpts) {
-    const {startTimestamp, endTimestamp, op, description, status, problemSpan} = opts;
+    const {startTimestamp, endTimestamp, op, description, hash, status, problemSpan} =
+      opts;
 
     this.span = {
       start_timestamp: startTimestamp,
       timestamp: endTimestamp,
       op,
       description,
+      hash,
       status: status ?? 'ok',
       data: opts.data || {},
       // These values are automatically assigned by the TransactionEventBuilder when the spans are added
@@ -203,7 +206,8 @@ export class MockSpan {
    * @param opts.numSpans If provided, will create the same span numSpan times
    */
   addChild(opts: AddSpanOpts, numSpans = 1) {
-    const {startTimestamp, endTimestamp, op, description, status, problemSpan} = opts;
+    const {startTimestamp, endTimestamp, op, description, hash, status, problemSpan} =
+      opts;
 
     for (let i = 0; i < numSpans; i++) {
       const span = new MockSpan({
@@ -211,6 +215,7 @@ export class MockSpan {
         endTimestamp,
         op,
         description,
+        hash,
         status,
         problemSpan,
       });


### PR DESCRIPTION
Span hashes take into consideration minor parameter differences, whereas the description does not.