### PR TITLE
ref(indexer): Retry indexer refactor

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/common.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/common.py
@@ -1,17 +1,13 @@
 import logging
-import time
-from typing import Any, List, MutableMapping, MutableSequence, Optional, Union
+from typing import Any, List, MutableMapping, MutableSequence, Union
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
-from arroyo.processing.strategies import MessageRejected
-from arroyo.processing.strategies import ProcessingStrategy
-from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
-from arroyo.types import Message, Value
+from arroyo.types import Message
 from django.conf import settings
 
 from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingPayload
-from sentry.utils import kafka_config, metrics
+from sentry.utils import kafka_config
 
 MessageBatch = List[Message[KafkaPayload]]
 IndexerOutputMessageBatch = MutableSequence[Message[Union[RoutingPayload, KafkaPayload]]]
@@ -37,123 +33,3 @@ def get_config(
         queued_min_messages=DEFAULT_QUEUED_MIN_MESSAGES,
     )
     return consumer_config
-
-
-class MetricsBatchBuilder:
-    """
-    Batches up individual messages - type: Message[KafkaPayload] - into a
-    list, which will later be the payload for the big outer message
-    that gets passed through to the ParallelTransformStep.
-
-    See `__flush` method of BatchMessages for when that happens.
-    """
-
-    def __init__(self, max_batch_size: int, max_batch_time: float) -> None:
-        self.__messages: MessageBatch = []
-        self.__max_batch_size = max_batch_size
-        self.__deadline = time.time() + max_batch_time / 1000.0
-
-    def __len__(self) -> int:
-        return len(self.__messages)
-
-    @property
-    def messages(self) -> MessageBatch:
-        return self.__messages
-
-    def append(self, message: Message[KafkaPayload]) -> None:
-        self.__messages.append(message)
-
-    def ready(self) -> bool:
-        if len(self.messages) >= self.__max_batch_size:
-            return True
-        elif time.time() >= self.__deadline:
-            return True
-        else:
-            return False
-
-
-class BatchMessages(ProcessingStep[KafkaPayload]):
-    """
-    First processing step in the MetricsConsumerStrategyFactory.
-    Keeps track of a batch of messages (using the MetricsBatchBuilder)
-    and then when at capacity, either max_batch_time or max_batch_size,
-    flushes the batch.
-
-    Flushing the batch here means wrapping the batch in a Message, the batch
-    itself being the payload. This is what the ParallelTransformStep will
-    process in the process_message function.
-    """
-
-    def __init__(
-        self,
-        next_step: ProcessingStrategy[MessageBatch],
-        max_batch_time: float,
-        max_batch_size: int,
-    ):
-        self.__max_batch_size = max_batch_size
-        self.__max_batch_time = max_batch_time
-
-        self.__next_step = next_step
-        self.__batch: Optional[MetricsBatchBuilder] = None
-        self.__closed = False
-        self.__batch_start: Optional[float] = None
-        # If we received MessageRejected from subsequent steps, this is set to true.
-        # It is reset to false upon the next successful submit.
-        self.__apply_backpressure = False
-
-    def poll(self) -> None:
-        assert not self.__closed
-
-        self.__next_step.poll()
-
-        if self.__batch and self.__batch.ready():
-            self.__flush()
-
-    def submit(self, message: Message[KafkaPayload]) -> None:
-        if self.__apply_backpressure is True:
-            raise MessageRejected
-
-        if self.__batch is None:
-            self.__batch_start = time.time()
-            self.__batch = MetricsBatchBuilder(self.__max_batch_size, self.__max_batch_time)
-
-        self.__batch.append(message)
-
-        if self.__batch and self.__batch.ready():
-            self.__flush()
-
-    def __flush(self) -> None:
-        if not self.__batch:
-            return
-        last = self.__batch.messages[-1]
-
-        new_message = Message(Value(self.__batch.messages, last.committable))
-        if self.__batch_start is not None:
-            elapsed_time = time.time() - self.__batch_start
-            metrics.timing("batch_messages.build_time", elapsed_time)
-
-        try:
-            self.__next_step.submit(new_message)
-            if self.__apply_backpressure is True:
-                self.__apply_backpressure = False
-            self.__batch_start = None
-            self.__batch = None
-        except MessageRejected:
-            self.__apply_backpressure = True
-
-    def terminate(self) -> None:
-        self.__closed = True
-        self.__next_step.terminate()
-
-    def close(self) -> None:
-        self.__closed = True
-
-    def join(self, timeout: Optional[float] = None) -> None:
-        if self.__batch:
-            last = self.__batch.messages[-1]
-            logger.debug(
-                f"Abandoning batch of {len(self.__batch)} messages...latest offset: {last.committable}"
-            )
-
-        self.__next_step.close()
-        self.__next_step.join(timeout)

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -227,4 +227,5 @@ def get_parallel_metrics_consumer(
             min_commit_frequency_sec=max_batch_time / 1000,
             min_commit_messages=max_batch_size,
         ),
