### PR TITLE
feat(perf-issues): Add show more button

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -154,12 +154,7 @@ const NPlusOneAPICallsSpanEvidence = ({
               )
             : null,
           problemParameters.length > 0
-            ? makeRow(t('Parameters'), [
-                ...problemParameters,
-                ...problemParameters,
-                ...problemParameters,
-                ...problemParameters,
-              ])
+            ? makeRow(t('Parameters'), problemParameters)
             : null,
         ].filter(Boolean) as KeyValueListData
       }

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import kebabCase from 'lodash/kebabCase';
 import mapValues from 'lodash/mapValues';
 
+import ClippedBox from 'sentry/components/clippedBox';
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {toRoundedPercent} from 'sentry/components/performance/waterfall/utils';
@@ -65,7 +66,11 @@ export function SpanEvidenceKeyValueList({event}: {event: EventTransaction}) {
       [IssueType.PERFORMANCE_UNCOMPRESSED_ASSET]: UncompressedAssetSpanEvidence,
     }[performanceProblem.issueType] ?? DefaultSpanEvidence;
 
-  return <Component event={event} {...spanInfo} />;
+  return (
+    <ClippedBox clipHeight={250}>
+      <Component event={event} {...spanInfo} />
+    </ClippedBox>
+  );
 }
 
 const ConsecutiveDBQueriesSpanEvidence = ({
@@ -149,7 +154,12 @@ const NPlusOneAPICallsSpanEvidence = ({
               )
             : null,
           problemParameters.length > 0
-            ? makeRow(t('Parameters'), problemParameters)
+            ? makeRow(t('Parameters'), [
+                ...problemParameters,
+                ...problemParameters,
+                ...problemParameters,
+                ...problemParameters,
+              ])
             : null,
         ].filter(Boolean) as KeyValueListData
       }

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -67,7 +67,7 @@ export function SpanEvidenceKeyValueList({event}: {event: EventTransaction}) {
     }[performanceProblem.issueType] ?? DefaultSpanEvidence;
 
   return (
-    <ClippedBox clipHeight={250}>
+    <ClippedBox clipHeight={300}>
       <Component event={event} {...spanInfo} />
     </ClippedBox>
   );


### PR DESCRIPTION
Fixes PERF-2009

A show more button will occur when the height of the span evidence section is >300px, which is >5 rows (when each row is minimum height). 

This solves the issue where there are too many rows in the span evidence section or a specfic item in the span evidence section (like a db query) is way too long. These scenarios make the UI overwhelming.

Unfortunately I couldn't figure out a way to test this, as in RTL, the components height gets returned as 0 so the show more button never shows. 

Before:
<img width="786" alt="image" src="https://user-images.githubusercontent.com/44422760/221219901-f2c35d46-fe1f-4998-9dee-3cbfb3877f41.png">

After:
<img width="775" alt="image" src="https://user-images.githubusercontent.com/44422760/221219751-d1793e67-4dfd-4751-b7c1-c18a3b2a724e.png">

