### PR TITLE
chore(instrumentation): Add span around ProguardMapper.open for comparison

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from symbolic import ProguardMapper
 
 from sentry.lang.java.processing import deobfuscate_exception_value
@@ -39,7 +40,8 @@ class JavaStacktraceProcessor(StacktraceProcessor):
             if dif_path is None:
                 error_type = EventError.PROGUARD_MISSING_MAPPING
             else:
-                view = ProguardMapper.open(dif_path)
+                with sentry_sdk.start_span(op="symbolic", description="ProguardMapper.open"):
+                    view = ProguardMapper.open(dif_path)
                 if not view.has_line_info:
                     error_type = EventError.PROGUARD_MISSING_LINENO
                 else:

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -791,7 +791,8 @@ class FileIOMainThreadDetector(PerformanceDetector):
                     if debug_file_path is None:
                         return
 
-                    mapper = ProguardMapper.open(debug_file_path)
+                    with sentry_sdk.start_span(op="symbolic", description="ProguardMapper.open"):
+                        mapper = ProguardMapper.open(debug_file_path)
                     if not mapper.has_line_info:
                         return
                     self.mapper = mapper


### PR DESCRIPTION
We noticed that the `ProguardMapper.open` line is one of the slowest parts in the profiling celery worker. We're unsure if its due to disk reads or some other reason at the moment. This adds a span around other `ProguardMapper.open` calls that we want to compare it to.
