### PR TITLE
ref(code mapping): Remove dryrun mode

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -75,7 +75,6 @@ def process_error(error: ApiError, extra: Dict[str, str]) -> None:
 def derive_code_mappings(
     project_id: int,
     data: NodeData,
-    dry_run=False,
 ) -> None:
     """
     Derive code mappings for a project given data from a recent event.
@@ -91,11 +90,11 @@ def derive_code_mappings(
     extra = {
         "organization.slug": org.slug,
     }
-    feat_key = "organizations:derive-code-mappings"
-    # Check the feature flag again to ensure the feature is still enabled.
-    org_has_flag = features.has(feat_key, org) or features.has(f"{feat_key}-dry-run", org)
 
-    if not org_has_flag or not data["platform"] in SUPPORTED_LANGUAGES:
+    if (
+        not features.has("organizations:derive-code-mappings", org)
+        or not data["platform"] in SUPPORTED_LANGUAGES
+    ):
         logger.info("Event should not be processed.", extra=extra)
         return
 
@@ -130,10 +129,6 @@ def derive_code_mappings(
 
     trees_helper = CodeMappingTreesHelper(trees)
     code_mappings = trees_helper.generate_code_mappings(stacktrace_paths)
-    if dry_run:
-        report_project_codemappings(code_mappings, stacktrace_paths, project)
-        return
-
     set_project_codemappings(code_mappings, organization_integration, project)
 
 
@@ -228,29 +223,3 @@ def set_project_codemappings(
                     "existing_code_mapping": cm,
                 },
             )
-
-
-def report_project_codemappings(
-    code_mappings: List[CodeMapping],
-    stacktrace_paths: List[str],
-    project: Project,
-) -> None:
-    """
-    Log the code mappings that would be created for a project.
-    """
-    extra = {
-        "org": project.organization.slug,
-        "project": project.slug,
-        "code_mappings": code_mappings,
-        "stacktrace_paths": stacktrace_paths,
-    }
-    if code_mappings:
-        msg = "Code mappings would have been created."
-    else:
-        msg = "NO code mappings would have been created."
-    existing_code_mappings = RepositoryProjectPathConfig.objects.filter(project=project)
-    if existing_code_mappings.exists():
-        msg = "Code mappings already exist."
-        extra["existing_code_mappings"] = existing_code_mappings
-
-    logger.info(msg, extra=extra)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -759,22 +759,13 @@ def process_code_mappings(job: PostProcessJob) -> None:
             org = event.project.organization
             org_slug = org.slug
             next_time = timezone.now() + timedelta(hours=1)
-            has_normal_run_flag = features.has("organizations:derive-code-mappings", org)
-            has_dry_run_flag = features.has("organizations:derive-code-mappings-dry-run", org)
 
-            if has_normal_run_flag:
+            if features.has("organizations:derive-code-mappings", org):
                 logger.info(
                     f"derive_code_mappings: Queuing code mapping derivation for {project.slug=} {event.group_id=}."
                     + f" Future events in {org_slug=} will not have not have code mapping derivation until {next_time}"
                 )
-                derive_code_mappings.delay(project.id, event.data, dry_run=False)
-            # Derive code mappings with dry_run=True to validate the generated mappings.
-            elif has_dry_run_flag:
-                logger.info(
-                    f"derive_code_mappings: Queuing dry run code mapping derivation for {project.slug=} {event.group_id=}."
-                    + f" Future events in {org_slug=} will not have not have code mapping derivation until {next_time}"
-                )
-                derive_code_mappings.delay(project.id, event.data, dry_run=True)
+                derive_code_mappings.delay(project.id, event.data)
 
     except Exception:
         logger.exception("derive_code_mappings: Failed to process code mappings")

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -451,41 +451,6 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
         assert code_mapping.first().automatically_generated is False
         assert mock_logger.info.call_count == 1
 
-    @patch("sentry.integrations.github.GitHubIntegration.get_trees_for_org")
-    @patch(
-        "sentry.integrations.utils.code_mapping.CodeMappingTreesHelper.generate_code_mappings",
-        return_value=[
-            CodeMapping(
-                repo=Repo(name="repo", branch="master"),
-                stacktrace_root="sentry/models",
-                source_path="src/sentry/models",
-            )
-        ],
-    )
-    @patch("sentry.tasks.derive_code_mappings.logger")
-    @with_feature("organizations:derive-code-mappings")
-    def test_derive_code_mappings_dry_run(
-        self, mock_logger, mock_generate_code_mappings, mock_get_trees_for_org
-    ):
-
-        event = self.store_event(data=self.test_data, project_id=self.project.id)
-
-        assert not RepositoryProjectPathConfig.objects.filter(project_id=self.project.id).exists()
-
-        with patch(
-            "sentry.tasks.derive_code_mappings.identify_stacktrace_paths",
-            return_value=["sentry/models/release.py", "sentry/tasks.py"],
-        ) as mock_identify_stacktraces, self.tasks():
-            derive_code_mappings(self.project.id, event.data, dry_run=True)
-
-        assert mock_logger.info.call_count == 1
-        assert mock_identify_stacktraces.call_count == 1
-        assert mock_get_trees_for_org.call_count == 1
-        assert mock_generate_code_mappings.call_count == 1
-
-        # We should not create the code mapping for dry runs
-        assert not RepositoryProjectPathConfig.objects.filter(project_id=self.project.id).exists()
-
     @responses.activate
     @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_stack_and_source_root_do_not_match(self):

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -164,7 +164,6 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
 
 
 @apply_feature_flag_on_cls("organizations:derive-code-mappings")
-@apply_feature_flag_on_cls("organizations:derive-code-mappings-dry-run")
 class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
     def _call_post_process_group(self, data: Dict[str, str]) -> None:
         event = self.create_event(data=data, project_id=self.project.id)


### PR DESCRIPTION
This removes all usage of the `"organizations:derive-code-mappings-dry-run"` feature flag, as well as the `dry_run` parameter in `derive_code_mappings()`.

Ref: WOR-2429