### PR TITLE
feat(perf): Swap most improved with most regressed as a default widget

### DIFF
--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -257,8 +257,8 @@ describe('Performance > Landing > Index', function () {
     const titles = await screen.findAllByTestId('performance-widget-title');
     expect(titles).toHaveLength(5);
 
-    expect(titles.at(0)).toHaveTextContent('Most Related Issues');
-    expect(titles.at(1)).toHaveTextContent('Most Improved');
+    expect(titles.at(0)).toHaveTextContent('Most Regressed');
+    expect(titles.at(1)).toHaveTextContent('Most Related Issues');
     expect(titles.at(2)).toHaveTextContent('User Misery');
     expect(titles.at(3)).toHaveTextContent('Transactions Per Minute');
     expect(titles.at(4)).toHaveTextContent('Failure Rate');

--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -15,9 +15,9 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
     canUseMetricsData(props.organization);
 
   const doubleChartRowCharts = [
+    PerformanceWidgetSetting.MOST_REGRESSED,
     PerformanceWidgetSetting.MOST_RELATED_ISSUES,
     PerformanceWidgetSetting.MOST_IMPROVED,
-    PerformanceWidgetSetting.MOST_REGRESSED,
   ];
 
   if (showSpanOperationsWidget) {


### PR DESCRIPTION
Based on the user feedback, most regressed widget is more useful than most improved. This PR makes most regressed widget a default landing page widget along with span op widget for the all transactions view