### PR TITLE
(chore): Bump self-hosted e2e tests action

### DIFF
--- a/.github/workflows/self-hosted-e2e-tests.yml
+++ b/.github/workflows/self-hosted-e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
           filters: .github/file-filters.yml
       - name: Run Sentry self-hosted e2e CI
         if: steps.changes.outputs.backend_all == 'true'
-        uses: getsentry/action-self-hosted-e2e-tests@627c9b50cb168c546ed6e2c461dae76d5d0c7cdb
+        uses: getsentry/action-self-hosted-e2e-tests@77805295ebff8a603def5970e18743ded72cb304
         with:
           project_name: sentry
           image_url: us.gcr.io/sentryio/sentry:${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Bumps action commit sha to fail test suite properly from typo fix here:
https://github.com/getsentry/action-self-hosted-e2e-tests/pull/7