### PR TITLE
ref(code mapping): Remove dryrun options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -665,9 +665,6 @@ register("dynamic-sampling.prioritise_transactions.load_rate", default=0.0)
 
 # Killswitch for deriving code mappings
 register("post_process.derive-code-mappings", default=True)
-# Allows adjusting the percentage of orgs we test under the dry run mode
-register("derive-code-mappings.dry-run.early-adopter-rollout", default=0.0)
-register("derive-code-mappings.dry-run.general-availability-rollout", default=0.0)
 # Allows adjusting the GA percentage
 register("derive-code-mappings.general-availability-rollout", default=0.0)
 register("hybrid_cloud.outbox_rate", default=0.0)


### PR DESCRIPTION
As a follow-up to https://github.com/getsentry/sentry/pull/45618 (which removed the dry run mode from `derive_code_mappings`, and therefore any use of the corresponding feature flag), https://github.com/getsentry/getsentry/pull/9779 (which removed the flag handler, the only thing using the corresponding options), and https://github.com/getsentry/sentry/pull/45620 (which removed the flag itself), this removes the now unused options.

Ref: WOR-2429