### PR TITLE
fix(monitors): Widen rate limit window

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -53,7 +53,6 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
         },
     )
 
-
     @extend_schema(
         operation_id="Create a new check-in",
         parameters=[

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -27,7 +27,9 @@ from sentry.monitors.models import (
 )
 from sentry.monitors.serializers import MonitorCheckInSerializerResponse
 from sentry.monitors.validators import MonitorCheckInValidator
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.signals import first_cron_checkin_received, first_cron_monitor_created
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 
 from .base import MonitorIngestEndpoint
@@ -40,6 +42,17 @@ CHECKIN_QUOTA_WINDOW = 60
 @extend_schema(tags=["Crons"])
 class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
     public = {"POST"}
+
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.IP: RateLimit(40 * 60, 60),
+                RateLimitCategory.USER: RateLimit(40 * 60, 60),
+                RateLimitCategory.ORGANIZATION: RateLimit(40 * 60, 60),
+            }
+        },
+    )
+
 
     @extend_schema(
         operation_id="Create a new check-in",


### PR DESCRIPTION
We got a request to increase number of checkins allowed per second, but the issue here is that this customer has a lot of checkins for different monitors happening at around the same time. This is causing them to bump into the rate limit. Instead of increasing our base limit, I'll widen the window so that we can received 40 * 60 (2400) a minute instead of 40/second.

Fixes #45583