### PR TITLE
fix(replays): add ui flag back in

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1250,6 +1250,7 @@ SENTRY_FEATURES = {
     "organizations:sentry-functions": False,
     # Enable experimental session replay backend APIs
     "organizations:session-replay": False,
+    "organizations:session-replay-ui": True,
     # Enabled for those orgs who participated in the Replay Beta program
     "organizations:session-replay-beta-grace": False,
     # Enable replay GA messaging (update paths from AM1 to AM2)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1250,6 +1250,7 @@ SENTRY_FEATURES = {
     "organizations:sentry-functions": False,
     # Enable experimental session replay backend APIs
     "organizations:session-replay": False,
+    # Enable Session Replay showing in the sidebar
     "organizations:session-replay-ui": True,
     # Enabled for those orgs who participated in the Replay Beta program
     "organizations:session-replay-beta-grace": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -157,8 +157,8 @@ default_manager.add("organizations:scim-orgmember-roles", OrganizationFeature, T
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, True)
 default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, True)
 default_manager.add("organizations:sentry-functions", OrganizationFeature, False)
-default_manager.add("organizations:session-replay", OrganizationFeature),
-default_manager.add("organizations:session-replay-ui", OrganizationFeature),
+default_manager.add("organizations:session-replay", OrganizationFeature)
+default_manager.add("organizations:session-replay-ui", OrganizationFeature)
 default_manager.add("organizations:session-replay-beta-grace", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-ga", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-sdk", OrganizationFeature, True)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -157,7 +157,8 @@ default_manager.add("organizations:scim-orgmember-roles", OrganizationFeature, T
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, True)
 default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, True)
 default_manager.add("organizations:sentry-functions", OrganizationFeature, False)
-default_manager.add("organizations:session-replay", OrganizationFeature)
+default_manager.add("organizations:session-replay", OrganizationFeature),
+default_manager.add("organizations:session-replay-ui", OrganizationFeature),
 default_manager.add("organizations:session-replay-beta-grace", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-ga", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-sdk", OrganizationFeature, True)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -75,6 +75,7 @@ class OrganizationSerializerTest(TestCase):
             "open-membership",
             "relay",
             "shared-issues",
+            "session-replay-ui",
             "sso-basic",
             "sso-saml2",
             "symbol-sources",


### PR DESCRIPTION
there are some cases when replays infra is not provisioned, so we want to hide it in the UI. this adds a feature flag back for that purpose.