### PR TITLE
fix(issue-platform): Accept new `ProfileFileIOGroupType` issue type

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -170,3 +170,11 @@ class ProfileJSONDecodeType(GroupType):
     slug = "profile_json_decode_main_thread"
     description = "JSON Decoding on Main Thread"
     category = GroupCategory.PROFILE.value
+
+
+PROFILE_FILE_IO_ISSUE_TYPES = frozenset(
+    [
+        ProfileBlockedThreadGroupType.type_id,
+        ProfileFileIOGroupType.type_id,
+    ]
+)

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -23,7 +23,7 @@ from django.utils import timezone
 from sentry import features, nodestore
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType, ProfileFileIOGroupType
+from sentry.issues.grouptype import PROFILE_FILE_IO_ISSUE_TYPES
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
@@ -41,14 +41,6 @@ class InvalidEventPayloadError(Exception):
 
 class EventLookupError(Exception):
     pass
-
-
-PROFILE_FILE_IO_ISSUE_TYPES = frozenset(
-    [
-        ProfileBlockedThreadGroupType.type_id,
-        ProfileFileIOGroupType.type_id,
-    ]
-)
 
 
 def get_occurrences_ingest_consumer(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -10,9 +10,8 @@ from django.utils import timezone
 
 from sentry import features
 from sentry.exceptions import PluginError
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import PROFILE_FILE_IO_ISSUE_TYPES, GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.occurrence_consumer import PROFILE_FILE_IO_ISSUE_TYPES
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -10,8 +10,9 @@ from django.utils import timezone
 
 from sentry import features
 from sentry.exceptions import PluginError
-from sentry.issues.grouptype import GroupCategory, ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.occurrence_consumer import PROFILE_FILE_IO_ISSUE_TYPES
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
@@ -526,7 +527,7 @@ def post_process_group(
 def run_post_process_job(job: PostProcessJob):
     group_event = job["event"]
     issue_category = group_event.group.issue_category
-    if group_event.group.issue_type is ProfileBlockedThreadGroupType and not features.has(
+    if group_event.group.issue_type.type_id in PROFILE_FILE_IO_ISSUE_TYPES and not features.has(
         "organizations:profile-blocked-main-thread-ppg", group_event.group.organization
     ):
         return

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -128,7 +128,7 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         message = get_test_message(self.project.id, type=300)
         with pytest.raises(InvalidEventPayloadError):
             with self.feature("organizations:profile-blocked-main-thread-ingest"), mock.patch(
-                "sentry.issues.occurrence_consumer.INGEST_ALLOWED_ISSUE_TYPES",
+                "sentry.issues.occurrence_consumer.PROFILE_FILE_IO_ISSUE_TYPES",
                 {300},
             ):
                 _process_message(message)
@@ -170,7 +170,7 @@ class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):
             type=PerformanceSlowDBQueryGroupType.type_id,
         )
         with self.feature("organizations:profile-blocked-main-thread-ingest"), mock.patch(
-            "sentry.issues.occurrence_consumer.INGEST_ALLOWED_ISSUE_TYPES",
+            "sentry.issues.occurrence_consumer.PROFILE_FILE_IO_ISSUE_TYPES",
             {PerformanceSlowDBQueryGroupType.type_id},
         ):
             processed = _process_message(message)


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/44913 we added new issue types, but also the profile team stopped sending type 2000, so we stopped ingesting all profile issues. Fixed that here.
