### PR TITLE
feat(roles): return all org roles for org member

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -89,10 +89,15 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             "dateCreated": obj.date_added,
             "inviteStatus": obj.get_invite_status_name(),
             "inviterName": obj.inviter.get_display_name() if obj.inviter else None,
-            "allOrgRoles": serialize(
-                obj.get_all_org_roles_sorted(),
-                serializer=OrganizationRoleSerializer(organization=obj.organization),
-            ),
+            "orgRolesFromTeams": [
+                {
+                    "slug": slug,
+                    "role": serialize(
+                        role, serializer=OrganizationRoleSerializer(organization=obj.organization)
+                    ),
+                }
+                for slug, role in obj.get_org_roles_from_teams_by_source()
+            ],
         }
 
         if "externalUsers" in self.expand:

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -5,6 +5,7 @@ from django.db.models import prefetch_related_objects
 
 from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.models.role import OrganizationRoleSerializer
 from sentry.models import ExternalActor, OrganizationMember, User
 from sentry.services.hybrid_cloud.user import user_service
 
@@ -88,6 +89,10 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             "dateCreated": obj.date_added,
             "inviteStatus": obj.get_invite_status_name(),
             "inviterName": obj.inviter.get_display_name() if obj.inviter else None,
+            "allOrgRoles": serialize(
+                obj.get_all_org_roles_sorted(),
+                serializer=OrganizationRoleSerializer(organization=obj.organization),
+            ),
         }
 
         if "externalUsers" in self.expand:

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -74,13 +74,13 @@ class OrganizationMemberResponse(OrganizationMemberResponseOptional):
     role: str  # Deprecated: use orgRole
     roleName: str  # Deprecated
     orgRole: str
+    orgRolesFromTeams: List[RoleSerializerResponse]
     pending: bool
     expired: str
     flags: _OrganizationMemberFlags
     dateCreated: datetime
     inviteStatus: str
     inviterName: Optional[str]
-    allOrgRoles: List[RoleSerializerResponse]
 
 
 class OrganizationMemberWithTeamsResponse(OrganizationMemberResponse):

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -80,6 +80,7 @@ class OrganizationMemberResponse(OrganizationMemberResponseOptional):
     dateCreated: datetime
     inviteStatus: str
     inviterName: Optional[str]
+    allOrgRoles: List[RoleSerializerResponse]
 
 
 class OrganizationMemberWithTeamsResponse(OrganizationMemberResponse):

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -437,6 +437,16 @@ class OrganizationMember(Model):
         all_org_roles.add(self.role)
         return list(all_org_roles)
 
+    def get_org_roles_from_teams_by_source(self) -> List[tuple(str, OrganizationRole)]:
+        org_roles = list(self.teams.all().exclude(org_role=None).values_list("slug", "org_role"))
+
+        sorted_org_roles = sorted(
+            [(slug, organization_roles.get(role)) for slug, role in org_roles],
+            key=lambda r: r[1].priority,
+            reverse=True,
+        )
+        return sorted_org_roles
+
     def get_all_org_roles_sorted(self) -> List[OrganizationRole]:
         return organization_roles.get_sorted_roles(self.get_all_org_roles())
 

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -35,10 +35,13 @@ class OrganizationMemberSerializerTest(TestCase):
 class OrganizationMemberAllRolesSerializerTest(OrganizationMemberSerializerTest):
     def test_all_org_roles(self):
         manager_team = self.create_team(organization=self.org, org_role="manager")
+        manager_team2 = self.create_team(organization=self.org, org_role="manager")
         member = self.create_member(
-            organization=self.org, user=self.create_user(), teams=[manager_team]
+            organization=self.org, user=self.create_user(), teams=[manager_team, manager_team2]
         )
         result = serialize(member, self.user_2, OrganizationMemberSerializer())
