### PR TITLE
chore(profiling): Rename context in profiles task

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -49,7 +49,7 @@ def process_profile_task(
     event_id = profile["event_id"] if "event_id" in profile else profile["profile_id"]
 
     sentry_sdk.set_context(
-        "profile",
+        "profile_metadata",
         {
             "organization_id": profile["organization_id"],
             "project_id": profile["project_id"],


### PR DESCRIPTION
This overlaps with the profile contexts which is used to associate transactions to profiles.