### PR TITLE
fix(profiling): Show full duration of transaction on profile

### DIFF
--- a/static/app/utils/profiling/flamegraph.spec.tsx
+++ b/static/app/utils/profiling/flamegraph.spec.tsx
@@ -365,12 +365,4 @@ describe('flamegraph', () => {
   it('Empty', () => {
     expect(Flamegraph.Empty().configSpace.equals(new Rect(0, 0, 1_000, 0))).toBe(true);
   });
-
-  it('setConfigSpace', () => {
-    expect(
-      Flamegraph.Empty()
-        .setConfigSpace(new Rect(0, 0, 10, 5))
-        .configSpace.equals(new Rect(0, 0, 10, 5))
-    ).toBe(true);
-  });
 });

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -338,9 +338,4 @@ export class Flamegraph {
 
     return matches;
   }
-
-  setConfigSpace(configSpace: Rect): Flamegraph {
-    this.configSpace = configSpace;
-    return this;
-  }
 }

--- a/static/app/utils/profiling/hooks/useSentryEvent.tsx
+++ b/static/app/utils/profiling/hooks/useSentryEvent.tsx
@@ -30,6 +30,8 @@ export function useSentryEvent<T extends Event>(
       return undefined;
     }
 
+    setRequestState({type: 'loading'});
+
     fetchSentryEvent<T>(api, organizationSlug, projectSlug, eventId)
       .then(event => {
         setRequestState({


### PR DESCRIPTION
When there is a transaction associated, the x axis should show the full width of the transaction.