### PR TITLE
fix(dx): Throw error on failing to drop db in reset-db

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -220,7 +220,7 @@ clean() {
 
 drop-db() {
     echo "--> Dropping existing 'sentry' database"
-    docker exec sentry_postgres dropdb -h 127.0.0.1 -U postgres sentry || true
+    docker exec sentry_postgres dropdb --if-exists -h 127.0.0.1 -U postgres sentry
 }
 
 reset-db() {


### PR DESCRIPTION
Originally this was likely `|| true` since it would fail if the db didn't already exist, we can use [`--if-exists`](https://www.postgresql.org/docs/current/app-dropdb.html#id-1.9.4.6.6) to make this better