### PR TITLE
fix(thread-selector): InteractionStateLayer not applying to whole button

### DIFF
--- a/static/app/components/events/interfaces/threads/threadSelector/index.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/index.tsx
@@ -132,9 +132,4 @@ const StyledDropdownButton = styled(DropdownButton)`
   }
   width: 100%;
   min-width: 150px;
-  @media (min-width: ${props => props.theme.breakpoints.small}) {
-    > *:first-child {
-      width: auto;
-    }
-  }
 `;


### PR DESCRIPTION
Hovering on the thread selector would only highligh a small 
sliver of the button instead of the expected entire button.

Before:

![Screenshot 2023-03-08 at 2 37 18 PM](https://user-images.githubusercontent.com/63818634/223826040-ca62e7d0-b8c1-4d81-9e34-f9b6729943b2.png)

After:
![Screenshot 2023-03-08 at 2 36 33 PM](https://user-images.githubusercontent.com/63818634/223825804-d76832d2-4d86-4b6c-9395-9addcdd9c86d.png)
