### PR TITLE
ref(metric alerts): Create new consumer using arroyo

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -433,6 +433,7 @@ def post_process_forwarder(**options):
     is_flag=True,
     help="Switches to the new arroyo consumer implementation.",
 )
+@strict_offset_reset_option()
 @log_options()
 @configuration
 def query_subscription_consumer(**options):
@@ -454,6 +455,9 @@ def query_subscription_consumer(**options):
         subscriber = get_query_subscription_consumer(
             topic=options["topic"],
             group_id=options["group"],
+            strict_offset_reset=options["strict_offset_reset"],
+            initial_offset_reset=options["initial_offset_reset"],
+            force_offset_reset=options["force_offset_reset"],
         )
 
     run_processor_with_signals(subscriber)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -441,7 +441,7 @@ def query_subscription_consumer(**options):
         get_query_subscription_consumer,
     )
 
-    if not options["use-arroyo-consumer"]:
+    if not options["use_arroyo_consumer"]:
         subscriber = QuerySubscriptionConsumer(
             group_id=options["group"],
             topic=options["topic"],
@@ -451,7 +451,10 @@ def query_subscription_consumer(**options):
             force_offset_reset=options["force_offset_reset"],
         )
     else:
-        subscriber = get_query_subscription_consumer(**options)
+        subscriber = get_query_subscription_consumer(
+            topic=options["topic"],
+            group_id=options["group"],
+        )
 
     run_processor_with_signals(subscriber)
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -427,20 +427,32 @@ def post_process_forwarder(**options):
     type=click.Choice(["earliest", "latest"]),
     help="Force subscriptions to start from a particular offset",
 )
+@click.option(
+    "--use-arroyo-consumer",
+    default=False,
+    is_flag=True,
+    help="Switches to the new arroyo consumer implementation.",
+)
 @log_options()
 @configuration
 def query_subscription_consumer(**options):
-    from sentry.snuba.query_subscription_consumer import QuerySubscriptionConsumer
-
-    # TODO replace this with get_query_subscription_consumer
-    subscriber = QuerySubscriptionConsumer(
-        group_id=options["group"],
-        topic=options["topic"],
-        commit_batch_size=options["commit_batch_size"],
-        commit_batch_timeout_ms=options["commit_batch_timeout_ms"],
-        initial_offset_reset=options["initial_offset_reset"],
-        force_offset_reset=options["force_offset_reset"],
+    from sentry.snuba.query_subscription_consumer import (
+        QuerySubscriptionConsumer,
+        get_query_subscription_consumer,
     )
+
+    if not options["use-arroyo-consumer"]:
+        subscriber = QuerySubscriptionConsumer(
+            group_id=options["group"],
+            topic=options["topic"],
+            commit_batch_size=options["commit_batch_size"],
+            commit_batch_timeout_ms=options["commit_batch_timeout_ms"],
+            initial_offset_reset=options["initial_offset_reset"],
+            force_offset_reset=options["force_offset_reset"],
+        )
+    else:
+        subscriber = get_query_subscription_consumer(**options)
+
     run_processor_with_signals(subscriber)
 
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -448,7 +448,7 @@ def query_subscription_consumer(**options):
             topic=options["topic"],
             commit_batch_size=options["commit_batch_size"],
             commit_batch_timeout_ms=options["commit_batch_timeout_ms"],
-            initial_offset_reset=options["initial_offset_reset"],
+            initial_offset_reset=options.get("initial_offset_reset", "earliest"),
             force_offset_reset=options["force_offset_reset"],
         )
     else:

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -457,7 +457,6 @@ def query_subscription_consumer(**options):
             group_id=options["group"],
             strict_offset_reset=options["strict_offset_reset"],
             initial_offset_reset=options["initial_offset_reset"],
-            force_offset_reset=options["force_offset_reset"],
         )
 
     run_processor_with_signals(subscriber)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -432,6 +432,7 @@ def post_process_forwarder(**options):
 def query_subscription_consumer(**options):
     from sentry.snuba.query_subscription_consumer import QuerySubscriptionConsumer
 
