### PR TITLE
feat(perf-issues): Add an option and project option to send occurrences to platform

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -127,6 +127,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     copy_from_project = serializers.IntegerField(required=False)
     dynamicSamplingBiases = DynamicSamplingBiasSerializer(required=False, many=True)
     performanceIssueCreationRate = serializers.FloatField(required=False, min_value=0, max_value=1)
+    performanceIssueCreationThroughPlatform = serializers.BooleanField(required=False)
 
     def validate(self, data):
         max_delay = (
@@ -617,6 +618,14 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:performance_issue_creation_rate"] = result[
                     "performanceIssueCreationRate"
+                ]
+        if "performanceIssueCreationThroughPlatform" in result:
+            if project.update_option(
+                "sentry:performance_issue_send_to_issues_platform",
+                result["performanceIssueCreationThroughPlatform"],
+            ):
+                changed_proj_settings["sentry:performance_issue_send_to_issues_platform"] = result[
+                    "performanceIssueCreationThroughPlatform"
                 ]
         # TODO(dcramer): rewrite options to use standard API config
         if has_project_write:

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -175,6 +175,9 @@ def format_options(attrs: defaultdict(dict)):
         "sentry:performance_issue_creation_rate": options.get(
             "sentry:performance_issue_creation_rate"
         ),
+        "sentry:performance_issue_send_to_issues_platform": options.get(
+            "sentry:performance_issue_send_to_issues_platform"
+        ),
         "filters:blacklisted_ips": "\n".join(options.get("sentry:blacklisted_ips", [])),
         "filters:react-hydration-errors": bool(options.get("filters:react-hydration-errors", True)),
         f"filters:{FilterTypes.RELEASES}": "\n".join(
@@ -881,6 +884,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "dynamicSamplingBiases": get_value_with_default("sentry:dynamic_sampling_biases"),
                 "performanceIssueCreationRate": get_value_with_default(
                     "sentry:performance_issue_creation_rate"
+                ),
+                "performanceIssueCreationThroughPlatform": get_value_with_default(
+                    "sentry:performance_issue_send_to_issues_platform"
                 ),
                 "eventProcessing": {
                     "symbolicationDegraded": False,

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -52,6 +52,7 @@ OPTION_KEYS = frozenset(
         "sentry:breakdowns",
         "sentry:span_attributes",
         "sentry:performance_issue_creation_rate",
+        "sentry:performance_issue_send_to_issues_platform",
         "sentry:transaction_name_cluster_rules",
         "quotas:spike-protection-disabled",
         "feedback:branding",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -642,6 +642,9 @@ register("performance.issues.render_blocking_assets.fcp_maximum_threshold", defa
 register("performance.issues.render_blocking_assets.fcp_ratio_threshold", default=0.33)
 register("performance.issues.render_blocking_assets.size_threshold", default=1000000)
 
+# System-wise option for performance issue creation through issues platform
+register("performance.issues.send_to_occurrences_platform", default=False)
+
 # Dynamic Sampling system wide options
 # Killswitch to disable new dynamic sampling behavior specifically new dynamic sampling biases
 register("dynamic-sampling:enabled-biases", default=True)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -643,7 +643,7 @@ register("performance.issues.render_blocking_assets.fcp_ratio_threshold", defaul
 register("performance.issues.render_blocking_assets.size_threshold", default=1000000)
 
 # System-wise option for performance issue creation through issues platform
-register("performance.issues.send_to_occurrences_platform", default=False)
+register("performance.issues.send_to_issues_platform", default=False)
 
 # Dynamic Sampling system wide options
 # Killswitch to disable new dynamic sampling behavior specifically new dynamic sampling biases

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -101,6 +101,10 @@ register(key="sentry:span_attributes", epoch_defaults={1: ["exclusive-time"]})
 # Can be used to turn off a projects detection for users if there is a project-specific issue.
 register(key="sentry:performance_issue_creation_rate", default=1.0)
 
+# Rate at which performance issues are created through issues platform per project. Defaults to False, system flags and options will determine if an organization creates issues through platform.
+# Can be used to turn off issue creation for users if there is a project-specific issue.
+register(key="sentry:performance_issue_send_to_issues_platform", default=False)
+
 DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "n_plus_one_db_detection_rate": 1.0,
     "n_plus_one_api_calls_detection_rate": 1.0,


### PR DESCRIPTION
Create a system-wide and per-project options that would control whether a performance problem is sent to the occurrences platform. Both options need to be booleans since the options will be checked first in `save_aggregate_performance` and then in `send_occurrence_to_platform` and there's no reliable way to ensure that only one function gets run.
