### PR TITLE
chore(profiling): Reduce date range to 24h on profiling

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -37,6 +37,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {DEFAULT_PROFILING_DATETIME_SELECTION} from 'sentry/views/profiling/utils';
 
 import {ProfileCharts} from './landing/profileCharts';
 import {ProfilingSlowestTransactionsPanel} from './landing/profilingSlowestTransactionsPanel';
@@ -149,7 +150,13 @@ function ProfilingContent({location}: ProfilingContentProps) {
 
   return (
     <SentryDocumentTitle title={t('Profiling')} orgSlug={organization.slug}>
-      <PageFiltersContainer>
+      <PageFiltersContainer
+        defaultSelection={
+          profilingUsingTransactions
+            ? {datetime: DEFAULT_PROFILING_DATETIME_SELECTION}
+            : undefined
+        }
+      >
         <Layout.Page>
           <Layout.Header>
             <Layout.HeaderContent>

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -30,6 +30,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
+import {DEFAULT_PROFILING_DATETIME_SELECTION} from 'sentry/views/profiling/utils';
 
 import {ProfileSummaryContent} from './content';
 
@@ -161,6 +162,11 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
         shouldForceProject={defined(project)}
         forceProject={project}
         specificProjectSlugs={defined(project) ? [project.slug] : []}
+        defaultSelection={
+          profilingUsingTransactions
+            ? {datetime: DEFAULT_PROFILING_DATETIME_SELECTION}
+            : undefined
+        }
       >
         <Layout.Page>
           {project && transaction && (

--- a/static/app/views/profiling/utils.tsx
+++ b/static/app/views/profiling/utils.tsx
@@ -68,3 +68,10 @@ export function renderTableHeader<K>(rightAlignedColumns: Set<K>) {
     );
   };
 }
+
+export const DEFAULT_PROFILING_DATETIME_SELECTION = {
+  start: null,
+  end: null,
+  utc: false,
+  period: '24h',
+};


### PR DESCRIPTION
Similar motivations to why performance initially used 24h as the default date range. Since we're using the transactions dataset for profiling now, querying 14d of data is a lot and can be slow, so reduce it to 24h by default. Users can still choose to select 14d if they explicitly change the date filters.