### PR TITLE
hotfix (dyn-sampling): Prevent to generate model negative sample_rates

### DIFF
--- a/src/sentry/dynamic_sampling/models/adjustment_models.py
+++ b/src/sentry/dynamic_sampling/models/adjustment_models.py
@@ -10,6 +10,7 @@ class DSProject:
     blended_sample_rate: float
     new_count_per_root: float = 0.0
     new_sample_rate: float = 0.0
+    _diff: float = 0.0
 
 
 @dataclass
@@ -57,18 +58,21 @@ class AdjustedModel:
                 (average - left.count_per_root),
                 (max_possible_count - left.count_per_root),
             )
+            left._diff = diff
             left.new_count_per_root = left.count_per_root + diff
             left.new_sample_rate = left.blended_sample_rate * (
                 left.new_count_per_root / left.count_per_root
             )
-            right.new_count_per_root = right.count_per_root - diff
+            right._diff = diff
+            # we want to calculate abs difference, and then calculate proportion
+            right.new_count_per_root = abs(right.count_per_root - diff)
             right.new_sample_rate = right.blended_sample_rate * (
                 right.new_count_per_root / right.count_per_root
             )
             new_left.append(left)
             new_right.append(right)
             # This opinionated `coefficient` reduces adjustment on every step
-            coefficient = diff / left.new_count_per_root
+            coefficient = abs(diff / left.new_count_per_root)
 
         if len(sorted_projects) % 2 == 0:
             return [*new_right, *reversed(new_left)]

--- a/tests/sentry/dynamic_sampling/test_adjusments_models.py
+++ b/tests/sentry/dynamic_sampling/test_adjusments_models.py
@@ -34,6 +34,7 @@ def test_adjust_sample_rates_org_with_few_projects():
             new_count_per_root=6.0,
             blended_sample_rate=0.25,
             new_sample_rate=pytest.approx(0.16666666666666666),
+            _diff=3.0,
         ),
         P(
             id=2,
@@ -41,6 +42,7 @@ def test_adjust_sample_rates_org_with_few_projects():
             new_count_per_root=5.5,
             blended_sample_rate=0.25,
             new_sample_rate=pytest.approx(0.19642857142857142),
+            _diff=1.5,
         ),
         P(
             id=3,
@@ -48,6 +50,7 @@ def test_adjust_sample_rates_org_with_few_projects():
             new_count_per_root=4.5,
             blended_sample_rate=0.25,
             new_sample_rate=0.375,
+            _diff=1.5,
         ),
         P(
             id=4,
@@ -55,6 +58,7 @@ def test_adjust_sample_rates_org_with_few_projects():
             new_count_per_root=4.0,
             blended_sample_rate=0.25,
             new_sample_rate=1.0,
+            _diff=3.0,
         ),
     ]
 
@@ -123,6 +127,7 @@ def test_adjust_sample_rates_org_with_even_num_projects():
             new_count_per_root=5.0,
             blended_sample_rate=0.25,
             new_sample_rate=0.15625,
+            _diff=3.0,
         ),
         P(
             id=2,
@@ -130,6 +135,7 @@ def test_adjust_sample_rates_org_with_even_num_projects():
             new_count_per_root=7.0,
             blended_sample_rate=0.25,
             new_sample_rate=0.0,
+            _diff=0.0,
         ),
         P(
             id=3,
@@ -137,6 +143,7 @@ def test_adjust_sample_rates_org_with_even_num_projects():
             new_count_per_root=6.0,
             blended_sample_rate=0.25,
             new_sample_rate=0.5,
+            _diff=3.0,
         ),
     ]
 
@@ -159,6 +166,7 @@ def test_adjust_sample_rates_org_with_same_counts_projects():
             new_count_per_root=6.0,
             blended_sample_rate=0.25,
             new_sample_rate=pytest.approx(0.16666666666666666),
