### PR TITLE
ref(codeowners): remove owners/api from unowned endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,6 @@
 /src/sentry/migrations/                                  @getsentry/owners-migrations
 /src/sentry/*/migrations/                                @getsentry/owners-migrations
 
-## API Owners for unowned endpoints / serializers
-/src/**/endpoints/                                       @getsentry/owners-api
-/src/sentry/api/                                         @getsentry/owners-api
-
 ## Snuba
 /src/sentry/eventstream/                                 @getsentry/owners-snuba
 /src/sentry/utils/snuba.py                               @getsentry/owners-snuba @getsentry/discover-n-dashboards


### PR DESCRIPTION
The original intention of this codeowners grouping was to review unowned code API / serializer code. unfortunately, there is _a lot_ of this, and I find this floods my inbox, and do not have enough time to review all of this code. owners-api will still be tagged on new endpoints and tooling for APIs. folks who would like a generic reviewer on an API can still tag the group, or `app-backend`.