### PR TITLE
feat: Handle frozen Windows/MacOS user agent versions

### DIFF
--- a/src/sentry/plugins/sentry_useragents/models.py
+++ b/src/sentry/plugins/sentry_useragents/models.py
@@ -82,6 +82,15 @@ class OsPlugin(UserAgentPlugin):
 
         version = ".".join(value for value in [ua["major"], ua["minor"], ua["patch"]] if value)
         tag = ua["family"]
+
+        # The version for Windows is capped at 10.0, so it may be newer than that
+        if tag == "Windows" and version == "10":
+            version = ">=10"
+
+        # The version for Mac OS X is capped at 10.15.7, so it may be newer than that
+        if tag == "Mac OS X" and version == "10.15.7":
+            version = ">=10.15.7"
+
         if version:
             tag += " " + version
 

--- a/tests/sentry/plugins/sentry_useragents/test_models.py
+++ b/tests/sentry/plugins/sentry_useragents/test_models.py
@@ -13,7 +13,19 @@ class UserAgentPlugins(TestCase):
             "browser_plugin_output": "Googlebot 2.1",
             "device_plugin_output": "Spider",
             "os_plugin_output": "Other",
-        }
+        },
+        {
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
+            "browser_plugin_output": "Chrome 110.0",
+            "device_plugin_output": "Mac",
+            "os_plugin_output": "Mac OS X >=10.15.7",
+        },
+        {
+            "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36.",
+            "browser_plugin_output": "Chrome 110.0",
+            "device_plugin_output": "Other",
+            "os_plugin_output": "Windows >=10",
+        },
     ]
 
     def test_plugins(self):


### PR DESCRIPTION
This PR updates our user agent parsing to account for the fact that both Windows and MacOS have frozen their versions some time ago.

For Windows, this means that any current version of Windows may report it's version as `10.0`.
For Mac OS, it seems to be capped at `10.15.7`.

This PR "fixes" this by indicating that these specific versions actually mean `>=`, not `==`. I hope this does not conflict with any code that expects this to be a proper semver string?

(You can try this out yourself by going to e.g. https://www.whatsmyua.info/ in MacOS/Windows and checking the version that is output there).

Closes https://github.com/getsentry/sentry-javascript/issues/6640