### PR TITLE
ref(profiling): align grid background with defaults

### DIFF
--- a/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
+++ b/static/app/components/profiling/flamegraph/collapsibleTimeline.tsx
@@ -20,7 +20,7 @@ function CollapsibleTimeline(props: CollapsibleTimelineProps) {
   return (
     <Fragment>
       <CollapsibleTimelineHeader border={theme.COLORS.GRID_LINE_COLOR}>
-        <span>{props.title}</span>
+        <CollapsibleTimelineLabel>{props.title}</CollapsibleTimelineLabel>
         <StyledButton
           size="xs"
           onClick={props.open ? props.onClose : props.onOpen}
@@ -90,9 +90,13 @@ const CollapsibleTimelineHeader = styled('div')<{border: string}>`
   position: relative;
   z-index: 1;
   height: 20px;
+  min-height: 20px;
   border-top: 1px solid ${p => p.border};
-  padding: 1px ${space(1.5)};
   background-color: ${p => p.theme.backgroundSecondary};
+`;
+
+export const CollapsibleTimelineLabel = styled('span')`
+  padding: 1px ${space(1)};
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 

--- a/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
@@ -2,6 +2,7 @@ import {cloneElement, useCallback, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences';
 import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
@@ -12,7 +13,7 @@ import {
   UseResizableDrawerOptions,
 } from 'sentry/utils/useResizableDrawer';
 
-import {CollapsibleTimeline} from './collapsibleTimeline';
+import {CollapsibleTimeline, CollapsibleTimelineLabel} from './collapsibleTimeline';
 
 // 664px is approximately the width where we start to scroll inside
 // 30px is the min height to where the drawer can still be resized
@@ -133,7 +134,7 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
     <FlamegraphLayoutContainer>
       <FlamegraphGrid layout={layout}>
         <MinimapContainer
-          height={
+          containerHeight={
             timelines.minimap
               ? flamegraphTheme.SIZES.MINIMAP_HEIGHT
               : TIMELINE_LABEL_HEIGHT
@@ -150,7 +151,7 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
         </MinimapContainer>
         {props.uiFrames ? (
           <UIFramesContainer
-            height={
+            containerHeight={
               timelines.ui_frames
                 ? flamegraphTheme.SIZES.UI_FRAMES_HEIGHT
                 : TIMELINE_LABEL_HEIGHT
@@ -168,7 +169,7 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
         ) : null}
         {props.spans ? (
           <SpansContainer
-            height={
+            containerHeight={
               // If we have a span depth
               timelines.transaction_spans
                 ? props.spansTreeDepth
@@ -187,7 +188,10 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
             </CollapsibleTimeline>
           </SpansContainer>
         ) : null}
-        <ZoomViewContainer>{props.flamegraph}</ZoomViewContainer>
+        <ZoomViewContainer>
+          <ProfileLabel>{t('Profile')}</ProfileLabel>
+          {props.flamegraph}
+        </ZoomViewContainer>
         <FlamegraphDrawerContainer ref={flamegraphDrawerRef} layout={layout}>
           {cloneElement(props.flamegraphDrawer, {
             onResize: onMouseDown,
@@ -198,6 +202,22 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
     </FlamegraphLayoutContainer>
   );
 }
+
+const ProfileLabel = styled(CollapsibleTimelineLabel)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: linear-gradient(
+    90deg,
+    ${p => p.theme.backgroundSecondary} 0%,
+    ${p => p.theme.backgroundSecondary} 80%,
+    transparent 100%
+  );
+  padding-right: ${space(2)};
+  z-index: 1;
+  /* Visually align with the grid */
+  transform: translateY(1px);
+`;
 
 const FlamegraphLayoutContainer = styled('div')`
   display: flex;
@@ -251,10 +271,10 @@ const FlamegraphGrid = styled('div')<{
 `;
 
 const MinimapContainer = styled('div')<{
-  height: FlamegraphTheme['SIZES']['MINIMAP_HEIGHT'];
+  containerHeight: FlamegraphTheme['SIZES']['MINIMAP_HEIGHT'];
 }>`
   position: relative;
-  height: ${p => p.height}px;
+  height: ${p => p.containerHeight}px;
   grid-area: minimap;
   display: flex;
   flex-direction: column;
@@ -269,18 +289,18 @@ const ZoomViewContainer = styled('div')`
 `;
 
 const SpansContainer = styled('div')<{
-  height: FlamegraphTheme['SIZES']['MAX_SPANS_HEIGHT'];
+  containerHeight: FlamegraphTheme['SIZES']['MAX_SPANS_HEIGHT'];
 }>`
   position: relative;
-  height: ${p => p.height}px;
+  height: ${p => p.containerHeight}px;
   grid-area: spans;
 `;
 
 const UIFramesContainer = styled('div')<{
-  height: FlamegraphTheme['SIZES']['UI_FRAMES_HEIGHT'];
+  containerHeight: FlamegraphTheme['SIZES']['UI_FRAMES_HEIGHT'];
 }>`
   position: relative;
-  height: ${p => p.height}px;
+  height: ${p => p.containerHeight}px;
   grid-area: ui-frames;
 `;
 

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -180,7 +180,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
     FOCUSED_FRAME_BORDER_COLOR: lightTheme.focus,
     FRAME_GRAYSCALE_COLOR: [0.5, 0.5, 0.6, 0.1],
     SPAN_FALLBACK_COLOR: [0, 0, 0, 0.1],
-    GRID_FRAME_BACKGROUND_COLOR: 'rgb(255, 255, 255)',
+    GRID_FRAME_BACKGROUND_COLOR: 'rgb(250, 249, 251, 1)', // theme.backgroundSecondary
     GRID_LINE_COLOR: '#e5e7eb',
     HIGHLIGHTED_LABEL_COLOR: [240, 240, 0, 1],
     HOVERED_FRAME_BORDER_COLOR: 'rgba(0, 0, 0, 0.8)',
@@ -223,7 +223,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     FOCUSED_FRAME_BORDER_COLOR: darkTheme.focus,
     FRAME_GRAYSCALE_COLOR: [0.5, 0.5, 0.5, 0.4],
     SPAN_FALLBACK_COLOR: [1, 1, 1, 0.3],
-    GRID_FRAME_BACKGROUND_COLOR: 'rgb(0, 0, 0)',
+    GRID_FRAME_BACKGROUND_COLOR: 'rgb(26, 20, 31,1)',
     GRID_LINE_COLOR: '#222227',
     HIGHLIGHTED_LABEL_COLOR: [136, 50, 0, 1],
     HOVERED_FRAME_BORDER_COLOR: 'rgba(255, 255, 255, 0.8)',


### PR DESCRIPTION

Add timeline label for profiling. Tbd if we want to actually do this, but we can discuss in the PR - it ensures we have consistent usage with the rest of the timeline labels, but we lose the ability to see the left most label (0)

Dark mode:

https://user-images.githubusercontent.com/9317857/222444626-4373ea14-4a98-4289-9531-4d84dcef7a29.mp4

Light mode:


https://user-images.githubusercontent.com/9317857/222444891-decd5a7e-20ae-475b-98e4-534af4effc90.mp4


Also aligns the grid background to be consistent with backgroundSecondary (used to just be white/black)



