### PR TITLE
feat(issue-platform): Use policy layer to control ingest of new occurrences

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -20,10 +20,10 @@ from arroyo.types import Commit, Message, Partition
 from django.conf import settings
 from django.utils import timezone
 
-from sentry import features, nodestore
+from sentry import nodestore
 from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
-from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
+from sentry.issues.grouptype import get_group_type_by_type_id
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
@@ -262,9 +262,8 @@ def _process_message(
             txn.set_tag("project_id", project.id)
             txn.set_tag("project_slug", project.slug)
 
-            if occurrence_data["type"] not in get_group_types_by_category(
-                GroupCategory.PROFILE.value
-            ) or not features.has("organizations:profile-blocked-main-thread-ingest", organization):
+            group_type = get_group_type_by_type_id(occurrence_data["type"])
+            if not group_type.allow_ingest(organization):
                 metrics.incr(
                     "occurrence_ingest.dropped_feature_disabled",
                     sample_rate=1.0,


### PR DESCRIPTION
This moves away from manually using feature flags to use `GroupType.allow_ingest` when ingesting occurrences. In production, control over whether to ingest events is now controlled via options in https://sentry.io/_admin/options/. The options are all in the format `issues.*.ingest.<cohort>-rollout`.

I've set all profiling issues to be rolled out to LA for ingest, so this should continue to work for profiling we're currently experimenting with.



