### PR TITLE
fix(replays): Only show the inline onboarding cta if the org has replays enabled

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -3,19 +3,21 @@ import {useCallback} from 'react';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import LazyLoad from 'sentry/components/lazyLoad';
 import {PlatformKey} from 'sentry/data/platformCategories';
+import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 
 type Props = {
   event: Event;
-  orgSlug: string;
+  organization: Organization;
   projectSlug: string;
   replayId: undefined | string;
 };
 
-export default function EventReplay({replayId, orgSlug, projectSlug, event}: Props) {
-  const {hasSentOneReplay} = useHaveSelectedProjectsSentAnyReplayEvents();
+export default function EventReplay({replayId, organization, projectSlug, event}: Props) {
+  const hasReplaysFeature = organization.features.includes('session-replay');
+  const {hasSentOneReplay, fetching} = useHaveSelectedProjectsSentAnyReplayEvents();
 
   const onboardingPanel = useCallback(() => import('./replayInlineOnboardingPanel'), []);
   const replayPreview = useCallback(() => import('./replayPreview'), []);
@@ -26,7 +28,7 @@ export default function EventReplay({replayId, orgSlug, projectSlug, event}: Pro
     platform: event.platform as PlatformKey,
   });
 
-  if (!supportsReplay) {
+  if (!hasReplaysFeature || fetching || !supportsReplay) {
     return null;
   }
 
@@ -47,7 +49,7 @@ export default function EventReplay({replayId, orgSlug, projectSlug, event}: Pro
       <LazyLoad
         component={replayPreview}
         replaySlug={`${projectSlug}:${replayId}`}
-        orgSlug={orgSlug}
+        orgSlug={organization.slug}
         event={event}
       />
     </ErrorBoundary>

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -219,7 +219,7 @@ describe('Breadcrumbs', () => {
             platform: 'javascript',
           })}
           organization={TestStubs.Organization({
-            features: ['session-replay-ui'],
+            features: ['session-replay', 'session-replay-ui'],
           })}
         />
       );
@@ -244,7 +244,7 @@ describe('Breadcrumbs', () => {
             tags: [],
           })}
           organization={TestStubs.Organization({
-            features: ['session-replay-ui'],
+            features: ['session-replay', 'session-replay-ui'],
           })}
         />
       );
@@ -273,7 +273,7 @@ describe('Breadcrumbs', () => {
             platform: 'javascript',
           })}
           organization={TestStubs.Organization({
-            features: ['session-replay-ui'],
+            features: ['session-replay', 'session-replay-ui'],
           })}
         />
       );

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -307,9 +307,9 @@ function BreadcrumbsContainer({data, event, organization, projectSlug, isShare}:
       {showReplay ? (
         <Fragment>
           <EventReplay
+            organization={organization}
             replayId={replayId}
             projectSlug={projectSlug}
-            orgSlug={organization.slug}
             event={event}
           />
           {actions}

--- a/static/app/utils/replays/projectSupportsReplay.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.tsx
@@ -1,8 +1,8 @@
 import {replayPlatforms} from 'sentry/data/platformCategories';
 import type {MinimalProject} from 'sentry/types';
 
-function projectSupportsReplay(project?: MinimalProject) {
-  return Boolean(project?.platform && replayPlatforms.includes(project.platform));
+function projectSupportsReplay(project: MinimalProject) {
+  return Boolean(project.platform && replayPlatforms.includes(project.platform));
 }
 
 export default projectSupportsReplay;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -67,7 +67,9 @@ function TransactionHeader({
   );
 
   const hasSessionReplay =
-    organization.features.includes('session-replay') && projectSupportsReplay(project);
+    organization.features.includes('session-replay') &&
+    project &&
+    projectSupportsReplay(project);
 
   const hasProfiling =
     project &&

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -99,6 +99,7 @@ function EventsContent(props: Props) {
 
   if (
     organization.features.includes('session-replay-ui') &&
+    project &&
     projectSupportsReplay(project)
   ) {
     transactionsListTitles.push(t('replay'));

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -249,6 +249,7 @@ function SummaryContent({
 
   if (
     organization.features.includes('session-replay-ui') &&
+    project &&
     projectSupportsReplay(project)
   ) {
     transactionsListTitles.push(t('replay'));


### PR DESCRIPTION
We should check the features list before showing the onboarding cta. On sentry.io features are enabled based on your subscription plan, and some (older) subscriptions don't have replays enabled.

Also, make it so that the ui waits for data to load before deciding to show/hide things.
Finally, `projectSupportsReplay()` should require a project to be sent in, so lets update that. 

Fixes #44865
Fixes #44917