### PR TITLE
feat(issue-platform): Use policy layer to control whether issue types should run `post_process_group`

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from sentry import features
 from sentry.exceptions import PluginError
-from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
+from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
@@ -544,11 +544,7 @@ def post_process_group(
 def run_post_process_job(job: PostProcessJob):
     group_event = job["event"]
     issue_category = group_event.group.issue_category
-    if group_event.group.issue_type.type_id in get_group_types_by_category(
-        GroupCategory.PROFILE.value
-    ) and not features.has(
-        "organizations:profile-blocked-main-thread-ppg", group_event.group.organization
-    ):
+    if not group_event.group.issue_type.allow_post_process_group(group_event.group.organization):
         return
     if issue_category not in GROUP_CATEGORY_POST_PROCESS_PIPELINE:
         # pipeline for generic issues

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -1,5 +1,6 @@
 from django.core import mail
 
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.mail.actions import NotifyEmailAction, NotifyEmailForm
 from sentry.models import OrganizationMember, OrganizationMemberTeam, ProjectOwnership, Rule
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
@@ -253,7 +254,9 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase):
             project=event.project, data={"conditions": [condition_data], "actions": [action_data]}
         )
 
-        with self.tasks():
+        with self.tasks(), self.feature(
+            PerformanceNPlusOneGroupType.build_post_process_group_feature_name()
+        ):
             post_process_group(
                 is_new=True,
                 is_regression=False,


### PR DESCRIPTION
This moves away from manually using feature flags to use GroupType.allow_post_process_group when running `post_process_group`. In production, control over whether to run `post_process_group` for an issue type is now controlled via options in https://sentry.io/_admin/options/. The options are all in the format issues.*.post-process-group.<cohort>-rollout.

Note that this should not be merged until:
 - https://github.com/getsentry/sentry/pull/45679 - Make sure errors still get processed here
 - We need to go through and make sure all performance issues that are in production have this option GAed.
