### PR TITLE
feat(perf-issues): Add link to transaction summary from Span Evidence

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -16,6 +16,7 @@ import {
 describe('SpanEvidenceKeyValueList', () => {
   describe('N+1 Database Queries', () => {
     const builder = new TransactionEventBuilder('a1', '/');
+    builder.getEvent().projectID = '123';
 
     const parentSpan = new MockSpan({
       startTimestamp: 0,
@@ -51,6 +52,12 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.transaction')
       ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+      );
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
@@ -74,6 +81,7 @@ describe('SpanEvidenceKeyValueList', () => {
 
   describe('MN+1 Database Queries', () => {
     const builder = new TransactionEventBuilder('a1', '/');
+    builder.getEvent().projectID = '123';
 
     const parentSpan = new MockSpan({
       startTimestamp: 0,
@@ -109,6 +117,12 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.transaction')
       ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+      );
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
@@ -136,6 +150,7 @@ describe('SpanEvidenceKeyValueList', () => {
       '/',
       IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES
     );
+    builder.getEvent().projectID = '123';
 
     const parentSpan = new MockSpan({
       startTimestamp: 0,
@@ -177,6 +192,12 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.transaction')
       ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+      );
 
       expect(screen.getByRole('cell', {name: 'Starting Span'})).toBeInTheDocument();
       expect(
@@ -209,6 +230,7 @@ describe('SpanEvidenceKeyValueList', () => {
       '/',
       IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS
     );
+    builder.getEvent().projectID = '123';
 
     const parentSpan = new MockSpan({
       startTimestamp: 0,
@@ -251,6 +273,12 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.transaction')
       ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+      );
 
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
@@ -350,6 +378,7 @@ describe('SpanEvidenceKeyValueList', () => {
       '/',
       IssueType.PERFORMANCE_SLOW_DB_QUERY
     );
+    builder.getEvent().projectID = '123';
 
     const parentSpan = new MockSpan({
       startTimestamp: 0,
@@ -375,6 +404,12 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.transaction')
       ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+      );
 
       expect(screen.getByRole('cell', {name: 'Slow DB Query'})).toBeInTheDocument();
       expect(
@@ -394,6 +429,7 @@ describe('SpanEvidenceKeyValueList', () => {
         fcp: 2500,
       }
     );
+    builder.getEvent().projectID = '123';
 
     const offenderSpan = new MockSpan({
       startTimestamp: 0,
@@ -412,6 +448,12 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.transaction')
       ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+      );
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();
       expect(
@@ -439,6 +481,7 @@ describe('SpanEvidenceKeyValueList', () => {
         duration: 0.931, // in seconds
       }
     );
+    builder.getEvent().projectID = '123';
 
     const offenderSpan = new MockSpan({
       startTimestamp: 0,
@@ -460,6 +503,12 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.getByTestId('span-evidence-key-value-list.transaction')
       ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+      );
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();
       expect(

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -56,7 +56,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
       ).toHaveAttribute(
         'href',
-        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
       ).toHaveAttribute(
         'href',
-        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
@@ -196,7 +196,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
       ).toHaveAttribute(
         'href',
-        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
 
       expect(screen.getByRole('cell', {name: 'Starting Span'})).toBeInTheDocument();
@@ -277,7 +277,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
       ).toHaveAttribute(
         'href',
-        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
 
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
@@ -408,7 +408,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
       ).toHaveAttribute(
         'href',
-        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
 
       expect(screen.getByRole('cell', {name: 'Slow DB Query'})).toBeInTheDocument();
@@ -452,7 +452,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
       ).toHaveAttribute(
         'href',
-        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();
@@ -507,7 +507,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
       ).toHaveAttribute(
         'href',
-        `/organizations/org-slug/performance/summary/?project=123&transaction=%2F`
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -21,7 +21,7 @@ import {
 } from 'sentry/types';
 import {formatBytesBase2} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
-import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils';
 
 import KeyValueList from '../keyValueList';
@@ -258,13 +258,12 @@ const PresortedKeyValueList = ({data}: {data: KeyValueListData}) => (
 );
 
 const makeTransactionNameRow = (event: Event, orgSlug: string) => {
-  const to = {
-    pathname: normalizeUrl(`/organizations/${orgSlug}/performance/summary/`),
-    query: {
-      project: event.projectID,
-      transaction: event.title,
-    },
-  };
+  const to = transactionSummaryRouteWithQuery({
+    orgSlug,
+    projectID: event.projectID,
+    transaction: event.title,
+    query: {},
+  });
   return makeRow(
     t('Transaction'),
     <pre>


### PR DESCRIPTION
In the `Transaction` line of Span Evidence, link the transaction title value to the transaction summary page for that transaction.

![Screenshot 2023-03-07 at 4 46 23 PM](https://user-images.githubusercontent.com/110054669/223560377-43263edc-f2bd-478d-b567-31051e2e7138.png)

The link takes you to the Transaction Summary page, e.g. https://try.sentry-demo.com/organizations/major-panther/performance/summary/?project=183242&query=&referrer=performance-transaction-summary&statsPeriod=7d&transaction=checkout&unselectedSeries=p100%28%29

![Screenshot 2023-03-07 at 4 48 45 PM](https://user-images.githubusercontent.com/110054669/223560885-acaf7a04-246f-4993-9971-4e2dc5e2af84.png)
