### PR TITLE
fix(replays): show replay index regardless of feature

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -242,16 +242,14 @@ function Sidebar({location, organization}: Props) {
   );
 
   const replays = hasOrganization && (
-    <Feature features={['session-replay']} organization={organization}>
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconPlay size="md" />}
-        label={t('Replays')}
-        to={`/organizations/${organization.slug}/replays/`}
-        id="replays"
-        isNew
-      />
-    </Feature>
+    <SidebarItem
+      {...sidebarItemProps}
+      icon={<IconPlay size="md" />}
+      label={t('Replays')}
+      to={`/organizations/${organization.slug}/replays/`}
+      id="replays"
+      isNew
+    />
   );
 
   const dashboards = hasOrganization && (

--- a/static/app/views/replays/index.tsx
+++ b/static/app/views/replays/index.tsx
@@ -1,11 +1,8 @@
 import {RouteComponentProps} from 'react-router';
 
 import Feature from 'sentry/components/acl/feature';
-import {Alert} from 'sentry/components/alert';
 import HookOrDefault from 'sentry/components/hookOrDefault';
-import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
-import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -14,37 +11,23 @@ type Props = RouteComponentProps<{}, {}> & {
   organization: Organization;
 };
 
-function renderNoAccess() {
-  return (
-    <Layout.Page withPadding>
-      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
-    </Layout.Page>
-  );
-}
-
 const BetaGracePeriodAlertHook = HookOrDefault({
   hookName: 'component:replay-beta-grace-period-alert',
 });
 
 function ReplaysContainer({organization, children}: Props) {
   return (
-    <Feature
-      features={['session-replay']}
-      organization={organization}
-      renderDisabled={renderNoAccess}
-    >
-      <NoProjectMessage organization={organization}>
-        <Feature
-          features={['session-replay-beta-grace']}
-          organization={organization}
-          renderDisabled={false}
-        >
-          <BetaGracePeriodAlertHook organization={organization} />
-        </Feature>
+    <NoProjectMessage organization={organization}>
+      <Feature
+        features={['session-replay-beta-grace']}
+        organization={organization}
+        renderDisabled={false}
+      >
+        <BetaGracePeriodAlertHook organization={organization} />
+      </Feature>
 
-        {children}
-      </NoProjectMessage>
-    </Feature>
+      {children}
+    </NoProjectMessage>
   );
 }
 


### PR DESCRIPTION
We were hiding this page if the user didn't have the session replay feature enabled, but everyone should be able to at least navigate to the replays index.