### PR TITLE
ref(perf-issues): lower thresholds for consecutive http

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -234,8 +234,8 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             "detection_enabled": settings["uncompressed_assets_detection_enabled"],
         },
         DetectorType.CONSECUTIVE_HTTP_OP: {
-            "span_duration_threshold": 1000,  # ms
-            "consecutive_count_threshold": 5,
+            "span_duration_threshold": 300,  # ms
+            "consecutive_count_threshold": 3,
         },
     }
 

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
@@ -78,7 +78,7 @@ class ConsecutiveDbDetectorTest(TestCase):
         ]
 
     def test_does_not_detect_conseucitve_http_issue_with_low_duration(self):
-        event = self.create_issue_event(500)
+        event = self.create_issue_event(100)
         problems = self.find_problems(event)
 
         assert problems == []


### PR DESCRIPTION
Currently there aren't many issues detected, i'm going to lower thresholds to audit more and then narrow down from there.