### PR TITLE
fix(gitlab): Do not mistag org slug

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -11,7 +11,7 @@ from django.views.generic import View
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.integrations.utils import clear_tags_and_context
+from sentry.integrations.utils.cleanup import clear_tags_and_context
 from sentry.models import Commit, CommitAuthor, Integration, PullRequest, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import json

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -11,6 +11,7 @@ from django.views.generic import View
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.integrations.utils import clear_tags_and_context
 from sentry.models import Commit, CommitAuthor, Integration, PullRequest, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import json
@@ -194,6 +195,7 @@ class GitlabWebhookEndpoint(View):
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request: Request) -> Response:
+        clear_tags_and_context()
         extra = {
             # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
             "user-agent": request.META.get("HTTP_USER_AGENT"),


### PR DESCRIPTION
[This error](https://sentry.sentry.io/discover/sentry:c504f90e8abe42eb947b9be2698af5ea/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=Exception%3A+The+webhook+secrets+do+not+match.&project=1&query=issue%3ASENTRY-W3F+organization.slug%3Afancy-bits-llc&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29) is tagged with a different org's slug.

This is a follow up to https://github.com/getsentry/sentry/pull/45368 and https://github.com/getsentry/sentry/pull/45139

The `extra` variable (trimmed to prevent PII leakeage) shows the correct slug but the `organization.slug` tag points to a different one.
<img width="196" alt="image" src="https://user-images.githubusercontent.com/44410/224774127-9f6ca18b-35b6-48b2-8e4f-6b90ba248d23.png">