+            _diff=3.0,
         ),
         P(
             id=2,
@@ -166,6 +174,7 @@ def test_adjust_sample_rates_org_with_same_counts_projects():
             new_count_per_root=6.375,
             blended_sample_rate=0.25,
             new_sample_rate=0.265625,
+            _diff=-0.375,
         ),
         P(
             id=3,
@@ -173,6 +182,7 @@ def test_adjust_sample_rates_org_with_same_counts_projects():
             new_count_per_root=5.625,
             blended_sample_rate=0.25,
             new_sample_rate=0.234375,
+            _diff=-0.375,
         ),
         P(
             id=4,
@@ -180,6 +190,7 @@ def test_adjust_sample_rates_org_with_same_counts_projects():
             new_count_per_root=4.0,
             blended_sample_rate=0.25,
             new_sample_rate=1.0,
+            _diff=3.0,
         ),
     ]
 
@@ -202,6 +213,7 @@ def test_adjust_sample_rates_org_with_counts_projects():
             new_count_per_root=8.0,
             blended_sample_rate=0.25,
             new_sample_rate=1.0,
+            _diff=6.0,
         ),
         P(
             id=2,
@@ -209,6 +221,7 @@ def test_adjust_sample_rates_org_with_counts_projects():
             new_count_per_root=4.0,
             blended_sample_rate=0.25,
             new_sample_rate=0.1,
+            _diff=6.0,
         ),
         P(
             id=3,
@@ -216,6 +229,7 @@ def test_adjust_sample_rates_org_with_counts_projects():
             new_count_per_root=11.5,
             blended_sample_rate=0.25,
             new_sample_rate=0.2875,
+            _diff=-1.5,
         ),
         P(
             id=4,
@@ -223,6 +237,7 @@ def test_adjust_sample_rates_org_with_counts_projects():
             new_count_per_root=8.5,
             blended_sample_rate=0.25,
             new_sample_rate=0.2125,
+            _diff=-1.5,
         ),
     ]
 

--- a/tests/sentry/dynamic_sampling/test_adjusments_models.py
+++ b/tests/sentry/dynamic_sampling/test_adjusments_models.py
@@ -61,6 +61,53 @@ def test_adjust_sample_rates_org_with_few_projects():
     assert p.adjust_sample_rates() == expected_projects
 
 
+def test_adjust_sample_rates_org_with_few_projects_and_zeros():
+    target = [
+        (1, 13369016.0),
+        (11276, 369985.0),
+        (37617, 55.0),
+        (155735, 126.0),
+        (162676, 10550.0),
+        (191772, 5.0),
+        (239368, 1.0),
+        (300688, 2595111.0),
+        (1267915, 15199.0),
+        (1886021, 445.0),
+        (2053674, 47.0),
+        (4857230, 26530.0),
+        (5246761, 8211.0),
+        (5266138, 737.0),
+        (5324467, 89.0),
+        (5350637, 11.0),
+        (5600888, 68.0),
+        (5613292, 161.0),
+        (5683166, 63.0),
+        (5738630, 257.0),
+        (5899451, 1417.0),
+        (5903949, 10263.0),
+        (6178942, 358470.0),
+        (6301746, 244.0),
+        (6418660, 21.0),
+        (6424467, 5055781.0),
+        (6690737, 773.0),
+        (4504044639748096, 493.0),
+        (4504044642107392, 1564.0),
+        (4504373448540160, 22.0),
+    ]
+    projects = [
+        P(id=p_id, count_per_root=count_per_root, blended_sample_rate=0.036)
+        for p_id, count_per_root in target
+    ]
+    p = AdjustedModel(projects=projects)
+
+    result = p.adjust_sample_rates()
+    for p in result:
+        assert 1.0 >= p.new_sample_rate > 0
+        assert (p.count_per_root / p.new_count_per_root) * p.new_sample_rate == pytest.approx(
+            p.blended_sample_rate
+        )
+
+
 def test_adjust_sample_rates_org_with_even_num_projects():
     projects = [
         P(id=1, count_per_root=8.0, blended_sample_rate=0.25),

--- a/tests/sentry/dynamic_sampling/test_adjusments_models.py
+++ b/tests/sentry/dynamic_sampling/test_adjusments_models.py
@@ -61,7 +61,7 @@ def test_adjust_sample_rates_org_with_few_projects():
     assert p.adjust_sample_rates() == expected_projects
 
 
-def test_adjust_sample_rates_org_with_few_projects_and_zeros():
+def test_adjust_sample_rates_org_with_many_projects():
     target = [
         (1, 13369016.0),
         (11276, 369985.0),


### PR DESCRIPTION
This PR fix issue in the calculation of newsample rate.