### PR TITLE
ref(referrers): Fix usage of tagstore enum

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -699,7 +699,7 @@ class SnubaTagStorage(TagStorage):
             aggregations=aggregations,
             orderby="-count",
             limitby=[value_limit, "tags_key"],
-            referrer="tagstore.__get_tag_keys_and_top_values",
+            referrer="tagstore._get_tag_keys_and_top_values",
         )
 
         # Then supplement the key objects with the top values for each.


### PR DESCRIPTION
I keep getting this error in my console: `Exception: referrer tagstore.__get_tag_keys_and_top_values is not part of Referrer Enum` - it seems like an extra underscore was added. This PR changes the usage to what it's supposed to be based on https://github.com/getsentry/sentry/blob/master/src/sentry/snuba/referrer.py#L510