### PR TITLE
fix(monitors): Allow checkin updates using slugs

### DIFF
--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -121,7 +121,6 @@ class MonitorCheckInEndpoint(MonitorEndpoint):
         request: Request,
         monitor_id: str,
         checkin_id: str,
-        organization_slug: str | None = None,
         *args,
         **kwargs,
     ):

--- a/tests/sentry/monitors/endpoints/test_monitor_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_checkin_details.py
@@ -38,6 +38,7 @@ class UpdateMonitorCheckInTest(APITestCase):
 
     def _create_monitor(self):
         return Monitor.objects.create(
+            slug="my-monitor",
             organization_id=self.organization.id,
             project_id=self.project.id,
             next_checkin=timezone.now() - timedelta(minutes=1),
@@ -47,8 +48,8 @@ class UpdateMonitorCheckInTest(APITestCase):
         )
 
     def test_noop_in_progress(self):
+        monitor = self._create_monitor()
         for path_func in self._get_path_functions():
-            monitor = self._create_monitor()
             checkin = MonitorCheckIn.objects.create(
                 monitor=monitor,
                 project_id=self.project.id,
@@ -65,8 +66,8 @@ class UpdateMonitorCheckInTest(APITestCase):
             assert checkin.date_updated > checkin.date_added
 
     def test_passing(self):
+        monitor = self._create_monitor()
         for path_func in self._get_path_functions():
-            monitor = self._create_monitor()
             checkin = MonitorCheckIn.objects.create(
                 monitor=monitor, project_id=self.project.id, date_added=monitor.date_added
             )
@@ -83,9 +84,24 @@ class UpdateMonitorCheckInTest(APITestCase):
             assert monitor.status == MonitorStatus.OK
             assert monitor.last_checkin > checkin.date_added
 
+    def test_passing_with_slug(self):
+        monitor = self._create_monitor()
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor, project_id=self.project.id, date_added=monitor.date_added
+        )
+
+        path = reverse(
+            self.endpoint_with_org, args=[self.organization.slug, monitor.slug, checkin.guid]
+        )
+        resp = self.client.put(path, data={"status": "ok"})
+        assert resp.status_code == 200, resp.content
+
+        checkin = MonitorCheckIn.objects.get(id=checkin.id)
+        assert checkin.status == CheckInStatus.OK
+
     def test_failing(self):
+        monitor = self._create_monitor()
         for path_func in self._get_path_functions():
-            monitor = self._create_monitor()
             checkin = MonitorCheckIn.objects.create(
                 monitor=monitor, project_id=self.project.id, date_added=monitor.date_added
             )
@@ -103,8 +119,8 @@ class UpdateMonitorCheckInTest(APITestCase):
             assert monitor.last_checkin > checkin.date_added
 
     def test_latest_returns_last_unfinished(self):
+        monitor = self._create_monitor()
         for path_func in self._get_path_functions():
-            monitor = self._create_monitor()
             checkin = MonitorCheckIn.objects.create(
                 monitor=monitor,
                 project_id=self.project.id,
@@ -143,8 +159,8 @@ class UpdateMonitorCheckInTest(APITestCase):
             assert monitor.last_checkin > checkin2.date_added
 
     def test_latest_with_no_unfinished_checkin(self):
+        monitor = self._create_monitor()
         for path_func in self._get_path_functions():
-            monitor = self._create_monitor()
             MonitorCheckIn.objects.create(
                 monitor=monitor,
                 project_id=self.project.id,
@@ -157,8 +173,8 @@ class UpdateMonitorCheckInTest(APITestCase):
             assert resp.status_code == 404, resp.content
 
     def test_invalid_checkin_id(self):
+        monitor = self._create_monitor()
         for path_func in self._get_path_functions():
-            monitor = self._create_monitor()
             MonitorCheckIn.objects.create(
                 monitor=monitor,
                 project_id=self.project.id,


### PR DESCRIPTION
This was broken and missing a test case.

The issue here is that the MonitorCheckInEndpoint base class was not passing the organization_slug to the parent MonitorEndpoint base class, thus it was ONLY accepting GUID lookups for monitors.

This was easily fixed by allowing the organization_slug to passthrough the `**kwargs` in the `super().convert_args(...)` call