### PR TITLE
feat(processor): Add meta field to react minified processor changes

### DIFF
--- a/src/sentry/lang/javascript/errormapping.py
+++ b/src/sentry/lang/javascript/errormapping.py
@@ -31,8 +31,8 @@ def is_expired(ts):
 
 
 class Processor:
-    def __init__(self, vendor, mapping_url, regex, func):
-        self.vendor = vendor
+    def __init__(self, vendor: str, mapping_url, regex, func):
+        self.vendor: str = vendor
         self.mapping_url = mapping_url
         self.regex = re.compile(regex)
         self.func = func
@@ -117,13 +117,17 @@ def rewrite_exception(data):
     rv = False
 
     values_meta = meta.enter("exception", "values")
-    for index, exc in enumerate(get_path(data, "exception", "values", filter=True, default=())):
+    for index, exc in enumerate(get_path(data, "exception", "values", default=())):
+        if exc is None:
+            continue
+
+        processor: Processor
         for processor in error_processors.values():
             try:
                 original_value = exc.get("value")
                 if processor.try_process(exc):
                     values_meta.enter(index, "value").add_remark(
-                        {"rule_id": "react_minified_error", "type": "s"}, original_value
+                        {"rule_id": f"@processing:{processor.vendor}", "type": "s"}, original_value
                     )
                     rv = True
                     break

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -7,8 +7,10 @@ RemarkType = Literal["a", "x", "s", "m", "p", "e"]
 class Remark(TypedDict):
     rule_id: str
     type: RemarkType
-    range_start: Optional[bytes]
-    range_end: Optional[bytes]
+    # Range start is a byte offset
+    range_start: Optional[int]
+    # Range end is a byte offset
+    range_end: Optional[int]
 
 
 class Meta:
@@ -166,6 +168,8 @@ class Meta:
         If an optional ``value`` is specified, it is attached as original value
         into the meta data. Note that there is only one original value, not one
         per remark.
+
+        `range_start` and `range_end` in `rem` are byte offsets.
 
         If no meta data entry exists for the current path, it is created, along
         with the entire parent tree.

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -6,9 +6,9 @@ RemarkType = Literal["a", "x", "s", "m", "p", "e"]
 
 class Remark(TypedDict):
     rule_id: str
-    ty: RemarkType
-    range_start: Optional[int]
-    range_end: Optional[int]
+    type: RemarkType
+    range_start: Optional[bytes]
+    range_end: Optional[bytes]
 
 
 class Meta:
@@ -174,7 +174,7 @@ class Meta:
         if "rem" not in meta or meta["rem"] is None:
             meta["rem"] = []
 
-        rem_list: List[Union[str, int]] = [rem["rule_id"], rem["ty"]]
+        rem_list: List[Union[str, int]] = [rem["rule_id"], rem["type"]]
 
         range_start = rem.get("range_start")
         if range_start is not None:

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -9,8 +9,10 @@ from unittest.mock import ANY, MagicMock, call, patch
 import pytest
 import responses
 from requests.exceptions import RequestException
+from sentry_relay.processing import StoreNormalizer
 
 from sentry import http, options
+from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.event_manager import get_tag
 from sentry.lang.javascript.errormapping import REACT_MAPPING_URL, rewrite_exception
 from sentry.lang.javascript.processor import (
@@ -1422,6 +1424,110 @@ class ErrorMappingTest(unittest.TestCase):
         assert data["exception"]["values"][0]["value"] == (
             '<redacted>.getChildContext(): key "<redacted>" is not defined in ' "childContextTypes."
         )
+
+    @responses.activate
+    def test_react_error_adds_meta(self):
+        responses.add(
+            responses.GET,
+            REACT_MAPPING_URL,
+            body=r"""
+        {
+          "108": "%s.getChildContext(): key \"%s\" is not defined in childContextTypes.",
+          "109": "%s.render(): A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.",
+          "110": "Stateless function components cannot have refs."
+        }
+        """,
+            content_type="application/json",
+        )
+
+        value_109 = (
+            "Minified React error #109; visit http://facebook"
+            ".github.io/react/docs/error-decoder.html?invariant="
+            "109&args[]=Component for the full message or use "
+            "the non-minified dev environment for full errors "
+            "and additional helpful warnings."
+        )
+
+        value_108 = (
+            "Minified React error #108; visit http://facebook"
+            ".github.io/react/docs/error-decoder.html?\u2026"
+        )
+
+        data = {
+            "platform": "javascript",
+            "transaction": "fancy",
+            "exception": {
+                "values": [
+                    {
+                        "type": "InvariantViolation",
+                        "value": value_109,
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "foo.js",
+                                    "lineno": 4,
+                                    "colno": 0,
+                                },
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "foo.js",
+                                    "lineno": 1,
+                                    "colno": 0,
+                                },
+                            ]
+                        },
+                    },
+                    {
+                        "type": "InvariantViolation",
+                        "value": value_108,
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "foo.js",
+                                    "lineno": 4,
+                                    "colno": 0,
+                                }
+                            ]
+                        },
+                    },
+                ]
+            },
+            "_meta": {
+                "transaction": {
+                    "": {
+                        "err": ["existing", "additional"],
+                    }
+                }
+            },
+        }
+
+        assert rewrite_exception(data)
+
+        # run data through normalization to ensure that the meta is set properly
+        normalizer = StoreNormalizer(
+            remove_other=False, is_renormalize=True, **DEFAULT_STORE_NORMALIZER_ARGS
+        )
+        data = normalizer.normalize_event(dict(data))
+
+        assert data["_meta"] == {
+            "exception": {
+                "values": {
+                    "0": {
+                        "value": {"": {"rem": [["react_minified_error", "s"]], "val": value_109}}
+                    },
+                    "1": {
+                        "value": {"": {"rem": [["react_minified_error", "s"]], "val": value_108}}
+                    },
+                }
+            },
+            "transaction": {
+                "": {
+                    "err": ["existing", "additional"],
+                }
+            },
+        }
 
     @responses.activate
     def test_skip_none_values(self):

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -1492,6 +1492,20 @@ class ErrorMappingTest(unittest.TestCase):
                             ]
                         },
                     },
