### PR TITLE
feat(targeting-context): Add parsed ownership rules to API

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -63,7 +63,17 @@ class ProjectOwnershipSerializer(serializers.Serializer):
                 {"raw": f"Raw needs to be <= {max_length} characters in length"}
             )
 
-        schema = create_schema_from_issue_owners(attrs["raw"], self.context["ownership"].project_id)
+        if features.has(
+            "organizations:streamline-targeting-context",
+            self.context["ownership"].project.organization,
+        ):
+            schema = create_schema_from_issue_owners(
+                attrs["raw"], self.context["ownership"].project_id, True
+            )
+        else:
+            schema = create_schema_from_issue_owners(
+                attrs["raw"], self.context["ownership"].project_id
+            )
 
         self._validate_no_codeowners(schema["rules"])
 
@@ -161,7 +171,15 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
 
         :auth: required
         """
-        return Response(serialize(self.get_ownership(project), request.user))
+        should_return_schema = features.has(
+            "organizations:streamline-targeting-context",
+            project.organization,
+        )
+        return Response(
+            serialize(
+                self.get_ownership(project), request.user, should_return_schema=should_return_schema
+            )
+        )
 
     def put(self, request: Request, project) -> Response:
         """
@@ -176,11 +194,17 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
                                     to fall through and make everyone an implicit owner.
         :auth: required
         """
+        should_return_schema = features.has(
+            "organizations:streamline-targeting-context",
+            project.organization,
+        )
         serializer = ProjectOwnershipSerializer(
             data=request.data, partial=True, context={"ownership": self.get_ownership(project)}
         )
         if serializer.is_valid():
             ownership = serializer.save()
             ownership_rule_created.send_robust(project=project, sender=self.__class__)
-            return Response(serialize(ownership, request.user))
+            return Response(
+                serialize(ownership, request.user, should_return_schema=should_return_schema)
+            )
         return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -172,8 +172,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
         :auth: required
         """
         should_return_schema = features.has(
-            "organizations:streamline-targeting-context",
-            project.organization,
+            "organizations:streamline-targeting-context", project.organization
         )
         return Response(
             serialize(
@@ -195,8 +194,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
         :auth: required
         """
         should_return_schema = features.has(
-            "organizations:streamline-targeting-context",
-            project.organization,
+            "organizations:streamline-targeting-context", project.organization
         )
         serializer = ProjectOwnershipSerializer(
             data=request.data, partial=True, context={"ownership": self.get_ownership(project)}

--- a/src/sentry/api/serializers/models/projectownership.py
+++ b/src/sentry/api/serializers/models/projectownership.py
@@ -4,7 +4,7 @@ from sentry.models import ProjectOwnership
 
 @register(ProjectOwnership)
 class ProjectOwnershipSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, should_return_schema=False):
         assignment = (
             "Auto Assign to Suspect Commits"
             if obj.auto_assignment and obj.suspect_committer_auto_assignment
@@ -13,10 +13,8 @@ class ProjectOwnershipSerializer(Serializer):
             else "Turn off Auto-Assignment"
         )
 
-        return {
+        project_ownership_data = {
             "raw": obj.raw,
-            # Should we expose this?
-            # 'schema': obj.schema,
             "fallthrough": obj.fallthrough,
             "dateCreated": obj.date_created,
             "lastUpdated": obj.last_updated,
@@ -24,3 +22,8 @@ class ProjectOwnershipSerializer(Serializer):
             "autoAssignment": assignment,
             "codeownersAutoSync": obj.codeowners_auto_sync,
         }
+
+        if should_return_schema:
+            project_ownership_data["schema"] = obj.schema
+
+        return project_ownership_data

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -2,7 +2,19 @@ from __future__ import annotations
 
 import re
 from collections import namedtuple
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Pattern, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Pattern,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar, NodeVisitor
@@ -569,7 +581,16 @@ def resolve_actors(owners: Iterable[Owner], project_id: int) -> Mapping[Owner, A
     return {o: actors.get((o.type, o.identifier.lower())) for o in owners}
 
 
-def create_schema_from_issue_owners(issue_owners: str, project_id: int) -> Mapping[str, Any]:
+def add_owner_ids_to_schema(rules: List[Dict[str, Any]], owners_id: Dict[str, int]) -> None:
+    for rule in rules:
+        for rule_owner in rule["owners"]:
+            if rule_owner["identifier"] in owners_id.keys():
+                rule_owner["id"] = owners_id[rule_owner["identifier"]]
+
+
+def create_schema_from_issue_owners(
+    issue_owners: str, project_id: int, add_project_ownership_data: bool = False
+) -> Mapping[str, Any]:
     try:
         rules = parse_rules(issue_owners)
     except ParseError as e:
@@ -580,6 +601,7 @@ def create_schema_from_issue_owners(issue_owners: str, project_id: int) -> Mappi
     schema = dump_schema(rules)
 
     owners = {o for rule in rules for o in rule.owners}
+    owners_id = {}
     actors = resolve_actors(owners, project_id)
 
     bad_actors = []
@@ -589,9 +611,14 @@ def create_schema_from_issue_owners(issue_owners: str, project_id: int) -> Mappi
                 bad_actors.append(owner.identifier)
             elif owner.type == "team":
                 bad_actors.append(f"#{owner.identifier}")
+        elif add_project_ownership_data:
+            owners_id[owner.identifier] = actor[0]
 
     if bad_actors:
         bad_actors.sort()
         raise ValidationError({"raw": "Invalid rule owners: {}".format(", ".join(bad_actors))})
+
+    if add_project_ownership_data:
+        add_owner_ids_to_schema(schema["rules"], owners_id)
 
     return schema

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -124,8 +124,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
                 {
                     "matcher": {"type": "path", "pattern": "*.js"},
                     "owners": [
-                        {"type": "user", "identifier": "admin@localhost", "id": 17},
-                        {"type": "team", "identifier": "tiger-team", "id": 10},
+                        {"type": "user", "identifier": "admin@localhost", "id": self.user.id},
+                        {"type": "team", "identifier": "tiger-team", "id": self.team.id},
                     ],
                 }
             ],

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry.models import ProjectOwnership
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 
 
@@ -56,6 +57,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp.data["dateCreated"] is not None
         assert resp.data["lastUpdated"] is not None
         assert resp.data["codeownersAutoSync"] is True
+        assert "schema" not in resp.data.keys()
 
         resp = self.client.put(self.path, {"fallthrough": False})
         assert resp.status_code == 200
@@ -112,6 +114,22 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         assert resp.data["autoAssignment"] == "Turn off Auto-Assignment"
+
+    @with_feature("organizations:streamline-targeting-context")
+    def test_update_with_streamline_targeting(self):
+        resp = self.client.put(self.path, {"raw": "*.js admin@localhost #tiger-team"})
+        assert resp.data["schema"] == {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"type": "path", "pattern": "*.js"},
+                    "owners": [
+                        {"type": "user", "identifier": "admin@localhost", "id": 17},
+                        {"type": "team", "identifier": "tiger-team", "id": 10},
+                    ],
+                }
+            ],
+        }
 
     def test_invalid_email(self):
         resp = self.client.put(self.path, {"raw": "*.js idont@exist.com #tiger-team"})


### PR DESCRIPTION
Add parsed ownership rules to project ownership endpoint so that the frontend can display the ownership rules. Currently, only the `raw` rules are exposed to the frontend. 

I discovered that the existing `schema` has the parsed ownership rules, and just added the owner IDs to it.

WOR-2675
