### PR TITLE
fix(profiling): reduce flamegraph depth offset

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -210,6 +210,8 @@ export function AggregateFlamegraph(): ReactElement {
       const fitToRatio = flamegraphFitTo / theme.SIZES.BAR_HEIGHT;
       const barHeightRatio = Math.min(Math.max(minReadableRatio, fitToRatio), 1);
 
+      // reduce the offset to leave just enough space for the toolbar
+      theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET = 2.5;
       theme.SIZES.BAR_HEIGHT = theme.SIZES.BAR_HEIGHT * barHeightRatio;
       theme.SIZES.BAR_FONT_SIZE = theme.SIZES.BAR_FONT_SIZE * barHeightRatio;
       return theme;


### PR DESCRIPTION
## Summary
Reduces the flamegraph depth offset to reduce spacing on y axis.

Before:
![image](https://user-images.githubusercontent.com/7349258/224411783-807db59d-ab5c-422f-8235-3e56c4e2b017.png)


After:
![image](https://user-images.githubusercontent.com/7349258/224411710-f312fde1-7922-459e-bbcc-0e7a3121a7cb.png)
