### PR TITLE
fix(ci/codecov): Disable codecov comments on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -64,15 +64,4 @@ flags:
     - "src/sentry/**/*.py"
     carryforward: true
 
-# This will add a comment to PRs
-# This is useful until the diff target check does not trigger early
-# Read more here: https://docs.codecov.com/docs/pull-request-comments#layout
-comment:
-  layout: "diff, files"
-  behavior: default # Update, if comment exists. Otherwise post new.
-  # Comments will now only post when coverage changes. Furthermore, if a comment
-  # already exists, and a newer commit results in no coverage change for the
-  # entire pull, the comment will be deleted.
-  require_changes: true
-  require_base: yes # must have a base report to post
-  require_head: yes # must have a head report to post
+comment: false


### PR DESCRIPTION
Unfortunately, the commenting system also suffers from the same problems as the GH status check where results are posted too soon.

I had added these changes in #45186 but I'm now reverting it until we have support for after_n_builds for flags.