### PR TITLE
feat(CapMan): More `tenant_ids` for TSDB Queries

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -120,7 +120,11 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
 
     @staticmethod
     def __group_hourly_daily_stats(group: Group, environment_ids: Sequence[int]):
-        get_range = functools.partial(tsdb.get_range, environment_ids=environment_ids)
+        get_range = functools.partial(
+            tsdb.get_range,
+            environment_ids=environment_ids,
+            tenant_ids={"organization_id": group.project.organization_id},
+        )
         model = get_issue_tsdb_group_model(group.issue_category)
         now = timezone.now()
         hourly_stats = tsdb.rollup(

--- a/src/sentry/api/endpoints/group_stats.py
+++ b/src/sentry/api/endpoints/group_stats.py
@@ -19,7 +19,10 @@ class GroupStatsEndpoint(GroupEndpoint, EnvironmentMixin, StatsMixin):
             raise ResourceDoesNotExist
 
         data = tsdb.get_range(
-            model=tsdb.models.group, keys=[group.id], **self._parse_args(request, environment_id)
+            model=tsdb.models.group,
+            keys=[group.id],
+            **self._parse_args(request, environment_id),
+            tenant_ids={"organization_id": group.project.organization_id},
         )[group.id]
 
         return Response(data)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/interaction.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/interaction.py
@@ -29,7 +29,10 @@ class SentryAppInteractionEndpoint(SentryAppBaseEndpoint, StatsMixin):
         """
 
         views = tsdb.get_range(
-            model=tsdb.models.sentry_app_viewed, keys=[sentry_app.id], **self._parse_args(request)
+            model=tsdb.models.sentry_app_viewed,
+            keys=[sentry_app.id],
+            **self._parse_args(request),
+            tenant_ids={"organization_id": sentry_app.owner.id},
         )[sentry_app.id]
 
         component_interactions = tsdb.get_range(
@@ -39,6 +42,7 @@ class SentryAppInteractionEndpoint(SentryAppBaseEndpoint, StatsMixin):
                 for component in sentry_app.components.all()
             ],
             **self._parse_args(request),
+            tenant_ids={"organization_id": sentry_app.owner.id},
         )
 
         return Response(

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -89,7 +89,10 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
         if stat_model is None:
             raise ValueError(f"Invalid group: {group}, stat: {stat}")
         data = tsdb.get_range(
-            model=stat_model, keys=keys, **self._parse_args(request, **query_kwargs)
+            model=stat_model,
+            keys=keys,
+            **self._parse_args(request, **query_kwargs),
+            tenant_ids={"organization_id": organization.id},
         )
 
         if group == "organization":

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -37,7 +37,10 @@ class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
             return Response(status=204)
 
         data = tsdb.get_range(
-            model=tsdb.models.group, keys=group_ids, **self._parse_args(request, environment_id)
+            model=tsdb.models.group,
+            keys=group_ids,
+            **self._parse_args(request, environment_id),
+            tenant_ids={"organization_id": project.organization_id},
         )
 
         return Response({str(k): v for k, v in data.items()})

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -20,7 +20,12 @@ class ProjectServiceHookStatsEndpoint(ProjectEndpoint, StatsMixin):
 
         stats = {}
         for model, name in ((tsdb.models.servicehook_fired, "total"),):
-            result = tsdb.get_range(model=model, keys=[hook.id], **stat_args)[hook.id]
+            result = tsdb.get_range(
+                model=model,
+                keys=[hook.id],
+                **stat_args,
+                tenant_ids={"organization_id": project.organization_id},
+            )[hook.id]
             for ts, count in result:
                 stats.setdefault(int(ts), {})[name] = count
 

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -62,7 +62,10 @@ class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
                 raise ValueError("Invalid stat: %s" % stat)
 
         data = tsdb.get_range(
-            model=stat_model, keys=[project.id], **self._parse_args(request, **query_kwargs)
+            model=stat_model,
+            keys=[project.id],
+            **self._parse_args(request, **query_kwargs),
+            tenant_ids={"organization_id": project.organization_id},
         )[project.id]
 
         return Response(data)

--- a/src/sentry/api/endpoints/team_stats.py
+++ b/src/sentry/api/endpoints/team_stats.py
@@ -51,6 +51,7 @@ class TeamStatsEndpoint(TeamEndpoint, EnvironmentMixin, StatsMixin):
                 model=tsdb.models.project,
                 keys=[p.id for p in projects],
                 **self._parse_args(request, environment_id),
+                tenant_ids={"organization_id": team.organization_id},
             ).values()
         )
 

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -25,8 +24,6 @@ from sentry.models.groupowner import get_owner_details
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import hash_values
-
-logger = logging.getLogger("bruh.group.stream")
 
 
 @dataclass
@@ -349,7 +346,6 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
         results = {}
 
-        logger.error(f"ORG ID ADDED {self.organization_id}")
         get_range = functools.partial(
             snuba_tsdb.get_range,
             environment_ids=environment_ids,

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -24,6 +25,8 @@ from sentry.models.groupowner import get_owner_details
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import hash_values
+
+logger = logging.getLogger("bruh.group.stream")
 
 
 @dataclass
@@ -158,6 +161,7 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
                 keys=[g.id for g in groups],
                 environment_ids=environment and [environment.id],
                 **query_params,
+                tenant_ids={"organization_id": environment.organization_id},
             )
 
         return stats
@@ -344,6 +348,8 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 generic_issue_ids.append(group.id)
 
         results = {}
+
+        logger.error(f"ORG ID ADDED {self.organization_id}")
         get_range = functools.partial(
             snuba_tsdb.get_range,
             environment_ids=environment_ids,

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -153,12 +153,13 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
         except Environment.DoesNotExist:
             stats = {g.id: tsdb.make_series(0, **query_params) for g in groups}
         else:
+            org_id = groups[0].project.organization_id if groups else None
             stats = tsdb.get_range(
                 model=tsdb.models.group,
                 keys=[g.id for g in groups],
                 environment_ids=environment and [environment.id],
                 **query_params,
-                tenant_ids={"organization_id": environment.organization_id},
+                tenant_ids={"organization_id": org_id} if org_id else None,
             )
 
         return stats

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -82,7 +82,13 @@ def fetch_state(project: Project, records: Sequence[Record]) -> Mapping[str, Any
         "rules": Rule.objects.in_bulk(
             itertools.chain.from_iterable(record.value.rules for record in records)
         ),
-        "event_counts": tsdb.get_sums(tsdb.models.group, list(groups.keys()), start, end),
+        "event_counts": tsdb.get_sums(
+            tsdb.models.group,
+            list(groups.keys()),
+            start,
+            end,
+            tenant_ids={"organization_id": project.organization_id},
+        ),
         "user_counts": tsdb.get_distinct_counts_totals(
             tsdb.models.users_affected_by_group, list(groups.keys()), start, end
         ),

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -98,6 +98,7 @@ class GroupSnooze(Model):
             keys=[self.group_id],
             start=start,
             end=end,
+            tenant_ids={"organization_id": self.group.project.organization_id},
         )[self.group_id]
 
         if rate >= self.count:

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -235,6 +235,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
             environment_id=environment_id,
             use_cache=True,
             jitter_value=event.group_id,
+            tenant_ids={"organization_id": event.group.project.organization_id},
         )
         return sums[event.group_id]
 
@@ -364,6 +365,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                 environment_id=environment_id,
                 use_cache=True,
                 jitter_value=event.group_id,
+                tenant_ids={"organization_id": event.group.project.organization_id},
             )[event.group_id]
             if issue_count > avg_sessions_in_interval:
                 # We want to better understand when and why this is happening, so we're logging it for now

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -355,7 +355,15 @@ class BaseTSDB(Service):
         raise NotImplementedError
 
     def get_range(
-        self, model, keys, start, end, rollup=None, environment_ids=None, use_cache=False
+        self,
+        model,
+        keys,
+        start,
+        end,
+        rollup=None,
+        environment_ids=None,
+        use_cache=False,
+        tenant_ids=None,
     ):
         """
         To get a range of data for group ID=[1, 2, 3]:

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -387,6 +387,7 @@ class BaseTSDB(Service):
         environment_id=None,
         use_cache=False,
         jitter_value=None,
+        tenant_ids=None,
     ):
         range_set = self.get_range(
             model,
@@ -397,6 +398,7 @@ class BaseTSDB(Service):
             environment_ids=[environment_id] if environment_id is not None else None,
             use_cache=use_cache,
             jitter_value=jitter_value,
+            tenant_ids=tenant_ids,
         )
         sum_set = {key: sum(p for _, p in points) for (key, points) in range_set.items()}
         return sum_set

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -31,6 +31,7 @@ class DummyTSDB(BaseTSDB):
         environment_ids=None,
         use_cache=False,
         jitter_value=None,
