### PR TITLE
feat(replays): Sort "Session Replays" under Transaction in /stats category dropdown

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -64,6 +64,12 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     yAxisMinInterval: 100,
   },
   {
+    label: DATA_CATEGORY_INFO.replay.titleName,
+    value: DATA_CATEGORY_INFO.replay.plural,
+    disabled: false,
+    yAxisMinInterval: 100,
+  },
+  {
     label: DATA_CATEGORY_INFO.attachment.titleName,
     value: DATA_CATEGORY_INFO.attachment.plural,
     disabled: false,
@@ -72,12 +78,6 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
   {
     label: DATA_CATEGORY_INFO.profile.titleName,
     value: DATA_CATEGORY_INFO.profile.plural,
-    disabled: false,
-    yAxisMinInterval: 100,
-  },
-  {
-    label: DATA_CATEGORY_INFO.replay.titleName,
-    value: DATA_CATEGORY_INFO.replay.plural,
     disabled: false,
     yAxisMinInterval: 100,
   },


### PR DESCRIPTION
Here's the new sorted list:
![SCR-20230302-kax](https://user-images.githubusercontent.com/187460/222575736-6604048e-2d87-414c-a3bc-2e1fbc42000d.png)

This page has a few different layouts, but they all use the same dropdown and sort order.

Fixes #45148
