### PR TITLE
chore(labels): Add Type: Power and Type: Simplicity labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -84,6 +84,12 @@
 - name: 'Type: User Feedback'
   color: '584774'
   description: ''
+- name: 'Type: Power'
+  color: '584774'
+  description: ''
+- name: 'Type: Simplicity'
+  color: '584774'
+  description: ''
 
 # Components
 - name: 'Component: Analytics'


### PR DESCRIPTION
Saw this here: https://github.com/getsentry/sentry/issues/44878#issuecomment-1440356107

We need to keep `labels.yml` in sync to avoid future deletion of these labels