### PR TITLE
ref(issue-owners): Ratelimit groups, not events

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -170,18 +170,6 @@ def handle_owner_assignment(job):
             # - an Assignee has been set with TTL of infinite
             with metrics.timer("post_process.handle_owner_assignment"):
 
-                with sentry_sdk.start_span(op="post_process.handle_owner_assignment.ratelimited"):
-
-                    if should_issue_owners_ratelimit(project.id):
-                        logger.info(
-                            "handle_owner_assignment.ratelimited",
-                            extra={
-                                **basic_logging_details,
-                                "reason": "ratelimited",
-                            },
-                        )
-                        return
-
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.cache_set_assignee"
                 ):
@@ -217,6 +205,18 @@ def handle_owner_assignment(job):
                             extra={
                                 **basic_logging_details,
                                 "reason": "issue_owners_exist",
+                            },
+                        )
+                        return
+
+                with sentry_sdk.start_span(op="post_process.handle_owner_assignment.ratelimited"):
+
+                    if should_issue_owners_ratelimit(project.id):
+                        logger.info(
+                            "handle_owner_assignment.ratelimited",
+                            extra={
+                                **basic_logging_details,
+                                "reason": "ratelimited",
                             },
                         )
                         return

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -992,8 +992,8 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.tasks.post_process.logger")
     def test_issue_owners_should_ratelimit(self, logger):
         cache.set(
-            f"issue_owner_assignment_ratelimit:{self.project.id}",
-            (ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT, datetime.now()),
+            f"issue_owner_assignment_ratelimiter:{self.project.id}",
+            (set(range(0, ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT * 10, 10)), datetime.now()),
         )
         event = self.create_event(
             data={


### PR DESCRIPTION
## Objective:
Currently, we are ratelimiting the events according to our `ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT`. This is incorrect and too aggressive. We should be ratelimiting the groups. Subsequent events for a new Issue will get debounced by the debounce logic. But we should not prevent new Issues from getting their Issue Owner assignments.