### PR TITLE
ref(crons): Prefer usage of monitor.slug in the frontend

### DIFF
--- a/static/app/actionCreators/monitors.tsx
+++ b/static/app/actionCreators/monitors.tsx
@@ -8,11 +8,11 @@ import {t} from 'sentry/locale';
 import {logException} from 'sentry/utils/logging';
 import {Monitor} from 'sentry/views/monitors/types';
 
-export async function deleteMonitor(api: Client, orgId: string, monitorId: string) {
+export async function deleteMonitor(api: Client, orgId: string, monitorSlug: string) {
   addLoadingMessage(t('Deleting Monitor...'));
 
   try {
-    await api.requestPromise(`/organizations/${orgId}/monitors/${monitorId}/`, {
+    await api.requestPromise(`/organizations/${orgId}/monitors/${monitorSlug}/`, {
       method: 'DELETE',
     });
     clearIndicators();
@@ -24,14 +24,14 @@ export async function deleteMonitor(api: Client, orgId: string, monitorId: strin
 export async function updateMonitor(
   api: Client,
   orgId: string,
-  monitorId: string,
+  monitorSlug: string,
   data: Partial<Monitor>
 ) {
   addLoadingMessage();
 
   try {
     const resp = await api.requestPromise(
-      `/organizations/${orgId}/monitors/${monitorId}/`,
+      `/organizations/${orgId}/monitors/${monitorSlug}/`,
       {method: 'PUT', data}
     );
     clearIndicators();

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1301,8 +1301,8 @@ function buildRoutes() {
         <Route
           path={
             forCustomerDomain
-              ? '/crons/:monitorId/'
-              : '/organizations/:orgId/crons/:monitorId/'
+              ? '/crons/:monitorSlug/'
+              : '/organizations/:orgId/crons/:monitorSlug/'
           }
           component={make(() => import('sentry/views/monitors/details'))}
           key={
@@ -1312,8 +1312,8 @@ function buildRoutes() {
         <Route
           path={
             forCustomerDomain
-              ? '/crons/:monitorId/edit/'
-              : '/organizations/:orgId/crons/:monitorId/edit/'
+              ? '/crons/:monitorSlug/edit/'
+              : '/organizations/:orgId/crons/:monitorSlug/edit/'
           }
           component={make(() => import('sentry/views/monitors/edit'))}
           key={forCustomerDomain ? 'orgless-monitors-edit' : 'org-monitors-edit'}

--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -36,14 +36,14 @@ const MonitorCheckIns = ({monitor, orgId}: Props) => {
     endpoints: [
       [
         'checkInList',
-        `/organizations/${orgId}/monitors/${monitor.id}/checkins/`,
+        `/organizations/${orgId}/monitors/${monitor.slug}/checkins/`,
         {query: {per_page: '10'}},
       ],
     ],
   });
 
   const generateDownloadUrl = (checkin: CheckIn) =>
-    `/api/0/organizations/${orgId}/monitors/${monitor.id}/checkins/${checkin.id}/attachment/`;
+    `/api/0/organizations/${orgId}/monitors/${monitor.slug}/checkins/${checkin.id}/attachment/`;
 
   const renderedComponent = renderComponent(
     <PanelBody>

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -150,13 +150,6 @@ class MonitorForm extends Component<Props> {
           <PanelHeader>{t('Details')}</PanelHeader>
 
           <PanelBody>
-            {monitor && (
-              <FieldGroup label={t('ID')}>
-                <div className="controls">
-                  <TextCopyInput>{monitor.id}</TextCopyInput>
-                </div>
-              </FieldGroup>
-            )}
             <SentryProjectSelectorField
               name="project"
               label={t('Project')}
@@ -169,6 +162,17 @@ class MonitorForm extends Component<Props> {
               )}
               required
             />
+            {monitor && (
+              <FieldGroup
+                label={t('Monitor Slug')}
+                flexibleControlStateSize
+                help={t(
+                  'The monitor slug is the organization-wide unique identifier for your monitor.'
+                )}
+              >
+                <TextCopyInput>{monitor.slug}</TextCopyInput>
+              </FieldGroup>
+            )}
             <TextField
               name="name"
               placeholder={t('My Cron Job')}
@@ -199,7 +203,7 @@ class MonitorForm extends Component<Props> {
               name="config.max_runtime"
               label={t('Max Runtime')}
               help={t(
-                "Set the number of minutes a recurring job is allowed to run before it's considered failed"
+                "Set the number of minutes a recurring job is allowed to run before it's considered failed."
               )}
               placeholder="e.g. 30"
             />

--- a/static/app/views/monitors/components/monitorHeader.tsx
+++ b/static/app/views/monitors/components/monitorHeader.tsx
@@ -49,10 +49,10 @@ const MonitorHeader = ({monitor, orgId, onUpdate}: Props) => {
           />
           {monitor.name}
         </Layout.Title>
-        <Clipboard value={monitor.id}>
-          <MonitorId>
-            {monitor.id} <IconCopy size="xs" />
-          </MonitorId>
+        <Clipboard value={monitor.slug}>
+          <MonitorSlug>
+            {monitor.slug} <IconCopy size="xs" />
+          </MonitorSlug>
         </Clipboard>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
@@ -73,7 +73,7 @@ const MonitorHeader = ({monitor, orgId, onUpdate}: Props) => {
   );
 };
 
-const MonitorId = styled('div')`
+const MonitorSlug = styled('div')`
   margin-top: ${space(1)};
   color: ${p => p.theme.subText};
   cursor: pointer;

--- a/static/app/views/monitors/components/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/components/monitorHeaderActions.tsx
@@ -23,12 +23,12 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
   const api = useApi();
 
   const handleDelete = async () => {
-    await deleteMonitor(api, orgId, monitor.id);
+    await deleteMonitor(api, orgId, monitor.slug);
     browserHistory.push(normalizeUrl(`/organizations/${orgId}/crons/`));
   };
 
   const handleUpdate = async (data: Partial<Monitor>) => {
-    const resp = await updateMonitor(api, orgId, monitor.id, data);
+    const resp = await updateMonitor(api, orgId, monitor.slug, data);
     onUpdate?.(resp);
   };
 
@@ -64,7 +64,7 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
         priority="primary"
         size="sm"
         icon={<IconEdit size="xs" />}
-        to={`/organizations/${orgId}/crons/${monitor.id}/edit/`}
+        to={`/organizations/${orgId}/crons/${monitor.slug}/edit/`}
       >
         {t('Edit')}
       </Button>

--- a/static/app/views/monitors/components/monitorStats.tsx
+++ b/static/app/views/monitors/components/monitorStats.tsx
@@ -42,7 +42,7 @@ const MonitorStats = ({monitor, orgId}: Props) => {
     endpoints: [
       [
         'stats',
-        `/organizations/${orgId}/monitors/${monitor.id}/stats/`,
+        `/organizations/${orgId}/monitors/${monitor.slug}/stats/`,
         {
           query: {
             since: since.toString(),

--- a/static/app/views/monitors/create.tsx
+++ b/static/app/views/monitors/create.tsx
@@ -22,7 +22,7 @@ function CreateMonitor({}: Props) {
   const {slug: orgSlug} = useOrganization();
 
   function onSubmitSuccess(data: Monitor) {
-    const url = normalizeUrl(`/organizations/${orgSlug}/crons/${data.id}/`);
+    const url = normalizeUrl(`/organizations/${orgSlug}/crons/${data.slug}/`);
     browserHistory.push(url);
   }
 

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -24,7 +24,7 @@ import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
   WithRouteAnalyticsProps &
-  RouteComponentProps<{monitorId: string}, {}> & {
+  RouteComponentProps<{monitorSlug: string}, {}> & {
     organization: Organization;
   };
 
@@ -42,7 +42,7 @@ class MonitorDetails extends AsyncView<Props, State> {
     return [
       [
         'monitor',
-        `/organizations/${this.orgSlug}/monitors/${params.monitorId}/`,
+        `/organizations/${this.orgSlug}/monitors/${params.monitorSlug}/`,
         {query: location.query},
       ],
     ];

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -12,7 +12,7 @@ import MonitorForm from './components/monitorForm';
 import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
-  RouteComponentProps<{monitorId: string}, {}> & {
+  RouteComponentProps<{monitorSlug: string}, {}> & {
     organization: Organization;
   };
 
@@ -27,14 +27,18 @@ class EditMonitor extends AsyncView<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {params} = this.props;
-    return [['monitor', `/organizations/${this.orgSlug}/monitors/${params.monitorId}/`]];
+    return [
+      ['monitor', `/organizations/${this.orgSlug}/monitors/${params.monitorSlug}/`],
+    ];
   }
 
   onUpdate = (data: Monitor) =>
     this.setState(state => ({monitor: {...state.monitor, ...data}}));
 
   onSubmitSuccess = (data: Monitor) =>
-    browserHistory.push(normalizeUrl(`/organizations/${this.orgSlug}/crons/${data.id}/`));
+    browserHistory.push(
+      normalizeUrl(`/organizations/${this.orgSlug}/crons/${data.slug}/`)
+    );
 
   getTitle() {
     if (this.state.monitor) {
@@ -73,7 +77,7 @@ class EditMonitor extends AsyncView<Props, State> {
             <MonitorForm
               monitor={monitor}
               apiMethod="PUT"
-              apiEndpoint={`/organizations/${this.orgSlug}/monitors/${monitor.id}/`}
+              apiEndpoint={`/organizations/${this.orgSlug}/monitors/${monitor.slug}/`}
               onSubmitSuccess={this.onSubmitSuccess}
             />
           </Layout.Main>

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -149,11 +149,11 @@ class Monitors extends AsyncView<Props, State> {
                 >
                   {monitorList?.map(monitor => (
                     <MonitorRow
-                      key={monitor.id}
+                      key={monitor.slug}
                       monitor={monitor}
                       onDelete={() => {
                         this.setState({
-                          monitorList: monitorList.filter(m => m.id !== monitor.id),
+                          monitorList: monitorList.filter(m => m.slug !== monitor.slug),
                         });
                       }}
                       organization={organization}

--- a/static/app/views/monitors/row.tsx
+++ b/static/app/views/monitors/row.tsx
@@ -70,7 +70,7 @@ function MonitorRow({monitor, organization, onDelete}: MonitorRowProps) {
     {
       key: 'edit',
       label: t('Edit'),
-      to: normalizeUrl(`/organizations/${organization.slug}/crons/${monitor.id}/edit/`),
+      to: normalizeUrl(`/organizations/${organization.slug}/crons/${monitor.slug}/edit/`),
     },
     {
       key: 'delete',
@@ -79,7 +79,7 @@ function MonitorRow({monitor, organization, onDelete}: MonitorRowProps) {
       onAction: () => {
         openConfirmModal({
           onConfirm: async () => {
-            await deleteMonitor(api, organization.slug, monitor.id);
+            await deleteMonitor(api, organization.slug, monitor.slug);
             onDelete();
           },
           header: t('Delete Monitor?'),
@@ -97,7 +97,7 @@ function MonitorRow({monitor, organization, onDelete}: MonitorRowProps) {
     <Fragment>
       <MonitorName>
         <MonitorBadge status={monitor.status} />
-        <Link to={`/organizations/${organization.slug}/crons/${monitor.id}/`}>
+        <Link to={`/organizations/${organization.slug}/crons/${monitor.slug}/`}>
           {monitor.name}
         </Link>
       </MonitorName>

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -74,6 +74,7 @@ export interface Monitor {
   name: string;
   nextCheckIn: string;
   project: Project;
+  slug: string;
   status: MonitorStatus;
   type: MonitorType;
 }


### PR DESCRIPTION
This is basically a no-op since currently all monitor slugs match the monitor guids

Improves the display in the form as well

![clipboard.png](https://i.imgur.com/gwNApSV.png)

This is the follow up from the completion of #45166. We're going to be deprecating GUIDs from a user perspective in the near future.
