### PR TITLE
feat(grouping): Add more js cdn rules

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -414,6 +414,9 @@ path:**/dist-packages/** -app
 path:**/node_modules/** -app
 module:unpkg/** -app
 path:**https://unpkg.com/** -app
+path:**https://cdnjs.cloudflare.com/** -app
+path:**https://cdn.jsdelivr.net/** -app
+path:**https://esm.run/** -app
 family:javascript function:reportError ^-app -app
 
 ### transpilers and polyfills are just noise, be more aggressive

--- a/tests/sentry/grouping/grouping_inputs/javascript-unpkg.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript-unpkg.json
@@ -8,6 +8,7 @@
         "stacktrace": {
           "frames": [
             {
+              "function": "unpkg",
               "module": "react-dom@16.13.1/umd/react-dom.production",
               "filename": "/react-dom@16.13.1/umd/react-dom.production.min.js",
               "abs_path": "https://unpkg.com/react-dom@16.13.1/umd/react-dom.production.min.js",
@@ -15,10 +16,20 @@
               "colno": 68
             },
             {
-              "function": "Te",
-              "module": "react-dom@16.13.1/umd/react-dom.production",
-              "filename": "/react-dom@16.13.1/umd/react-dom.production.min.js",
-              "abs_path": "https://unpkg.com/react-dom@16.13.1/umd/react-dom.production.min.js",
+              "function": "cdnjs",
+              "abs_path": "https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js",
+              "lineno": 146,
+              "colno": 151
+            },
+            {
+              "function": "jsdelivr",
+              "abs_path": "https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js",
+              "lineno": 146,
+              "colno": 151
+            },
+            {
+              "function": "esm.run",
+              "abs_path": "https://esm.run/d3@7.6.1",
               "lineno": 146,
               "colno": 151
             }

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_unpkg.pysnap
@@ -1,5 +1,7 @@
 ---
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["module","react-dom@16.13.1/umd/react-dom.production"]],[["function","Te"],["module","react-dom@16.13.1/umd/react-dom.production"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","cdnjs"]],[["function","jsdelivr"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","jsdelivr"]],[["function","run"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","unpkg"],["module","react-dom@16.13.1/umd/react-dom.production"]],[["function","cdnjs"]]]
 similarity:2020-07-23:type:ident-shingle: "Error"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_unpkg.pysnap
@@ -12,16 +12,30 @@ app:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (module takes precedence)
               "/react-dom@16.13.1/umd/react-dom.production.min.js"
-            lineno*
-              61
-          frame* (frame considered in-app because no frame is in-app)
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
-            filename (module takes precedence)
-              "/react-dom@16.13.1/umd/react-dom.production.min.js"
             function*
-              "Te"
+              "unpkg"
             lineno (function takes precedence)
+              61
+          frame (frame considered in-app because no frame is in-app)
+            filename (ignored because filename is a URL)
+              "/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"
+            function (function name is not used if module or filename are available)
+              "cdnjs"
+            lineno (line number is not used if module or filename are available)
+              146
+          frame (frame considered in-app because no frame is in-app)
+            filename (ignored because filename is a URL)
+              "/npm/jquery@3.2.1/dist/jquery.min.js"
+            function (function name is not used if module or filename are available)
+              "jsdelivr"
+            lineno (line number is not used if module or filename are available)
+              146
+          frame (frame considered in-app because no frame is in-app)
+            filename (ignored because filename is a URL)
+              "/d3@7.6.1"
+            function (function name is not used if module or filename are available)
+              "esm.run"
+            lineno (line number is not used if module or filename are available)
               146
         type*
           "Error"
@@ -29,7 +43,7 @@ app:
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "4ee404c13ebc4a7097d65b0a19e98b3c"
+  hash: "5a78ef040b2122b94fc8d7756971739c"
   component:
     system*
       exception*
@@ -39,16 +53,30 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (module takes precedence)
               "/react-dom@16.13.1/umd/react-dom.production.min.js"
-            lineno*
-              61
-          frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
-            filename (module takes precedence)
-              "/react-dom@16.13.1/umd/react-dom.production.min.js"
             function*
-              "Te"
+              "unpkg"
             lineno (function takes precedence)
+              61
+          frame
+            filename (ignored because filename is a URL)
+              "/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"
+            function (function name is not used if module or filename are available)
+              "cdnjs"
+            lineno (line number is not used if module or filename are available)
+              146
+          frame
+            filename (ignored because filename is a URL)
+              "/npm/jquery@3.2.1/dist/jquery.min.js"
+            function (function name is not used if module or filename are available)
+              "jsdelivr"
+            lineno (line number is not used if module or filename are available)
+              146
+          frame
+            filename (ignored because filename is a URL)
+              "/d3@7.6.1"
+            function (function name is not used if module or filename are available)
+              "esm.run"
+            lineno (line number is not used if module or filename are available)
               146
         type*
           "Error"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_unpkg.pysnap
@@ -2,29 +2,76 @@
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "b746dd9c32716f9c823129cb30f26338"
-  tree_label: "Te"
+  hash: "4364639e22250950545ba3c16a0654d0"
+  tree_label: "run"
   component:
     app-depth-1*
       exception*
         stacktrace*
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
-              "react-dom.production.min.js"
-            function*
-              "Te"
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "bad"
 --------------------------------------------------------------------------
 app-depth-2:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
-  tree_label: "Te"
+  hash: "4c25698b1cc1c8396ddad0cd3da00b7d"
+  tree_label: "run | jsdelivr"
   component:
     app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "a9af34790c14bc5193c005ba555d9842"
+  tree_label: "run | jsdelivr | cdnjs"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            filename (ignored because frame points to a URL)
+              "react-dom.production.min.js"
+            function*
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
+        type*
+          "Error"
+        value (ignored because stacktrace takes precedence)
+          "bad"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "6ab78545e13144405fb21dadb9045b91"
+  tree_label: "run | jsdelivr | cdnjs | unpkg"
+  component:
+    app-depth-4*
       exception*
         stacktrace*
           frame*
@@ -32,21 +79,31 @@ app-depth-2:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "bad"
 --------------------------------------------------------------------------
 app-depth-max:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
-  tree_label: "Te"
+  hash: "6ab78545e13144405fb21dadb9045b91"
+  tree_label: "run | jsdelivr | cdnjs | unpkg"
   component:
     app-depth-max*
       exception*
@@ -56,21 +113,31 @@ app-depth-max:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
-  tree_label: "Te"
+  hash: "6ab78545e13144405fb21dadb9045b91"
+  tree_label: "run | jsdelivr | cdnjs | unpkg"
   component:
     system*
       exception*
@@ -80,13 +147,23 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/javascript_unpkg.pysnap
@@ -12,18 +12,28 @@ app:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame (non app frame)
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function*
+              "esm.run"
         type*
           "Error"
 --------------------------------------------------------------------------
 system:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
+  hash: "e8336133eef3799c5dfe334b523717b2"
   component:
     system*
       exception*
@@ -33,12 +43,22 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function*
+              "esm.run"
         type*
           "Error"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/javascript_unpkg.pysnap
@@ -12,20 +12,30 @@ app:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame (non app frame)
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function*
+              "esm.run"
         type*
           "Error"
         value*
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
+  hash: "e8336133eef3799c5dfe334b523717b2"
   component:
     system*
       exception*
@@ -35,13 +45,23 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function*
+              "esm.run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_unpkg.pysnap
@@ -12,20 +12,30 @@ app:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame (non app frame)
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value*
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
+  hash: "6ab78545e13144405fb21dadb9045b91"
   component:
     system*
       exception*
@@ -35,13 +45,23 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_unpkg.pysnap
@@ -12,20 +12,30 @@ app:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame (non app frame)
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value*
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
+  hash: "6ab78545e13144405fb21dadb9045b91"
   component:
     system*
       exception*
@@ -35,13 +45,23 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -12,20 +12,30 @@ app:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
-          frame (marked out of app by stack trace rule (path:**https://unpkg.com/** -app))
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
+            function*
+              "unpkg"
+          frame (marked out of app by stack trace rule (path:**https://cdnjs.cloudflare.com/** -app))
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame (marked out of app by stack trace rule (path:**https://cdn.jsdelivr.net/** -app))
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame (marked out of app by stack trace rule (path:**https://esm.run/** -app))
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value*
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
+  hash: "6ab78545e13144405fb21dadb9045b91"
   component:
     system*
       exception*
@@ -35,13 +45,23 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
-          frame* (marked out of app by stack trace rule (path:**https://unpkg.com/** -app))
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
+            function*
+              "unpkg"
+          frame* (marked out of app by stack trace rule (path:**https://cdnjs.cloudflare.com/** -app))
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame* (marked out of app by stack trace rule (path:**https://cdn.jsdelivr.net/** -app))
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame* (marked out of app by stack trace rule (path:**https://esm.run/** -app))
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/javascript_unpkg.pysnap
@@ -12,20 +12,30 @@ app:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame (non app frame)
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame (non app frame)
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value*
           "bad"
 --------------------------------------------------------------------------
 system:
-  hash: "728bbcb0ca8aaf4d90feed1f320bf9f6"
+  hash: "6ab78545e13144405fb21dadb9045b91"
   component:
     system*
       exception*
@@ -35,13 +45,23 @@ system:
               "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
+            function*
+              "unpkg"
           frame*
-            module*
-              "react-dom@16.13.1/umd/react-dom.production"
             filename (ignored because frame points to a URL)
               "react-dom.production.min.js"
             function*
-              "Te"
+              "cdnjs"
+          frame*
+            filename (ignored because frame points to a URL)
+              "jquery.min.js"
+            function*
+              "jsdelivr"
+          frame*
+            filename (ignored because frame points to a URL)
+              "d3@7.6.1"
+            function* (trimmed javascript function)
+              "run"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)


### PR DESCRIPTION
Similar to unkpg, also mark cdnjs, jsdelivr and esm.run as out of app