### PR TITLE
fix: Remove process_owner_assignments task

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -149,7 +149,11 @@ def handle_owner_assignment(job):
 
     with sentry_sdk.start_span(op="tasks.post_process_group.handle_owner_assignment"):
         try:
-            from sentry.models import ISSUE_OWNERS_DEBOUNCE_KEY
+            from sentry.models import (
+                ISSUE_OWNERS_DEBOUNCE_DURATION,
+                ISSUE_OWNERS_DEBOUNCE_KEY,
+                ProjectOwnership,
+            )
 
             event = job["event"]
             project, group = event.project, event.group
@@ -215,52 +219,41 @@ def handle_owner_assignment(job):
                         )
                         metrics.incr("sentry.tasks.post_process.handle_owner_assignment.debounce")
                         return
-                process_owner_assignments.delay(job)
+
+                with metrics.timer("post_process.process_owner_assignments.duration"):
+                    with sentry_sdk.start_span(
+                        op="post_process.handle_owner_assignment.get_issue_owners"
+                    ):
+                        if killswitch_matches_context(
+                            "post_process.get-autoassign-owners",
+                            {
+                                "project_id": project.id,
+                            },
+                        ):
+                            # see ProjectOwnership.get_issue_owners
+                            issue_owners = []
+                        else:
+
+                            issue_owners = ProjectOwnership.get_issue_owners(project.id, event.data)
+
+                            # Cache for 1 day after we calculated. We don't need to move that fast.
+                            cache.set(
+                                issue_owners_key,
+                                True,
+                                ISSUE_OWNERS_DEBOUNCE_DURATION,
+                            )
+
+                    with sentry_sdk.start_span(
+                        op="post_process.handle_owner_assignment.handle_group_owners"
+                    ):
+                        if issue_owners:
+                            try:
+                                handle_group_owners(project, group, issue_owners)
+                            except Exception:
+                                logger.exception("Failed to store group owners")
+
         except Exception:
             logger.exception("Failed to handle owner assignments")
-
-
-@instrumented_task(name="sentry.tasks.process_owner_assignments", queue="process_owner_assignments")
-def process_owner_assignments(job: PostProcessJob) -> None:
-    metrics.incr("sentry.tasks.post_process.process_owner_assignments")
-    with metrics.timer("post_process.process_owner_assignments.duration"):
-        with sentry_sdk.start_span(op="post_process.handle_owner_assignment.get_issue_owners"):
-            from sentry.models import (
-                ISSUE_OWNERS_DEBOUNCE_DURATION,
-                ISSUE_OWNERS_DEBOUNCE_KEY,
-                ProjectOwnership,
-            )
-
-            event = job["event"]
-            project, group = event.project, event.group
-            issue_owners_key = ISSUE_OWNERS_DEBOUNCE_KEY(group.id)
-
-            if killswitch_matches_context(
-                "post_process.get-autoassign-owners",
-                {
-                    "project_id": project.id,
-                },
-            ):
-                # see ProjectOwnership.get_issue_owners
-                issue_owners = []
-            else:
-
-                issue_owners = ProjectOwnership.get_issue_owners(project.id, event.data)
-
-                # Cache for 1 day after we calculated. We don't need to move that fast.
-                cache.set(
-                    issue_owners_key,
-                    True,
-                    ISSUE_OWNERS_DEBOUNCE_DURATION,
-                )
-
-        with sentry_sdk.start_span(op="post_process.handle_owner_assignment.handle_group_owners"):
-            if issue_owners:
-                try:
-                    handle_group_owners(project, group, issue_owners)
-                except Exception:
-                    logger.exception("Failed to store group owners")
-    handle_auto_assignment(job)
 
 
 def handle_group_owners(project, group, issue_owners):
@@ -968,6 +961,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE = {
         process_inbox_adds,
         process_commits,
         handle_owner_assignment,
+        handle_auto_assignment,
         process_rules,
         process_service_hooks,
         process_resource_change_bounds,


### PR DESCRIPTION
The new `process_owner_assignments` task was causing the `handle_owner_assignment` and `handle_auto_assignment` steps to complete after the `process_rules` step. This PR removes this new task.

Fixes GH-45362
