### PR TITLE
fix(rules): Add project status filter

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -46,9 +46,9 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             user_team_list = OrganizationMemberTeam.objects.filter(
                 organizationmember__user=request.user, team__in=org_team_list
             ).values_list("team", flat=True)
-            project_ids = Project.objects.filter(teams__in=user_team_list).values_list(
-                "id", flat=True
-            )
+            project_ids = Project.objects.filter(
+                teams__in=user_team_list, status=ProjectStatus.VISIBLE
+            ).values_list("id", flat=True)
 
         # Materialize the project ids here. This helps us to not overwhelm the query planner with
         # overcomplicated subqueries. Previously, this was causing Postgres to use a suboptimal

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1184,3 +1184,21 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         RuleFireHistory.objects.create(project=self.project, rule=rule, group=self.group)
         resp = self.get_success_response(self.organization.slug, expand=["lastTriggered"])
         assert resp.data[0]["lastTriggered"] == datetime.now().replace(tzinfo=pytz.UTC)
+
+    def test_project_deleted(self):
+        from sentry.models import ScheduledDeletion
+        from sentry.tasks.deletion.scheduled import run_deletion
+
+        org = self.create_organization(owner=self.user, name="Rowdy Tiger")
+        team = self.create_team(organization=org, name="Mariachi Band", members=[self.user])
+        delete_project = self.create_project(organization=org, teams=[team], name="Bengal")
+        self.login_as(self.user)
+        self.create_project_rule(project=delete_project)
+
+        deletion = ScheduledDeletion.schedule(delete_project, days=0)
+        deletion.update(in_progress=True)
+
+        with self.tasks():
+            run_deletion(deletion.id)
+
+        self.get_success_response(org.slug)


### PR DESCRIPTION
When a user deletes a project that had an alert rule (or rules) and then visits the Alerts page before the scheduled deletion task has run (~15 minutes), we attempt to look up a project whose status is not visible and the page 403s. This PR adds the status filter to the project lookup in the case that no project id(s) was specified, which is the default behavior. 

Closes #38337 and [WOR-2160](https://getsentry.atlassian.net/browse/WOR-2160)

[WOR-2160]: https://getsentry.atlassian.net/browse/WOR-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