### PR TITLE
refs(monitors): Split legacy ingest endpoints out

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 
+from sentry.api.utils import method_dispatch
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
 from sentry.discover.endpoints.discover_homepage_query import DiscoverHomepageQueryEndpoint
@@ -54,6 +55,12 @@ from sentry.monitors.endpoints.monitor_ingest_checkin_details import (
     MonitorIngestCheckInDetailsEndpoint,
 )
 from sentry.monitors.endpoints.monitor_ingest_checkin_index import MonitorIngestCheckInIndexEndpoint
+from sentry.monitors.endpoints.organization_monitor_checkin_attachment import (
+    OrganizationMonitorCheckInAttachmentEndpoint,
+)
+from sentry.monitors.endpoints.organization_monitor_checkin_index import (
+    OrganizationMonitorCheckInIndexEndpoint,
+)
 from sentry.monitors.endpoints.organization_monitor_details import (
     OrganizationMonitorDetailsEndpoint,
 )
@@ -1322,20 +1329,27 @@ ORGANIZATION_URLS = [
         OrganizationMonitorStatsEndpoint.as_view(),
         name="sentry-api-0-organization-monitor-stats",
     ),
-    # Monitor checkin org-level ingestion
     url(
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/$",
-        MonitorIngestCheckInIndexEndpoint.as_view(),
+        method_dispatch(
+            GET=OrganizationMonitorCheckInIndexEndpoint.as_view(),
+            POST=MonitorIngestCheckInIndexEndpoint.as_view(),  # Legacy ingest endpoint
+        ),
         name="sentry-api-0-organization-monitor-check-in-index",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/$",
-        MonitorIngestCheckInDetailsEndpoint.as_view(),
+        method_dispatch(
+            PUT=MonitorIngestCheckInDetailsEndpoint.as_view(),  # Legacy ingest endpoint
+        ),
         name="sentry-api-0-organization-monitor-check-in-details",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/attachment/$",
-        MonitorIngestCheckinAttachmentEndpoint.as_view(),
+        method_dispatch(
+            GET=OrganizationMonitorCheckInAttachmentEndpoint.as_view(),
+            POST=MonitorIngestCheckinAttachmentEndpoint.as_view(),  # Legacy ingest endpoint
+        ),
         name="sentry-api-0-organization-monitor-check-in-attachment",
     ),
     # Pinned and saved search

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from django.core.files.uploadedfile import UploadedFile
-from django.http.response import FileResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -21,23 +20,6 @@ class MonitorIngestCheckinAttachmentEndpoint(MonitorCheckInEndpoint):
     private = True
     authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
     permission_classes = (MonitorCheckInAttachmentPermission,)
