### PR TITLE
ref(project selector): Select a project if superuser

### DIFF
--- a/static/app/components/organizations/pageFilters/container.spec.jsx
+++ b/static/app/components/organizations/pageFilters/container.spec.jsx
@@ -3,6 +3,7 @@ import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as globalActions from 'sentry/actionCreators/pageFilters';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
@@ -524,6 +525,39 @@ describe('PageFiltersContainer', function () {
       expect(initializationObj.router.replace).toHaveBeenCalledWith(
         expect.objectContaining({
           query: {environment: [], project: ['1']},
+        })
+      );
+    });
+
+    it('selects a project if user is superuser and belongs to no projects', function () {
+      ConfigStore.init();
+      ConfigStore.loadInitialData(
+        TestStubs.Config({
+          user: TestStubs.User({isSuperuser: true}),
+        })
+      );
+      const project = TestStubs.Project({id: '3', isMember: false});
+      const org = TestStubs.Organization({projects: [project]});
+
+      ProjectsStore.loadInitialData(org.projects);
+
+      const initializationObj = initializeOrg({
+        organization: org,
+        router: {
+          params: {orgId: 'org-slug'},
+          location: {pathname: '/test', query: {}},
+        },
+      });
+
+      renderComponent(
+        <PageFiltersContainer />,
+        initializationObj.routerContext,
+        initializationObj.organization
+      );
+
+      expect(initializationObj.router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {environment: [], project: ['3']},
         })
       );
     });

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -12,6 +12,8 @@ import {
 import * as Layout from 'sentry/components/layouts/thirds';
 import DesyncedFilterAlert from 'sentry/components/organizations/pageFilters/desyncedFiltersAlert';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -70,7 +72,11 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
   const specifiedProjects = specificProjectSlugs
     ? projects.filter(project => specificProjectSlugs.includes(project.slug))
     : projects;
-  const memberProjects = specifiedProjects.filter(project => project.isMember);
+
+  const {user} = useLegacyStore(ConfigStore);
+  const memberProjects = user.isSuperuser
+    ? specifiedProjects
+    : specifiedProjects.filter(project => project.isMember);
 
   const doInitialization = () =>
     initializeUrlState({


### PR DESCRIPTION
If a superuser goes to a non-biz plan org where they're not a member of any projects, they're presented with the "You do not have the multi project stream feature enabled" error message. This PR checks if the user is a superuser and picks a project to avoid that.

Addresses [45222](https://github.com/getsentry/sentry/issues/45222)