### PR TITLE
fix(auth): Clean up auth login path for the sudo modal form

### DIFF
--- a/static/app/components/modals/sudoModal.spec.jsx
+++ b/static/app/components/modals/sudoModal.spec.jsx
@@ -15,7 +15,6 @@ describe('Sudo Modal', function () {
         organizationUrl: 'https://albertos-apples.sentry.io',
         regionUrl: 'https://albertos-apples.sentry.io',
         sentryUrl: 'https://sentry.io',
-        // superuserUrl?: string;
       },
     };
 

--- a/static/app/components/modals/sudoModal.spec.jsx
+++ b/static/app/components/modals/sudoModal.spec.jsx
@@ -10,6 +10,15 @@ describe('Sudo Modal', function () {
     ConfigStore.set('user', {...ConfigStore.get('user'), hasPasswordAuth});
 
   beforeEach(function () {
+    window.__initialData = {
+      links: {
+        organizationUrl: 'https://albertos-apples.sentry.io',
+        regionUrl: 'https://albertos-apples.sentry.io',
+        sentryUrl: 'https://sentry.io',
+        // superuserUrl?: string;
+      },
+    };
+
     Client.clearMockResponses();
     Client.addMockResponse({
       url: '/internal/health/',
@@ -156,7 +165,7 @@ describe('Sudo Modal', function () {
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
       'href',
-      '/auth/login/?next=%2F'
+      '/auth/login/?next=http%3A%2F%2Flocalhost%2F'
     );
   });
 });

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -168,6 +168,15 @@ class SudoModal extends Component<Props, State> {
     }
   };
 
+  getAuthLoginPath(): string {
+    const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
+    const {superuserUrl} = window.__initialData.links;
+    if (window.__initialData?.customerDomain && superuserUrl) {
+      return `${trimEnd(superuserUrl, '/')}${authLoginPath}`;
+    }
+    return authLoginPath;
+  }
+
   handleLogout = async () => {
     const {api} = this.props;
     try {
@@ -175,14 +184,7 @@ class SudoModal extends Component<Props, State> {
     } catch {
       // ignore errors
     }
-    const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
-    const {superuserUrl} = window.__initialData.links;
-    if (window.__initialData?.customerDomain && superuserUrl) {
-      const redirectURL = `${trimEnd(superuserUrl, '/')}${authLoginPath}`;
-      window.location.assign(redirectURL);
-      return;
-    }
-    window.location.assign(authLoginPath);
+    window.location.assign(this.getAuthLoginPath());
   };
 
   async getAuthenticators() {
@@ -256,10 +258,7 @@ class SudoModal extends Component<Props, State> {
               )}
             </Form>
           ) : (
-            <Button
-              priority="primary"
-              href={`/auth/login/?next=${encodeURIComponent(location.pathname)}`}
-            >
+            <Button priority="primary" href={this.getAuthLoginPath()}>
               {t('Continue')}
             </Button>
           )}


### PR DESCRIPTION
This pull request updates the auth login path for the "Continue" button on the sudo modal access form.  

This clean up ensures the  auth login path has proper customer domain support.