### PR TITLE
test(py): Do not pass `project_id` to Environment

### DIFF
--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -54,7 +54,7 @@ class DeleteOrganizationTest(TransactionTestCase):
             organization_id=org.id, release=release, commit=commit, order=0
         )
 
-        env = Environment.objects.create(organization_id=org.id, project_id=4, name="foo")
+        env = Environment.objects.create(organization_id=org.id, name="foo")
         release_env = ReleaseEnvironment.objects.create(
             organization_id=org.id, project_id=4, release_id=release.id, environment_id=env.id
         )


### PR DESCRIPTION
This is legacy, would be nice to delete this column