### PR TITLE
feat(metrics): Better default for release health.

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -352,6 +352,9 @@ register("processing.can-use-scrubbers", default=True)
 # Set this value of the fraction of projects that you want to use it for.
 register("processing.sourcemapcache-processor", default=0.0)  # unused
 
+# Flag for enabling deobfuscation for ProGuard files in ingest consumer
+register("processing.view-hierarchies-deobfuscation-general-availability", default=0.0)
+
 # Killswitch for sending internal errors to the internal project or
 # `SENTRY_SDK_CONFIG.relay_dsn`. Set to `0` to only send to
 # `SENTRY_SDK_CONFIG.dsn` (the "upstream transport") and nothing else.
@@ -418,11 +421,6 @@ register("relay.drop-transaction-metrics", default=[])
 
 # [Unused] Sample rate for opting in orgs into transaction metrics extraction.
 register("relay.transaction-metrics-org-sample-rate", default=0.0)
-
-# Sample rate for opting in orgs into the new transaction name handling.
-# old behavior: Treat transactions from old SDKs as high-cardinality.
-# new behavior: Treat transactions from old SDKs as low-cardinality, except for browser JS.
-register("relay.transaction-names-client-based", default=0.0)
 
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True)
@@ -553,10 +551,7 @@ register("sentry-metrics.writes-limiter.limits.releasehealth.global", default=[]
 # Note that changing either window or granularity_seconds of a limit will
 # effectively reset it, as the previous data can't/won't be converted.
 register("sentry-metrics.cardinality-limiter.limits.performance.per-org", default=[])
-register(
-    "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
-    default=[{"window_seconds": 3600, "granularity_seconds": 300, "limit": 10000}],
-)
+register("sentry-metrics.cardinality-limiter.limits.releasehealth.per-org", default=[{"window_seconds": 3600, "granularity_seconds": 300, "limit": 10000}])
 register("sentry-metrics.cardinality-limiter.orgs-rollout-rate", default=0.0)
 register("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", default=0.0)
 
@@ -591,6 +586,10 @@ register("performance.issues.render_blocking_assets.problem-creation", default=0
 register("performance.issues.render_blocking_assets.la-rollout", default=0.0)
 register("performance.issues.render_blocking_assets.ea-rollout", default=0.0)
 register("performance.issues.render_blocking_assets.ga-rollout", default=0.0)
+register("performance.issues.m_n_plus_one_db.problem-creation", default=0.0)
+register("performance.issues.m_n_plus_one_db.la-rollout", default=0.0)
+register("performance.issues.m_n_plus_one_db.ea-rollout", default=0.0)
+register("performance.issues.m_n_plus_one_db.ga-rollout", default=0.0)
 
 
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
@@ -607,6 +606,7 @@ register("dynamic-sampling:enabled-biases", default=True)
 # System-wide options that observes latest releases on transactions and caches these values to be used later in
 # project config computation. This is temporary option to monitor the performance of this feature.
 register("dynamic-sampling:boost-latest-release", default=False)
+register("dynamic-sampling.prioritise_projects.sample_rate", default=0.0)
 
 # Killswitch for deriving code mappings
 register("post_process.derive-code-mappings", default=True)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -551,7 +551,10 @@ register("sentry-metrics.writes-limiter.limits.releasehealth.global", default=[]
 # Note that changing either window or granularity_seconds of a limit will
 # effectively reset it, as the previous data can't/won't be converted.
 register("sentry-metrics.cardinality-limiter.limits.performance.per-org", default=[])
-register("sentry-metrics.cardinality-limiter.limits.releasehealth.per-org", default=[{"window_seconds": 3600, "granularity_seconds": 300, "limit": 10000}])
+register(
+    "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
+    default=[{"window_seconds": 3600, "granularity_seconds": 300, "limit": 10000}],
+)
 register("sentry-metrics.cardinality-limiter.orgs-rollout-rate", default=0.0)
 register("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", default=0.0)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -352,9 +352,6 @@ register("processing.can-use-scrubbers", default=True)
 # Set this value of the fraction of projects that you want to use it for.
 register("processing.sourcemapcache-processor", default=0.0)  # unused
 
-# Flag for enabling deobfuscation for ProGuard files in ingest consumer
-register("processing.view-hierarchies-deobfuscation-general-availability", default=0.0)
-
 # Killswitch for sending internal errors to the internal project or
 # `SENTRY_SDK_CONFIG.relay_dsn`. Set to `0` to only send to
 # `SENTRY_SDK_CONFIG.dsn` (the "upstream transport") and nothing else.
@@ -421,6 +418,11 @@ register("relay.drop-transaction-metrics", default=[])
 
 # [Unused] Sample rate for opting in orgs into transaction metrics extraction.
 register("relay.transaction-metrics-org-sample-rate", default=0.0)
+
+# Sample rate for opting in orgs into the new transaction name handling.
+# old behavior: Treat transactions from old SDKs as high-cardinality.
+# new behavior: Treat transactions from old SDKs as low-cardinality, except for browser JS.
+register("relay.transaction-names-client-based", default=0.0)
 
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True)
@@ -551,7 +553,10 @@ register("sentry-metrics.writes-limiter.limits.releasehealth.global", default=[]
 # Note that changing either window or granularity_seconds of a limit will
 # effectively reset it, as the previous data can't/won't be converted.
 register("sentry-metrics.cardinality-limiter.limits.performance.per-org", default=[])
-register("sentry-metrics.cardinality-limiter.limits.releasehealth.per-org", default=[])
+register(
+    "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
+    default=[{"window_seconds": 3600, "granularity_seconds": 300, "limit": 10000}],
+)
 register("sentry-metrics.cardinality-limiter.orgs-rollout-rate", default=0.0)
 register("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", default=0.0)
 
@@ -586,10 +591,6 @@ register("performance.issues.render_blocking_assets.problem-creation", default=0
 register("performance.issues.render_blocking_assets.la-rollout", default=0.0)
 register("performance.issues.render_blocking_assets.ea-rollout", default=0.0)
 register("performance.issues.render_blocking_assets.ga-rollout", default=0.0)
-register("performance.issues.m_n_plus_one_db.problem-creation", default=0.0)
-register("performance.issues.m_n_plus_one_db.la-rollout", default=0.0)
-register("performance.issues.m_n_plus_one_db.ea-rollout", default=0.0)
-register("performance.issues.m_n_plus_one_db.ga-rollout", default=0.0)
 
 
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
@@ -606,7 +607,6 @@ register("dynamic-sampling:enabled-biases", default=True)
 # System-wide options that observes latest releases on transactions and caches these values to be used later in
 # project config computation. This is temporary option to monitor the performance of this feature.
 register("dynamic-sampling:boost-latest-release", default=False)
-register("dynamic-sampling.prioritise_projects.sample_rate", default=0.0)
 
 # Killswitch for deriving code mappings
 register("post_process.derive-code-mappings", default=True)


### PR DESCRIPTION

Updating the default values for `sentry-metrics.cardinality-limiter.limits.releasehealth.per-org` to `[{"window_seconds": 3600, "granularity_seconds": 300, "limit": 10000}]`

Ticket: https://getsentry.atlassian.net/browse/OPS-2962