### PR TITLE
feat(view-hierarchy): Move transaction start

### DIFF
--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -87,13 +87,13 @@ def deobfuscate_view_hierarchy(data):
     ):
         return
 
+    cache_key = cache_key_for_event(data)
+    attachments = [*attachment_cache.get(cache_key)]
+
+    if not any(attachment.type == "event.view_hierarchy" for attachment in attachments):
+        return
+
     with sentry_sdk.start_transaction(name="proguard.deobfuscate_view_hierarchy", sampled=True):
-        cache_key = cache_key_for_event(data)
-        attachments = [*attachment_cache.get(cache_key)]
-
-        if not any(attachment.type == "event.view_hierarchy" for attachment in attachments):
-            return
-
         new_attachments = []
         for attachment in attachments:
             if attachment.type == "event.view_hierarchy":


### PR DESCRIPTION
We should start the transaction when we know there are view hierarchy attachments to loop over