### PR TITLE
chore(issue-platform): Register profiling issue post process group options in admin ui

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -50,6 +50,9 @@ const optionsAvailable = [
   'profile.issues.blocked_main_thread-ingest.la-rollout',
   'profile.issues.blocked_main_thread-ingest.ea-rollout',
   'profile.issues.blocked_main_thread-ingest.ga-rollout',
+  'profile.issues.blocked_main_thread-ppg.la-rollout',
+  'profile.issues.blocked_main_thread-ppg.ea-rollout',
+  'profile.issues.blocked_main_thread-ppg.ga-rollout',
   'processing.view-hierarchies-deobfuscation-general-availability',
 ];
 
@@ -184,10 +187,20 @@ export default class AdminSettings extends AsyncView<{}, State> {
               {fields['performance.issues.m_n_plus_one_db.ga-rollout']}
             </Panel>
             <Panel>
-              <PanelHeader>Profiling Issues - Block Main Thread Detector</PanelHeader>
+              <PanelHeader>
+                Profiling Issues - Block Main Thread Detector Ingest
+              </PanelHeader>
               {fields['profile.issues.blocked_main_thread-ingest.la-rollout']}
               {fields['profile.issues.blocked_main_thread-ingest.ea-rollout']}
               {fields['profile.issues.blocked_main_thread-ingest.ga-rollout']}
+            </Panel>
+            <Panel>
+              <PanelHeader>
+                Profiling Issues - Block Main Thread Detector Post Process Group
+              </PanelHeader>
+              {fields['profile.issues.blocked_main_thread-ppg.la-rollout']}
+              {fields['profile.issues.blocked_main_thread-ppg.ea-rollout']}
+              {fields['profile.issues.blocked_main_thread-ppg.ga-rollout']}
             </Panel>
           </Feature>
           <Feature features={['organizations:view-hierarchies-options-dev']}>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -395,6 +395,30 @@ const performanceOptionDefinitions: Field[] = [
     ),
     ...HIGH_THROUGHPUT_RATE_OPTION,
   },
+  {
+    key: 'profile.issues.blocked_main_thread-ppg.la-rollout',
+    label: t('Limited Availability Detection Rate'),
+    help: t(
+      'Controls the rate at which profile blocked main thread performance problems are sent to post process group for LA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'profile.issues.blocked_main_thread-ppg.ea-rollout',
+    label: t('Early Adopter Detection Rate'),
+    help: t(
+      'Controls the rate at which profile blocked main thread performance problems are sent to post process group for EA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'profile.issues.blocked_main_thread-ppg.ga-rollout',
+    label: t('General Availability Detection Rate'),
+    help: t(
+      'Controls the rate at which profile blocked main thread performance problems are sent to post process group for GA organizations.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
 ];
 
 // This are ordered based on their display order visually


### PR DESCRIPTION
This adds in ui options to roll out post process group for blocked main thread issues.