### PR TITLE
feat(profiling): Add thread info and pagination to inline profiles

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -26,11 +26,11 @@ type Props = {
   platform: PlatformType;
   className?: string;
   debugFrames?: StacktraceFilenameQuery[];
+  hideIcon?: boolean;
   isHoverPreviewed?: boolean;
   meta?: Record<any, any>;
   newestFirst?: boolean;
   organization?: Organization;
-  showIcon?: boolean;
 } & Partial<DefaultProps>;
 
 type State = {
@@ -142,7 +142,7 @@ class Content extends Component<Props, State> {
       isHoverPreviewed,
       meta,
       debugFrames,
-      showIcon,
+      hideIcon,
     } = this.props;
 
     const {showingAbsoluteAddresses, showCompleteFunctionName} = this.state;
@@ -268,7 +268,7 @@ class Content extends Component<Props, State> {
 
     return (
       <Wrapper className={className} data-test-id="stack-trace-content">
-        {showIcon && <StacktracePlatformIcon platform={platformIcon} />}
+        {!hideIcon && <StacktracePlatformIcon platform={platformIcon} />}
         <GuideAnchor target="stack_trace">
           <StyledList data-test-id="frames">{frames}</StyledList>
         </GuideAnchor>

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -30,6 +30,7 @@ type Props = {
   meta?: Record<any, any>;
   newestFirst?: boolean;
   organization?: Organization;
+  showIcon?: boolean;
 } & Partial<DefaultProps>;
 
 type State = {
@@ -141,6 +142,7 @@ class Content extends Component<Props, State> {
       isHoverPreviewed,
       meta,
       debugFrames,
+      showIcon,
     } = this.props;
 
     const {showingAbsoluteAddresses, showCompleteFunctionName} = this.state;
@@ -266,7 +268,7 @@ class Content extends Component<Props, State> {
 
     return (
       <Wrapper className={className} data-test-id="stack-trace-content">
-        <StacktracePlatformIcon platform={platformIcon} />
+        {showIcon && <StacktracePlatformIcon platform={platformIcon} />}
         <GuideAnchor target="stack_trace">
           <StyledList data-test-id="frames">{frames}</StyledList>
         </GuideAnchor>

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -23,11 +23,11 @@ type Props = {
   debugFrames?: StacktraceFilenameQuery[];
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
+  hideIcon?: boolean;
   includeSystemFrames?: boolean;
   isHoverPreviewed?: boolean;
   meta?: Record<any, any>;
   newestFirst?: boolean;
-  showIcon?: boolean;
 };
 
 function Content({
@@ -40,7 +40,7 @@ function Content({
   isHoverPreviewed,
   groupingCurrentLevel,
   meta,
-  showIcon,
+  hideIcon,
   includeSystemFrames = true,
   expandFirstFrame = true,
 }: Props) {
@@ -254,7 +254,7 @@ function Content({
 
   return (
     <Wrapper className={getClassName()} data-test-id="stack-trace-content-v2">
-      {showIcon && <StacktracePlatformIcon platform={platformIcon} />}
+      {!hideIcon && <StacktracePlatformIcon platform={platformIcon} />}
       <StyledList>{renderConvertedFrames()}</StyledList>
     </Wrapper>
   );

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -27,6 +27,7 @@ type Props = {
   isHoverPreviewed?: boolean;
   meta?: Record<any, any>;
   newestFirst?: boolean;
+  showIcon?: boolean;
 };
 
 function Content({
@@ -39,6 +40,7 @@ function Content({
   isHoverPreviewed,
   groupingCurrentLevel,
   meta,
+  showIcon,
   includeSystemFrames = true,
   expandFirstFrame = true,
 }: Props) {
@@ -252,7 +254,7 @@ function Content({
 
   return (
     <Wrapper className={getClassName()} data-test-id="stack-trace-content-v2">
-      <StacktracePlatformIcon platform={platformIcon} />
+      {showIcon && <StacktracePlatformIcon platform={platformIcon} />}
       <StyledList>{renderConvertedFrames()}</StyledList>
     </Wrapper>
   );

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -21,6 +21,7 @@ type Props = {
   isHoverPreviewed?: boolean;
   meta?: Record<any, any>;
   newestFirst?: boolean;
+  showIcon?: boolean;
 };
 
 function Content({

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -17,11 +17,11 @@ type Props = {
   platform: PlatformType;
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
+  hideIcon?: boolean;
   includeSystemFrames?: boolean;
   isHoverPreviewed?: boolean;
   meta?: Record<any, any>;
   newestFirst?: boolean;
-  showIcon?: boolean;
 };
 
 function Content({

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -17,6 +17,7 @@ type Props = Pick<React.ComponentProps<typeof ContentV2>, 'groupingCurrentLevel'
   stacktrace: StacktraceType;
   meta?: Record<any, any>;
   nativeV2?: boolean;
+  showIcon?: boolean;
   stackView?: STACK_VIEW;
 };
 
@@ -30,6 +31,7 @@ function StackTrace({
   groupingCurrentLevel,
   nativeV2,
   meta,
+  showIcon = true,
 }: Props) {
   if (stackView === STACK_VIEW.RAW) {
     return (
@@ -52,6 +54,7 @@ function StackTrace({
           newestFirst={newestFirst}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
+          showIcon={showIcon}
         />
       </ErrorBoundary>
     );
@@ -69,6 +72,7 @@ function StackTrace({
           newestFirst={newestFirst}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
+          showIcon={showIcon}
         />
       </ErrorBoundary>
     );
@@ -84,6 +88,7 @@ function StackTrace({
         event={event}
         newestFirst={newestFirst}
         meta={meta}
+        showIcon={showIcon}
       />
     </ErrorBoundary>
   );

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -15,9 +15,9 @@ type Props = Pick<React.ComponentProps<typeof ContentV2>, 'groupingCurrentLevel'
   newestFirst: boolean;
   platform: PlatformType;
   stacktrace: StacktraceType;
+  hideIcon?: boolean;
   meta?: Record<any, any>;
   nativeV2?: boolean;
-  showIcon?: boolean;
   stackView?: STACK_VIEW;
 };
 
@@ -31,7 +31,7 @@ function StackTrace({
   groupingCurrentLevel,
   nativeV2,
   meta,
-  showIcon = true,
+  hideIcon,
 }: Props) {
   if (stackView === STACK_VIEW.RAW) {
     return (
@@ -54,7 +54,7 @@ function StackTrace({
           newestFirst={newestFirst}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
-          showIcon={showIcon}
+          hideIcon={hideIcon}
         />
       </ErrorBoundary>
     );
@@ -72,7 +72,7 @@ function StackTrace({
           newestFirst={newestFirst}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
-          showIcon={showIcon}
+          hideIcon={hideIcon}
         />
       </ErrorBoundary>
     );
@@ -88,7 +88,7 @@ function StackTrace({
         event={event}
         newestFirst={newestFirst}
         meta={meta}
-        showIcon={showIcon}
+        hideIcon={hideIcon}
       />
     </ErrorBoundary>
   );

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -192,7 +192,7 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
         }}
         nativeV2
         stackView={STACK_VIEW.APP}
-        showIcon={false}
+        hideIcon
       />
     </Fragment>
   );

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -1,16 +1,33 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import StackTrace from 'sentry/components/events/interfaces/crashContent/stackTrace';
+import Link from 'sentry/components/links/link';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconChevron, IconProfiling} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {EventTransaction, Frame, PlatformType} from 'sentry/types/event';
 import {STACK_VIEW} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
+import {formatPercentage} from 'sentry/utils/formatters';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {Frame as ProfilingFrame} from 'sentry/utils/profiling/frame';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
+import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {formatTo} from 'sentry/utils/profiling/units/units';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
 import {SpanType} from './types';
+
+const MAX_STACK_DEPTH = 16;
+const MAX_TOP_NODES = 10;
+const MIN_TOP_NODES = 3;
+const TOP_NODE_THRESHOLD = 3;
 
 interface SpanProfileDetailsProps {
   event: Readonly<EventTransaction>;
@@ -18,6 +35,10 @@ interface SpanProfileDetailsProps {
 }
 
 export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const project = projects.find(p => p.id === event.projectID);
+
   const profileGroup = useProfileGroup();
 
   // TODO: Pick another thread if it's more relevant.
@@ -52,50 +73,142 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
     return getTopNodes(profile, relativeStartTimestamp, relativeStopTimestamp);
   }, [profile, span, event]);
 
-  const frames = useMemo(() => {
-    if (!nodes.length) {
-      return [];
+  const [index, setIndex] = useState(0);
+
+  const totalWeight = useMemo(
+    () => nodes.reduce((count, node) => count + node.count, 0),
+    [nodes]
+  );
+
+  const {frames, hasPrevious, hasNext} = useMemo(() => {
+    if (index >= nodes.length) {
+      return {frames: [], hasPrevious: false, hasNext: false};
     }
 
-    return extractFrames(nodes[0], event.platform || 'other');
-  }, [event, nodes]);
+    const lastIndex = Math.max(
+      MIN_TOP_NODES,
+      nodes.findIndex(node => node.count < TOP_NODE_THRESHOLD) - 1
+    );
 
-  if (!defined(profile)) {
+    return {
+      frames: extractFrames(nodes[index], event.platform || 'other'),
+      hasPrevious: index > 0,
+      hasNext: index < nodes.length - 1 && index + 1 < Math.min(MAX_TOP_NODES, lastIndex),
+    };
+  }, [index, event, nodes]);
+
+  const profileTarget =
+    project &&
+    profileGroup &&
+    profile &&
+    generateProfileFlamechartRouteWithQuery({
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+      profileId: profileGroup.traceID,
+      query: {tid: String(profile.threadId)},
+    });
+
+  const spanTarget =
+    project &&
+    profileGroup &&
+    profile &&
+    generateProfileFlamechartRouteWithQuery({
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+      profileId: profileGroup.traceID,
+      query: {
+        tid: String(profile.threadId),
+        spanId: span.span_id,
+      },
+    });
+
+  const threadName = profile ? profile.name ?? `tid(${profile.threadId})` : t('unknown');
+
+  if (!defined(profile) || !defined(profileTarget) || !defined(spanTarget)) {
     return null;
   }
 
-  if (!nodes.length) {
+  if (!frames.length) {
     return null;
   }
 
   return (
-    <StackTrace
-      event={event}
-      hasHierarchicalGrouping
-      newestFirst
-      platform={event.platform || 'other'}
-      stacktrace={{
-        framesOmitted: null,
-        hasSystemFrames: false,
-        registers: null,
-        frames,
-      }}
-      nativeV2
-      stackView={STACK_VIEW.APP}
-    />
+    <Fragment>
+      <SpanDetails>
+        <SpanDetailsItem grow>
+          <Label>
+            {tct('Thread [name]', {
+              name: <Link to={profileTarget}>{threadName}</Link>,
+            })}
+          </Label>
+        </SpanDetailsItem>
+        <SpanDetailsItem>
+          <Label>
+            <Tooltip title={t('%s out of %s samples', nodes[index].count, totalWeight)}>
+              {tct('[percentage]', {
+                percentage: formatPercentage(nodes[index].count / totalWeight),
+              })}
+            </Tooltip>
+          </Label>
+        </SpanDetailsItem>
+        <SpanDetailsItem>
+          <Button icon={<IconProfiling />} to={spanTarget} size="sm">
+            {t('View Profile')}
+          </Button>
+        </SpanDetailsItem>
+        <SpanDetailsItem>
+          <ButtonBar merged>
+            <Button
+              icon={<IconChevron direction="left" size="sm" />}
+              aria-label={t('Previous')}
+              size="sm"
+              disabled={!hasPrevious}
+              onClick={() => {
+                setIndex(prevIndex => prevIndex - 1);
+              }}
+            />
+            <Button
+              icon={<IconChevron direction="right" size="sm" />}
+              aria-label={t('Next')}
+              size="sm"
+              disabled={!hasNext}
+              onClick={() => {
+                setIndex(prevIndex => prevIndex + 1);
+              }}
+            />
+          </ButtonBar>
+        </SpanDetailsItem>
+      </SpanDetails>
+      <StackTrace
+        event={event}
+        hasHierarchicalGrouping
+        newestFirst={false}
+        platform={event.platform || 'other'}
+        stacktrace={{
+          framesOmitted: null,
+          hasSystemFrames: false,
+          registers: null,
+          frames,
+        }}
+        nativeV2
+        stackView={STACK_VIEW.APP}
+        showIcon={false}
+      />
+    </Fragment>
   );
 }
 
 function getTopNodes(profile: Profile, startTimestamp, stopTimestamp): CallTreeNode[] {
-  let duration = 0;
+  let duration = profile.startedAt;
 
   const callTree: CallTreeNode = new CallTreeNode(ProfilingFrame.Root, null);
 
-  for (const sample of profile.samples) {
+  for (let i = 0; i < profile.samples.length; i++) {
+    const sample = profile.samples[i];
     // TODO: should this take self times into consideration?
     const inRange = startTimestamp <= duration && duration < stopTimestamp;
 
-    duration += sample.selfWeight;
+    duration += profile.weights[i];
 
     if (sample.isRoot() || !inRange) {
       continue;
@@ -113,8 +226,8 @@ function getTopNodes(profile: Profile, startTimestamp, stopTimestamp): CallTreeN
 
     // make sure to iterate the stack backwards here, the 0th index is the
     // inner most frame, and the last index is the outer most frame
-    for (let i = stack.length - 1; i >= 0; i--) {
-      node = stack[i]!;
+    for (let j = stack.length - 1; j >= 0; j--) {
+      node = stack[j]!;
       const frame = node.frame;
 
       // find a child in the current tree with the same frame,
@@ -127,7 +240,7 @@ function getTopNodes(profile: Profile, startTimestamp, stopTimestamp): CallTreeN
       }
 
       // make sure to increment the count/weight so it can be sorted later
-      last.incrementCount();
+      last.count += node.count;
       last.addToSelfWeight(node.selfWeight);
 
       tree = last;
@@ -165,8 +278,11 @@ function sortByCount(a: CallTreeNode, b: CallTreeNode) {
 function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame[] {
   const frames: Frame[] = [];
 
-  while (node && !node.isRoot()) {
-    frames.push({
+  let framesCount = 0;
+  let prevFrame: Frame | null = null;
+
+  while (framesCount < MAX_STACK_DEPTH && node && !node.isRoot()) {
+    const frame = {
       absPath: node.frame.path ?? null,
       colNo: node.frame.column ?? null,
       context: [],
@@ -185,10 +301,40 @@ function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame
       symbolAddr: null,
       trust: null,
       vars: null,
-    });
+    };
+
+    if (
+      // In app frames are not collapsed so count it.
+      frame.inApp ||
+      // Only count non in app frames if the previous frame is in app.
+      // This is because a group of non in app frames will be collapsed
+      // into a single frame, so we only count the entire group once.
+      prevFrame?.inApp
+    ) {
+      framesCount += 1;
+    }
+
+    frames.push(frame);
+
+    prevFrame = frame;
 
     node = node.parent;
   }
 
   return frames;
 }
+
+const SpanDetails = styled('div')`
+  padding: ${space(2)};
+  display: flex;
+  align-items: baseline;
+  gap: ${space(1)};
+`;
+
+const Label = styled('span')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+`;
+
+const SpanDetailsItem = styled('span')<{grow?: boolean}>`
+  ${p => (p.grow ? 'flex: 1 2 auto' : 'flex: 0 1 auto')}
+`;


### PR DESCRIPTION
This starts to pull in some of the designs by incorporating the thread information and pagination to see other stacktraces.

# Screenshots

![image](https://user-images.githubusercontent.com/10239353/224163454-8a27ebe3-b0bb-4e90-9001-262e3a5930ff.png)
