### PR TITLE
ref: add workflow to create a version bump PR

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,47 @@
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        required: true
+        type: string
+        description: package name such as `sentry-arroyo`
+      version:
+        required: true
+        type: string
+        description: desired version such as `1.2.3`
+
+# disable all permissions -- we use the PAT's permissions instead
+permissions: {}
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+      with:
+        token: ${{ secrets.BUMP_SENTRY_TOKEN }}
+    - run: |
+        set -euxo pipefail
+
+        git checkout -b "bot/bump-version/$PACKAGE/$VERSION"
+
+        re="$(sed 's/[_-]/[_-]/g' <<< "$PACKAGE")"
+        sed -i "s/^$re==.*/$PACKAGE==$VERSION/g" -- requirements*.txt
+
+        git \
+            -c user.name=getsentry-bot \
+            -c user.email='10587625+getsentry-bot@users.noreply.github.com' \
+            commit \
+            --all \
+            --message "ref: bump $PACKAGE to $VERSION" \
+            --message "Co-Authored-By: $SENDER <$SENDER_ID+$SENDER@users.noreply.github.com>"
+
+        git push origin HEAD --quiet
+
+        gh pr create --fill
+      env:
+        GH_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
+        PACKAGE: ${{ inputs.package }}
+        VERSION: ${{ inputs.version }}
+        SENDER: ${{ github.event.sender.login }}
+        SENDER_ID: ${{ github.event.sender.id }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,10 +63,11 @@ repos:
       args: [ '--project', 'pyrightconfig-commithook.json' ]
 
 -   repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.16.0
+    rev: 0.21.0
     hooks:
     - id: check-github-actions
     - id: check-github-workflows
+      args: [--verbose]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0


### PR DESCRIPTION
the idea is to add a shortcut to "wait for dependabot to open a PR" such that developers can bump internal libraries more rapidly

(I tried this out in a personal repo, seems to work well assuming the permissions are correct)