+
+        assert len(result["allOrgRoles"]) == 2
         assert result["allOrgRoles"][0]["id"] == "manager"
         assert result["allOrgRoles"][1]["id"] == "member"
 

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -1,4 +1,8 @@
-from sentry.api.serializers import OrganizationMemberWithProjectsSerializer, serialize
+from sentry.api.serializers import (
+    OrganizationMemberSerializer,
+    OrganizationMemberWithProjectsSerializer,
+    serialize,
+)
 from sentry.api.serializers.models.organization_member import (
     OrganizationMemberSCIMSerializer,
     OrganizationMemberWithTeamsSerializer,
@@ -25,6 +29,18 @@ class OrganizationMemberSerializerTest(TestCase):
                 "user__email"
             )
         )
+
+
+@region_silo_test(stable=True)
+class OrganizationMemberAllRolesSerializerTest(OrganizationMemberSerializerTest):
+    def test_all_org_roles(self):
+        manager_team = self.create_team(organization=self.org, org_role="manager")
+        member = self.create_member(
+            organization=self.org, user=self.create_user(), teams=[manager_team]
+        )
+        result = serialize(member, self.user_2, OrganizationMemberSerializer())
+        assert result["allOrgRoles"][0]["id"] == "manager"
+        assert result["allOrgRoles"][1]["id"] == "member"
 
 
 @region_silo_test(stable=True)

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -41,9 +41,9 @@ class OrganizationMemberAllRolesSerializerTest(OrganizationMemberSerializerTest)
         )
         result = serialize(member, self.user_2, OrganizationMemberSerializer())
 
-        assert len(result["allOrgRoles"]) == 2
-        assert result["allOrgRoles"][0]["id"] == "manager"
-        assert result["allOrgRoles"][1]["id"] == "member"
+        assert len(result["orgRolesFromTeams"]) == 2
+        assert result["orgRolesFromTeams"][0]["role"]["id"] == "manager"
+        assert result["orgRolesFromTeams"][1]["role"]["id"] == "manager"
 
 
 @region_silo_test(stable=True)

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -417,7 +417,5 @@ class OrganizationMemberTest(TestCase):
 
         roles = member.get_org_roles_from_teams_by_source()
         assert roles[0][1].id == "owner"
-        assert roles[-2][0] == manager_team.slug
-        assert roles[-2][1].id == "manager"
-        assert roles[-1][0] is None
-        assert roles[-1][1].id == "member"
+        assert roles[-1][0] == manager_team.slug
+        assert roles[-1][1].id == "manager"

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -416,7 +416,6 @@ class OrganizationMemberTest(TestCase):
         )
 
         roles = member.get_org_roles_from_teams_by_source()
-        assert roles[0][0] == owner_team.slug or roles[0]["slug"] == owner_team2.slug
         assert roles[0][1].id == "owner"
         assert roles[-2][0] == manager_team.slug
         assert roles[-2][1].id == "manager"

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -403,3 +403,22 @@ class OrganizationMemberTest(TestCase):
             roles.get("admin"),
             roles.get("manager"),
         ]
+
+    def test_org_roles_by_source(self):
+        manager_team = self.create_team(organization=self.organization, org_role="manager")
+        owner_team = self.create_team(organization=self.organization, org_role="owner")
+        owner_team2 = self.create_team(organization=self.organization, org_role="owner")
+        member = self.create_member(
+            organization=self.organization,
+            teams=[manager_team, owner_team, owner_team2],
+            user=self.create_user(),
+            role="member",
+        )
+
+        roles = member.get_org_roles_from_teams_by_source()
+        assert roles[0][0] == owner_team.slug or roles[0]["slug"] == owner_team2.slug
+        assert roles[0][1].id == "owner"
+        assert roles[-2][0] == manager_team.slug
+        assert roles[-2][1].id == "manager"
+        assert roles[-1][0] is None
+        assert roles[-1][1].id == "member"


### PR DESCRIPTION
`orgRolesFromTeams` return a blob like this

```
[
    {
        "slug": team-slug,
        "role": OrganizationRole
    },
    {
        "slug": None,
        "role": OrganizationRole (member's org role)
    }
]
```

For ER-1415