+    # TODO replace this with get_query_subscription_consumer
     subscriber = QuerySubscriptionConsumer(
         group_id=options["group"],
         topic=options["topic"],
@@ -440,7 +441,6 @@ def query_subscription_consumer(**options):
         initial_offset_reset=options["initial_offset_reset"],
         force_offset_reset=options["force_offset_reset"],
     )
-
     run_processor_with_signals(subscriber)
 
 

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -2,7 +2,7 @@ import logging
 import re
 import time
 from random import random
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Union, cast
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, cast
 
 import jsonschema
 import pytz
@@ -262,25 +262,17 @@ class QuerySubscriptionStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 def get_query_subscription_consumer(
     topic: str,
     group_id: str,
-    auto_offset_reset: str,
-    strict_offset_reset: bool,
-    force_topic: Union[str, None],
-    initial_offset_reset: str = "earliest",
 ) -> StreamProcessor[KafkaPayload]:
-    topic = force_topic or topic
     cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
     cluster_options = kafka_config.get_kafka_consumer_cluster_options(cluster_name)
     consumer = KafkaConsumer(
         build_kafka_consumer_configuration(
             cluster_options,
-            auto_offset_reset=auto_offset_reset,
             group_id=group_id,
-            strict_offset_reset=strict_offset_reset,
         )
     )
     metrics_wrapper = MetricsWrapper(metrics.backend, name="query_subscription_consumer")
     configure_metrics(metrics_wrapper)
