### PR TITLE
ref(jira): Remove unused/wontfix things

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -902,7 +902,6 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                         account_id = possible_user.get("accountId")
                         email = client.get_email(account_id)
                     # match on lowercase email
-                    # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
                     if email and email.lower() == ue.lower():
                         jira_user = possible_user
                         break

--- a/src/sentry/integrations/jira/utils/api.py
+++ b/src/sentry/integrations/jira/utils/api.py
@@ -67,7 +67,6 @@ def handle_assignee_change(
         return
 
     email = get_assignee_email(integration, assignee, use_email_scope)
-    # TODO(steve) check display name
     if not email:
         logger.info(
             "missing-assignee-email",

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -35,7 +35,6 @@ class JiraServerClient(ApiClient):
     SERVER_INFO_URL = "/rest/api/2/serverInfo"
     ASSIGN_URL = "/rest/api/2/issue/%s/assignee"
     TRANSITION_URL = "/rest/api/2/issue/%s/transitions"
-    EMAIL_URL = "/rest/api/3/user/email"
     AUTOCOMPLETE_URL = "/rest/api/2/jql/autocompletedata/suggestions"
     PROPERTIES_URL = "/rest/api/3/issue/%s/properties/%s"
 
@@ -187,10 +186,6 @@ class JiraServerClient(ApiClient):
         properties_key = f"com.atlassian.jira.issue:{JIRA_KEY}:{module_key}:status"
         data = {"type": "badge", "value": {"label": badge_num}}
         return self.put(self.PROPERTIES_URL % (issue_key, properties_key), data=data)
-
-    def get_email(self, account_id):
-        user = self.get_cached(self.EMAIL_URL, params={"accountId": account_id})
-        return user.get("email")
 
     def get_field_autocomplete(self, name, value):
         if name.startswith(CUSTOMFIELD_PREFIX):

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -44,7 +44,6 @@ from sentry.shared_integrations.exceptions import (
     IntegrationFormError,
 )
 from sentry.tasks.integrations import migrate_issues
-from sentry.utils.decorators import classproperty
 from sentry.utils.hashlib import sha1_text
 from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
@@ -274,11 +273,6 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
     issues_ignored_fields_key = "issues_ignored_fields"
 
     default_identity = None
-
-    @classproperty
-    def use_email_scope(cls):
-        # jira server doesn't need the email scope since it's not restricted by GDPR
-        return False
 
     def get_client(self):
         if self.default_identity is None:
@@ -982,12 +976,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                     continue
                 for possible_user in possible_users:
                     email = possible_user.get("emailAddress")
-                    # pull email from API if we can use it
-                    if not email and self.use_email_scope:
-                        account_id = possible_user.get("accountId")
-                        email = client.get_email(account_id)
                     # match on lowercase email
-                    # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
                     if email and email.lower() == ue.lower():
                         jira_user = possible_user
                         break

--- a/src/sentry/integrations/jira_server/utils/api.py
+++ b/src/sentry/integrations/jira_server/utils/api.py
@@ -31,21 +31,14 @@ def _get_client(integration: Integration) -> JiraServerClient:
 def get_assignee_email(
     integration: Integration,
     assignee: Mapping[str, str],
-    use_email_scope: bool = False,
 ) -> str | None:
-    """Get email from `assignee` or pull it from API (if we have the scope for it.)"""
-    email = assignee.get("emailAddress")
-    if not email and use_email_scope:
-        account_id = assignee.get("accountId")
-        client = _get_client(integration)
-        email = client.get_email(account_id)
-    return email
+    """Get email from `assignee`."""
+    return assignee.get("emailAddress")
 
 
 def handle_assignee_change(
     integration: Integration,
     data: Mapping[str, Any],
-    use_email_scope: bool = False,
 ) -> None:
     assignee_changed = any(
         item for item in data["changelog"]["items"] if item["field"] == "assignee"
@@ -63,8 +56,7 @@ def handle_assignee_change(
         sync_group_assignee_inbound(integration, None, issue_key, assign=False)
         return
 
-    email = get_assignee_email(integration, assignee, use_email_scope)
-    # TODO(steve) check display name
+    email = get_assignee_email(integration, assignee)
     if not email:
         logger.info(
             "missing-assignee-email",

--- a/tests/sentry/integrations/jira_server/test_installation.py
+++ b/tests/sentry/integrations/jira_server/test_installation.py
@@ -1,5 +1,4 @@
 import responses
-from django.test.utils import override_settings
 from requests.exceptions import ReadTimeout
 
 from sentry.integrations.jira_server import JiraServerIntegrationProvider
@@ -427,7 +426,3 @@ class JiraServerInstallationTest(IntegrationTestCase):
         self.assertContains(resp, "Could not create issue webhook")
 
         assert Integration.objects.count() == 0
-
-    @override_settings(JIRA_USE_EMAIL_SCOPE=True)
-    def test_email_scope(self):
-        assert not self.provider.integration_cls.use_email_scope


### PR DESCRIPTION
Remove the TODOs around matching on display name since we've decided it's a bad idea due to possible name collision, as well as remove references to `use_email_scope` in Jira Server since it's an unused code path (always resolves to `False`) and the related unused code. We used to try to keep Jira and Jira Server as similar as possible, but since the code has been split I don't think it matters anymore.