### PR TITLE
chore(webhooks): Track when the organization.slug is already set

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -14,6 +14,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from rest_framework.request import Request
+from sentry_sdk import configure_scope
 
 from sentry import options
 from sentry.constants import ObjectStatus
@@ -30,10 +31,24 @@ from sentry.models import (
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json
 from sentry.utils.json import JSONData
+from sentry.utils.sdk import report_tags_already_set
 
 from .repository import GitHubRepositoryProvider
 
 logger = logging.getLogger("sentry.webhooks")
+
+
+def clear_tags_and_context_if_already_set():
+    with configure_scope() as scope:
+        report_tags_already_set(scope)
+        for tag in ["organization", "organization.slug"]:
+            if tag in scope._tags:
+                del scope._tags[tag]
+
+        if "organization" in scope._contexts:
+            del scope._contexts["organization"]
+
+        logger.info("We've reset the context and tags.")
 
 
 class Webhook:
@@ -456,6 +471,7 @@ class GitHubWebhookBase(View):  # type: ignore
         raise NotImplementedError
 
     def handle(self, request: Request) -> HttpResponse:
+        clear_tags_and_context_if_already_set()
         secret = self.get_secret()
 
         if secret is None:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -38,7 +38,7 @@ from .repository import GitHubRepositoryProvider
 logger = logging.getLogger("sentry.webhooks")
 
 
-def clear_tags_and_context_if_already_set():
+def clear_tags_and_context_if_already_set() -> None:
     with configure_scope() as scope:
         report_tags_already_set(scope)
         for tag in ["organization", "organization.slug"]:


### PR DESCRIPTION
We have events tagged with organization.slug even when it is not possible.

This change reports instances of this and resets the values for the Github webhook. The resetting would prove that we're understanding the problem and we can fix it in some instances. Finding the root problem will take a bit more work.

You can trigger this code with:
```
curl http://localhost:8000/extensions/github/webhook/ -d '{}'
```

A sample event can be seen [here](https://sentry.sentry.io/discover/sentry:99c8b9c9d2c241cc90e52c307faa45eb/?field=organization.slug&field=user.display&field=timestamp&name=Integration.DoesNotExist%3A+Integration+matching+query+does+not+exist.&project=1&query=issue%3ASENTRY-W7T&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29) (private link)

A query showing transactions that should not have the event can be seen [here](https://sentry.sentry.io/discover/results/?field=transaction&field=count_unique%28organization.slug%29&field=count%28%29&name=Integration.DoesNotExist%3A+Integration+matching+query+does+not+exist.&project=1&query=%21organization.slug%3A%22%22+error.value%3A%22Integration+matching+query+does+not+exist.%22&sort=-transaction&statsPeriod=14d&yAxis=count%28%29). There may be more since I'm narrowing it down to just `error.value:"Integration matching query does not exist."`

It helps investigate: [WOR-2464](https://getsentry.atlassian.net/browse/WOR-2464)

[WOR-2464]: https://getsentry.atlassian.net/browse/WOR-2464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