### PR TITLE
ref(py): Move sentry-app authorizations endpoint to SENTRY_APP_INSTALLATION_URLS

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2342,6 +2342,11 @@ SENTRY_APP_INSTALLATION_URLS = [
         name="sentry-api-0-sentry-app-installation-details",
     ),
     url(
+        r"^(?P<uuid>[^\/]+)/authorizations/$",
+        SentryAppAuthorizationsEndpoint.as_view(),
+        name="sentry-api-0-sentry-app-installation-authorizations",
+    ),
+    url(
         r"^(?P<uuid>[^\/]+)/external-requests/$",
         SentryAppInstallationExternalRequestsEndpoint.as_view(),
         name="sentry-api-0-sentry-app-installation-external-requests",
@@ -2593,11 +2598,6 @@ urlpatterns = [
         r"^sentry-apps-stats/$",
         SentryAppsStatsEndpoint.as_view(),
         name="sentry-api-0-sentry-apps-stats",
-    ),
-    url(
-        r"^sentry-app-installations/(?P<uuid>[^\/]+)/authorizations/$",
-        SentryAppAuthorizationsEndpoint.as_view(),
-        name="sentry-api-0-sentry-app-authorizations",
     ),
     url(
         r"^organizations/(?P<organization_slug>[^\/]+)/sentry-app-components/$",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -42,7 +42,7 @@ SAMPLED_URL_NAMES = {
     "sentry-api-0-organization-external-user-details": settings.SAMPLED_DEFAULT_RATE,
     # integration platform
     "external-issues": settings.SAMPLED_DEFAULT_RATE,
-    "sentry-api-0-sentry-app-authorizations": settings.SAMPLED_DEFAULT_RATE,
+    "sentry-api-0-sentry-app-installation-authorizations": settings.SAMPLED_DEFAULT_RATE,
     # integrations
     "sentry-extensions-jira-issue-hook": 0.05,
     "sentry-extensions-vercel-webhook": settings.SAMPLED_DEFAULT_RATE,

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -9,7 +9,7 @@ from sentry.testutils import APITestCase
 
 
 class TestSentryAppAuthorizations(APITestCase):
-    endpoint = "sentry-api-0-sentry-app-authorizations"
+    endpoint = "sentry-api-0-sentry-app-installation-authorizations"
     method = "post"
 
     def setUp(self):


### PR DESCRIPTION
This definitely looks like it should have been in here