### PR TITLE
fix(scim): Allow boolean strings

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -68,16 +68,22 @@ class OperationValue(Field):
             return value
         elif isinstance(value, dict):
             return value
-        else:
-            raise ValidationError("value must be a boolean or object")
+        elif isinstance(value, str):
+            value = resolve_maybe_bool_value(value)
+            if value is not None:
+                return value
+        raise ValidationError("value must be a boolean or object")
 
     def to_internal_value(self, data) -> Union[Dict, bool]:
         if isinstance(data, bool):
             return data
         elif isinstance(data, dict):
             return data
-        else:
-            raise ValidationError("value must be a boolean or object")
+        elif isinstance(data, str):
+            value = resolve_maybe_bool_value(data)
+            if value is not None:
+                return value
+        raise ValidationError("value must be a boolean or object")
 
 
 class SCIMPatchOperationSerializer(serializers.Serializer):
@@ -116,6 +122,19 @@ def _scim_member_serializer_with_expansion(organization):
     return OrganizationMemberSCIMSerializer(expand=expand)
 
 
+def resolve_maybe_bool_value(value):
+    if isinstance(value, str):
+        value = value.lower()
+        # Some IdP vendors such as Azure send boolean values as actual strings.
+        if value == "true":
+            return True
+        elif value == "false":
+            return False
+    if isinstance(value, bool):
+        return value
+    return None
+
+
 @region_silo_endpoint
 class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
     permission_classes = (OrganizationSCIMMemberPermission,)
@@ -143,11 +162,14 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         if operation.get("op").lower() == MemberPatchOps.REPLACE:
             if (
                 isinstance(operation.get("value"), dict)
-                and operation.get("value").get("active") is False
+                and resolve_maybe_bool_value(operation.get("value").get("active")) is False
             ):
                 # how okta sets active to false
                 return True
-            elif operation.get("path") == "active" and operation.get("value") is False:
+            elif (
+                operation.get("path") == "active"
+                and resolve_maybe_bool_value(operation.get("value")) is False
+            ):
                 # how other idps set active to false
                 return True
         return False

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -351,7 +351,82 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         )
         patch_req = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "Replace", "path": "active", "value": False}],
+        }
+        response = self.client.patch(url, patch_req)
+
+        assert response.status_code == 204, response.content
+
+        with pytest.raises(OrganizationMember.DoesNotExist):
+            OrganizationMember.objects.get(organization=self.organization, id=member.id)
+
+        with pytest.raises(AuthIdentity.DoesNotExist):
+            AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
+
+    def test_user_details_set_inactive_dict(self):
+        member = self.create_member(
+            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+        )
+        AuthIdentity.objects.create(
+            user=member.user, auth_provider=self.auth_provider, ident="test_ident"
+        )
+        url = reverse(
+            "sentry-api-0-organization-scim-member-details",
+            args=[self.organization.slug, member.id],
+        )
+        patch_req = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "Operations": [{"op": "Replace", "value": {"active": False}}],
+        }
+        response = self.client.patch(url, patch_req)
+
+        assert response.status_code == 204, response.content
+
+        with pytest.raises(OrganizationMember.DoesNotExist):
+            OrganizationMember.objects.get(organization=self.organization, id=member.id)
+
+        with pytest.raises(AuthIdentity.DoesNotExist):
+            AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
+
+    def test_user_details_set_inactive_with_bool_string(self):
+        member = self.create_member(
+            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+        )
+        AuthIdentity.objects.create(
+            user=member.user, auth_provider=self.auth_provider, ident="test_ident"
+        )
+        url = reverse(
+            "sentry-api-0-organization-scim-member-details",
+            args=[self.organization.slug, member.id],
+        )
+        patch_req = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "Replace", "path": "active", "value": "False"}],
+        }
+        response = self.client.patch(url, patch_req)
+
+        assert response.status_code == 204, response.content
+
+        with pytest.raises(OrganizationMember.DoesNotExist):
+            OrganizationMember.objects.get(organization=self.organization, id=member.id)
+
+        with pytest.raises(AuthIdentity.DoesNotExist):
+            AuthIdentity.objects.get(auth_provider=self.auth_provider, id=member.id)
+
+    def test_user_details_set_inactive_with_dict_bool_string(self):
+        member = self.create_member(
+            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+        )
+        AuthIdentity.objects.create(
+            user=member.user, auth_provider=self.auth_provider, ident="test_ident"
+        )
+        url = reverse(
+            "sentry-api-0-organization-scim-member-details",
+            args=[self.organization.slug, member.id],
+        )
+        patch_req = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "Replace", "value": {"id": "xxxx", "active": "False"}}],
         }
         response = self.client.patch(url, patch_req)
 
@@ -377,6 +452,25 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         patch_req = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "Operations": [{"op": "invalid", "value": {"active": False}}],
+        }
+        response = self.client.patch(url, patch_req)
+
+        assert response.status_code == 400, response.content
+
+    def test_invalid_patch_op_value(self):
+        member = self.create_member(
+            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+        )
+        AuthIdentity.objects.create(
+            user=member.user, auth_provider=self.auth_provider, ident="test_ident"
+        )
+        url = reverse(
+            "sentry-api-0-organization-scim-member-details",
+            args=[self.organization.slug, member.id],
+        )
+        patch_req = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "REPLACE", "value": {"active": "invalid"}}],
         }
         response = self.client.patch(url, patch_req)
 


### PR DESCRIPTION
Some IdPs such as Azure may not be SCIM compliant, and as such, may send booleans as string representations (e.g. `"False"` or `"true"`).

This pull request updates the member SCIM endpoint to support boolean string representations.

See:
- https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/application-provisioning-config-problem-scim-compatibility
- https://stackoverflow.com/questions/59264809/azure-user-group-provisioning-with-scim-problem-with-boolean-values