### PR TITLE
feat(roles): add flags and update audit log entry

### DIFF
--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -116,12 +116,14 @@ class TeamDetailsEndpoint(TeamEndpoint):
         if serializer.is_valid():
             team = serializer.save()
 
+            data = team.get_audit_log_data()
+            data["old_org_role"] = team_org_role
             self.create_audit_entry(
                 request=request,
                 organization=team.organization,
                 target_object=team.id,
                 event=audit_log.get_event_id("TEAM_EDIT"),
-                data=team.get_audit_log_data(),
+                data=data,
             )
 
             return Response(serialize(team, request.user))

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -4,7 +4,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log, roles
+from sentry import audit_log, features, roles
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.decorators import sudo_required
@@ -17,7 +17,7 @@ from sentry.models import ScheduledDeletion, Team, TeamStatus
 class TeamSerializer(CamelSnakeModelSerializer):
     slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50)
     org_role = serializers.ChoiceField(
-        choices=tuple(list(roles.get_choices()) + [("", None)]),
+        choices=tuple(list(roles.get_choices()) + [("")]),
         default="",
     )
 
@@ -31,6 +31,11 @@ class TeamSerializer(CamelSnakeModelSerializer):
         )
         if qs.exists():
             raise serializers.ValidationError(f'The slug "{value}" is already in use.')
+        return value
+
+    def validate_org_role(self, value):
+        if value == "":
+            return None
         return value
 
 
@@ -83,7 +88,12 @@ class TeamDetailsEndpoint(TeamEndpoint):
                                owners can set this value.
         :auth: required
         """
-        if team.org_role != request.data.get("orgRole"):
+        team_org_role = team.org_role
+        if team_org_role != request.data.get("orgRole"):
+            if not features.has("organizations:org-roles-for-teams", team.organization, actor=None):
+                # remove the org role, but other fields can still be set
+                del request.data["orgRole"]
+
             if team.idp_provisioned:
                 return Response(
                     {
@@ -94,7 +104,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
 
             # users should not be able to set the role of a team to something higher than themselves
             # only allow the top dog to do this so they can set the org_role to any role in the org
-            elif roles.get_top_dog() not in request.access.get_organization_roles():
+            elif not request.access.has_scope("org:admin"):
                 return Response(
                     {
                         "detail": f"You must have the role of {roles.get_top_dog().id} to perform this action."

--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -90,6 +90,20 @@ class OrgEditAuditLogEvent(AuditLogEvent):
         return "edited the organization setting: " + items_string
 
 
+class TeamEditAuditLogEvent(AuditLogEvent):
+    def __init__(self):
+        super().__init__(event_id=21, name="TEAM_EDIT", api_name="team.edit")
+
+    def render(self, audit_log_entry: AuditLogEntry):
+        old_org_role = audit_log_entry.data.get("old_org_role")
+        new_org_role = audit_log_entry.data.get("org_role")
+        slug = audit_log_entry.data["slug"]
+
+        if old_org_role != new_org_role:
+            return f"edited team {slug}'s org role to {new_org_role}"
+        return f"edited team {slug}"
+
+
 class ProjectEditAuditLogEvent(AuditLogEvent):
     def __init__(self):
         super().__init__(event_id=31, name="PROJECT_EDIT", api_name="project.edit")

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -50,11 +50,7 @@ default_manager.add(
         event_id=20, name="TEAM_ADD", api_name="team.create", template="created team {slug}"
     )
 )
-default_manager.add(
-    AuditLogEvent(
-        event_id=21, name="TEAM_EDIT", api_name="team.edit", template="edited team {slug}"
-    )
-)
+default_manager.add(events.TeamEditAuditLogEvent())
 default_manager.add(
     AuditLogEvent(
         event_id=22, name="TEAM_REMOVE", api_name="team.remove", template="removed team {slug}"

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -288,7 +288,13 @@ class Team(Model):
                 cursor.close()
 
     def get_audit_log_data(self):
-        return {"id": self.id, "slug": self.slug, "name": self.name, "status": self.status}
+        return {
+            "id": self.id,
+            "slug": self.slug,
+            "name": self.name,
+            "status": self.status,
+            "org_role": self.org_role,
+        }
 
     def get_projects(self):
         from sentry.models import Project


### PR DESCRIPTION
Update the `TeamDetails` API to use the feature flags and parse an empty `org_role` (aka no `org_role`) field from the frontend correctly. Update the audit log to show if a team's org role has been updated.