### PR TITLE
bug(perf-issues): hook up N+1 Query detection rate again

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -194,6 +194,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         DetectorType.N_PLUS_ONE_DB_QUERIES: {
             "count": settings["n_plus_one_db_count"],
             "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
+            "detection_rate": settings["n_plus_one_db_detection_rate"],
         },
         DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: {
             "count": settings["n_plus_one_db_count"],
@@ -226,6 +227,7 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             "total_duration_threshold": 100.0,  # ms
             "minimum_occurrences_of_pattern": 3,
             "max_sequence_length": 5,
+            "detection_rate": settings["n_plus_one_db_detection_rate"],
         },
         DetectorType.UNCOMPRESSED_ASSETS: {
             "size_threshold_bytes": 500 * 1024,
@@ -566,7 +568,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         return True  # This detector is fully rolled out
 
     def is_creation_allowed_for_project(self, project: Optional[Project]) -> bool:
-        return True  # This should probably use the `n_plus_one_db.problem-creation` option, which is currently not in use
+        return self.settings["detection_rate"] > random.random()
 
     def visit_span(self, span: Span) -> None:
         span_id = span.get("span_id", None)
@@ -1099,7 +1101,7 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
         )
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:
-        return True  # Detection always allowed by project for now
+        return self.settings["detection_rate"] > random.random()
 
     def visit_span(self, span):
         self.state, performance_problem = self.state.next(span)

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -180,15 +180,6 @@ class ProjectPerformance extends AsyncView<Props, State> {
         defaultValue: 0,
       },
       {
-        name: 'n_plus_one_db_issue_rate',
-        type: 'range',
-        label: t('N+1 (DB) Issue Rate'),
-        min: 0.0,
-        max: 1.0,
-        step: 0.01,
-        defaultValue: 0,
-      },
-      {
         name: 'n_plus_one_db_count',
         type: 'number',
         label: t('N+1 (DB) Minimum Count'),

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -180,6 +180,15 @@ class ProjectPerformance extends AsyncView<Props, State> {
         defaultValue: 0,
       },
       {
+        name: 'n_plus_one_db_issue_rate',
+        type: 'range',
+        label: t('N+1 (DB) Issue Rate'),
+        min: 0.0,
+        max: 1.0,
+        step: 0.01,
+        defaultValue: 0,
+      },
+      {
         name: 'n_plus_one_db_count',
         type: 'number',
         label: t('N+1 (DB) Minimum Count'),

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_db_span_detector.py
@@ -5,6 +5,8 @@ import pytest
 
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+from sentry.models.options.project_option import ProjectOption
+from sentry.testutils import TestCase
 from sentry.testutils.performance_issues.event_generators import get_event
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.performance_issues.base import DetectorType
@@ -140,3 +142,27 @@ class NPlusOneDbDetectorTest(unittest.TestCase):
                 ],
             ),
         ]
+
+
+@pytest.mark.django_db
+class NPlusOneDbSettingTest(TestCase):
+    def test_respects_project_option(self):
+        project = self.create_project()
+        event = get_event("n-plus-one-in-django-index-view-activerecord")
+        event["project_id"] = project.id
+
+        settings = get_detection_settings(project.id)
+        detector = NPlusOneDBSpanDetector(settings, event)
+
+        assert detector.is_creation_allowed_for_project(project)
+
+        ProjectOption.objects.set_value(
+            project=project,
+            key="sentry:performance_issue_settings",
+            value={"n_plus_one_db_detection_rate": 0.0},
+        )
+
+        settings = get_detection_settings(project.id)
+        detector = NPlusOneDBSpanDetector(settings, event)
+
+        assert not detector.is_creation_allowed_for_project(project)


### PR DESCRIPTION
The `n_plus_one_db_detection_rate` project option was being used to disable N+1 detection on projects with fingerprint issues. At some point the N+1 Query detector stopped respecting that option. Hook it back up, and hook up the MN+1 Query detector to it as well (as they create the same type of issue). If we have a reason in the future to split that option into two, we might, but for now they seem to share fingerprinting issues (typically dynamic custom parent span descriptions).
