### PR TITLE
feat(profile-issues): Use buttons to link to transaction and profile

### DIFF
--- a/static/app/components/events/profileEventEvidence.spec.tsx
+++ b/static/app/components/events/profileEventEvidence.spec.tsx
@@ -14,7 +14,7 @@ describe('ProfileEventEvidence', function () {
           frameName: 'some_func',
           framePackage: 'something.dll',
           transactionId: 'transaction-id',
-          transactionName: '/some/transaction/',
+          transactionName: 'SomeTransaction',
         },
       },
     }),
@@ -29,10 +29,10 @@ describe('ProfileEventEvidence', function () {
     render(<ProfileEventEvidence {...defaultProps} />);
 
     expect(screen.getByRole('cell', {name: 'Transaction Name'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '/some/transaction/'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: /SomeTransaction/})).toBeInTheDocument();
 
     expect(screen.getByRole('cell', {name: 'Profile ID'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: 'profile-id'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: /profile-id/})).toBeInTheDocument();
 
     expect(screen.getByRole('cell', {name: 'Evidence name'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: 'Evidence value'})).toBeInTheDocument();
@@ -41,7 +41,7 @@ describe('ProfileEventEvidence', function () {
   it('correctly links to the profile frame', function () {
     render(<ProfileEventEvidence {...defaultProps} />);
 
-    expect(screen.getByRole('link', {name: 'profile-id'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'View Profile'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/profiling/profile/project-slug/profile-id/flamechart/?frameName=some_func&framePackage=something.dll&referrer=issue'
     );
@@ -50,7 +50,7 @@ describe('ProfileEventEvidence', function () {
   it('correctly links to the transaction', function () {
     render(<ProfileEventEvidence {...defaultProps} />);
 
-    expect(screen.getByRole('link', {name: '/some/transaction/'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'View Transaction'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/performance/project-slug:transaction-id/?referrer=issue'
     );

--- a/static/app/components/events/profileEventEvidence.tsx
+++ b/static/app/components/events/profileEventEvidence.tsx
@@ -1,6 +1,8 @@
+import {Button} from 'sentry/components/button';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import Link from 'sentry/components/links/link';
+import {IconProfiling} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {Event} from 'sentry/types';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
@@ -20,22 +22,22 @@ export const ProfileEventEvidence = ({event, projectSlug}: ProfileEvidenceProps)
           {
             subject: 'Transaction Name',
             key: 'Transaction Name',
-            value: (
-              <pre>
-                <Link
-                  to={getTransactionDetailsUrl(
-                    organization.slug,
-                    generateEventSlug({
-                      id: evidenceData.transactionId,
-                      project: projectSlug,
-                    }),
-                    undefined,
-                    {referrer: 'issue'}
-                  )}
-                >
-                  {evidenceData.transactionName}
-                </Link>
-              </pre>
+            value: evidenceData.transactionName,
+            actionButton: (
+              <Button
+                size="xs"
+                to={getTransactionDetailsUrl(
+                  organization.slug,
+                  generateEventSlug({
+                    id: evidenceData.transactionId,
+                    project: projectSlug,
+                  }),
+                  undefined,
+                  {referrer: 'issue'}
+                )}
+              >
+                {t('View Transaction')}
+              </Button>
             ),
           },
         ]
@@ -45,23 +47,24 @@ export const ProfileEventEvidence = ({event, projectSlug}: ProfileEvidenceProps)
           {
             subject: 'Profile ID',
             key: 'Profile ID',
-            value: (
-              <pre>
-                <Link
-                  to={generateProfileFlamechartRouteWithHighlightFrame({
-                    profileId: evidenceData.profileId,
-                    projectSlug,
-                    orgSlug: organization.slug,
-                    frameName: evidenceData.frameName,
-                    framePackage: evidenceData.framePackage,
-                    query: {
-                      referrer: 'issue',
-                    },
-                  })}
-                >
-                  {evidenceData.profileId}
-                </Link>
-              </pre>
+            value: evidenceData.profileId,
+            actionButton: (
+              <Button
+                size="xs"
+                to={generateProfileFlamechartRouteWithHighlightFrame({
+                  profileId: evidenceData.profileId,
+                  projectSlug,
+                  orgSlug: organization.slug,
+                  frameName: evidenceData.frameName,
+                  framePackage: evidenceData.framePackage,
+                  query: {
+                    referrer: 'issue',
+                  },
+                })}
+                icon={<IconProfiling size="xs" />}
+              >
+                {t('View Profile')}
+              </Button>
             ),
           },
         ]


### PR DESCRIPTION
This is more consistent with how performance links to profiles from the transaction.

Before:

![CleanShot 2023-03-09 at 14 31 39](https://user-images.githubusercontent.com/10888943/224175256-efb4284a-4ba1-4a33-bc3e-542767c00310.png)

After:

![CleanShot 2023-03-09 at 14 31 11](https://user-images.githubusercontent.com/10888943/224175271-9b1402fe-d4a1-461f-8599-4bc08baac218.png)