+        tenant_ids=None,
     ):
         self.validate_arguments([model], environment_ids if environment_ids is not None else [None])
         _, series = self.get_optimal_rollup_series(start, end, rollup)

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -70,6 +70,7 @@ class InMemoryTSDB(BaseTSDB):
         environment_ids=None,
         use_cache=False,
         jitter_value=None,
+        tenant_ids=None,
     ):
         self.validate_arguments([model], environment_ids if environment_ids is not None else [None])
 

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -272,6 +272,7 @@ class RedisTSDB(BaseTSDB):
         environment_ids=None,
         use_cache=False,
         jitter_value=None,
+        tenant_ids=None,
     ):
         """
         To get a range of data for group ID=[1, 2, 3]:

--- a/src/sentry/utils/suspect_resolutions/metric_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/metric_correlation.py
@@ -44,6 +44,7 @@ def is_issue_error_rate_correlated(
         rollup=600,
         start=start_time,
         end=end_time,
+        tenant_ids={"organization_id": resolved_issue.project.organization_id},
     )
 
     x = [events for _, events in data[resolved_issue.id]]


### PR DESCRIPTION
### Overview
- Added `organization_id` to more Snuba Requests, specifically targeting `tsdb-modelid:4` queries as they are the biggest chunk of queries Snuba is handling in production
- Most calls to `tsdb.get_range` handled as well, some I wasn't able to figure out
- More context: #44788