### PR TITLE
ref: bump migration tests timeout

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -114,7 +114,7 @@ jobs:
     needs: files-changed
     name: backend migration tests
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         pg-version: ['9.6']


### PR DESCRIPTION
if a migration test retries 5x it will exceed timeout currently




<!-- Describe your PR here. -->