### PR TITLE
fix(py): Correct monitors module path in cleanup

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -155,6 +155,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
         from sentry.constants import ObjectStatus
         from sentry.data_export.models import ExportedData
         from sentry.db.deletion import BulkDeleteQuery
+        from sentry.monitors import models as monitor_models
         from sentry.replays import models as replay_models
         from sentry.utils import metrics
         from sentry.utils.query import RangeQuerySetWrapper
@@ -180,7 +181,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             (models.GroupEmailThread, "date", None),
             (models.GroupRuleStatus, "date_added", None),
             (models.RuleFireHistory, "date_added", None),
-            (models.MonitorCheckIn, "date_added", None),
+            (monitor_models.MonitorCheckIn, "date_added", None),
         ] + EXTRA_BULK_QUERY_DELETES
 
         # Deletions that use the `deletions` code path (which handles their child relations)


### PR DESCRIPTION
Missed this in #45439 

Fixes: SENTRY-FOR-SENTRY-SRC