### PR TITLE
fix(issue-platform): Event title should be in metadata, not a top level property

### DIFF
--- a/src/sentry/issues/json_schemas.py
+++ b/src/sentry/issues/json_schemas.py
@@ -10,7 +10,6 @@ EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
         "tags": {"type": "object"},
         "timestamp": {"type": "string", "format": "date-time"},
         "received": {"type": "string", "format": "date-time"},
-        "title": {"type": "string", "minLength": 1},
         # non-required properties
         "breadcrumbs": {
             "type": ["array", "null"],
@@ -136,7 +135,6 @@ EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
         "project_id",
         "tags",
         "timestamp",
-        "title",
     ],
     "additionalProperties": False,
 }

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -180,8 +180,6 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "tags": event_payload.get("tags"),
                     "timestamp": event_payload.get("timestamp"),
                     "received": event_payload.get("received", timezone.now()),
-                    # This allows us to show the title consistently in discover
-                    "title": occurrence_data["issue_title"],
                 }
 
                 optional_params = [
@@ -205,6 +203,11 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                         event_data[optional_param] = event_payload.get(optional_param)
 
                 _validate_event_data(event_data)
+
+                event_data["metadata"] = {
+                    # This allows us to show the title consistently in discover
+                    "title": occurrence_data["issue_title"],
+                }
 
                 return {"occurrence_data": occurrence_data, "event_data": event_data}
             else:

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -285,4 +285,4 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
     def test_occurrence_title_on_event(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
         kwargs = _get_kwargs(message)
-        assert kwargs["occurrence_data"]["issue_title"] == kwargs["event_data"]["title"]
+        assert kwargs["occurrence_data"]["issue_title"] == kwargs["event_data"]["metadata"]["title"]


### PR DESCRIPTION
Title is fetched from the event here: https://github.com/getsentry/sentry/blob/6257dff574ff8c3c90d4e737e8e47364eb750784/src/sentry/eventstore/models.py#L238-L245

When not fetched from snuba, we fetch it from the event metadata, which happens on the base event type here: https://github.com/getsentry/sentry/blob/6257dff574ff8c3c90d4e737e8e47364eb750784/src/sentry/eventtypes/base.py#L67-L71

I also decided to just move this to after validation. Not a lot of value to validating things we're automatically setting.