### PR TITLE
bug(perf-issues): remove unused N+1 Query issue rate UI

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -180,15 +180,6 @@ class ProjectPerformance extends AsyncView<Props, State> {
         defaultValue: 0,
       },
       {
-        name: 'n_plus_one_db_issue_rate',
-        type: 'range',
-        label: t('N+1 (DB) Issue Rate'),
-        min: 0.0,
-        max: 1.0,
-        step: 0.01,
-        defaultValue: 0,
-      },
-      {
         name: 'n_plus_one_db_count',
         type: 'number',
         label: t('N+1 (DB) Minimum Count'),


### PR DESCRIPTION
There's UI to change the `n_plus_one_db_issue_rate` project option but it is no longer in use anywhere (it's the only remaining reference to `n_plus_one_db_issue_rate` in the codebase).
