### PR TITLE
bug(replays): Fix spacing below Replays Tags table

### DIFF
--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -9,9 +9,10 @@ type Props = {
   value: React.ReactNode;
 };
 
-export const KeyValueTable = styled('dl')`
+export const KeyValueTable = styled('dl')<{noMargin?: boolean}>`
   display: grid;
   grid-template-columns: 50% 50%;
+  ${p => (p.noMargin ? 'margin-bottom: 0;' : null)}
 `;
 
 export const KeyValueTableRow = ({keyName, value}: Props) => {

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -57,7 +57,7 @@ function TagPanel() {
     <Panel>
       <FluidPanel>
         {tags.length ? (
-          <KeyValueTable>
+          <KeyValueTable noMargin>
             {tags.map(([key, values]) => (
               <ReplayTagsTableRow
                 key={key}


### PR DESCRIPTION
**Before** there wa
<img width="665" alt="SCR-20230310-ged" src="https://user-images.githubusercontent.com/187460/224415105-e552614d-9e9d-4d34-ae43-49d0ee230677.png">
s some space under our tags table:


**Now** it's gone:
<img width="661" alt="SCR-20230310-gea" src="https://user-images.githubusercontent.com/187460/224415122-2df0e143-91e5-4ddf-b981-dfbf7a18bbb9.png">


I looked at some of the other places that use `KeyValueTable` and some can clearly have `noMargin` added because their wrapping div also has `bottom-margin: ${space(3)};`. Some cases were less clear though

I'd be interested in the default for this stuff being no margin, and then folks can add spacing with `gap` or `margin` as needed.

