### PR TITLE
fix(auth): Updated CSRF error msg with extra "/" warning

### DIFF
--- a/src/sentry/templates/sentry/403-csrf-failure.html
+++ b/src/sentry/templates/sentry/403-csrf-failure.html
@@ -18,6 +18,7 @@
           <li>{% trans "Clear cookies (at least for Sentry's domain)." %}</li>
           <li>{% trans "Reload the page you're trying to submit (don't re-submit data)." %}</li>
           <li>{% trans "Re-enter the information, and submit the form again." %}</li>
+          <li>{% trans "Ensure the URL does not contain an extra "/" anywhere (eg: https://foo//saml -> https://foo/saml)." %}</li>
         </ol>
 
         {% if no_referer %}

--- a/src/sentry/templates/sentry/403-csrf-failure.html
+++ b/src/sentry/templates/sentry/403-csrf-failure.html
@@ -18,7 +18,7 @@
           <li>{% trans "Clear cookies (at least for Sentry's domain)." %}</li>
           <li>{% trans "Reload the page you're trying to submit (don't re-submit data)." %}</li>
           <li>{% trans "Re-enter the information, and submit the form again." %}</li>
-          <li>{% trans "Ensure the URL does not contain an extra "/" anywhere (eg: https://foo//saml -> https://foo/saml)." %}</li>
+          <li>{% trans "Ensure the URL does not contain an extra 	&quot;/&quot; anywhere (eg: https://foo//saml -> https://foo/saml)." %}</li>
         </ol>
 
         {% if no_referer %}


### PR DESCRIPTION
Added extra line in error message to inform user to check for extra "/" in URL

Fixes ER-1219
<img width="790" alt="Screenshot 2023-03-06 at 2 28 03 PM" src="https://user-images.githubusercontent.com/67301797/223260274-fe08aa01-92af-43fa-a101-96838a4a3893.png">
