### PR TITLE
fix(devserver): Fix metrics indexer CLI args

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -14,9 +14,9 @@ from sentry.runner.decorators import configuration, log_options
 _DEV_METRICS_INDEXER_ARGS = [
     # We don't want to burn laptop CPU while idle, but do want for
     # metrics to be ingested with lowest latency possible.
-    "--max-batch-time-ms",
+    "--max-msg-batch-time-ms",
     "10000",
-    "--max-batch-size",
+    "--max-msg-batch-size",
     "1",
     # We don't really need more than 1 process.
     "--processes",


### PR DESCRIPTION
Change devserver args to the metrics indexer consumer from `--max-batch-size` to `--max-msg-batch-size`.

The consumer failed to start because as of https://github.com/getsentry/sentry/pull/45092, the former argument does not exist on this consumer anymore.
