### PR TITLE
fix(metrics): Delete StringIndexer and PerfStringIndexer past TTL

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -157,6 +157,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
         from sentry.db.deletion import BulkDeleteQuery
         from sentry.monitors import models as monitor_models
         from sentry.replays import models as replay_models
+        from sentry.sentry_metrics.indexer.postgres import models as metrics_indexer_models
         from sentry.utils import metrics
         from sentry.utils.query import RangeQuerySetWrapper
 
@@ -182,6 +183,8 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             (models.GroupRuleStatus, "date_added", None),
             (models.RuleFireHistory, "date_added", None),
             (monitor_models.MonitorCheckIn, "date_added", None),
+            (metrics_indexer_models.StringIndexer, "last_seen", None),
+            (metrics_indexer_models.PerfStringIndexer, "last_seen", None),
         ] + EXTRA_BULK_QUERY_DELETES
 
         # Deletions that use the `deletions` code path (which handles their child relations)

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -9,7 +9,6 @@ from django.db.models import Q
 from psycopg2 import OperationalError
 from psycopg2.errorcodes import DEADLOCK_DETECTED
 
-from sentry.runner.commands import cleanup
 from sentry.sentry_metrics.configuration import IndexerStorage, UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.indexer.base import (
     FetchType,
@@ -21,12 +20,6 @@ from sentry.sentry_metrics.indexer.base import (
 from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCache
 from sentry.sentry_metrics.indexer.limiters.writes import writes_limiter_factory
 from sentry.sentry_metrics.indexer.postgres.models import TABLE_MAPPING, BaseIndexer, IndexerTable
-from sentry.sentry_metrics.indexer.postgres.models import (
-    PerfStringIndexer as PerfStringIndexerPostgresModel,
-)
-from sentry.sentry_metrics.indexer.postgres.models import (
-    StringIndexer as StringIndexerPostgresModel,
-)
 from sentry.sentry_metrics.indexer.strings import StaticStringIndexer
 from sentry.utils import metrics
 
@@ -219,9 +212,3 @@ class PGStringIndexerV2(StringIndexer):
 class PostgresIndexer(StaticStringIndexer):
     def __init__(self) -> None:
         super().__init__(CachingIndexer(indexer_cache, PGStringIndexerV2()))
-        cleanup.EXTRA_BULK_QUERY_DELETES.extend(
-            [
-                (StringIndexerPostgresModel, "last_seen", None),
-                (PerfStringIndexerPostgresModel, "last_seen", None),
-            ]
-        )


### PR DESCRIPTION
### Overview
Adding cleanup tasks for `StringIndexer` and `PerfStringIndexer`. This makes sure we delete rows after 90 days to stay compliant.

### Changes
- Add `StringIndexer` and `PrefStringIndexer` to `BULK_QUERY_DELETES`
- Update [ops/.../services/getsentry/_values.yaml](https://github.com/getsentry/ops/blob/master/k8s/services/getsentry/_values.yaml#L283) to supply additional `PerfStringIndexer` to `--model` command line arguments (see https://github.com/getsentry/sentry/pull/45673)
- Update [ops/.../services/getsentry/_values.yaml](https://github.com/getsentry/ops/blob/master/k8s/services/getsentry/_values.yaml#L283) to supply additional `StringIndexer` to `--model` command line arguments (see https://github.com/getsentry/ops/pull/6301)


Closes [SNS-2109](https://getsentry.atlassian.net/browse/SNS-2109)

[SNS-2109]: https://getsentry.atlassian.net/browse/SNS-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