### PR TITLE
ref(replays): Move the REPLAY_LIST_FIELDS list next to the ReplayListRecord definition

### DIFF
--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -10,18 +10,6 @@ import type {ReplayListRecord} from 'sentry/views/replays/types';
 
 export const DEFAULT_SORT = '-started_at';
 
-export const REPLAY_LIST_FIELDS = [
-  'activity',
-  'count_errors',
-  'duration',
-  'finished_at',
-  'id',
-  'project_id',
-  'started_at',
-  'urls',
-  'user',
-];
-
 type State = {
   fetchError: undefined | RequestError;
   pageLinks: null | string;

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -5,9 +5,10 @@ import {Location} from 'history';
 import type {Group, Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {DEFAULT_SORT, REPLAY_LIST_FIELDS} from 'sentry/utils/replays/fetchReplayList';
+import {DEFAULT_SORT} from 'sentry/utils/replays/fetchReplayList';
 import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
+import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
 
 function useReplayFromIssue({
   group,

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -6,9 +6,10 @@ import type {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {DEFAULT_SORT, REPLAY_LIST_FIELDS} from 'sentry/utils/replays/fetchReplayList';
+import {DEFAULT_SORT} from 'sentry/utils/replays/fetchReplayList';
 import useApi from 'sentry/utils/useApi';
 import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
+import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
 
 type Options = {
   location: Location;

--- a/static/app/views/replays/list/replays.tsx
+++ b/static/app/views/replays/list/replays.tsx
@@ -7,7 +7,7 @@ import Pagination from 'sentry/components/pagination';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {DEFAULT_SORT, REPLAY_LIST_FIELDS} from 'sentry/utils/replays/fetchReplayList';
+import {DEFAULT_SORT} from 'sentry/utils/replays/fetchReplayList';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -19,6 +19,7 @@ import ReplayOnboardingPanel from 'sentry/views/replays/list/replayOnboardingPan
 import ReplayTable from 'sentry/views/replays/replayTable';
 import {ReplayColumns} from 'sentry/views/replays/replayTable/types';
 import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
+import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
 
 function ReplaysList() {
   const location = useLocation<ReplayListLocationQuery>();

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -93,6 +93,7 @@ export type ReplayListLocationQuery = {
   utc?: 'true' | 'false';
 };
 
+// Sync with REPLAY_LIST_FIELDS below
 export type ReplayListRecord = Pick<
   ReplayRecord,
   | 'activity'
@@ -105,6 +106,19 @@ export type ReplayListRecord = Pick<
   | 'urls'
   | 'user'
 >;
+
+// Sync with ReplayListRecord above
+export const REPLAY_LIST_FIELDS: (keyof ReplayListRecord)[] = [
+  'activity',
+  'count_errors',
+  'duration',
+  'finished_at',
+  'id',
+  'project_id',
+  'started_at',
+  'urls',
+  'user',
+];
 
 export type ReplaySegment = {
   dateAdded: string;


### PR DESCRIPTION
I want to move these two things together because they need to be kept in sync, and having them sit in far apart files wasn't making that easy.