### PR TITLE
feat(issue-platform): Add ability to control how grouptypes are released via features

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type
 
 from django.conf import settings
 
@@ -26,8 +26,6 @@ class GroupCategory(Enum):
 GROUP_CATEGORIES_CUSTOM_EMAIL = (GroupCategory.ERROR, GroupCategory.PERFORMANCE)
 # GroupCategories which have customized email templates. If not included here, will fall back to a generic template.
 
-_group_type_registry: Dict[int, Type[GroupType]] = {}
-_category_lookup: Dict[int, Set[int]] = defaultdict(set)
 DEFAULT_IGNORE_LIMIT: int = 3
 DEFAULT_EXPIRY_TIME: timedelta = timedelta(hours=24)
 
@@ -46,6 +44,9 @@ class GroupTypeRegistry:
         self._registry[group_type.type_id] = group_type
         self._slug_lookup[group_type.slug] = group_type
         self._category_lookup[group_type.category].add(group_type.type_id)
+
+    def all(self) -> List[Type[GroupType]]:
+        return list(self._registry.values())
 
     def get_all_group_type_ids(self) -> Set[int]:
         return {type.type_id for type in self._registry.values()}

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Type
 
 from django.conf import settings
 
+from sentry import features
+from sentry.features.base import OrganizationFeature
 from sentry.utils import metrics, redis
 
 if TYPE_CHECKING:
-    from sentry.models import Project
+    from sentry.models import Organization, Project, User
     from sentry.utils.performance_issues.performance_detection import PerformanceProblem
 
 
@@ -25,10 +27,44 @@ GROUP_CATEGORIES_CUSTOM_EMAIL = (GroupCategory.ERROR, GroupCategory.PERFORMANCE)
 # GroupCategories which have customized email templates. If not included here, will fall back to a generic template.
 
 _group_type_registry: Dict[int, Type[GroupType]] = {}
-_slug_lookup: Dict[str, Type[GroupType]] = {}
 _category_lookup: Dict[int, Set[int]] = defaultdict(set)
 DEFAULT_IGNORE_LIMIT: int = 3
 DEFAULT_EXPIRY_TIME: timedelta = timedelta(hours=24)
+
+
+@dataclass()
+class GroupTypeRegistry:
+    _registry: Dict[int, Type[GroupType]] = field(default_factory=dict)
+    _slug_lookup: Dict[str, Type[GroupType]] = field(default_factory=dict)
+    _category_lookup: Dict[int, Set[int]] = field(default_factory=lambda: defaultdict(set))
+
+    def add(self, group_type: Type[GroupType]):
+        if self._registry.get(group_type.type_id):
+            raise ValueError(
+                f"A group type with the type_id {group_type.type_id} has already been registered."
+            )
+        self._registry[group_type.type_id] = group_type
+        self._slug_lookup[group_type.slug] = group_type
+        self._category_lookup[group_type.category].add(group_type.type_id)
+
+    def get_all_group_type_ids(self) -> Set[int]:
+        return {type.type_id for type in self._registry.values()}
+
+    def get_by_category(self, category: int) -> Set[int]:
+        return self._category_lookup[category]
+
+    def get_by_slug(self, slug: str) -> Optional[Type[GroupType]]:
+        if slug not in self._slug_lookup:
+            return None
+        return self._slug_lookup[slug]
+
+    def get_by_type_id(self, id_: int) -> Type[GroupType]:
+        if id_ not in self._registry:
+            raise ValueError(f"No group type with the id {id_} is registered.")
+        return self._registry[id_]
+
+
+registry = GroupTypeRegistry()
 
 
 @dataclass(frozen=True)
@@ -49,41 +85,80 @@ class GroupType:
     description: str
     category: int
     noise_config: Optional[NoiseConfig] = None
