### PR TITLE
fix(grouping): Always assign group ids to group hashes

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1561,16 +1561,10 @@ def _save_aggregate(
 
     is_new = False
 
-    if root_hierarchical_grouphash is None:
-        # No hierarchical grouping was run, only consider flat hashes
-        new_hashes = [h for h in flat_grouphashes if h.group_id is None]
-    elif root_hierarchical_grouphash.group_id is None:
-        # The root hash is not assigned to a group.
-        # We ran multiple grouping algorithms
-        # (see secondary grouping), and the hierarchical hash is new
-        new_hashes = [root_hierarchical_grouphash]
-    else:
-        new_hashes = []
+    # Figure out which group hashes need to have the group assigned.
+    new_hashes = [h for h in flat_grouphashes if h.group_id is None]
+    if root_hierarchical_grouphash:
+        new_hashes.append(root_hierarchical_grouphash)
 
     if new_hashes:
         # There may still be secondary hashes that we did not use to find an

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -521,7 +521,7 @@ class EventManager:
         # migrate from a hierarchical hash to a non hierarchical hash.  The reason being that
         # _save_aggregate needs special logic to not create orphaned hashes in migration cases
         # but it wants a different logic to implement splitting of hierarchical hashes.
-        migrate_off_hierarchical = (
+        migrate_off_hierarchical = bool(
             secondary_hashes
             and secondary_hashes.hierarchical_hashes
             and not hashes.hierarchical_hashes


### PR DESCRIPTION
We cannot fully explain why the hashes were only assigned to group hashes, but the end result is that the `GroupHash` table creates a lot of orphaned hashes. Currently only the secondary grouping created hashes have the group id associated. This should resolve the issue that the smooth upgrade does not work.