### PR TITLE
fix(issues): Wrap annotated issue messages

### DIFF
--- a/static/app/components/events/meta/annotatedText/annotatedTextValue.tsx
+++ b/static/app/components/events/meta/annotatedText/annotatedTextValue.tsx
@@ -58,8 +58,4 @@ export function AnnotatedTextValue({value, meta, organization, project}: Props) 
 
 const ChunksSpan = styled('span')`
   word-break: break-word;
-
-  span {
-    display: inline;
-  }
 `;

--- a/static/app/components/events/meta/annotatedText/annotatedTextValue.tsx
+++ b/static/app/components/events/meta/annotatedText/annotatedTextValue.tsx
@@ -22,6 +22,7 @@ export function AnnotatedTextValue({value, meta, organization, project}: Props) 
           if (chunk.type === 'redaction') {
             return (
               <Tooltip
+                skipWrapper
                 title={getTooltipText({rule_id: chunk.rule_id, remark: chunk.remark})}
                 key={index}
               >
@@ -56,6 +57,8 @@ export function AnnotatedTextValue({value, meta, organization, project}: Props) 
 }
 
 const ChunksSpan = styled('span')`
+  word-break: break-word;
+
   span {
     display: inline;
   }

--- a/static/app/components/events/meta/annotatedText/redaction.tsx
+++ b/static/app/components/events/meta/annotatedText/redaction.tsx
@@ -1,14 +1,6 @@
 import styled from '@emotion/styled';
 
-type Props = {
-  children: React.ReactNode;
-  className?: string;
-  withoutBackground?: boolean;
-};
-
-export const Redaction = styled(({children, className}: Props) => (
-  <span className={className}>{children}</span>
-))`
+export const Redaction = styled('span')<{withoutBackground?: boolean}>`
   cursor: default;
   vertical-align: middle;
   ${p => !p.withoutBackground && `background: rgba(255, 0, 0, 0.05);`}


### PR DESCRIPTION
Adds text wrapping to the issue message when it includes annotated text
fixes #44995 

<img width="757" alt="Screenshot 2023-02-22 at 2 36 59 PM" src="https://user-images.githubusercontent.com/1400464/220776240-f258251d-762e-412b-b530-b68a1188e2f9.png">
