### PR TITLE
bug(replays): Use the new `/replays-count/?returnIds=true` query to list replays related to issues

### DIFF
--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -45,7 +45,7 @@ function useReplayFromIssue({
   }, [api, organization.slug, group.id, group.project.id]);
 
   const eventView = useMemo(() => {
-    if (!replayIds) {
+    if (!replayIds.length) {
       return null;
     }
     return EventView.fromSavedQuery({

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -55,6 +55,7 @@ function useReplayFromIssue({
       fields: REPLAY_LIST_FIELDS,
       projects: [Number(group.project.id)],
       query: `id:[${String(replayIds)}]`,
+      range: '14d',
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
   }, [location.query.sort, group.project.id, replayIds]);

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -3,14 +3,11 @@ import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
 import type {Group, Organization} from 'sentry/types';
-import {TableData} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
-import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {DEFAULT_SORT, REPLAY_LIST_FIELDS} from 'sentry/utils/replays/fetchReplayList';
 import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
-import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
 function useReplayFromIssue({
   group,
@@ -23,45 +20,32 @@ function useReplayFromIssue({
 }) {
   const api = useApi();
 
-  const [response, setResponse] = useState<{
-    pageLinks: null | string;
-    replayIds: undefined | string[];
-  }>({pageLinks: null, replayIds: undefined});
+  const [replayIds, setReplayIds] = useState<string[]>([]);
 
   const [fetchError, setFetchError] = useState();
 
-  const {cursor} = location.query;
   const fetchReplayIds = useCallback(async () => {
-    const eventView = EventView.fromSavedQuery({
-      id: '',
-      name: `Errors within replay`,
-      version: 2,
-      fields: ['replayId', 'count()'],
-      query: `issue.id:${group.id} !replayId:""`,
-      projects: [Number(group.project.id)],
-    });
-
     try {
-      const [{data}, _textStatus, resp] = await doDiscoverQuery<TableData>(
-        api,
-        `/organizations/${organization.slug}/events/`,
-        eventView.getEventsAPIPayload({
-          query: {cursor},
-        } as Location<ReplayListLocationQuery>)
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/replay-count/`,
+        {
+          query: {
+            returnIds: true,
+            query: `issue.id:[${group.id}]`,
+            statsPeriod: '14d',
+            project: group.project.id,
+          },
+        }
       );
-
-      setResponse({
-        pageLinks: resp?.getResponseHeader('Link') ?? '',
-        replayIds: data.map(record => String(record.replayId)),
-      });
-    } catch (err) {
-      Sentry.captureException(err);
-      setFetchError(err);
+      setReplayIds(response[group.id] || []);
+    } catch (error) {
+      Sentry.captureException(error);
+      setFetchError(error);
     }
-  }, [api, cursor, organization.slug, group.id, group.project.id]);
+  }, [api, organization.slug, group.id, group.project.id]);
 
   const eventView = useMemo(() => {
-    if (!response.replayIds) {
+    if (!replayIds) {
       return null;
     }
     return EventView.fromSavedQuery({
@@ -70,10 +54,10 @@ function useReplayFromIssue({
       version: 2,
       fields: REPLAY_LIST_FIELDS,
       projects: [Number(group.project.id)],
-      query: `id:[${String(response.replayIds)}]`,
+      query: `id:[${String(replayIds)}]`,
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, group.project.id, response.replayIds]);
+  }, [location.query.sort, group.project.id, replayIds]);
 
   useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor']});
   useEffect(() => {
@@ -83,7 +67,7 @@ function useReplayFromIssue({
   return {
     eventView,
     fetchError,
-    pageLinks: response.pageLinks,
+    pageLinks: null,
   };
 }
 


### PR DESCRIPTION
This follows the backend work done in https://github.com/getsentry/sentry/pull/44774

Basically we're asking now for a list of replays, that are related to this issue, and where the replays are guaranteed to exist. 

Before we were asking for issues with replay_id attached, but the replay itself might be missing (there are many reasons it could be gone. ie: deleted). 

For this example issue it was common to get back a list of 3 replays, even though the title suggested that there were 13.
After we see all 13:
<img width="1277" alt="SCR-20230301-j4r" src="https://user-images.githubusercontent.com/187460/222273029-aae790d0-b04b-4309-942a-6d1f38ebc0c8.png">

I also checked against an example issue that has over 50 replays in the count, we do still see 50 in the table. As before there is no pagination, so 50 is the maximum that people will see.

50 replays in the table means 50 examples of the issue. It should be enough to start a debugging session.

Fixes #44267