### PR TITLE
chore(scim): return error schema

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, Union
 
 import sentry_sdk
@@ -20,6 +22,7 @@ from sentry import audit_log, features, roles
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organizationmember import OrganizationMemberEndpoint
 from sentry.api.endpoints.organization_member.index import OrganizationMemberSerializer
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import (
@@ -139,6 +142,25 @@ def resolve_maybe_bool_value(value):
 class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
     permission_classes = (OrganizationSCIMMemberPermission,)
     public = {"GET", "DELETE", "PATCH"}
+
+    def convert_args(
+        self,
+        request: Request,
+        organization_slug: str,
+        member_id: str = "me",
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[Any, Any]:
+        try:
+            args, kwargs = super().convert_args(
+                request, organization_slug, member_id, *args, **kwargs
+            )
+            return args, kwargs
+        except ResourceDoesNotExist:
+            raise SCIMApiError(
+                status_code=ResourceDoesNotExist.status_code,
+                detail=ResourceDoesNotExist.default_detail,
+            )
 
     def _delete_member(self, request: Request, organization, member):
         audit_data = member.get_audit_log_data()

--- a/tests/apidocs/endpoints/scim/test_member_details.py
+++ b/tests/apidocs/endpoints/scim/test_member_details.py
@@ -24,3 +24,12 @@ class SCIMMemberDetailsDocs(APIDocsTestCase, SCIMTestCase):
         response = self.client.delete(self.url)
         request = RequestFactory().delete(self.url)
         self.validate_schema(request, response)
+
+    def test_get_invalid(self):
+        url = reverse(
+            "sentry-api-0-organization-scim-member-details",
+            kwargs={"organization_slug": self.organization.slug, "member_id": 321},
+        )
+        response = self.client.get(url)
+        assert response.status_code == 404
+        assert response.data["schemas"] == ["urn:ietf:params:scim:api:messages:2.0:Error"]


### PR DESCRIPTION
From #45479 

Return the appropriate error schema as expected by SCIM SPEC tests