### PR TITLE
fix(issue-platform): Don't remove extra params for generic events

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -94,7 +94,7 @@ def save_event_from_occurrence(
     project_id = data.pop("project_id")
 
     with metrics.timer("occurrence_consumer.save_event_occurrence.event_manager.save"):
-        manager = EventManager(data)
+        manager = EventManager(data, remove_other=False)
         event = manager.save(project_id=project_id)
 
         return event


### PR DESCRIPTION
Since the event data is already normalized in relay, do not strip extra data during renormalization