### PR TITLE
ref(perf): Add VCD to performance landing

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -27,6 +27,7 @@ import EventView, {isFieldSortable, MetaType} from 'sentry/utils/discover/eventV
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'sentry/utils/discover/fields';
 import {MEPConsumer} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import {TableColumn} from 'sentry/views/discover/table/types';
 
@@ -424,24 +425,31 @@ class _Table extends Component<Props, State> {
                 >
                   {({pageLinks, isLoading, tableData}) => (
                     <Fragment>
-                      <GridEditable
-                        isLoading={isLoading}
-                        data={tableData ? tableData.data : []}
-                        columnOrder={columnOrder}
-                        columnSortBy={columnSortBy}
-                        grid={{
-                          onResizeColumn: this.handleResizeColumn,
-                          renderHeadCell: this.renderHeadCellWithMeta(
-                            tableData?.meta
-                          ) as any,
-                          renderBodyCell: this.renderBodyCellWithData(tableData) as any,
-                          renderPrependColumns: this.renderPrependCellWithData(
-                            tableData
-                          ) as any,
-                          prependColumnWidths,
-                        }}
-                        location={location}
-                      />
+                      <VisuallyCompleteWithData
+                        id="PerformanceTable"
+                        hasData={
+                          !isLoading && !!tableData?.data && tableData.data.length > 0
+                        }
+                      >
+                        <GridEditable
+                          isLoading={isLoading}
+                          data={tableData ? tableData.data : []}
+                          columnOrder={columnOrder}
+                          columnSortBy={columnSortBy}
+                          grid={{
+                            onResizeColumn: this.handleResizeColumn,
+                            renderHeadCell: this.renderHeadCellWithMeta(
+                              tableData?.meta
+                            ) as any,
+                            renderBodyCell: this.renderBodyCellWithData(tableData) as any,
+                            renderPrependColumns: this.renderPrependCellWithData(
+                              tableData
+                            ) as any,
+                            prependColumnWidths,
+                          }}
+                          location={location}
+                        />
+                      </VisuallyCompleteWithData>
                       <Pagination
                         pageLinks={pageLinks}
                         paginationAnalyticsEvent={this.paginationAnalyticsEvent}


### PR DESCRIPTION
### Summary
The table is usually the slowest and the primary action for this page, it makes a good candidate for visually complete w/ data (vcd in our custom measurements, something I'm collecting alongside LCP to check LCP accuracy). 

I'll probably change the component later to just accept a loading/data props and have it align with our query output, but for now I just want to start measuring the table load time. 

