### PR TITLE
ref(monitors): Rename ingest endpoints

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -47,11 +47,13 @@ from sentry.incidents.endpoints.project_alert_rule_index import (
 from sentry.incidents.endpoints.project_alert_rule_task_details import (
     ProjectAlertRuleTaskDetailsEndpoint,
 )
-from sentry.monitors.endpoints.monitor_checkin_details import MonitorCheckInDetailsEndpoint
-from sentry.monitors.endpoints.monitor_checkins import MonitorCheckInsEndpoint
-from sentry.monitors.endpoints.organization_monitor_checkin_attachment import (
-    OrganizationMonitorCheckInAttachmentEndpoint,
+from sentry.monitors.endpoints.monitor_ingest_checkin_attachment import (
+    MonitorIngestCheckinAttachmentEndpoint,
 )
+from sentry.monitors.endpoints.monitor_ingest_checkin_details import (
+    MonitorIngestCheckInDetailsEndpoint,
+)
+from sentry.monitors.endpoints.monitor_ingest_checkin_index import MonitorIngestCheckInIndexEndpoint
 from sentry.monitors.endpoints.organization_monitor_details import (
     OrganizationMonitorDetailsEndpoint,
 )
@@ -1320,21 +1322,23 @@ ORGANIZATION_URLS = [
         OrganizationMonitorStatsEndpoint.as_view(),
         name="sentry-api-0-organization-monitor-stats",
     ),
-    url(
-        r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/attachment/$",
-        OrganizationMonitorCheckInAttachmentEndpoint.as_view(),
-        name="sentry-api-0-organization-monitor-check-in-attachment",
-    ),
+    # Monitor checkin org-level ingestion
     url(
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/$",
-        MonitorCheckInsEndpoint.as_view(),
+        MonitorIngestCheckInIndexEndpoint.as_view(),
         name="sentry-api-0-organization-monitor-check-in-index",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/$",
-        MonitorCheckInDetailsEndpoint.as_view(),
+        MonitorIngestCheckInDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-monitor-check-in-details",
     ),
+    url(
+        r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/attachment/$",
+        MonitorIngestCheckinAttachmentEndpoint.as_view(),
+        name="sentry-api-0-organization-monitor-check-in-attachment",
+    ),
+    # Pinned and saved search
     url(
         r"^(?P<organization_slug>[^\/]+)/pinned-searches/$",
         OrganizationPinnedSearchEndpoint.as_view(),
@@ -2543,16 +2547,16 @@ urlpatterns = [
         name="sentry-api-0-accept-organization-invite",
     ),
     # Top-level monitor checkin APIs. NOTE that there are also organization
-    # level checkin APIs.
+    # level checkin ingest APIs.
     url(
         r"^monitors/(?P<monitor_id>[^\/]+)/checkins/$",
-        MonitorCheckInsEndpoint.as_view(),
-        name="sentry-api-0-monitor-check-in-index",
+        MonitorIngestCheckInIndexEndpoint.as_view(),
+        name="sentry-api-0-monitor-ingest-check-in-index",
     ),
     url(
         r"^monitors/(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/$",
-        MonitorCheckInDetailsEndpoint.as_view(),
-        name="sentry-api-0-monitor-check-in-details",
+        MonitorIngestCheckInDetailsEndpoint.as_view(),
+        name="sentry-api-0-monitor-ingest-check-in-details",
     ),
     # Profiling - This is a temporary endpoint to easily go from a project id + profile id to a flamechart.
     # It will be removed in the near future.

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -16,7 +16,7 @@ MAX_ATTACHMENT_SIZE = 1024 * 100  # 100kb
 
 
 @region_silo_endpoint
-class OrganizationMonitorCheckInAttachmentEndpoint(MonitorCheckInEndpoint):
+class MonitorIngestCheckinAttachmentEndpoint(MonitorCheckInEndpoint):
     # TODO(davidenwang): Add documentation after uploading feature is complete
     private = True
     authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -27,7 +27,7 @@ from .base import MonitorCheckInEndpoint
 
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
-class MonitorCheckInDetailsEndpoint(MonitorCheckInEndpoint):
+class MonitorIngestCheckInDetailsEndpoint(MonitorCheckInEndpoint):
     authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
     public = {"PUT"}
 

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -43,7 +43,7 @@ CHECKIN_QUOTA_WINDOW = 60
 
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
-class MonitorCheckInsEndpoint(MonitorEndpoint):
+class MonitorIngestCheckInIndexEndpoint(MonitorEndpoint):
     authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
     public = {"GET", "POST"}
 

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
@@ -12,7 +12,7 @@ from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class OrganizationMonitorCheckInAttachmentEndpointTest(APITestCase):
+class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-monitor-check-in-attachment"
 
     def setUp(self):
@@ -100,7 +100,7 @@ class OrganizationMonitorCheckInAttachmentEndpointTest(APITestCase):
         assert resp.data["detail"] == "Check-in has no attachment"
 
     @mock.patch(
-        "sentry.monitors.endpoints.organization_monitor_checkin_attachment.MAX_ATTACHMENT_SIZE", 1
+        "sentry.monitors.endpoints.monitor_ingest_checkin_attachment.MAX_ATTACHMENT_SIZE", 1
     )
     def test_upload_file_too_big(self):
         monitor = self._create_monitor()

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -15,8 +15,8 @@ from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class UpdateMonitorCheckInTest(APITestCase):
-    endpoint = "sentry-api-0-monitor-check-in-details"
+class UpdateMonitorIngestCheckinTest(APITestCase):
+    endpoint = "sentry-api-0-monitor-ingest-check-in-details"
     endpoint_with_org = "sentry-api-0-organization-monitor-check-in-details"
 
     def setUp(self):

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -23,7 +23,7 @@ from sentry.testutils.silo import region_silo_test
 @region_silo_test(stable=True)
 @freeze_time()
 class CreateMonitorCheckInTest(MonitorTestCase):
-    endpoint = "sentry-api-0-monitor-check-in-index"
+    endpoint = "sentry-api-0-monitor-ingest-check-in-index"
     endpoint_with_org = "sentry-api-0-organization-monitor-check-in-index"
 
     def setUp(self):
@@ -257,7 +257,9 @@ class CreateMonitorCheckInTest(MonitorTestCase):
 
             path = path_func(monitor.guid)
 
-            with mock.patch("sentry.monitors.endpoints.monitor_checkins.CHECKIN_QUOTA_LIMIT", 1):
+            with mock.patch(
+                "sentry.monitors.endpoints.monitor_ingest_checkin_index.CHECKIN_QUOTA_LIMIT", 1
+            ):
                 resp = self.client.post(path, {"status": "ok"})
                 assert resp.status_code == 201, resp.content
                 resp = self.client.post(path, {"status": "ok"})


### PR DESCRIPTION
This will be in support of splitting the base classes for the existing
monitor ingestion endpoints