### PR TITLE
fix(snoozes): Limit snoozes we process per task

### DIFF
--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -9,7 +9,7 @@ from sentry.tasks.base import instrumented_task
 @instrumented_task(name="sentry.tasks.clear_expired_snoozes", time_limit=65, soft_time_limit=60)
 def clear_expired_snoozes():
     groupsnooze_list = list(
-        GroupSnooze.objects.filter(until__lte=timezone.now()).values_list("id", "group")
+        GroupSnooze.objects.filter(until__lte=timezone.now()).values_list("id", "group")[:1000]
     )
     group_snooze_ids = [gs[0] for gs in groupsnooze_list]
     group_list = [gs[1] for gs in groupsnooze_list]


### PR DESCRIPTION
We're hitting errors like https://sentry.my.sentry.io/organizations/sentry/issues/393139/ when this task runs. At the moment there are 40k pending deletions here, which is likely causing the timeout.

Once we catch up we'll likely never need more than 1k deletions at once, since we process these every 5 minutes.
