### PR TITLE
fix(performance): NaN transaction percentage

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/transactionPercentage.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/transactionPercentage.tsx
@@ -30,7 +30,7 @@ export function TransactionPercentage({
 
   function getValueFromTotals(field, totalValues, unfilteredTotalValues) {
     if (totalValues) {
-      if (unfilteredTotalValues) {
+      if (unfilteredTotalValues?.[field]) {
         return tct('[tpm]', {
           tpm: formatPercentage(totalValues[field] / unfilteredTotalValues[field]),
         });


### PR DESCRIPTION
When the denominator is 0, this shows `NaN%`. This changes it to show `0 tpm` instead.