### PR TITLE
chore(typing) Improve types for env()

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -9,7 +9,7 @@ import socket
 import sys
 import tempfile
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Tuple, Union, overload
 from urllib.parse import urlparse
 
 import sentry
@@ -25,11 +25,31 @@ def gettext_noop(s):
 socket.setdefaulttimeout(5)
 
 
+@overload
+def env(key: str, default: int, type: Optional[Callable[[Any], int]] = None) -> int:
+    ...
+
+
+@overload
+def env(key: str, default: float, type: Optional[Callable[[Any], float]] = None) -> float:
+    ...
+
+
+@overload
+def env(key: str, default: bool, type: Optional[Callable[[Any], bool]] = None) -> bool:
+    ...
+
+
+@overload
+def env(key: str, default: str, type: Optional[Callable[[Any], str]] = None) -> str:
+    ...
+
+
 def env(
     key: str,
     default: Union[str, int, float, bool, None] = "",
     type: Optional[Callable[[Any], Any]] = None,
-):
+) -> Any:
     """
     Extract an environment variable for use in configuration
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -9,7 +9,7 @@ import socket
 import sys
 import tempfile
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, Mapping, Tuple
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import sentry
@@ -25,7 +25,11 @@ def gettext_noop(s):
 socket.setdefaulttimeout(5)
 
 
-def env(key, default="", type=None):
+def env(
+    key: str,
+    default: Union[str, int, float, bool, None] = "",
+    type: Optional[Callable[[Any], Any]] = None,
+):
     """
     Extract an environment variable for use in configuration
 

--- a/src/sentry/utils/types.py
+++ b/src/sentry/utils/types.py
@@ -1,4 +1,4 @@
-from typing import Callable
+import typing
 
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
@@ -171,9 +171,9 @@ _type_mapping = {
 }
 
 
-def type_from_value(value):
+def type_from_value(value: typing.Any) -> typing.Callable[[typing.Any], typing.Any]:
     """Fetch Type based on a primitive value"""
     return _type_mapping[type(value)]
 
 
-AnyCallable = Callable[..., AnyType]
+AnyCallable = typing.Callable[..., AnyType]


### PR DESCRIPTION
I'm working on config file changes and noticed that many of our calls to env() are flagged as invalid by pyright
