### PR TITLE
fix(routes): Add org restore route compatible with customer domains

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -593,6 +593,12 @@ urlpatterns += [
         DisabledMemberView.as_view(),
         name="sentry-customer-domain-organization-disabled-member",
     ),
+    # Restore organization
+    url(
+        r"^restore/",
+        RestoreOrganizationView.as_view(),
+        name="sentry-customer-domain-restore-organization",
+    ),
     # Project on-boarding
     # We map /:orgid/:projectid/getting-started/* to /getting-started/:projectid/*
     url(

--- a/tests/sentry/web/frontend/test_restore_organization.py
+++ b/tests/sentry/web/frontend/test_restore_organization.py
@@ -61,6 +61,31 @@ class RemoveOrganizationTest(TestCase):
         assert resp.context["deleting_organization"] == self.organization
         assert resp.context["pending_deletion"] is False
 
+    def test_renders_with_context_customer_domain(self):
+        path = reverse("sentry-customer-domain-restore-organization")
+
+        resp = self.client.get(path, SERVER_NAME=f"{self.organization.slug}.testserver")
+
+        assert resp.status_code == 200
+
+        self.assertTemplateUsed(resp, "sentry/restore-organization.html")
+
+        assert resp.context["deleting_organization"] == self.organization
+        assert resp.context["pending_deletion"] is True
+
+        Organization.objects.filter(id=self.organization.id).update(
+            status=OrganizationStatus.DELETION_IN_PROGRESS
+        )
+
+        resp = self.client.get(path, SERVER_NAME=f"{self.organization.slug}.testserver")
+
+        assert resp.status_code == 200
+
+        self.assertTemplateUsed(resp, "sentry/restore-organization.html")
+
+        assert resp.context["deleting_organization"] == self.organization
+        assert resp.context["pending_deletion"] is False
+
     def test_success(self):
         resp = self.client.post(self.path)
 


### PR DESCRIPTION
This should enable `orgslug.sentry.io/restore/` to be accessible; especially from emails we send out to owners when an organization is scheduled to be deleted.