### PR TITLE
fix(profiling): Pagination for suspect functions

### DIFF
--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -56,6 +56,7 @@ export function SuspectFunctionsTable({
     sort: functionsSort,
     functionType,
   });
+
   return (
     <Fragment>
       <TableHeader>
@@ -80,7 +81,9 @@ export function SuspectFunctionsTable({
         />
         <StyledPagination
           pageLinks={
-            functionsQuery.isFetched ? functionsQuery.data?.[0]?.pageLinks : null
+            functionsQuery.isFetched
+              ? functionsQuery.data?.[2]?.getResponseHeader('Link') ?? null
+              : null
           }
           onCursor={handleFunctionsCursor}
           size="xs"


### PR DESCRIPTION
The page links were being read from the wrong place. This fixes the pagination buttons.