### PR TITLE
ref: Clarify OS-specific heuristics to silence missing dsym errors

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -8,7 +8,7 @@ from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.lang.native.utils import (
     get_event_attachment,
-    get_sdk_from_event,
+    get_os_from_event,
     image_name,
     is_applecrashreport_event,
     is_minidump_event,
@@ -88,15 +88,17 @@ def _merge_frame(new_frame, symbolicated, platform="native"):
         frame_meta["symbolicator_status"] = symbolicated["status"]
 
 
-def _handle_image_status(status, image, sdk_info, data):
+def _handle_image_status(status, image, os, data):
     if status in ("found", "unused"):
         return
     elif status == "missing":
         package = image.get("code_file")
+        if not package:
+            return
         # TODO(mitsuhiko): This check seems wrong?  This call seems to
         # mirror the one in the ios symbol server support.  If we change
         # one we need to change the other.
-        if not package or is_known_third_party(package, sdk_info=sdk_info):
+        if is_known_third_party(package, os):
             return
 
         # FIXME(swatinem): .NET never had debug images before, and it is possible
@@ -110,7 +112,7 @@ def _handle_image_status(status, image, sdk_info, data):
         if image.get("type") == "pe_dotnet":
             return
 
-        if is_optional_package(package, sdk_info=sdk_info):
+        if is_optional_package(package):
             error = SymbolicationFailed(type=EventError.NATIVE_MISSING_OPTIONALLY_BUNDLED_DSYM)
         else:
             error = SymbolicationFailed(type=EventError.NATIVE_MISSING_DSYM)
@@ -134,7 +136,7 @@ def _handle_image_status(status, image, sdk_info, data):
     write_error(error, data)
 
 
-def _merge_image(raw_image, complete_image, sdk_info, data):
+def _merge_image(raw_image, complete_image, os, data):
     statuses = set()
 
     # Set image data from symbolicator as symbolicator might know more
@@ -146,7 +148,7 @@ def _merge_image(raw_image, complete_image, sdk_info, data):
             raw_image[k] = v
 
     for status in set(statuses):
-        _handle_image_status(status, raw_image, sdk_info, data)
+        _handle_image_status(status, raw_image, os, data)
 
 
 def _handle_response_status(event_data, response_json):
@@ -166,7 +168,7 @@ def _handle_response_status(event_data, response_json):
 
 
 def _merge_system_info(data, system_info):
-    set_path(data, "contexts", "os", "type", value="os")  # Required by "get_sdk_from_event"
+    set_path(data, "contexts", "os", "type", value="os")  # Required by "get_os_from_event"
 
     os_name = system_info.get("os_name")
     os_version = system_info.get("os_version")
@@ -197,14 +199,14 @@ def _merge_full_response(data, response):
     if response.get("system_info"):
         _merge_system_info(data, response["system_info"])
 
-    sdk_info = get_sdk_from_event(data)
+    os = get_os_from_event(data)
 
     images = []
     set_path(data, "debug_meta", "images", value=images)
 
     for complete_image in response["modules"]:
         image = {}
-        _merge_image(image, complete_image, sdk_info, data)
+        _merge_image(image, complete_image, os, data)
         images.append(image)
 
     # Extract the crash reason and infos
@@ -410,10 +412,10 @@ def process_payload(data):
 
     assert len(modules) == len(response["modules"]), (modules, response)
 
-    sdk_info = get_sdk_from_event(data)
+    os = get_os_from_event(data)
 
     for raw_image, complete_image in zip(modules, response["modules"]):
-        _merge_image(raw_image, complete_image, sdk_info, data)
+        _merge_image(raw_image, complete_image, os, data)
 
     assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)
 

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -71,33 +71,22 @@ def image_name(pkg):
     return pkg.rsplit(split, 1)[-1]
 
 
-def get_sdk_from_event(event):
-    sdk_info = get_path(event, "debug_meta", "sdk_info")
-    if sdk_info:
-        return sdk_info
-
+def get_os_from_event(event) -> Optional[str]:
+    """
+    Gets the OS name from either the OS context, or the SDK Info, which represents
+    the runtime SDK and *NOT* the Sentry SDK.
+    """
     os = get_path(event, "contexts", "os")
     if os and os.get("type") == "os":
