### PR TITLE
feat(admin) Add admin relay project config view [TET-509]

### DIFF
--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -14,7 +14,7 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:
-        project_id = request.GET.get("project-id")
+        project_id = request.GET.get("projectId")
 
         project_keys = []
         if project_id is not None:
@@ -26,7 +26,7 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
             except Exception:
                 raise Http404
 
-        project_key = request.GET.get("project-key")
+        project_key = request.GET.get("projectKey")
         if project_key is not None:
             project_keys.append(project_key)
 

--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -1,0 +1,42 @@
+from django.http import Http404
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint, pending_silo_endpoint
+from sentry.api.permissions import SuperuserPermission
+from sentry.models import Project
+from sentry.relay import projectconfig_cache
+
+
+@pending_silo_endpoint
+class AdminRelayProjectConfigsEndpoint(Endpoint):
+    permission_classes = (SuperuserPermission,)
+
+    def get(self, request: Request) -> Response:
+        project_id = request.GET.get("project-id")
+
+        project_keys = []
+        if project_id is not None:
+            try:
+                project = Project.objects.get_from_cache(id=project_id)
+                for project_key in project.key_set.all():
+                    project_keys.append(project_key.public_key)
+
+            except Exception:
+                raise Http404
+
+        project_key = request.GET.get("project-key")
+        if project_key is not None:
+            project_keys.append(project_key)
+
+        configs = {}
+        for key in project_keys:
+            cached_config = projectconfig_cache.get(key)
+            if cached_config is not None:
+                configs[key] = cached_config
+            else:
+                configs[key] = "EMPTY"
+
+        # TODO if we don't think we'll add anything to the endpoint
+        # we may as well return just the configs
+        return Response({"configs": configs}, status=200)

--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -36,7 +36,7 @@ class AdminRelayProjectConfigsEndpoint(Endpoint):
             if cached_config is not None:
                 configs[key] = cached_config
             else:
-                configs[key] = "EMPTY"
+                configs[key] = None
 
         # TODO if we don't think we'll add anything to the endpoint
         # we may as well return just the configs

--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -10,6 +10,7 @@ from sentry.relay import projectconfig_cache
 
 @pending_silo_endpoint
 class AdminRelayProjectConfigsEndpoint(Endpoint):
+    private = True
     permission_classes = (SuperuserPermission,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -69,6 +69,7 @@ from sentry.scim.endpoints.teams import OrganizationSCIMTeamDetails, Organizatio
 
 from .endpoints.accept_organization_invite import AcceptOrganizationInvite
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
+from .endpoints.admin_project_configs import AdminRelayProjectConfigsEndpoint
 from .endpoints.api_application_details import ApiApplicationDetailsEndpoint
 from .endpoints.api_applications import ApiApplicationsEndpoint
 from .endpoints.api_authorizations import ApiAuthorizationsEndpoint
@@ -2485,6 +2486,11 @@ urlpatterns = [
                 url(r"^packages/$", InternalPackagesEndpoint.as_view()),
                 url(r"^environment/$", InternalEnvironmentEndpoint.as_view()),
                 url(r"^mail/$", InternalMailEndpoint.as_view()),
+                url(
+                    r"^project-config/$",
+                    AdminRelayProjectConfigsEndpoint.as_view(),
+                    name="sentry-api-0-internal-project-config",
+                ),
             ]
         ),
     ),

--- a/tests/sentry/api/endpoints/test_admin_project_configs.py
+++ b/tests/sentry/api/endpoints/test_admin_project_configs.py
@@ -52,8 +52,10 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         Request denied for non super-users
         """
         self.login_as(self.user)
+
         url = self.get_url(proj_id=self.proj1.id)
         response = self.client.get(url)
+
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_retrieving_project_configs(self):
@@ -62,10 +64,11 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         keys in redis
         """
         self.login_as(self.superuser, superuser=True)
+
         url = self.get_url(proj_id=self.proj1.id)
         response = self.client.get(url)
-        assert response.status_code == status.HTTP_200_OK
 
+        assert response.status_code == status.HTTP_200_OK
         expected = {"configs": {self.p1_pk.public_key: "proj1 config"}}
         actual = response.json()
         assert actual == expected
@@ -76,10 +79,11 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         for that public key
         """
         self.login_as(self.superuser, superuser=True)
+
         url = self.get_url(key=self.p1_pk.public_key)
         response = self.client.get(url)
-        assert response.status_code == status.HTTP_200_OK
 
+        assert response.status_code == status.HTTP_200_OK
         expected = {"configs": {self.p1_pk.public_key: "proj1 config"}}
         actual = response.json()
         assert actual == expected
@@ -92,15 +96,41 @@ class AdminRelayProjectConfigsEndpointTest(APITestCase):
         expected = {"configs": {self.p2_pk.public_key: "EMPTY"}}
 
         self.login_as(self.superuser, superuser=True)
+
         url = self.get_url(proj_id=self.proj2.id)
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
-
         actual = response.json()
         assert actual == expected
+
         url = self.get_url(key=self.p2_pk.public_key)
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
+        actual = response.json()
+        assert actual == expected
 
+    def test_inexistent_project(self):
+        """
+        Asking for an inexitent project will return 404
+        """
+        inexistent_project_id = 2 ^ 32
+        self.login_as(self.superuser, superuser=True)
+
+        url = self.get_url(proj_id=inexistent_project_id)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_inexistent_key(self):
+        """
+        Asking for an inexistent project key will return an empty result
+        """
+        inexsitent_key = 123
+        self.login_as(self.superuser, superuser=True)
+
+        url = self.get_url(key=inexsitent_key)
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        expected = {"configs": {str(inexsitent_key): "EMPTY"}}
         actual = response.json()
         assert actual == expected

--- a/tests/sentry/api/endpoints/test_admin_project_configs.py
+++ b/tests/sentry/api/endpoints/test_admin_project_configs.py
@@ -7,7 +7,7 @@ from sentry.testutils.silo import no_silo_test
 
 
 @no_silo_test
-class AcceptTransferProjectTest(APITestCase):
+class AdminRelayProjectConfigsEndpointTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.owner = self.create_user(
@@ -39,11 +39,11 @@ class AcceptTransferProjectTest(APITestCase):
         ret_val = reverse(self.path)
         ret_val += "?"
         if proj_id:
-            ret_val += f"project-id={proj_id}"
+            ret_val += f"projectId={proj_id}"
         if proj_id and key:
             ret_val += "&"
         if key:
-            ret_val += f"project-key={key}"
+            ret_val += f"projectKey={key}"
 
         return ret_val
 


### PR DESCRIPTION
This PR adds an endpoint that returns all cached project configs for a project id.
This endpoint is intended mostly for debugging purposes and it is restricted to superuser accounts only

The response will have the following structure:
```JSON
{
  "configs": {
    "proj key 1": "full project config passed to Sentry",
    "proj key 2": "full project config passed to Sentry",
  }
}
```