### PR TITLE
feat(ci/codecov): Do not trigger check until five codecov CI checks complete

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+codecov:
+  notify:
+    # The minimum amount of codecov reporting checks that need to complete
+    # For FE we have 5 checks and for BE we have 11
+    # TODO: Remove this when we have support of after_n_builds per flag
+    after_n_builds: 5
+
 # Setting coverage targets per flag
 coverage:
   status:


### PR DESCRIPTION
Without this, we have the diff target triggered soon after the symbolicator test finishes (under 10 mins) rather than waiting for the backend tests (about 20 mins).

If you are watching at the results of your pull request, you would be surprised as to why codecov is complaining.

Docs in [here](https://docs.codecov.com/docs/codecovyml-reference).

Screenshot for early diff target check:
![image](https://user-images.githubusercontent.com/44410/221681093-c2442383-15af-44b2-81e1-4b8fa9dfbaed.png)
