### PR TITLE
fix(flamechart): prevent debug mode from opening the email client

### DIFF
--- a/static/app/utils/profiling/hooks/useInternalFlamegraphDebugMode.ts
+++ b/static/app/utils/profiling/hooks/useInternalFlamegraphDebugMode.ts
@@ -12,6 +12,7 @@ export function useInternalFlamegraphDebugMode() {
       const isCtrlOrMeta = evt.ctrlKey || evt.metaKey;
 
       if (isCtrlOrMeta && evt.shiftKey && evt.code === 'KeyI') {
+        evt.preventDefault();
         setIsEnabled(val => {
           const next = !val;
           if (next) {


### PR DESCRIPTION
Seems that this is a shared shortcut on macos that opens the email client...