### PR TITLE
fix(profiling): clamp the aggregateFlamegraph barHeightRatio

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -208,11 +208,10 @@ export function AggregateFlamegraph(): ReactElement {
       const flamegraphFitTo = canvasHeight / flamegraph.depth;
       const minReadableRatio = 0.8; // this is quite small
       const fitToRatio = flamegraphFitTo / theme.SIZES.BAR_HEIGHT;
+      const barHeightRatio = Math.min(Math.max(minReadableRatio, fitToRatio), 1);
 
-      theme.SIZES.BAR_HEIGHT =
-        theme.SIZES.BAR_HEIGHT * Math.max(minReadableRatio, fitToRatio);
-      theme.SIZES.BAR_FONT_SIZE =
-        theme.SIZES.BAR_FONT_SIZE * Math.max(minReadableRatio, fitToRatio);
+      theme.SIZES.BAR_HEIGHT = theme.SIZES.BAR_HEIGHT * barHeightRatio;
+      theme.SIZES.BAR_FONT_SIZE = theme.SIZES.BAR_FONT_SIZE * barHeightRatio;
       return theme;
     });
 


### PR DESCRIPTION
## Summary
There was a logical error w/ the calculating the barheight ratio that allowed flamegraph barheights to take the maximum allowed space.

In reality we should clamp this value to the default theme size. If we really wanted to we could scale it up ever so slightly, but never the vertical space.


Before:
![image](https://user-images.githubusercontent.com/7349258/224405962-4affe2e8-0a0e-4c2f-8bdb-de4bc78cf2d6.png)

After:
![image](https://user-images.githubusercontent.com/7349258/224405927-383b4e10-5167-41a1-98f4-8315f2de7181.png)
