### PR TITLE
feat: Add the `kafka-options` decorator

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Mapping, Optional, Union
 
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
-from arroyo.commit import CommitPolicy
+from arroyo.commit import ONCE_PER_SECOND
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
@@ -177,8 +177,6 @@ def get_parallel_metrics_consumer(
     max_msg_batch_time: float,
     max_parallel_batch_size: int,
     max_parallel_batch_time: float,
-    max_batch_size: int,
-    max_batch_time: float,
     processes: int,
     input_block_size: int,
     output_block_size: int,
@@ -214,8 +212,5 @@ def get_parallel_metrics_consumer(
         ),
         Topic(indexer_profile.input_topic),
         processing_factory,
-        CommitPolicy(
-            min_commit_frequency_sec=max_batch_time / 1000,
-            min_commit_messages=max_batch_size,
-        ),
+        ONCE_PER_SECOND,
     )


### PR DESCRIPTION
This is intended to replace the `batching_kafka_options` decorator for consumers that don't actually do batching. Eventually, `batching_kafka_options` should be updated to only include those options actually related to batching (i.e. --max-batch-size and --max-batch-time).

This PR also updates the indexer to remove some of the options being passed. There were previously way too many types of batching options being passed in here, and it was very unexpected that --max-batch-size and --max-batch-time had no impact on the actual batch size but only controlled the commit policy. Configuring the commit policy separately to the batch size should not be necessary.
