### PR TITLE
feat(issue-platform): ingest more profiling issue types

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -176,6 +176,7 @@ class PerformanceUncompressedAssetsGroupType(PerformanceGroupTypeDefaults, Group
 
 
 @dataclass(frozen=True)
+# deprecated: use ProfileFileIOGroupType, ProfileImageDecodeGroupType, or ProfileJSONDecodeType
 class ProfileBlockedThreadGroupType(GroupType):
     type_id = 2000
     slug = "profile_blocked_thread"
@@ -211,6 +212,8 @@ PROFILE_FILE_IO_ISSUE_TYPES = frozenset(
     [
         ProfileBlockedThreadGroupType.type_id,
         ProfileFileIOGroupType.type_id,
+        ProfileImageDecodeGroupType.type_id,
+        ProfileJSONDecodeType.type_id,
     ]
 )
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -208,7 +208,7 @@ class ProfileJSONDecodeType(GroupType):
     category = GroupCategory.PROFILE.value
 
 
-PROFILE_FILE_IO_ISSUE_TYPES = frozenset(
+PROFILE_ISSUE_TYPES = frozenset(
     [
         ProfileBlockedThreadGroupType.type_id,
         ProfileFileIOGroupType.type_id,

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -23,7 +23,7 @@ from django.utils import timezone
 from sentry import features, nodestore
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
-from sentry.issues.grouptype import PROFILE_FILE_IO_ISSUE_TYPES
+from sentry.issues.grouptype import PROFILE_ISSUE_TYPES
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
@@ -261,7 +261,7 @@ def _process_message(
             txn.set_tag("project_id", project.id)
             txn.set_tag("project_slug", project.slug)
 
-            if occurrence_data["type"] not in PROFILE_FILE_IO_ISSUE_TYPES or not features.has(
+            if occurrence_data["type"] not in PROFILE_ISSUE_TYPES or not features.has(
                 "organizations:profile-blocked-main-thread-ingest", organization
             ):
                 metrics.incr(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from sentry import features
 from sentry.exceptions import PluginError
-from sentry.issues.grouptype import PROFILE_FILE_IO_ISSUE_TYPES, GroupCategory
+from sentry.issues.grouptype import PROFILE_ISSUE_TYPES, GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
@@ -526,7 +526,7 @@ def post_process_group(
 def run_post_process_job(job: PostProcessJob):
     group_event = job["event"]
     issue_category = group_event.group.issue_category
-    if group_event.group.issue_type.type_id in PROFILE_FILE_IO_ISSUE_TYPES and not features.has(
+    if group_event.group.issue_type.type_id in PROFILE_ISSUE_TYPES and not features.has(
         "organizations:profile-blocked-main-thread-ppg", group_event.group.organization
     ):
         return

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Iterable, Mapping
 
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.models import Team, User
 from sentry.notifications.notifications.base import BaseNotification
@@ -84,7 +84,7 @@ TEST_ISSUE_OCCURRENCE = IssueOccurrence(
         IssueEvidence("Evidence 2", "Not important", False),
         IssueEvidence("Evidence 3", "Nobody cares about this", False),
     ],
-    ProfileBlockedThreadGroupType,
+    ProfileFileIOGroupType,
     ensure_aware(datetime.now()),
     "info",
 )

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from unittest import mock
 
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models import OrganizationMemberTeam
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
@@ -55,7 +55,7 @@ class IssueOccurrenceTest(APITestCase):
                     "important": False,
                 },
             ],
-            "type": ProfileBlockedThreadGroupType.type_id,
+            "type": ProfileFileIOGroupType.type_id,
             "detection_time": ensure_aware(datetime.now()),
             "event": self.event,
         }

--- a/tests/sentry/api/serializers/test_group_stream.py
+++ b/tests/sentry/api/serializers/test_group_stream.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.models.group_stream import (
 from sentry.issues.grouptype import (
     GroupCategory,
     PerformanceNPlusOneGroupType,
-    ProfileBlockedThreadGroupType,
+    ProfileFileIOGroupType,
 )
 from sentry.models import Environment
 from sentry.testutils import SnubaTestCase, TestCase
@@ -87,7 +87,7 @@ class StreamGroupSerializerTestCase(TestCase, SnubaTestCase, SearchIssueTestMixi
         proj = self.create_project()
         cur_time = before_now(minutes=5).replace(tzinfo=datetime.timezone.utc)
         event, occurrence, group_info = self.store_search_issue(
-            proj.id, 1, [f"{ProfileBlockedThreadGroupType.type_id}-group100"], None, cur_time
+            proj.id, 1, [f"{ProfileFileIOGroupType.type_id}-group100"], None, cur_time
         )
         assert group_info
         serialized = serialize(
@@ -95,6 +95,6 @@ class StreamGroupSerializerTestCase(TestCase, SnubaTestCase, SearchIssueTestMixi
         )
         assert serialized["count"] == "1"
         assert serialized["issueCategory"] == str(GroupCategory.PROFILE.name).lower()
-        assert serialized["issueType"] == str(ProfileBlockedThreadGroupType.slug)
+        assert serialized["issueType"] == str(ProfileFileIOGroupType.slug)
         assert [stat[1] for stat in serialized["stats"]["24h"][:-1]] == [0] * 23
         assert serialized["stats"]["24h"][-1][1] == 1

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -16,7 +16,7 @@ from sentry.integrations.slack.message_builder.issues import (
     get_option_groups,
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
-from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
 from sentry.models import Group, Team, User
 from sentry.testutils import TestCase
 from sentry.testutils.cases import PerformanceIssueTestCase
@@ -173,7 +173,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         occurrence.save()
         event.occurrence = occurrence
 
-        event.group.type = ProfileBlockedThreadGroupType.type_id
+        event.group.type = ProfileFileIOGroupType.type_id
 
         attachments = SlackIssuesMessageBuilder(group=event.group, event=event).build()
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -9,7 +9,7 @@ import pytest
 
 from sentry import eventstore
 from sentry.eventstore.snuba.backend import SnubaEventStorage
-from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType, ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType, ProfileFileIOGroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.occurrence_consumer import (
     EventLookupError,
@@ -44,7 +44,7 @@ def get_test_message(
             {"name": "Line", "value": "40", "important": True},
             {"name": "Memory", "value": "breached", "important": False},
         ],
-        "type": ProfileBlockedThreadGroupType.type_id,
+        "type": ProfileFileIOGroupType.type_id,
         "detection_time": now.isoformat(),
     }
 

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence, IssueOccurrenceData
 from sentry.models import Group
@@ -43,7 +43,7 @@ class OccurrenceTestMixin:
                 {"name": "hi", "value": "bye", "important": True},
                 {"name": "what", "value": "where", "important": False},
             ],
-            "type": ProfileBlockedThreadGroupType.type_id,
+            "type": ProfileFileIOGroupType.type_id,
             "detection_time": datetime.now().timestamp(),
             "level": "warning",
         }

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -15,7 +15,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.userreport import UserReportWithGroupSerializer
 from sentry.digests.notifications import build_digest, event_to_record
 from sentry.event_manager import EventManager, get_event_type
-from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.mail import build_subject_prefix, mail_adapter
 from sentry.models import (
@@ -202,14 +202,14 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
                 IssueEvidence("Evidence 2", "Value 2", False),
                 IssueEvidence("Evidence 3", "Value 3", False),
             ],
-            ProfileBlockedThreadGroupType,
+            ProfileFileIOGroupType,
             ensure_aware(datetime.now()),
             "info",
         )
         occurrence.save()
         event.occurrence = occurrence
 
-        event.group.type = ProfileBlockedThreadGroupType.type_id
+        event.group.type = ProfileFileIOGroupType.type_id
 
         rule = Rule.objects.create(project=self.project, label="my rule")
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
@@ -251,14 +251,14 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             "1234",
             {"Test": 123},
             [],  # no evidence
-            ProfileBlockedThreadGroupType,
+            ProfileFileIOGroupType,
             ensure_aware(datetime.now()),
             "info",
         )
         occurrence.save()
         event.occurrence = occurrence
 
-        event.group.type = ProfileBlockedThreadGroupType.type_id
+        event.group.type = ProfileFileIOGroupType.type_id
 
         rule = Rule.objects.create(project=self.project, label="my rule")
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.db.models import ProtectedError
 from django.utils import timezone
 
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models import (
     Group,
@@ -376,7 +376,7 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
         )[0]
 
         group = Group.objects.first()
-        group.update(type=ProfileBlockedThreadGroupType.type_id)
+        group.update(type=ProfileFileIOGroupType.type_id)
 
         group_event = group.get_latest_event()
         assert group_event.event_id == event_id

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -7,7 +7,7 @@ from sentry.issues.grouptype import (
     ErrorGroupType,
     GroupCategory,
     PerformanceNPlusOneGroupType,
-    ProfileBlockedThreadGroupType,
+    ProfileFileIOGroupType,
 )
 from sentry.models import Activity, Group, Project
 from sentry.rules.history.preview import (
@@ -217,7 +217,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
                     Group.objects.create(
                         project=self.project,
                         first_seen=prev_hour,
-                        type=ProfileBlockedThreadGroupType.type_id,
+                        type=ProfileFileIOGroupType.type_id,
                     )
                 )
 
@@ -726,7 +726,7 @@ class FrequencyConditionTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
                 occurrence = self.build_occurrence(level="info")
                 occurrence.save()
                 event.occurrence = occurrence
-                event.group.type = ProfileBlockedThreadGroupType.type_id
+                event.group.type = ProfileFileIOGroupType.type_id
 
         conditions = [
             {

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.utils import timezone
 from freezegun import freeze_time
 
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers import parse_link_header
@@ -439,14 +439,14 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         event_1, _, group_info = self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             before_now(hours=1).replace(tzinfo=timezone.utc),
         )
         event_2, _, _ = self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             before_now(hours=1).replace(tzinfo=timezone.utc),
         )

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -13,7 +13,7 @@ from snuba_sdk.column import Column
 from snuba_sdk.function import Function
 
 from sentry.discover.models import TeamKeyTransaction
-from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
 from sentry.models import ApiKey, ProjectTeam, ProjectTransactionThreshold, ReleaseStages
 from sentry.models.transaction_threshold import (
     ProjectTransactionThresholdOverride,
@@ -618,7 +618,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
         event, _, group_info = self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             before_now(hours=1).replace(tzinfo=timezone.utc),
             user=user_data,

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from pytz import utc
 from rest_framework.exceptions import ParseError
 
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -117,7 +117,7 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTest
         _, _, group_info = self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             before_now(hours=1).replace(tzinfo=timezone.utc),
         )

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -12,7 +12,7 @@ from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.function import Function
 
 from sentry.constants import MAX_TOP_EVENTS
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models.transaction_threshold import ProjectTransactionThreshold, TransactionMetric
 from sentry.snuba.discover import OTHER_KEY
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -97,21 +97,21 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         _, _, group_info = self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             self.day_ago.replace(tzinfo=utc),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             self.day_ago.replace(tzinfo=utc) + timedelta(hours=1, minutes=1),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             self.day_ago.replace(tzinfo=utc) + timedelta(hours=1, minutes=2),
         )
@@ -139,21 +139,21 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         _, _, group_info = self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             self.day_ago.replace(tzinfo=utc) + timedelta(minutes=1),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             self.day_ago.replace(tzinfo=utc) + timedelta(minutes=1),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
             self.day_ago.replace(tzinfo=utc) + timedelta(minutes=2),
         )

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -1,4 +1,4 @@
-from sentry.issues.grouptype import ProfileBlockedThreadGroupType
+from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -72,7 +72,7 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         )
         event_group = event.for_group(event.group)
         event_group.occurrence = self.build_occurrence()
-        event.group.type = ProfileBlockedThreadGroupType.type_id
+        event.group.type = ProfileFileIOGroupType.type_id
 
         self.login_as(user=self.user)
         response = self.get_response(

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -8,7 +8,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializerSnuba
 from sentry.issues.grouptype import (
     PerformanceRenderBlockingAssetSpanGroupType,
-    ProfileBlockedThreadGroupType,
+    ProfileFileIOGroupType,
 )
 from sentry.models import (
     Group,
@@ -497,7 +497,7 @@ class ProfilingGroupSerializerSnubaTest(
         proj = self.create_project()
         environment = self.create_environment(project=proj)
 
-        first_group_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group1"
+        first_group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group1"
         timestamp = timezone.now().replace(hour=0, minute=0, second=0)
         times = 5
         for incr in range(0, times):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from sentry.issues.grouptype import (
     PerformanceRenderBlockingAssetSpanGroupType,
-    ProfileBlockedThreadGroupType,
+    ProfileFileIOGroupType,
 )
 from sentry.models import Environment, EventUser, Release, ReleaseProjectEnvironment, ReleaseStages
 from sentry.search.events.constants import (
@@ -177,7 +177,7 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
         _, _, group_info = self.store_search_issue(
             self.project.id,
             self.user.id,
-            [f"{ProfileBlockedThreadGroupType.type_id}-group1"],
+            [f"{ProfileFileIOGroupType.type_id}-group1"],
             env.name,
             timezone.now().replace(hour=0, minute=0, second=0) + timedelta(minutes=1),
             [("foo", "bar"), ("biz", "baz")],
@@ -1188,7 +1188,7 @@ class ProfilingTagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
         self.ts = SnubaTagStorage()
 
     def test_get_profiling_groups_user_counts_simple(self):
-        first_group_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group1"
+        first_group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group1"
         first_group_timestamp_start = timezone.now() - timedelta(days=5)
 
         self.store_search_issue(
@@ -1224,7 +1224,7 @@ class ProfilingTagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
         )
         first_group = group_info.group if group_info else None
 
-        second_group_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group2"
+        second_group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group2"
         second_group_timestamp_start = timezone.now() - timedelta(hours=5)
         for incr in range(1, 5):
             event, issue_occurrence, group_info = self.store_search_issue(
@@ -1246,7 +1246,7 @@ class ProfilingTagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
         ) == {first_group.id: 3, second_group.id: 4}
 
     def test_get_profiling_group_list_tag_value_by_environment(self):
-        group_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group1"
+        group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group1"
         start_timestamp = timezone.now() - timedelta(hours=1)
         first_event_ts = start_timestamp + timedelta(minutes=1)
         self.store_search_issue(

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -7,7 +7,7 @@ from snuba_sdk import Limit
 from sentry.issues.grouptype import (
     PerformanceNPlusOneGroupType,
     PerformanceRenderBlockingAssetSpanGroupType,
-    ProfileBlockedThreadGroupType,
+    ProfileFileIOGroupType,
 )
 from sentry.models import Environment, Group, GroupRelease, Release
 from sentry.testutils import SnubaTestCase, TestCase
@@ -772,8 +772,8 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
         )[0]
         defaultenv = ""
 
-        group1_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group1"
-        group2_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group2"
+        group1_fingerprint = f"{ProfileFileIOGroupType.type_id}-group1"
+        group2_fingerprint = f"{ProfileFileIOGroupType.type_id}-group2"
 
         groups = {}
         for r in range(0, 14400, 600):  # Every 10 min for 4 hours
@@ -842,7 +842,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
         )
         dts = [now + timedelta(hours=i) for i in range(4)]
         project = self.create_project()
-        group_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group4"
+        group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group4"
         groups = []
         for i in range(0, 11):
             _, _, group_info = self.store_search_issue(
@@ -876,7 +876,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
         now = (datetime.utcnow() - timedelta(days=1)).replace(
             hour=10, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
         )
-        group_fingerprint = f"{ProfileBlockedThreadGroupType.type_id}-group5"
+        group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group5"
         ids = [1, 2, 3, 4, 5]
         groups = []
         for r in ids:


### PR DESCRIPTION
`ProfileBlockedThreadGroupType` is a catch all type that got split into three more specific types. 

Replaces `ProfileBlockedThreadGroupType` usage with `ProfileFileIOGroupType` in tests.