+        join_timeout=0.0,
     )

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -7,11 +7,9 @@ from typing import Any, Mapping, Optional, Union
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.commit import CommitPolicy
 from arroyo.processing import StreamProcessor
-from arroyo.processing.strategies import ProcessingStrategy
-from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
-from arroyo.processing.strategies import ProcessingStrategyFactory
+from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyFactory, Reduce
 from arroyo.processing.strategies.transform import ParallelTransformStep
-from arroyo.types import Commit, Message, Partition, Topic
+from arroyo.types import BaseValue, Commit, Message, Partition, Topic
 from django.conf import settings
 
 from sentry.sentry_metrics.configuration import (
@@ -19,8 +17,8 @@ from sentry.sentry_metrics.configuration import (
     initialize_sentry_and_global_consumer_state,
 )
 from sentry.sentry_metrics.consumers.indexer.common import (
-    BatchMessages,
     IndexerOutputMessageBatch,
+    MessageBatch,
     get_config,
 )
 from sentry.sentry_metrics.consumers.indexer.multiprocess import SimpleProduceStep
@@ -35,10 +33,10 @@ from sentry.utils.batching_kafka_consumer import create_topics
 logger = logging.getLogger(__name__)
 
 
-class Unbatcher(ProcessingStep[IndexerOutputMessageBatch]):
+class Unbatcher(ProcessingStrategy[IndexerOutputMessageBatch]):
     def __init__(
         self,
-        next_step: ProcessingStep[Union[KafkaPayload, RoutingPayload]],
+        next_step: ProcessingStrategy[Union[KafkaPayload, RoutingPayload]],
     ) -> None:
         self.__next_step = next_step
         self.__closed = False
@@ -146,8 +144,19 @@ class MetricsConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             ),
         )
 
-        strategy = BatchMessages(
-            parallel_strategy, self.__max_msg_batch_time, self.__max_msg_batch_size
+        def accumulator(result: MessageBatch, value: BaseValue[KafkaPayload]) -> MessageBatch:
+            result.append(Message(value))
+            return result
+
+        def initializer() -> MessageBatch:
+            return []
+
+        strategy = Reduce(
+            self.__max_msg_batch_size,
+            self.__max_msg_batch_time,
+            accumulator,
+            initializer,
+            parallel_strategy,
         )
 
         return strategy


### PR DESCRIPTION
Brings back https://github.com/getsentry/sentry/pull/44721 with a small difference.

Now we pass a join_timeout of 0.0 to the stream processor, so it shuts down immediately dropping any in process batches. 

This matches the current behaviour in the batching step which immediately drops any in flight batches during shutdown https://github.com/getsentry/sentry/blob/be6286e1d40e445760dd6f5c209574090cc05add/src/sentry/sentry_metrics/consumers/indexer/common.py#L151-L156

The previous version of the PR took a much long time to revoke partitions as it attempted to finish processing all in flight batches. This caused timeouts and other weird behaviour during deployment / rebalancing.