### PR TITLE
fix(profiling): Update transactions profile id provider to use transa…

### DIFF
--- a/static/app/components/profiling/transactionProfileIdProvider.tsx
+++ b/static/app/components/profiling/transactionProfileIdProvider.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {PageFilters} from 'sentry/types';
 import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import useOrganization from 'sentry/utils/useOrganization';
 
 const TransactionProfileContext = createContext<string | null | undefined>(undefined);
 
@@ -19,6 +20,7 @@ export function TransactionProfileIdProvider({
   transactionId,
   children,
 }: TransactionToProfileIdProviderProps) {
+  const organization = useOrganization();
   // create a 24h timeframe relative from the transaction timestamp to use for
   // the profile events query
   const datetime: PageFilters['datetime'] | undefined = useMemo(() => {
@@ -37,16 +39,26 @@ export function TransactionProfileIdProvider({
     };
   }, [timestamp]);
 
+  const profileIdColumn = organization.features.includes('profiling-using-transactions')
+    ? 'profile.id'
+    : 'id';
+
+  const transactionIdColumn = organization.features.includes(
+    'profiling-using-transactions'
+  )
+    ? 'id'
+    : 'trace.transaction';
+
   const {status, data, error} = useProfileEvents({
     projects: projectId ? [projectId] : undefined,
-    fields: ['id'],
+    fields: [profileIdColumn],
     referrer: 'transactionToProfileProvider',
     limit: 1,
     sort: {
       key: 'id',
       order: 'asc',
     },
-    query: `trace.transaction:${transactionId}`,
+    query: `${transactionIdColumn}:${transactionId}`,
     enabled: Boolean(transactionId),
     datetime,
   });
@@ -61,7 +73,7 @@ export function TransactionProfileIdProvider({
     }
   }, [status, error]);
 
-  const profileId = (data?.[0].data[0]?.id as string | undefined) ?? null;
+  const profileId = (data?.[0].data[0]?.[profileIdColumn] as string | undefined) ?? null;
 
   return (
     <TransactionProfileContext.Provider value={profileId}>


### PR DESCRIPTION
…ctions

When using the transactions table, a few columns have a different name here, so make sure to use the right names. Long term, we should try to use the profile context + the profile we load for previews directly without making an extra query here.