### PR TITLE
ref(git hooks): Only suggest autoupdate variable when pulling if not already set

### DIFF
--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -8,11 +8,11 @@ reset="$(tput sgr0)"
 files_changed_upstream="$(mktemp)"
 trap "rm -f ${files_changed_upstream}" EXIT
 
-git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD > "$files_changed_upstream"
+git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD >"$files_changed_upstream"
 
 grep --quiet 'requirements-dev-frozen.txt' "$files_changed_upstream" && py="install-py-dev "
-grep --quiet 'yarn.lock' "$files_changed_upstream"                   && js="install-js-dev "
-grep --quiet 'migrations' "$files_changed_upstream"                  && migrations="apply-migrations "
+grep --quiet 'yarn.lock' "$files_changed_upstream" && js="install-js-dev "
+grep --quiet 'migrations' "$files_changed_upstream" && migrations="apply-migrations "
 
 [[ "$pc" || "$py" || "$js" || "$migrations" ]] && needs_update=1
 

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -15,18 +15,22 @@ grep --quiet 'yarn.lock' "$files_changed_upstream"                   && js="inst
 grep --quiet 'migrations' "$files_changed_upstream"                  && migrations="apply-migrations "
 
 [[ "$pc" || "$py" || "$js" || "$migrations" ]] && needs_update=1
-update_command="make ${pc}${py}${js}${migrations}"
 
-[[ "$needs_update" ]] && cat <<EOF
+if [[ "$needs_update" ]]; then
+  update_command="make ${pc}${py}${js}${migrations}"
+
+  cat <<EOF
 
 [${red}${bold}!!!${reset}] ${red} It looks like some dependencies have changed that will require your intervention. Run the following to update:${reset}
 
     ${red}${bold}${update_command}${reset}
 
-${yellow}If you want these commands to automatically be executed after pulling code you can export the SENTRY_POST_MERGE_AUTO_UPDATE variable.${reset}
-
 EOF
 
-if [[ "$SENTRY_POST_MERGE_AUTO_UPDATE" && "$needs_update" ]]; then
-  $update_command
+  if [[ "$SENTRY_POST_MERGE_AUTO_UPDATE" ]]; then
+    echo "${yellow}Automatically running update command because SENTRY_POST_MERGE_AUTO_UPDATE is set.${reset}"
+    $update_command
+  else
+    echo "${yellow}If you want these commands to be executed automatically after pulling code, you can export the SENTRY_POST_MERGE_AUTO_UPDATE variable.${reset}"
+  fi
 fi


### PR DESCRIPTION
This PR refactors the post-merge git hook so that it not longer suggests setting `SENTRY_POST_MERGE_AUTO_UPDATE` if it's already set. Instead, it prints a message confirming that it's running the auto-update because it's detected the variable.

![image](https://user-images.githubusercontent.com/14812505/221736910-c80f7826-3c73-4ae3-997d-03d1efd2769a.png)

It also:
- gathers all of the update logic inside a single `if [[ "$needs_update" ]]` block
- fixes two spacing issues the auto-formatter didn't like