### PR TITLE
feat(perf-issues): Ignore nextjs assets

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -99,6 +99,9 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         ):  # Just using all methods to see if anything interesting pops up
             return False
 
+        if any([x in description for x in ["_next/static/", "_next/data/"]]):
+            return False
+
         return True
 
     def _fingerprint(self) -> str:

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
@@ -145,12 +145,6 @@ class ConsecutiveDbDetectorTest(TestCase):
             create_span(
                 "http.client", span_duration, "GET /api/0/organizations/endpoint3", "hash3"
             ),
-            create_span(
-                "http.client", span_duration, "GET /api/0/organizations/endpoint4", "hash4"
-            ),
-            create_span(
-                "http.client", span_duration, "GET /api/0/organizations/endpoint5", "hash5"
-            ),
         ]
 
         spans = [
@@ -158,9 +152,11 @@ class ConsecutiveDbDetectorTest(TestCase):
         ]  # ensure spans don't overlap
         assert len(self.find_problems(create_event(spans))) == 1
 
-        spans[2] = modify_span_start(
-            create_span("http.client", span_duration, "GET /_next/static/css/hash123.css", "hash3"),
-            4000,
+        spans[0] = modify_span_start(
+            create_span(
+                "http.client", span_duration, "GET /_next/static/css/file-hash-abc.css", "hash4"
+            ),
+            0,
         )
 
-        assert self.find_problems(create_event(spans)) == 0
+        assert self.find_problems(create_event(spans)) == []


### PR DESCRIPTION
Work on PERF-2024

Ignore next js assets in span description. Sometimes an asset in next.js occurs as a `http.client` span, rather then a `resource.link` span. This detector doesn't focus on resources.

Ignore `_next/data/` as it contains a build id, which we can't fingerprint correctly.