### PR TITLE
fix(devserver): Remove kafka batching settings from devserver start command 

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -12,12 +12,6 @@ from sentry.runner.commands.devservices import get_docker_client
 from sentry.runner.decorators import configuration, log_options
 
 _DEV_METRICS_INDEXER_ARGS = [
-    # We don't want to burn laptop CPU while idle, but do want for
-    # metrics to be ingested with lowest latency possible.
-    "--max-batch-time-ms",
-    "10000",
-    "--max-batch-size",
-    "1",
     # We don't really need more than 1 process.
     "--processes",
     "1",


### PR DESCRIPTION
The options are not available anymore and the devserver fails to start when the options are provided.
