### PR TITLE
feat(modals): Add option to round corner of highlight corners modal container

### DIFF
--- a/static/app/components/highlightModalContainer.tsx
+++ b/static/app/components/highlightModalContainer.tsx
@@ -7,6 +7,7 @@ import TopRight from 'sentry-images/pattern/highlight-top-right.svg';
 type Props = {
   bottomWidth: string;
   children: React.ReactNode;
+  roundCorner: boolean;
   topWidth: string;
 };
 
@@ -14,12 +15,17 @@ export default function HighlightModalContainer({
   topWidth,
   bottomWidth,
   children,
+  roundCorner,
 }: Props) {
   return (
     <Fragment>
       <PositionTopRight src={TopRight} width={topWidth} />
       {children}
-      <PositionBottomLeft src={BottomLeft} width={bottomWidth} />
+      <PositionBottomLeft
+        src={BottomLeft}
+        width={bottomWidth}
+        roundCorner={roundCorner}
+      />
     </Fragment>
   );
 }
@@ -32,15 +38,17 @@ const PositionTopRight = styled('img')<{width: string}>`
   pointer-events: none;
 `;
 
-const PositionBottomLeft = styled('img')<{width: string}>`
+const PositionBottomLeft = styled('img')<{roundCorner: boolean; width: string}>`
   position: absolute;
   width: ${p => p.width};
   bottom: 0;
   left: 0;
   pointer-events: none;
+  border-radius: ${p => (p.roundCorner ? '0 0 0 8px' : '0')};
 `;
 
 HighlightModalContainer.defaultProps = {
   topWidth: '400px',
   bottomWidth: '200px',
+  roundCorner: false,
 };

--- a/static/app/components/highlightModalContainer.tsx
+++ b/static/app/components/highlightModalContainer.tsx
@@ -30,7 +30,7 @@ const PositionTopRight = styled('img')<{width: string}>`
   right: 0;
   top: 0;
   pointer-events: none;
-  border-radius: 0 8px 0 0;
+  border-radius: 0 ${p => p.theme.modalBorderRadius} 0 0;
 `;
 
 const PositionBottomLeft = styled('img')<{width: string}>`
@@ -39,7 +39,7 @@ const PositionBottomLeft = styled('img')<{width: string}>`
   bottom: 0;
   left: 0;
   pointer-events: none;
-  border-radius: 0 0 0 8px;
+  border-radius: 0 0 0 ${p => p.theme.modalBorderRadius};
 `;
 
 HighlightModalContainer.defaultProps = {

--- a/static/app/components/highlightModalContainer.tsx
+++ b/static/app/components/highlightModalContainer.tsx
@@ -7,7 +7,6 @@ import TopRight from 'sentry-images/pattern/highlight-top-right.svg';
 type Props = {
   bottomWidth: string;
   children: React.ReactNode;
-  roundCorner: boolean;
   topWidth: string;
 };
 
@@ -15,17 +14,12 @@ export default function HighlightModalContainer({
   topWidth,
   bottomWidth,
   children,
-  roundCorner,
 }: Props) {
   return (
     <Fragment>
       <PositionTopRight src={TopRight} width={topWidth} />
       {children}
-      <PositionBottomLeft
-        src={BottomLeft}
-        width={bottomWidth}
-        roundCorner={roundCorner}
-      />
+      <PositionBottomLeft src={BottomLeft} width={bottomWidth} />
     </Fragment>
   );
 }
@@ -36,19 +30,19 @@ const PositionTopRight = styled('img')<{width: string}>`
   right: 0;
   top: 0;
   pointer-events: none;
+  border-radius: 0 8px 0 0;
 `;
 
-const PositionBottomLeft = styled('img')<{roundCorner: boolean; width: string}>`
+const PositionBottomLeft = styled('img')<{width: string}>`
   position: absolute;
   width: ${p => p.width};
   bottom: 0;
   left: 0;
   pointer-events: none;
-  border-radius: ${p => (p.roundCorner ? '0 8px 0 8px' : '0')};
+  border-radius: 0 0 0 8px;
 `;
 
 HighlightModalContainer.defaultProps = {
   topWidth: '400px',
   bottomWidth: '200px',
-  roundCorner: false,
 };

--- a/static/app/components/highlightModalContainer.tsx
+++ b/static/app/components/highlightModalContainer.tsx
@@ -44,7 +44,7 @@ const PositionBottomLeft = styled('img')<{roundCorner: boolean; width: string}>`
   bottom: 0;
   left: 0;
   pointer-events: none;
-  border-radius: ${p => (p.roundCorner ? '0 0 0 8px' : '0')};
+  border-radius: ${p => (p.roundCorner ? '0 8px 0 8px' : '0')};
 `;
 
 HighlightModalContainer.defaultProps = {


### PR DESCRIPTION
this pr adds  rounding the corners of the highlightModalContainer illustrations . Right now, if you use highlightModalContainer, then you can set `overflow: hidden` to round the corners of the modal, but if you use the close modal button then you can't have `overflow: hidden` or it will hide part of the button. Getting rid of `overflow: hidden` will expose the bottom left corner of the illustration. this pr will round the corners so the `overflow` value doesn't impact the illustrations.