### PR TITLE
ref(occurrences): Use feature flag instead of superuser permission

### DIFF
--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -20,6 +20,7 @@ from sentry.utils.samples import load_data
 @region_silo_endpoint
 class IssueOccurrenceEndpoint(Endpoint):
     permission_classes = (OrganizationPermission,)
+    private = True
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -14,37 +14,43 @@ from sentry.services.hybrid_cloud.user import user_service
 from sentry.utils import json
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options
 from sentry.utils.samples import load_data
+from sentry import features
+from sentry.api.bases.organization import OrganizationEndpoint
+
 
 
 @region_silo_endpoint
 class IssueOccurrenceEndpoint(Endpoint):
-    permission_classes = (SuperuserPermission,)
-    private = True
+    # permission_classes = (SuperuserPermission,)
+    # private = True
 
     def post(self, request: Request) -> Response:
         """
         Write issue occurrence and event data to a Kafka topic
         ``````````````````````````````````````````````````````
-        :auth: superuser required
         :pparam: string dummyEvent: pass 'True' to load a dummy event instead of providing one in the request
         :pparam: string dummyOccurrence: pass 'True' to load a dummy occurrence instead of providing one in the request
         """
+        project_id = request.query_params.get("project_id")
+        if project_id:
+            project = Project.objects.get(id=project_id)
+        else:
+            user = user_service.get_user(request.user.id)
+            projects = Project.objects.get_for_user_ids({user.id})
+            if not projects:
+                return Response(
+                    "Requesting user must belong to at least one project.",
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            project = projects[0]
+
+        if not features.has("organizations:issue-occurrences", project.organization, actor=request.user):
+            return Response(403)
+
         if request.query_params.get("dummyOccurrence") == "True":
             dummy_occurrence = dict(load_data("generic-event-profiling"))
             dummy_occurrence["event"]["received"] = datetime.utcnow().isoformat()
             dummy_occurrence["event"]["timestamp"] = datetime.utcnow().isoformat()
-            project_id = request.query_params.get("project_id")
-            if project_id:
-                project = Project.objects.get(id=project_id)
-            else:
-                user = user_service.get_user(request.user.id)
-                projects = Project.objects.get_for_user_ids({user.id})
-                if not projects:
-                    return Response(
-                        "Requesting user must belong to at least one project.",
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
-                project = projects[0]
             dummy_occurrence["id"] = uuid.uuid4().hex
             dummy_occurrence["event"]["event_id"] = uuid.uuid4().hex
             dummy_occurrence["project_id"] = project.id

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -7,22 +7,19 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.api.permissions import SuperuserPermission
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.models import Project
 from sentry.services.hybrid_cloud.user import user_service
 from sentry.utils import json
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options
 from sentry.utils.samples import load_data
-from sentry import features
-from sentry.api.bases.organization import OrganizationEndpoint
-
 
 
 @region_silo_endpoint
 class IssueOccurrenceEndpoint(Endpoint):
-    # permission_classes = (SuperuserPermission,)
-    # private = True
+    permission_classes = (OrganizationPermission,)
 
     def post(self, request: Request) -> Response:
         """
@@ -44,7 +41,9 @@ class IssueOccurrenceEndpoint(Endpoint):
                 )
             project = projects[0]
 
-        if not features.has("organizations:issue-occurrences", project.organization, actor=request.user):
+        if not features.has(
+            "organizations:issue-occurrences", project.organization, actor=request.user
+        ):
             return Response(403)
 
         if request.query_params.get("dummyOccurrence") == "True":

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1080,6 +1080,8 @@ SENTRY_FEATURES = {
     "organizations:issue-alert-preview": False,
     # Enable issue alert test notifications
     "organizations:issue-alert-test-notifications": False,
+    # Enable creating issue occurrences
+    "organizations:issue-occurrences": False,
     # Enable issue platform
     "organizations:issue-platform": False,
     # Whether to allow issue only search on the issue list

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -89,6 +89,7 @@ default_manager.add("organizations:issue-alert-test-notifications", Organization
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, True)
 default_manager.add("organizations:issue-list-removal-action", OrganizationFeature, True)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, True)
+default_manager.add("organizations:issue-occurrences", OrganizationFeature, True)
 default_manager.add("organizations:issue-platform", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, True)

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -14,7 +14,6 @@ from sentry.utils.samples import load_data
 class IssueOccurrenceTest(APITestCase):
     def setUp(self):
         super().setUp()
-        # self.user = self.create_user(is_superuser=False)
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.org, members=[self.user])


### PR DESCRIPTION
We need to test occurrences on production but still limit it to internal organizations. Use a feature flag instead of the superuser permission to be able to easily curl the endpoint for flagged in orgs. 