### PR TITLE
ref(sdk): Move idleTimeout back to default

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -45,10 +45,6 @@ function getSentryIntegrations(sentryConfig: Config['sentryConfig'], routes?: Fu
             ),
           }
         : {}),
-      idleTimeout: 5000,
-      _metricOptions: {
-        _reportAllChanges: false,
-      },
       _experiments: {
         enableInteractions: true,
       },


### PR DESCRIPTION
## Summary
We should be dogfooding our default idleTimeout (1000ms) in the application, after the timeout quiesence changes we made last year, 1 second should be more than sufficient to capture activity as part of pageloads etc. Right now we're seeing to many erroneous check-in type events (analytics / sideloads) which are artificially extending our transactions.

### Other
- Removing report all changes since we finished that experiment as well.

