### PR TITLE
ref(hc): Remove future annotations in HC service declarations

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/__init__.py
+++ b/src/sentry/services/hybrid_cloud/app/__init__.py
@@ -1,4 +1,7 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 import abc
 import datetime
@@ -28,6 +31,19 @@ class RpcSentryAppService:
 
 
 @dataclass
+class RpcSentryApp:
+    id: int = -1
+    scope_list: List[str] = field(default_factory=list)
+    application_id: int = -1
+    proxy_user_id: Optional[int] = None  # can be null on deletion.
+    owner_id: int = -1  # relation to an organization
+    name: str = ""
+    slug: str = ""
+    uuid: str = ""
+    events: List[str] = field(default_factory=list)
+
+
+@dataclass
 class RpcSentryAppInstallation:
     id: int = -1
     organization_id: int = -1
@@ -43,19 +59,6 @@ class RpcSentryAppComponent:
     sentry_app_id: int = -1
     type: str = ""
     schema: Mapping[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class RpcSentryApp:
-    id: int = -1
-    scope_list: List[str] = field(default_factory=list)
-    application_id: int = -1
-    proxy_user_id: int | None = None  # can be null on deletion.
-    owner_id: int = -1  # relation to an organization
-    name: str = ""
-    slug: str = ""
-    uuid: str = ""
-    events: List[str] = field(default_factory=list)
 
 
 class SentryAppEventDataInterface(Protocol):
@@ -90,7 +93,7 @@ class RpcSentryAppEventData(SentryAppEventDataInterface):
         return self.enabled
 
     @classmethod
-    def from_event(cls, data_interface: SentryAppEventDataInterface) -> RpcSentryAppEventData:
+    def from_event(cls, data_interface: SentryAppEventDataInterface) -> "RpcSentryAppEventData":
         return RpcSentryAppEventData(
             id=data_interface.id,
             label=data_interface.label,
@@ -113,7 +116,7 @@ class AppService(
     @abc.abstractmethod
     def find_installation_by_proxy_user(
         self, *, proxy_user_id: int, organization_id: int
-    ) -> RpcSentryAppInstallation | None:
+    ) -> Optional[RpcSentryAppInstallation]:
         pass
 
     @abc.abstractmethod
@@ -143,7 +146,11 @@ class AppService(
 
     @abc.abstractmethod
     def get_custom_alert_rule_actions(
-        self, *, event_data: RpcSentryAppEventData, organization_id: int, project_slug: str | None
+        self,
+        *,
+        event_data: RpcSentryAppEventData,
+        organization_id: int,
+        project_slug: Optional[str],
     ) -> List[Mapping[str, Any]]:
         pass
 
@@ -163,7 +170,7 @@ class AppService(
         pass
 
     def serialize_sentry_app_installation(
-        self, installation: SentryAppInstallation, app: SentryApp | None = None
+        self, installation: SentryAppInstallation, app: Optional[SentryApp] = None
     ) -> RpcSentryAppInstallation:
         if app is None:
             app = installation.sentry_app
@@ -179,8 +186,8 @@ class AppService(
 
     @abc.abstractmethod
     def trigger_sentry_app_action_creators(
-        self, *, fields: List[Mapping[str, Any]], install_uuid: str | None
-    ) -> AlertRuleActionResult:
+        self, *, fields: List[Mapping[str, Any]], install_uuid: Optional[str]
+    ) -> "AlertRuleActionResult":
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/app/__init__.py
+++ b/src/sentry/services/hybrid_cloud/app/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 import abc
 import datetime

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -1,17 +1,21 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 import abc
 import base64
 import contextlib
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Any, Dict, Generator, List, Mapping, Tuple, Type
+from typing import Any, Dict, Generator, List, Mapping, Optional, Tuple, Type, Union
 
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.request import Request
 
 from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
+from sentry.models import OrganizationMember
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
 from sentry.services.hybrid_cloud.organization import RpcOrganization, RpcOrganizationMember
@@ -26,7 +30,9 @@ class RpcAuthenticatorType(IntEnum):
     SESSION_AUTHENTICATION = 2
 
     @classmethod
-    def from_authenticator(self, auth: Type[BaseAuthentication]) -> RpcAuthenticatorType | None:
+    def from_authenticator(
+        self, auth: Type[BaseAuthentication]
+    ) -> Optional["RpcAuthenticatorType"]:
         if auth == ApiKeyAuthentication:
             return RpcAuthenticatorType.API_KEY_AUTHENTICATION
         if auth == TokenAuthentication:
@@ -40,6 +46,61 @@ class RpcAuthenticatorType(IntEnum):
             return TokenAuthentication()
         else:
             raise ValueError(f"{self!r} has not authenticator associated with it.")
+
+
+def _normalize_to_b64(input: Optional[Union[str, bytes]]) -> Optional[str]:
+    if input is None:
+        return None
+    if isinstance(input, str):
+        input = input.encode("utf8")
+    return base64.b64encode(input).decode("utf8")
+
+
+class RpcAuthentication(BaseAuthentication):  # type: ignore
+    types: List[RpcAuthenticatorType]
+
+    def __init__(self, types: List[RpcAuthenticatorType]):
+        self.types = types
+
+    def authenticate(self, request: Request) -> Optional[Tuple[Any, Any]]:
+        response = auth_service.authenticate_with(
+            request=authentication_request_from(request), authenticator_types=self.types
+        )
+
+        if response.user is not None:
+            return response.user, response.auth
+
+        return None
+
+
+@dataclass(eq=True)
+class RpcMemberSsoState:
+    is_required: bool = False
+    is_valid: bool = False
+
+
+@dataclass
+class RpcAuthState:
+    sso_state: RpcMemberSsoState
+    permissions: List[str]
+
+
+@dataclass
+class AuthenticationRequest:
+    # HTTP_X_SENTRY_RELAY_ID
+    sentry_relay_id: Optional[str] = None
+    # HTTP_X_SENTRY_RELAY_SIGNATURE
+    sentry_relay_signature: Optional[str] = None
+    backend: Optional[str] = None
+    user_id: Optional[str] = None
+    user_hash: Optional[str] = None
+    nonce: Optional[str] = None
+    remote_addr: Optional[str] = None
+    signature: Optional[str] = None
+    absolute_url: str = ""
+    absolute_url_root: str = ""
+    path: str = ""
+    authorization_b64: Optional[str] = None
 
 
 def authentication_request_from(request: Request) -> AuthenticationRequest:
@@ -59,142 +120,18 @@ def authentication_request_from(request: Request) -> AuthenticationRequest:
     )
 
 
-def _normalize_to_b64(input: str | bytes | None) -> str | None:
-    if input is None:
-        return None
-    if isinstance(input, str):
-        input = input.encode("utf8")
-    return base64.b64encode(input).decode("utf8")
-
-
-class RpcAuthentication(BaseAuthentication):  # type: ignore
-    types: List[RpcAuthenticatorType]
-
-    def __init__(self, types: List[RpcAuthenticatorType]):
-        self.types = types
-
-    def authenticate(self, request: Request) -> Tuple[Any, Any] | None:
-        response = auth_service.authenticate_with(
-            request=authentication_request_from(request), authenticator_types=self.types
-        )
-
-        if response.user is not None:
-            return response.user, response.auth
-
-        return None
-
-
-class AuthService(InterfaceWithLifecycle):
-    @abc.abstractmethod
-    def authenticate(self, *, request: AuthenticationRequest) -> MiddlewareAuthenticationResponse:
-        pass
-
-    @abc.abstractmethod
-    def authenticate_with(
-        self, *, request: AuthenticationRequest, authenticator_types: List[RpcAuthenticatorType]
-    ) -> AuthenticationContext:
-        pass
-
-    @abc.abstractmethod
-    def get_org_auth_config(
-        self, *, organization_ids: List[int]
-    ) -> List[RpcOrganizationAuthConfig]:
-        pass
-
-    @abc.abstractmethod
-    def get_user_auth_state(
-        self,
-        *,
-        user_id: int,
-        is_superuser: bool,
-        organization_id: int | None,
-        org_member: RpcOrganizationMember | OrganizationMember | None,
-    ) -> RpcAuthState:
-        pass
-
-    # TODO: Denormalize this scim enabled flag onto organizations?
-    # This is potentially a large list
-    @abc.abstractmethod
-    def get_org_ids_with_scim(
-        self,
-    ) -> List[int]:
-        """
-        This method returns a list of org ids that have scim enabled
-        :return:
-        """
-        pass
-
-    @abc.abstractmethod
-    def get_auth_providers(self, organization_id: int) -> List[RpcAuthProvider]:
-        """
-        This method returns a list of auth providers for an org
-        :return:
-        """
-        pass
-
-    @abc.abstractmethod
-    def handle_new_membership(
-        self,
-        request: Request,
-        organization: RpcOrganization,
-        auth_identity: RpcAuthIdentity,
-        auth_provider: RpcAuthProvider,
-    ) -> Tuple[RpcUser, RpcOrganizationMember]:
-        pass
-
-    @abc.abstractmethod
-    def token_has_org_access(self, *, token: AuthenticatedToken, organization_id: int) -> bool:
-        pass
-
-
-def impl_with_db() -> AuthService:
-    from sentry.services.hybrid_cloud.auth.impl import DatabaseBackedAuthService
-
-    return DatabaseBackedAuthService()
-
-
-@dataclass
-class RpcAuthState:
-    sso_state: RpcMemberSsoState
-    permissions: List[str]
-
-
-@dataclass(eq=True)
-class RpcMemberSsoState:
-    is_required: bool = False
-    is_valid: bool = False
-
-
-@dataclass
-class AuthenticationRequest:
-    # HTTP_X_SENTRY_RELAY_ID
-    sentry_relay_id: str | None = None
-    # HTTP_X_SENTRY_RELAY_SIGNATURE
-    sentry_relay_signature: str | None = None
-    backend: str | None = None
-    user_id: str | None = None
-    user_hash: str | None = None
-    nonce: str | None = None
-    remote_addr: str | None = None
-    signature: str | None = None
-    absolute_url: str = ""
-    absolute_url_root: str = ""
-    path: str = ""
-    authorization_b64: str | None = None
-
-
 @dataclass(eq=True)
 class AuthenticatedToken:
-    entity_id: int | None = None
+    entity_id: Optional[int] = None
     kind: str = "system"
-    user_id: int | None = None  # only relevant for ApiToken
-    organization_id: int | None = None
+    user_id: Optional[int] = None  # only relevant for ApiToken
+    organization_id: Optional[int] = None
     allowed_origins: List[str] = field(default_factory=list)
     audit_log_data: Dict[str, Any] = field(default_factory=dict)
     scopes: List[str] = field(default_factory=list)
 
     @classmethod
-    def from_token(cls, token: Any) -> AuthenticatedToken | None:
+    def from_token(cls, token: Any) -> Optional["AuthenticatedToken"]:
         if token is None:
             return None
 
@@ -235,7 +172,7 @@ class AuthenticatedToken:
     def get_allowed_origins(self) -> List[str]:
         return self.allowed_origins
 
-    def get_scopes(self) -> list[str]:
+    def get_scopes(self) -> List[str]:
         return self.scopes
 
     def has_scope(self, scope: str) -> bool:
@@ -250,10 +187,10 @@ class AuthenticationContext:
     The default of all values should be a valid, non authenticated context.
     """
 
-    auth: AuthenticatedToken | None = None
-    user: RpcUser | None = None
+    auth: Optional[AuthenticatedToken] = None
+    user: Optional[RpcUser] = None
 
-    def _get_user(self) -> RpcUser | AnonymousUser:
+    def _get_user(self) -> Union[RpcUser, AnonymousUser]:
         """
         Helper function to avoid importing AnonymousUser when `applied_to_request` is run on startup
         """
@@ -333,8 +270,77 @@ class RpcAuthIdentity:
 @dataclass(eq=True)
 class RpcOrganizationAuthConfig:
     organization_id: int = -1
-    auth_provider: RpcAuthProvider | None = None
+    auth_provider: Optional[RpcAuthProvider] = None
     has_api_key: bool = False
+
+
+class AuthService(InterfaceWithLifecycle):
+    @abc.abstractmethod
+    def authenticate(self, *, request: AuthenticationRequest) -> MiddlewareAuthenticationResponse:
+        pass
+
+    @abc.abstractmethod
+    def authenticate_with(
+        self, *, request: AuthenticationRequest, authenticator_types: List[RpcAuthenticatorType]
+    ) -> AuthenticationContext:
+        pass
+
+    @abc.abstractmethod
+    def get_org_auth_config(
+        self, *, organization_ids: List[int]
+    ) -> List[RpcOrganizationAuthConfig]:
+        pass
+
+    @abc.abstractmethod
+    def get_user_auth_state(
+        self,
+        *,
+        user_id: int,
+        is_superuser: bool,
+        organization_id: Optional[int],
+        org_member: Optional[Union[RpcOrganizationMember, OrganizationMember]],
+    ) -> RpcAuthState:
+        pass
+
+    # TODO: Denormalize this scim enabled flag onto organizations?
+    # This is potentially a large list
+    @abc.abstractmethod
+    def get_org_ids_with_scim(
+        self,
+    ) -> List[int]:
+        """
+        This method returns a list of org ids that have scim enabled
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_auth_providers(self, organization_id: int) -> List[RpcAuthProvider]:
+        """
+        This method returns a list of auth providers for an org
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
+    def handle_new_membership(
+        self,
+        request: Request,
+        organization: RpcOrganization,
+        auth_identity: RpcAuthIdentity,
+        auth_provider: RpcAuthProvider,
+    ) -> Tuple[RpcUser, RpcOrganizationMember]:
+        pass
+
+    @abc.abstractmethod
+    def token_has_org_access(self, *, token: AuthenticatedToken, organization_id: int) -> bool:
+        pass
+
+
+def impl_with_db() -> AuthService:
+    from sentry.services.hybrid_cloud.auth.impl import DatabaseBackedAuthService
+
+    return DatabaseBackedAuthService()
 
 
 auth_service: AuthService = silo_mode_delegation(
@@ -346,5 +352,3 @@ auth_service: AuthService = silo_mode_delegation(
         ),  # this must eventually be purely RPC
     }
 )
-
-from sentry.models import OrganizationMember

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 import abc
 import base64

--- a/src/sentry/services/hybrid_cloud/identity/__init__.py
+++ b/src/sentry/services/hybrid_cloud/identity/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
 from dataclasses import dataclass

--- a/src/sentry/services/hybrid_cloud/identity/__init__.py
+++ b/src/sentry/services/hybrid_cloud/identity/__init__.py
@@ -1,9 +1,13 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
+from sentry.models.identity import Identity, IdentityProvider
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
 from sentry.silo import SiloMode
 
@@ -45,10 +49,10 @@ class IdentityService(InterfaceWithLifecycle):
     def get_provider(
         self,
         *,
-        provider_id: int | None = None,
-        provider_type: str | None = None,
-        provider_ext_id: str | None = None,
-    ) -> RpcIdentityProvider | None:
+        provider_id: Optional[int] = None,
+        provider_type: Optional[str] = None,
+        provider_ext_id: Optional[str] = None,
+    ) -> Optional[RpcIdentityProvider]:
         """
         Returns an RpcIdentityProvider either by using the idp.id (provider_id), or a combination
         of idp.type (provider_type) and idp.external_id (provider_ext_id)
@@ -60,9 +64,9 @@ class IdentityService(InterfaceWithLifecycle):
         self,
         *,
         provider_id: int,
-        user_id: int | None = None,
-        identity_ext_id: str | None = None,
-    ) -> RpcIdentity | None:
+        user_id: Optional[int] = None,
+        identity_ext_id: Optional[str] = None,
+    ) -> Optional[RpcIdentity]:
         """
         Returns an RpcIdentity using the idp.id (provider_id) and either the user.id (user_id)
         or identity.external_id (identity_ext_id)
@@ -98,5 +102,3 @@ identity_service: IdentityService = silo_mode_delegation(
         SiloMode.CONTROL: impl_with_db,
     }
 )
-
-from sentry.models.identity import Identity, IdentityProvider

--- a/src/sentry/services/hybrid_cloud/integration/__init__.py
+++ b/src/sentry/services/hybrid_cloud/integration/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
 from dataclasses import dataclass

--- a/src/sentry/services/hybrid_cloud/integration/__init__.py
+++ b/src/sentry/services/hybrid_cloud/integration/__init__.py
@@ -1,11 +1,15 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from sentry.constants import ObjectStatus
+from sentry.models.integrations import Integration, OrganizationIntegration
 from sentry.services.hybrid_cloud import (
     InterfaceWithLifecycle,
     RpcPaginationArgs,
@@ -14,6 +18,13 @@ from sentry.services.hybrid_cloud import (
     stubbed,
 )
 from sentry.silo import SiloMode
+
+if TYPE_CHECKING:
+    from sentry.integrations.base import (
+        IntegrationFeatures,
+        IntegrationInstallation,
+        IntegrationProvider,
+    )
 
 
 @dataclass(frozen=True, eq=True)
@@ -28,7 +39,7 @@ class RpcIntegration:
     def __hash__(self) -> int:
         return hash(self.id)
 
-    def get_provider(self) -> IntegrationProvider:
+    def get_provider(self) -> "IntegrationProvider":
         from sentry import integrations
 
         return integrations.get(self.provider)  # type: ignore
@@ -48,7 +59,7 @@ class RpcOrganizationIntegration:
     integration_id: int
     config: Dict[str, Any]
     status: int  # As ObjectStatus
-    grace_period_end: datetime | None
+    grace_period_end: Optional[datetime]
 
     def __hash__(self) -> int:
         return hash(self.id)
@@ -100,7 +111,7 @@ class IntegrationService(InterfaceWithLifecycle):
         *,
         organization_id: int,
         statuses: List[int],
-        provider_key: str | None = None,
+        provider_key: Optional[str] = None,
         args: RpcPaginationArgs,
     ) -> RpcPaginationResult:
         pass
@@ -109,12 +120,12 @@ class IntegrationService(InterfaceWithLifecycle):
     def get_integrations(
         self,
         *,
-        integration_ids: Iterable[int] | None = None,
-        organization_id: int | None = None,
-        status: int | None = None,
-        providers: List[str] | None = None,
-        org_integration_status: int | None = None,
-        limit: int | None = None,
+        integration_ids: Optional[Iterable[int]] = None,
+        organization_id: Optional[int] = None,
+        status: Optional[int] = None,
+        providers: Optional[List[str]] = None,
+        org_integration_status: Optional[int] = None,
+        limit: Optional[int] = None,
     ) -> List[RpcIntegration]:
         """
         Returns all APIIntegrations matching the provided kwargs.
@@ -125,10 +136,10 @@ class IntegrationService(InterfaceWithLifecycle):
     def get_integration(
         self,
         *,
-        integration_id: int | None = None,
-        provider: str | None = None,
-        external_id: str | None = None,
-    ) -> RpcIntegration | None:
+        integration_id: Optional[int] = None,
+        provider: Optional[str] = None,
+        external_id: Optional[str] = None,
+    ) -> Optional[RpcIntegration]:
         """
         Returns an RpcIntegration using either the id or a combination of the provider and external_id
         """
