### PR TITLE
feat(codecov-v2): Add flag to restrict by plan

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1020,6 +1020,8 @@ SENTRY_FEATURES = {
     "organizations:codecov-stacktrace-integration-v2": False,
     # Enables the cron job to auto-enable codecov integrations.
     "organizations:auto-enable-codecov": False,
+    # The overall flag for codecov integration, gated by plans.
+    "organizations:codecov-integration": False,
     # Enables getting commit sha from git blame for codecov.
     "organizations:codecov-commit-sha-from-git-blame": False,
     # Enables automatically deriving of code mappings

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -227,6 +227,7 @@ default_manager.add("organizations:derive-code-mappings", OrganizationFeature)
 default_manager.add("organizations:derive-code-mappings-dry-run", OrganizationFeature)
 default_manager.add("organizations:codecov-stacktrace-integration", OrganizationFeature, True)
 default_manager.add("organizations:codecov-stacktrace-integration-v2", OrganizationFeature, True)
+default_manager.add("organizations:codecov-integration", OrganizationFeature)
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature)
 default_manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, True)
 


### PR DESCRIPTION
Add a new flag to limit the codecov feature to team+ plans.