### PR TITLE
fix(issue-platform): Store level as part of ingest

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -96,8 +96,7 @@ def _create_issue_kwargs(
         "message": event.search_message,
         # TODO: Not sure what to put here
         # "logger": job["logger_name"],
-        # TODO: Level override from occurrence?
-        "level": LOG_LEVELS_MAP.get(event.data["level"]),
+        "level": LOG_LEVELS_MAP.get(occurrence.level),
         "culprit": occurrence.subtitle,
         "last_seen": event.datetime,
         "first_seen": event.datetime,

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -11,6 +11,8 @@ from sentry import nodestore
 from sentry.issues.grouptype import GroupType, get_group_type_by_type_id
 from sentry.utils.dates import parse_timestamp
 
+DEFAULT_LEVEL = "info"
+
 
 class IssueEvidenceData(TypedDict):
     name: str
@@ -80,7 +82,7 @@ class IssueOccurrence:
     evidence_display: Sequence[IssueEvidence]
     type: Type[GroupType]
     detection_time: datetime
-    level: Optional[str] = None
+    level: str
 
     def __post_init__(self) -> None:
         if not is_aware(self.detection_time):
@@ -106,6 +108,10 @@ class IssueOccurrence:
 
     @classmethod
     def from_dict(cls, data: IssueOccurrenceData) -> IssueOccurrence:
+        # Backwards compatibility - we used to not require this field, so set a default when `None`
+        level = data.get("level")
+        if not level:
+            level = DEFAULT_LEVEL
         return cls(
             data["id"],
             data["project_id"],
@@ -122,7 +128,7 @@ class IssueOccurrence:
             ],
             get_group_type_by_type_id(data["type"]),
             cast(datetime, parse_timestamp(data["detection_time"])),
-            data.get("level"),
+            level,
         )
 
     @property

--- a/src/sentry/issues/json_schemas.py
+++ b/src/sentry/issues/json_schemas.py
@@ -5,11 +5,12 @@ EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
     "properties": {
         # required properties
         "event_id": {"type": "string", "minLength": 1},
+        "level": {"type": "string", "minLength": 1},
         "platform": {"type": "string", "minLength": 1},
         "project_id": {"type": "integer"},
+        "received": {"type": "string", "format": "date-time"},
         "tags": {"type": "object"},
         "timestamp": {"type": "string", "format": "date-time"},
-        "received": {"type": "string", "format": "date-time"},
         # non-required properties
         "breadcrumbs": {
             "type": ["array", "null"],
@@ -131,6 +132,7 @@ EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
     },
     "required": [
         "event_id",
+        "level",
         "platform",
         "project_id",
         "tags",

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -43,6 +43,9 @@ class EventLookupError(Exception):
     pass
 
 
+DEFAULT_LEVEL = "error"
+
+
 def get_occurrences_ingest_consumer(
     consumer_type: str,
     auto_offset_reset: str,
@@ -155,7 +158,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 "evidence_display": payload.get("evidence_display"),
                 "type": payload["type"],
                 "detection_time": payload["detection_time"],
-                # TODO: need to parse level
+                "level": payload.get("level", DEFAULT_LEVEL),
             }
 
             if payload.get("event_id"):
@@ -175,11 +178,12 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
 
                 event_data = {
                     "event_id": UUID(event_payload.get("event_id")).hex,
+                    "level": occurrence_data["level"],
                     "project_id": event_payload.get("project_id"),
                     "platform": event_payload.get("platform"),
+                    "received": event_payload.get("received", timezone.now()),
                     "tags": event_payload.get("tags"),
                     "timestamp": event_payload.get("timestamp"),
-                    "received": event_payload.get("received", timezone.now()),
                 }
 
                 optional_params = [

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -25,7 +25,7 @@ from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import PROFILE_FILE_IO_ISSUE_TYPES
 from sentry.issues.ingest import save_issue_occurrence
-from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
+from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
 from sentry.models import Organization, Project
 from sentry.utils import json, metrics
@@ -41,9 +41,6 @@ class InvalidEventPayloadError(Exception):
 
 class EventLookupError(Exception):
     pass
-
-
-DEFAULT_LEVEL = "error"
 
 
 def get_occurrences_ingest_consumer(

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -86,4 +86,5 @@ TEST_ISSUE_OCCURRENCE = IssueOccurrence(
     ],
     ProfileBlockedThreadGroupType,
     ensure_aware(datetime.now()),
+    "info",
 )

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -123,7 +123,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignor
         group = group_info.group
         assert group.title == occurrence.issue_title
         assert group.platform == event.platform
-        assert group.level == LOG_LEVELS_MAP.get(event.data["level"])
+        assert group.level == LOG_LEVELS_MAP.get(occurrence.level)
         assert group.last_seen == event.datetime
         assert group.first_seen == event.datetime
         assert group.active_at == event.datetime
@@ -198,7 +198,7 @@ class CreateIssueKwargsTest(OccurrenceTestMixin, TestCase):  # type: ignore
         assert _create_issue_kwargs(occurrence, event, None) == {
             "platform": event.platform,
             "message": event.search_message,
-            "level": LOG_LEVELS_MAP.get(event.data["level"]),
+            "level": LOG_LEVELS_MAP.get(occurrence.level),
             "culprit": occurrence.subtitle,
             "last_seen": event.datetime,
             "first_seen": event.datetime,

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -14,7 +14,7 @@ class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):  # type: ignor
 
     def test_level_default(self) -> None:
         occurrence_data = self.build_occurrence_data()
-        del occurrence_data["level"]
+        occurrence_data["level"] = None
         occurrence = IssueOccurrence.from_dict(occurrence_data)
         assert occurrence.level == DEFAULT_LEVEL
 

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -1,4 +1,4 @@
-from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueEvidence, IssueOccurrence
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -11,6 +11,12 @@ class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):  # type: ignor
         self.assert_occurrences_identical(
             occurrence, IssueOccurrence.from_dict(occurrence.to_dict())
         )
+
+    def test_level_default(self) -> None:
+        occurrence_data = self.build_occurrence_data()
+        del occurrence_data["level"]
+        occurrence = IssueOccurrence.from_dict(occurrence_data)
+        assert occurrence.level == DEFAULT_LEVEL
 
 
 @region_silo_test

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -286,3 +286,8 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         message = deepcopy(get_test_message(self.project.id))
         kwargs = _get_kwargs(message)
         assert kwargs["occurrence_data"]["issue_title"] == kwargs["event_data"]["metadata"]["title"]
+
+    def test_occurrence_level_on_event(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["level"] == kwargs["event_data"]["level"]

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -204,6 +204,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             ],
             ProfileBlockedThreadGroupType,
             ensure_aware(datetime.now()),
+            "info",
         )
         occurrence.save()
         event.occurrence = occurrence
@@ -252,6 +253,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             [],  # no evidence
             ProfileBlockedThreadGroupType,
             ensure_aware(datetime.now()),
+            "info",
         )
         occurrence.save()
         event.occurrence = occurrence


### PR DESCRIPTION
We didn't handle level earlier, just using the level on the occurrence as the override and storing it on the event as well.
