### PR TITLE
feat(crons): Add monitor slug to APIs

### DIFF
--- a/src/sentry/api/endpoints/organization_monitor_details.py
+++ b/src/sentry/api/endpoints/organization_monitor_details.py
@@ -91,6 +91,8 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         params = {}
         if "name" in result:
             params["name"] = result["name"]
+        if "slug" in result:
+            params["slug"] = result["slug"]
         if "status" in result:
             if result["status"] == MonitorStatus.ACTIVE:
                 if monitor.status not in (MonitorStatus.OK, MonitorStatus.ERROR):

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -122,6 +122,7 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
             project_id=result["project"].id,
             organization_id=organization.id,
             name=result["name"],
+            slug=result.get("slug"),
             status=result["status"],
             type=result["type"],
             config=result["config"],

--- a/src/sentry/api/serializers/models/monitor.py
+++ b/src/sentry/api/serializers/models/monitor.py
@@ -34,6 +34,7 @@ class MonitorSerializer(Serializer):
             "status": obj.get_status_display(),
             "type": obj.get_type_display(),
             "name": obj.name,
+            "slug": obj.slug,
             "config": config,
             "lastCheckIn": obj.last_checkin,
             "nextCheckIn": obj.next_checkin,
@@ -45,6 +46,7 @@ class MonitorSerializer(Serializer):
 class MonitorSerializerResponse(TypedDict):
     id: str
     name: str
+    slug: str
     status: str
     type: str
     config: Any

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -89,6 +89,7 @@ class CronJobValidator(serializers.Serializer):
 class MonitorValidator(serializers.Serializer):
     project = ProjectField(scope="project:read")
     name = serializers.CharField()
+    slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50, required=False)
     status = serializers.ChoiceField(
         choices=list(zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys())), default="active"
     )

--- a/src/sentry/models/monitor.py
+++ b/src/sentry/models/monitor.py
@@ -156,7 +156,7 @@ class Monitor(Model):
         # NOTE: We ONLY set a slug while saving when creating a new monitor and
         # the slug has not been set. Otherwise existing monitors without slugs
         # would have their guids changed
-        if self._state.adding is True and self.slug == "":
+        if self._state.adding is True and not self.slug:
             self.guid = uuid4()
             self.slug = str(self.guid)
         return super().save(*args, **kwargs)

--- a/tests/sentry/api/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_organization_monitor_details.py
@@ -22,6 +22,12 @@ class OrganizationMonitorDetailsTest(MonitorTestCase):
 
         resp = self.get_success_response(self.organization.slug, monitor.slug)
         assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == "my-monitor"
+
+        # GUID based lookup also works
+        resp = self.get_success_response(self.organization.slug, monitor.guid)
+        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == "my-monitor"
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
@@ -49,6 +55,24 @@ class UpdateMonitorTest(MonitorTestCase):
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.name == "Monitor Name"
+
+    def test_slug(self):
+        monitor = self._create_monitor()
+        resp = self.get_success_response(
+            self.organization.slug, monitor.guid, method="PUT", **{"slug": "my-monitor"}
+        )
+        assert resp.data["id"] == str(monitor.guid)
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.slug == "my-monitor"
+
+        # Validate error cases jsut to be safe
+        self.get_error_response(
+            self.organization.slug, monitor.guid, method="PUT", status_code=400, **{"slug": ""}
+        )
+        self.get_error_response(
+            self.organization.slug, monitor.guid, method="PUT", status_code=400, **{"slug": None}
+        )
 
     def test_can_disable(self):
         monitor = self._create_monitor()

--- a/tests/sentry/api/endpoints/test_organization_monitors.py
+++ b/tests/sentry/api/endpoints/test_organization_monitors.py
@@ -105,3 +105,16 @@ class CreateOrganizationMonitorTest(OrganizationMonitorsTestBase):
             organization_id=self.organization.id,
             project_id=self.project.id,
         )
+
+    def test_slug(self):
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "slug": "my-monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+        response = self.get_success_response(self.organization.slug, **data)
+
+        assert response.data["id"]
+        assert response.data["slug"] == "my-monitor"


### PR DESCRIPTION
* Returns slug as part of the serialized monitor
 * Allows slug to be specified for creation and updates