### PR TITLE
feat(perf-issues): Improve Render Blocking Asset email alert evidence

### DIFF
--- a/src/sentry/data/samples/transaction-render-blocking-asset.json
+++ b/src/sentry/data/samples/transaction-render-blocking-asset.json
@@ -1,0 +1,150 @@
+{
+  "event_id": "1",
+  "platform": "other",
+  "message": "",
+  "datetime": "2023-02-22T15:02:44.096560Z",
+  "tags": [
+    ["application", "countries"],
+    ["browser", "Python Requests 2.22"],
+    ["browser.name", "Python Requests"],
+    ["environment", "dev"],
+    ["level", "info"],
+    ["runtime", "CPython 3.7.3"],
+    ["runtime.name", "CPython"],
+    ["user", "username:matt"],
+    ["transaction", "/render-blocking-asset/"],
+    ["url", "http://countries:8010/country_by_code/"]
+  ],
+  "_metrics": {
+    "bytes.stored.event": 3054
+  },
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1562681591,
+        "type": "default",
+        "category": "query",
+        "level": "info",
+        "message": "SELECT \"countries\".\"id\", \"countries\".\"name\", \"countries\".\"continent\", \"countries\".\"region\", \"countries\".\"surface_area\", \"coun...'CAN'"
+      }
+    ]
+  },
+  "breakdowns": {
+    "span_ops": {
+      "ops.browser": {
+        "value": 633.474827
+      },
+      "ops.db": {
+        "value": 91.876
+      },
+      "ops.http": {
+        "value": 2039.16049
+      },
+      "ops.resource": {
+        "value": 2024.234772
+      },
+      "total.time": {
+        "value": 2875.570536
+      }
+    }
+  },
+  "contexts": {
+    "browser": {
+      "name": "Python Requests",
+      "version": "2.22",
+      "type": "browser"
+    },
+    "runtime": {
+      "name": "CPython",
+      "version": "3.7.3",
+      "build": "3.7.3 (default, Jun 27 2019, 22:53:21) \n[GCC 8.3.0]",
+      "type": "runtime"
+    },
+    "trace": {
+      "trace_id": "af6cd4ed98d1459a9d496071342ab3e7",
+      "span_id": "ff2776d0dcfd474c",
+      "parent_span_id": "d333ac34048040f7",
+      "op": "http.server",
+      "status": "ok",
+      "hash": "35488174ce510b81",
+      "type": "trace"
+    }
+  },
+  "culprit": "/country_by_code/",
+  "environment": "dev",
+  "hashes": ["92872d9cb7e134b1654c81929e3983d1"],
+  "level": "info",
+  "location": "/render-blocking-asset/",
+  "logger": "",
+  "measurements": {
+    "fcp": {
+      "value": 2500,
+      "unit": "millisecond"
+    }
+  },
+  "metadata": {
+    "location": "/render-blocking-asset/",
+    "title": "/render-blocking-asset/"
+  },
+  "modules": {
+    "my.package": "1.0.0"
+  },
+  "nodestore_insert": 1677078167.623985,
+  "received": 1677078167.57445,
+  "request": {
+    "url": "http://countries:8010/country_by_code/",
+    "method": "GET",
+    "query_string": [["code", "CAN"]],
+    "headers": [
+      ["Accept", "*/*"],
+      ["Accept-Encoding", "gzip, deflate"],
+      ["Connection", "keep-alive"],
+      ["Content-Length", ""],
+      ["Content-Type", "text/plain"],
+      ["Host", "countries:8010"],
+      ["Referer", "fixtures.transaction"],
+      ["Sentry-Trace", "a7d67cf796774551a95be6543cacd459-8988cec7cc0779c1-1"],
+      ["User-Agent", "python-requests/2.22.0"]
+    ],
+    "env": {
+      "SERVER_NAME": "a90286977562",
+      "SERVER_PORT": "8010"
+    },
+    "inferred_content_type": "text/plain"
+  },
+  "span_grouping_config": {
+    "id": "default:2022-10-27"
+  },
+  "spans": [
+    {
+      "description": "/asset.js",
+      "op": "resource.script",
+      "span_id": "5b35bf3458d54fd7",
+      "parent_span_id": "d333ac34048040f7",
+      "trace_id": "af6cd4ed98d1459a9d496071342ab3e7",
+      "data": {
+        "Encoded Body Size": 1000001,
+        "duration": 1
+      },
+      "hash": "a8b09954a220aea9"
+    }
+  ],
+  "start_timestamp": 1677078163.79656,
+  "timestamp": 1677078168.09656,
+  "title": "/render-blocking-asset/",
+  "transaction": "/render-blocking-asset/",
+  "transaction_info": {
+    "source": "unknown"
+  },
+  "type": "transaction",
+  "user": {
+    "email": "matt@example.com",
+    "ip_address": "127.0.0.1",
+    "geo": {
+      "country_code": "AU",
+      "city": "Melbourne",
+      "region": "VIC"
+    }
+  },
+  "version": "5"
+}

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -505,8 +505,14 @@ class PerformanceProblemContext:
         if not self.event:
             return 0
 
