### PR TITLE
fix(codecov): Call new API with walk_back of 10

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -94,7 +94,7 @@ def get_codecov_data(repo: str, service: str, path: str) -> Tuple[LineCoverage |
     with configure_scope() as scope:
         response = requests.get(
             url,
-            params={},
+            params={"walk_back": 10},
             headers={"Authorization": f"Bearer {codecov_token}"},
             timeout=CODECOV_TIMEOUT,
         )


### PR DESCRIPTION
The new API does not have a default walk_back of 20 but it allows walking back up to 20.

We can start with a low value and measure the new p95.