### PR TITLE
fix(replays): Fix race condition when loading replay errors & attachments

### DIFF
--- a/fixtures/js-stubs/replayReaderParams.js
+++ b/fixtures/js-stubs/replayReaderParams.js
@@ -1,3 +1,5 @@
+import {duration} from 'moment';
+
 const defaultRRWebEvents = [
   {
     type: 0,
@@ -77,7 +79,7 @@ export function ReplayReaderParams({
         family: 'Other',
       },
       dist: '',
-      duration: 84,
+      duration: duration(84000),
       environment: 'demo',
       error_ids: ['5c83aaccfffb4a708ae893bad9be3a1c'],
       finished_at: new Date('Sep 22, 2022 5:00:03 PM UTC'),
@@ -95,7 +97,16 @@ export function ReplayReaderParams({
         version: '7.1.1',
       },
       started_at: new Date('Sep 22, 2022 4:58:39 PM UTC'),
-      tags: {},
+      tags: {
+        'browser.name': ['Other'],
+        'device.family': ['Other'],
+        'os.name': ['Other'],
+        platform: ['javascript'],
+        releases: ['1.0.0', '2.0.0'],
+        'sdk.name': ['sentry.javascript.browser'],
+        'sdk.version': ['7.1.1'],
+        'user.ip': ['127.0.0.1'],
+      },
       trace_ids: [],
       urls: ['http://localhost:3000/'],
       user: {

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -1,0 +1,124 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {BreadcrumbType} from 'sentry/types/breadcrumbs';
+import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
+
+jest.useFakeTimers();
+
+const {organization} = initializeOrg();
+const HYDRATED_REPLAY = TestStubs.ReplayReaderParams().replayRecord;
+const RAW_REPLAY = TestStubs.ReplayReaderParams({
+  replayRecord: {
+    duration: HYDRATED_REPLAY.duration.asMilliseconds() / 1000,
+    started_at: HYDRATED_REPLAY.started_at.toString(),
+    finished_at: HYDRATED_REPLAY.finished_at.toString(),
+    tags: {},
+  },
+}).replayRecord;
+
+const ORG_SLUG = organization.slug;
+const PROJECT_SLUG = 'project-slug';
+const REPLAY_ID = RAW_REPLAY.id;
+
+const INIT_BREADCRUMB = expect.objectContaining({
+  type: BreadcrumbType.INIT,
+});
+const END_RRWEB_EVENT = expect.objectContaining({
+  type: 5, // EventType.Custom,
+  data: {
+    tag: 'replay-end',
+  },
+});
+
+describe('useReplayData', () => {
+  beforeAll(function () {
+    MockApiClient.mockAsync = true;
+  });
+
+  afterAll(function () {
+    MockApiClient.mockAsync = false;
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('should fetch the data for a given project + replayId + org', async () => {
+    const mockedReplayCall = MockApiClient.addMockResponse({
+      url: `/projects/${ORG_SLUG}/${PROJECT_SLUG}/replays/${REPLAY_ID}/`,
+      body: {data: RAW_REPLAY},
+    });
+    const mockedAttachmentsCall = MockApiClient.addMockResponse({
+      url: `/organizations/${ORG_SLUG}/replays-events-meta/`,
+      body: {data: []},
+    });
+    const mockedErrorsCall = MockApiClient.addMockResponse({
+      url: `/projects/${ORG_SLUG}/${PROJECT_SLUG}/replays/${REPLAY_ID}/recording-segments/`,
+      body: [],
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
+      initialProps: {
+        replaySlug: `${PROJECT_SLUG}:${REPLAY_ID}`,
+        orgSlug: ORG_SLUG,
+      },
+    });
+
+    // Immediatly we will see the replay call is made
+    expect(mockedReplayCall).toHaveBeenCalledTimes(1);
+    expect(mockedAttachmentsCall).not.toHaveBeenCalledTimes(1);
+    expect(mockedErrorsCall).not.toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({
+      fetchError: undefined,
+      fetching: true,
+      onRetry: expect.any(Function),
+      replay: null,
+      replayRecord: undefined,
+    });
+
+    jest.runAllTimers();
+    await waitForNextUpdate();
+
+    // Afterwards we see the attachments & errors requests are made
+    expect(mockedReplayCall).toHaveBeenCalledTimes(1);
+    expect(mockedAttachmentsCall).toHaveBeenCalledTimes(1);
+    expect(mockedErrorsCall).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({
+      fetchError: undefined,
+      fetching: true,
+      onRetry: expect.any(Function),
+      replay: expect.objectContaining({
+        replayRecord: HYDRATED_REPLAY,
+        rrwebEvents: expect.arrayContaining([END_RRWEB_EVENT]),
+        breadcrumbs: expect.arrayContaining([INIT_BREADCRUMB]),
+        consoleCrumbs: [],
+        networkSpans: [],
+        memorySpans: [],
+      }),
+      replayRecord: HYDRATED_REPLAY,
+    });
+
+    jest.runAllTimers();
+    await waitForNextUpdate();
+
+    // Finally we see fetching is complete
+    expect(mockedReplayCall).toHaveBeenCalledTimes(1);
+    expect(mockedAttachmentsCall).toHaveBeenCalledTimes(1);
+    expect(mockedErrorsCall).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({
+      fetchError: undefined,
+      fetching: false,
+      onRetry: expect.any(Function),
+      replay: expect.objectContaining({
+        replayRecord: HYDRATED_REPLAY,
+        rrwebEvents: expect.arrayContaining([END_RRWEB_EVENT]),
+        breadcrumbs: expect.arrayContaining([INIT_BREADCRUMB]),
+        consoleCrumbs: [],
+        networkSpans: [],
+        memorySpans: [],
+      }),
+      replayRecord: HYDRATED_REPLAY,
+    });
+  });
+});

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -65,7 +65,7 @@ describe('useReplayData', () => {
       },
     });
 
-    // Immediatly we will see the replay call is made
+    // Immediately we will see the replay call is made
     expect(mockedReplayCall).toHaveBeenCalledTimes(1);
     expect(mockedAttachmentsCall).not.toHaveBeenCalledTimes(1);
     expect(mockedErrorsCall).not.toHaveBeenCalledTimes(1);

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -54,7 +54,7 @@ const INITIAL_STATE: State = Object.freeze({
 
 function responseToAttachments(segment: unknown[]) {
   // Each segment includes an array of attachments
-  // Therefore we flatten 2 levels deep
+  // Therefore we flatten 1 levels deep
   return segment.flat(1);
 }
 

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -83,8 +83,8 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
   const api = useApi();
 
   const [state, setState] = useState<State>(INITIAL_STATE);
-  const [attachments, setAttachments] = useState<unknown[]>();
-  const [errors, setErrors] = useState<ReplayError[]>();
+  const [attachments, setAttachments] = useState<unknown[]>([]);
+  const [errors, setErrors] = useState<ReplayError[]>([]);
   const [replayRecord, setReplayRecord] = useState<ReplayRecord>();
 
   // Fetch every field of the replay. We're overfetching, not every field is used

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -42,11 +42,8 @@ interface Result extends Pick<State, 'fetchError' | 'fetching'> {
 }
 
 const INITIAL_STATE: State = Object.freeze({
-  // attachments: undefined,
-  // errors: undefined,
   fetchError: undefined,
   fetching: true,
-  // replayRecord: undefined,
 });
 
 function responsesToAttachments(responses: Array<unknown>) {

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -104,7 +104,12 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
   }, [api, orgSlug, projectSlug, replayId]);
 
   const fetchAttachments = useCallback(async () => {
-    if (!replayRecord || !replayRecord.count_segments) {
+    if (!replayRecord) {
+      return;
+    }
+
+    if (!replayRecord.count_segments) {
+      setState(prev => ({...prev, fetchingAttachments: false}));
       return;
     }
 
@@ -131,7 +136,12 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
   }, [api, orgSlug, projectSlug, replayRecord]);
 
   const fetchErrors = useCallback(async () => {
-    if (!replayRecord || !replayRecord.error_ids.length) {
+    if (!replayRecord) {
+      return;
+    }
+
+    if (!replayRecord.error_ids.length) {
+      setState(prev => ({...prev, fetchingErrors: false}));
       return;
     }
 

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -95,7 +95,8 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
     const response = await api.requestPromise(
       `/projects/${orgSlug}/${projectSlug}/replays/${replayId}/`
     );
-    return response.data;
+    const mappedRecord = mapResponseToReplayRecord(response.data);
+    setReplayRecord(mappedRecord);
   }, [api, orgSlug, projectSlug, replayId]);
 
   const fetchAttachments = useCallback(async () => {
@@ -168,12 +169,7 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
 
   useEffect(() => {
     setState(INITIAL_STATE);
-    fetchReplay()
-      .then(fetchedRecord => {
-        const mappedRecord = mapResponseToReplayRecord(fetchedRecord);
-        setReplayRecord(mappedRecord);
-      })
-      .catch(onError);
+    fetchReplay().catch(onError);
   }, [fetchReplay, onError]);
 
   useEffect(() => {

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -86,7 +86,7 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
       : {}),
     ...(apiResponse.device?.name ? {'device.name': [apiResponse.device.name]} : {}),
     ...(apiResponse.platform ? {platform: [apiResponse.platform]} : {}),
-    ...(apiResponse.releases ? {releases: [apiResponse.releases]} : {}),
+    ...(apiResponse.releases ? {releases: [...apiResponse.releases]} : {}),
     ...(apiResponse.os?.name ? {'os.name': [apiResponse.os.name]} : {}),
     ...(apiResponse.os?.version ? {'os.version': [apiResponse.os.version]} : {}),
     ...(apiResponse.sdk?.name ? {'sdk.name': [apiResponse.sdk.name]} : {}),

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -46,7 +46,7 @@ function ReplayDetails({
 
   const startTimestampMs = replayRecord?.started_at.getTime() ?? 0;
 
-  if (!fetching && !replay && fetchError) {
+  if (fetchError) {
     if (fetchError.statusText === 'Not Found') {
       return (
         <Page orgSlug={orgSlug} replayRecord={replayRecord}>


### PR DESCRIPTION
This PR fixes an issue where error data doesn't get set into state if that payload is ready before the first attachments payload.

I've highlighted the actual problem in the original code in the PR, but I also took the chance to stream line everything so state is more separate, and we rely only on react useCallback and useEffect hooks to trigger fetch requests.

Tested incremental loading against the huge replay `/replays/javascript:23003c384e0c4fc084c44ea906240a4a/` 
Also tested against `/replays/javascript:2dfcb09f8efd455ab0627514aa2ece5d/` which loads one error
And finally a replay that has no errors to load: `/replays/javascript:f927296182c74dd3bcf4d089a3c819ac/`
All in the sentry org.

Fixes #45224
