### PR TITLE
ref(roles): fix n+1 query

### DIFF
--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -39,7 +39,7 @@ from sentry.models import (
     TeamAvatar,
     User,
 )
-from sentry.roles import team_roles
+from sentry.roles import organization_roles, team_roles
 from sentry.scim.endpoints.constants import SCIM_SCHEMA_GROUP
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -115,7 +115,7 @@ def get_member_orgs_and_roles(org_ids: Set[int], user_id: int) -> Mapping[int, S
         orgs_and_roles[org_id].add(org_role)
 
     return {
-        org: [r.id for r in roles.get_sorted_organization_roles(org_roles)]
+        org: [r.id for r in organization_roles.get_sorted_roles(org_roles)]
         for org, org_roles in orgs_and_roles.items()
     }
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -93,10 +93,14 @@ def get_member_totals(team_list: Sequence[Team], user: User) -> Mapping[str, int
     return {item["id"]: item["member_count"] for item in query}
 
 
-def get_member_orgs_and_roles(org_ids: Set[int], user_id: int):
+def get_member_orgs_and_roles(org_ids: Set[int], user_id: int) -> Mapping[int, Sequence[str]]:
     org_members = OrganizationMember.objects.filter(
         user_id=user_id, organization__in=org_ids
     ).values_list("organization_id", "id", "role")
+
+    if not len(org_members):
+        return {}
+
     _, org_member_ids, _ = zip(*org_members)
 
     roles_from_teams = (

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import timedelta
 from enum import Enum
 from hashlib import md5
-from typing import TYPE_CHECKING, FrozenSet, List, Mapping, MutableMapping
+from typing import TYPE_CHECKING, FrozenSet, List, Mapping, MutableMapping, Set
 from urllib.parse import urlencode
 from uuid import uuid4
 
@@ -28,6 +28,7 @@ from sentry.db.models import (
 )
 from sentry.db.models.manager import BaseManager
 from sentry.exceptions import UnableToAcceptMemberInvitationException
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
 from sentry.models.team import TeamStatus
 from sentry.roles import organization_roles
@@ -103,8 +104,6 @@ class OrganizationMemberManager(BaseManager):
         return user_teams
 
     def get_members_by_email_and_role(self, email: str, role: str) -> QuerySet:
-        from sentry.models import OrganizationMemberTeam
-
         org_members = self.filter(user__email__iexact=email, user__is_active=True).values_list(
             "id", flat=True
         )
@@ -429,23 +428,17 @@ class OrganizationMember(Model):
             scopes.update(self.organization.get_scopes(role_obj))
         return frozenset(scopes)
 
-    def get_org_roles_from_teams(self) -> List[str]:
+    def get_org_roles_from_teams(self) -> Set[str]:
         # results in an extra query when calling get_scopes()
-        return list(
-            self.teams.all().exclude(org_role=None).values_list("org_role", flat=True).distinct()
-        )
+        return set(self.teams.all().exclude(org_role=None).values_list("org_role", flat=True))
 
     def get_all_org_roles(self) -> List[str]:
         all_org_roles = self.get_org_roles_from_teams()
-        all_org_roles.append(self.role)
-        return all_org_roles
+        all_org_roles.add(self.role)
+        return list(all_org_roles)
 
     def get_all_org_roles_sorted(self) -> List[OrganizationRole]:
-        return sorted(
-            [organization_roles.get(role) for role in self.get_all_org_roles()],
-            key=lambda r: r.priority,
-            reverse=True,
-        )
+        return roles.get_sorted_organization_roles(self.get_all_org_roles)
 
     def validate_invitation(self, user_to_approve, allowed_roles):
         """
@@ -464,7 +457,7 @@ class OrganizationMember(Model):
 
         # members cannot invite roles higher than their own
         all_org_roles = self.get_all_org_roles()
-        if not len(set(all_org_roles) & {r.id for r in allowed_roles}):
+        if not len(all_org_roles & {r.id for r in allowed_roles}):
             highest_role = sorted(
                 [organization_roles.get(role) for role in all_org_roles], key=lambda r: r.priority
             )[-1].id

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -438,7 +438,7 @@ class OrganizationMember(Model):
         return list(all_org_roles)
 
     def get_all_org_roles_sorted(self) -> List[OrganizationRole]:
-        return roles.get_sorted_organization_roles(self.get_all_org_roles)
+        return roles.get_sorted_organization_roles(self.get_all_org_roles())
 
     def validate_invitation(self, user_to_approve, allowed_roles):
         """
@@ -457,10 +457,8 @@ class OrganizationMember(Model):
 
         # members cannot invite roles higher than their own
         all_org_roles = self.get_all_org_roles()
-        if not len(all_org_roles & {r.id for r in allowed_roles}):
-            highest_role = sorted(
-                [organization_roles.get(role) for role in all_org_roles], key=lambda r: r.priority
-            )[-1].id
+        if not len(set(all_org_roles) & {r.id for r in allowed_roles}):
+            highest_role = roles.get_sorted_organization_roles(all_org_roles)[0].id
             raise UnableToAcceptMemberInvitationException(
                 f"You do not have permission to approve a member invitation with the role {highest_role}."
             )

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -438,7 +438,7 @@ class OrganizationMember(Model):
         return list(all_org_roles)
 
     def get_all_org_roles_sorted(self) -> List[OrganizationRole]:
-        return roles.get_sorted_organization_roles(self.get_all_org_roles())
+        return organization_roles.get_sorted_roles(self.get_all_org_roles())
 
     def validate_invitation(self, user_to_approve, allowed_roles):
         """
@@ -458,7 +458,7 @@ class OrganizationMember(Model):
         # members cannot invite roles higher than their own
         all_org_roles = self.get_all_org_roles()
         if not len(set(all_org_roles) & {r.id for r in allowed_roles}):
-            highest_role = roles.get_sorted_organization_roles(all_org_roles)[0].id
+            highest_role = organization_roles.get_sorted_roles(all_org_roles)[0].id
             raise UnableToAcceptMemberInvitationException(
                 f"You do not have permission to approve a member invitation with the role {highest_role}."
             )

--- a/src/sentry/roles/__init__.py
+++ b/src/sentry/roles/__init__.py
@@ -9,7 +9,6 @@ default_manager = RoleManager(
 organization_roles = default_manager.organization_roles
 team_roles = default_manager.team_roles
 get_minimum_team_role = default_manager.get_minimum_team_role
-get_sorted_organization_roles = default_manager.get_sorted_organization_roles
 
 # Deprecated: Prefer calling methods on organization_roles
 can_manage = default_manager.can_manage

--- a/src/sentry/roles/__init__.py
+++ b/src/sentry/roles/__init__.py
@@ -9,6 +9,7 @@ default_manager = RoleManager(
 organization_roles = default_manager.organization_roles
 team_roles = default_manager.team_roles
 get_minimum_team_role = default_manager.get_minimum_team_role
+get_sorted_organization_roles = default_manager.get_sorted_organization_roles
 
 # Deprecated: Prefer calling methods on organization_roles
 can_manage = default_manager.can_manage

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -118,6 +118,13 @@ class RoleLevel(Generic[R]):
             if any(role.has_scope(scope) for scope in scopes):
                 yield role
 
+    def get_sorted_roles(self, roles: Iterable[str]) -> Iterable[Role]:
+        return sorted(
+            [self.get(role) for role in roles],
+            key=lambda r: r.priority,
+            reverse=True,
+        )
+
 
 class RoleManager:
     def __init__(
@@ -200,10 +207,3 @@ class RoleManager:
 
     def get_minimum_team_role(self, org_role: str) -> TeamRole:
         return self.team_roles.get(self._minimum_team_role_map[org_role])
-
-    def get_sorted_organization_roles(self, org_roles: Iterable[str]) -> Iterable[OrganizationRole]:
-        return sorted(
-            [self.organization_roles.get(role) for role in org_roles],
-            key=lambda r: r.priority,
-            reverse=True,
-        )

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -200,3 +200,10 @@ class RoleManager:
 
     def get_minimum_team_role(self, org_role: str) -> TeamRole:
         return self.team_roles.get(self._minimum_team_role_map[org_role])
+
+    def get_sorted_organization_roles(self, org_roles: Iterable[str]) -> Iterable[OrganizationRole]:
+        return sorted(
+            [self.organization_roles.get(role) for role in org_roles],
+            key=lambda r: r.priority,
+            reverse=True,
+        )

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -303,16 +303,17 @@ class DatabaseBackedOrganizationService(OrganizationService):
             member = OrganizationMember.objects.get(id=member_id)
             organization_member = self.serialize_member(member)
 
-        org_roles = []
+        org_roles: List[str] = []
         if organization_member:
             team_ids = [mt.team_id for mt in organization_member.member_teams]
-            org_roles = set(
+            all_roles: Set[str] = set(
                 Team.objects.filter(id__in=team_ids)
                 .exclude(org_role=None)
                 .values_list("org_role", flat=True)
             )
-            org_roles.add(organization_member.role)
-        return list(org_roles)
+            all_roles.add(organization_member.role)
+            org_roles.extend(list(all_roles))
+        return org_roles
 
     def get_top_dog_team_member_ids(self, organization_id: int) -> List[int]:
         owner_teams = list(

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -306,14 +306,13 @@ class DatabaseBackedOrganizationService(OrganizationService):
         org_roles = []
         if organization_member:
             team_ids = [mt.team_id for mt in organization_member.member_teams]
-            org_roles = list(
+            org_roles = set(
                 Team.objects.filter(id__in=team_ids)
                 .exclude(org_role=None)
                 .values_list("org_role", flat=True)
-                .distinct()
             )
-            org_roles.append(organization_member.role)
-        return org_roles
+            org_roles.add(organization_member.role)
+        return list(org_roles)
 
     def get_top_dog_team_member_ids(self, organization_id: int) -> List[int]:
         owner_teams = list(

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -143,7 +143,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             sentry_options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 50 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 52
+        expected_queries = 49 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 51
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)


### PR DESCRIPTION
[N+1 Issue](https://sentry.sentry.io/issues/3950968531/?project=1) -- but only happening for 1 user in 1 org

The n+1 query appears to be coming from `team.py` where we're repeatedly calling `get_all_org_roles_sorted` for each `OrganizationMember` object that is associated with a particular user. Here, this logic is separated out into a helper function of its own to remove duplicate similar queries.

Also, across a couple of places, use sets instead of lists to prevent duplicates and avoid calling `distinct()` on the DB