### PR TITLE
ref(profiling): Add optional request header for profiling

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -90,7 +90,10 @@ class ReactMixin:
                         if redirect_url:
                             return HttpResponseRedirect(redirect_url)
 
-        return render_to_response("sentry/base-react.html", context=context, request=request)
+        response = render_to_response("sentry/base-react.html", context=context, request=request)
+        if "x-sentry-browser-profiling" in request.headers:
+            response["Document-Policy"] = "js-profiling"
+        return response
 
 
 # TODO(dcramer): once we implement basic auth hooks in React we can make this


### PR DESCRIPTION
### Summary
This is the opt-in introduction of the document-policy header required to enable browser profiling.

Since js-self-profiling has some overhead this is added as a conditional response header only if the request header is present for the time being, which should allow some of us to dogfood browser profiling from the upcoming sdk browser profiling package.

Required request header to enable this will be `x-sentry-browser-profiling` although I'm open to other suggestions.


