### PR TITLE
feat(ui): Ignore "can't access dead object" firefox errors

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -110,17 +110,25 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       }
       return event;
     },
-    /**
-     * There is a bug in Safari, that causes `AbortError` when fetch is
-     * aborted, and you are in the middle of reading the response. In Chrome
-     * and other browsers, it is handled gracefully, where in Safari, it
-     * produces additional error, that is jumping outside of the original
-     * Promise chain and bubbles up to the `unhandledRejection` handler, that
-     * we then captures as error.
-     *
-     * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
-     */
-    ignoreErrors: ['AbortError: Fetch is aborted'],
+
+    ignoreErrors: [
+      /**
+       * There is a bug in Safari, that causes `AbortError` when fetch is
+       * aborted, and you are in the middle of reading the response. In Chrome
+       * and other browsers, it is handled gracefully, where in Safari, it
+       * produces additional error, that is jumping outside of the original
+       * Promise chain and bubbles up to the `unhandledRejection` handler, that
+       * we then captures as error.
+       *
+       * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
+       */
+      'AbortError: Fetch is aborted',
+      /**
+       * Thrown when firefox prevents an add-on from refrencing a DOM element
+       * that has been removed.
+       */
+      "TypeError: can't access dead object",
+    ],
   });
 
   // Track timeOrigin Selection by the SDK to see if it improves transaction durations


### PR DESCRIPTION
We've had 500 of these in the last 90 days and they usually aren't grouped or actionable (missing stacktrace etc)


https://udn.realityripple.com/docs/Web/JavaScript/Reference/Errors/Dead_object

[discover query](https://sentry.sentry.io/discover/homepage/?field=issue&field=title&field=event.type&field=user.display&field=timestamp&field=browser.name&name=All+Events&project=11276&query=can%27t+access+dead+object&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29)
