### PR TITLE
fix(perf-issues): Fix colour of duration pill in affected autogrouped spans

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
@@ -154,7 +154,11 @@ export function SpanDescendantGroupBar(props: SpanDescendantGroupBarProps) {
           width: toPercent(bounds.width || 0),
         }}
       >
-        <DurationPill durationDisplay={durationDisplay} showDetail={false}>
+        <DurationPill
+          durationDisplay={durationDisplay}
+          showDetail={false}
+          spanBarType={spanBarType}
+        >
           {durationString}
         </DurationPill>
       </RowRectangle>

--- a/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
@@ -12,9 +12,11 @@ import {getSpanGroupTimestamps, SpanViewBoundsType} from './utils';
 export function SpanRectangleOverlay({
   bounds,
   spanGrouping,
+  spanBarType,
 }: {
   bounds: SpanViewBoundsType;
   spanGrouping: EnhancedSpan[];
+  spanBarType?: SpanBarType;
 }) {
   const {startTimestamp, endTimestamp} = getSpanGroupTimestamps(spanGrouping);
   const duration = Math.abs(endTimestamp - startTimestamp);
@@ -31,7 +33,7 @@ export function SpanRectangleOverlay({
       <DurationPill
         durationDisplay={durationDisplay}
         showDetail={false}
-        spanBarType={SpanBarType.AUTOGROUPED}
+        spanBarType={spanBarType}
       >
         {durationString}
       </DurationPill>

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -138,6 +138,7 @@ export default function SpanSiblingGroupBar(props: SpanSiblingGroupBarProps) {
         <SpanRectangleOverlay
           spanGrouping={spanGrouping}
           bounds={getSpanGroupBounds(spanGrouping, generateBounds)}
+          spanBarType={spanBarType}
         />
       </Fragment>
     );


### PR DESCRIPTION
The duration pill inside autogrouped spans with a problem span was not using the correct background colour, since we were not passing the `spanBarType` prop 

### Before
![image](https://user-images.githubusercontent.com/16740047/221673485-964b09de-dc62-46db-b1c7-40848a9fc9d7.png)

### After
![image](https://user-images.githubusercontent.com/16740047/221673560-ad1a355d-981d-4fd4-920f-4053a4c6b375.png)
