### PR TITLE
fix(stacktrace): Adjust table border in dark mode

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -171,6 +171,13 @@ const styles = (theme: Theme, isDark: boolean) => css`
             }
             .context {
               background: ${theme.background};
+
+              table.key-value {
+                border-color: ${theme.border};
+                td {
+                  border-color: ${theme.border} !important;
+                }
+              }
             }
           }
         }

--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -480,7 +480,7 @@ div.traceback > ul {
       table.key-value {
         border-top: 1px solid @trim;
         padding: 0;
-        margin: 0 0 -8px;
+        margin: 0;
 
         td {
           border-bottom: 1px solid @trim !important;


### PR DESCRIPTION
a little was cut off on the bottom and the border was wrong on dark mode

dark mode before
![image](https://user-images.githubusercontent.com/1400464/223867434-27fef424-86b7-4189-9eb7-e9bdfcbd0bfc.png)

dark mode after
![Screenshot 2023-03-08 at 2 35 28 PM](https://user-images.githubusercontent.com/1400464/223867310-a8c65473-7bf3-4ee5-8d2d-f90d69d01676.png)
