### PR TITLE
__iexact reduce call has default value now.

### DIFF
--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -170,8 +170,10 @@ def in_iexact(column: str, values: Any) -> Q:
     from operator import or_
 
     query = f"{column}__iexact"
+    # if values is empty, have a default value for the reduce call that will essentially resolve a colum in []
+    query_in = f"{column}__in"
 
-    return reduce(or_, [Q(**{query: v}) for v in values])
+    return reduce(or_, [Q(**{query: v}) for v in values], Q(**{query_in: []}))
 
 
 def in_icontains(column: str, values: Any) -> Q:

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -170,7 +170,7 @@ def in_iexact(column: str, values: Any) -> Q:
     from operator import or_
 
     query = f"{column}__iexact"
-    # if values is empty, have a default value for the reduce call that will essentially resolve a colum in []
+    # if values is empty, have a default value for the reduce call that will essentially resolve a column in []
     query_in = f"{column}__in"
 
     return reduce(or_, [Q(**{query: v}) for v in values], Q(**{query_in: []}))

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -1,6 +1,18 @@
-from sentry.models import Team, User
+from sentry.db.models.query import in_iexact
+from sentry.models import Organization, Team, User
 from sentry.testutils import TestCase
 from sentry.utils.query import RangeQuerySetWrapper, bulk_delete_objects
+
+
+class InIexactQueryTest(TestCase):
+    def test_basic(self):
+        self.create_organization(slug="SlugA")
+        self.create_organization(slug="slugB")
+        self.create_organization(slug="slugc")
+
+        assert Organization.objects.filter(in_iexact("slug", ["sluga", "slugb"])).count() == 2
+        assert Organization.objects.filter(in_iexact("slug", ["slugC"])).count() == 1
+        assert Organization.objects.filter(in_iexact("slug", [])).count() == 0
 
 
 class RangeQuerySetWrapperTest(TestCase):


### PR DESCRIPTION
Addresses https://sentry.my.sentry.io/organizations/sentry/issues/392893/?project=2 by allowing empty `values` arrays and letting django orm resolve to a falsey `Q`.  Interestingly, there doesn't seem to be a consistent safe way to do this other than create a Q that will always be false incidentally.