### PR TITLE
bug(replays): Remove extra query params when fetching replay count for transactions

### DIFF
--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -314,7 +314,7 @@ describe('useReplaysCount', () => {
       '/organizations/org-slug/replay-count/',
       expect.objectContaining({
         query: {
-          query: `event.type:transaction transaction:["/home","/profile"]`,
+          query: `transaction:["/home","/profile"]`,
           statsPeriod: '14d',
           project: [2],
         },

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -87,9 +87,7 @@ function useReplaysCount({
       if (txnsToFetch.length) {
         return {
           field: 'transaction' as const,
-          conditions: `event.type:transaction transaction:[${txnsToFetch
-            .map(t => `"${t}"`)
-            .join(',')}]`,
+          conditions: `transaction:[${txnsToFetch.map(t => `"${t}"`).join(',')}]`,
         };
       }
       return null;


### PR DESCRIPTION
Fix a problem where we were including `event.type:transaction` with the the `/replay-count/` query for transactions.

This is an unsupported field that isn't meant to do anything. In reality it was causing the count to return zero in all cases. 