### PR TITLE
fix(hybrid-cloud): Fix redirect on org removal for customer domains

### DIFF
--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {resetPageFilters} from 'sentry/actionCreators/pageFilters';
 import {Client} from 'sentry/api';
+import {usingCustomerDomain} from 'sentry/constants';
 import GuideStore from 'sentry/stores/guideStore';
 import LatestContextStore from 'sentry/stores/latestContextStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
@@ -10,6 +11,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {Organization} from 'sentry/types';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type RedirectRemainingOrganizationParams = {
   /**
@@ -44,9 +46,15 @@ export function redirectToRemainingOrganization({
 
   // Let's be smart and select the best org to redirect to
   const firstRemainingOrg = allOrgs[0];
-  // TODO(domains) Need to find a good way to handle this. useResolveRoute()
-  // doesn't currently work because it is a hook.
-  browserHistory.push(`/organizations/${firstRemainingOrg.slug}/issues/`);
+
+  const route = `/organizations/${firstRemainingOrg.slug}/issues/`;
+  if (usingCustomerDomain) {
+    const {organizationUrl} = firstRemainingOrg.links;
+    window.location.assign(`${organizationUrl}${normalizeUrl(route)}`);
+    return;
+  }
+
+  browserHistory.push(route);
 
   // Remove org from SidebarDropdown
   if (removeOrg) {


### PR DESCRIPTION
A continuation of https://github.com/getsentry/sentry/pull/45159, this pull request finishes up an incomplete work on redirecting the user to any other remaining active organization after queueing an organization up for deletion. 