### PR TITLE
fix(monitors): Store duration as milliseconds

### DIFF
--- a/src/sentry/monitors/consumers/check_in.py
+++ b/src/sentry/monitors/consumers/check_in.py
@@ -37,7 +37,9 @@ def process_message(message: Message[KafkaPayload]) -> None:
                 return
 
             status = getattr(CheckInStatus, params["status"].upper())
-            duration = int(params["duration"]) if params.get("duration") is not None else None
+            duration = (
+                int(params["duration"] * 1000) if params.get("duration") is not None else None
+            )
 
             try:
                 check_in = MonitorCheckIn.objects.select_for_update().get(


### PR DESCRIPTION
Follow-up to #45079. Stores durations correctly when they are specified by the
client. The Relay and Kafka protocol specify them as seconds, and the consumer
misses a conversion to integer milliseconds.

