### PR TITLE
feat(crons): Allow lookup via organization level monitor slug

### DIFF
--- a/src/sentry/api/bases/monitor.py
+++ b/src/sentry/api/bases/monitor.py
@@ -11,12 +11,15 @@ from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases.project import ProjectPermission
 from sentry.api.endpoints.event_attachment_details import EventAttachmentDetailsPermission
 from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist
-from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, Project, ProjectStatus
+from sentry.models import (
+    CheckInStatus,
+    Monitor,
+    MonitorCheckIn,
+    Organization,
+    Project,
+    ProjectStatus,
+)
 from sentry.utils.sdk import bind_organization_context, configure_scope
-
-
-class InvalidAuthProject(Exception):
-    pass
 
 
 class OrganizationMonitorPermission(OrganizationPermission):
@@ -57,23 +60,56 @@ class MonitorEndpoint(Endpoint):
     def respond_invalid() -> Response:
         return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": "Invalid monitor"})
 
-    def convert_args(self, request: Request, monitor_id: str, *args, **kwargs):
-        try:
-            UUID(monitor_id)
-        except ValueError:
-            raise ParameterValidationError("Invalid monitor UUID")
+    def convert_args(
+        self,
+        request: Request,
+        monitor_id: str,
+        organization_slug: str | None = None,
+        *args,
+        **kwargs,
+    ):
+        organization = None
+        monitor = None
 
-        try:
-            monitor = Monitor.objects.get(guid=monitor_id)
-        except Monitor.DoesNotExist:
-            raise ResourceDoesNotExist
+        # The only monitor endpoints that do not have the org slug in their
+        # parameters are the GUID-style checkin endpoints
+        if organization_slug:
+            try:
+                organization = Organization.objects.get_from_cache(slug=organization_slug)
+                # Try lookup by slug first. This requires organization context since
+                # slugs are unique only to the organization
+                monitor = Monitor.objects.get(organization_id=organization.id, slug=monitor_id)
+            except (Organization.DoesNotExist, Monitor.DoesNotExist):
+                pass
+
+        # Try lookup by GUID
+        if not monitor:
+            # Validate GUIDs
+            try:
+                UUID(monitor_id)
+            except ValueError:
+                # This error is a bit confusing, because this may also mean
+                # that we've failed to lookup their monitor by slug.
+                raise ParameterValidationError("Invalid monitor UUID")
+            # When looking up by guid we don't include the org conditional
+            # (since GUID lookup allows orgless routes), we will validate
+            # permissions later in this function
+            try:
+                monitor = Monitor.objects.get(guid=monitor_id)
+            except Monitor.DoesNotExist:
+                raise ResourceDoesNotExist
 
         project = Project.objects.get_from_cache(id=monitor.project_id)
         if project.status != ProjectStatus.VISIBLE:
             raise ResourceDoesNotExist
 
         if hasattr(request.auth, "project_id") and project.id != request.auth.project_id:
-            raise InvalidAuthProject
+            raise ResourceDoesNotExist
+
+        # When looking up via GUID we do not check the organiation slug,
+        # validate that the slug matches the org of the monitors project
+        if organization_slug and project.organization.slug != organization_slug:
+            raise ResourceDoesNotExist
 
         self.check_object_permissions(request, project)
 
@@ -86,11 +122,6 @@ class MonitorEndpoint(Endpoint):
 
         kwargs.update({"monitor": monitor, "project": project})
         return args, kwargs
-
-    def handle_exception(self, request: Request, exc: Exception) -> Response:
-        if isinstance(exc, InvalidAuthProject):
-            return self.respond(status=400)
-        return super().handle_exception(request, exc)
 
 
 class MonitorCheckInEndpoint(MonitorEndpoint):

--- a/src/sentry/api/endpoints/organization_monitor_details.py
+++ b/src/sentry/api/endpoints/organization_monitor_details.py
@@ -48,10 +48,6 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         """
         Retrieves details for a monitor.
         """
-        if organization_slug:
-            if project.organization.slug != organization_slug:
-                return self.respond_invalid()
-
         return self.respond(serialize(monitor, request.user))
 
     @extend_schema(
@@ -75,10 +71,6 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         """
         Update a monitor.
         """
-        if organization_slug:
-            if project.organization.slug != organization_slug:
-                return self.respond_invalid()
-
         validator = MonitorValidator(
             data=request.data,
             partial=True,

--- a/src/sentry/api/endpoints/organization_monitor_stats.py
+++ b/src/sentry/api/endpoints/organization_monitor_stats.py
@@ -15,10 +15,6 @@ class OrganizationMonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
     def get(
         self, request: Request, project, monitor, organization_slug: str | None = None
     ) -> Response:
-        if organization_slug:
-            if project.organization.slug != organization_slug:
-                return self.respond_invalid()
-
         args = self._parse_args(request)
 
         stats = {}

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2314,11 +2314,12 @@ class MonitorTestCase(APITestCase):
             ),
         )
 
-    def _create_monitor(self):
+    def _create_monitor(self, **kwargs):
         return Monitor.objects.create(
             organization_id=self.organization.id,
             project_id=self.project.id,
             next_checkin=timezone.now() - timedelta(minutes=1),
             type=MonitorType.CRON_JOB,
             config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+            **kwargs,
         )

--- a/tests/sentry/api/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_organization_monitor_details.py
@@ -17,9 +17,15 @@ class OrganizationMonitorDetailsTest(MonitorTestCase):
         resp = self.get_success_response(self.organization.slug, monitor.guid)
         assert resp.data["id"] == str(monitor.guid)
 
+    def test_simple_slug(self):
+        monitor = self._create_monitor(slug="my-monitor")
+
+        resp = self.get_success_response(self.organization.slug, monitor.slug)
+        assert resp.data["id"] == str(monitor.guid)
+
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        self.get_error_response("asdf", monitor.guid, status_code=400)
+        self.get_error_response("asdf", monitor.guid, status_code=404)
 
     def test_invalid_monitor_id(self):
         self._create_monitor()
@@ -238,7 +244,7 @@ class UpdateMonitorTest(MonitorTestCase):
             "asdf",
             monitor.guid,
             method="PUT",
-            status_code=400,
+            status_code=404,
             **{"config": {"schedule_type": "interval", "schedule": [1, "month"]}},
         )
 
@@ -281,4 +287,4 @@ class DeleteMonitorTest(MonitorTestCase):
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        self.get_error_response("asdf", monitor.guid, status_code=400)
+        self.get_error_response("asdf", monitor.guid, status_code=404)


### PR DESCRIPTION
Refactors the MonitorEndpoint base class to first try lookup via the monitor slug. This is only supported when the organization_slug is in the route parameters.

Fallback to looking up via GUID

This is pending a https://github.com/getsentry/sentry/pull/45292