### PR TITLE
feat(segmentedControl): Add optional `icon` prop

### DIFF
--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -11,12 +11,20 @@ import {LayoutGroup, motion} from 'framer-motion';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {InternalTooltipProps, Tooltip} from 'sentry/components/tooltip';
+import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {FormSize} from 'sentry/utils/theme';
 
-export interface SegmentedControlItemProps<Value extends string> extends ItemProps<any> {
+export interface SegmentedControlItemProps<Value extends string>
+  extends Omit<ItemProps<any>, 'children'> {
   key: Value;
+  children?: React.ReactNode;
   disabled?: boolean;
+  /**
+   * Optional icon to be rendered to the left of the segment label. Use this prop to
+   * ensure proper vertical alignment.
+   */
+  icon?: React.ReactNode;
   /**
    * Optional tooltip that appears when the use hovers over the segment. Avoid using
    * tooltips if there are other, more visible ways to display the same information.
@@ -99,7 +107,7 @@ SegmentedControl.Item = Item as <Value extends string>(
 ) => JSX.Element;
 
 interface SegmentProps<Value extends string>
-  extends Omit<SegmentedControlItemProps<Value>, keyof ItemProps<any>>,
+  extends SegmentedControlItemProps<Value>,
     AriaRadioProps {
   lastKey: string;
   layoutGroupId: string;
@@ -119,6 +127,7 @@ function Segment<Value extends string>({
   layoutGroupId,
   tooltip,
   tooltipOptions = {},
+  icon,
   ...props
 }: SegmentProps<Value>) {
   const ref = useRef<HTMLInputElement>(null);
@@ -157,15 +166,25 @@ function Segment<Value extends string>({
 
       <Divider visible={showDivider} role="separator" aria-hidden />
 
-      {/* Once an item is selected, it gets a heavier font weight and becomes slightly
-      wider. To prevent layout shifts, we need a hidden container (HiddenLabel) that will
-      always have normal weight to take up constant space; and a visible, absolutely
-      positioned container (VisibleLabel) that doesn't affect the layout. */}
-      <LabelWrap>
-        <HiddenLabel aria-hidden>{props.children}</HiddenLabel>
-        <VisibleLabel isSelected={isSelected} isDisabled={isDisabled} priority={priority}>
-          {props.children}
-        </VisibleLabel>
+      <LabelWrap size={size} role="presentation">
+        {icon}
+        {/* Once an item is selected, it gets a heavier font weight and becomes slightly
+        wider. To prevent layout shifts, we need a hidden container (HiddenLabel) that
+        will always have normal weight to take up constant space; and a visible,
+        absolutely positioned container (VisibleLabel) that doesn't affect the layout. */}
+        {props.children && (
+          <InnerLabelWrap role="presentation">
+            <HiddenLabel aria-hidden>{props.children}</HiddenLabel>
+            <VisibleLabel
+              isSelected={isSelected}
+              isDisabled={isDisabled}
+              priority={priority}
+              role="presentation"
+            >
+              {props.children}
+            </VisibleLabel>
+          </InnerLabelWrap>
+        )}
       </LabelWrap>
     </SegmentWrap>
   );
@@ -205,9 +224,11 @@ const SegmentWrap = styled('label')<{
 }>`
   position: relative;
   display: flex;
+  align-items: center;
   margin: 0;
   border-radius: calc(${p => p.theme.borderRadius} - 1px);
   cursor: ${p => (p.isDisabled ? 'default' : 'pointer')};
+  min-height: 0;
   min-width: 0;
 
   ${p => p.theme.buttonPadding[p.size]}
@@ -306,7 +327,15 @@ const SegmentSelectionIndicator = styled(motion.div)<{priority: Priority}>`
   `}
 `;
 
-const LabelWrap = styled('span')`
+const LabelWrap = styled('span')<{size: FormSize}>`
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: ${p => (p.size === 'xs' ? space(0.5) : space(0.75))};
+  z-index: 1;
+`;
+
+const InnerLabelWrap = styled('span')`
   position: relative;
   display: flex;
   line-height: 1;
@@ -314,11 +343,10 @@ const LabelWrap = styled('span')`
 `;
 
 const HiddenLabel = styled('span')`
-  display: inline-block;
+  ${p => p.theme.overflowEllipsis}
   margin: 0 2px;
   visibility: hidden;
   user-select: none;
-  ${p => p.theme.overflowEllipsis}
 `;
 
 function getTextColor({
@@ -350,10 +378,11 @@ const VisibleLabel = styled('span')<{
   priority: Priority;
   isDisabled?: boolean;
 }>`
+  ${p => p.theme.overflowEllipsis}
+
   position: absolute;
   top: 50%;
   left: 50%;
-  width: max-content;
   transform: translate(-50%, -50%);
   transition: color 0.25s ease-out;
 
@@ -363,7 +392,6 @@ const VisibleLabel = styled('span')<{
   text-align: center;
   line-height: ${p => p.theme.text.lineHeightBody};
   ${getTextColor}
-  ${p => p.theme.overflowEllipsis}
 `;
 
 const Divider = styled('div')<{visible: boolean}>`

--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -23,6 +23,9 @@ export interface SegmentedControlItemProps<Value extends string>
   /**
    * Optional icon to be rendered to the left of the segment label. Use this prop to
    * ensure proper vertical alignment.
+   *
+   * NOTE: if the segment contains only an icon and no text label (i.e. `children` is
+   * not defined), then an `aria-label` must be provided for screen reader support.
    */
   icon?: React.ReactNode;
   /**


### PR DESCRIPTION
Add an optional `icon` prop to render icons inside segments, similar to `<Button />`'s `icon` prop.

NOTE: if the segment contains only an icon and no text label (i.e. `children` is not defined), then an `aria-label` must be provided for proper screen reader support.

**Before ——** with the icon nested alongisde text label
<img width="438" alt="Screenshot 2023-03-02 at 11 19 01 AM" src="https://user-images.githubusercontent.com/44172267/222530810-54bb2c8c-9387-482d-b303-ea1fc3fa31d7.png">

**After ——** with the icon provided via the `icon` prop
<img width="457" alt="Screenshot 2023-03-02 at 11 18 19 AM" src="https://user-images.githubusercontent.com/44172267/222530902-acf96c38-0824-4a23-a73a-092fc493a33a.png">
