### PR TITLE
feat(py): Add `method_dispatch` helper for splitting endpoints

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from typing import Any, List, Literal, Tuple, overload
 from urllib.parse import urlparse
 
+from django.http import HttpResponseNotAllowed
 from django.utils import timezone
 from rest_framework.request import Request
 
@@ -266,3 +267,20 @@ def customer_domain_path(path: str) -> str:
         if updated != path:
             return updated
     return path
+
+
+def method_dispatch(**dispatch_mapping):  # type: ignore[no-untyped-def]
+    """
+    Dispatches a incoming request to a different handler based on the HTTP method
+
+    >>> url('^foo$', method_dispatch(POST = post_handler, GET = get_handler)))
+    """
+
+    def invalid_method(request, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return HttpResponseNotAllowed(dispatch_mapping.keys())
+
+    def dispatcher(request, *args, **kwargs):  # type: ignore[no-untyped-def]
+        handler = dispatch_mapping.get(request.method, invalid_method)
+        return handler(request, *args, **kwargs)
+
+    return dispatcher


### PR DESCRIPTION
This will be in support of https://github.com/getsentry/sentry/pull/45665 + https://github.com/getsentry/sentry/pull/45672 to help split up our legacy monitor ingest endpoints, from the non-legacy API endpoints used in the frontend.

This will look sometihng like this

```py
url(
    r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/$",
    method_dispatch(
        GET=OrganizationMonitorCheckInIndexEndpoint.as_view(),
        POST=MonitorIngestCheckInIndexEndpoint.as_view(),  # Legacy ingest endpoint
    ),
    name="sentry-api-0-organization-monitor-check-in-index",
),
```
