### PR TITLE
fix(replays): sort list to fix test flake

### DIFF
--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -196,7 +196,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
 
             assert len(response_data["data"][0]) == 1
             assert "tags" in response_data["data"][0]
-            assert response_data["data"][0]["tags"]["test"] == ["world", "hello"]
+            assert sorted(response_data["data"][0]["tags"]["test"]) == ["hello", "world"]
             assert response_data["data"][0]["tags"]["other"] == ["hello"]
 
     def test_get_replays_minimum_field_set(self):


### PR DESCRIPTION
this was flaking as the order wasn't deterministic. 