### PR TITLE
Add more DB spans to db hash generation

### DIFF
--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -104,7 +104,16 @@ def raw_description_strategy(span: Span) -> Sequence[str]:
 IN_CONDITION_PATTERN = re.compile(r" IN \(%s(\s*,\s*%s)*\)")
 
 
-@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record", "db.sql.execute", "db.sql.transaction"])
+@span_op(
+    [
+        "db",
+        "db.query",
+        "db.sql.query",
+        "db.sql.active_record",
+        "db.sql.execute",
+        "db.sql.transaction",
+    ]
+)
 def normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[str]]:
     """For a `db` query span, the `IN` condition contains the same number of
     elements on the right hand side as the raw query. This results in identical
@@ -123,7 +132,16 @@ def normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[st
 LOOSE_IN_CONDITION_PATTERN = re.compile(r" IN \(((%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)", re.I)
 
 
-@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record", "db.sql.execute", "db.sql.transaction"])
+@span_op(
+    [
+        "db",
+        "db.query",
+        "db.sql.query",
+        "db.sql.active_record",
+        "db.sql.execute",
+        "db.sql.transaction",
+    ]
+)
 def loose_normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[str]]:
     """This is identical to the above
     `normalized_db_span_in_condition_strategy` but it uses a looser regular
@@ -152,7 +170,16 @@ DB_PARAMETRIZATION_PATTERN = re.compile(
 DB_SAVEPOINT_PATTERN = re.compile(r'SAVEPOINT (?:(?:"[^"]+")|(?:`[^`]+`)|(?:[a-z]\w+))', re.I)
 
 
-@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record", "db.sql.execute", "db.sql.transaction"])
+@span_op(
+    [
+        "db",
+        "db.query",
+        "db.sql.query",
+        "db.sql.active_record",
+        "db.sql.execute",
+        "db.sql.transaction",
+    ]
+)
 def parametrize_db_span_strategy(span: Span) -> Optional[Sequence[str]]:
     """First, apply the same IN-condition normalization as
     loose_normalized_db_span_condition_strategy. Then, replace all numeric,

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -104,7 +104,7 @@ def raw_description_strategy(span: Span) -> Sequence[str]:
 IN_CONDITION_PATTERN = re.compile(r" IN \(%s(\s*,\s*%s)*\)")
 
 
-@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record"])
+@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record", "db.sql.execute", "db.sql.transaction"])
 def normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[str]]:
     """For a `db` query span, the `IN` condition contains the same number of
     elements on the right hand side as the raw query. This results in identical
@@ -123,7 +123,7 @@ def normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[st
 LOOSE_IN_CONDITION_PATTERN = re.compile(r" IN \(((%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)", re.I)
 
 
-@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record"])
+@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record", "db.sql.execute", "db.sql.transaction"])
 def loose_normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[str]]:
     """This is identical to the above
     `normalized_db_span_in_condition_strategy` but it uses a looser regular
@@ -152,7 +152,7 @@ DB_PARAMETRIZATION_PATTERN = re.compile(
 DB_SAVEPOINT_PATTERN = re.compile(r'SAVEPOINT (?:(?:"[^"]+")|(?:`[^`]+`)|(?:[a-z]\w+))', re.I)
 
 
-@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record"])
+@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record", "db.sql.execute", "db.sql.transaction"])
 def parametrize_db_span_strategy(span: Span) -> Optional[Sequence[str]]:
     """First, apply the same IN-condition normalization as
     loose_normalized_db_span_condition_strategy. Then, replace all numeric,


### PR DESCRIPTION
https://develop.sentry.dev/sdk/performance/span-operations/#database
I don't know if `db.sql.prisma` and `db.redis` should be added since I've never used them nor I do know if it's used.