### PR TITLE
feat(perf-issues): Add preceding span row to Span Evidence for N+1 DB Issues

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {getProblemSpansForSpanTree} from 'sentry/components/events/interfaces/performance/utils';
 import {t} from 'sentry/locale';
-import {EventTransaction, IssueType, Organization} from 'sentry/types';
+import {EventTransaction, Organization} from 'sentry/types';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesProvider';
 
@@ -27,22 +28,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
     return null;
   }
 
-  const parentSpanIDs = event?.perfProblem?.parentSpanIds ?? [];
-  const offendingSpanIDs = event?.perfProblem?.offenderSpanIds ?? [];
-
-  const affectedSpanIds = [...offendingSpanIDs];
-  const focusedSpanIds: string[] = [];
-  const issueType = event?.perfProblem?.issueType;
-  if (issueType !== IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS) {
-    affectedSpanIds.push(...parentSpanIDs);
-  }
-  if (issueType === IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES) {
-    const consecutiveSpanIds = event?.perfProblem?.causeSpanIds ?? [];
-
-    if (consecutiveSpanIds.length < 11) {
-      focusedSpanIds.push(...consecutiveSpanIds);
-    }
-  }
+  const {affectedSpanIds, focusedSpanIds} = getProblemSpansForSpanTree(event);
 
   const profileId = event.contexts?.profile?.profile_id ?? null;
 

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -104,6 +104,7 @@ const ConsecutiveDBQueriesSpanEvidence = ({
 
 const NPlusOneDBQueriesSpanEvidence = ({
   event,
+  causeSpans,
   parentSpan,
   offendingSpans,
   orgSlug,
@@ -124,6 +125,9 @@ const NPlusOneDBQueriesSpanEvidence = ({
         [
           makeTransactionNameRow(event, orgSlug),
           parentSpan ? makeRow(t('Parent Span'), getSpanEvidenceValue(parentSpan)) : null,
+          causeSpans.length > 0
+            ? makeRow(t('Preceding Span'), getSpanEvidenceValue(causeSpans[0]))
+            : null,
           ...repeatingSpanRows,
         ].filter(Boolean) as KeyValueListData
       }

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -1,7 +1,13 @@
 import * as Sentry from '@sentry/react';
 import keyBy from 'lodash/keyBy';
 
-import {EntrySpans, EntryType, EventTransaction, IssueCategory} from 'sentry/types';
+import {
+  EntrySpans,
+  EntryType,
+  EventTransaction,
+  IssueCategory,
+  IssueType,
+} from 'sentry/types';
 
 import {RawSpanType} from '../spans/types';
 
@@ -47,4 +53,45 @@ export function getSpanInfoFromTransactionEvent(
     offendingSpans: offendingSpanIDs.map(spanID => spansById[spanID]),
     causeSpans: causeSpanIDs.map(spanID => spansById[spanID]),
   };
+}
+
+/**
+ * Given an event for a performance issue, returns the `affectedSpanIds` and `focusedSpanIds`.
+ * Both of these subsets of spans are used to determine which spans are initially visible on the span tree on the issue details
+ * page. The main difference is that the former will be highlighted in red, these spans are intended to indicate the 'root cause' spans
+ * of the issue, with the latter being supplemental spans that are involved in the issue but not necessarily the cause of it.
+ *
+ * @param event
+ */
+export function getProblemSpansForSpanTree(event: EventTransaction): {
+  affectedSpanIds: string[];
+  focusedSpanIds: string[];
+} {
+  const issueType = event?.perfProblem?.issueType;
+  const affectedSpanIds: string[] = [];
+  const focusedSpanIds: string[] = [];
+
+  // By default, offender spans will always be `affected spans`
+  const offenderSpanIds = event.perfProblem?.offenderSpanIds ?? [];
+  affectedSpanIds.push(...offenderSpanIds);
+
+  if (issueType !== IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS) {
+    const parentSpanIds = event.perfProblem?.parentSpanIds ?? [];
+    affectedSpanIds.push(...parentSpanIds);
+  }
+
+  if (issueType === IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES) {
+    const consecutiveSpanIds = event?.perfProblem?.causeSpanIds ?? [];
+
+    if (consecutiveSpanIds.length < 11) {
+      focusedSpanIds.push(...consecutiveSpanIds);
+    }
+  }
+
+  if (issueType === IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES) {
+    const precedingSpans = event.perfProblem?.causeSpanIds ?? [];
+    focusedSpanIds.push(...precedingSpans);
+  }
+
+  return {affectedSpanIds, focusedSpanIds};
 }

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -67,7 +67,7 @@ export function getProblemSpansForSpanTree(event: EventTransaction): {
   affectedSpanIds: string[];
   focusedSpanIds: string[];
 } {
-  const issueType = event?.perfProblem?.issueType;
+  const issueType = event.perfProblem?.issueType;
   const affectedSpanIds: string[] = [];
   const focusedSpanIds: string[] = [];
 
@@ -81,7 +81,7 @@ export function getProblemSpansForSpanTree(event: EventTransaction): {
   }
 
   if (issueType === IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES) {
-    const consecutiveSpanIds = event?.perfProblem?.causeSpanIds ?? [];
+    const consecutiveSpanIds = event.perfProblem?.causeSpanIds ?? [];
 
     if (consecutiveSpanIds.length < 11) {
       focusedSpanIds.push(...consecutiveSpanIds);


### PR DESCRIPTION
For N+1 DB issues, we should show the preceding span (simply the span the occurs right before the repeating spans), since this is factored into the fingerprinting strategy. 

This PR brings this span into the Span Evidence section and also shows it in the span tree as a `focusedSpan`.

There is also a bit of refactoring involved in this PR to make it easier to make changes like this in the future

![image](https://user-images.githubusercontent.com/16740047/224404394-d98a77be-cbd8-43df-828e-de4d6f5ecae5.png)
