### PR TITLE
fix(targeting-context): Fix incorrect parameter type in codeowner API

### DIFF
--- a/src/sentry/api/endpoints/codeowners/index.py
+++ b/src/sentry/api/endpoints/codeowners/index.py
@@ -29,7 +29,7 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):  # typ
             codeowner.raw = convert_codeowners_syntax(
                 codeowner.raw,
                 associations,
-                codeowner.repository_project_path_config_id,
+                codeowner.repository_project_path_config,
             )
             codeowner.schema = create_schema_from_issue_owners(codeowner.raw, project.id, True)
 


### PR DESCRIPTION
Incorrect parameter type was being passed into `convert_codeowners_syntax`

Fixes [SENTRY-ZHM](https://sentry.sentry.io/issues/3991058603/events/034548655edf4d2a87813c645c3c9aa2/?project=1&referrer=issue-list&statsPeriod=14d)
