### PR TITLE
fix(profiling): Fall back to default platform on profiling panel

### DIFF
--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -147,7 +147,7 @@ function SlowestTransactionPanelItem({
   return (
     <PanelItem key={transaction.transaction}>
       <Flex justify="space-between" gap={space(1)}>
-        <PlatformIcon platform={transactionProject?.platform || 'default'} />
+        <PlatformIcon platform={transactionProject?.platform ?? 'default'} />
         <Flex.Item grow={1}>
           <Link
             to={generateProfileSummaryRouteWithQuery({

--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -147,7 +147,7 @@ function SlowestTransactionPanelItem({
   return (
     <PanelItem key={transaction.transaction}>
       <Flex justify="space-between" gap={space(1)}>
-        <PlatformIcon platform={transactionProject?.platform} />
+        <PlatformIcon platform={transactionProject?.platform || 'default'} />
         <Flex.Item grow={1}>
           <Link
             to={generateProfileSummaryRouteWithQuery({


### PR DESCRIPTION
The project's platform can be null and would crash PlatformIcon.