### PR TITLE
fix(search): Use consistent border radii

### DIFF
--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -270,7 +270,7 @@ Modal.defaultProps = {
 
 const Content = styled('div')`
   background: ${p => p.theme.background};
-  border-radius: 8px;
+  border-radius: ${p => p.theme.modalBorderRadius};
   box-shadow: 0 0 0 1px ${p => p.theme.translucentBorder}, ${p => p.theme.dropShadowHeavy};
   position: relative;
   padding: ${space(4)} ${space(3)};

--- a/static/app/components/modals/commandPalette.tsx
+++ b/static/app/components/modals/commandPalette.tsx
@@ -64,7 +64,7 @@ const InputWrapper = styled('div')`
 const StyledInput = styled(Input)`
   width: 100%;
   padding: ${space(1)};
-  border-radius: 8px;
+  border-radius: ${p => p.theme.modalBorderRadius};
 
   outline: none;
   border: none;

--- a/static/app/components/search/list.tsx
+++ b/static/app/components/search/list.tsx
@@ -136,12 +136,12 @@ export default List;
 const DropdownBox = styled('div')`
   background: ${p => p.theme.background};
   border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.modalBorderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};
   position: absolute;
   top: 36px;
   right: 0;
   width: 400px;
-  border-radius: 5px;
   overflow: auto;
   max-height: 60vh;
 `;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -738,6 +738,7 @@ const commonTheme = {
   borderRadiusRight: '0 6px 6px 0',
 
   panelBorderRadius: '6px',
+  modalBorderRadius: '8px',
   linkBorderRadius: '2px',
 
   headerSelectorRowHeight: 44,


### PR DESCRIPTION
**Before ——**
<img width="666" alt="Screenshot 2023-03-01 at 3 26 31 PM" src="https://user-images.githubusercontent.com/44172267/222289829-02199218-d15b-42be-9a82-6252f417fcb4.png">

**After ——**
<img width="666" alt="Screenshot 2023-03-01 at 3 25 48 PM" src="https://user-images.githubusercontent.com/44172267/222289764-1e85e77d-7da6-4692-9055-2ebbd7d32abe.png">