-
     return StreamProcessor(
         consumer=consumer,
         topic=Topic(topic),

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -267,18 +267,7 @@ def get_query_subscription_consumer(
 ) -> StreamProcessor[KafkaPayload]:
     topic = force_topic or topic
     cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
-    cluster_options = kafka_config.get_kafka_consumer_cluster_options(
-        cluster_name,
-        # {
-        #     "group.id": group_id,
-        #     "session.timeout.ms": 6000,
-        #     "auto.offset.reset": initial_offset_reset,
-        #     "enable.auto.commit": "false",
-        #     "enable.auto.offset.store": "false",
-        #     "enable.partition.eof": "false",
-        #     "default.topic.config": {"auto.offset.reset": initial_offset_reset},
-        # },
-    )
+    cluster_options = kafka_config.get_kafka_consumer_cluster_options(cluster_name)
     consumer = KafkaConsumer(
         build_kafka_consumer_configuration(
             cluster_options,

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -25,6 +25,15 @@ TQuerySubscriptionCallable = Callable[[Dict[str, Any], QuerySubscription], None]
 
 subscriber_registry: Dict[str, TQuerySubscriptionCallable] = {}
 
+topic_to_dataset: Dict[str, Dataset] = {
+    settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: Dataset.Events,
+    settings.KAFKA_TRANSACTIONS_SUBSCRIPTIONS_RESULTS: Dataset.Transactions,
+    settings.KAFKA_GENERIC_METRICS_DISTRIBUTIONS_SUBSCRIPTIONS_RESULTS: Dataset.PerformanceMetrics,
+    settings.KAFKA_GENERIC_METRICS_SETS_SUBSCRIPTIONS_RESULTS: Dataset.PerformanceMetrics,
+    settings.KAFKA_SESSIONS_SUBSCRIPTIONS_RESULTS: Dataset.Sessions,
+    settings.KAFKA_METRICS_SUBSCRIPTIONS_RESULTS: Dataset.Metrics,
+}
+
 
 def register_subscriber(
     subscriber_key: str,
@@ -36,6 +45,156 @@ def register_subscriber(
         return func
 
     return inner
+
+
+def parse_message_value(value: str) -> Dict[str, Any]:
+    """
+    Parses the value received via the Kafka consumer and verifies that it
+    matches the expected schema.
+    :param value: A json formatted string
+    :return: A dict with the parsed message
+    """
+    with metrics.timer("snuba_query_subscriber.parse_message_value.json_parse"):
+        wrapper: Dict[str, Any] = json.loads(value)
+
+    with metrics.timer("snuba_query_subscriber.parse_message_value.json_validate_wrapper"):
+        try:
+            jsonschema.validate(wrapper, SUBSCRIPTION_WRAPPER_SCHEMA)
+        except jsonschema.ValidationError:
+            metrics.incr("snuba_query_subscriber.message_wrapper_invalid")
+            raise InvalidSchemaError("Message wrapper does not match schema")
+
+    schema_version: int = wrapper["version"]
+    if schema_version not in SUBSCRIPTION_PAYLOAD_VERSIONS:
+        metrics.incr("snuba_query_subscriber.message_wrapper_invalid_version")
+        raise InvalidMessageError("Version specified in wrapper has no schema")
+
+    payload: Dict[str, Any] = wrapper["payload"]
+    with metrics.timer("snuba_query_subscriber.parse_message_value.json_validate_payload"):
+        try:
+            jsonschema.validate(payload, SUBSCRIPTION_PAYLOAD_VERSIONS[schema_version])
+        except jsonschema.ValidationError:
+            metrics.incr("snuba_query_subscriber.message_payload_invalid")
+            raise InvalidSchemaError("Message payload does not match schema")
+    # XXX: Since we just return the raw dict here, when the payload changes it'll
+    # break things. This should convert the payload into a class rather than passing
+    # the dict around, but until we get time to refactor we can keep things working
+    # here.
+    payload.setdefault("values", payload.get("result"))
+
+    payload["timestamp"] = parse_date(payload["timestamp"]).replace(tzinfo=pytz.utc)
+    return payload
+
+
+def handle_message(message: Message, __batch_deadline, commit_batch_timeout_ms) -> None:
+    """
+    Parses the value from Kafka, and if valid passes the payload to the callback defined by the
+    subscription. If the subscription has been removed, or no longer has a valid callback then
+    just log metrics/errors and continue.
+    :param message:
+    :return:
+    """
+    # set a commit time deadline only after the first message for this batch is seen
+    if not __batch_deadline:
+        __batch_deadline = commit_batch_timeout_ms / 1000.0 + time.time()
+
+    with sentry_sdk.push_scope() as scope:
+        try:
+            with metrics.timer("snuba_query_subscriber.parse_message_value"):
+                contents = parse_message_value(message.value())
+        except InvalidMessageError:
+            # If the message is in an invalid format, just log the error
+            # and continue
+            logger.exception(
+                "Subscription update could not be parsed",
+                extra={
+                    "offset": message.offset(),
+                    "partition": message.partition(),
+                    "value": message.value(),
+                },
+            )
+            return
+        scope.set_tag("query_subscription_id", contents["subscription_id"])
+
+        try:
+            with metrics.timer("snuba_query_subscriber.fetch_subscription"):
+                subscription: QuerySubscription = QuerySubscription.objects.get_from_cache(
+                    subscription_id=contents["subscription_id"]
+                )
+                if subscription.status != QuerySubscription.Status.ACTIVE.value:
+                    metrics.incr("snuba_query_subscriber.subscription_inactive")
+                    return
+        except QuerySubscription.DoesNotExist:
+            metrics.incr("snuba_query_subscriber.subscription_doesnt_exist")
+            logger.warning(
+                "Received subscription update, but subscription does not exist",
+                extra={
+                    "offset": message.offset(),
+                    "partition": message.partition(),
+                    "value": message.value(),
+                },
+            )
+            try:
+                if "entity" in contents:
+                    entity_key = contents["entity"]
+                else:
+                    # XXX(ahmed): Remove this logic. This was kept here as backwards compat
+                    # for subscription updates with schema version `2`. However schema version 3
+                    # sends the "entity" in the payload
+                    entity_regex = r"^(MATCH|match)[ ]*\(([^)]+)\)"
+                    entity_match = re.match(entity_regex, contents["request"]["query"])
+                    if not entity_match:
+                        raise InvalidMessageError("Unable to fetch entity from query in message")
+                    entity_key = entity_match.group(2)
+                topic = message.topic()
+                if topic in topic_to_dataset:
+                    _delete_from_snuba(
+                        topic_to_dataset[topic],
+                        contents["subscription_id"],
+                        EntityKey(entity_key),
+                    )
+                else:
+                    logger.error(
+                        "Topic not registered with QuerySubscriptionConsumer, can't remove "
+                        "non-existent subscription from Snuba",
+                        extra={"topic": topic, "subscription_id": contents["subscription_id"]},
+                    )
+            except InvalidMessageError as e:
+                logger.exception(e)
+            except Exception:
+                logger.exception("Failed to delete unused subscription from snuba.")
+            return
+
+        if subscription.type not in subscriber_registry:
+            metrics.incr("snuba_query_subscriber.subscription_type_not_registered")
+            logger.error(
+                "Received subscription update, but no subscription handler registered",
+                extra={
+                    "offset": message.offset(),
+                    "partition": message.partition(),
+                    "value": message.value(),
+                },
+            )
+            return
+
+        sentry_sdk.set_tag("project_id", subscription.project_id)
+        sentry_sdk.set_tag("query_subscription_id", contents["subscription_id"])
+
+        callback = subscriber_registry[subscription.type]
+        with sentry_sdk.start_span(op="process_message") as span, metrics.timer(
+            "snuba_query_subscriber.callback.duration", instance=subscription.type
+        ):
+            span.set_data("payload", contents)
+            span.set_data("subscription_dataset", subscription.snuba_query.dataset)
+            span.set_data("subscription_query", subscription.snuba_query.query)
+            span.set_data("subscription_aggregation", subscription.snuba_query.aggregate)
+            span.set_data("subscription_time_window", subscription.snuba_query.time_window)
+            span.set_data("subscription_resolution", subscription.snuba_query.resolution)
+            span.set_data("message_offset", message.offset())
+            span.set_data("message_partition", message.partition())
+            span.set_data("message_value", message.value())
+
+            callback(contents, subscription)
 
 
 class InvalidMessageError(Exception):
@@ -52,15 +211,6 @@ class QuerySubscriptionConsumer:
     a related subscription id and the latest values related to the subscribed query.
     These values are passed along to a callback associated with the subscription.
     """
-
-    topic_to_dataset: Dict[str, Dataset] = {
-        settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: Dataset.Events,
-        settings.KAFKA_TRANSACTIONS_SUBSCRIPTIONS_RESULTS: Dataset.Transactions,
-        settings.KAFKA_GENERIC_METRICS_DISTRIBUTIONS_SUBSCRIPTIONS_RESULTS: Dataset.PerformanceMetrics,
-        settings.KAFKA_GENERIC_METRICS_SETS_SUBSCRIPTIONS_RESULTS: Dataset.PerformanceMetrics,
-        settings.KAFKA_SESSIONS_SUBSCRIPTIONS_RESULTS: Dataset.Sessions,
-        settings.KAFKA_METRICS_SUBSCRIPTIONS_RESULTS: Dataset.Metrics,
-    }
 
     def __init__(
         self,
@@ -183,7 +333,7 @@ class QuerySubscriptionConsumer:
                 sampled=random() <= options.get("subscriptions-query.sample-rate"),
             ), metrics.timer("snuba_query_subscriber.handle_message"):
                 try:
-                    self.handle_message(message)
+                    handle_message(message)
                 except Exception:
                     # This is a failsafe to make sure that no individual message will block this
                     # consumer. If we see errors occurring here they need to be investigated to
@@ -239,153 +389,3 @@ class QuerySubscriptionConsumer:
 
     def signal_shutdown(self) -> None:
         self.__shutdown_requested = True
-
-    def handle_message(self, message: Message) -> None:
-        """
-        Parses the value from Kafka, and if valid passes the payload to the callback defined by the
-        subscription. If the subscription has been removed, or no longer has a valid callback then
-        just log metrics/errors and continue.
-        :param message:
-        :return:
-        """
-        # set a commit time deadline only after the first message for this batch is seen
-        if not self.__batch_deadline:
-            self.__batch_deadline = self.commit_batch_timeout_ms / 1000.0 + time.time()
-
-        with sentry_sdk.push_scope() as scope:
-            try:
-                with metrics.timer("snuba_query_subscriber.parse_message_value"):
-                    contents = self.parse_message_value(message.value())
-            except InvalidMessageError:
-                # If the message is in an invalid format, just log the error
-                # and continue
-                logger.exception(
-                    "Subscription update could not be parsed",
-                    extra={
-                        "offset": message.offset(),
-                        "partition": message.partition(),
-                        "value": message.value(),
-                    },
-                )
-                return
-            scope.set_tag("query_subscription_id", contents["subscription_id"])
-
-            try:
-                with metrics.timer("snuba_query_subscriber.fetch_subscription"):
-                    subscription: QuerySubscription = QuerySubscription.objects.get_from_cache(
-                        subscription_id=contents["subscription_id"]
-                    )
-                    if subscription.status != QuerySubscription.Status.ACTIVE.value:
-                        metrics.incr("snuba_query_subscriber.subscription_inactive")
-                        return
-            except QuerySubscription.DoesNotExist:
-                metrics.incr("snuba_query_subscriber.subscription_doesnt_exist")
-                logger.warning(
-                    "Received subscription update, but subscription does not exist",
-                    extra={
-                        "offset": message.offset(),
-                        "partition": message.partition(),
-                        "value": message.value(),
-                    },
-                )
-                try:
-                    if "entity" in contents:
-                        entity_key = contents["entity"]
-                    else:
-                        # XXX(ahmed): Remove this logic. This was kept here as backwards compat
-                        # for subscription updates with schema version `2`. However schema version 3
-                        # sends the "entity" in the payload
-                        entity_regex = r"^(MATCH|match)[ ]*\(([^)]+)\)"
-                        entity_match = re.match(entity_regex, contents["request"]["query"])
-                        if not entity_match:
-                            raise InvalidMessageError(
-                                "Unable to fetch entity from query in message"
-                            )
-                        entity_key = entity_match.group(2)
-                    topic = message.topic()
-                    if topic in self.topic_to_dataset:
-                        _delete_from_snuba(
-                            self.topic_to_dataset[topic],
-                            contents["subscription_id"],
-                            EntityKey(entity_key),
-                        )
-                    else:
-                        logger.error(
-                            "Topic not registered with QuerySubscriptionConsumer, can't remove "
-                            "non-existent subscription from Snuba",
-                            extra={"topic": topic, "subscription_id": contents["subscription_id"]},
-                        )
-                except InvalidMessageError as e:
-                    logger.exception(e)
-                except Exception:
-                    logger.exception("Failed to delete unused subscription from snuba.")
-                return
-
-            if subscription.type not in subscriber_registry:
-                metrics.incr("snuba_query_subscriber.subscription_type_not_registered")
-                logger.error(
-                    "Received subscription update, but no subscription handler registered",
-                    extra={
-                        "offset": message.offset(),
-                        "partition": message.partition(),
-                        "value": message.value(),
-                    },
-                )
-                return
-
-            sentry_sdk.set_tag("project_id", subscription.project_id)
-            sentry_sdk.set_tag("query_subscription_id", contents["subscription_id"])
-
-            callback = subscriber_registry[subscription.type]
-            with sentry_sdk.start_span(op="process_message") as span, metrics.timer(
-                "snuba_query_subscriber.callback.duration", instance=subscription.type
-            ):
-                span.set_data("payload", contents)
-                span.set_data("subscription_dataset", subscription.snuba_query.dataset)
-                span.set_data("subscription_query", subscription.snuba_query.query)
-                span.set_data("subscription_aggregation", subscription.snuba_query.aggregate)
-                span.set_data("subscription_time_window", subscription.snuba_query.time_window)
-                span.set_data("subscription_resolution", subscription.snuba_query.resolution)
-                span.set_data("message_offset", message.offset())
-                span.set_data("message_partition", message.partition())
-                span.set_data("message_value", message.value())
-
-                callback(contents, subscription)
-
-    def parse_message_value(self, value: str) -> Dict[str, Any]:
-        """
-        Parses the value received via the Kafka consumer and verifies that it
-        matches the expected schema.
-        :param value: A json formatted string
-        :return: A dict with the parsed message
-        """
-        with metrics.timer("snuba_query_subscriber.parse_message_value.json_parse"):
-            wrapper: Dict[str, Any] = json.loads(value)
-
-        with metrics.timer("snuba_query_subscriber.parse_message_value.json_validate_wrapper"):
-            try:
-                jsonschema.validate(wrapper, SUBSCRIPTION_WRAPPER_SCHEMA)
-            except jsonschema.ValidationError:
-                metrics.incr("snuba_query_subscriber.message_wrapper_invalid")
-                raise InvalidSchemaError("Message wrapper does not match schema")
-
-        schema_version: int = wrapper["version"]
-        if schema_version not in SUBSCRIPTION_PAYLOAD_VERSIONS:
-            metrics.incr("snuba_query_subscriber.message_wrapper_invalid_version")
-            raise InvalidMessageError("Version specified in wrapper has no schema")
-
-        payload: Dict[str, Any] = wrapper["payload"]
-        with metrics.timer("snuba_query_subscriber.parse_message_value.json_validate_payload"):
-            try:
-                jsonschema.validate(payload, SUBSCRIPTION_PAYLOAD_VERSIONS[schema_version])
-            except jsonschema.ValidationError:
-                metrics.incr("snuba_query_subscriber.message_payload_invalid")
-                raise InvalidSchemaError("Message payload does not match schema")
-        # XXX: Since we just return the raw dict here, when the payload changes it'll
-        # break things. This should convert the payload into a class rather than passing
-        # the dict around, but until we get time to refactor we can keep things working
-        # here.
-        payload.setdefault("values", payload.get("result"))
-
-        payload["timestamp"] = parse_date(payload["timestamp"]).replace(tzinfo=pytz.utc)
-        return payload

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -238,7 +238,7 @@ class QuerySubscriptionStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
                 partition = value.partition.index
                 try:
                     handle_message(
-                        str(message.payload.value),
+                        message.payload.value,
                         offset,
                         partition,
                         self.topic,
@@ -262,6 +262,9 @@ class QuerySubscriptionStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 def get_query_subscription_consumer(
     topic: str,
     group_id: str,
+    strict_offset_reset: bool,
+    initial_offset_reset: str = "earliest",
+    force_offset_reset: Optional[str] = None,
 ) -> StreamProcessor[KafkaPayload]:
     cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
     cluster_options = kafka_config.get_kafka_consumer_cluster_options(cluster_name)
@@ -269,6 +272,9 @@ def get_query_subscription_consumer(
         build_kafka_consumer_configuration(
             cluster_options,
             group_id=group_id,
+            strict_offset_reset=strict_offset_reset,
+            initial_offset_reset=initial_offset_reset,
+            force_offset_reset=force_offset_reset,
         )
     )
     metrics_wrapper = MetricsWrapper(metrics.backend, name="query_subscription_consumer")

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -269,15 +269,15 @@ def get_query_subscription_consumer(
     cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
     cluster_options = kafka_config.get_kafka_consumer_cluster_options(
         cluster_name,
-        {
-            "group.id": group_id,
-            "session.timeout.ms": 6000,
-            "auto.offset.reset": initial_offset_reset,
-            "enable.auto.commit": "false",
-            "enable.auto.offset.store": "false",
-            "enable.partition.eof": "false",
-            "default.topic.config": {"auto.offset.reset": initial_offset_reset},
-        },
+        # {
+        #     "group.id": group_id,
+        #     "session.timeout.ms": 6000,
+        #     "auto.offset.reset": initial_offset_reset,
+        #     "enable.auto.commit": "false",
+        #     "enable.auto.offset.store": "false",
+        #     "enable.partition.eof": "false",
+        #     "default.topic.config": {"auto.offset.reset": initial_offset_reset},
+        # },
     )
     consumer = KafkaConsumer(
         build_kafka_consumer_configuration(

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -236,9 +236,10 @@ class QuerySubscriptionStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
                 assert isinstance(value, BrokerValue)
                 offset = value.offset
                 partition = value.partition.index
+                message_value = value.payload.value
                 try:
                     handle_message(
-                        message.payload.value,
+                        message_value,
                         offset,
                         partition,
                         self.topic,
@@ -252,7 +253,7 @@ class QuerySubscriptionStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
                         extra={
                             "offset": offset,
                             "partition": partition,
-                            "value": message.value,
+                            "value": message_value,
                         },
                     )
 
@@ -273,8 +274,6 @@ def get_query_subscription_consumer(
             cluster_options,
             group_id=group_id,
             strict_offset_reset=strict_offset_reset,
-            initial_offset_reset=initial_offset_reset,
-            force_offset_reset=force_offset_reset,
         )
     )
     metrics_wrapper = MetricsWrapper(metrics.backend, name="query_subscription_consumer")

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -264,7 +264,7 @@ def get_query_subscription_consumer(
     topic: str,
     group_id: str,
     strict_offset_reset: bool,
-    initial_offset_reset: str = "earliest",
+    initial_offset_reset: str,
 ) -> StreamProcessor[KafkaPayload]:
     cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
     cluster_options = kafka_config.get_kafka_consumer_cluster_options(cluster_name)

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -265,7 +265,6 @@ def get_query_subscription_consumer(
     group_id: str,
     strict_offset_reset: bool,
     initial_offset_reset: str = "earliest",
-    force_offset_reset: Optional[str] = None,
 ) -> StreamProcessor[KafkaPayload]:
     cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
     cluster_options = kafka_config.get_kafka_consumer_cluster_options(cluster_name)
@@ -274,6 +273,7 @@ def get_query_subscription_consumer(
             cluster_options,
             group_id=group_id,
             strict_offset_reset=strict_offset_reset,
+            auto_offset_reset=initial_offset_reset,
         )
     )
     metrics_wrapper = MetricsWrapper(metrics.backend, name="query_subscription_consumer")

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -156,4 +156,4 @@ class PostProcessForwarderTest(TestCase):
             occurrence_id=None,
         )
 
-        consumer.signal_shutdown()
+        consumer._shutdown()

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -5,6 +5,7 @@ import uuid
 from contextlib import contextmanager
 from unittest.mock import patch
 
+from arroyo.utils import metrics
 from confluent_kafka import Producer
 from confluent_kafka.admin import AdminClient
 from django.conf import settings
@@ -100,6 +101,7 @@ class PostProcessForwarderTest(TestCase):
         super().tearDown()
         self.override_settings_cm.__exit__(None, None, None)
         self.admin_client.delete_topics([self.events_topic, self.commit_log_topic])
+        metrics._metrics_backend = None
 
     @patch(
         "sentry.eventstream.kafka.consumer_strategy.dispatch_post_process_group_task", autospec=True

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -121,7 +121,6 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
             tzinfo=pytz.utc
         )
         mock_callback.assert_called_once_with(data["payload"], sub)
-        assert False
 
     def test_no_subscription(self):
         with mock.patch("sentry.snuba.tasks._snuba_pool") as pool:

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -1,11 +1,13 @@
 import unittest
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta
 from functools import cached_property
 from unittest import mock
 
 import pytest
 import pytz
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import BrokerValue, Message, Partition, Topic
 from dateutil.parser import parse as parse_date
 from django.conf import settings
 
@@ -15,6 +17,7 @@ from sentry.snuba.query_subscription_consumer import (
     InvalidMessageError,
     InvalidSchemaError,
     QuerySubscriptionConsumer,
+    QuerySubscriptionStrategyFactory,
     parse_message_value,
     register_subscriber,
     subscriber_registry,
@@ -25,6 +28,10 @@ from sentry.utils import json
 
 
 class BaseQuerySubscriptionTest:
+    @cached_property
+    def topic(self):
+        return settings.KAFKA_METRICS_SUBSCRIPTIONS_RESULTS
+
     @cached_property
     def consumer(self):
         return QuerySubscriptionConsumer("hello")
@@ -71,13 +78,56 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
         with mock.patch("sentry.snuba.query_subscription_consumer.metrics") as self.metrics:
             yield
 
+    def test_arroyo_consumer(self):
+        registration_key = "registered_test_2"
+        mock_callback = mock.Mock()
+        register_subscriber(registration_key)(mock_callback)
+        with self.tasks():
+            snuba_query = create_snuba_query(
+                SnubaQuery.Type.ERROR,
+                Dataset.Events,
+                "hello",
+                "count()",
+                timedelta(minutes=10),
+                timedelta(minutes=1),
+                None,
+            )
+            sub = create_snuba_subscription(self.project, registration_key, snuba_query)
+        sub.refresh_from_db()
+
+        data = self.valid_wrapper
+        data["payload"]["subscription_id"] = sub.subscription_id
+        commit = mock.Mock()
+        partition = Partition(Topic("test"), 0)
+        strategy = QuerySubscriptionStrategyFactory(self.topic).create_with_partitions(
+            commit, {partition: 0}
+        )
+        message = self.build_mock_message(self.valid_wrapper, topic=self.topic)
+
+        strategy.submit(
+            Message(
+                BrokerValue(
+                    KafkaPayload(b"key", message.value(), [("should_drop", b"1")]),
+                    partition,
+                    1,
+                    datetime.now(),
+                )
+            )
+        )
+
+        data = deepcopy(data)
+        data["payload"]["values"] = data["payload"]["result"]
+        data["payload"]["timestamp"] = parse_date(data["payload"]["timestamp"]).replace(
+            tzinfo=pytz.utc
+        )
+        mock_callback.assert_called_once_with(data["payload"], sub)
+
     def test_no_subscription(self):
         with mock.patch("sentry.snuba.tasks._snuba_pool") as pool:
             pool.urlopen.return_value.status = 202
+
             self.consumer.handle_message(
-                self.build_mock_message(
-                    self.valid_wrapper, topic=settings.KAFKA_METRICS_SUBSCRIPTIONS_RESULTS
-                )
+                self.build_mock_message(self.valid_wrapper, topic=self.topic), self.topic
             )
             pool.urlopen.assert_called_once_with(
                 "DELETE",
@@ -97,7 +147,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
         )
         data = self.valid_wrapper
         data["payload"]["subscription_id"] = sub.subscription_id
-        self.consumer.handle_message(self.build_mock_message(data))
+        self.consumer.handle_message(self.build_mock_message(data), self.topic)
         self.metrics.incr.assert_called_once_with(
             "snuba_query_subscriber.subscription_type_not_registered"
         )
@@ -121,7 +171,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
 
         data = self.valid_wrapper
         data["payload"]["subscription_id"] = sub.subscription_id
-        self.consumer.handle_message(self.build_mock_message(data))
+        self.consumer.handle_message(self.build_mock_message(data), self.topic)
         data = deepcopy(data)
         data["payload"]["values"] = data["payload"]["result"]
         data["payload"]["timestamp"] = parse_date(data["payload"]["timestamp"]).replace(

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -121,6 +121,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
             tzinfo=pytz.utc
         )
         mock_callback.assert_called_once_with(data["payload"], sub)
+        assert False
 
     def test_no_subscription(self):
         with mock.patch("sentry.snuba.tasks._snuba_pool") as pool:

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from functools import cached_property
 from uuid import uuid4
 
+from arroyo.utils import metrics
 from confluent_kafka import Producer
 from confluent_kafka.admin import AdminClient
 from django.conf import settings
@@ -61,6 +62,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
         subscriber_registry.update(self.orig_registry)
 
         self.admin_client.delete_topics([self.topic])
+        metrics._metrics_backend = None
 
     @cached_property
     def subscription(self):

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -166,5 +166,10 @@ class HandleSnubaQueryUpdateTest(TestCase):
         self.run_test(consumer)
 
     def test_arroyo(self):
-        consumer = get_query_subscription_consumer(self.topic, "hi", False)
+        from sentry.utils.batching_kafka_consumer import create_topics
+
+        kafka_cluster = settings.KAFKA_TOPICS[self.topic]["cluster"]
+        create_topics(kafka_cluster, [self.topic])
+
+        consumer = get_query_subscription_consumer(self.topic, "hi", True)
         self.run_test(consumer)

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -178,5 +178,5 @@ class HandleSnubaQueryUpdateTest(TestCase):
         self.run_test(consumer)
 
     def test_arroyo(self):
-        consumer = get_query_subscription_consumer(self.topic, "hi", True)
+        consumer = get_query_subscription_consumer(self.topic, "hi", True, "earliest")
         self.run_test(consumer)


### PR DESCRIPTION
High metric alert volume is causing notification delays. This PR implements (but does not yet use) a new consumer that uses arroyo so we can take advantage of multi threaded processing. 

See [WOR-2747](https://getsentry.atlassian.net/browse/WOR-2747)

[WOR-2747]: https://getsentry.atlassian.net/browse/WOR-2747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