### PR TITLE
fix(crons) Add missing CSRF exemption for checkin endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1334,6 +1334,7 @@ ORGANIZATION_URLS = [
         method_dispatch(
             GET=OrganizationMonitorCheckInIndexEndpoint.as_view(),
             POST=MonitorIngestCheckInIndexEndpoint.as_view(),  # Legacy ingest endpoint
+            csrf_exempt=True,
         ),
         name="sentry-api-0-organization-monitor-check-in-index",
     ),

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from django.http import HttpResponseNotAllowed
 from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
 from sentry import options
@@ -282,5 +283,8 @@ def method_dispatch(**dispatch_mapping):  # type: ignore[no-untyped-def]
     def dispatcher(request, *args, **kwargs):  # type: ignore[no-untyped-def]
         handler = dispatch_mapping.get(request.method, invalid_method)
         return handler(request, *args, **kwargs)
+
+    if dispatch_mapping.get("csrf_exempt"):
+        return csrf_exempt(dispatcher)
 
     return dispatcher


### PR DESCRIPTION
The method delegator also needs to be able to apply CSRF exemption so that monitors can accept a DSN auth. There is an existing test for this authentication mode but it doesn't have issues with CSRF and I don't yet know why.

Refs #45690
