### PR TITLE
fix(source-maps): add check for context_line to source map debug endpoint

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -95,7 +95,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
 
         frame, filename, abs_path = self._get_frame_filename_and_path(exception, frame_idx)
 
-        if frame.pre_context or frame.post_context:
+        if frame.context_line:
             return self._create_response()
 
         try:

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -12,6 +12,28 @@ from sentry.testutils.silo import region_silo_test
 class SourceMapDebugEndpointTestCase(APITestCase):
     endpoint = "sentry-api-0-event-source-map-debug"
 
+    base_data = {
+        "event_id": "a" * 32,
+        "exception": {
+            "values": [
+                {
+                    "type": "Error",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "abs_path": "https://app.example.com/static/js/main.fa8fe19f.js",
+                                "filename": "/static/js/main.fa8fe19f.js",
+                                "lineno": 1,
+                                "colno": 39,
+                                "context_line": "function foo() {",
+                            }
+                        ]
+                    },
+                },
+            ]
+        },
+    }
+
     def setUp(self) -> None:
         self.login_as(self.user)
         return super().setUp()
@@ -72,27 +94,7 @@ class SourceMapDebugEndpointTestCase(APITestCase):
     @with_feature("organizations:fix-source-map-cta")
     def test_frame_out_of_bounds(self):
         event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "Error",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "abs_path": "https://app.example.com/static/js/main.fa8fe19f.js",
-                                        "filename": "/static/js/main.fa8fe19f.js",
-                                        "lineno": 1,
-                                        "colno": 39,
-                                        "context_line": "function foo() {",
-                                    }
-                                ]
-                            },
-                        },
-                    ]
-                },
-            },
+            data=self.base_data,
             project_id=self.project.id,
         )
 
@@ -108,27 +110,7 @@ class SourceMapDebugEndpointTestCase(APITestCase):
     @with_feature("organizations:fix-source-map-cta")
     def test_exception_out_of_bounds(self):
         event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "Error",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "abs_path": "https://app.example.com/static/js/main.fa8fe19f.js",
-                                        "filename": "/static/js/main.fa8fe19f.js",
-                                        "lineno": 1,
-                                        "colno": 39,
-                                        "context_line": "function foo() {",
-                                    }
-                                ]
-                            },
-                        },
-                    ]
-                },
-            },
+            data=self.base_data,
             project_id=self.project.id,
         )
 
@@ -144,27 +126,7 @@ class SourceMapDebugEndpointTestCase(APITestCase):
     @with_feature("organizations:fix-source-map-cta")
     def test_event_has_context_line(self):
         event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "Error",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "abs_path": "https://app.example.com/static/js/main.fa8fe19f.js",
-                                        "filename": "/static/js/main.fa8fe19f.js",
-                                        "lineno": 1,
-                                        "colno": 39,
-                                        "context_line": "function foo() {",
-                                    }
-                                ]
-                            },
-                        },
-                    ]
-                },
-            },
+            data=self.base_data,
             project_id=self.project.id,
         )
 

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -70,6 +70,43 @@ class SourceMapDebugEndpointTestCase(APITestCase):
         assert resp.data["detail"] == "Query parameter 'frame_idx' is required"
 
     @with_feature("organizations:fix-source-map-cta")
+    def test_event_has_context_line(self):
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Error",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "abs_path": "https://app.example.com/static/js/main.fa8fe19f.js",
+                                        "filename": "/static/js/main.fa8fe19f.js",
+                                        "lineno": 1,
+                                        "colno": 39,
+                                        "context_line": "function foo() {",
+                                    }
+                                ]
+                            },
+                        },
+                    ]
+                },
+            },
+            project_id=self.project.id,
+        )
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            event.event_id,
+            frame_idx=0,
+            exception_idx=0,
+        )
+        error = resp.data["errors"]
+        assert error == []
+
+    @with_feature("organizations:fix-source-map-cta")
     def test_event_has_no_release(self):
         event = self.store_event(
             data={


### PR DESCRIPTION
this pr adds a check to see if context_line exists on the frame for the source map debug endpoint. if those exist, then we can say that the frame has been un-minified. this will fix a bug where node projects are getting the source map debug alerts even though they don't need to upload source maps. 