### PR TITLE
feat(profiling): make keyboard navigation smooth

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -677,8 +677,18 @@ function Flamegraph(): ReactElement {
     [flamegraphRenderer]
   );
 
+  const physicalToConfig =
+    flamegraphView && flamegraphCanvas
+      ? mat3.invert(
+          mat3.create(),
+          flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
+        )
+      : mat3.create();
+
+  const configSpacePixel = new Rect(0, 0, 1, 1).transformRect(physicalToConfig);
+
   // Register keyboard navigation
-  useViewKeyboardNavigation(flamegraphView, canvasPoolManager);
+  useViewKeyboardNavigation(flamegraphView, canvasPoolManager, configSpacePixel.width);
 
   // referenceNode is passed down to the flamegraphdrawer and is used to determine
   // the weights of each frame. In other words, in case there is no user selected root, then all

--- a/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
@@ -12,11 +12,45 @@ const KEYDOWN_LISTENER_OPTIONS: AddEventListenerOptions & EventListenerOptions =
   passive: true,
 };
 
+function easeOutCubic(x: number): number {
+  return 1 - Math.pow(1 - x, 3);
+}
+
+function rafAnimation(
+  ref: React.MutableRefObject<number | null>,
+  cb: (easing: number) => void,
+  done: () => void
+) {
+  const time = {
+    start: 0,
+    total: 160,
+  };
+
+  function tick(now: number) {
+    if (!time.start) {
+      time.start = now;
+    }
+
+    cb(easeOutCubic(1 - (now - time.start) / time.total));
+
+    if (now - time.start < time.total) {
+      ref.current = requestAnimationFrame(tick);
+    } else {
+      ref.current = null;
+      done();
+    }
+  }
+
+  ref.current = requestAnimationFrame(tick);
+}
+
 export function useViewKeyboardNavigation(
   view: CanvasView<any> | null,
   canvasPoolManager: CanvasPoolManager,
   pixelInConfigSpace: number
 ) {
+  const holdingKeyRef = useRef<string | null>(null);
+  const animationRef = useRef<number | null>(null);
   const inertia = useRef<number | null>(null);
 
   useEffect(() => {
@@ -34,63 +68,101 @@ export function useViewKeyboardNavigation(
         return;
       }
 
-      if (event.key === 'w') {
-        if (inertia.current === null) {
-          inertia.current = 1;
-        }
+      if (animationRef.current !== null) {
+        window.cancelAnimationFrame(animationRef.current);
+      }
 
-        canvasPoolManager.dispatch('transform config view', [
-          getCenterScaleMatrixFromConfigPosition(
-            vec2.fromValues(
-              1 - (pixelInConfigSpace / view.configView.width) * inertia.current,
-              1
-            ),
-            vec2.fromValues(view.configView.centerX, view.configView.y)
-          ),
-          view,
-        ]);
-        inertia.current = inertia.current * 1.2;
+      if (event.key === 'w') {
+        if (inertia.current === null || holdingKeyRef.current !== 'w') {
+          inertia.current = 0.005;
+        }
+        holdingKeyRef.current = 'w';
+
+        rafAnimation(
+          animationRef,
+          easing => {
+            const i = inertia.current ?? 1;
+            canvasPoolManager.dispatch('transform config view', [
+              getCenterScaleMatrixFromConfigPosition(
+                vec2.fromValues(1 - easing * i, 1),
+                vec2.fromValues(view.configView.centerX, view.configView.y)
+              ),
+              view,
+            ]);
+          },
+          () => (inertia.current = null)
+        );
+        inertia.current = inertia.current * 1.08;
       }
 
       if (event.key === 's') {
-        if (inertia.current === null) {
-          inertia.current = 1;
+        if (inertia.current === null || holdingKeyRef.current !== 's') {
+          inertia.current = 0.005;
         }
-        canvasPoolManager.dispatch('transform config view', [
-          getCenterScaleMatrixFromConfigPosition(
-            vec2.fromValues(1.01 * inertia.current, 1),
-            vec2.fromValues(view.configView.centerX, view.configView.y)
-          ),
-          view,
-        ]);
-        inertia.current = inertia.current * 1.01;
+        holdingKeyRef.current = 's';
+        rafAnimation(
+          animationRef,
+          easing => {
+            const i = inertia.current ?? 1;
+            canvasPoolManager.dispatch('transform config view', [
+              getCenterScaleMatrixFromConfigPosition(
+                vec2.fromValues(1 + easing * i, 1),
+                vec2.fromValues(view.configView.centerX, view.configView.y)
+              ),
+              view,
+            ]);
+          },
+          () => (inertia.current = null)
+        );
+        inertia.current = inertia.current * 1.08;
       }
       if (event.key === 'a') {
-        if (inertia.current === null) {
+        if (inertia.current === null || holdingKeyRef.current !== 'a') {
           // We'll start at 1% of the view width
           inertia.current = view.configView.width / 100;
         }
-        canvasPoolManager.dispatch('transform config view', [
-          getTranslationMatrixFromConfigSpace(1 * -inertia.current, 0),
-          view,
-        ]);
-        inertia.current = inertia.current * 1.01;
+        holdingKeyRef.current = 'a';
+
+        rafAnimation(
+          animationRef,
+          easing => {
+            const i = inertia.current ?? 1;
+            canvasPoolManager.dispatch('transform config view', [
+              getTranslationMatrixFromConfigSpace(1 * -(easing * i), 0),
+              view,
+            ]);
+          },
+          () => (inertia.current = null)
+        );
+        inertia.current = inertia.current * 1.1;
       }
       if (event.key === 'd') {
-        if (inertia.current === null) {
+        if (inertia.current === null || holdingKeyRef.current !== 'd') {
           // We'll start at 1% of the view width
           inertia.current = view.configView.width / 100;
         }
-        canvasPoolManager.dispatch('transform config view', [
-          getTranslationMatrixFromConfigSpace(1 * inertia.current, 0),
-          view,
-        ]);
-        inertia.current = inertia.current * 1.01;
+        holdingKeyRef.current = 'd';
+        rafAnimation(
+          animationRef,
+          easing => {
+            const i = inertia.current ?? 1;
+            canvasPoolManager.dispatch('transform config view', [
+              getTranslationMatrixFromConfigSpace(1 * easing * i, 0),
+              view,
+            ]);
+          },
+          () => (inertia.current = null)
+        );
+        inertia.current = inertia.current * 1.1;
       }
     }
 
     function onKeyUp() {
-      inertia.current = null;
+      if (!animationRef.current) {
+        // if the animation finished, reset inertia
+        inertia.current = null;
+      }
+      holdingKeyRef.current = null;
     }
 
     document.addEventListener('keyup', onKeyUp, KEYDOWN_LISTENER_OPTIONS);

--- a/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
@@ -14,7 +14,8 @@ const KEYDOWN_LISTENER_OPTIONS: AddEventListenerOptions & EventListenerOptions =
 
 export function useViewKeyboardNavigation(
   view: CanvasView<any> | null,
-  canvasPoolManager: CanvasPoolManager
+  canvasPoolManager: CanvasPoolManager,
+  pixelInConfigSpace: number
 ) {
   const inertia = useRef<number | null>(null);
 
@@ -37,14 +38,18 @@ export function useViewKeyboardNavigation(
         if (inertia.current === null) {
           inertia.current = 1;
         }
+
         canvasPoolManager.dispatch('transform config view', [
           getCenterScaleMatrixFromConfigPosition(
-            vec2.fromValues(0.99 * inertia.current, 1),
+            vec2.fromValues(
+              1 - (pixelInConfigSpace / view.configView.width) * inertia.current,
+              1
+            ),
             vec2.fromValues(view.configView.centerX, view.configView.y)
           ),
           view,
         ]);
-        inertia.current = Math.max(Math.abs(inertia.current * 0.99), 0.01);
+        inertia.current = inertia.current * 1.2;
       }
 
       if (event.key === 's') {
@@ -69,7 +74,7 @@ export function useViewKeyboardNavigation(
           getTranslationMatrixFromConfigSpace(1 * -inertia.current, 0),
           view,
         ]);
-        inertia.current = inertia.current * 1.18;
+        inertia.current = inertia.current * 1.01;
       }
       if (event.key === 'd') {
         if (inertia.current === null) {
@@ -80,7 +85,7 @@ export function useViewKeyboardNavigation(
           getTranslationMatrixFromConfigSpace(1 * inertia.current, 0),
           view,
         ]);
-        inertia.current = inertia.current * 1.18;
+        inertia.current = inertia.current * 1.01;
       }
     }
 
@@ -95,5 +100,5 @@ export function useViewKeyboardNavigation(
       document.removeEventListener('keyup', onKeyUp, KEYDOWN_LISTENER_OPTIONS);
       document.removeEventListener('keydown', onKeyDown, KEYDOWN_LISTENER_OPTIONS);
     };
-  }, [view, canvasPoolManager]);
+  }, [view, canvasPoolManager, pixelInConfigSpace]);
 }


### PR DESCRIPTION
This used to feel janky because we were previously just moving into X direction for each keydown click (incremented by inertia) and not really animating between the two states, hence where the jumpyness (not sure if this is even a word) originated from.

We change that so that we can animate between steps and make this appear smooth

Before

https://user-images.githubusercontent.com/9317857/222497187-14a90b35-bf60-4b66-adf3-01f82de783e7.mp4

After

https://user-images.githubusercontent.com/9317857/222497173-cf380905-b5df-419b-a229-64b6322e28d5.mp4



