### PR TITLE
feat(compactSelect): Add empty search message

### DIFF
--- a/static/app/components/compactSelect/composite.tsx
+++ b/static/app/components/compactSelect/composite.tsx
@@ -3,10 +3,12 @@ import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {Item} from '@react-stately/collections';
 
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 import {Control, ControlProps} from './control';
 import {List, MultipleListProps, SingleListProps} from './list';
+import {EmptyMessage} from './styles';
 import {SelectOption} from './types';
 
 interface BaseCompositeSelectRegion<Value extends React.Key> {
@@ -83,6 +85,7 @@ function CompositeSelect({
   // Control props
   grid,
   disabled,
+  emptyMessage,
   size = 'md',
   closeOnSelect,
   ...controlProps
@@ -106,6 +109,9 @@ function CompositeSelect({
               />
             );
           })}
+
+          {/* Only displayed when all lists (regions) are empty */}
+          <EmptyMessage>{emptyMessage ?? t('No options found')}</EmptyMessage>
         </RegionsWrap>
       </FocusScope>
     </Control>

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -68,6 +68,10 @@ export interface ControlProps extends UseOverlayProps {
   clearable?: boolean;
   disabled?: boolean;
   /**
+   * Message to be displayed when all options have been filtered out (via search).
+   */
+  emptyMessage?: string;
+  /**
    * Whether to render a grid list rather than a list box.
    *
    * Unlike list boxes, grid lists are two-dimensional. Users can press Arrow Up/Down to

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -1,10 +1,12 @@
 import {useMemo} from 'react';
 import {Item, Section} from '@react-stately/collections';
 
+import {t} from 'sentry/locale';
 import domId from 'sentry/utils/domId';
 
 import {Control, ControlProps} from './control';
 import {List, MultipleListProps, SingleListProps} from './list';
+import {EmptyMessage} from './styles';
 import type {
   SelectOption,
   SelectOptionOrSection,
@@ -58,6 +60,7 @@ function CompactSelect<Value extends React.Key>({
   // Control props
   grid,
   disabled,
+  emptyMessage,
   size = 'md',
   closeOnSelect,
   triggerProps,
@@ -124,6 +127,9 @@ function CompactSelect<Value extends React.Key>({
           );
         }}
       </List>
+
+      {/* Only displayed when List is empty */}
+      <EmptyMessage>{emptyMessage ?? t('No options found')}</EmptyMessage>
     </Control>
   );
 }

--- a/static/app/components/compactSelect/styles.tsx
+++ b/static/app/components/compactSelect/styles.tsx
@@ -25,6 +25,10 @@ export const ListWrap = styled('ul')`
     padding-top: 0;
   }
 
+  &:empty {
+    padding: 0;
+  }
+
   /* Should scroll if it's in a non-composite select */
   :only-of-type {
     min-height: 0;
@@ -133,4 +137,17 @@ export const CheckWrap = styled('div')<{isSelected: boolean; multiple: boolean}>
   height: 1.4em;
   padding-bottom: 1px;
   pointer-events: none;
+`;
+
+export const EmptyMessage = styled('p')`
+  text-align: center;
+  color: ${p => p.theme.subText};
+  padding: ${space(1)} ${space(1.5)} ${space(1.5)};
+  margin: 0;
+
+  /* Message should only be displayed when _all_ preceding lists are empty */
+  display: block;
+  ul:not(:empty) ~ & {
+    display: none;
+  }
 `;


### PR DESCRIPTION
**Before ——**
<img width="291" alt="Screenshot 2023-03-02 at 5 26 31 PM" src="https://user-images.githubusercontent.com/44172267/222608279-4f06212c-82f0-45e5-8655-65777bfc0f2b.png">


**After ——**
<img width="291" alt="Screenshot 2023-03-02 at 5 25 59 PM" src="https://user-images.githubusercontent.com/44172267/222608207-55c3b84a-5d8b-4ad7-a972-3ac55a87229c.png">