@@ -138,13 +149,13 @@ class IntegrationService(InterfaceWithLifecycle):
     def get_organization_integrations(
         self,
         *,
-        org_integration_ids: List[int] | None = None,
-        integration_id: int | None = None,
-        organization_id: int | None = None,
-        status: int | None = None,
-        providers: List[str] | None = None,
-        has_grace_period: bool | None = None,
-        limit: int | None = None,
+        org_integration_ids: Optional[List[int]] = None,
+        integration_id: Optional[int] = None,
+        organization_id: Optional[int] = None,
+        status: Optional[int] = None,
+        providers: Optional[List[str]] = None,
+        has_grace_period: Optional[bool] = None,
+        limit: Optional[int] = None,
     ) -> List[RpcOrganizationIntegration]:
         """
         Returns all APIOrganizationIntegrations from the matching kwargs.
@@ -155,7 +166,7 @@ class IntegrationService(InterfaceWithLifecycle):
 
     def get_organization_integration(
         self, *, integration_id: int, organization_id: int
-    ) -> RpcOrganizationIntegration | None:
+    ) -> Optional[RpcOrganizationIntegration]:
         """
         Returns an RpcOrganizationIntegration from the integration and organization ids.
         """
@@ -169,10 +180,10 @@ class IntegrationService(InterfaceWithLifecycle):
         self,
         *,
         organization_id: int,
-        integration_id: int | None = None,
-        provider: str | None = None,
-        external_id: str | None = None,
-    ) -> Tuple[RpcIntegration | None, RpcOrganizationIntegration | None]:
+        integration_id: Optional[int] = None,
+        provider: Optional[str] = None,
+        external_id: Optional[str] = None,
+    ) -> Tuple[Optional[RpcIntegration], Optional[RpcOrganizationIntegration]]:
         """
         Returns a tuple of RpcIntegration and RpcOrganizationIntegration. The integration is selected
         by either integration_id, or a combination of provider and external_id.
