### PR TITLE
chore(profiling): Give user misery column a suggested width

### DIFF
--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -442,7 +442,7 @@ const COLUMN_ORDERS: Record<FieldType, GridColumnOrder<FieldType>> = {
   'user_misery()': {
     key: 'user_misery()',
     name: t('User Misery'),
-    width: COL_WIDTH_UNDEFINED,
+    width: 110,
   },
 };
 


### PR DESCRIPTION
Use a suggested with of 110 for user misery, same as what performance uses.