### PR TITLE
feat(codecov-v2): Use newly added commit_file_url

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -118,21 +118,15 @@ def get_codecov_data(
             if use_new_api:
                 tags["codecov.new_endpoint"] = True
                 line_coverage = response_json.get("line_coverage")
-                coverage_found = line_coverage not in [None, [], [[]]]
-                tags["codecov.coverage_found"] = coverage_found
-
-                commit_sha = response_json.get("commit_sha")
-                codecov_url = f"https://app.codecov.io/{service}/{owner_username}/{repo_name}/commit/{commit_sha}/{path}"
-                tags["codecov.coverage_url"] = codecov_url
             else:
                 files = response_json.get("files")
                 line_coverage = files[0].get("line_coverage") if files else None
 
-                coverage_found = line_coverage not in [None, [], [[]]]
-                tags["codecov.coverage_found"] = coverage_found
+            coverage_found = line_coverage not in [None, [], [[]]]
+            tags["codecov.coverage_found"] = coverage_found
 
-                codecov_url = response_json.get("commit_file_url", "")
-                tags["codecov.coverage_url"] = codecov_url
+            codecov_url = response_json.get("commit_file_url", "")
+            tags["codecov.coverage_url"] = codecov_url
 
             for key, value in tags.items():
                 scope.set_tag(key, value)

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -532,6 +532,7 @@ class ProjectStracktraceLinkTestCodecov(BaseProjectStacktraceLink):
             status=200,
             json={
                 "line_coverage": self.expected_line_coverage,
+                "commit_file_url": self.expected_codecov_url,
                 "commit_sha": "a67ea84967ed1ec42844720d9daf77be36ff73b0",
             },
             content_type="application/json",

--- a/tests/sentry/integrations/utils/test_codecov.py
+++ b/tests/sentry/integrations/utils/test_codecov.py
@@ -99,6 +99,7 @@ class TestCodecovIntegration(APITestCase):
             status=200,
             json={
                 "line_coverage": expected_line_coverage,
+                "commit_file_url": expected_codecov_url,
                 "commit_sha": "0f1e2d",
             },
         )


### PR DESCRIPTION
Use the newly added commit_file_url for the new endpoint. Since this field is included, we can remove the code to put together the URL with the commit_sha.