### PR TITLE
chore(issue-platform): Mark error issues as released

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -172,6 +172,7 @@ class ErrorGroupType(GroupType):
     slug = "error"
     description = "Error"
     category = GroupCategory.ERROR.value
+    released = True
 
 
 # used as an additional superclass for Performance GroupType defaults


### PR DESCRIPTION
Error issues are the only ones that are fully released to all customers right now, so marking as released. All other issue types are either completely unreleased, or GAed via flags
