### PR TITLE
fix(replays): Make sure props to useReplaysCount() are all memoized

### DIFF
--- a/static/app/components/replays/replayIdCountProvider.tsx
+++ b/static/app/components/replays/replayIdCountProvider.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, ReactText} from 'react';
+import {ReactNode, ReactText, useMemo} from 'react';
 
 import ReplayCountContext from 'sentry/components/replays/replayCountContext';
 import useReplaysCount from 'sentry/components/replays/useReplaysCount';
@@ -14,12 +14,14 @@ function unique<T>(arr: T[]) {
   return Array.from(new Set(arr));
 }
 
+const projectIds = [];
+
 function ReplayIdCountProvider({children, organization, replayIds}: Props) {
-  const ids = replayIds?.map(String)?.filter(Boolean) || [];
+  const ids = useMemo(() => replayIds?.map(String)?.filter(Boolean) || [], [replayIds]);
   const counts = useReplaysCount({
     replayIds: unique(ids),
     organization,
-    projectIds: [],
+    projectIds,
   });
 
   return (

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -60,10 +60,14 @@ function GroupHeaderTabs({
   project,
 }: GroupHeaderTabsProps) {
   const organization = useOrganization();
+  const projectIds = useMemo(
+    () => (project.id ? [Number(project.id)] : []),
+    [project.id]
+  );
   const replaysCount = useReplaysCount({
     groupIds: group.id,
     organization,
-    projectIds: [Number(project.id)],
+    projectIds,
   })[group.id];
   const projectFeatures = new Set(project ? project.features : []);
   const organizationFeatures = new Set(organization ? organization.features : []);

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
@@ -103,10 +103,15 @@ function TransactionHeader({
     [hasWebVitals, location, projects, eventView]
   );
 
+  const projectIds = useMemo(
+    () => (project?.id ? [Number(project.id)] : []),
+    [project?.id]
+  );
+
   const replaysCount = useReplaysCount({
     transactionNames: transactionName,
     organization,
-    projectIds: project ? [Number(project.id)] : [],
+    projectIds,
   })[transactionName];
 
   return (

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -79,10 +79,14 @@ function IssueList({projectId, replayId}: Props) {
     fetchIssueData();
   }, [fetchIssueData]);
 
+  const projectIds = useMemo(
+    () => (project?.id ? [Number(project.id)] : []),
+    [project?.id]
+  );
   const counts = useReplaysCount({
     groupIds: state.issues.map(issue => issue.id),
     organization,
-    projectIds: project ? [Number(project.id)] : [],
+    projectIds,
   });
 
   return (


### PR DESCRIPTION
memoizing the props makes sure that we're not re-rendering, or making a new request whenever the identity (object ref) of an array changes. We only want to make requests for data when the contents of the array have changed.

**Before:**
<img width="821" alt="SCR-20230228-jrz" src="https://user-images.githubusercontent.com/187460/222219538-db933f55-709a-49d1-baf6-0665e336dd41.png">
**After:**
<img width="917" alt="SCR-20230228-js2" src="https://user-images.githubusercontent.com/187460/222219543-e0592fbe-e4cc-4478-8ca2-0b01d8218200.png">


Fixes #44176