### PR TITLE
ref(monitors): Use MonitorCheckInEndpoint for both checkin endpoints

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_checkin_details.py
@@ -6,7 +6,6 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -29,7 +28,6 @@ from .base import MonitorCheckInEndpoint
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class MonitorCheckInDetailsEndpoint(MonitorCheckInEndpoint):
-    authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
     public = {"GET", "PUT"}
 
     @extend_schema(

--- a/src/sentry/monitors/endpoints/monitor_checkins.py
+++ b/src/sentry/monitors/endpoints/monitor_checkins.py
@@ -9,7 +9,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import ratelimits
-from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -35,7 +34,7 @@ from sentry.monitors.validators import MonitorCheckInValidator
 from sentry.signals import first_cron_checkin_received, first_cron_monitor_created
 from sentry.utils import metrics
 
-from .base import MonitorEndpoint
+from .base import MonitorCheckInEndpoint
 
 CHECKIN_QUOTA_LIMIT = 5
 CHECKIN_QUOTA_WINDOW = 60
@@ -43,8 +42,7 @@ CHECKIN_QUOTA_WINDOW = 60
 
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
-class MonitorCheckInsEndpoint(MonitorEndpoint):
-    authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
+class MonitorCheckInsEndpoint(MonitorCheckInEndpoint):
     public = {"GET", "POST"}
 
     @extend_schema(


### PR DESCRIPTION
This allows us to re-use the authentication_classes in once places and I
think makes things a bit more clear