### PR TITLE
test: redact IDs in email acceptance tests

### DIFF
--- a/fixtures/emails/alert.txt
+++ b/fixtures/emails/alert.txt
@@ -1,7 +1,7 @@
 Details
 -------
 
-http://testserver/organizations/sentry/issues/1/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
+http://testserver/organizations/sentry/issues/x/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
 
 
 Suspect Commits

--- a/fixtures/emails/n1_api_call.txt
+++ b/fixtures/emails/n1_api_call.txt
@@ -1,7 +1,7 @@
 Details
 -------
 
-http://testserver/organizations/sentry/issues/1/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
+http://testserver/organizations/sentry/issues/x/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
 
 
 Suspect Commits

--- a/fixtures/emails/performance.txt
+++ b/fixtures/emails/performance.txt
@@ -1,7 +1,7 @@
 Details
 -------
 
-http://testserver/organizations/sentry/issues/1/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
+http://testserver/organizations/sentry/issues/x/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
 
 
 Suspect Commits


### PR DESCRIPTION
IDs can cause tests to flake if the test if run in a diff order
