### PR TITLE
ref(deletions): Delete metric alerts when project is deleted

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -5,7 +5,7 @@ class ProjectDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry import models
         from sentry.discover.models import DiscoverSavedQueryProject
-        from sentry.incidents.models import IncidentProject
+        from sentry.incidents.models import AlertRule, IncidentProject
         from sentry.replays.models import ReplayRecordingSegment
         from sentry.snuba.models import QuerySubscription
 
@@ -13,6 +13,12 @@ class ProjectDeletionTask(ModelDeletionTask):
             # ProjectKey gets revoked immediately, in bulk
             ModelRelation(models.ProjectKey, {"project_id": instance.id})
         ]
+        relations.append(
+            ModelRelation(
+                AlertRule,
+                {"snuba_query__subscriptions__project": instance, "include_all_projects": False},
+            )
+        )
 
         # in bulk
         model_list = (
@@ -47,7 +53,6 @@ class ProjectDeletionTask(ModelDeletionTask):
             IncidentProject,
             QuerySubscription,
         )
-
         relations.extend(
             [
                 ModelRelation(m, {"project_id": instance.id}, BulkModelDeletionTask)
@@ -66,5 +71,4 @@ class ProjectDeletionTask(ModelDeletionTask):
         relations.extend(
             [ModelRelation(m, {"project_id": instance.id}, ModelDeletionTask) for m in model_list]
         )
-
         return relations

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -1,4 +1,5 @@
 from sentry import eventstore
+from sentry.incidents.models import AlertRule
 from sentry.models import (
     Commit,
     CommitAuthor,
@@ -20,13 +21,13 @@ from sentry.models import (
     ServiceHook,
 )
 from sentry.tasks.deletion.scheduled import run_deletion
-from sentry.testutils import TransactionTestCase
+from sentry.testutils import APITestCase, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
-class DeleteProjectTest(TransactionTestCase):
+class DeleteProjectTest(APITestCase, TransactionTestCase):
     def test_simple(self):
         project = self.create_project(name="test")
         event = self.store_event(data={}, project_id=project.id)
@@ -80,6 +81,9 @@ class DeleteProjectTest(TransactionTestCase):
             project=project,
             url="https://example.com/webhook",
         )
+        metric_alert_rule = self.create_alert_rule(
+            organization=project.organization, projects=[project]
+        )
 
         deletion = ScheduledDeletion.schedule(project, days=0)
         deletion.update(in_progress=True)
@@ -100,6 +104,7 @@ class DeleteProjectTest(TransactionTestCase):
         assert not ProjectDebugFile.objects.filter(id=dif.id).exists()
         assert not File.objects.filter(id=file.id).exists()
         assert not ServiceHook.objects.filter(id=hook.id).exists()
+        assert not AlertRule.objects.filter(id=metric_alert_rule.id).exists()
 
     def test_delete_error_events(self):
         keeper = self.create_project(name="keeper")


### PR DESCRIPTION
When a project is deleted, we don't delete the project's metric alert rules. The table is actually set up to allow multiple projects to map to a metric alert rule, but the feature was never implemented that way. Regardless, I'm checking the `include_all_projects` boolean to future proof it in case we ever allow that. I'll follow this up with a migration to remove all the old metric alert rules that belong to deleted projects.