### PR TITLE
fix(code mappings): Fix enablement checks

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -95,7 +95,7 @@ def derive_code_mappings(
     # Check the feature flag again to ensure the feature is still enabled.
     org_has_flag = features.has(feat_key, org) or features.has(f"{feat_key}-dry-run", org)
 
-    if not (dry_run or org_has_flag or data["platform"] not in SUPPORTED_LANGUAGES):
+    if not org_has_flag or not data["platform"] in SUPPORTED_LANGUAGES:
         logger.info("Event should not be processed.", extra=extra)
         return
 

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -58,21 +58,23 @@ class TestTaskBehavior(BaseDeriveCodeMappings):
 
     @patch("sentry.tasks.derive_code_mappings.logger")
     def test_raises_other_api_errors(self, mock_logger):
-        with patch(
-            "sentry.integrations.github.client.GitHubClientMixin.get_trees_for_org",
-            side_effect=ApiError("foo"),
-        ):
-            derive_code_mappings(self.project.id, self.event_data)
-            assert mock_logger.exception.call_count == 1
+        with patch("sentry.tasks.derive_code_mappings.SUPPORTED_LANGUAGES", ["other"]):
+            with patch(
+                "sentry.integrations.github.client.GitHubClientMixin.get_trees_for_org",
+                side_effect=ApiError("foo"),
+            ):
+                derive_code_mappings(self.project.id, self.event_data)
+                assert mock_logger.exception.call_count == 1
 
     def test_unable_to_get_lock(self):
-        with patch(
-            "sentry.integrations.github.client.GitHubClientMixin.get_trees_for_org",
-            side_effect=UnableToAcquireLock,
-        ):
-            # We should raise an exception since the request will be retried
-            with pytest.raises(UnableToAcquireLock):
-                derive_code_mappings(self.project.id, self.event_data)
+        with patch("sentry.tasks.derive_code_mappings.SUPPORTED_LANGUAGES", ["other"]):
+            with patch(
+                "sentry.integrations.github.client.GitHubClientMixin.get_trees_for_org",
+                side_effect=UnableToAcquireLock,
+            ):
+                # We should raise an exception since the request will be retried
+                with pytest.raises(UnableToAcquireLock):
+                    derive_code_mappings(self.project.id, self.event_data)
 
 
 class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):


### PR DESCRIPTION
There's currently a bug in our main `derive_code_mappings` function wherein we bail under the wrong circumstances. (In the table below, the fourth and fifth columns are the current logic and behavior, and the last two columns are the fixed logic and behavior.)

```
| dry_run (DR) | org_has_flag (OHF) | language_supported (LS) | not (DR or OHF or not LS) | current behavior | correct behavior | not OHF or not LS |
|--------------|--------------------|-------------------------|---------------------------|------------------|------------------|-------------------|
|       F      |          F         |            F            |             F             | continue         | bail with error  |         T         |
|       F      |          T         |            F            |             F             | continue         | bail with error  |         T         |
|       F      |          F         |            T            |             T             | bail with error  | bail with error  |         T         |
|       F      |          T         |            T            |             F             | continue         | continue         |         F         |
|       T      |          F         |            F            |             F             | continue         | bail with error  |         T         |
|       T      |          T         |            F            |             F             | continue         | bail with error  |         T         |
|       T      |          F         |            T            |             F             | continue         | bail with error  |         T         |
|       T      |          T         |            T            |             F             | continue         | continue         |         F         |
```

This fixes the bug, and adjusts two tests which should have been failing (their platform is `other`, meaning they should have failed the unsupported language check and not gotten far enough through `derive_code_mappings` to reach the code they're testing) but which were passing because of the broken behavior.

_h/t to https://web.stanford.edu/class/cs103/tools/truth-table-tool/ for generating the truth table above_