### PR TITLE
fix(profiling): Stop profile.id autocompletion from erroring

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1205,7 +1205,7 @@ class SnubaTagStorage(TagStorage):
         # time:         This is a column computed from timestamp so it suffers the same issues
         if snuba_key in {"group_id"}:
             snuba_key = f"tags[{snuba_key}]"
-        if snuba_key in {"event_id", "timestamp", "time"} or key in {
+        if snuba_key in {"event_id", "timestamp", "time", "profile_id"} or key in {
             "trace",
             "trace.span",
             "trace.parent_span",

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1193,6 +1193,7 @@ class SnubaTagStorage(TagStorage):
         #               but does work with !=. However, for consistency sake we disallow it
         #               entirely, furthermore, suggesting an event_id is not a very useful feature
         #               as they are not human readable.
+        # profile_id    Same as event_id
         # trace.*:      The same logic of event_id not being useful applies to the trace fields
         #               which are all also non human readable ids
         # timestamp:    This is a DateTime which disallows us to use both LIKE and != on it when

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -556,6 +556,7 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
         self.run_test("trace.span", expected=[])
         self.run_test("trace", expected=[])
         self.run_test("event_id", expected=[])
+        self.run_test("profile_id", expected=[])
 
     def test_boolean_fields(self):
         self.run_test("error.handled", expected=[("true", None), ("false", None)])


### PR DESCRIPTION
Like `event_id`, it doesn't make sense to autocomplete `profile_id`, so exit early and return an empty sequence.