-        return get_sdk_from_os(os)
+        if (os_name := os.get("name")) is not None:
+            return os_name.lower()
 
+    sdk_info = get_path(event, "debug_meta", "sdk_info")
+    if sdk_info:
+        if (sdk_name := sdk_info.get("sdk_name")) is not None:
+            return sdk_name.lower()
 
-def get_sdk_from_os(data):
-    if data.get("name") is None or data.get("version") is None:
-        return
-
-    try:
-        version = str(data["version"]).split("-", 1)[0] + ".0" * 3
-        system_version = tuple(int(x) for x in version.split(".")[:3])
-    except ValueError:
-        return
-
-    return {
-        "sdk_name": data["name"],
-        "version_major": system_version[0],
-        "version_minor": system_version[1],
-        "version_patchlevel": system_version[2],
-        "build": data.get("build"),
-    }
+    return None
 
 
 def signal_from_data(data):

--- a/src/sentry/utils/in_app.py
+++ b/src/sentry/utils/in_app.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 # Absolute paths where iOS mounts application files.
 IOS_APP_PATHS = (
@@ -26,12 +27,12 @@ SUPPORT_FRAMEWORK_RE = re.compile(
 )
 
 
-def _is_support_framework(package):
+def _is_support_framework(package: str) -> bool:
     return SUPPORT_FRAMEWORK_RE.search(package) is not None
 
 
 # TODO(ja): Translate these rules to grouping enhancers
-def is_known_third_party(package, sdk_info=None):
+def is_known_third_party(package: str, os: Optional[str]) -> bool:
     """
     Checks whether this package matches one of the well-known system image
     locations across platforms. The given package must not be ``None``.
@@ -54,12 +55,11 @@ def is_known_third_party(package, sdk_info=None):
         return False
 
     # Check for OS-specific rules
-    sdk_name = sdk_info["sdk_name"].lower() if sdk_info else ""
-    if sdk_name == "macos":
+    if os == "macos":
         return not any(p in package for p in MACOS_APP_PATHS)
-    if sdk_name == "linux":
+    if os == "linux":
         return package.startswith(LINUX_SYS_PATHS)
-    if sdk_name == "windows":
+    if os == "windows":
         return WINDOWS_SYS_PATH_RE.match(package) is not None
 
     # Everything else we don't know is considered third_party
@@ -67,7 +67,7 @@ def is_known_third_party(package, sdk_info=None):
 
 
 # TODO(ja): Improve reprocessing heuristics
-def is_optional_package(package, sdk_info=None):
+def is_optional_package(package: str) -> bool:
     """
     Determines whether the given package is considered optional.
 

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -1,8 +1,8 @@
-from sentry.lang.native.utils import get_sdk_from_event, is_minidump_event
+from sentry.lang.native.utils import get_os_from_event, is_minidump_event
 
 
-def test_get_sdk_from_event():
-    sdk_info = get_sdk_from_event(
+def test_get_os_from_event():
+    os = get_os_from_event(
         {
             "debug_meta": {
                 "sdk_info": {
@@ -14,19 +14,12 @@ def test_get_sdk_from_event():
             }
         }
     )
-    assert sdk_info["sdk_name"] == "iOS"
-    assert sdk_info["version_major"] == 9
-    assert sdk_info["version_minor"] == 3
-    assert sdk_info["version_patchlevel"] == 0
+    assert os == "ios"
 
-    sdk_info = get_sdk_from_event(
+    os = get_os_from_event(
         {"contexts": {"os": {"type": "os", "name": "iOS", "version": "9.3.1.1234"}}}
     )
-
-    assert sdk_info["sdk_name"] == "iOS"
-    assert sdk_info["version_major"] == 9
-    assert sdk_info["version_minor"] == 3
-    assert sdk_info["version_patchlevel"] == 1
+    assert os == "ios"
 
 
 def test_is_minidump():


### PR DESCRIPTION
The usage of `sdk_info` was confusing (it was *NOT* the Sentry SDK) and needlessly detailed.
It is clearer now that we are dealing with the OS (name) when filtering for known system images.

This is on top of https://github.com/getsentry/sentry/pull/45571