### PR TITLE
fix(stats): Display abuse outcome on stats page

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -113,6 +113,7 @@ export enum Outcome {
   DROPPED = 'dropped', // this is not a real outcome coming from the server
   RATE_LIMITED = 'rate_limited',
   CLIENT_DISCARD = 'client_discard',
+  ABUSE = 'abuse',
 }
 
 export type IntervalPeriod = ReturnType<typeof getInterval>;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -32,6 +32,7 @@ import {
   DataCategoryInfo,
   DateString,
   Organization,
+  Outcome,
   PageFilters,
   Project,
 } from 'sentry/types';
@@ -42,6 +43,14 @@ import HeaderTabs from 'sentry/views/organizationStats/header';
 import {CHART_OPTIONS_DATACATEGORY, ChartDataTransform} from './usageChart';
 import UsageStatsOrg from './usageStatsOrg';
 import UsageStatsProjects from './usageStatsProjects';
+
+export const HIDDEN_OUTCOMES = new Set([Outcome.CLIENT_DISCARD]);
+export const DROPPED_OUTCOMES = new Set([
+  Outcome.ABUSE,
+  Outcome.DROPPED,
+  Outcome.INVALID,
+  Outcome.RATE_LIMITED,
+]);
 
 const HookHeader = HookOrDefault({hookName: 'component:org-stats-banner'});
 

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -32,7 +32,6 @@ import {
   DataCategoryInfo,
   DateString,
   Organization,
-  Outcome,
   PageFilters,
   Project,
 } from 'sentry/types';
@@ -43,14 +42,6 @@ import HeaderTabs from 'sentry/views/organizationStats/header';
 import {CHART_OPTIONS_DATACATEGORY, ChartDataTransform} from './usageChart';
 import UsageStatsOrg from './usageStatsOrg';
 import UsageStatsProjects from './usageStatsProjects';
-
-export const HIDDEN_OUTCOMES = new Set([Outcome.CLIENT_DISCARD]);
-export const DROPPED_OUTCOMES = new Set([
-  Outcome.ABUSE,
-  Outcome.DROPPED,
-  Outcome.INVALID,
-  Outcome.RATE_LIMITED,
-]);
 
 const HookHeader = HookOrDefault({hookName: 'component:org-stats-banner'});
 

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -16,7 +16,13 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategoryInfo, IntervalPeriod, Organization, Outcome} from 'sentry/types';
 import {parsePeriodToHours} from 'sentry/utils/dates';
-import {DROPPED_OUTCOMES, HIDDEN_OUTCOMES} from 'sentry/views/organizationStats';
+import {
+  DROPPED_OUTCOMES,
+  formatUsageWithUnits,
+  getFormatUsageOptions,
+  HIDDEN_OUTCOMES,
+  isDisplayUtc,
+} from 'sentry/views/organizationStats/utils';
 
 import {
   FORMAT_DATETIME_DAILY,
@@ -31,7 +37,6 @@ import UsageChart, {
   UsageChartProps,
 } from './usageChart';
 import UsageStatsPerMin from './usageStatsPerMin';
-import {formatUsageWithUnits, getFormatUsageOptions, isDisplayUtc} from './utils';
 
 export type UsageStatsOrganizationProps = {
   dataCategory: DataCategoryInfo['plural'];

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -14,7 +14,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategoryInfo, Organization, Outcome, Project} from 'sentry/types';
 import withProjects from 'sentry/utils/withProjects';
-import {DROPPED_OUTCOMES, HIDDEN_OUTCOMES} from 'sentry/views/organizationStats';
+import {DROPPED_OUTCOMES, HIDDEN_OUTCOMES} from 'sentry/views/organizationStats/utils';
 
 import {UsageSeries} from './types';
 import UsageTable, {CellProject, CellStat, TableStat} from './usageTable';

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -1,12 +1,19 @@
 import {DateTimeObject, getSeriesApiInterval} from 'sentry/components/charts/utils';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
-import {DataCategoryInfo} from 'sentry/types';
+import {DataCategoryInfo, Outcome} from 'sentry/types';
 import {formatBytesBase10} from 'sentry/utils';
 import {parsePeriodToHours} from 'sentry/utils/dates';
 
 export const MILLION = 10 ** 6;
 export const BILLION = 10 ** 9;
 export const GIGABYTE = 10 ** 9;
+export const HIDDEN_OUTCOMES = new Set([Outcome.CLIENT_DISCARD]);
+export const DROPPED_OUTCOMES = new Set([
+  Outcome.ABUSE,
+  Outcome.DROPPED,
+  Outcome.INVALID,
+  Outcome.RATE_LIMITED,
+]);
 
 type FormatOptions = {
   /**


### PR DESCRIPTION
This PR refactors the display logic for the stats page to allow the abuse outcome to be collected as 'dropped'

todo:
- [ ] Test that the counters and sums are still as expected
