### PR TITLE
fix(auth): Fix loginUrl for when SSO is required

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -59,7 +59,10 @@ class AuthIndexEndpoint(Endpoint):
         if not is_safe_url(redirect, allowed_hosts=(request.get_host(),)):
             redirect = None
         initiate_login(request, redirect)
-        raise SsoRequired(Organization.objects.get_from_cache(id=org_id))
+        raise SsoRequired(
+            organization=Organization.objects.get_from_cache(id=org_id),
+            after_login_redirect=redirect,
+        )
 
     @staticmethod
     def _verify_user_via_inputs(validator, request):

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -4,7 +4,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.exceptions import APIException
 
+from sentry.app import env
 from sentry.utils.auth import make_login_link_with_redirect
+from sentry.utils.http import is_using_customer_domain
 
 
 class ResourceDoesNotExist(APIException):
@@ -56,6 +58,9 @@ class SsoRequired(SentryAPIException):
 
     def __init__(self, organization, after_login_redirect=None):
         login_url = reverse("sentry-auth-organization", args=[organization.slug])
+        request = env.request
+        if request and is_using_customer_domain(request):
+            login_url = organization.absolute_url(login_url)
 
         if after_login_redirect:
             login_url = make_login_link_with_redirect(login_url, after_login_redirect)

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -1,6 +1,7 @@
 from base64 import b64encode
 from datetime import datetime, timedelta, timezone
 from unittest import mock
+from urllib.parse import urlencode
 
 from django.test import override_settings
 
@@ -243,6 +244,71 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                         "detail": {
                             "code": "sso-required",
                             "extra": {"loginUrl": f"/auth/login/{self.organization.slug}/"},
+                            "message": "Must login via SSO",
+                        }
+                    }
+                    assert COOKIE_NAME not in response.cookies
+
+    @with_feature("organizations:u2f-superuser-form")
+    @mock.patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
+    @mock.patch("sentry.auth.authenticators.U2fInterface.validate_response", return_value=False)
+    def test_superuser_expired_sso_user_no_password_saas_product_customer_domain(
+        self, validate_response, is_available
+    ):
+        from sentry.auth.superuser import COOKIE_NAME, Superuser
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            # An organization that a superuser is not a member of, but will try to access.
+            other_org = self.create_organization(name="other_org")
+
+            org_provider = AuthProvider.objects.create(
+                organization=self.organization, provider="dummy"
+            )
+
+            user = self.create_user("foo@example.com", is_superuser=True)
+
+            self.get_auth(user)
+
+            user.update(password="")
+
+            AuthIdentity.objects.create(user=user, auth_provider=org_provider)
+
+            with mock.patch.object(Superuser, "org_id", self.organization.id), override_settings(
+                SUPERUSER_ORG_ID=self.organization.id
+            ):
+                with self.settings(SENTRY_SELF_HOSTED=False):
+                    self.login_as(user, organization_id=self.organization.id)
+
+                    sso_session_expired = SsoSession(
+                        self.organization.id,
+                        datetime.now(tz=timezone.utc) - SSO_EXPIRY_TIME - timedelta(hours=1),
+                    )
+                    self.session[sso_session_expired.session_key] = sso_session_expired.to_dict()
+                    self.save_session()
+
+                    referrer = f"http://{other_org.slug}.testserver/issues/"
+
+                    response = self.client.put(
+                        self.path,
+                        data={
+                            "isSuperuserModal": True,
+                            "challenge": """{"challenge":"challenge"}""",
+                            "response": """{"response":"response"}""",
+                            "superuserAccessCategory": "for_unit_test",
+                            "superuserReason": "for testing",
+                        },
+                        SERVER_NAME=f"{other_org.slug}.testserver",
+                        HTTP_REFERER=referrer,
+                    )
+                    # status code of 401 means invalid SSO session
+                    assert response.status_code == 401
+                    query_string = urlencode({"next": referrer})
+                    assert response.data == {
+                        "detail": {
+                            "code": "sso-required",
+                            "extra": {
+                                "loginUrl": f"http://{self.organization.slug}.testserver/auth/login/{self.organization.slug}/?{query_string}"
+                            },
                             "message": "Must login via SSO",
                         }
                     }

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -239,6 +239,13 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                     )
                     # status code of 401 means invalid SSO session
                     assert response.status_code == 401
+                    assert response.data == {
+                        "detail": {
+                            "code": "sso-required",
+                            "extra": {"loginUrl": f"/auth/login/{self.organization.slug}/"},
+                            "message": "Must login via SSO",
+                        }
+                    }
                     assert COOKIE_NAME not in response.cookies
 
     @with_feature("organizations:u2f-superuser-form")


### PR DESCRIPTION
Whenever users use the auth endpoint and if they need to re-authenticate via SSO, we raise a `SsoRequired` error. This error includes a `loginUrl` attribute from which users need to re-authenticate from.

The redirect to `loginUrl` occurs here on the frontend: https://github.com/getsentry/sentry/blob/bd538d7482a3cc00e70e85b0c1727ad3e25e0475/static/app/api.tsx#L117-L121

-----


This pull request
- adds customer domain support to `loginUrl` for the `SsoRequired` API exception and,
- properly attaches `?next=...` to `loginUrl` from any referrer. 

This addresses SSO redirect issues that superusers face when using the sudo modal form.