### PR TITLE
fix(issue-stream): Adjust pagination caption to be more accurate

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1136,28 +1136,14 @@ class IssueListOverview extends Component<Props, State> {
       issuesLoading,
       error,
     } = this.state;
-    const {organization, selection, location, router} = this.props;
-    const links = parseLinkHeader(pageLinks);
+    const {organization, selection, router} = this.props;
     const query = this.getQuery();
-    const queryPageInt = parseInt(location.query.page, 10);
-    // Cursor must be present for the page number to be used
-    const page = isNaN(queryPageInt) || !location.query.cursor ? 0 : queryPageInt;
-    const pageBasedCount = page * MAX_ITEMS + groupIds.length;
 
-    let pageCount = pageBasedCount > queryCount ? queryCount : pageBasedCount;
-    if (!links?.next?.results || this.allResultsVisible()) {
-      // On last available page
-      pageCount = queryCount;
-    } else if (!links?.previous?.results) {
-      // On first available page
-      pageCount = groupIds.length;
-    }
+    const numIssuesOnPage = groupIds.length;
 
-    // Subtract # items that have been marked reviewed
-    pageCount = Math.max(pageCount - itemsRemoved, 0);
     const modifiedQueryCount = Math.max(queryCount - itemsRemoved, 0);
     const displayCount = tct('[count] of [total]', {
-      count: pageCount,
+      count: numIssuesOnPage,
       total: (
         <StyledQueryCount
           hideParens


### PR DESCRIPTION
The caption was saying "Showing <total_issues_up_to_this_page> of <total> issues", but it's really only showing the number of issues that are rendered. This also simplifies the logic.

Before:

![CleanShot 2023-02-27 at 12 21 15](https://user-images.githubusercontent.com/10888943/221677920-21c7bf23-6cf1-4c0f-9386-c6c7ef947f3a.png)

After:

![CleanShot 2023-02-27 at 12 20 59](https://user-images.githubusercontent.com/10888943/221677939-e1734cd6-4810-41f0-a793-5f8645b3f73d.png)
