### PR TITLE
fix(reprocessing): Fix crash in finish_processing when activities exist

### DIFF
--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -9,6 +9,7 @@ from sentry.eventstore.models import Event
 from sentry.reprocessing2 import buffered_delete_old_primary_hash
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.process_buffer import buffer_incr
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.utils.query import celery_run_batch_query
 
@@ -155,6 +156,9 @@ def handle_remaining_events(
 
     See doc comment in sentry.reprocessing2.
     """
+    sentry_sdk.set_tag("project", project_id)
+    sentry_sdk.set_tag("old_group_id", old_group_id)
+    sentry_sdk.set_tag("new_group_id", new_group_id)
 
     from sentry.models.group import Group
     from sentry.reprocessing2 import EVENT_MODELS_TO_MIGRATE, pop_batched_events_from_redis
@@ -223,7 +227,9 @@ def finish_reprocessing(project_id, group_id):
         # While we migrated all associated models at the beginning of
         # reprocessing, there is still the "reprocessing" activity that we need
         # to transfer manually.
-        activity = Activity.objects.get(group_id=group_id)
+        # Any activities created during reprocessing (e.g. user clicks "assign" in an old browser tab)
+        # are ignored.
+        activity = Activity.objects.get(group_id=group_id, type=ActivityType.REPROCESS.value)
         new_group_id = activity.group_id = activity.data["newGroupId"]
         activity.save()
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -611,9 +611,13 @@ def test_apply_new_stack_trace_rules(
 def test_finish_reprocessing(default_project):
     # Pretend that the old group has more than one activity still connected:
     old_group = Group.objects.create(project=default_project)
+    new_group = Group.objects.create(project=default_project)
 
-    old_group.activity_set.create(project=default_project, type=ActivityType.REPROCESS.value)
-    old_group.activity_set.create(project=default_project, type=ActivityType.REPROCESS.value)
+    old_group.activity_set.create(
+        project=default_project,
+        type=ActivityType.REPROCESS.value,
+        data={"newGroupId": new_group.id},
+    )
     old_group.activity_set.create(project=default_project, type=ActivityType.NOTE.value)
 
     finish_reprocessing(old_group.project_id, old_group.id)

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -23,7 +23,7 @@ from sentry.models import (
 from sentry.plugins.base.v2 import Plugin2
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG
 from sentry.reprocessing2 import is_group_finished
-from sentry.tasks.reprocessing2 import reprocess_group
+from sentry.tasks.reprocessing2 import finish_reprocessing, reprocess_group
 from sentry.tasks.store import preprocess_event
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -605,3 +605,15 @@ def test_apply_new_stack_trace_rules(
     assert event1.group.id == event2.group.id
 
     assert event1.data["grouping_config"] != original_grouping_config
+
+
+@pytest.mark.django_db
+def test_finish_reprocessing(default_project):
+    # Pretend that the old group has more than one activity still connected:
+    old_group = Group.objects.create(project=default_project)
+
+    old_group.activity_set.create(project=default_project, type=ActivityType.REPROCESS.value)
+    old_group.activity_set.create(project=default_project, type=ActivityType.REPROCESS.value)
+    old_group.activity_set.create(project=default_project, type=ActivityType.NOTE.value)
+
+    finish_reprocessing(old_group.project_id, old_group.id)


### PR DESCRIPTION
When activities are logged on the old group that is being reprocessed, `finish_reprocessing` will crash because it assumes that there is only one activity left.