### PR TITLE
feat(search): basic SearchFilter validation before querying snuba

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -13,6 +13,10 @@ from sentry.utils import snuba
 from sentry.utils.snuba import SnubaQueryParams
 
 
+class UnsupportedSearchQuery(Exception):
+    pass
+
+
 class IntermediateSearchQueryPartial(Protocol):
     def __call__(
         self,
@@ -235,8 +239,10 @@ def _update_profiling_search_filters(
     for sf in search_filters:
         # XXX: we replace queries on these keys to something that should return nothing since
         # profiling issues doesn't support have stacktraces
-        if sf.key.name in ("notHandled", "error.handled"):
-            updated_filters.append(SearchFilter(SearchKey("1"), "=", SearchValue("2")))
+        if sf.key.name in ("error.unhandled", "error.handled"):
+            raise UnsupportedSearchQuery(
+                f"{sf.key.name} filter isn't support for {GroupCategory.PROFILE.name}"
+            )
         else:
             updated_filters.append(sf)
 

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -238,7 +238,7 @@ def _update_profiling_search_filters(
 
     for sf in search_filters:
         # XXX: we replace queries on these keys to something that should return nothing since
-        # profiling issues doesn't support have stacktraces
+        # profiling issues doesn't support stacktraces
         if sf.key.name in ("error.unhandled", "error.handled"):
             raise UnsupportedSearchQuery(
                 f"{sf.key.name} filter isn't support for {GroupCategory.PROFILE.name}"

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -241,7 +241,7 @@ def _update_profiling_search_filters(
         # profiling issues doesn't support stacktraces
         if sf.key.name in ("error.unhandled", "error.handled"):
             raise UnsupportedSearchQuery(
-                f"{sf.key.name} filter isn't support for {GroupCategory.PROFILE.name}"
+                f"{sf.key.name} filter isn't supported for {GroupCategory.PROFILE.name}"
             )
         else:
             updated_filters.append(sf)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2491,7 +2491,11 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         assert list(results) == []
         assert results.hits == 2
 
-    def test_not_handled_function(self):
+    def test_rejected_filters(self):
+        """
+        Any queries with `error.handled` or `error.unhandled` filters querying the search_issues dataset
+        should be rejected and return empty results.
+        """
         with self.feature("organizations:issue-platform"):
             results = self.make_query(
                 projects=[self.project],
@@ -2509,11 +2513,7 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
                 count_hits=True,
             )
 
-            assert list(results) == list(results2) == []
-
-    def test_is_handled_function(self):
-        with self.feature("organizations:issue-platform"):
-            results = self.make_query(
+            result3 = self.make_query(
                 projects=[self.project],
                 search_filter_query="issue.category:profile error.handled:0",
                 sort_by="date",
@@ -2521,7 +2521,7 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
                 count_hits=True,
             )
 
-            results2 = self.make_query(
+            results4 = self.make_query(
                 projects=[self.project],
                 search_filter_query="issue.category:profile error.handled:1",
                 sort_by="date",
@@ -2529,7 +2529,7 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
                 count_hits=True,
             )
 
-            assert list(results) == list(results2) == []
+            assert list(results) == list(results2) == list(result3) == list(results4) == []
 
 
 class CdcEventsSnubaSearchTest(SharedSnubaTest):

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2495,13 +2495,41 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         with self.feature("organizations:issue-platform"):
             results = self.make_query(
                 projects=[self.project],
+                search_filter_query="issue.category:profile error.unhandled:0",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            results2 = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile error.unhandled:1",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            assert list(results) == list(results2) == []
+
+    def test_is_handled_function(self):
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                projects=[self.project],
                 search_filter_query="issue.category:profile error.handled:0",
                 sort_by="date",
                 limit=1,
                 count_hits=True,
             )
 
-            assert list(results) == []
+            results2 = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile error.handled:1",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+            assert list(results) == list(results2) == []
 
 
 class CdcEventsSnubaSearchTest(SharedSnubaTest):


### PR DESCRIPTION
Adds a validation step when querying `search_issues` dataset to avoid making erroneous queries to snuba, like `error.handled:<true/false>`, `error.unhandled:<true/false>`.

Resolves https://github.com/getsentry/sentry/issues/44941