### PR TITLE
fix(profiling): Use slug from project for inline docs if possible

### DIFF
--- a/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
@@ -110,7 +110,7 @@ export function GapSpanDetails({
       <InlineDocs
         orgSlug={organization.slug}
         platform={event.sdk?.name || ''}
-        projectSlug={project?.slug ?? event?.projectSlug ?? ''}
+        projectSlug={event?.projectSlug ?? project?.slug ?? ''}
         resetCellMeasureCache={resetCellMeasureCache}
       />
     );

--- a/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
@@ -110,7 +110,7 @@ export function GapSpanDetails({
       <InlineDocs
         orgSlug={organization.slug}
         platform={event.sdk?.name || ''}
-        projectSlug={event?.projectSlug ?? ''}
+        projectSlug={project?.slug ?? event?.projectSlug ?? ''}
         resetCellMeasureCache={resetCellMeasureCache}
       />
     );


### PR DESCRIPTION
The event may not always have a project slug, so we will fall back to the slug from the project.