### PR TITLE
feat(ui): Allow event timestamp tooltip to be hovered

### DIFF
--- a/static/app/views/issueDetails/eventToolbar.tsx
+++ b/static/app/views/issueDetails/eventToolbar.tsx
@@ -89,6 +89,7 @@ class GroupEventToolbar extends Component<Props> {
             </Heading>
             <Tooltip
               title={<EventCreatedTooltip event={evt} />}
+              isHoverable
               showUnderline
               disableForVisualTest
             >


### PR DESCRIPTION
Sometimes it would be nice to be able to copy the timestamp. Let's allow
people to hover over this to select the text

![image](https://user-images.githubusercontent.com/1421724/222836335-1fe7f474-cfca-43a1-9d5b-d2b5cb956045.png)
