### PR TITLE
fix(hybrid-cloud): unignored signal fix for user => user_id

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -613,7 +613,7 @@ def update_groups(
                     if group.status == GroupStatus.IGNORED:
                         issue_unignored.send_robust(
                             project=project_lookup[group.project_id],
-                            user=acting_user,
+                            user_id=acting_user.id if acting_user else None,
                             group=group,
                             transition_type="manual",
                             sender=update_groups,

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -471,11 +471,10 @@ def record_issue_ignored(project, user, group_list, activity_data, **kwargs):
 
 
 @issue_unignored.connect(weak=False)
-def record_issue_unignored(project, user, group, transition_type, **kwargs):
-    if user and user.is_authenticated:
-        user_id = default_user_id = user.id
+def record_issue_unignored(project, user_id, group, transition_type, **kwargs):
+    if user_id is not None:
+        default_user_id = user_id
     else:
-        user_id = None
         default_user_id = project.organization.get_default_owner().id
 
     analytics.record(

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -168,7 +168,7 @@ issue_resolved = BetterSignal(
 )
 issue_unresolved = BetterSignal(providing_args=["project", "user", "group", "transition_type"])
 issue_ignored = BetterSignal(providing_args=["project", "user", "group_list", "activity_data"])
-issue_unignored = BetterSignal(providing_args=["project", "user", "group", "transition_type"])
+issue_unignored = BetterSignal(providing_args=["project", "user_id", "group", "transition_type"])
 issue_mark_reviewed = BetterSignal(providing_args=["project", "user", "group"])
 
 # comments

--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -23,7 +23,7 @@ def clear_expired_snoozes():
         record_group_history(group, GroupHistoryStatus.UNIGNORED)
         issue_unignored.send_robust(
             project=group.project,
-            user=None,
+            user_id=None,
             group=group,
             transition_type="automatic",
             sender="clear_expired_snoozes",

--- a/tests/sentry/receivers/test_signals.py
+++ b/tests/sentry/receivers/test_signals.py
@@ -21,7 +21,7 @@ class SignalsTest(TestCase, SnubaTestCase):
         issue_unignored.send(
             project=self.project,
             group=self.group,
-            user=self.owner,
+            user_id=self.owner.id,
             transition_type="manual",
             sender=type(self.project),
         )
@@ -32,7 +32,7 @@ class SignalsTest(TestCase, SnubaTestCase):
         issue_unignored.send(
             project=self.project,
             group=self.group,
-            user=None,
+            user_id=None,
             transition_type="automatic",
             sender="clear_expired_snoozes",
         )


### PR DESCRIPTION
Fixing the signal and related tests for receiving user_id instead of user.  Will try to keep a closer eye on these signals in further HC work.