### PR TITLE
fix(dynamic-sampling): Handle 0.0 sample rate for dynamic factor function

### DIFF
--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -38,7 +38,7 @@ def _get_rules_of_enabled_biases(
         # the first place. Technically dynamic sampling it is still enabled but for our customers this detail is
         # not important.
         if rule_type in ALWAYS_ALLOWED_RULE_TYPES or (
-            rule_type.value in enabled_biases and base_sample_rate < 1.0
+            rule_type.value in enabled_biases and 0.0 < base_sample_rate < 1.0
         ):
             rules += bias.get_rules(BiasParams(project, base_sample_rate))
 

--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -191,9 +191,12 @@ def apply_dynamic_factor(base_sample_rate: float, x: float) -> float:
     The high-level idea is that we want to reduce the factor the bigger the base_sample_rate becomes, this is done
     because multiplication will exceed 1 very quickly in case we don't reduce the factor.
     """
-    if base_sample_rate <= 0.0 or base_sample_rate > 1.0:
+    if x == 0:
+        raise Exception("A dynamic factor of 0 cannot be set.")
+
+    if base_sample_rate < 0.0 or base_sample_rate > 1.0:
         raise Exception(
-            "The dynamic factor function requires a sample rate in the interval [0.x, 1.0] with x > 0."
+            "The dynamic factor function requires a sample rate in the interval [0.0, 1.0]."
         )
 
     return float(x / x**base_sample_rate)

--- a/tests/sentry/dynamic_sampling/test_utils.py
+++ b/tests/sentry/dynamic_sampling/test_utils.py
@@ -16,7 +16,7 @@ def test_apply_dynamic_factor_with_valid_params(base_sample_rate, x, expected):
     assert apply_dynamic_factor(base_sample_rate, x) == pytest.approx(expected)
 
 
-@pytest.mark.parametrize("base_sample_rate", [-0.1, 1.1])
-def test_apply_dynamic_factor_with_invalid_params(base_sample_rate):
+@pytest.mark.parametrize(["base_sample_rate", "x"], [(-0.1, 1.5), (1.1, 2.5), (0.5, 0)])
+def test_apply_dynamic_factor_with_invalid_params(base_sample_rate, x):
     with pytest.raises(Exception):
-        apply_dynamic_factor(base_sample_rate, 1)
+        apply_dynamic_factor(base_sample_rate, x)

--- a/tests/sentry/dynamic_sampling/test_utils.py
+++ b/tests/sentry/dynamic_sampling/test_utils.py
@@ -6,6 +6,7 @@ from sentry.dynamic_sampling.rules.utils import apply_dynamic_factor
 @pytest.mark.parametrize(
     ["base_sample_rate", "x", "expected"],
     [
+        (0.0, 2.0, 2.0),
         (0.1, 2.0, 1.8660659830736148),
         (0.5, 3.0, 1.7320508075688774),
         (1.0, 4.0, 1.0),
@@ -15,7 +16,7 @@ def test_apply_dynamic_factor_with_valid_params(base_sample_rate, x, expected):
     assert apply_dynamic_factor(base_sample_rate, x) == pytest.approx(expected)
 
 
-@pytest.mark.parametrize("base_sample_rate", [0.0, 1.1])
+@pytest.mark.parametrize("base_sample_rate", [-0.1, 1.1])
 def test_apply_dynamic_factor_with_invalid_params(base_sample_rate):
     with pytest.raises(Exception):
         apply_dynamic_factor(base_sample_rate, 1)


### PR DESCRIPTION
This PR adds support for `0.0` sample rate in the `dynamic_factor` function.