-
-    def download(self, file_id):
-        file = File.objects.get(id=file_id)
-        fp = file.getfile()
-        response = FileResponse(
-            fp,
-            content_type=file.headers.get("Content-Type", "application/octet-stream"),
-        )
-        response["Content-Length"] = file.size
-        response["Content-Disposition"] = f"attachment; filename={file.name}"
-        return response
-
-    def get(self, request: Request, project, monitor, checkin) -> Response:
-        if checkin.attachment_id:
-            return self.download(checkin.attachment_id)
-        else:
-            return Response({"detail": "Check-in has no attachment"}, status=404)
 
     def post(self, request: Request, project, monitor, checkin) -> Response:
         """

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -1,19 +1,15 @@
 from __future__ import annotations
 
-from typing import List
-
 from django.db import transaction
 from drf_spectacular.utils import extend_schema
-from rest_framework.exceptions import ParseError, Throttled
+from rest_framework.exceptions import Throttled
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import ratelimits
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
-from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
     RESPONSE_FORBIDDEN,
@@ -45,49 +41,7 @@ CHECKIN_QUOTA_WINDOW = 60
 @extend_schema(tags=["Crons"])
 class MonitorIngestCheckInIndexEndpoint(MonitorEndpoint):
     authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
-    public = {"GET", "POST"}
-
-    @extend_schema(
-        operation_id="Retrieve check-ins for a monitor",
-        parameters=[
-            GLOBAL_PARAMS.ORG_SLUG,
-            MONITOR_PARAMS.MONITOR_ID,
-            MONITOR_PARAMS.CHECKIN_ID,
-        ],
-        responses={
-            200: inline_sentry_response_serializer(
-                "CheckInList", List[MonitorCheckInSerializerResponse]
-            ),
-            401: RESPONSE_UNAUTHORIZED,
-            403: RESPONSE_FORBIDDEN,
-            404: RESPONSE_NOTFOUND,
-        },
-    )
-    def get(
-        self, request: Request, project, monitor, organization_slug: str | None = None
-    ) -> Response:
-        """
-        Retrieve a list of check-ins for a monitor
-        """
-        # we don't allow read permission with DSNs
-        if isinstance(request.auth, ProjectKey):
-            return self.respond(status=401)
-
-        start, end = get_date_range_from_params(request.GET)
-        if start is None or end is None:
-            raise ParseError(detail="Invalid date range")
-
-        queryset = MonitorCheckIn.objects.filter(
-            monitor_id=monitor.id, date_added__gte=start, date_added__lte=end
-        )
-
-        return self.paginate(
-            request=request,
-            queryset=queryset,
-            order_by="-date_added",
-            on_results=lambda x: serialize(x, request.user),
-            paginator_cls=OffsetPaginator,
-        )
+    public = {"POST"}
 
     @extend_schema(
         operation_id="Create a new check-in",

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_attachment.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from django.http.response import FileResponse
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.authentication import DSNAuthentication
+from sentry.api.base import region_silo_endpoint
+from sentry.models import File
+
+from .base import MonitorCheckInAttachmentPermission, MonitorCheckInEndpoint
+
+
+@region_silo_endpoint
+class OrganizationMonitorCheckInAttachmentEndpoint(MonitorCheckInEndpoint):
+    # TODO(davidenwang): Add documentation after uploading feature is complete
+    private = True
+
+    # TODO: Remove DSN authentication for get
+    authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
+    permission_classes = (MonitorCheckInAttachmentPermission,)
+
+    def download(self, file_id):
+        file = File.objects.get(id=file_id)
+        fp = file.getfile()
+        response = FileResponse(
+            fp,
+            content_type=file.headers.get("Content-Type", "application/octet-stream"),
+        )
+        response["Content-Length"] = file.size
+        response["Content-Disposition"] = f"attachment; filename={file.name}"
+        return response
+
+    def get(self, request: Request, project, monitor, checkin) -> Response:
+        if checkin.attachment_id:
+            return self.download(checkin.attachment_id)
+        else:
+            return Response({"detail": "Check-in has no attachment"}, status=404)

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import List
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.authentication import DSNAuthentication
+from sentry.api.base import region_silo_endpoint
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.api.utils import get_date_range_from_params
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOTFOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GLOBAL_PARAMS, MONITOR_PARAMS
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.models import ProjectKey
+from sentry.monitors.models import MonitorCheckIn
+from sentry.monitors.serializers import MonitorCheckInSerializerResponse
+
+from .base import MonitorEndpoint
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Crons"])
+class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint):
+    authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
+    public = {"GET"}
+
+    @extend_schema(
+        operation_id="Retrieve check-ins for a monitor",
+        parameters=[
+            GLOBAL_PARAMS.ORG_SLUG,
+            MONITOR_PARAMS.MONITOR_ID,
+            MONITOR_PARAMS.CHECKIN_ID,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "CheckInList", List[MonitorCheckInSerializerResponse]
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOTFOUND,
+        },
+    )
+    def get(
+        self, request: Request, project, monitor, organization_slug: str | None = None
+    ) -> Response:
+        """
+        Retrieve a list of check-ins for a monitor
+        """
+        # we don't allow read permission with DSNs
+        if isinstance(request.auth, ProjectKey):
+            return self.respond(status=401)
+
+        start, end = get_date_range_from_params(request.GET)
+        if start is None or end is None:
+            raise ParseError(detail="Invalid date range")
+
+        queryset = MonitorCheckIn.objects.filter(
+            monitor_id=monitor.id, date_added__gte=start, date_added__lte=end
+        )
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by="-date_added",
+            on_results=lambda x: serialize(x, request.user),
+            paginator_cls=OffsetPaginator,
+        )

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -264,36 +264,3 @@ class CreateMonitorCheckInTest(MonitorTestCase):
                 assert resp.status_code == 201, resp.content
                 resp = self.client.post(path, {"status": "ok"})
                 assert resp.status_code == 429, resp.content
-
-    def test_statsperiod_constraints(self):
-        self.login_as(self.user)
-
-        for path_func in self._get_path_functions():
-            monitor = self._create_monitor()
-
-            path = path_func(monitor.guid)
-
-            checkin = MonitorCheckIn.objects.create(
-                project_id=self.project.id,
-                monitor_id=monitor.id,
-                status=MonitorStatus.OK,
-                date_added=timezone.now() - timedelta(hours=12),
-            )
-
-            end = timezone.now()
-            startOneHourAgo = end - timedelta(hours=1)
-            startOneDayAgo = end - timedelta(days=1)
-
-            resp = self.client.get(path, {"statsPeriod": "1h"})
-            assert resp.json() == []
-            resp = self.client.get(
-                path, {"start": startOneHourAgo.isoformat(), "end": end.isoformat()}
-            )
-            assert resp.json() == []
-
-            resp = self.client.get(path, {"statsPeriod": "1d"})
-            assert resp.json()[0]["id"] == str(checkin.guid)
-            resp = self.client.get(
-                path, {"start": startOneDayAgo.isoformat(), "end": end.isoformat()}
-            )
-            assert resp.json()[0]["id"] == str(checkin.guid)

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_attachment.py
@@ -1,0 +1,62 @@
+from datetime import timedelta
+
+from django.core.files.base import ContentFile
+from django.urls import reverse
+from django.utils import timezone
+
+from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorType
+from sentry.testutils import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class OrganizationMonitorCheckInAttachmentEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-monitor-check-in-attachment"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+    def _path_func(self, monitor, checkin):
+        return reverse(self.endpoint, args=[self.organization.slug, monitor.guid, checkin.guid])
+
+    def _create_monitor(self):
+        return Monitor.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            config={"schedule": "* * * * *"},
+            date_added=timezone.now() - timedelta(minutes=1),
+        )
+
+    def test_download(self):
+        file = self.create_file(name="log.txt", type="checkin.attachment")
+        file.putfile(ContentFile(b"some data!"))
+
+        monitor = self._create_monitor()
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=self.project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.IN_PROGRESS,
+            attachment_id=file.id,
+        )
+
+        resp = self.get_success_response(self.organization.slug, monitor.slug, checkin.guid)
+        assert resp.get("Content-Disposition") == "attachment; filename=log.txt"
+        assert b"".join(resp.streaming_content) == b"some data!"
+
+    def test_download_no_file(self):
+        monitor = self._create_monitor()
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=self.project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.IN_PROGRESS,
+        )
+
+        resp = self.get_error_response(
+            self.organization.slug, monitor.slug, checkin.guid, status_code=404
+        )
+        assert resp.data["detail"] == "Check-in has no attachment"

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
@@ -1,0 +1,77 @@
+from datetime import timedelta
+
+from django.utils import timezone
+from freezegun import freeze_time
+
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorStatus
+from sentry.testutils import MonitorTestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+@freeze_time()
+class ListMonitorCheckInsTest(MonitorTestCase):
+    endpoint = "sentry-api-0-organization-monitor-check-in-index"
+
+    def setUp(self):
+        super().setUp()
+
+    def test_simple(self):
+        self.login_as(self.user)
+
+        monitor = self._create_monitor()
+        checkin1 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=self.project.id,
+            date_added=monitor.date_added - timedelta(minutes=2),
+            status=CheckInStatus.OK,
+        )
+        checkin2 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=self.project.id,
+            date_added=monitor.date_added - timedelta(minutes=1),
+            status=CheckInStatus.OK,
+        )
+
+        resp = self.get_success_response(
+            self.organization.slug, monitor.slug, **{"statsPeriod": "1d"}
+        )
+        assert len(resp.data) == 2
+
+        # Newest first
+        assert resp.data[0]["id"] == str(checkin2.guid)
+        assert resp.data[1]["id"] == str(checkin1.guid)
+
+    def test_statsperiod_constraints(self):
+        self.login_as(self.user)
+
+        monitor = self._create_monitor()
+
+        checkin = MonitorCheckIn.objects.create(
+            project_id=self.project.id,
+            monitor_id=monitor.id,
+            status=MonitorStatus.OK,
+            date_added=timezone.now() - timedelta(hours=12),
+        )
+
+        end = timezone.now()
+        startOneHourAgo = end - timedelta(hours=1)
+        startOneDayAgo = end - timedelta(days=1)
+
+        resp = self.get_response(self.organization.slug, monitor.slug, **{"statsPeriod": "1h"})
+        assert resp.data == []
+        resp = self.get_response(
+            self.organization.slug,
+            monitor.slug,
+            **{"start": startOneHourAgo.isoformat(), "end": end.isoformat()},
+        )
+        assert resp.data == []
+
+        resp = self.get_response(self.organization.slug, monitor.slug, **{"statsPeriod": "1d"})
+        assert resp.data[0]["id"] == str(checkin.guid)
+        resp = self.get_response(
+            self.organization.slug,
+            monitor.slug,
+            **{"start": startOneDayAgo.isoformat(), "end": end.isoformat()},
+        )
+        assert resp.data[0]["id"] == str(checkin.guid)


### PR DESCRIPTION
This

* splits the GET from the POST in the monitor checkin creation /
  checkin listing endpoint into two.

* splits the GET and POST in the checkin attachment upload / download

The reason we are splitting these is because authentication and
authorization is completely different between these two endpoints, so
really we want to have two totally different base endpoints.

I will be following up with an update to the authentication and base
endpoint classes that should make things much more clear and make
authentication more strict.

Requires #45667 