### PR TITLE
feat(workflow): Remove issue alert fallback experiment

### DIFF
--- a/src/sentry/mail/analytics.py
+++ b/src/sentry/mail/analytics.py
@@ -12,8 +12,6 @@ class EmailNotificationSent(analytics.Event):
         analytics.Attribute("actor_id"),
         analytics.Attribute("user_id", required=False),
         analytics.Attribute("group_id", required=False),
-        # Remove after IssueAlertFallbackExperiment
-        analytics.Attribute("fallback_experiment", required=False),
     )
 
 

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -26,11 +26,7 @@ from sentry.notifications.utils import (
     has_alert_integration,
     has_integrations,
 )
-from sentry.notifications.utils.participants import (
-    get_owner_reason,
-    get_send_to,
-    should_use_issue_alert_fallback,
-)
+from sentry.notifications.utils.participants import get_owner_reason, get_send_to
 from sentry.plugins.base.structs import Notification
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import metrics
@@ -111,19 +107,12 @@ class AlertRuleNotification(ProjectNotification):
             event=self.event,
             fallthrough_choice=self.fallthrough_choice,
         )
-        fallback_params: MutableMapping[str, str] = {}
-        # Piggybacking off of notification_reason that already determines if we're using the fallback
-        if notification_reason and self.fallthrough_choice == FallthroughChoiceType.ACTIVE_MEMBERS:
-            _, fallback_experiment = should_use_issue_alert_fallback(org=self.organization)
-            fallback_params = {"ref_fallback": fallback_experiment}
 
         context = {
             "project_label": self.project.get_full_name(),
             "group": self.group,
             "event": self.event,
-            "link": get_group_settings_link(
-                self.group, environment, rule_details, None, **fallback_params
-            ),
+            "link": get_group_settings_link(self.group, environment, rule_details),
             "rules": rule_details,
             "has_integrations": has_integrations(self.organization, self.project),
             "enhanced_privacy": enhanced_privacy,
@@ -218,10 +207,8 @@ class AlertRuleNotification(ProjectNotification):
             notify(provider, self, participants, shared_context)
 
     def get_log_params(self, recipient: Team | User) -> Mapping[str, Any]:
-        _, fallback_experiment = should_use_issue_alert_fallback(org=self.organization)
         return {
             "target_type": self.target_type,
             "target_identifier": self.target_identifier,
-            "fallback_experiment": fallback_experiment,
             **super().get_log_params(recipient),
         }

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, MutableMapping, Sequence
 
 from sentry import features
-from sentry.experiments import manager as expt_manager
 from sentry.models import (
     ActorTuple,
     Group,
@@ -338,19 +337,6 @@ def get_send_to(
     return get_recipients_by_provider(project, recipients, notification_type)
 
 
-def should_use_issue_alert_fallback(org: Organization) -> Tuple[bool, str]:
-    """
-    Remove after IssueAlertFallbackExperiment experiment
-    Returns a tuple of (enabled, analytics_label)
-    """
-    if org.flags.early_adopter.is_set:
-        return (True, "early")
-    org_exposed = expt_manager.get("IssueAlertFallbackExperiment", org=org) == 1
-    if org_exposed:
-        return (True, "expt")
-    return (False, "ctrl")
-
-
 def get_fallthrough_recipients(
     project: Project, fallthrough_choice: FallthroughChoiceType | None
 ) -> Iterable[RpcUser]:
@@ -374,20 +360,13 @@ def get_fallthrough_recipients(
         )
 
     elif fallthrough_choice == FallthroughChoiceType.ACTIVE_MEMBERS:
-        use_active_members, _ = should_use_issue_alert_fallback(org=project.organization)
-        if use_active_members:
-            return user_service.get_many(
-                filter={
-                    "user_ids": project.member_set.order_by("-user__last_active").values_list(
-                        "user_id", flat=True
-                    )
-                }
-            )[:FALLTHROUGH_NOTIFICATION_LIMIT_EA]
-
-        # Return all members for non-EA orgs. This line will be removed once EA is over.
         return user_service.get_many(
-            filter=dict(user_ids=project.member_set.values_list("user_id", flat=True))
-        )
+            filter={
+                "user_ids": project.member_set.order_by("-user__last_active").values_list(
+                    "user_id", flat=True
+                )
+            }
+        )[:FALLTHROUGH_NOTIFICATION_LIMIT_EA]
 
     raise NotImplementedError(f"Unknown fallthrough choice: {fallthrough_choice}")
 

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -773,7 +773,6 @@ class GetSendToFallthroughTest(TestCase):
             organization=self.organization, members=[self.user, self.user2]
         )
         self.project.add_team(self.team2)
-        self.organization.flags.early_adopter = True
 
         ProjectOwnership.objects.create(
             project_id=self.project.id,
@@ -977,31 +976,3 @@ class GetSendToFallthroughTest(TestCase):
 
         assert len(notified_users) == FALLTHROUGH_NOTIFICATION_LIMIT_EA
         assert notified_users.issubset(expected_notified_users)
-
-    @with_feature("organizations:issue-alert-fallback-targeting")
-    def test_fallthrough_ga_limit(self):
-        self.organization.flags.early_adopter = False
-
-        notifiable_users = [self.user, self.user2]
-        for i in range(FALLTHROUGH_NOTIFICATION_LIMIT_EA + 5):
-            new_user = self.create_user(email=f"user_{i}@example.com", is_active=True)
-            self.create_member(
-                user=new_user, organization=self.organization, role="owner", teams=[self.team2]
-            )
-            notifiable_users.append(new_user)
-
-        for user in notifiable_users:
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.SLACK,
-                NotificationSettingTypes.ISSUE_ALERTS,
-                NotificationSettingOptionValues.NEVER,
-                user=user,
-            )
-
-        event = self.store_event("admin.lol", self.project)
-        notified_users = self.get_send_to_fallthrough(
-            event, self.project, FallthroughChoiceType.ACTIVE_MEMBERS
-        )[ExternalProviders.EMAIL]
-
-        # Check that we notify all possible folks with the GA limit.
-        assert len(notified_users) == len(notifiable_users)


### PR DESCRIPTION
The experiment was a success, everyone will get the new experience of a limited number of "Active Members" as the default issue alert fallback