### PR TITLE
ref: gettext things return a str Promise

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Collection, Dict, Mapping, Sequence, Tuple, cast
+from typing import TYPE_CHECKING, Any, Collection, Dict, Mapping, Sequence, Tuple, cast
 from uuid import uuid4
 
 import sentry_sdk
@@ -56,6 +56,9 @@ from sentry.web.helpers import render_to_response
 
 from ..services.hybrid_cloud.log import AuditLogEvent, log_service
 from . import manager
+
+if TYPE_CHECKING:
+    from django.utils.functional import _StrPromise  # fake type added by django-stubs
 
 logger = logging.getLogger("sentry.auth")
 
@@ -856,7 +859,7 @@ class AuthHelper(Pipeline):
         )
         return HttpResponseRedirect(next_uri)
 
-    def error(self, message: str) -> HttpResponseRedirect:
+    def error(self, message: str | _StrPromise) -> HttpResponseRedirect:
         redirect_uri = "/"
 
         if self.state.flow == self.FLOW_LOGIN:


### PR DESCRIPTION
on its own, this doesn't do anything (`_StrPromise` is treated as `Any`) -- but with `django-stubs` this fixes ~10 type errors