### PR TITLE
test: Output error message when fixtures are unable to load

### DIFF
--- a/tests/js/sentry-test/loadFixtures.ts
+++ b/tests/js/sentry-test/loadFixtures.ts
@@ -145,16 +145,27 @@ export function makeLazyFixtures<UserProvidedFixtures extends Record<any, any>>(
           for (const exportKey in maybeModule) {
             target[exportKey] = maybeModule[exportKey];
           }
-        } catch {
-          // ignore
+        } catch (error) {
+          return () => {
+            throw new Error(
+              error +
+                '\n\n' +
+                `Failed to resolve ${prop} fixture.
+              - Your fixture does not map directly to file on disk or fixture file could be exporting > 1 fixture.
+              - To resolve this, add a mapping to SPECIAL_MAPPING in loadFixtures.ts or ensure fixture export name maps to the file on disk.
+              - If you are seeing this only in CI and you have followed the step above, check the exact casing of the file as it is case sensitive.
+
+              `
+            );
+          };
         }
 
         if (target[prop] === undefined) {
           return () => {
             throw new Error(
-              `Failed to resolve ${prop} fixture. \n
-              - Your fixture does not map directly to file on disk or fixture file could be exporting > 1 fixture. \n
-              - To resolve this, add a mapping to SPECIAL_MAPPING in loadFixtures.ts or ensure fixture export name maps to the file on disk. \n
+              `Failed to resolve ${prop} fixture.
+              - Your fixture does not map directly to file on disk or fixture file could be exporting > 1 fixture.
+              - To resolve this, add a mapping to SPECIAL_MAPPING in loadFixtures.ts or ensure fixture export name maps to the file on disk.
               - If you are seeing this only in CI and you have followed the step above, check the exact casing of the file as it is case sensitive.`
             );
           };


### PR DESCRIPTION
Before we just had one error message whenever a fixture file couldn't be loaded. The assumption is that the fixture you asked for doesn't match to any filename, and there's two ways to fix that (fix typo, or map mock fn to filename manually)

It looks like this:
<img width="1149" alt="SCR-20230310-eet" src="https://user-images.githubusercontent.com/187460/224394396-9f0ce30b-9619-46b9-8cf3-9928eb82ef34.png">


There's another case though: if the fixture file has an error it can't be imported, like a syntax error or something. Now we're going to print that out too so it's easier to debug the problem:
<img width="1185" alt="SCR-20230310-em1" src="https://user-images.githubusercontent.com/187460/224396109-f62be195-a72b-4c23-b432-7cc5c8e9d21e.png">