+    # If True this group type should be released everywhere. If False, fall back to features to
+    # decide if this is released.
+    released: bool = False
 
     def __init_subclass__(cls: Type[GroupType], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        if _group_type_registry.get(cls.type_id):
-            raise ValueError(
-                f"A group type with the type_id {cls.type_id} has already been registered."
-            )
-        _group_type_registry[cls.type_id] = cls
-        _slug_lookup[cls.slug] = cls
-        _category_lookup[cls.category].add(cls.type_id)
+        registry.add(cls)
+
+        if not cls.released:
+            features.add(cls.build_visible_feature_name(), OrganizationFeature, True)
+            features.add(cls.build_ingest_feature_name(), OrganizationFeature)
+            features.add(cls.build_post_process_group_feature_name(), OrganizationFeature)
 
     def __post_init__(self) -> None:
         valid_categories = [category.value for category in GroupCategory]
         if self.category not in valid_categories:
             raise ValueError(f"Category must be one of {valid_categories} from GroupCategory.")
 
+    @classmethod
+    def is_visible(cls, organization: Organization, user: Optional[User] = None) -> bool:
+        if cls.released:
+            return True
+
+        return features.has(cls.build_visible_feature_name(), organization, actor=user)
+
+    @classmethod
+    def allow_ingest(cls, organization: Organization) -> bool:
+        if cls.released:
+            return True
+
+        return features.has(cls.build_ingest_feature_name(), organization)
+
+    @classmethod
+    def allow_post_process_group(cls, organization: Organization) -> bool:
+        if cls.released:
+            return True
+
+        return features.has(cls.build_post_process_group_feature_name(), organization)
+
+    @classmethod
+    def build_base_feature_name(cls) -> str:
+        return f"organizations:{cls.slug.replace('_', '-')}"
+
+    @classmethod
+    def build_visible_feature_name(cls) -> str:
+        return f"{cls.build_base_feature_name()}-visible"
+
+    @classmethod
+    def build_ingest_feature_name(cls) -> str:
+        return f"{cls.build_base_feature_name()}-ingest"
+
+    @classmethod
+    def build_post_process_group_feature_name(cls) -> str:
+        return f"{cls.build_base_feature_name()}-post-process-group"
+
 
 def get_all_group_type_ids() -> Set[int]:
-    return {type.type_id for type in _group_type_registry.values()}
+    # TODO: Replace uses of this with the registry
+    return registry.get_all_group_type_ids()
 
 
 def get_group_types_by_category(category: int) -> Set[int]:
-    return _category_lookup[category]
+    # TODO: Replace uses of this with the registry
+    return registry.get_by_category(category)
 
 
 def get_group_type_by_slug(slug: str) -> Optional[Type[GroupType]]:
-    if slug not in _slug_lookup:
-        return None
-    return _slug_lookup[slug]
+    # TODO: Replace uses of this with the registry
+    return registry.get_by_slug(slug)
 
 
 def get_group_type_by_type_id(id: int) -> Type[GroupType]:
-    if id not in _group_type_registry:
-        raise ValueError(f"No group type with the id {id} is registered.")
-    return _group_type_registry[id]
+    # TODO: Replace uses of this with the registry
+    return registry.get_by_type_id(id)
 
 
 @dataclass(frozen=True)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -38,7 +38,7 @@ class GroupTypeRegistry:
     _slug_lookup: Dict[str, Type[GroupType]] = field(default_factory=dict)
     _category_lookup: Dict[int, Set[int]] = field(default_factory=lambda: defaultdict(set))
 
-    def add(self, group_type: Type[GroupType]):
+    def add(self, group_type: Type[GroupType]) -> None:
         if self._registry.get(group_type.type_id):
             raise ValueError(
                 f"A group type with the type_id {group_type.type_id} has already been registered."

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -17,19 +17,19 @@ from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
-class BaseGroupTypeTest:
-    def setUp(self):
+class BaseGroupTypeTest(TestCase):  # type: ignore
+    def setUp(self) -> None:
         super().setUp()
         self.registry_patcher = patch("sentry.issues.grouptype.registry", new=GroupTypeRegistry())
         self.registry_patcher.__enter__()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
         self.registry_patcher.__exit__(None, None, None)
 
 
 @region_silo_test
-class GroupTypeTest(BaseGroupTypeTest, TestCase):  # type: ignore
+class GroupTypeTest(BaseGroupTypeTest):
     def test_get_types_by_category(self) -> None:
         @dataclass(frozen=True)
         class TestGroupType(GroupType):
@@ -116,7 +116,7 @@ class GroupTypeTest(BaseGroupTypeTest, TestCase):  # type: ignore
 
 
 @region_silo_test
-class GroupTypeReleasedTest(BaseGroupTypeTest, TestCase):  # type: ignore
+class GroupTypeReleasedTest(BaseGroupTypeTest):
     def test_released(self) -> None:
         @dataclass(frozen=True)
         class TestGroupType(PerformanceGroupTypeDefaults, GroupType):

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
 from unittest.mock import patch
@@ -8,10 +7,9 @@ from sentry.issues.grouptype import (
     DEFAULT_IGNORE_LIMIT,
     GroupCategory,
     GroupType,
+    GroupTypeRegistry,
     NoiseConfig,
     PerformanceGroupTypeDefaults,
-    _category_lookup,
-    _group_type_registry,
     get_group_type_by_slug,
     get_group_types_by_category,
 )
@@ -19,62 +17,64 @@ from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 
 
+class BaseGroupTypeTest:
+    def setUp(self):
+        super().setUp()
+        self.registry_patcher = patch("sentry.issues.grouptype.registry", new=GroupTypeRegistry())
+        self.registry_patcher.__enter__()
+
+    def tearDown(self):
+        super().tearDown()
+        self.registry_patcher.__exit__(None, None, None)
+
+
 @region_silo_test
-class GroupTypeTest(TestCase):  # type: ignore
+class GroupTypeTest(BaseGroupTypeTest, TestCase):  # type: ignore
     def test_get_types_by_category(self) -> None:
-        with patch.dict(_group_type_registry, {}, clear=True), patch.dict(
-            _category_lookup, defaultdict(set), clear=True
-        ):
+        @dataclass(frozen=True)
+        class TestGroupType(GroupType):
+            type_id = 1
+            slug = "test"
+            description = "Test"
+            category = GroupCategory.ERROR.value
+            ignore_limit = 0
 
-            @dataclass(frozen=True)
-            class TestGroupType(GroupType):
-                type_id = 1
-                slug = "test"
-                description = "Test"
-                category = GroupCategory.ERROR.value
-                ignore_limit = 0
+        @dataclass(frozen=True)
+        class TestGroupType2(GroupType):
+            type_id = 2
+            slug = "hellboy"
+            description = "Hellboy"
+            category = GroupCategory.PERFORMANCE.value
 
-            @dataclass(frozen=True)
-            class TestGroupType2(GroupType):
-                type_id = 2
-                slug = "hellboy"
-                description = "Hellboy"
-                category = GroupCategory.PERFORMANCE.value
+        @dataclass(frozen=True)
+        class TestGroupType3(GroupType):
+            type_id = 3
+            slug = "angelgirl"
+            description = "AngelGirl"
+            category = GroupCategory.PERFORMANCE.value
 
-            @dataclass(frozen=True)
-            class TestGroupType3(GroupType):
-                type_id = 3
-                slug = "angelgirl"
-                description = "AngelGirl"
-                category = GroupCategory.PERFORMANCE.value
-
-            assert get_group_types_by_category(GroupCategory.PERFORMANCE.value) == {2, 3}
-            assert get_group_types_by_category(GroupCategory.ERROR.value) == {1}
+        assert get_group_types_by_category(GroupCategory.PERFORMANCE.value) == {2, 3}
+        assert get_group_types_by_category(GroupCategory.ERROR.value) == {1}
 
     def test_get_group_type_by_slug(self) -> None:
-        with patch.dict(_group_type_registry, {}, clear=True):
+        @dataclass(frozen=True)
+        class TestGroupType(GroupType):
+            type_id = 1
+            slug = "test"
+            description = "Test"
+            category = GroupCategory.ERROR.value
+            ignore_limit = 0
 
-            @dataclass(frozen=True)
-            class TestGroupType(GroupType):
-                type_id = 1
-                slug = "test"
-                description = "Test"
-                category = GroupCategory.ERROR.value
-                ignore_limit = 0
-
-            assert get_group_type_by_slug(TestGroupType.slug) == TestGroupType
-
-            assert get_group_type_by_slug("meow") is None
+        assert get_group_type_by_slug(TestGroupType.slug) == TestGroupType
+        assert get_group_type_by_slug("meow") is None
 
     def test_category_validation(self) -> None:
-        with patch.dict(_group_type_registry, {}, clear=True):
-
-            @dataclass(frozen=True)
-            class TestGroupType(GroupType):
-                type_id = 1
-                slug = "error"
-                description = "Error"
-                category = 22
+        @dataclass(frozen=True)
+        class TestGroupType(GroupType):
+            type_id = 1
+            slug = "error"
+            description = "Error"
+            category = 22
 
         with self.assertRaisesMessage(
             ValueError,
@@ -83,41 +83,78 @@ class GroupTypeTest(TestCase):  # type: ignore
             TestGroupType(1, "error", "Error", 22)
 
     def test_default_noise_config(self) -> None:
-        with patch.dict(_group_type_registry, {}, clear=True), patch.dict(
-            _category_lookup, defaultdict(set), clear=True
-        ):
+        @dataclass(frozen=True)
+        class TestGroupType(GroupType):
+            type_id = 1
+            slug = "test"
+            description = "Test"
+            category = GroupCategory.ERROR.value
 
-            @dataclass(frozen=True)
-            class TestGroupType(GroupType):
-                type_id = 1
-                slug = "test"
-                description = "Test"
-                category = GroupCategory.ERROR.value
+        @dataclass(frozen=True)
+        class TestGroupType2(PerformanceGroupTypeDefaults, GroupType):
+            type_id = 2
+            slug = "hellboy"
+            description = "Hellboy"
+            category = GroupCategory.PERFORMANCE.value
 
-            @dataclass(frozen=True)
-            class TestGroupType2(PerformanceGroupTypeDefaults, GroupType):
-                type_id = 2
-                slug = "hellboy"
-                description = "Hellboy"
-                category = GroupCategory.PERFORMANCE.value
-
-            assert TestGroupType.noise_config is None
-            assert TestGroupType2.noise_config == NoiseConfig()
-            assert TestGroupType2.noise_config.ignore_limit == DEFAULT_IGNORE_LIMIT
-            assert TestGroupType2.noise_config.expiry_time == DEFAULT_EXPIRY_TIME
+        assert TestGroupType.noise_config is None
+        assert TestGroupType2.noise_config == NoiseConfig()
+        assert TestGroupType2.noise_config.ignore_limit == DEFAULT_IGNORE_LIMIT
+        assert TestGroupType2.noise_config.expiry_time == DEFAULT_EXPIRY_TIME
 
     def test_noise_config(self) -> None:
-        with patch.dict(_group_type_registry, {}, clear=True), patch.dict(
-            _category_lookup, defaultdict(set), clear=True
-        ):
+        @dataclass(frozen=True)
+        class TestGroupType(PerformanceGroupTypeDefaults, GroupType):
+            type_id = 2
+            slug = "hellboy"
+            description = "Hellboy"
+            category = GroupCategory.PERFORMANCE.value
+            noise_config = NoiseConfig(ignore_limit=100, expiry_time=timedelta(hours=12))
 
-            @dataclass(frozen=True)
-            class TestGroupType(PerformanceGroupTypeDefaults, GroupType):
-                type_id = 2
-                slug = "hellboy"
-                description = "Hellboy"
-                category = GroupCategory.PERFORMANCE.value
-                noise_config = NoiseConfig(ignore_limit=100, expiry_time=timedelta(hours=12))
+        assert TestGroupType.noise_config.ignore_limit == 100
+        assert TestGroupType.noise_config.expiry_time == timedelta(hours=12)
 
-            assert TestGroupType.noise_config.ignore_limit == 100
-            assert TestGroupType.noise_config.expiry_time == timedelta(hours=12)
+
+@region_silo_test
+class GroupTypeReleasedTest(BaseGroupTypeTest, TestCase):  # type: ignore
+    def test_released(self) -> None:
+        @dataclass(frozen=True)
+        class TestGroupType(PerformanceGroupTypeDefaults, GroupType):
+            type_id = 1
+            slug = "test"
+            description = "Test"
+            category = GroupCategory.PERFORMANCE.value
+            released = True
+
+        assert TestGroupType.is_visible(self.organization)
+        assert TestGroupType.allow_post_process_group(self.organization)
+        assert TestGroupType.allow_ingest(self.organization)
+
+    def test_not_released(self) -> None:
+        @dataclass(frozen=True)
+        class TestGroupType(PerformanceGroupTypeDefaults, GroupType):
+            type_id = 1
+            slug = "test"
+            description = "Test"
+            category = GroupCategory.PERFORMANCE.value
+            released = False
+
+        assert not TestGroupType.is_visible(self.organization)
+        assert not TestGroupType.allow_post_process_group(self.organization)
+        assert not TestGroupType.allow_ingest(self.organization)
+
+    def test_not_released_features(self) -> None:
+        @dataclass(frozen=True)
+        class TestGroupType(PerformanceGroupTypeDefaults, GroupType):
+            type_id = 1
+            slug = "test"
+            description = "Test"
+            category = GroupCategory.PERFORMANCE.value
+            released = False
+
+        with self.feature(TestGroupType.build_visible_feature_name()):
+            assert TestGroupType.is_visible(self.organization)
+        with self.feature(TestGroupType.build_post_process_group_feature_name()):
+            assert TestGroupType.allow_post_process_group(self.organization)
+        with self.feature(TestGroupType.build_ingest_feature_name()):
+            assert TestGroupType.allow_ingest(self.organization)


### PR DESCRIPTION
This adds `is_visible`, `allow_ingest` and `allow_post_process_group` to the `GroupType` class. These are unused at the moment, but will be used to control how a new issue type is released to customers.

The way it works is that we now have `released` on each group type. When we're fine to release a group type everywhere (including self-hosted and ST) then we can set this to True and it'll be available everywhere. Before we fully release a group type, we instead rely on feature flags to control how different parts of the group type are released.

These feature flags all default to false, and they won't be set to True in sentry. In getsentry, we'll add another feature handler that register options for allow_ingest and allow_post_process_group. That way we can partially roll out to LA/EA/GA customers. `is_visible` controls whether these issue types are returned from issue search and visible in the UI, and just relies on a flagr feature flag in getsentry.

While I was here I also refactored the group registry to all be contained in a single class. I noticed that in test_grouptype.py we were initially patching the various lookup dicts correctly, but since we've added more it has started to diverge. To avoid weird problems in the future where we pollute between tests I consolidated into a single registry that can be patched. It also keeps all these dicts in one place, and keeps the logic to populate them contained. Might make a refactoring pr at some point to remove the old shims and use the registry directly.

