### PR TITLE
ref(autoassignment): Add test and audit log entry

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -3,13 +3,14 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import audit_log, features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectOwnershipPermission
 from sentry.api.serializers import serialize
 from sentry.models import ProjectOwnership
 from sentry.ownership.grammar import CODEOWNERS, create_schema_from_issue_owners
 from sentry.signals import ownership_rule_created
+from sentry.utils.audit import create_audit_entry
 
 MAX_RAW_LENGTH = 100_000
 HIGHER_MAX_RAW_LENGTH = 200_000
@@ -191,6 +192,8 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
         :param string raw: Raw input for ownership configuration.
         :param boolean fallthrough: Indicate if there is no match on explicit rules,
                                     to fall through and make everyone an implicit owner.
+
+        :param autoAssignment: String detailing automatic assignment setting
         :auth: required
         """
         should_return_schema = features.has(
@@ -201,6 +204,14 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
         )
         if serializer.is_valid():
             ownership = serializer.save()
+            create_audit_entry(
+                request=self.request,
+                actor=request.user,
+                organization=project.organization,
+                target_object=project.id,
+                event=audit_log.get_event_id("PROJECT_EDIT"),
+                data={**serializer.validated_data, **project.get_audit_log_data()},
+            )
             ownership_rule_created.send_robust(project=project, sender=self.__class__)
             return Response(
                 serialize(ownership, request.user, should_return_schema=should_return_schema)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -597,10 +597,14 @@ class Factories:
 
     @staticmethod
     @exempt_from_silo_limits()
-    def create_commit_author(organization_id=None, project=None, user=None):
+    def create_commit_author(organization_id=None, project=None, user=None, email=None):
+        if email:
+            user_email = email
+        else:
+            user_email = user.email if user else f"{make_word()}@example.com"
         return CommitAuthor.objects.get_or_create(
             organization_id=organization_id or project.organization_id,
-            email=user.email if user else f"{make_word()}@example.com",
+            email=user_email,
             defaults={"name": user.name if user else make_word()},
         )[0]
 

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -121,7 +121,8 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp.status_code == 200
 
         auditlog = AuditLogEntry.objects.filter(
-            organization=self.project.organization, event=audit_log.get_event_id("PROJECT_EDIT")
+            organization_id=self.project.organization.id,
+            event=audit_log.get_event_id("PROJECT_EDIT"),
         )
         assert len(auditlog) == 1
         assert "Auto Assign to Issue Owner" in auditlog[0].data["autoAssignment"]

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -121,7 +121,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp.status_code == 200
 
         auditlog = AuditLogEntry.objects.filter(
-            organization=self.organization, event=audit_log.get_event_id("PROJECT_EDIT")
+            organization=self.project.organization, event=audit_log.get_event_id("PROJECT_EDIT")
         )
         assert len(auditlog) == 1
         assert "Auto Assign to Issue Owner" in auditlog[0].data["autoAssignment"]

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -3,7 +3,8 @@ from unittest import mock
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.models import ProjectOwnership
+from sentry import audit_log
+from sentry.models import AuditLogEntry, ProjectOwnership
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
@@ -114,6 +115,16 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         assert resp.data["autoAssignment"] == "Turn off Auto-Assignment"
+
+    def test_audit_log_entry(self):
+        resp = self.client.put(self.path, {"autoAssignment": "Auto Assign to Issue Owner"})
+        assert resp.status_code == 200
+
+        auditlog = AuditLogEntry.objects.filter(
+            organization=self.organization, event=audit_log.get_event_id("PROJECT_EDIT")
+        )
+        assert len(auditlog) == 1
+        assert "Auto Assign to Issue Owner" in auditlog[0].data["autoAssignment"]
 
     @with_feature("organizations:streamline-targeting-context")
     def test_update_with_streamline_targeting(self):

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -360,7 +360,7 @@ class ProjectOwnershipTestCase(TestCase):
         ProjectOwnership.handle_auto_assignment(self.project2.id, self.event)
         assert len(GroupAssignee.objects.all()) == 1
         assignee = GroupAssignee.objects.get(group=self.event.group)
-        assert assignee.user_id == self.user.id
+        assert assignee.user_id == self.user2.id
 
     def test_handle_skip_auto_assignment(self):
         """Test that if an issue has already been manually assigned, we skip overriding the assignment

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -1,4 +1,12 @@
-from sentry.models import ActorTuple, GroupAssignee, ProjectOwnership, Repository, Team, User
+from sentry.models import (
+    ActorTuple,
+    GroupAssignee,
+    ProjectOwnership,
+    Repository,
+    Team,
+    User,
+    UserEmail,
+)
 from sentry.models.groupowner import GroupOwner, GroupOwnerType, OwnerRuleType
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema, resolve_actors
 from sentry.services.hybrid_cloud.user import user_service
@@ -304,6 +312,55 @@ class ProjectOwnershipTestCase(TestCase):
         assert len(GroupAssignee.objects.all()) == 1
         assignee = GroupAssignee.objects.get(group=self.event.group)
         assert assignee.team_id == self.team.id
+
+    def test_handle_auto_assignment_when_only_suspect_commit_exists_multiple_emails(self):
+        """Test that if a user has 2 verified email addresses, the non-primary one is the commit author, and the project
+        is using the suspect committer auto assignment we correctly assign the issue to the user.
+        """
+        self.ownership = ProjectOwnership.objects.create(
+            project_id=self.project2.id,
+            fallthrough=False,
+            auto_assignment=True,
+            suspect_committer_auto_assignment=True,
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.project2.organization.id,
+            name="example",
+            integration_id=self.integration.id,
+        )
+        self.second_email = UserEmail.objects.create(
+            user=self.user2, email="hb@mysecondemail.com", is_verified=True
+        )
+        self.commit_author = self.create_commit_author(
+            project=self.project2, user=self.user2, email=self.second_email.email
+        )
+        self.commit = self.create_commit(
+            project=self.project2,
+            repo=self.repo,
+            author=self.commit_author,
+            key="asdfwreqr",
+            message="placeholder commit message",
+        )
+
+        self.event = self.store_event(
+            data=self.python_event_data(),
+            project_id=self.project2.id,
+        )
+
+        GroupOwner.objects.create(
+            group=self.event.group,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=self.user2.id,
+            team_id=None,
+            project=self.project2,
+            organization=self.project2.organization,
+            context={"commitId": self.commit.id},
+        )
+
+        ProjectOwnership.handle_auto_assignment(self.project2.id, self.event)
+        assert len(GroupAssignee.objects.all()) == 1
+        assignee = GroupAssignee.objects.get(group=self.event.group)
+        assert assignee.user_id == self.user.id
 
     def test_handle_skip_auto_assignment(self):
         """Test that if an issue has already been manually assigned, we skip overriding the assignment


### PR DESCRIPTION
Add audit log entries for changes to the project ownership settings to help with future debugging, as well as a test to replicate an issue a customer is experiencing (see [WOR-2724](https://getsentry.atlassian.net/browse/WOR-2724)). 

[WOR-2724]: https://getsentry.atlassian.net/browse/WOR-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