### PR TITLE
feat(source-maps): handles new source map errors

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -168,6 +168,48 @@ function getErrorMessage(
           docsLink: getTroubleshootingLink(),
         },
       ];
+    // event errors
+    case SourceMapProcessingIssueType.TOO_LARGE_FOR_CACHE:
+      return [
+        {
+          title: t('Source Map File too large to cache'),
+          desc: t('TODO UPDATE'),
+          docsLink: getTroubleshootingLink(),
+        },
+      ];
+
+    case SourceMapProcessingIssueType.FETCH_INVALID_HTTP_CODE:
+      return [
+        {
+          title: t('Sentry received an invalid HTTP code fetching the source map'),
+          desc: t('TODO UPDATE'),
+          docsLink: getTroubleshootingLink(),
+        },
+      ];
+    case SourceMapProcessingIssueType.JS_INVALID_CONTENT:
+      return [
+        {
+          title: t('Sentry received an invalid content type fetching the source map'),
+          desc: t('TODO UPDATE'),
+          docsLink: getTroubleshootingLink(),
+        },
+      ];
+    case SourceMapProcessingIssueType.FETCH_GENERIC_ERROR:
+      return [
+        {
+          title: t('The source map failed to load because of an unkown error'),
+          desc: t('TODO UPDATE'),
+          docsLink: getTroubleshootingLink(),
+        },
+      ];
+    case SourceMapProcessingIssueType.RESTRICTED_IP:
+      return [
+        {
+          title: t('The source map failed to load because of a restricted IP'),
+          desc: t('TODO UPDATE'),
+          docsLink: getTroubleshootingLink(),
+        },
+      ];
     case SourceMapProcessingIssueType.UNKNOWN_ERROR:
     default:
       return [];

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
@@ -44,6 +44,39 @@ interface NoURLMatchDebugError extends BaseSourceMapDebugError {
   type: SourceMapProcessingIssueType.NO_URL_MATCH;
 }
 
+interface TooLargeForCacheError extends BaseSourceMapDebugError {
+  type: SourceMapProcessingIssueType.TOO_LARGE_FOR_CACHE;
+}
+
+interface FetchInvalidHttpCodeError extends BaseSourceMapDebugError {
+  data: {
+    url: string;
+    value: number;
+  };
+  type: SourceMapProcessingIssueType.FETCH_INVALID_HTTP_CODE;
+}
+
+interface JSInvalidContentError extends BaseSourceMapDebugError {
+  data: {
+    url: string;
+  };
+  type: SourceMapProcessingIssueType.JS_INVALID_CONTENT;
+}
+
+interface GenericFetchError extends BaseSourceMapDebugError {
+  data: {
+    value: string;
+  };
+  type: SourceMapProcessingIssueType.FETCH_GENERIC_ERROR;
+}
+
+interface RestrictedIPError extends BaseSourceMapDebugError {
+  data: {
+    url: string;
+  };
+  type: SourceMapProcessingIssueType.RESTRICTED_IP;
+}
+
 export type SourceMapDebugError =
   | UnknownErrorDebugError
   | MissingReleaseDebugError
@@ -53,7 +86,12 @@ export type SourceMapDebugError =
   | PartialMatchDebugError
   | DistMismatchDebugError
   | SourcemapNotFoundDebugError
-  | NoURLMatchDebugError;
+  | NoURLMatchDebugError
+  | TooLargeForCacheError
+  | FetchInvalidHttpCodeError
+  | JSInvalidContentError
+  | GenericFetchError
+  | RestrictedIPError;
 
 export interface SourceMapDebugResponse {
   errors: SourceMapDebugError[];
@@ -69,6 +107,11 @@ export enum SourceMapProcessingIssueType {
   PARTIAL_MATCH = 'partial_match',
   DIST_MISMATCH = 'dist_mismatch',
   SOURCEMAP_NOT_FOUND = 'sourcemap_not_found',
+  TOO_LARGE_FOR_CACHE = 'too_large_for_cache',
+  FETCH_INVALID_HTTP_CODE = 'fetch_invalid_http_code',
+  JS_INVALID_CONTENT = 'js_invalid_content',
+  FETCH_GENERIC_ERROR = 'generic_fetch_error',
+  RESTRICTED_IP = 'restricted_ip',
 }
 
 const sourceMapDebugQuery = ({


### PR DESCRIPTION
This PR handles 5 new additional source map errors that map to existing event errors:
* TOO_LARGE_FOR_CACHE
* FETCH_INVALID_HTTP_CODE
* JS_INVALID_CONTENT
* FETCH_GENERIC_ERROR
* RESTRICTED_IP