+                    {
+                        "type": "Error",
+                        "value": "this is not a react minified error",
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "foo.js",
+                                    "lineno": 1,
+                                    "colno": 0,
+                                },
+                            ],
+                        },
+                    },
                 ]
             },
             "_meta": {

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -1458,6 +1458,8 @@ class ErrorMappingTest(unittest.TestCase):
             "transaction": "fancy",
             "exception": {
                 "values": [
+                    # Set first item to be None to check that we handle this case.
+                    None,
                     {
                         "type": "InvariantViolation",
                         "value": value_109,
@@ -1478,20 +1480,7 @@ class ErrorMappingTest(unittest.TestCase):
                             ]
                         },
                     },
-                    {
-                        "type": "InvariantViolation",
-                        "value": value_108,
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "abs_path": "http://example.com/foo.js",
-                                    "filename": "foo.js",
-                                    "lineno": 4,
-                                    "colno": 0,
-                                }
-                            ]
-                        },
-                    },
+                    # Non react minified error
                     {
                         "type": "Error",
                         "value": "this is not a react minified error",
@@ -1504,6 +1493,20 @@ class ErrorMappingTest(unittest.TestCase):
                                     "colno": 0,
                                 },
                             ],
+                        },
+                    },
+                    {
+                        "type": "InvariantViolation",
+                        "value": value_108,
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "foo.js",
+                                    "lineno": 4,
+                                    "colno": 0,
+                                }
+                            ]
                         },
                     },
                 ]
@@ -1528,12 +1531,8 @@ class ErrorMappingTest(unittest.TestCase):
         assert data["_meta"] == {
             "exception": {
                 "values": {
-                    "0": {
-                        "value": {"": {"rem": [["react_minified_error", "s"]], "val": value_109}}
-                    },
-                    "1": {
-                        "value": {"": {"rem": [["react_minified_error", "s"]], "val": value_108}}
-                    },
+                    "1": {"value": {"": {"rem": [["@processing:react", "s"]], "val": value_109}}},
+                    "3": {"value": {"": {"rem": [["@processing:react", "s"]], "val": value_108}}},
                 }
             },
             "transaction": {

--- a/tests/sentry/utils/test_meta.py
+++ b/tests/sentry/utils/test_meta.py
@@ -224,18 +224,18 @@ class MetaTests(TestCase):
 
     def test_add_remark(self):
         meta = Meta()
-        meta.add_remark({"rule_id": "react", "ty": "s"})
+        meta.add_remark({"rule_id": "react", "type": "s"})
         assert meta.get() == {
             "rem": [["react", "s"]],
         }
-        meta.add_remark({"rule_id": "removal-rule", "ty": "x"})
+        meta.add_remark({"rule_id": "removal-rule", "type": "x"})
         assert meta.get() == {
             "rem": [["react", "s"], ["removal-rule", "x"]],
         }
 
     def test_add_remark_with_value(self):
         meta = Meta()
-        meta.add_remark({"rule_id": "react", "ty": "s"}, "Minified React error #109")
+        meta.add_remark({"rule_id": "react", "type": "s"}, "Minified React error #109")
         assert meta.get() == {
             "rem": [["react", "s"]],
             "val": "Minified React error #109",


### PR DESCRIPTION
ref https://github.com/getsentry/sentry/issues/44877

Continuing our work from https://github.com/getsentry/sentry/pull/44884, this PR takes the `add_remark` implementation from there and uses it to add a substitution remark every time we process a react minified event message.

https://github.com/getsentry/relay/blob/d465f2d5effc013039a4fca884bc663efcb46527/relay-general/src/types/meta.rs#L24

In addition, as per feedback, we also test to make sure that store normalization works properly with this new set up.