### PR TITLE
feat(perf-issues): Make autogroups in Issue Details red if they contain a problem span

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
@@ -179,6 +179,7 @@ export function SpanDescendantGroupBar(props: SpanDescendantGroupBarProps) {
       removeContentSpanBarRef={removeContentSpanBarRef}
       didAnchoredSpanMount={didAnchoredSpanMount}
       getCurrentLeftPos={getCurrentLeftPos}
+      spanBarType={spanBarType}
     />
   );
 }

--- a/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
@@ -1,6 +1,11 @@
+import {useTheme} from '@emotion/react';
 import countBy from 'lodash/countBy';
 
-import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
+import {
+  getSpanBarColours,
+  ROW_HEIGHT,
+  SpanBarType,
+} from 'sentry/components/performance/waterfall/constants';
 import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {
   ConnectorBar,
@@ -14,7 +19,6 @@ import {
 } from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {EventTransaction} from 'sentry/types/event';
-import theme from 'sentry/utils/theme';
 
 import {SpanGroupBar} from './spanGroupBar';
 import {EnhancedSpan, ProcessedSpanType, TreeDepthType} from './types';
@@ -43,6 +47,7 @@ export type SpanDescendantGroupBarProps = {
   spanNumber: number;
   toggleSpanGroup: () => void;
   treeDepth: number;
+  spanBarType?: SpanBarType;
 };
 
 export function SpanDescendantGroupBar(props: SpanDescendantGroupBarProps) {
@@ -59,7 +64,10 @@ export function SpanDescendantGroupBar(props: SpanDescendantGroupBarProps) {
     addContentSpanBarRef,
     removeContentSpanBarRef,
     didAnchoredSpanMount,
+    spanBarType,
   } = props;
+
+  const theme = useTheme();
 
   function renderGroupSpansTitle() {
     if (spanGrouping.length === 0) {
@@ -141,7 +149,7 @@ export function SpanDescendantGroupBar(props: SpanDescendantGroupBarProps) {
     return (
       <RowRectangle
         style={{
-          backgroundColor: theme.blue300,
+          backgroundColor: getSpanBarColours(spanBarType, theme).primary,
           left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
           width: toPercent(bounds.width || 0),
         }}

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -6,9 +6,14 @@ import {
   useEffect,
   useRef,
 } from 'react';
+import {useTheme} from '@emotion/react';
 
 import Count from 'sentry/components/count';
-import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
+import {
+  getSpanBarColours,
+  ROW_HEIGHT,
+  SpanBarType,
+} from 'sentry/components/performance/waterfall/constants';
 import {
   Row,
   RowCell,
@@ -64,6 +69,7 @@ type Props = {
   spanNumber: number;
   toggleSpanGroup: () => void;
   treeDepth: number;
+  spanBarType?: SpanBarType;
 };
 
 function renderGroupedSpansToggler(props: Props) {
@@ -163,7 +169,10 @@ export function SpanGroupBar(props: Props) {
     spanGrouping,
     toggleSpanGroup,
     getCurrentLeftPos,
+    spanBarType,
   } = props;
+
+  const theme = useTheme();
 
   // On mount, it is necessary to set the left styling of the content here due to the span tree being virtualized.
   // If we rely on the scrollBarManager to set the styling, it happens too late and awkwardly applies an animation.
@@ -271,7 +280,9 @@ export function SpanGroupBar(props: Props) {
                       width: '100%',
                     }}
                   >
-                    <SpanGroupRowTitleContent>
+                    <SpanGroupRowTitleContent
+                      color={getSpanBarColours(spanBarType, theme).primary}
+                    >
                       {props.renderGroupSpansTitle()}
                     </SpanGroupRowTitleContent>
                   </RowTitle>

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -73,7 +73,8 @@ type Props = {
 };
 
 function renderGroupedSpansToggler(props: Props) {
-  const {treeDepth, spanGrouping, renderSpanTreeConnector, toggleSpanGroup} = props;
+  const {treeDepth, spanGrouping, renderSpanTreeConnector, toggleSpanGroup, spanBarType} =
+    props;
 
   const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
 
@@ -89,6 +90,7 @@ function renderGroupedSpansToggler(props: Props) {
           event.stopPropagation();
           toggleSpanGroup();
         }}
+        spanBarType={spanBarType}
       >
         <Count value={spanGrouping.length} />
       </TreeToggle>

--- a/static/app/components/events/interfaces/spans/spanRectangle.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangle.tsx
@@ -1,20 +1,28 @@
+import {useTheme} from '@emotion/react';
+
+import {
+  getSpanBarColours,
+  SpanBarType,
+} from 'sentry/components/performance/waterfall/constants';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {toPercent} from 'sentry/components/performance/waterfall/utils';
-import theme from 'sentry/utils/theme';
 
 import {EnhancedSpan} from './types';
 import {SpanViewBoundsType} from './utils';
 
 export default function SpanRectangle({
   bounds,
+  spanBarType,
 }: {
   bounds: SpanViewBoundsType;
   spanGrouping: EnhancedSpan[];
+  spanBarType?: SpanBarType;
 }) {
+  const theme = useTheme();
   return (
     <RowRectangle
       style={{
-        backgroundColor: theme.blue300,
+        backgroundColor: getSpanBarColours(spanBarType, theme).primary,
         left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
         width: toPercent(bounds.width || 0),
       }}

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {SpanBarType} from 'sentry/components/performance/waterfall/constants';
 import {
   ConnectorBar,
   TOGGLE_BORDER_BOX,
@@ -40,6 +41,7 @@ export type SpanSiblingGroupBarProps = {
   spanNumber: number;
   toggleSiblingSpanGroup: (span: SpanType, occurrence: number) => void;
   treeDepth: number;
+  spanBarType?: SpanBarType;
 };
 
 export default function SpanSiblingGroupBar(props: SpanSiblingGroupBarProps) {
@@ -59,6 +61,7 @@ export default function SpanSiblingGroupBar(props: SpanSiblingGroupBarProps) {
     removeContentSpanBarRef,
     isEmbeddedSpanTree,
     didAnchoredSpanMount,
+    spanBarType,
   } = props;
 
   const organization = useOrganization();
@@ -129,6 +132,7 @@ export default function SpanSiblingGroupBar(props: SpanSiblingGroupBarProps) {
             key={index}
             spanGrouping={spanGrouping}
             bounds={getSpanGroupBounds([spanGrouping[index]], generateBounds)}
+            spanBarType={spanBarType}
           />
         ))}
         <SpanRectangleOverlay

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -167,6 +167,7 @@ export default function SpanSiblingGroupBar(props: SpanSiblingGroupBarProps) {
       removeContentSpanBarRef={removeContentSpanBarRef}
       didAnchoredSpanMount={didAnchoredSpanMount}
       getCurrentLeftPos={getCurrentLeftPos}
+      spanBarType={spanBarType}
     />
   );
 }

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -474,11 +474,21 @@ class SpanTree extends Component<PropType> {
         const {span, treeDepth, continuingTreeDepths} = payload;
 
         if (payload.type === 'span_group_chain') {
+          const groupingContainsAffectedSpan =
+            isEmbeddedSpanTree &&
+            payload.spanNestedGrouping?.find(
+              ({span: s}) =>
+                !isGapSpan(s) && waterfallModel.affectedSpanIds?.includes(s.span_id)
+            );
+
           acc.spanTree.push({
             type: SpanTreeNodeType.DESCENDANT_GROUP,
             props: {
               event: waterfallModel.event,
               span,
+              spanBarType: groupingContainsAffectedSpan
+                ? SpanBarType.AUTOGROUPED_AND_AFFECTED
+                : SpanBarType.AUTOGROUPED,
               generateBounds,
               getCurrentLeftPos: this.props.getCurrentLeftPos,
               treeDepth,
@@ -500,11 +510,21 @@ class SpanTree extends Component<PropType> {
         }
 
         if (payload.type === 'span_group_siblings') {
+          const groupingContainsAffectedSpan =
+            isEmbeddedSpanTree &&
+            payload.spanSiblingGrouping?.find(
+              ({span: s}) =>
+                !isGapSpan(s) && waterfallModel.affectedSpanIds?.includes(s.span_id)
+            );
+
           acc.spanTree.push({
             type: SpanTreeNodeType.SIBLING_GROUP,
             props: {
               event: waterfallModel.event,
               span,
+              spanBarType: groupingContainsAffectedSpan
+                ? SpanBarType.AUTOGROUPED_AND_AFFECTED
+                : SpanBarType.AUTOGROUPED,
               generateBounds,
               getCurrentLeftPos: this.props.getCurrentLeftPos,
               treeDepth,

--- a/static/app/components/performance/waterfall/constants.tsx
+++ b/static/app/components/performance/waterfall/constants.tsx
@@ -7,6 +7,7 @@ export enum SpanBarType {
   GAP = 'gap',
   AFFECTED = 'affected',
   AUTOGROUPED = 'autogrouped',
+  AUTOGROUPED_AND_AFFECTED = 'autogrouped_and_affected',
 }
 
 type SpanBarColours = {
@@ -30,6 +31,12 @@ export function getSpanBarColours(
         primary: theme.blue300,
         alternate: '#d1dff9',
         insetTextColour: theme.gray300,
+      };
+    case SpanBarType.AUTOGROUPED_AND_AFFECTED:
+      return {
+        primary: '#f55459',
+        alternate: '#faa9ac',
+        insetTextColour: theme.white,
       };
     default:
       return {primary: '', alternate: '', insetTextColour: theme.white};

--- a/static/app/components/performance/waterfall/rowTitle.tsx
+++ b/static/app/components/performance/waterfall/rowTitle.tsx
@@ -27,6 +27,6 @@ export const RowTitleContent = styled('span')<{errored: boolean}>`
   color: ${p => (p.errored ? p.theme.error : 'inherit')};
 `;
 
-export const SpanGroupRowTitleContent = styled('span')`
-  color: ${p => p.theme.linkColor};
+export const SpanGroupRowTitleContent = styled('span')<{color: string}>`
+  color: ${p => p.color};
 `;

--- a/static/app/components/performance/waterfall/treeConnector.tsx
+++ b/static/app/components/performance/waterfall/treeConnector.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {ROW_HEIGHT} from 'sentry/components/performance/waterfall/constants';
+import {ROW_HEIGHT, SpanBarType} from 'sentry/components/performance/waterfall/constants';
 import {getToggleTheme} from 'sentry/components/performance/waterfall/utils';
 import {IconChevron} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
@@ -63,6 +63,7 @@ type SpanTreeTogglerAndDivProps = {
   errored: boolean;
   isExpanded: boolean;
   isSpanGroupToggler?: boolean;
+  spanBarType?: SpanBarType;
 };
 
 export const TreeToggle = styled('div')<SpanTreeTogglerAndDivProps>`

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -99,13 +99,25 @@ export const getToggleTheme = ({
   disabled,
   errored,
   isSpanGroupToggler,
+  spanBarType,
 }: {
   disabled: boolean;
   errored: boolean;
   isExpanded: boolean;
   theme: Theme;
   isSpanGroupToggler?: boolean;
+  spanBarType?: SpanBarType;
 }) => {
+  if (spanBarType) {
+    const {primary} = getSpanBarColours(spanBarType, theme);
+    return `
+    background: ${primary};
+    border: 2px solid ${theme.button.default.border};
+    color: ${theme.button.primary.color};
+    cursor: pointer;
+  `;
+  }
+
   const buttonTheme = isExpanded ? theme.button.default : theme.button.primary;
   const errorTheme = theme.button.danger;
 
@@ -124,7 +136,7 @@ export const getToggleTheme = ({
   if (isSpanGroupToggler) {
     return `
     background: ${theme.blue300};
-    border: 1px solid ${theme.button.default.border};
+    border: 2px solid ${theme.button.default.border};
     color: ${color};
     cursor: pointer;
   `;
@@ -133,7 +145,7 @@ export const getToggleTheme = ({
   if (disabled) {
     return `
     background: ${background};
-    border: 1px solid ${border};
+    border: 2px solid ${border};
     color: ${color};
     cursor: default;
   `;
@@ -141,7 +153,7 @@ export const getToggleTheme = ({
 
   return `
     background: ${background};
-    border: 1px solid ${border};
+    border: 2px solid ${border};
     color: ${color};
   `;
 };


### PR DESCRIPTION
Updates the colours for Autogroup rows in the span tree, if and only if the grouping contains a "problem" span, aka a span that is associated with the perf issue. Also updates the design for the togglebuttons so the border size is `2px` instead of `1px` for consistency with the span tree lines

### Before
![image](https://user-images.githubusercontent.com/16740047/221320972-5f2a70af-9790-42ad-af5b-3e5f31e983fc.png)


### After
![image](https://user-images.githubusercontent.com/16740047/221321027-8f5d342c-36f7-4ba3-9623-45bc7fc0901d.png)

Fixes PERF-1771