### PR TITLE
feat(perf): Decode URLs in span tree

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -77,6 +77,7 @@ import {
 } from './types';
 import {
   durationlessBrowserOps,
+  formatSpanTreeLabel,
   getMeasurementBounds,
   getMeasurements,
   getSpanID,
@@ -578,8 +579,6 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
 
     titleFragments = titleFragments.flatMap(current => [current, ' \u2014 ']);
 
-    const description = span?.description ?? getSpanID(span);
-
     const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
     const errored = Boolean(errors && errors.length > 0);
 
@@ -608,7 +607,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
             data-test-id={`row-title-content${spanBarType ? `-${spanBarType}` : ''}`}
           >
             <strong>{titleFragments}</strong>
-            {description}
+            {formatSpanTreeLabel(span)}
           </RowTitleContent>
         </RowTitle>
       </RowTitleContainer>

--- a/static/app/components/events/interfaces/spans/utils.spec.tsx
+++ b/static/app/components/events/interfaces/spans/utils.spec.tsx
@@ -1,4 +1,6 @@
+import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {
+  formatSpanTreeLabel,
   getCumulativeAlertLevelFromErrors,
   getFormattedTimeRangeWithLeadingAndTrailingZero,
 } from 'sentry/components/events/interfaces/spans/utils';
@@ -33,6 +35,34 @@ describe('test utility functions', function () {
     );
     expect(result.start).toEqual('1658925888.601534');
     expect(result.end).toEqual('1658925888.601935');
+  });
+});
+
+describe('formatSpanTreeLabel', () => {
+  it('returns the span id if description is missing', () => {
+    expect(
+      formatSpanTreeLabel({
+        span_id: 'ba4e7d11',
+      } as RawSpanType)
+    ).toBe('ba4e7d11');
+  });
+
+  it('returns the description for database spans', () => {
+    expect(
+      formatSpanTreeLabel({
+        op: 'db',
+        description: 'SELECT * FROM books',
+      } as RawSpanType)
+    ).toBe('SELECT * FROM books');
+  });
+
+  it('decodes the URL for http spans', () => {
+    expect(
+      formatSpanTreeLabel({
+        op: 'http.client',
+        description: 'GET /items?query=hello%20world',
+      } as RawSpanType)
+    ).toBe('GET /items?query=hello world');
   });
 });
 

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -300,7 +300,11 @@ export function getSpanParentSpanID(span: ProcessedSpanType): string | undefined
   return span.parent_span_id;
 }
 
-export function formatSpanTreeLabel(span: ProcessedSpanType): string {
+export function formatSpanTreeLabel(span: ProcessedSpanType): string | undefined {
+  if (isGapSpan(span)) {
+    return undefined;
+  }
+
   return span?.description ?? getSpanID(span);
 }
 

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -300,6 +300,10 @@ export function getSpanParentSpanID(span: ProcessedSpanType): string | undefined
   return span.parent_span_id;
 }
 
+export function formatSpanTreeLabel(span: ProcessedSpanType): string {
+  return span?.description ?? getSpanID(span);
+}
+
 export function getTraceContext(
   event: Readonly<EventTransaction>
 ): TraceContextType | undefined {

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -305,7 +305,17 @@ export function formatSpanTreeLabel(span: ProcessedSpanType): string | undefined
     return undefined;
   }
 
-  return span?.description ?? getSpanID(span);
+  const label = span?.description ?? getSpanID(span);
+
+  if (span.op === 'http.client') {
+    try {
+      return decodeURIComponent(label);
+    } catch {
+      // Do nothing
+    }
+  }
+
+  return label;
 }
 
 export function getTraceContext(


### PR DESCRIPTION
Closes PERF-1955. Decodes `http.client` span descriptions when making span tree labels. This makes it much easier to figure out what's going on at a glance!

**Before:**
Huh what what are those URLs?
<img width="175" alt="Screenshot 2023-03-10 at 9 37 19 AM" src="https://user-images.githubusercontent.com/989898/224374040-4def06b0-831b-4107-a59b-d2a3d8c83e6b.png">

**After:**
Ahh, colons!
<img width="111" alt="Screenshot 2023-03-10 at 11 17 44 AM" src="https://user-images.githubusercontent.com/989898/224374091-f847cf9d-5817-433f-9054-b85864acc33a.png">

