### PR TITLE
fix(hybrid-cloud): Uncache organization when queueing it for deletion

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -598,6 +598,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     transaction_id=schedule.guid,
                 )
                 organization.send_delete_confirmation(entry, ONE_DAY)
+                Organization.objects.uncache_object(organization.id)
         context = serialize(
             organization,
             request.user,

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -819,6 +819,10 @@ class OrganizationDeleteTest(OrganizationDetailsTestBase):
         # No owners should be remaining
         assert len(owner_emails) == 0
 
+        # Ensure cache was flushed
+        org = Organization.objects.get_from_cache(slug=org.slug)
+        assert org.status == OrganizationStatus.PENDING_DELETION
+
     def test_cannot_remove_as_admin(self):
         org = self.create_organization(owner=self.user)
         user = self.create_user(email="foo@example.com", is_superuser=False)


### PR DESCRIPTION
When an organization owner queues their organization up for deletion, we want to flush the cache of the organization to be able to immediately redirect the owner to the org restoration page (redirects fixed in https://github.com/getsentry/sentry/pull/45159).

