### PR TITLE
fix(inbound-filter): Fix react hydration errors message condition

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -125,7 +125,7 @@ def get_filter_settings(project: Project) -> Mapping[str, Any]:
         # 423 - There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.
         # 425 - Text content does not match server-rendered HTML.
         error_messages += [
-            "https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}"
+            "*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*"
         ]
 
     if error_messages:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-03-02T14:24:26.512612Z'
+created: '2023-03-03T12:37:18.832972Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -84,7 +84,7 @@ config:
       - promfflinkdev.com
     errorMessages:
       patterns:
-      - https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}
+      - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
     legacyBrowsers:
       isEnabled: false
     localhost:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-03-02T14:24:26.635295Z'
+created: '2023-03-03T12:37:18.951044Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -84,7 +84,7 @@ config:
       - promfflinkdev.com
     errorMessages:
       patterns:
-      - https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}
+      - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
     legacyBrowsers:
       isEnabled: false
     localhost:


### PR DESCRIPTION
Relay was not filtering out react hydration errors events because the relay message condition didn't contain `*message*`

This PR fixes the issue.

Related to https://github.com/getsentry/sentry/pull/45188