### PR TITLE
ref(codeowners): Add analytics for issue owners rate limiting (#44929)

### DIFF
--- a/src/sentry/tasks/__init__.py
+++ b/src/sentry/tasks/__init__.py
@@ -1,3 +1,5 @@
+from .analytics import *  # NOQA
+
 """Celery tasks.
 
 Celery tasks are used to create asynchronous workers which communicate their tasks via a

--- a/src/sentry/tasks/analytics.py
+++ b/src/sentry/tasks/analytics.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class IssueOwnersEventRatelimited(analytics.Event):
+    type = "issue_owners_event.ratelimited"
+
+    attributes = (
+        analytics.Attribute("event_id"),
+        analytics.Attribute("group_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("organization_id"),
+    )
+
+
+analytics.register(IssueOwnersEventRatelimited)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
 
-from sentry import features
+from sentry import analytics, features
 from sentry.exceptions import PluginError
 from sentry.issues.grouptype import PROFILE_FILE_IO_ISSUE_TYPES, GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -177,6 +177,13 @@ def handle_owner_assignment(job):
                                 **basic_logging_details,
                                 "reason": "ratelimited",
                             },
+                        )
+                        analytics.record(
+                            "issue_owners_event.ratelimited",
+                            event_id=event.event_id,
+                            group_id=event.group_id,
+                            project_id=event.project_id,
+                            organization_id=event.project.organization_id,
                         )
                         return
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -180,7 +180,6 @@ def handle_owner_assignment(job):
                         )
                         analytics.record(
                             "issue_owners_event.ratelimited",
-                            event_id=event.event_id,
                             group_id=event.group_id,
                             project_id=event.project_id,
                             organization_id=event.project.organization_id,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -990,8 +990,9 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
         )
 
+    @patch("sentry.analytics.record")
     @patch("sentry.tasks.post_process.logger")
-    def test_issue_owners_should_ratelimit(self, logger):
+    def test_issue_owners_should_ratelimit(self, logger, record_mock):
         cache.set(
             f"issue_owner_assignment_ratelimiter:{self.project.id}",
             (set(range(0, ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT * 10, 10)), datetime.now()),
@@ -1020,6 +1021,13 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
                 "organization": event.project.organization_id,
                 "reason": "ratelimited",
             },
+        )
+        record_mock.assert_called_with(
+            "issue_owners_event.ratelimited",
+            event_id=event.event_id,
+            group_id=event.group_id,
+            project_id=event.project_id,
+            organization_id=event.project.organization_id,
         )
 
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1024,7 +1024,6 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         )
         record_mock.assert_called_with(
             "issue_owners_event.ratelimited",
-            event_id=event.event_id,
             group_id=event.group_id,
             project_id=event.project_id,
             organization_id=event.project.organization_id,


### PR DESCRIPTION
Creates an analytic event to track the events getting ratelimited by the Issue Owners ratelimit

WOR-2682

Same as https://github.com/getsentry/sentry/pull/44929, but this initially needed to be reverted as too many analytic events were being sent. https://github.com/getsentry/sentry/commit/1e8d7c769b2ca2db6aba6a2bd92588b253a174ae changed the ratelimit to groups instead of events
