### PR TITLE
ref(monitors): Only allow ingest endpoints to use DSN / Token / APIKey auth

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -4,22 +4,19 @@ from django.core.files.uploadedfile import UploadedFile
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.models import File
 
-from .base import MonitorCheckInAttachmentPermission, MonitorCheckInEndpoint
+from .base import MonitorIngestEndpoint
 
 MAX_ATTACHMENT_SIZE = 1024 * 100  # 100kb
 
 
 @region_silo_endpoint
-class MonitorIngestCheckinAttachmentEndpoint(MonitorCheckInEndpoint):
+class MonitorIngestCheckinAttachmentEndpoint(MonitorIngestEndpoint):
     # TODO(davidenwang): Add documentation after uploading feature is complete
     private = True
-    authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
-    permission_classes = (MonitorCheckInAttachmentPermission,)
 
     def post(self, request: Request, project, monitor, checkin) -> Response:
         """

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -6,7 +6,6 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -22,13 +21,12 @@ from sentry.monitors.models import CheckInStatus, Monitor, MonitorStatus
 from sentry.monitors.serializers import MonitorCheckInSerializerResponse
 from sentry.monitors.validators import MonitorCheckInValidator
 
-from .base import MonitorCheckInEndpoint
+from .base import MonitorIngestEndpoint
 
 
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
-class MonitorIngestCheckInDetailsEndpoint(MonitorCheckInEndpoint):
-    authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
+class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
     public = {"PUT"}
 
     @extend_schema(

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -7,7 +7,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import ratelimits
-from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -31,7 +30,7 @@ from sentry.monitors.validators import MonitorCheckInValidator
 from sentry.signals import first_cron_checkin_received, first_cron_monitor_created
 from sentry.utils import metrics
 
-from .base import MonitorEndpoint
+from .base import MonitorIngestEndpoint
 
 CHECKIN_QUOTA_LIMIT = 5
 CHECKIN_QUOTA_WINDOW = 60
@@ -39,8 +38,7 @@ CHECKIN_QUOTA_WINDOW = 60
 
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
-class MonitorIngestCheckInIndexEndpoint(MonitorEndpoint):
-    authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
+class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
     public = {"POST"}
 
     @extend_schema(

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_attachment.py
@@ -4,18 +4,29 @@ from django.http.response import FileResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
+from sentry.api.endpoints.event_attachment_details import EventAttachmentDetailsPermission
 from sentry.models import File
 
-from .base import MonitorCheckInAttachmentPermission, MonitorCheckInEndpoint
+from .base import MonitorCheckInEndpoint, ProjectMonitorPermission
+
+
+class MonitorCheckInAttachmentPermission(EventAttachmentDetailsPermission):
+    scope_map = ProjectMonitorPermission.scope_map
+
+    def has_object_permission(self, request: Request, view, project):
+        result = super().has_object_permission(request, view, project)
+
+        # Allow attachment uploads via DSN
+        if request.method == "POST":
+            return True
+
+        return result
 
 
 @region_silo_endpoint
 class OrganizationMonitorCheckInAttachmentEndpoint(MonitorCheckInEndpoint):
     # TODO(davidenwang): Add documentation after uploading feature is complete
-
-    authentication_classes = MonitorCheckInEndpoint.authentication_classes + (DSNAuthentication,)
     permission_classes = (MonitorCheckInAttachmentPermission,)
 
     def download(self, file_id):

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -7,7 +7,6 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -25,7 +24,6 @@ from .base import MonitorEndpoint
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint):
-    authentication_classes = MonitorEndpoint.authentication_classes + (DSNAuthentication,)
     public = {"GET"}
 
     @extend_schema(

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
@@ -7,17 +7,13 @@ from django.utils import timezone
 
 from sentry.models import File
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorType
-from sentry.testutils import APITestCase
+from sentry.testutils import MonitorIngestTestCase
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
+class MonitorIngestCheckinAttachmentEndpointTest(MonitorIngestTestCase):
     endpoint = "sentry-api-0-organization-monitor-check-in-attachment"
-
-    def setUp(self):
-        super().setUp()
-        self.login_as(self.user)
 
     def get_path(self, monitor, checkin):
         return reverse(self.endpoint, args=[self.organization.slug, monitor.guid, checkin.guid])
@@ -50,6 +46,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
                 ),
             },
             format="multipart",
+            **self.token_auth_headers,
         )
 
         assert resp.status_code == 200, resp.content
@@ -75,6 +72,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
             path,
             {},
             format="multipart",
+            **self.token_auth_headers,
         )
 
         assert resp.status_code == 400
@@ -101,6 +99,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
                 ),
             },
             format="multipart",
+            **self.token_auth_headers,
         )
 
         assert resp.status_code == 400
@@ -124,6 +123,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
                 ),
             },
             format="multipart",
+            **self.token_auth_headers,
         )
 
         assert resp.status_code == 200, resp.content
@@ -143,6 +143,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
                 ),
             },
             format="multipart",
+            **self.token_auth_headers,
         )
 
         assert resp.status_code == 400
@@ -162,6 +163,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(APITestCase):
             path,
             {"file": "invalid_file"},
             format="multipart",
+            **self.token_auth_headers,
         )
 
         assert resp.status_code == 400

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -10,18 +10,17 @@ from sentry.monitors.models import (
     MonitorStatus,
     MonitorType,
 )
-from sentry.testutils import APITestCase
+from sentry.testutils import MonitorIngestTestCase
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class UpdateMonitorIngestCheckinTest(APITestCase):
+class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
     endpoint = "sentry-api-0-monitor-ingest-check-in-details"
     endpoint_with_org = "sentry-api-0-organization-monitor-check-in-details"
 
     def setUp(self):
         super().setUp()
-        self.login_as(self.user)
         self.latest = lambda: None
         self.latest.guid = "latest"
 
@@ -58,7 +57,7 @@ class UpdateMonitorIngestCheckinTest(APITestCase):
             )
 
             path = path_func(monitor.guid, checkin.guid)
-            resp = self.client.put(path)
+            resp = self.client.put(path, **self.token_auth_headers)
             assert resp.status_code == 200, resp.content
 
             checkin = MonitorCheckIn.objects.get(id=checkin.id)
@@ -73,7 +72,7 @@ class UpdateMonitorIngestCheckinTest(APITestCase):
             )
 
             path = path_func(monitor.guid, checkin.guid)
-            resp = self.client.put(path, data={"status": "ok"})
+            resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
             assert resp.status_code == 200, resp.content
 
             checkin = MonitorCheckIn.objects.get(id=checkin.id)
@@ -93,7 +92,7 @@ class UpdateMonitorIngestCheckinTest(APITestCase):
         path = reverse(
             self.endpoint_with_org, args=[self.organization.slug, monitor.slug, checkin.guid]
         )
-        resp = self.client.put(path, data={"status": "ok"})
+        resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
         assert resp.status_code == 200, resp.content
 
         checkin = MonitorCheckIn.objects.get(id=checkin.id)
@@ -107,7 +106,7 @@ class UpdateMonitorIngestCheckinTest(APITestCase):
             )
 
             path = path_func(monitor.guid, checkin.guid)
-            resp = self.client.put(path, data={"status": "error"})
+            resp = self.client.put(path, data={"status": "error"}, **self.token_auth_headers)
             assert resp.status_code == 200, resp.content
 
             checkin = MonitorCheckIn.objects.get(id=checkin.id)
@@ -141,7 +140,7 @@ class UpdateMonitorIngestCheckinTest(APITestCase):
             )
 
             path = path_func(monitor.guid, self.latest.guid)
-            resp = self.client.put(path, data={"status": "ok"})
+            resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
             assert resp.status_code == 200, resp.content
 
             checkin = MonitorCheckIn.objects.get(id=checkin.id)
@@ -169,7 +168,7 @@ class UpdateMonitorIngestCheckinTest(APITestCase):
             )
 
             path = path_func(monitor.guid, self.latest.guid)
-            resp = self.client.put(path, data={"status": "ok"})
+            resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
             assert resp.status_code == 404, resp.content
 
     def test_invalid_checkin_id(self):
@@ -183,5 +182,5 @@ class UpdateMonitorIngestCheckinTest(APITestCase):
             )
 
             path = path_func("invalid-guid", self.latest.guid)
-            resp = self.client.put(path, data={"status": "ok"})
+            resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
             assert resp.status_code == 400, resp.content

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -16,34 +16,29 @@ from sentry.monitors.models import (
     MonitorStatus,
     MonitorType,
 )
-from sentry.testutils import MonitorTestCase
+from sentry.testutils import MonitorIngestTestCase
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
 @freeze_time()
-class CreateMonitorCheckInTest(MonitorTestCase):
+class CreateMonitorCheckInTest(MonitorIngestTestCase):
     endpoint = "sentry-api-0-monitor-ingest-check-in-index"
     endpoint_with_org = "sentry-api-0-organization-monitor-check-in-index"
 
-    def setUp(self):
-        super().setUp()
-
     def test_checkin_using_slug(self):
-        self.login_as(self.user)
         monitor = self._create_monitor(slug="my-monitor")
 
         path = reverse(self.endpoint_with_org, args=[self.organization.slug, monitor.slug])
-        resp = self.client.post(path, {"status": "ok"})
+        resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
 
         assert resp.status_code == 201, resp.content
 
     def test_checkin_slug_orgless(self):
-        self.login_as(self.user)
         monitor = self._create_monitor(slug="my-monitor")
 
         path = reverse(self.endpoint, args=[monitor.slug])
-        resp = self.client.post(path, {"status": "ok"})
+        resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
 
         # Slug based check-ins only work when using the organization routes.
         # This is a 400 unfortunately since we cannot differentiate between a
@@ -51,13 +46,12 @@ class CreateMonitorCheckInTest(MonitorTestCase):
         assert resp.status_code == 400, resp.content
 
     def test_headers_on_creation(self):
-        self.login_as(self.user)
 
         for path_func in self._get_path_functions():
             monitor = self._create_monitor()
             path = path_func(monitor.guid)
 
-            resp = self.client.post(path, {"status": "ok"})
+            resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
             assert resp.status_code == 201, resp.content
 
             # XXX(dcramer): pretty gross assertion but due to the pathing theres no easier way
@@ -69,7 +63,6 @@ class CreateMonitorCheckInTest(MonitorTestCase):
 
     @patch("sentry.analytics.record")
     def test_passing(self, mock_record):
-        self.login_as(self.user)
 
         first_monitor_id = None
         for path_func in self._get_path_functions():
@@ -79,7 +72,7 @@ class CreateMonitorCheckInTest(MonitorTestCase):
 
             path = path_func(monitor.guid)
 
-            resp = self.client.post(path, {"status": "ok"})
+            resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
             assert resp.status_code == 201, resp.content
 
             checkin = MonitorCheckIn.objects.get(guid=resp.data["id"])
@@ -109,13 +102,12 @@ class CreateMonitorCheckInTest(MonitorTestCase):
         )
 
     def test_failing(self):
-        self.login_as(self.user)
 
         for path_func in self._get_path_functions():
             monitor = self._create_monitor()
             path = path_func(monitor.guid)
 
-            resp = self.client.post(path, {"status": "error"})
+            resp = self.client.post(path, {"status": "error"}, **self.token_auth_headers)
             assert resp.status_code == 201, resp.content
 
             checkin = MonitorCheckIn.objects.get(guid=resp.data["id"])
@@ -134,7 +126,6 @@ class CreateMonitorCheckInTest(MonitorTestCase):
             )
 
     def test_disabled(self):
-        self.login_as(self.user)
 
         for path_func in self._get_path_functions():
             monitor = Monitor.objects.create(
@@ -147,7 +138,7 @@ class CreateMonitorCheckInTest(MonitorTestCase):
             )
             path = path_func(monitor.guid)
 
-            resp = self.client.post(path, {"status": "error"})
+            resp = self.client.post(path, {"status": "error"}, **self.token_auth_headers)
             assert resp.status_code == 201, resp.content
 
             checkin = MonitorCheckIn.objects.get(guid=resp.data["id"])
@@ -166,7 +157,6 @@ class CreateMonitorCheckInTest(MonitorTestCase):
             )
 
     def test_pending_deletion(self):
-        self.login_as(self.user)
 
         monitor = Monitor.objects.create(
             organization_id=self.organization.id,
@@ -180,11 +170,10 @@ class CreateMonitorCheckInTest(MonitorTestCase):
         for path_func in self._get_path_functions():
             path = path_func(monitor.guid)
 
-            resp = self.client.post(path, {"status": "error"})
+            resp = self.client.post(path, {"status": "error"}, **self.token_auth_headers)
             assert resp.status_code == 404
 
     def test_deletion_in_progress(self):
-        self.login_as(self.user)
 
         monitor = Monitor.objects.create(
             organization_id=self.organization.id,
@@ -198,18 +187,18 @@ class CreateMonitorCheckInTest(MonitorTestCase):
         for path_func in self._get_path_functions():
             path = path_func(monitor.guid)
 
-            resp = self.client.post(path, {"status": "error"})
+            resp = self.client.post(path, {"status": "error"}, **self.token_auth_headers)
             assert resp.status_code == 404
 
     def test_with_dsn_auth(self):
-        project_key = self.create_project_key(project=self.project)
-
         for path_func in self._get_path_functions():
             monitor = self._create_monitor()
             path = path_func(monitor.guid)
 
             resp = self.client.post(
-                path, {"status": "ok"}, HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}"
+                path,
+                {"status": "ok"},
+                **self.dsn_auth_headers,
             )
             assert resp.status_code == 201, resp.content
 
@@ -219,7 +208,6 @@ class CreateMonitorCheckInTest(MonitorTestCase):
 
     def test_with_dsn_auth_invalid_project(self):
         project2 = self.create_project()
-        project_key = self.create_project_key(project=self.project)
 
         monitor = Monitor.objects.create(
             organization_id=project2.organization_id,
@@ -235,7 +223,7 @@ class CreateMonitorCheckInTest(MonitorTestCase):
             resp = self.client.post(
                 path,
                 {"status": "ok"},
-                HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
+                **self.dsn_auth_headers,
             )
 
             assert resp.status_code == 404, resp.content
@@ -243,14 +231,12 @@ class CreateMonitorCheckInTest(MonitorTestCase):
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
         path = f"/api/0/organizations/asdf/monitors/{monitor.guid}/checkins/"
-        self.login_as(user=self.user)
 
-        resp = self.client.post(path)
+        resp = self.client.post(path, **self.token_auth_headers)
 
         assert resp.status_code == 404
 
     def test_rate_limit(self):
-        self.login_as(self.user)
 
         for path_func in self._get_path_functions():
             monitor = self._create_monitor()
@@ -260,7 +246,7 @@ class CreateMonitorCheckInTest(MonitorTestCase):
             with mock.patch(
                 "sentry.monitors.endpoints.monitor_ingest_checkin_index.CHECKIN_QUOTA_LIMIT", 1
             ):
-                resp = self.client.post(path, {"status": "ok"})
+                resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
                 assert resp.status_code == 201, resp.content
-                resp = self.client.post(path, {"status": "ok"})
+                resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
                 assert resp.status_code == 429, resp.content

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_attachment.py
@@ -1,34 +1,17 @@
-from datetime import timedelta
-
 from django.core.files.base import ContentFile
-from django.urls import reverse
-from django.utils import timezone
 
-from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorType
-from sentry.testutils import APITestCase
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn
+from sentry.testutils import MonitorTestCase
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
-class OrganizationMonitorCheckInAttachmentEndpointTest(APITestCase):
+class OrganizationMonitorCheckInAttachmentEndpointTest(MonitorTestCase):
     endpoint = "sentry-api-0-organization-monitor-check-in-attachment"
 
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
-
-    def _path_func(self, monitor, checkin):
-        return reverse(self.endpoint, args=[self.organization.slug, monitor.guid, checkin.guid])
-
-    def _create_monitor(self):
-        return Monitor.objects.create(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
-            date_added=timezone.now() - timedelta(minutes=1),
-        )
 
     def test_download(self):
         file = self.create_file(name="log.txt", type="checkin.attachment")

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
@@ -15,10 +15,9 @@ class ListMonitorCheckInsTest(MonitorTestCase):
 
     def setUp(self):
         super().setUp()
+        self.login_as(user=self.user)
 
     def test_simple(self):
-        self.login_as(self.user)
-
         monitor = self._create_monitor()
         checkin1 = MonitorCheckIn.objects.create(
             monitor=monitor,
@@ -43,8 +42,6 @@ class ListMonitorCheckInsTest(MonitorTestCase):
         assert resp.data[1]["id"] == str(checkin1.guid)
 
     def test_statsperiod_constraints(self):
-        self.login_as(self.user)
-
         monitor = self._create_monitor()
 
         checkin = MonitorCheckIn.objects.create(

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -9,8 +9,8 @@ class OrganizationMonitorDetailsTest(MonitorTestCase):
     endpoint = "sentry-api-0-organization-monitor-details"
 
     def setUp(self):
-        self.login_as(user=self.user)
         super().setUp()
+        self.login_as(user=self.user)
 
     def test_simple(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
* Adds a new MonitorIngestEndpoint base class that only allows for DSN and Token / API Key based authentication. This means the endpoints no longer need to specify this themselves.

 * Updates ingestion test cases to only use Token or DSN auth

 * Cleans up test cases by adding a new MonitorIngestTestCase and simplifying the MonitorTestCase (since it does not need the dual-url path generation helpers)

 * Remove DSN authentication from the checkin index listing endpoint

A follow up to this will be to break apart the inheritance of the MonitorEndpoint since it is trying to do far too much, and now is able to be much simpler since ingestion is separated out.

This is a follow up of https://github.com/getsentry/sentry/pull/45672