### PR TITLE
feat(options): Add grouping metadata to options

### DIFF
--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -5,7 +5,7 @@ import dataclasses
 import logging
 from random import random
 from time import time
-from typing import Any
+from typing import Any, Optional
 
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils import timezone
@@ -20,6 +20,14 @@ logger = logging.getLogger("sentry")
 
 
 @dataclasses.dataclass
+class GroupingInfo:
+    # Name of the group of options to include this option in
+    name: str
+    # Order of the option within the group
+    order: int
+
+
+@dataclasses.dataclass
 class Key:
     name: str
     default: Any
@@ -28,6 +36,7 @@ class Key:
     ttl: int
     grace: int
     cache_key: str
+    grouping_info: Optional[GroupingInfo]
 
 
 def _make_cache_value(key, value):

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -34,7 +34,7 @@ class OptionsStoreTest(TestCase):
         self.store.flush_local_cache()
 
     def make_key(self, ttl=10, grace=10):
-        return self.manager.make_key(uuid1().hex, "", object, 0, ttl, grace)
+        return self.manager.make_key(uuid1().hex, "", object, 0, ttl, grace, None)
 
     def test_simple(self):
         store, key = self.store, self.key


### PR DESCRIPTION
This adds the ability to add grouping information to options. This will be used in the `_admin` ui to group related options together and sort them appropriately.


