### PR TITLE
ref(monitors): Remove checkin GET endpoint

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_checkin_details.py
@@ -18,7 +18,6 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import GLOBAL_PARAMS, MONITOR_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.models import ProjectKey
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorStatus
 from sentry.monitors.serializers import MonitorCheckInSerializerResponse
 from sentry.monitors.validators import MonitorCheckInValidator
@@ -30,37 +29,7 @@ from .base import MonitorCheckInEndpoint
 @extend_schema(tags=["Crons"])
 class MonitorCheckInDetailsEndpoint(MonitorCheckInEndpoint):
     authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
-    public = {"GET", "PUT"}
-
-    @extend_schema(
-        operation_id="Retrieve a check-in",
-        parameters=[
-            GLOBAL_PARAMS.ORG_SLUG,
-            MONITOR_PARAMS.MONITOR_ID,
-            MONITOR_PARAMS.CHECKIN_ID,
-        ],
-        request=None,
-        responses={
-            201: inline_sentry_response_serializer(
-                "MonitorCheckIn", MonitorCheckInSerializerResponse
-            ),
-            401: RESPONSE_UNAUTHORIZED,
-            403: RESPONSE_FORBIDDEN,
-            404: RESPONSE_NOTFOUND,
-        },
-    )
-    def get(self, request: Request, project, monitor, checkin) -> Response:
-        """
-        Retrieves details for a check-in.
-
-        You may use `latest` for the `checkin_id` parameter in order to retrieve
-        the most recent (by creation date) check-in which is still mutable (not marked as finished).
-        """
-        # we don't allow read permission with DSNs
-        if isinstance(request.auth, ProjectKey):
-            return self.respond(status=401)
-
-        return self.respond(serialize(checkin, request.user))
+    public = {"PUT"}
 
     @extend_schema(
         operation_id="Update a check-in",


### PR DESCRIPTION
We will be consolidating the checkin POST and PUT endpoints into controllers who's ONLY responsability is to support DSN and API Token based ingestion of monitor checkins

This allows us to have a unified base class for those endpoints, thus vastly simplifying the existing MonitorEndpoint class

To this end we are removing the GET endpoint for checkins. I have validated that this API is used by no one (there have been 2 requests in the last month as of writing)