### PR TITLE
feat(ci/codecov): Enable PR comment and make patch check always green

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,12 +15,16 @@ coverage:
       frontend:
         # codecov will not fail status checks for master
         only_pulls: true
+        # This will be needed until codecov supports after_n_builds for flags
+        informational: true # Do not fail the check
         target: 60%
         flags:
         - frontend
       backend:
         # codecov will not fail status checks for master
         only_pulls: true
+        # This will be needed until codecov supports after_n_builds for flags
+        informational: true # Do not fail the check
         target: 90%
         flags:
           - backend
@@ -60,4 +64,15 @@ flags:
     - "src/sentry/**/*.py"
     carryforward: true
 
-comment: false
+# This will add a comment to PRs
+# This is useful until the diff target check does not trigger early
+# Read more here: https://docs.codecov.com/docs/pull-request-comments#layout
+comment:
+  layout: "diff, files"
+  behavior: default # Update, if comment exists. Otherwise post new.
+  # Comments will now only post when coverage changes. Furthermore, if a comment
+  # already exists, and a newer commit results in no coverage change for the
+  # entire pull, the comment will be deleted.
+  require_changes: true
+  require_base: yes # must have a base report to post
+  require_head: yes # must have a head report to post


### PR DESCRIPTION
Unfortunately, the backend patch check triggers early. As soon as there are five jobs (current after_n_builds set) that upload coverage data the check will be triggered. We use a value of 5 because that's the number of FE checks that upload coverage data.

If you are watching the CI running for your PR, you will get at first a red check with bad coverage. It will get updated later.

This change makes the check alwaysgreen, thus, not distracting engineers while also adding a comment to the PR with coverage information.

Once we have support for after_n_build for flags we can re-enable it.