### PR TITLE
feat(perf-issues): Add `View Full Event` button to Span Evidence section

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -58,7 +58,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
         'Span Evidence identifies the root cause of this issue, found in other similar events within the same issue.'
       )}
     >
-      <SpanEvidenceKeyValueList event={event} />
+      <SpanEvidenceKeyValueList event={event} projectSlug={projectSlug} />
       {hasProfilingPreviewsFeature ? (
         <ProfilesProvider
           orgSlug={organization.slug}

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -14,6 +14,8 @@ import {
 } from './spanEvidenceKeyValueList';
 
 describe('SpanEvidenceKeyValueList', () => {
+  const projectSlug = 'project';
+
   describe('N+1 Database Queries', () => {
     const builder = new TransactionEventBuilder('a1', '/');
     builder.getEvent().projectID = '123';
@@ -46,7 +48,9 @@ describe('SpanEvidenceKeyValueList', () => {
     builder.addSpan(parentSpan);
 
     it('Renders relevant fields', () => {
-      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
 
       expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
       expect(
@@ -111,7 +115,9 @@ describe('SpanEvidenceKeyValueList', () => {
     builder.addSpan(parentSpan);
 
     it('Renders relevant fields', () => {
-      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
 
       expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
       expect(
@@ -186,7 +192,9 @@ describe('SpanEvidenceKeyValueList', () => {
     builder.addSpan(parentSpan);
 
     it('Renders relevant fields', () => {
-      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
 
       expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
       expect(
@@ -267,7 +275,9 @@ describe('SpanEvidenceKeyValueList', () => {
     );
 
     it('Renders relevant fields', () => {
-      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
 
       expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
       expect(
@@ -398,7 +408,9 @@ describe('SpanEvidenceKeyValueList', () => {
     builder.addSpan(parentSpan);
 
     it('Renders relevant fields', () => {
-      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
 
       expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
       expect(
@@ -442,7 +454,9 @@ describe('SpanEvidenceKeyValueList', () => {
     builder.addSpan(offenderSpan);
 
     it('Renders relevant fields', () => {
-      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
 
       expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
       expect(
@@ -497,7 +511,9 @@ describe('SpanEvidenceKeyValueList', () => {
     builder.addSpan(offenderSpan);
 
     it('Renders relevant fields', () => {
-      render(<SpanEvidenceKeyValueList event={builder.getEvent()} />);
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
 
       expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
       expect(

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -62,6 +62,11 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
@@ -129,6 +134,11 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
 
       expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
       expect(
@@ -206,6 +216,11 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
 
       expect(screen.getByRole('cell', {name: 'Starting Span'})).toBeInTheDocument();
       expect(
@@ -289,6 +304,11 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
 
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
@@ -422,6 +442,11 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
 
       expect(screen.getByRole('cell', {name: 'Slow DB Query'})).toBeInTheDocument();
       expect(
@@ -468,6 +493,11 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();
       expect(
@@ -525,6 +555,11 @@ describe('SpanEvidenceKeyValueList', () => {
         'href',
         `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
       );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
 
       expect(screen.getByRole('cell', {name: 'Slow Resource Span'})).toBeInTheDocument();
       expect(

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -85,7 +85,12 @@ export function SpanEvidenceKeyValueList({
 
   return (
     <ClippedBox clipHeight={300}>
-      <Component event={event} orgSlug={orgSlug} {...spanInfo} />
+      <Component
+        event={event}
+        orgSlug={orgSlug}
+        projectSlug={projectSlug}
+        {...spanInfo}
+      />
     </ClippedBox>
   );
 }
@@ -198,18 +203,20 @@ const SlowDBQueryEvidence = ({
   offendingSpans,
   orgSlug,
   projectSlug,
-}: SpanEvidenceKeyValueListProps) => (
-  <PresortedKeyValueList
-    data={[
-      makeTransactionNameRow(event, orgSlug, projectSlug),
-      makeRow(t('Slow DB Query'), getSpanEvidenceValue(offendingSpans[0])),
-      makeRow(
-        t('Duration Impact'),
-        getSingleSpanDurationImpact(event, offendingSpans[0])
-      ),
-    ]}
-  />
-);
+}: SpanEvidenceKeyValueListProps) => {
+  return (
+    <PresortedKeyValueList
+      data={[
+        makeTransactionNameRow(event, orgSlug, projectSlug),
+        makeRow(t('Slow DB Query'), getSpanEvidenceValue(offendingSpans[0])),
+        makeRow(
+          t('Duration Impact'),
+          getSingleSpanDurationImpact(event, offendingSpans[0])
+        ),
+      ]}
+    />
+  );
+};
 
 const RenderBlockingAssetSpanEvidence = ({
   event,

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import kebabCase from 'lodash/kebabCase';
 import mapValues from 'lodash/mapValues';
 
+import {Button} from 'sentry/components/button';
 import ClippedBox from 'sentry/components/clippedBox';
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
@@ -267,7 +268,10 @@ const makeTransactionNameRow = (event: Event, orgSlug: string) => {
   return makeRow(
     t('Transaction'),
     <pre>
-      <Link to={to}>{event.title}</Link>
+      <TransactionRowContainer>
+        <Link to={to}>{event.title}</Link>
+        <StyledButton size="xs">{t('View Full Event')}</StyledButton>
+      </TransactionRowContainer>
     </pre>
   );
 };
@@ -455,3 +459,13 @@ function formatBasePath(span: Span, baseURL?: string): string {
 
   return spanURL?.pathname ?? '';
 }
+
+const TransactionRowContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledButton = styled(Button)`
+  font-family: ${p => p.theme.text.family};
+`;

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -21,6 +21,8 @@ import {
   KeyValueListDataItem,
 } from 'sentry/types';
 import {formatBytesBase2} from 'sentry/utils';
+import {generateEventSlug} from 'sentry/utils/discover/urls';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import useOrganization from 'sentry/utils/useOrganization';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils';
@@ -42,11 +44,18 @@ type SpanEvidenceKeyValueListProps = {
   offendingSpans: Span[];
   orgSlug: string;
   parentSpan: Span | null;
+  projectSlug: string;
 };
 
 const TEST_ID_NAMESPACE = 'span-evidence-key-value-list';
 
-export function SpanEvidenceKeyValueList({event}: {event: EventTransaction}) {
+export function SpanEvidenceKeyValueList({
+  event,
+  projectSlug,
+}: {
+  event: EventTransaction;
+  projectSlug: string;
+}) {
   const {slug: orgSlug} = useOrganization();
   const spanInfo = getSpanInfoFromTransactionEvent(event);
   const performanceProblem = event?.perfProblem;
@@ -59,6 +68,7 @@ export function SpanEvidenceKeyValueList({event}: {event: EventTransaction}) {
         causeSpans={[]}
         parentSpan={null}
         orgSlug={orgSlug}
+        projectSlug={projectSlug}
       />
     );
   }
@@ -85,11 +95,12 @@ const ConsecutiveDBQueriesSpanEvidence = ({
   causeSpans,
   offendingSpans,
   orgSlug,
+  projectSlug,
 }: SpanEvidenceKeyValueListProps) => (
   <PresortedKeyValueList
     data={
       [
-        makeTransactionNameRow(event, orgSlug),
+        makeTransactionNameRow(event, orgSlug, projectSlug),
         causeSpans
           ? makeRow(t('Starting Span'), getSpanEvidenceValue(causeSpans[0]))
           : null,
@@ -108,6 +119,7 @@ const NPlusOneDBQueriesSpanEvidence = ({
   parentSpan,
   offendingSpans,
   orgSlug,
+  projectSlug,
 }: SpanEvidenceKeyValueListProps) => {
   const dbSpans = offendingSpans.filter(span => (span.op || '').startsWith('db'));
   const repeatingSpanRows = dbSpans
@@ -123,7 +135,7 @@ const NPlusOneDBQueriesSpanEvidence = ({
     <PresortedKeyValueList
       data={
         [
-          makeTransactionNameRow(event, orgSlug),
+          makeTransactionNameRow(event, orgSlug, projectSlug),
           parentSpan ? makeRow(t('Parent Span'), getSpanEvidenceValue(parentSpan)) : null,
           ...repeatingSpanRows,
         ].filter(Boolean) as KeyValueListData
@@ -136,6 +148,7 @@ const NPlusOneAPICallsSpanEvidence = ({
   event,
   offendingSpans,
   orgSlug,
+  projectSlug,
 }: SpanEvidenceKeyValueListProps) => {
   const requestEntry = event?.entries?.find(isRequestEntry);
   const baseURL = requestEntry?.data?.url;
@@ -147,7 +160,7 @@ const NPlusOneAPICallsSpanEvidence = ({
     <PresortedKeyValueList
       data={
         [
-          makeTransactionNameRow(event, orgSlug),
+          makeTransactionNameRow(event, orgSlug, projectSlug),
           commonPathPrefix
             ? makeRow(
                 t('Repeating Spans (%s)', offendingSpans.length),
@@ -184,10 +197,11 @@ const SlowDBQueryEvidence = ({
   event,
   offendingSpans,
   orgSlug,
+  projectSlug,
 }: SpanEvidenceKeyValueListProps) => (
   <PresortedKeyValueList
     data={[
-      makeTransactionNameRow(event, orgSlug),
+      makeTransactionNameRow(event, orgSlug, projectSlug),
       makeRow(t('Slow DB Query'), getSpanEvidenceValue(offendingSpans[0])),
       makeRow(
         t('Duration Impact'),
@@ -201,13 +215,14 @@ const RenderBlockingAssetSpanEvidence = ({
   event,
   offendingSpans,
   orgSlug,
+  projectSlug,
 }: SpanEvidenceKeyValueListProps) => {
   const offendingSpan = offendingSpans[0]; // For render-blocking assets, there is only one offender
 
   return (
     <PresortedKeyValueList
       data={[
-        makeTransactionNameRow(event, orgSlug),
+        makeTransactionNameRow(event, orgSlug, projectSlug),
         makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpan)),
         makeRow(
           t('FCP Delay'),
@@ -223,10 +238,11 @@ const UncompressedAssetSpanEvidence = ({
   event,
   offendingSpans,
   orgSlug,
+  projectSlug,
 }: SpanEvidenceKeyValueListProps) => (
   <PresortedKeyValueList
     data={[
-      makeTransactionNameRow(event, orgSlug),
+      makeTransactionNameRow(event, orgSlug, projectSlug),
       makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpans[0])),
       makeRow(t('Asset Size'), getSpanFieldBytes(offendingSpans[0], 'Encoded Body Size')),
       makeRow(
@@ -241,11 +257,12 @@ const DefaultSpanEvidence = ({
   event,
   offendingSpans,
   orgSlug,
+  projectSlug,
 }: SpanEvidenceKeyValueListProps) => (
   <PresortedKeyValueList
     data={
       [
-        makeTransactionNameRow(event, orgSlug),
+        makeTransactionNameRow(event, orgSlug, projectSlug),
         offendingSpans.length > 0
           ? makeRow(t('Offending Span'), getSpanEvidenceValue(offendingSpans[0]))
           : null,
@@ -258,19 +275,29 @@ const PresortedKeyValueList = ({data}: {data: KeyValueListData}) => (
   <KeyValueList shouldSort={false} data={data} />
 );
 
-const makeTransactionNameRow = (event: Event, orgSlug: string) => {
-  const to = transactionSummaryRouteWithQuery({
+const makeTransactionNameRow = (event: Event, orgSlug: string, projectSlug: string) => {
+  const transactionSummaryLocation = transactionSummaryRouteWithQuery({
     orgSlug,
     projectID: event.projectID,
     transaction: event.title,
     query: {},
   });
+
+  const eventSlug = generateEventSlug({
+    id: event.eventID,
+    project: projectSlug,
+  });
+
+  const eventDetailsLocation = getTransactionDetailsUrl(orgSlug, eventSlug);
+
   return makeRow(
     t('Transaction'),
     <pre>
       <TransactionRowContainer>
-        <Link to={to}>{event.title}</Link>
-        <StyledButton size="xs">{t('View Full Event')}</StyledButton>
+        <Link to={transactionSummaryLocation}>{event.title}</Link>
+        <StyledButton size="xs" to={eventDetailsLocation}>
+          {t('View Full Event')}
+        </StyledButton>
       </TransactionRowContainer>
     </pre>
   );

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, ReactNode} from 'react';
 import styled from '@emotion/styled';
 import kebabCase from 'lodash/kebabCase';
 import mapValues from 'lodash/mapValues';
@@ -296,24 +296,26 @@ const makeTransactionNameRow = (event: Event, orgSlug: string, projectSlug?: str
   });
 
   const eventDetailsLocation = getTransactionDetailsUrl(orgSlug, eventSlug);
+
+  const actionButton = projectSlug ? (
+    <Button size="xs" to={eventDetailsLocation}>
+      {t('View Full Event')}
+    </Button>
+  ) : undefined;
+
   return makeRow(
     t('Transaction'),
     <pre>
-      <TransactionRowContainer>
-        <Link to={transactionSummaryLocation}>{event.title}</Link>
-        {projectSlug && (
-          <StyledButton size="xs" to={eventDetailsLocation}>
-            {t('View Full Event')}
-          </StyledButton>
-        )}
-      </TransactionRowContainer>
-    </pre>
+      <Link to={transactionSummaryLocation}>{event.title}</Link>
+    </pre>,
+    actionButton
   );
 };
 
 const makeRow = (
   subject: KeyValueListDataItem['subject'],
-  value: KeyValueListDataItem['value'] | KeyValueListDataItem['value'][]
+  value: KeyValueListDataItem['value'] | KeyValueListDataItem['value'][],
+  actionButton?: ReactNode
 ): KeyValueListDataItem => {
   const itemKey = kebabCase(subject);
 
@@ -323,6 +325,7 @@ const makeRow = (
     value,
     subjectDataTestId: `${TEST_ID_NAMESPACE}.${itemKey}`,
     isMultiValue: Array.isArray(value),
+    actionButton,
   };
 };
 
@@ -494,13 +497,3 @@ function formatBasePath(span: Span, baseURL?: string): string {
 
   return spanURL?.pathname ?? '';
 }
-
-const TransactionRowContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-`;
-
-const StyledButton = styled(Button)`
-  font-family: ${p => p.theme.text.family};
-`;

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -44,7 +44,7 @@ type SpanEvidenceKeyValueListProps = {
   offendingSpans: Span[];
   orgSlug: string;
   parentSpan: Span | null;
-  projectSlug: string;
+  projectSlug?: string;
 };
 
 const TEST_ID_NAMESPACE = 'span-evidence-key-value-list';
@@ -54,7 +54,7 @@ export function SpanEvidenceKeyValueList({
   projectSlug,
 }: {
   event: EventTransaction;
-  projectSlug: string;
+  projectSlug?: string;
 }) {
   const {slug: orgSlug} = useOrganization();
   const spanInfo = getSpanInfoFromTransactionEvent(event);
@@ -282,7 +282,7 @@ const PresortedKeyValueList = ({data}: {data: KeyValueListData}) => (
   <KeyValueList shouldSort={false} data={data} />
 );
 
-const makeTransactionNameRow = (event: Event, orgSlug: string, projectSlug: string) => {
+const makeTransactionNameRow = (event: Event, orgSlug: string, projectSlug?: string) => {
   const transactionSummaryLocation = transactionSummaryRouteWithQuery({
     orgSlug,
     projectID: event.projectID,
@@ -296,15 +296,16 @@ const makeTransactionNameRow = (event: Event, orgSlug: string, projectSlug: stri
   });
 
   const eventDetailsLocation = getTransactionDetailsUrl(orgSlug, eventSlug);
-
   return makeRow(
     t('Transaction'),
     <pre>
       <TransactionRowContainer>
         <Link to={transactionSummaryLocation}>{event.title}</Link>
-        <StyledButton size="xs" to={eventDetailsLocation}>
-          {t('View Full Event')}
-        </StyledButton>
+        {projectSlug && (
+          <StyledButton size="xs" to={eventDetailsLocation}>
+            {t('View Full Event')}
+          </StyledButton>
+        )}
       </TransactionRowContainer>
     </pre>
   );

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -23,6 +23,7 @@ type SpanEvidencePreviewBodyProps = {
   onRequestBegin: () => void;
   onRequestEnd: () => void;
   onUnmount: () => void;
+  projectSlug?: string;
 };
 
 const makeGroupPreviewRequestUrl = ({
@@ -52,6 +53,7 @@ const SpanEvidencePreviewBody = ({
   onRequestBegin,
   onRequestEnd,
   onUnmount,
+  projectSlug,
 }: SpanEvidencePreviewBodyProps) => {
   const {data, isLoading, isError} = useQuery<EventTransaction>(
     [endpointUrl, {query: {referrer: 'api.issues.preview-performance'}}],
@@ -83,7 +85,7 @@ const SpanEvidencePreviewBody = ({
   if (data) {
     return (
       <SpanEvidencePreviewWrapper data-test-id="span-evidence-preview-body">
-        <SpanEvidenceKeyValueList event={data} />
+        <SpanEvidenceKeyValueList event={data} projectSlug={projectSlug} />
       </SpanEvidencePreviewWrapper>
     );
   }
@@ -124,6 +126,7 @@ export const SpanEvidencePreview = ({
           onRequestEnd={onRequestEnd}
           onUnmount={reset}
           endpointUrl={endpointUrl}
+          projectSlug={projectSlug}
         />
       }
     >


### PR DESCRIPTION
To make the navigability of Performance Issues less frustrating, we're adding this button to the Span Evidence section, so users can click to view the full event details page.

![image](https://user-images.githubusercontent.com/16740047/224148889-63178f4d-c116-42ae-a322-ed08b3d7beb6.png)
