### PR TITLE
feat(menuListItem): Provide `leading`/`trailingItems` as render props

### DIFF
--- a/static/app/components/compactSelect/gridList/option.tsx
+++ b/static/app/components/compactSelect/gridList/option.tsx
@@ -113,6 +113,7 @@ export function GridListOption({node, listState, size}: GridListOptionProps) {
       label={label}
       details={details}
       disabled={isDisabled}
+      isSelected={isSelected}
       isFocused={isFocusWithin}
       priority={priority ?? (isSelected && !multiple) ? 'primary' : 'default'}
       innerWrapProps={gridCellPropsMemo}

--- a/static/app/components/compactSelect/listBox/option.tsx
+++ b/static/app/components/compactSelect/listBox/option.tsx
@@ -84,6 +84,7 @@ export function ListBoxOption({item, listState, size}: ListBoxOptionProps) {
       label={label}
       details={details}
       disabled={isDisabled}
+      isSelected={isSelected}
       isFocused={listState.selectionManager.isFocused && isFocused}
       priority={priority ?? (isSelected && !multiple) ? 'primary' : 'default'}
       labelProps={labelPropsMemo}

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -14,6 +14,17 @@ import {FormSize} from 'sentry/utils/theme';
  */
 type Priority = 'primary' | 'danger' | 'default';
 
+/**
+ * Leading/trailing items to be rendered alongside the main text label.
+ */
+type EdgeItems =
+  | React.ReactNode
+  | ((state: {
+      disabled: boolean;
+      isFocused: boolean;
+      isSelected: boolean;
+    }) => React.ReactNode);
+
 export type MenuListItemProps = {
   /**
    * Optional descriptive text. Like 'label', should preferably be a string or
@@ -33,13 +44,7 @@ export type MenuListItemProps = {
   /*
    * Items to be added to the left of the label
    */
-  leadingItems?:
-    | React.ReactNode
-    | ((state: {
-        disabled: boolean;
-        isFocused: boolean;
-        isSelected: boolean;
-      }) => React.ReactNode);
+  leadingItems?: EdgeItems;
   /*
    * Whether leading items should be centered with respect to the entire
    * height of the item. If false (default), they will be centered with
@@ -67,13 +72,7 @@ export type MenuListItemProps = {
   /*
    * Items to be added to the right of the label.
    */
-  trailingItems?:
-    | React.ReactNode
-    | ((state: {
-        disabled: boolean;
-        isFocused: boolean;
-        isSelected: boolean;
-      }) => React.ReactNode);
+  trailingItems?: EdgeItems;
   /*
    * Whether trailing items should be centered wrt/ the entire height of the
    * item. If false (default), they will be centered wrt/ the first line of

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -33,7 +33,13 @@ export type MenuListItemProps = {
   /*
    * Items to be added to the left of the label
    */
-  leadingItems?: React.ReactNode;
+  leadingItems?:
+    | React.ReactNode
+    | ((state: {
+        disabled: boolean;
+        isFocused: boolean;
+        isSelected: boolean;
+      }) => React.ReactNode);
   /*
    * Whether leading items should be centered with respect to the entire
    * height of the item. If false (default), they will be centered with
@@ -61,7 +67,13 @@ export type MenuListItemProps = {
   /*
    * Items to be added to the right of the label.
    */
-  trailingItems?: React.ReactNode;
+  trailingItems?:
+    | React.ReactNode
+    | ((state: {
+        disabled: boolean;
+        isFocused: boolean;
+        isSelected: boolean;
+      }) => React.ReactNode);
   /*
    * Whether trailing items should be centered wrt/ the entire height of the
    * item. If false (default), they will be centered wrt/ the first line of
@@ -75,6 +87,7 @@ interface OtherProps {
   detailsProps?: object;
   innerWrapProps?: object;
   isFocused?: boolean;
+  isSelected?: boolean;
   labelProps?: object;
   showDivider?: boolean;
 }
@@ -96,6 +109,7 @@ function BaseMenuListItem({
   trailingItems = false,
   trailingItemsSpanFullHeight = false,
   isFocused = false,
+  isSelected = false,
   innerWrapProps = {},
   labelProps = {},
   detailsProps = {},
@@ -135,7 +149,9 @@ function BaseMenuListItem({
               spanFullHeight={leadingItemsSpanFullHeight}
               size={size}
             >
-              {leadingItems}
+              {typeof leadingItems === 'function'
+                ? leadingItems({disabled, isFocused, isSelected})
+                : leadingItems}
             </LeadingItems>
           )}
           <ContentWrap isFocused={isFocused} showDivider={showDivider} size={size}>
@@ -164,7 +180,9 @@ function BaseMenuListItem({
                 disabled={disabled}
                 spanFullHeight={trailingItemsSpanFullHeight}
               >
-                {trailingItems}
+                {typeof trailingItems === 'function'
+                  ? trailingItems({disabled, isFocused, isSelected})
+                  : trailingItems}
               </TrailingItems>
             )}
           </ContentWrap>


### PR DESCRIPTION
The `leading`/`trailingItems` props on `MenuListItem` will now accept render functions of type `((state: {disabled: boolean; isFocused: boolean; isSelected: boolean }) => React.ReactNode)` (in addition to plain React nodes).

This allows us to conditionally render leading/trailing items, e.g. here where the trailing item only appears on focused options:
<img width="305" alt="Screenshot 2023-03-02 at 1 41 20 PM" src="https://user-images.githubusercontent.com/44172267/222562371-006b1fd3-016e-4d22-8aad-73beb75aea7b.png">
