### PR TITLE
(perf-issues): group duplicate span hashes in consecutive http detector

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -180,7 +180,7 @@ def fingerprint_spans(spans: List[Span], unique_only: bool = False):
     for span in spans:
         hash = str(span.get("hash", "") or "")
         if not unique_only or hash not in span_hashes:
-            span_hashes.append(str(hash))
+            span_hashes.append(hash)
     joined_hashes = "-".join(span_hashes)
     return hashlib.sha1(joined_hashes.encode("utf8")).hexdigest()
 

--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -175,11 +175,12 @@ def get_url_from_span(span: Span) -> str:
     return url
 
 
-def fingerprint_spans(spans: List[Span]):
+def fingerprint_spans(spans: List[Span], unique_only: bool = False):
     span_hashes = []
     for span in spans:
-        hash = span.get("hash", "") or ""
-        span_hashes.append(str(hash))
+        hash = str(span.get("hash", "") or "")
+        if not unique_only or hash not in span_hashes:
+            span_hashes.append(str(hash))
     joined_hashes = "-".join(span_hashes)
     return hashlib.sha1(joined_hashes.encode("utf8")).hexdigest()
 

--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -123,7 +123,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         return True
 
     def _fingerprint(self) -> str:
-        hashed_spans = fingerprint_spans(self.consecutive_http_spans)
+        hashed_spans = fingerprint_spans(self.consecutive_http_spans, True)
         return f"1-{PerformanceConsecutiveHTTPQueriesGroupType.type_id}-{hashed_spans}"
 
     def on_complete(self) -> None:

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
@@ -137,3 +137,28 @@ class ConsecutiveDbDetectorTest(TestCase):
         ]  # ensure spans don't overlap
 
         assert self.find_problems(create_event(spans)) == []
+
+    def test_fingerprints_match_with_duplicate_http(self):
+        span_duration = 2000
+        spans = [
+            create_span("http.client", span_duration, "GET /api/endpoint1", "hash1"),
+            create_span("http.client", span_duration, "GET /api/endpoint2", "hash2"),
+            create_span("http.client", span_duration, "GET /api/endpoint3", "hash3"),
+        ]
+
+        spans = [
+            modify_span_start(span, span_duration * spans.index(span)) for span in spans
+        ]  # ensure spans don't overlap
+
+        problem_1 = self.find_problems(create_event(spans))[0]
+
+        spans.append(
+            modify_span_start(
+                create_span("http.client", span_duration, "GET /api/endpoint3", "hash3"), 6000
+            )
+        )
+
+        problem_2 = self.find_problems(create_event(spans))[0]
+
+        assert problem_2.fingerprint == "1-1009-30ce2c8eaf7cae732346206dcd23c3f016e75f64"
+        assert problem_1.fingerprint == problem_2.fingerprint


### PR DESCRIPTION
There are cases where you make consecutive calls to the same endpoint, but the number of those consecutive calls varies, we want to make sure these cases get grouped together.