@@ -184,9 +195,9 @@ class IntegrationService(InterfaceWithLifecycle):
         self,
         *,
         integration_ids: List[int],
-        name: str | None = None,
-        metadata: Dict[str, Any] | None = None,
-        status: int | None = None,
+        name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        status: Optional[int] = None,
     ) -> List[RpcIntegration]:
         """
         Returns a list of APIIntegrations after updating the fields provided.
@@ -199,10 +210,10 @@ class IntegrationService(InterfaceWithLifecycle):
         self,
         *,
         integration_id: int,
-        name: str | None = None,
-        metadata: Dict[str, Any] | None = None,
-        status: int | None = None,
-    ) -> RpcIntegration | None:
+        name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        status: Optional[int] = None,
+    ) -> Optional[RpcIntegration]:
         """
         Returns an RpcIntegration after updating the fields provided.
         To set a field as null, use the `set_{FIELD}_null` keyword argument.
@@ -214,10 +225,10 @@ class IntegrationService(InterfaceWithLifecycle):
         self,
         *,
         org_integration_ids: List[int],
-        config: Dict[str, Any] | None = None,
-        status: int | None = None,
-        grace_period_end: datetime | None = None,
-        set_grace_period_end_null: bool | None = None,
+        config: Optional[Dict[str, Any]] = None,
+        status: Optional[int] = None,
+        grace_period_end: Optional[datetime] = None,
+        set_grace_period_end_null: Optional[bool] = None,
     ) -> List[RpcOrganizationIntegration]:
         """
         Returns a list of APIOrganizationIntegrations after updating the fields provided.
@@ -230,11 +241,11 @@ class IntegrationService(InterfaceWithLifecycle):
         self,
         *,
         org_integration_id: int,
-        config: Dict[str, Any] | None = None,
-        status: int | None = None,
-        grace_period_end: datetime | None = None,
-        set_grace_period_end_null: bool | None = None,
-    ) -> RpcOrganizationIntegration | None:
+        config: Optional[Dict[str, Any]] = None,
+        status: Optional[int] = None,
+        grace_period_end: Optional[datetime] = None,
+        set_grace_period_end_null: Optional[bool] = None,
+    ) -> Optional[RpcOrganizationIntegration]:
         """
         Returns an RpcOrganizationIntegration after updating the fields provided.
         To set a field as null, use the `set_{FIELD}_null` keyword argument.
