### PR TITLE
chore(issue assignment): Add logging for`GroupOwner` auto assignment

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Tuple, Union
 
 from django.db import models
@@ -17,6 +18,8 @@ from sentry.utils.cache import cache
 if TYPE_CHECKING:
     from sentry.models import ProjectCodeOwners, Team
     from sentry.services.hybrid_cloud.user import RpcUser
+
+logger = logging.getLogger(__name__)
 
 READ_CACHE_DURATION = 3600
 
@@ -302,6 +305,19 @@ class ProjectOwnership(Model):
                     organization_id=ownership.project.organization_id,
                     project_id=project_id,
                     group_id=event.group.id,
+                )
+                logger.info(
+                    "handle_auto_assignment.success",
+                    extra={
+                        "event": event.event_id,
+                        "group": event.group_id,
+                        "project": event.project_id,
+                        "organization": event.project.organization_id,
+                        # owner_id returns a string including the owner type (user or team) and id
+                        "assignee": issue_owner.owner_id(),
+                        "reason": "created" if assignment["new_assignment"] else "updated",
+                        **details,
+                    },
                 )
 
     @classmethod

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -248,6 +248,13 @@ def handle_owner_assignment(job):
                     if issue_owners:
                         try:
                             handle_group_owners(project, group, issue_owners)
+                            logger.info(
+                                "handle_owner_assignment.success",
+                                extra={
+                                    **basic_logging_details,
+                                    "reason": "stored_issue_owners",
+                                },
+                            )
                         except Exception:
                             logger.exception("Failed to store group owners")
         except Exception:


### PR DESCRIPTION
There's currently a bug in our issue assignment logic such that suspect commits are sometimes passed over in favor of issue ownership rules or codeowners when auto-assigning an issue. 

For folks with Commit Context enabled, the calculating of suspect commits involves an API call to an outside service (GitHub or GitLab), meaning it's possible that this problem is caused by a race condition: when assignment happens, the data for suspect commit calculation may or may not have come back from the API yet. 

To test this hypothesis, it would be helpful to know when each stage of the process happened for an event with the wrong assignee. We already log the completion of suspect commit processing, but we don't log the completion of either ownership rule/code owners processing or the completion of auto-assignment. This PR adds that logging. 

Once it's merged, we'll need to look at logs for `process_commit_context.success` , `handle_owner_assignment.success`, and `handle_auto_assignment.success` . 

Ref: WOR-2505