### PR TITLE
feat(replays): Show replayId in table columns instead of the PlayIcon button

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -18,7 +18,7 @@ import {pickBarColor, toPercent} from 'sentry/components/performance/waterfall/u
 import {Tooltip} from 'sentry/components/tooltip';
 import UserMisery from 'sentry/components/userMisery';
 import Version from 'sentry/components/version';
-import {IconDownload, IconPlay} from 'sentry/icons';
+import {IconDownload} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {AvatarProject, IssueAttachment, Organization, Project} from 'sentry/types';
@@ -452,13 +452,7 @@ const SPECIAL_FIELDS: SpecialFields = {
         return emptyValue;
       }
 
-      return (
-        <Container>
-          <Button size="xs">
-            <IconPlay size="xs" />
-          </Button>
-        </Container>
-      );
+      return <Container>{getShortEventId(replayId)}</Container>;
     },
   },
   'profile.id': {

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -43,6 +43,7 @@ import {
   generateEventSlug,
 } from 'sentry/utils/discover/urls';
 import ViewReplayLink from 'sentry/utils/discover/viewReplayLink';
+import {getShortEventId} from 'sentry/utils/events';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -341,6 +342,10 @@ function TableView(props: TableViewProps) {
       }
     } else if (columnKey === 'replayId') {
       if (dataRow.replayId) {
+        if (!dataRow['project.name']) {
+          return getShortEventId(String(dataRow.replayId));
+        }
+
         const target = replayLinkGenerator(organization, dataRow, undefined);
         cell = (
           <ViewReplayLink replayId={dataRow.replayId} to={target}>

--- a/static/app/views/issueDetails/groupTagValues.tsx
+++ b/static/app/views/issueDetails/groupTagValues.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {RouteComponentProps} from 'react-router';
+import {RouteComponentProps, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -23,6 +23,8 @@ import {space} from 'sentry/styles/space';
 import {Group, Project, SavedQueryVersions, Tag, TagValue} from 'sentry/types';
 import {isUrl, percent} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type RouteParams = {
   groupId: string;
@@ -46,7 +48,7 @@ type State = {
 const DEFAULT_SORT = 'count';
 
 class GroupTagValues extends AsyncComponent<
-  Props & AsyncComponent['props'],
+  Props & AsyncComponent['props'] & WithRouterProps,
   State & AsyncComponent['state']
 > {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
@@ -279,7 +281,7 @@ class GroupTagValues extends AsyncComponent<
   }
 }
 
-export default GroupTagValues;
+export default withSentryRouter(GroupTagValues);
 
 const TitleWrapper = styled('div')`
   display: flex;

--- a/static/app/views/issueDetails/groupTagValues.tsx
+++ b/static/app/views/issueDetails/groupTagValues.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {RouteComponentProps, WithRouterProps} from 'react-router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -17,16 +17,12 @@ import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import TimeSince from 'sentry/components/timeSince';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconArrow, IconEllipsis, IconMail, IconOpen, IconPlay} from 'sentry/icons';
+import {IconArrow, IconEllipsis, IconMail, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Group, Project, SavedQueryVersions, Tag, TagValue} from 'sentry/types';
 import {isUrl, percent} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
-import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
-// eslint-disable-next-line no-restricted-imports
-import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type RouteParams = {
   groupId: string;
@@ -50,7 +46,7 @@ type State = {
 const DEFAULT_SORT = 'count';
 
 class GroupTagValues extends AsyncComponent<
-  Props & AsyncComponent['props'] & WithRouterProps,
+  Props & AsyncComponent['props'],
   State & AsyncComponent['state']
 > {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
@@ -76,7 +72,6 @@ class GroupTagValues extends AsyncComponent<
 
   renderResults() {
     const {
-      routes,
       baseUrl,
       project,
       environments: environment,
@@ -149,14 +144,6 @@ class GroupTagValues extends AsyncComponent<
                 <IconOpen size="xs" color="gray300" />
               </StyledExternalLink>
             )}
-            {key === 'replayId' ? (
-              <ReplayButton
-                project={project}
-                routes={routes}
-                orgId={orgId}
-                tagValue={tagValue}
-              />
-            ) : null}
           </NameColumn>
           <RightAlignColumn>{pct}</RightAlignColumn>
           <RightAlignColumn>{tagValue.count.toLocaleString()}</RightAlignColumn>
@@ -292,30 +279,7 @@ class GroupTagValues extends AsyncComponent<
   }
 }
 
-export default withSentryRouter(GroupTagValues);
-
-function ReplayButton({project, routes, orgId, tagValue}) {
-  const replaySlug = `${project?.slug}:${tagValue.value}`;
-  const referrer = getRouteStringFromRoutes(routes);
-
-  const target = {
-    pathname: `/organizations/${orgId}/replays/${replaySlug}/`,
-    query: {
-      referrer,
-    },
-  };
-  return (
-    <RightAligned>
-      <Tooltip title={t('View Replay')}>
-        <Link to={target}>
-          <Button size="xs" aria-label={t('View Replay')}>
-            <IconPlay size="xs" />
-          </Button>
-        </Link>
-      </Tooltip>
-    </RightAligned>
-  );
-}
+export default GroupTagValues;
 
 const TitleWrapper = styled('div')`
   display: flex;
@@ -355,13 +319,6 @@ const StyledSortLink = styled(Link)`
   :hover {
     color: inherit;
   }
-`;
-
-const RightAligned = styled('div')`
-  display: block;
-  flex-grow: 1;
-  text-align: right;
-  padding-left: ${space(0.5)};
 `;
 
 const StyledExternalLink = styled(ExternalLink)`


### PR DESCRIPTION
On all the screens we're dropping the play button and instead relying on the `replayId` (which is truncated).

| | Before | After |
| --- | --- | --- |
| Issues > All Events | <img width="1308" alt="issue all events - before" src="https://user-images.githubusercontent.com/187460/221983050-7f65cbaf-8eda-4fa2-b9b8-d53c70aeac94.png"> | <img width="1306" alt="issue all events - after" src="https://user-images.githubusercontent.com/187460/221983058-22430d87-fb6c-4615-aba6-7063db10376b.png"> |
| Discover Events | <img width="1309" alt="discover events - before" src="https://user-images.githubusercontent.com/187460/221983052-8dcb9b9a-c0e7-4f63-a7af-cc5cd3e5572d.png"> | <img width="1308" alt="discover events - after" src="https://user-images.githubusercontent.com/187460/221983054-2907f178-b24f-49d0-a223-df0053462b51.png"> |
| Discover Aggregated | <img width="1300" alt="discover agg - after" src="https://user-images.githubusercontent.com/187460/221983062-e012d52b-d9b7-47f7-8f3c-ef574ed14341.png"> | <img width="1316" alt="discover agg - before" src="https://user-images.githubusercontent.com/187460/221983064-18cdda6a-c7d5-4365-be82-3708905b5c20.png"> |
| Transaction Summary | <img width="942" alt="txn summary - before" src="https://user-images.githubusercontent.com/187460/221983067-4e1ded5e-4462-48aa-8873-d105b917b5a8.png"> | <img width="954" alt="txn summary - after" src="https://user-images.githubusercontent.com/187460/221983065-9f96e6c9-8836-40ce-afc6-ca5d5516ecb5.png"> |
| Issue Tags | <img width="985" alt="issue tags - before" src="https://user-images.githubusercontent.com/187460/221983075-b0086161-b80d-42df-bc10-55fb3d528d1d.png"> | <img width="942" alt="issue tags - after" src="https://user-images.githubusercontent.com/187460/221983070-f85b7dd2-8c08-4113-bee0-05319297bcb9.png"> |

Not shown is the Transaction > All Events page, it's using all the same code so it works fine too.

Fixes #44345