@@ -246,9 +257,9 @@ class IntegrationService(InterfaceWithLifecycle):
     def get_installation(
         self,
         *,
-        integration: RpcIntegration | Integration,
+        integration: Union[RpcIntegration, Integration],
         organization_id: int,
-    ) -> IntegrationInstallation:
+    ) -> "IntegrationInstallation":
         """
         Returns the IntegrationInstallation class for a given integration.
         Intended to replace calls of `integration.get_installation`.
@@ -257,13 +268,13 @@ class IntegrationService(InterfaceWithLifecycle):
         from sentry import integrations
 
         provider = integrations.get(integration.provider)
-        installation: IntegrationInstallation = provider.get_installation(
+        installation: "IntegrationInstallation" = provider.get_installation(
             model=integration,
             organization_id=organization_id,
         )
         return installation
 
-    def has_feature(self, *, provider: str, feature: IntegrationFeatures) -> bool:
+    def has_feature(self, *, provider: str, feature: "IntegrationFeatures") -> bool:
         """
         Returns True if the IntegrationProvider subclass contains a given feature
         Intended to replace calls of `integration.has_feature`.
@@ -271,7 +282,7 @@ class IntegrationService(InterfaceWithLifecycle):
         """
         from sentry import integrations
 
-        int_provider: IntegrationProvider = integrations.get(provider)
+        int_provider: "IntegrationProvider" = integrations.get(provider)
         return feature in int_provider.features
 
 
@@ -288,10 +299,3 @@ integration_service: IntegrationService = silo_mode_delegation(
         SiloMode.CONTROL: impl_with_db,
     }
 )
-
-from sentry.integrations.base import (
-    IntegrationFeatures,
-    IntegrationInstallation,
-    IntegrationProvider,
-)
-from sentry.models.integrations import Integration, OrganizationIntegration

--- a/src/sentry/services/hybrid_cloud/log/__init__.py
+++ b/src/sentry/services/hybrid_cloud/log/__init__.py
@@ -1,3 +1,8 @@
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
+
 import abc
 import datetime
 from dataclasses import dataclass

--- a/src/sentry/services/hybrid_cloud/log/__init__.py
+++ b/src/sentry/services/hybrid_cloud/log/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 import abc
 import datetime

--- a/src/sentry/services/hybrid_cloud/lost_password_hash/__init__.py
+++ b/src/sentry/services/hybrid_cloud/lost_password_hash/__init__.py
@@ -1,3 +1,8 @@
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
+
 import datetime
 from abc import abstractmethod
 from dataclasses import dataclass, fields

--- a/src/sentry/services/hybrid_cloud/lost_password_hash/__init__.py
+++ b/src/sentry/services/hybrid_cloud/lost_password_hash/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 import datetime
 from abc import abstractmethod

--- a/src/sentry/services/hybrid_cloud/notifications/__init__.py
+++ b/src/sentry/services/hybrid_cloud/notifications/__init__.py
@@ -1,8 +1,11 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 import dataclasses
 from abc import abstractmethod
-from typing import TYPE_CHECKING, List, Protocol, Sequence
+from typing import TYPE_CHECKING, List, Optional, Protocol, Sequence
 
 from sentry.notifications.types import (
     NotificationScopeType,
@@ -34,7 +37,7 @@ class MayHaveActor(Protocol):
         pass
 
     @property
-    def actor_id(self) -> int | None:
+    def actor_id(self) -> Optional[int]:
         pass
 
     def class_name(self) -> str:
@@ -69,7 +72,7 @@ class NotificationsService(InterfaceWithLifecycle):
         pass
 
     def _serialize_notification_settings(
-        self, setting: NotificationSetting
+        self, setting: "NotificationSetting"
     ) -> RpcNotificationSetting:
         return RpcNotificationSetting(
             scope_type=setting.scope_type,

--- a/src/sentry/services/hybrid_cloud/notifications/__init__.py
+++ b/src/sentry/services/hybrid_cloud/notifications/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 import dataclasses
 from abc import abstractmethod

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
 from dataclasses import dataclass, field

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -1,133 +1,17 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, List, Mapping, Optional
 
 from sentry.models.organization import OrganizationStatus
+from sentry.roles.manager import TeamRole
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
-
-
-class OrganizationService(InterfaceWithLifecycle):
-    @abstractmethod
-    def get_organization_by_id(
-        self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
-    ) -> Optional[RpcUserOrganizationContext]:
-        """
-        Fetches the organization, team, and project data given by an organization id, regardless of its visibility
-        status.  When user_id is provided, membership data related to that user from the organization
-        is also given in the response.  See RpcUserOrganizationContext for more info.
-        """
-        pass
-
-    # TODO: This should return RpcOrganizationSummary objects, since we cannot realistically span out requests and
-    #  capture full org objects / teams / permissions.  But we can gather basic summary data from the control silo.
-    @abstractmethod
-    def get_organizations(
-        self,
-        user_id: Optional[int],
-        scope: Optional[str],
-        only_visible: bool,
-        organization_ids: Optional[List[int]] = None,
-    ) -> List[RpcOrganizationSummary]:
-        """
-        When user_id is set, returns all organizations associated with that user id given
-        a scope and visibility requirement.  When user_id is not set, but organization_ids is, provides the
-        set of organizations matching those ids, ignore scope and user_id.
-
-        When only_visible set, the organization object is only returned if it's status is Visible, otherwise any
-        organization will be returned.
-
-        Because this endpoint fetches not from region silos, but the control silo organization membership table,
-        only a subset of all organization metadata is available.  Spanning out and querying multiple organizations
-        for their full metadata is greatly discouraged for performance reasons.
-        """
-        pass
-
-    @abstractmethod
-    def check_membership_by_email(
-        self, organization_id: int, email: str
-    ) -> Optional[RpcOrganizationMember]:
-        """
-        Used to look up an organization membership by an email
-        """
-        pass
-
-    @abstractmethod
-    def check_membership_by_id(
-        self, organization_id: int, user_id: int
-    ) -> Optional[RpcOrganizationMember]:
-        """
-        Used to look up an organization membership by a user id
-        """
-        pass
-
-    @abstractmethod
-    def check_organization_by_slug(self, *, slug: str, only_visible: bool) -> Optional[int]:
-        """
-        If exists and matches the only_visible requirement, returns an organization's id by the slug.
-        """
-        pass
-
-    def get_organization_by_slug(
-        self, *, user_id: Optional[int], slug: str, only_visible: bool
-    ) -> Optional[RpcUserOrganizationContext]:
-        """
-        Defers to check_organization_by_slug -> get_organization_by_id
-        """
-        org_id = self.check_organization_by_slug(slug=slug, only_visible=only_visible)
-        if org_id is None:
-            return None
-
-        return self.get_organization_by_id(id=org_id, user_id=user_id)
-
-    @abstractmethod
-    def add_organization_member(
-        self,
-        *,
-        organization: RpcOrganization,
-        user: RpcUser,
-        flags: RpcOrganizationMemberFlags | None,
-        role: str | None,
-    ) -> RpcOrganizationMember:
-        pass
-
-    @abstractmethod
-    def add_team_member(self, *, team_id: int, organization_member: RpcOrganizationMember) -> None:
-        pass
-
-    @abstractmethod
-    def update_membership_flags(self, *, organization_member: RpcOrganizationMember) -> None:
-        pass
-
-    @abstractmethod
-    def get_all_org_roles(
-        self,
-        organization_member: Optional[RpcOrganizationMember] = None,
-        member_id: Optional[int] = None,
-    ) -> List[str]:
-        pass
-
-    @abstractmethod
-    def get_top_dog_team_member_ids(self, organization_id: int) -> List[int]:
-        pass
-
-
-def impl_with_db() -> OrganizationService:
-    from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
-
-    return DatabaseBackedOrganizationService()
-
-
-organization_service: OrganizationService = silo_mode_delegation(
-    {
-        SiloMode.MONOLITH: impl_with_db,
-        SiloMode.REGION: impl_with_db,
-        SiloMode.CONTROL: stubbed(impl_with_db, SiloMode.REGION),
-    }
-)
 
 
 def team_status_visible() -> int:
@@ -142,7 +26,7 @@ class RpcTeam:
     status: int = field(default_factory=team_status_visible)
     organization_id: int = -1
     slug: str = ""
-    actor_id: int | None = None
+    actor_id: Optional[int] = None
     org_role: str = ""
 
     def class_name(self) -> str:
@@ -281,4 +165,121 @@ class RpcUserOrganizationContext:
             assert self.user_id == self.member.user_id
 
 
-from sentry.roles.manager import TeamRole
+class OrganizationService(InterfaceWithLifecycle):
+    @abstractmethod
+    def get_organization_by_id(
+        self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
+    ) -> Optional[RpcUserOrganizationContext]:
+        """
+        Fetches the organization, team, and project data given by an organization id, regardless of its visibility
+        status.  When user_id is provided, membership data related to that user from the organization
+        is also given in the response.  See RpcUserOrganizationContext for more info.
+        """
+        pass
+
+    # TODO: This should return RpcOrganizationSummary objects, since we cannot realistically span out requests and
+    #  capture full org objects / teams / permissions.  But we can gather basic summary data from the control silo.
+    @abstractmethod
+    def get_organizations(
+        self,
+        user_id: Optional[int],
+        scope: Optional[str],
+        only_visible: bool,
+        organization_ids: Optional[List[int]] = None,
+    ) -> List[RpcOrganizationSummary]:
+        """
+        When user_id is set, returns all organizations associated with that user id given
+        a scope and visibility requirement.  When user_id is not set, but organization_ids is, provides the
+        set of organizations matching those ids, ignore scope and user_id.
+
+        When only_visible set, the organization object is only returned if it's status is Visible, otherwise any
+        organization will be returned.
+
+        Because this endpoint fetches not from region silos, but the control silo organization membership table,
+        only a subset of all organization metadata is available.  Spanning out and querying multiple organizations
+        for their full metadata is greatly discouraged for performance reasons.
+        """
+        pass
+
+    @abstractmethod
+    def check_membership_by_email(
+        self, organization_id: int, email: str
+    ) -> Optional[RpcOrganizationMember]:
+        """
+        Used to look up an organization membership by an email
+        """
+        pass
+
+    @abstractmethod
+    def check_membership_by_id(
+        self, organization_id: int, user_id: int
+    ) -> Optional[RpcOrganizationMember]:
+        """
+        Used to look up an organization membership by a user id
+        """
+        pass
+
+    @abstractmethod
+    def check_organization_by_slug(self, *, slug: str, only_visible: bool) -> Optional[int]:
+        """
+        If exists and matches the only_visible requirement, returns an organization's id by the slug.
+        """
+        pass
+
+    def get_organization_by_slug(
+        self, *, user_id: Optional[int], slug: str, only_visible: bool
+    ) -> Optional[RpcUserOrganizationContext]:
+        """
+        Defers to check_organization_by_slug -> get_organization_by_id
+        """
+        org_id = self.check_organization_by_slug(slug=slug, only_visible=only_visible)
+        if org_id is None:
+            return None
+
+        return self.get_organization_by_id(id=org_id, user_id=user_id)
+
+    @abstractmethod
+    def add_organization_member(
+        self,
+        *,
+        organization: RpcOrganization,
+        user: RpcUser,
+        flags: Optional[RpcOrganizationMemberFlags],
+        role: Optional[str],
+    ) -> RpcOrganizationMember:
+        pass
+
+    @abstractmethod
+    def add_team_member(self, *, team_id: int, organization_member: RpcOrganizationMember) -> None:
+        pass
+
+    @abstractmethod
+    def update_membership_flags(self, *, organization_member: RpcOrganizationMember) -> None:
+        pass
+
+    @abstractmethod
+    def get_all_org_roles(
+        self,
+        organization_member: Optional[RpcOrganizationMember] = None,
+        member_id: Optional[int] = None,
+    ) -> List[str]:
+        pass
+
+    @abstractmethod
+    def get_top_dog_team_member_ids(self, organization_id: int) -> List[int]:
+        pass
+
+
+def impl_with_db() -> OrganizationService:
+    from sentry.services.hybrid_cloud.organization.impl import DatabaseBackedOrganizationService
+
+    return DatabaseBackedOrganizationService()
+
+
+organization_service: OrganizationService = silo_mode_delegation(
+    {
+        SiloMode.MONOLITH: impl_with_db,
+        SiloMode.REGION: impl_with_db,
+        SiloMode.CONTROL: stubbed(impl_with_db, SiloMode.REGION),
+    }
+)

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
 from dataclasses import dataclass

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -1,4 +1,7 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -7,6 +10,7 @@ from typing import Optional
 
 from django.utils import timezone
 
+from sentry.models import Organization
 from sentry.models.user import User
 from sentry.services.hybrid_cloud import (
     InterfaceWithLifecycle,
@@ -37,7 +41,7 @@ class RpcOrganizationMappingUpdate(PatchableMixin["Organization"]):
     customer_id: Unset[str] = UnsetVal
 
     @classmethod
-    def from_instance(cls, inst: Organization) -> RpcOrganizationMappingUpdate:
+    def from_instance(cls, inst: Organization) -> "RpcOrganizationMappingUpdate":
         return cls(**cls.params_from_instance(inst), organization_id=inst.id)
 
 
@@ -101,5 +105,3 @@ organization_mapping_service: OrganizationMappingService = silo_mode_delegation(
         SiloMode.CONTROL: impl_with_db,
     }
 )
-
-from sentry.models import Organization

--- a/src/sentry/services/hybrid_cloud/project_key/__init__.py
+++ b/src/sentry/services/hybrid_cloud/project_key/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
 from dataclasses import dataclass

--- a/src/sentry/services/hybrid_cloud/project_key/__init__.py
+++ b/src/sentry/services/hybrid_cloud/project_key/__init__.py
@@ -1,3 +1,8 @@
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
+
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum

--- a/src/sentry/services/hybrid_cloud/tombstone/__init__.py
+++ b/src/sentry/services/hybrid_cloud/tombstone/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
 from dataclasses import dataclass

--- a/src/sentry/services/hybrid_cloud/tombstone/__init__.py
+++ b/src/sentry/services/hybrid_cloud/tombstone/__init__.py
@@ -1,3 +1,8 @@
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
+
 from abc import abstractmethod
 from dataclasses import dataclass
 

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 import datetime
 from abc import abstractmethod

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -1,4 +1,7 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 import datetime
 from abc import abstractmethod
@@ -12,6 +15,31 @@ from sentry.silo import SiloMode
 
 if TYPE_CHECKING:
     from sentry.models import Group
+
+
+@dataclass(frozen=True, eq=True)
+class RpcAvatar:
+    id: int = 0
+    file_id: int = 0
+    ident: str = ""
+    avatar_type: str = "letter_avatar"
+
+
+@dataclass(frozen=True, eq=True)
+class RpcUserEmail:
+    id: int = 0
+    email: str = ""
+    is_verified: bool = False
+
+
+@dataclass(frozen=True, eq=True)
+class RpcAuthenticator:
+    id: int = 0
+    user_id: int = -1
+    created_at: datetime.datetime = datetime.datetime(2000, 1, 1)
+    last_used_at: datetime.datetime = datetime.datetime(2000, 1, 1)
+    type: int = -1
+    config: Any = None
 
 
 @dataclass(frozen=True, eq=True)
@@ -30,7 +58,7 @@ class RpcUser:
     is_anonymous: bool = False
     is_active: bool = False
     is_staff: bool = False
-    last_active: datetime.datetime | None = None
+    last_active: Optional[datetime.datetime] = None
     is_sentry_app: bool = False
     password_usable: bool = False
     is_password_expired: bool = False
@@ -67,31 +95,6 @@ class RpcUser:
 
     def has_2fa(self) -> bool:
         return len(self.authenticators) > 0
-
-
-@dataclass(frozen=True, eq=True)
-class RpcAvatar:
-    id: int = 0
-    file_id: int = 0
-    ident: str = ""
-    avatar_type: str = "letter_avatar"
-
-
-@dataclass(frozen=True, eq=True)
-class RpcUserEmail:
-    id: int = 0
-    email: str = ""
-    is_verified: bool = False
-
-
-@dataclass(frozen=True, eq=True)
-class RpcAuthenticator:
-    id: int = 0
-    user_id: int = -1
-    created_at: datetime.datetime = datetime.datetime(2000, 1, 1)
-    last_used_at: datetime.datetime = datetime.datetime(2000, 1, 1)
-    type: int = -1
-    config: Any = None
 
 
 class UserSerializeType(IntEnum):  # annoying
@@ -132,7 +135,7 @@ class UserService(
 
     @abstractmethod
     def get_by_username(
-        self, username: str, with_valid_password: bool = True, is_active: bool | None = None
+        self, username: str, with_valid_password: bool = True, is_active: Optional[bool] = None
     ) -> List[RpcUser]:
         """
         Return a list of users that match a username and falling back to email
