### PR TITLE
ref: Use @kafka_options decorator for ingest-consumer cli

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -548,7 +548,7 @@ def batching_kafka_options(
     is_flag=True,
     help="Listen to all consumer types at once.",
 )
-@batching_kafka_options("ingest-consumer", max_batch_size=100)
+@kafka_options("ingest-consumer", include_batching_options=True, default_max_batch_size=100)
 @click.option(
     "--concurrency",
     type=int,


### PR DESCRIPTION
The @batching_kafka_options decorator will be deprecated in favour of @kafka_options which supports both batching and non batching mode.

