### PR TITLE
feat(perf): Show total self time instead of percentage

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -21,7 +21,7 @@ import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
-import {generateQueryWithTag} from 'sentry/utils';
+import {defined, generateQueryWithTag} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import {
@@ -388,11 +388,8 @@ function SummaryContent({
           organization={organization}
           eventView={eventView}
           totals={
-            totalValues
-              ? {
-                  'count()': totalValues['count()'],
-                  'sum(transaction.duration)': totalValues['sum(transaction.duration)'],
-                }
+            defined(totalValues?.['count()'])
+              ? {'count()': totalValues!['count()']}
               : null
           }
           projectId={projectId}

--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
@@ -67,7 +67,7 @@ describe('SuspectSpans', function () {
               eventView={initialData.eventView}
               projectId="1"
               transactionName="Test Transaction"
-              totals={{'count()': 1, 'sum(transaction.duration)': 1000}}
+              totals={{'count()': 1}}
             />
           </MEPSettingProvider>
         </OrganizationContext.Provider>
@@ -79,7 +79,7 @@ describe('SuspectSpans', function () {
       expect(await screen.findByText('Span Name')).toBeInTheDocument();
       expect(await screen.findByText('Frequency')).toBeInTheDocument();
       expect(await screen.findByText('P75 Self Time')).toBeInTheDocument();
-      expect(await screen.findByText('Total Self Time %')).toBeInTheDocument();
+      expect(await screen.findByText('Total Self Time')).toBeInTheDocument();
     });
 
     // Due to the createHref being stubbed out (see link below),

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
@@ -114,7 +114,7 @@ describe('Performance > Transaction Spans', function () {
       expect(await within(grid).findByText('Span Name')).toBeInTheDocument();
       expect(await within(grid).findByText('Frequency')).toBeInTheDocument();
       expect(await within(grid).findByText('P75 Self Time')).toBeInTheDocument();
-      expect(await within(grid).findByText('Total Self Time %')).toBeInTheDocument();
+      expect(await within(grid).findByText('Total Self Time')).toBeInTheDocument();
 
       // there should be a row for each of the spans
       expect(await within(grid).findByText('op1')).toBeInTheDocument();
@@ -143,7 +143,7 @@ describe('Performance > Transaction Spans', function () {
         expect(await within(grid).findByText('Span Name')).toBeInTheDocument();
         expect(await within(grid).findByText('Frequency')).toBeInTheDocument();
         expect(await within(grid).findByText(label)).toBeInTheDocument();
-        expect(await within(grid).findByText('Total Self Time %')).toBeInTheDocument();
+        expect(await within(grid).findByText('Total Self Time')).toBeInTheDocument();
       });
     });
 
@@ -160,7 +160,7 @@ describe('Performance > Transaction Spans', function () {
       expect(await within(grid).findByText('Average Occurrences')).toBeInTheDocument();
       expect(await within(grid).findByText('Frequency')).toBeInTheDocument();
       expect(await within(grid).findByText('P75 Self Time')).toBeInTheDocument();
-      expect(await within(grid).findByText('Total Self Time %')).toBeInTheDocument();
+      expect(await within(grid).findByText('Total Self Time')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
@@ -31,7 +31,7 @@ describe('SuspectSpansTable', () => {
         transactionName="Test Transaction"
         isLoading={false}
         suspectSpans={[suspectSpan]}
-        totals={{'count()': 100, 'sum(transaction.duration)': 9999}}
+        totals={{'count()': 100}}
         sort={SpanSortOthers.SUM_EXCLUSIVE_TIME}
       />,
       {context: initialData.routerContext}

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.tsx
@@ -56,12 +56,7 @@ export default function SuspectSpansTable(props: Props) {
     p75ExclusiveTime: suspectSpan.p75ExclusiveTime,
     p95ExclusiveTime: suspectSpan.p95ExclusiveTime,
     p99ExclusiveTime: suspectSpan.p99ExclusiveTime,
-    sumExclusiveTime:
-      totals &&
-      defined(totals?.['sum(transaction.duration)']) &&
-      defined(suspectSpan.sumExclusiveTime)
-        ? suspectSpan.sumExclusiveTime / totals['sum(transaction.duration)']
-        : null,
+    sumExclusiveTime: suspectSpan.sumExclusiveTime,
   }));
 
   return (
@@ -233,7 +228,7 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   },
   sumExclusiveTime: {
     key: 'sumExclusiveTime',
-    name: t('Total Self Time %'),
+    name: t('Total Self Time'),
     width: COL_WIDTH_UNDEFINED,
   },
 };
@@ -247,5 +242,5 @@ const COLUMN_TYPE: Record<TableColumnKey, ColumnType> = {
   p75ExclusiveTime: 'duration',
   p95ExclusiveTime: 'duration',
   p99ExclusiveTime: 'duration',
-  sumExclusiveTime: 'percentage',
+  sumExclusiveTime: 'duration',
 };

--- a/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
@@ -20,5 +20,4 @@ export type SpanSortOption = {
 
 export type SpansTotalValues = {
   'count()': number;
-  'sum(transaction.duration)': number;
 };


### PR DESCRIPTION
It doesn't really make sense to show span's total self time as a percentage of transaction duration because, when there are spans of the same group running in parallel, `sum(exclusiveTime)` isn't indicative of how much these spans contribute to the transaction duration.

This is an example where representing total self time as a % would appear more inflated because of the last two spans being parallel:
<img width="919" alt="Screenshot 2023-02-27 at 1 57 08 PM" src="https://user-images.githubusercontent.com/23648387/221657423-1c511267-7fc2-44aa-b8c1-4d6a3c56bd19.png">

Here are another example where db spans seem to have total self time almost as long as transaction duration (from Discover)
<img width="778" alt="Screenshot 2023-02-27 at 1 52 10 PM" src="https://user-images.githubusercontent.com/23648387/221657672-f27feedb-6376-4673-b366-db457379f9f4.png">

but when inspecting further we can see that truly db spans only make up 40% of transaction duration
<img width="1043" alt="Screenshot 2023-02-27 at 1 51 07 PM" src="https://user-images.githubusercontent.com/23648387/221657809-719c7400-33f3-47e6-9cbd-ef958696434c.png">