-        start = self.event.data.get("start_timestamp", 0)
-        end = self.event.data.get("timestamp", 0)
+        return self.duration(self.event.data)
+
+    def duration(self, item: Mapping | None) -> float:
+        if not item:
+            return 0
+
+        start = float(item.get("start_timestamp", 0) or 0)
+        end = float(item.get("timestamp", 0) or 0)
 
         return (end - start) * 1000
 
@@ -652,14 +658,7 @@ class RenderBlockingAssetProblemContext(PerformanceProblemContext):
 
     @property
     def slow_span_duration(self) -> float:
-        slow_span = self.slow_span
-        if not slow_span:
-            return 0
-
-        start = float(slow_span.get("start_timestamp", 0))
-        end = float(slow_span.get("timestamp", 0))
-
-        return (end - start) * 1000
+        return self.duration(self.slow_span)
 
     @property
     def fcp(self) -> float:

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -484,7 +484,7 @@ class PerformanceProblemContext:
         self.parent_span = parent_span
         self.repeating_spans = repeating_spans
 
-    def to_dict(self) -> Dict[str, str | List[str]]:
+    def to_dict(self) -> Dict[str, str | float | List[str]]:
         return {
             "transaction_name": self.transaction,
             "parent_span": get_span_evidence_value(self.parent_span),
@@ -507,7 +507,7 @@ class PerformanceProblemContext:
 
         return self.duration(self.event.data)
 
-    def duration(self, item: Mapping | None) -> float:
+    def duration(self, item: Mapping[str, Any] | None) -> float:
         if not item:
             return 0
 
@@ -544,7 +544,7 @@ class PerformanceProblemContext:
 
 
 class NPlusOneAPICallProblemContext(PerformanceProblemContext):
-    def to_dict(self) -> Dict[str, str | List[str]]:
+    def to_dict(self) -> Dict[str, str | float | List[str]]:
         return {
             "transaction_name": self.transaction,
             "repeating_spans": self.path_prefix,
@@ -665,4 +665,4 @@ class RenderBlockingAssetProblemContext(PerformanceProblemContext):
         if not self.event:
             return 0
 
-        return self.event.data.get("measurements", {}).get("fcp", {}).get("value", 0)
+        return float(self.event.data.get("measurements", {}).get("fcp", {}).get("value", 0) or 0)

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -26,6 +26,7 @@
         <option value="mail/error-alert/">Error Alert</option>
         <option value="mail/performance-alert/transaction-n-plus-one">N+1 Database Query Alert</option>
         <option value="mail/performance-alert/transaction-n-plus-one-api-call">N+1 API Call Alert</option>
+        <option value="mail/performance-alert/transaction-render-blocking-asset">Render Blocking Asset Alert</option>
         <option value="mail/generic-alert/">Generic Alert</option>
         <option value="mail/digest/">Digest</option>
       </optgroup>

--- a/src/sentry/templates/sentry/emails/transactions.html
+++ b/src/sentry/templates/sentry/emails/transactions.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load sentry_helpers %}
 <table>
     <colgroup>
       <col style="width:130px;">
@@ -20,6 +21,14 @@
             </td>
         </tr>
         {% endif %}
+        {% if slow_span_description %}
+        <tr>
+            <th>{% trans "Slow Resource Span" %}</th>
+            <td>
+                <code>{{ slow_span_description|truncatechars:50 }}</code>
+            </td>
+        </tr>
+        {% endif %}
         {% if preceding_span %}
         <tr>
             <th>{% trans "Preceding Span" %}</th>
@@ -33,6 +42,22 @@
             <th>{% blocktrans %} Repeating Spans ({{ num_repeating_spans }}) {% endblocktrans %}</th>
             <td>
                 <code>{{ repeating_spans|truncatechars:75 }}{% if parameters %}<span class="parameter-placeholder">[{% trans "Parameters" %}]</span>{% endif %}</code>
+            </td>
+        </tr>
+        {% endif %}
+        {% if transaction_duration and fcp %}
+        <tr>
+            <th>{% trans "FCP Delay" %}</th>
+            <td>
+                <code>{{ fcp|duration }} ({% percent fcp transaction_duration %}% of {{ transaction_duration|duration }})</code>
+            </td>
+        </tr>
+        {% endif %}
+        {% if transaction_duration and slow_span_duration %}
+        <tr>
+            <th>{% trans "Duration Impact" %}</th>
+            <td>
+                <code>{% percent slow_span_duration transaction_duration %}% ({{ slow_span_duration|duration }}/{{ transaction_duration|duration }})</code>
             </td>
         </tr>
         {% endif %}

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -201,10 +201,14 @@ def make_performance_event(project, sample_name: str):
             "organizations:performance-issues-render-blocking-assets-detector": True,
         }
     ):
