### PR TITLE
fix(view-hierarchy): Add a threshold for movement on mouse clicks

### DIFF
--- a/static/app/components/events/viewHierarchy/wireframe.tsx
+++ b/static/app/components/events/viewHierarchy/wireframe.tsx
@@ -21,6 +21,7 @@ import {
 } from 'sentry/utils/profiling/gl/utils';
 
 const MIN_BORDER_SIZE = 20;
+const MOUSE_DRAG_THRESHOLD = 3;
 
 export interface ViewNode {
   node: ViewHierarchyWindow;
@@ -185,14 +186,23 @@ function Wireframe({hierarchy, selectedNode, onNodeSelect, project}: WireframePr
 
     const handleMouseMove = (e: MouseEvent) => {
       if (start) {
+        const currPosition = vec2.fromValues(e.offsetX, e.offsetY);
+        const delta = vec2.sub(vec2.create(), currPosition, start);
+
+        // If the mouse hasn't moved significantly, then don't consider
+        // this a drag. This prevents missed selections when the user
+        // moves their mouse slightly when clicking
+        const distance = vec2.len(delta);
+        if (!isDragging && distance < MOUSE_DRAG_THRESHOLD) {
+          return;
+        }
+
         overlayRef.style.cursor = 'grabbing';
         isDragging = true;
         hoveredRect = null;
-        const currPosition = vec2.fromValues(e.offsetX, e.offsetY);
 
         // Delta needs to be scaled by the devicePixelRatio and how
         // much we've zoomed the image by to get an accurate translation
-        const delta = vec2.sub(vec2.create(), currPosition, start);
         vec2.scale(delta, delta, window.devicePixelRatio / transformationMatrix[0]);
 
         // Translate from the original matrix as a starting point


### PR DESCRIPTION
If the mouse click moved slightly, it was being treated as a drag and wouldn't select the node in the wireframe. This adds a threshold on the mouse move handler so movement under that threshold won't get picked it up as a drag.

Currently I've set the threshold to be `3` which means the user can move up to `3px` before the drag starts.

Closes #44743 