### PR TITLE
feat(profiling): flamegraph loader

### DIFF
--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -1,15 +1,17 @@
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
+import {Flex} from 'sentry/components/profiling/flex';
+import {t} from 'sentry/locale';
 import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
 import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 
 export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
-  const query = useAggregateFlamegraphQuery({transaction});
-
+  const {data, isLoading} = useAggregateFlamegraphQuery({transaction});
   return (
-    <ProfileGroupProvider type="flamegraph" input={query.data ?? null} traceID="">
+    <ProfileGroupProvider type="flamegraph" input={data ?? null} traceID="">
       <FlamegraphStateProvider
         initialState={{
           preferences: {
@@ -20,7 +22,13 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
       >
         <FlamegraphThemeProvider>
           <Panel>
-            <AggregateFlamegraph />
+            <Flex h={400} column justify="center">
+              {isLoading ? (
+                <LoadingIndicator>{t('Loading Flamegraph')}</LoadingIndicator>
+              ) : (
+                <AggregateFlamegraph />
+              )}
+            </Flex>
           </Panel>
         </FlamegraphThemeProvider>
       </FlamegraphStateProvider>

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -1,11 +1,17 @@
-import {ReactElement, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import {
+  Fragment,
+  ReactElement,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {mat3, vec2} from 'gl-matrix';
 
 import {Button} from 'sentry/components/button';
 import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
-import {Flex} from 'sentry/components/profiling/flex';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -376,7 +382,7 @@ export function AggregateFlamegraph(): ReactElement {
   }, [profileGroup, highlightFrames, profiles.threadId, dispatch, sorting]);
 
   return (
-    <Flex h={500} column>
+    <Fragment>
       <FlamegraphZoomView
         canvasBounds={flamegraphCanvasBounds}
         canvasPoolManager={canvasPoolManager}
@@ -397,7 +403,7 @@ export function AggregateFlamegraph(): ReactElement {
           {t('Reset Zoom')}
         </Button>
       </AggregateFlamegraphToolbar>
-    </Flex>
+    </Fragment>
   );
 }
 


### PR DESCRIPTION
# Summary
Flamegraph loading state. Currently the `AggregateFlamegraph` renders a blank canvas while the flamegraph request is in flight.

This PR introduces loading indicator to this panel.

![image](https://user-images.githubusercontent.com/7349258/224417003-b4281aba-5f27-425d-a892-53560e1abef8.png)
