### PR TITLE
feat(codecov): Switch to new Codecov API

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -269,7 +269,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
                 scope.set_tag("codecov.enabled", should_get_coverage)
                 if should_get_coverage:
                     codecov_data, err = fetch_codecov_data(
-                        organization=project.organization,
                         sha=ctx.get("commit_id"),
                         config=current_config,
                     )

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -268,10 +268,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
                 should_get_coverage = codecov_enabled(project.organization, request.user)
                 scope.set_tag("codecov.enabled", should_get_coverage)
                 if should_get_coverage:
-                    codecov_data, err = fetch_codecov_data(
-                        sha=ctx.get("commit_id"),
-                        config=current_config,
-                    )
+                    codecov_data, err = fetch_codecov_data(config=current_config)
                     if codecov_data:
                         result["codecov"] = codecov_data
                     if err:

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -128,10 +128,7 @@ def get_codecov_data(repo: str, service: str, path: str) -> Tuple[LineCoverage |
     return line_coverage, codecov_url
 
 
-def fetch_codecov_data(
-    sha: str | None,
-    config: Any,
-) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+def fetch_codecov_data(config: Any) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
     try:
         repo = config["repository"].name
         service = config["config"]["provider"]["key"]

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, Literal, Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import requests
 from rest_framework import status
@@ -13,14 +13,10 @@ from sentry.models.organization import Organization
 
 LineCoverage = Sequence[Tuple[int, int]]
 CODECOV_REPORT_URL = (
-    "https://api.codecov.io/api/v2/{service}/{owner_username}/repos/{repo_name}/report"
-)
-NEW_CODECOV_REPORT_URL = (
     "https://api.codecov.io/api/v2/{service}/{owner_username}/repos/{repo_name}/file_report/{path}"
 )
 CODECOV_REPOS_URL = "https://api.codecov.io/api/v2/{service}/{owner_username}/repos"
-REF_TYPE = Literal["branch", "sha"]
-CODECOV_TIMEOUT = 10
+CODECOV_TIMEOUT = 2
 
 
 class CodecovIntegrationError(Enum):
@@ -78,14 +74,7 @@ def has_codecov_integration(organization: Organization) -> Tuple[bool, str | Non
     )
 
 
-def get_codecov_data(
-    repo: str,
-    service: str,
-    ref: str,
-    ref_type: REF_TYPE,
-    path: str,
-    organization: Organization,
-) -> Tuple[LineCoverage | None, str | None]:
+def get_codecov_data(repo: str, service: str, path: str) -> Tuple[LineCoverage | None, str | None]:
     codecov_token = options.get("codecov.client-secret")
     if not codecov_token:
         return None, None
@@ -95,46 +84,41 @@ def get_codecov_data(
 
     path = path.lstrip("/")
     url = CODECOV_REPORT_URL.format(
-        service=service, owner_username=owner_username, repo_name=repo_name
+        service=service,
+        owner_username=owner_username,
+        repo_name=repo_name,
+        path=path,
     )
-    params = {ref_type: ref, "path": path}
-
-    use_new_api = features.has("organizations:codecov-stacktrace-integration-v2", organization)
-    if use_new_api:
-        url = NEW_CODECOV_REPORT_URL.format(
-            service=service, owner_username=owner_username, repo_name=repo_name, path=path
-        )
-        params = {}
 
     line_coverage, codecov_url = None, None
     with configure_scope() as scope:
-        timeout = CODECOV_TIMEOUT if use_new_api else None
+        timeout = CODECOV_TIMEOUT
 
         response = requests.get(
             url,
-            params=params,
+            params={},
             headers={"Authorization": f"Bearer {codecov_token}"},
             timeout=timeout,
         )
         tags = {
             "codecov.request_url": url,
-            "codecov.request_params": params,
             "codecov.request_path": path,
-            "codecov.request_ref": ref,
             "codecov.http_code": response.status_code,
         }
 
         response_json = response.json()
-        if use_new_api:
-            tags["codecov.new_endpoint"] = True
-            line_coverage = response_json.get("line_coverage")
-        else:
-            files = response_json.get("files")
-            line_coverage = files[0].get("line_coverage") if files else None
+
+        tags["codecov.new_endpoint"] = True
+        line_coverage = response_json.get("line_coverage")
 
         coverage_found = line_coverage not in [None, [], [[]]]
         codecov_url = response_json.get("commit_file_url", "")
-        tags.update({"codecov.coverage_found": coverage_found, "codecov.coverage_url": codecov_url})
+        tags.update(
+            {
+                "codecov.coverage_found": coverage_found,
+                "codecov.coverage_url": codecov_url,
+            },
+        )
 
         for key, value in tags.items():
             scope.set_tag(key, value)
@@ -145,7 +129,6 @@ def get_codecov_data(
 
 
 def fetch_codecov_data(
-    organization: Organization,
     sha: str | None,
     config: Any,
 ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
@@ -154,12 +137,7 @@ def fetch_codecov_data(
         service = config["config"]["provider"]["key"]
         path = config["outcome"]["sourcePath"]
 
-        ref = sha if sha else config["config"]["defaultBranch"]
-        ref_type: REF_TYPE = "sha" if sha else "branch"
-
-        lineCoverage, codecovUrl = get_codecov_data(
-            repo, service, ref, ref_type, path, organization
-        )
+        lineCoverage, codecovUrl = get_codecov_data(repo, service, path)
         if lineCoverage and codecovUrl:
             return {
                 "lineCoverage": lineCoverage,

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -92,13 +92,11 @@ def get_codecov_data(repo: str, service: str, path: str) -> Tuple[LineCoverage |
 
     line_coverage, codecov_url = None, None
     with configure_scope() as scope:
-        timeout = CODECOV_TIMEOUT
-
         response = requests.get(
             url,
             params={},
             headers={"Authorization": f"Bearer {codecov_token}"},
-            timeout=timeout,
+            timeout=CODECOV_TIMEOUT,
         )
         tags = {
             "codecov.request_url": url,

--- a/tests/sentry/integrations/utils/test_codecov.py
+++ b/tests/sentry/integrations/utils/test_codecov.py
@@ -64,33 +64,8 @@ class TestCodecovIntegration(APITestCase):
         assert has_integration
 
     @responses.activate
-    def test_get_codecov_report(self):
-        expected_line_coverage = [[1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]
-        expected_codecov_url = "https://codecov.io/gh/testgit/abc/commit/abc"
-        responses.add(
-            responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit/repos/abc/report",
-            status=200,
-            json={
-                "files": [{"line_coverage": expected_line_coverage}],
-                "commit_file_url": expected_codecov_url,
-            },
-        )
-
-        coverage, url = get_codecov_data(
-            repo="testgit/abc",
-            service="github",
-            ref="master",
-            ref_type="branch",
-            path="path/to/file.py",
-            organization=self.organization,
-        )
-        assert coverage == expected_line_coverage
-        assert url == expected_codecov_url
-
-    @responses.activate
     @with_feature("organizations:codecov-stacktrace-integration-v2")
-    def test_get_codecov_report_new_endpoint(self):
+    def test_get_codecov_report(self):
         expected_line_coverage = [[1, 1], [2, 1], [3, 1], [4, 1], [5, 1]]
         expected_codecov_url = "https://app.codecov.io/gh/testgit/abc/commit/0f1e2d/path/to/file.py"
         responses.add(
@@ -107,17 +82,14 @@ class TestCodecovIntegration(APITestCase):
         coverage, url = get_codecov_data(
             repo="testgit/abc",
             service="github",
-            ref="master",
-            ref_type="branch",
             path="path/to/file.py",
-            organization=self.organization,
         )
         assert coverage == expected_line_coverage
         assert url == expected_codecov_url
 
     @responses.activate
     @with_feature("organizations:codecov-stacktrace-integration-v2")
-    def test_get_codecov_report_new_endpoint_error(self):
+    def test_get_codecov_report_error(self):
         responses.add(
             responses.GET,
             "https://api.codecov.io/api/v2/gh/testgit/repos/abc/file_report/path/to/file.py",
@@ -128,10 +100,7 @@ class TestCodecovIntegration(APITestCase):
             _, _ = get_codecov_data(
                 repo="testgit/abc",
                 service="github",
-                ref="master",
-                ref_type="branch",
                 path="path/to/file.py",
-                organization=self.organization,
             )
 
             assert e.status == 404


### PR DESCRIPTION
The new API [works](https://sentry.sentry.io/dashboard/36228/?project=1&statsPeriod=7d), let's ship it! 