### PR TITLE
feat(workflow): Center assignee loading spinner

### DIFF
--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -345,7 +345,6 @@ function Menu({
                 {...{style, css, blendCorner, detached, alignMenu, minWidth}}
               >
                 <DropdownMainContent minWidth={minWidth}>
-                  {itemsLoading && <LoadingIndicator mini />}
                   {showInput && (
                     <InputWrapper>
                       <StyledInput
@@ -374,9 +373,10 @@ function Menu({
                           {noResultsMessage ?? `${emptyMessage} ${t('found')}`}
                         </EmptyMessage>
                       )}
-                      {busy && (
+                      {(itemsLoading || busy) && (
                         <BusyMessage>
-                          <EmptyMessage>{t('Searching\u2026')}</EmptyMessage>
+                          {itemsLoading && <LoadingIndicator mini />}
+                          {busy && <EmptyMessage>{t('Searching\u2026')}</EmptyMessage>}
                         </BusyMessage>
                       )}
                       {!busy && (
@@ -501,5 +501,6 @@ const ItemList = styled('div')<{maxHeight: NonNullable<Props['maxHeight']>}>`
 const BusyMessage = styled('div')`
   display: flex;
   justify-content: center;
-  padding: ${space(1)};
+  align-items: center;
+  padding: ${space(3)} ${space(1)};
 `;


### PR DESCRIPTION
put the spinner in line with the loading message if used

before
<img width="429" alt="Screenshot 2023-02-24 at 1 57 51 PM" src="https://user-images.githubusercontent.com/1400464/221301163-98caf45e-dd05-4b75-b8c6-ad65052eb7c8.png">

after
<img width="334" alt="Screenshot 2023-02-24 at 1 51 21 PM" src="https://user-images.githubusercontent.com/1400464/221301183-265b7dbd-2213-434a-9fa6-4f8bec05869d.png">
