### PR TITLE
flake: Skip flakey SQS plugin test

### DIFF
--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -77,6 +77,7 @@ class AmazonSQSPluginTest(PluginTestCase):
 
     @patch("sentry_plugins.amazon_sqs.plugin.logger")
     @patch("boto3.client")
+    @pytest.mark.skip(reason="https://github.com/getsentry/sentry/issues/44858")
     def test_message_group_error(self, mock_client, logger):
         mock_client.return_value.send_message.side_effect = ClientError(
             {


### PR DESCRIPTION
I didn't realize the original flakey behavior was more than one test.

I've checked the sentry events for all tests in this fail and it looks like this is the only other test that is flakey.

https://github.com/getsentry/sentry/issues/44858