+        timestamp = datetime(2017, 9, 6, 0, 0)
+        start_timestamp = timestamp - timedelta(seconds=3)
+
         perf_data = dict(
             load_data(
                 sample_name,
-                timestamp=datetime(2017, 9, 6, 0, 0),
+                start_timestamp=start_timestamp,
+                timestamp=timestamp,
             )
         )
         perf_data["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
@@ -213,7 +217,8 @@ def make_performance_event(project, sample_name: str):
         perf_data = perf_event_manager.get_data()
         perf_event = perf_event_manager.save(project.id)
         # Prevent CI screenshot from constantly changing
-        perf_event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
+        perf_event.data["timestamp"] = timestamp.timestamp()
+        perf_event.data["start_timestamp"] = start_timestamp.timestamp()
 
     perf_event = perf_event.for_group(perf_event.groups[0])
     return perf_event

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -193,8 +193,14 @@ def make_performance_event(project, sample_name: str):
             "performance.issues.all.problem-detection": 1.0,
             "performance.issues.n_plus_one_db.problem-creation": 1.0,
             "performance.issues.n_plus_one_api_calls.problem-creation": 1.0,
+            "performance.issues.render_blocking_assets.problem-creation": 1.0,
         }
-    ), Feature({"organizations:performance-n-plus-one-api-calls-detector": True}):
+    ), Feature(
+        {
+            "organizations:performance-n-plus-one-api-calls-detector": True,
+            "organizations:performance-issues-render-blocking-assets-detector": True,
+        }
+    ):
         perf_data = dict(
             load_data(
                 sample_name,

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -308,7 +308,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             "Parent Span",
             "django.view - index",
             "Repeating Spans (10)",
-            "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author`",
+            "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_autho...",
         ]
         for checked_value in checked_values:
             assert (

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlparse
 from sentry.issues.grouptype import (
     PerformanceNPlusOneAPICallsGroupType,
     PerformanceNPlusOneGroupType,
+    PerformanceRenderBlockingAssetSpanGroupType,
 )
 from sentry.models import NotificationSetting, Rule
 from sentry.notifications.helpers import (
@@ -25,6 +26,7 @@ from sentry.notifications.utils import (
     NotificationRuleDetails,
     NPlusOneAPICallProblemContext,
     PerformanceProblemContext,
+    RenderBlockingAssetProblemContext,
     get_email_link_extra_params,
     get_group_settings_link,
     get_rules,
@@ -35,6 +37,7 @@ from sentry.utils.performance_issues.performance_problem import PerformanceProbl
 
 
 class MockEvent:
+    data: dict
     transaction: str
 
 
@@ -319,4 +322,43 @@ class PerformanceProblemContextTestCase(TestCase):
             "repeating_spans": "/resource",
             "parameters": ["{id: 1,2}"],
             "num_repeating_spans": "3",
+        }
+
+    def test_returns_render_blocking_asset_context(self):
+        event = MockEvent()
+        event.transaction = "/details"
+        event.data = {
+            "start_timestamp": 0,
+            "timestamp": 3,
+            "measurements": {"fcp": {"value": 1500, "unit": "milliseconds"}},
+        }
+
+        context = RenderBlockingAssetProblemContext(
+            PerformanceProblem(
+                fingerprint=f"1-{PerformanceRenderBlockingAssetSpanGroupType.type_id}-153198dd61706844cf3d9a922f6f82543df8125f",
+                op="http.client",
+                desc="/details",
+                type=PerformanceRenderBlockingAssetSpanGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=["b93d2be92cd64fd5"],
+            ),
+            [
+                {
+                    "op": "resource.script",
+                    "span_id": "b93d2be92cd64fd5",
+                    "description": "/assets/script.js",
+                    "start_timestamp": 1677078164.09656,
+                    "timestamp": 1677078165.09656,
+                },
+            ],
+            event,
+        )
+
+        assert context.to_dict() == {
+            "transaction_name": "/details",
+            "slow_span_description": "/assets/script.js",
+            "slow_span_duration": 1000,
+            "transaction_duration": 3000,
+            "fcp": 1500,
         }


### PR DESCRIPTION
**e.g.,**
<img width="629" alt="Screenshot 2023-02-22 at 4 28 58 PM" src="https://user-images.githubusercontent.com/989898/220765487-2ceb3d84-a301-48b2-8de2-fab3a8a6e724.png">

## Changes

- Enable render blocking asset detection in debug
- Use more stable timestamps
- Add render blocking asset fixture
- Add extended span evidence
