### PR TITLE
feat(mobile): extract device class context as tag

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -142,7 +142,7 @@ class AppContextType(ContextType):
 @contexttype
 class DeviceContextType(ContextType):
     type = "device"
-    context_to_tag_mapping = {"": "{model}", "family": "{family}"}
+    context_to_tag_mapping = {"": "{model}", "family": "{family}", "class": "{class}"}
     # model_id, arch
 
 


### PR DESCRIPTION
Adds `device.class` to `context_to_tag_mapping` so that `device.class` context is also created as a tag when it exists.