@@ -147,7 +150,7 @@ class UserService(
         pass
 
     @abstractmethod
-    def get_from_group(self, group: Group) -> List[RpcUser]:
+    def get_from_group(self, group: "Group") -> List[RpcUser]:
         """Get all users in all teams in a given Group's project."""
         pass
 

--- a/src/sentry/services/hybrid_cloud/user_option/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user_option/__init__.py
@@ -1,7 +1,7 @@
 # Please do not use
 #     from __future__ import annotations
-# in this module, as we want to reflect on type annotations and avoid forward
-# references where hybrid cloud service classes and data models are defined.
+# in modules such as this one where hybrid cloud service classes and data models are
+# defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
 from dataclasses import dataclass

--- a/src/sentry/services/hybrid_cloud/user_option/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user_option/__init__.py
@@ -1,4 +1,7 @@
-from __future__ import annotations
+# Please do not use
+#     from __future__ import annotations
+# in this module, as we want to reflect on type annotations and avoid forward
+# references where hybrid cloud service classes and data models are defined.
 
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -15,15 +18,15 @@ class RpcUserOption:
     user_id: int = -1
     value: Any = None
     key: str = ""
-    project_id: int | None = None
-    organization_id: int | None = None
+    project_id: Optional[int] = None
+    organization_id: Optional[int] = None
 
 
 def get_option_from_list(
     options: List[RpcUserOption],
     *,
-    key: str | None = None,
-    user_id: int | None = None,
+    key: Optional[str] = None,
+    user_id: Optional[int] = None,
     default: Any = None,
 ) -> Any:
     for option in options:
@@ -57,8 +60,8 @@ class UserOptionService(
         user_id: int,
         value: Any,
         key: str,
-        project_id: int | None = None,
-        organization_id: int | None = None,
+        project_id: Optional[int] = None,
+        organization_id: Optional[int] = None,
     ) -> None:
         pass
 


### PR DESCRIPTION
The motive is to be able to reflect on type annotations when automatically wiring the services into remote procedure calls, including serializing and deserializing arguments. The main benefit is to fail loudly in case a type annotation makes a forward reference.

This would ideally be a temporary convention: the problem would go away if we upgrade to Python 3.10.