### PR TITLE
ref(crons): Check-in endpoint now respects date filter

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -4,7 +4,7 @@ from typing import List
 
 from django.db import transaction
 from drf_spectacular.utils import extend_schema
-from rest_framework.exceptions import Throttled
+from rest_framework.exceptions import ParseError, Throttled
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,6 +15,7 @@ from sentry.api.bases.monitor import MonitorEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.monitorcheckin import MonitorCheckInSerializerResponse
+from sentry.api.utils import get_date_range_from_stats_period
 from sentry.api.validators import MonitorCheckInValidator
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -68,7 +69,14 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
             if project.organization.slug != organization_slug:
                 return self.respond_invalid()
 
-        queryset = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
+        params = request.GET
+        start, end = get_date_range_from_stats_period(params)
+        if start is None or end is None:
+            raise ParseError(detail="Invalid date range")
+
+        queryset = MonitorCheckIn.objects.filter(
+            monitor_id=monitor.id, date_added__gte=start, date_added__lte=end
+        )
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -15,7 +15,7 @@ from sentry.api.bases.monitor import MonitorEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.monitorcheckin import MonitorCheckInSerializerResponse
-from sentry.api.utils import get_date_range_from_stats_period
+from sentry.api.utils import get_date_range_from_params
 from sentry.api.validators import MonitorCheckInValidator
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -69,7 +69,7 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
             if project.organization.slug != organization_slug:
                 return self.respond_invalid()
 
-        start, end = get_date_range_from_stats_period(request.GET)
+        start, end = get_date_range_from_params(request.GET)
         if start is None or end is None:
             raise ParseError(detail="Invalid date range")
 

--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -69,8 +69,7 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
             if project.organization.slug != organization_slug:
                 return self.respond_invalid()
 
-        params = request.GET
-        start, end = get_date_range_from_stats_period(params)
+        start, end = get_date_range_from_stats_period(request.GET)
         if start is None or end is None:
             raise ParseError(detail="Invalid date range")
 

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -212,3 +212,36 @@ class CreateMonitorCheckInTest(MonitorTestCase):
                 assert resp.status_code == 201, resp.content
                 resp = self.client.post(path, {"status": "ok"})
                 assert resp.status_code == 429, resp.content
+
+    def test_statsperiod_constraints(self):
+        self.login_as(self.user)
+
+        for path_func in self._get_path_functions():
+            monitor = self._create_monitor()
+
+            path = path_func(monitor.guid)
+
+            checkin = MonitorCheckIn.objects.create(
+                project_id=self.project.id,
+                monitor_id=monitor.id,
+                status=MonitorStatus.OK,
+                date_added=timezone.now() - timedelta(hours=12),
+            )
+
+            end = timezone.now()
+            startOneHourAgo = end - timedelta(hours=1)
+            startOneDayAgo = end - timedelta(days=1)
+
+            resp = self.client.get(path, {"statsPeriod": "1h"})
+            assert resp.json() == []
+            resp = self.client.get(
+                path, {"start": startOneHourAgo.isoformat(), "end": end.isoformat()}
+            )
+            assert resp.json() == []
+
+            resp = self.client.get(path, {"statsPeriod": "1d"})
+            assert resp.json()[0]["id"] == str(checkin.guid)
+            resp = self.client.get(
+                path, {"start": startOneDayAgo.isoformat(), "end": end.isoformat()}
+            )
+            assert resp.json()[0]["id"] == str(checkin.guid)


### PR DESCRIPTION
GET requests on this endpoint will now read in date query params (`statsPeriod`, `start`, `end`) generated from date page filter to restrict list of returned checkins

resolves: https://github.com/getsentry/sentry/issues/44715