### PR TITLE
chore(py): Consistently name urls using `organization-` prefix

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -652,7 +652,7 @@ urlpatterns = [
     url(
         r"^accept-invite/(?P<organization_slug>[^\/]+)/(?P<member_id>[^\/]+)/(?P<token>[^\/]+)/$",
         AcceptOrganizationInvite.as_view(),
-        name="sentry-api-0-accept-organization-invite-with-org",
+        name="sentry-api-0-organization-accept-organization-invite",
     ),
     url(
         r"^accept-invite/(?P<member_id>[^\/]+)/(?P<token>[^\/]+)/$",
@@ -695,27 +695,27 @@ urlpatterns = [
                 url(
                     r"^(?P<monitor_id>[^\/]+)/$",
                     MonitorDetailsEndpoint.as_view(),
-                    name="sentry-api-0-monitor-details-with-org",
+                    name="sentry-api-0-organization-monitor-details",
                 ),
                 url(
                     r"^(?P<monitor_id>[^\/]+)/checkins/$",
                     MonitorCheckInsEndpoint.as_view(),
-                    name="sentry-api-0-monitor-check-in-index-with-org",
+                    name="sentry-api-0-organization-monitor-check-in-index",
                 ),
                 url(
                     r"^(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/$",
                     MonitorCheckInDetailsEndpoint.as_view(),
-                    name="sentry-api-0-monitor-check-in-details-with-org",
+                    name="sentry-api-0-organization-monitor-check-in-details",
                 ),
                 url(
                     r"^(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/attachment/$",
                     MonitorCheckInAttachmentEndpoint.as_view(),
-                    name="sentry-api-0-monitor-check-in-attachment-with-org",
+                    name="sentry-api-0-organization-monitor-check-in-attachment",
                 ),
                 url(
                     r"^(?P<monitor_id>[^\/]+)/stats/$",
                     MonitorStatsEndpoint.as_view(),
-                    name="sentry-api-0-monitor-stats-with-org",
+                    name="sentry-api-0-organization-monitor-stats",
                 ),
             ]
         ),
@@ -2335,7 +2335,7 @@ urlpatterns = [
     url(
         r"^organizations/(?P<organization_slug>[^\/]+)/issues/(?P<issue_id>[^\/]+)/participants/$",
         GroupParticipantsEndpoint.as_view(),
-        name="sentry-api-0-group-stats-with-org",
+        name="sentry-api-0-organization-group-stats",
     ),
     url(
         r"^issues/(?P<issue_id>[^\/]+)/participants/$",
@@ -2346,7 +2346,7 @@ urlpatterns = [
     url(
         r"^organizations/(?P<organization_slug>[^\/]+)/shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",
         SharedGroupDetailsEndpoint.as_view(),
-        name="sentry-api-0-shared-group-details-with-org",
+        name="sentry-api-0-organization-shared-group-details",
     ),
     url(
         r"^shared/(?:issues|groups)/(?P<share_id>[^\/]+)/$",

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -366,7 +366,7 @@ urlpatterns += [
     url(
         r"^accept/(?P<organization_slug>[^/]+)/(?P<member_id>\d+)/(?P<token>\w+)/$",
         GenericReactPageView.as_view(auth_required=False),
-        name="sentry-accept-invite-with-org",
+        name="sentry-organization-accept-invite",
     ),
     # User settings use generic_react_page_view, while any view acting on
     # behalf of an organization should use react_page_view

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -28,7 +28,7 @@ class AcceptInviteTest(TestCase):
         return (
             reverse("sentry-api-0-accept-organization-invite", args=args),
             reverse(
-                "sentry-api-0-accept-organization-invite-with-org",
+                "sentry-api-0-organization-accept-organization-invite",
                 args=[self.organization.slug] + args,
             ),
         )
@@ -36,7 +36,7 @@ class AcceptInviteTest(TestCase):
     def _get_urls(self):
         return (
             "sentry-api-0-accept-organization-invite",
-            "sentry-api-0-accept-organization-invite-with-org",
+            "sentry-api-0-organization-accept-organization-invite",
         )
 
     def _get_path(self, url, args):
@@ -350,7 +350,7 @@ class AcceptInviteTest(TestCase):
         )
 
         path = reverse(
-            "sentry-api-0-accept-organization-invite-with-org", args=["asdf", om.id, om.token]
+            "sentry-api-0-organization-accept-organization-invite", args=["asdf", om.id, om.token]
         )
 
         resp = self.client.get(path)

--- a/tests/sentry/api/endpoints/test_group_participants.py
+++ b/tests/sentry/api/endpoints/test_group_participants.py
@@ -19,7 +19,7 @@ class GroupParticipantsTest(APITestCase):
         return (
             lambda group: reverse("sentry-api-0-group-stats", args=[group.id]),
             lambda group: reverse(
-                "sentry-api-0-group-stats-with-org", args=[self.organization.slug, group.id]
+                "sentry-api-0-organization-group-stats", args=[self.organization.slug, group.id]
             ),
         )
 

--- a/tests/sentry/api/endpoints/test_monitor_checkin_attachment.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkin_attachment.py
@@ -12,7 +12,7 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test(stable=True)
 class UploadMonitorCheckInAttachmentTest(APITestCase):
-    endpoint = "sentry-api-0-monitor-check-in-attachment-with-org"
+    endpoint = "sentry-api-0-organization-monitor-check-in-attachment"
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_monitor_checkin_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkin_details.py
@@ -11,7 +11,7 @@ from sentry.testutils.silo import region_silo_test
 @region_silo_test(stable=True)
 class UpdateMonitorCheckInTest(APITestCase):
     endpoint = "sentry-api-0-monitor-check-in-details"
-    endpoint_with_org = "sentry-api-0-monitor-check-in-details-with-org"
+    endpoint_with_org = "sentry-api-0-organization-monitor-check-in-details"
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -16,7 +16,7 @@ from sentry.testutils.silo import region_silo_test
 @freeze_time()
 class CreateMonitorCheckInTest(MonitorTestCase):
     endpoint = "sentry-api-0-monitor-check-in-index"
-    endpoint_with_org = "sentry-api-0-monitor-check-in-index-with-org"
+    endpoint_with_org = "sentry-api-0-organization-monitor-check-in-index"
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_details.py
@@ -6,7 +6,7 @@ from sentry.testutils.silo import region_silo_test
 @region_silo_test(stable=True)
 class MonitorDetailsTest(MonitorTestCase):
     endpoint = "sentry-api-0-monitor-details"
-    endpoint_with_org = "sentry-api-0-monitor-details-with-org"
+    endpoint_with_org = "sentry-api-0-organization-monitor-details"
 
     def setUp(self):
         super().setUp()
@@ -44,7 +44,7 @@ class MonitorDetailsTest(MonitorTestCase):
 @region_silo_test(stable=True)
 class UpdateMonitorTest(MonitorTestCase):
     endpoint = "sentry-api-0-monitor-details"
-    endpoint_with_org = "sentry-api-0-monitor-details-with-org"
+    endpoint_with_org = "sentry-api-0-organization-monitor-details"
 
     def setUp(self):
         super().setUp()
@@ -281,7 +281,7 @@ class UpdateMonitorTest(MonitorTestCase):
 @region_silo_test()
 class DeleteMonitorTest(MonitorTestCase):
     endpoint = "sentry-api-0-monitor-details"
-    endpoint_with_org = "sentry-api-0-monitor-details-with-org"
+    endpoint_with_org = "sentry-api-0-organization-monitor-details"
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
We added some url routes suffixed `-with-org`, this is inconsistent with
most of our other API routes which match the url and typically use
`sentry-api-0-organization-*`