### PR TITLE
chore(txnames): Feature to mark scrubbed as sanitized

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1131,8 +1131,12 @@ SENTRY_FEATURES = {
     "organizations:metric-alert-chartcuterie": False,
     # Extract metrics for sessions during ingestion.
     "organizations:metrics-extraction": False,
-    # Normalize transaction names during ingestion.
+    # Normalize URL transaction names during ingestion.
     "organizations:transaction-name-normalize": False,
+    # Mark URL transactions scrubbed by regex patterns as "sanitized".
+    # NOTE: This flag does not concern transactions rewritten by clusterer rules.
+    # Those are always marked as "sanitized".
+    "organizations:transaction-name-mark-scrubbed-as-sanitized": False,
     # Try to derive normalization rules by clustering transaction names.
     "organizations:transaction-name-clusterer": False,
     # Use a larger sample size & merge threshold for transaction clustering.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -169,6 +169,7 @@ default_manager.add("organizations:streamline-targeting-context", OrganizationFe
 default_manager.add("organizations:symbol-sources", OrganizationFeature)
 default_manager.add("organizations:team-roles", OrganizationFeature)
 default_manager.add("organizations:transaction-name-normalize", OrganizationFeature)
+default_manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized", OrganizationFeature)
 default_manager.add("organizations:transaction-name-clusterer", OrganizationFeature)
 default_manager.add("organizations:transaction-name-clusterer-2x", OrganizationFeature)
 default_manager.add("organizations:transaction-name-sanitization", OrganizationFeature, False)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -45,6 +45,7 @@ from .measurements import CUSTOM_MEASUREMENT_LIMIT, get_measurements_config
 #: These features will be listed in the project config
 EXPOSABLE_FEATURES = [
     "organizations:transaction-name-normalize",
+    "organizations:transaction-name-mark-scrubbed-as-sanitized",
     "organizations:profiling",
     "organizations:session-replay",
     "organizations:session-replay-recording-scrubbing",


### PR DESCRIPTION
Pass a feature flag to Relay to indicate that all normalized transaction names should be marked as `sanitized`. See https://github.com/getsentry/relay/pull/1917.

https://github.com/getsentry/team-ingest/issues/69