### PR TITLE
feat(dev): Set a dynamic hostname when api requests proxy to the server in dev-ui

### DIFF
--- a/static/app/utils/extractSlug.tsx
+++ b/static/app/utils/extractSlug.tsx
@@ -3,8 +3,9 @@ type ExtractedSlug = {
   slug: string;
 };
 
-// XXX: If you change this also change its sibiling in static/index.ejs
-// The two regexps are not exactly the same
+// XXX: If you change this also change its sibiling in:
+// - static/index.ejs
+// - webpack.config.ts
 const KNOWN_DOMAINS = /(?:\.?)((?:localhost|dev\.getsentry\.net|sentry\.dev)(?:\:\d*)?)$/;
 
 /**

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -15,8 +15,10 @@
     <script type="text/javascript">
     try {
       function extractSlug() {
-        // XXX: If you change this also change its sibiling in static/app/utils/extractSlug.tsx
-        // The two regexps are not meant to be exactly the same
+        // XXX: If you change this also change its sibilings in:
+        // - static/app/utils/extractSlug.tsx
+        // - webpack.config.ts
+        // NB: This RegExp is not exactly the same as the other two
         var knownDomains = /\.(?:localhost|dev\.getsentry\.net|sentry\.dev)(?:\:\d*)?$/;
         if (window.location.host.match(knownDomains)) {
           var domainParts = window.location.host.split('.');

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -584,6 +584,26 @@ if (
 //
 // Various sentry pages still rely on django to serve html views.
 if (IS_UI_DEV_ONLY) {
+  // XXX: If you change this also change its sibiling in:
+  // - static/index.ejs
+  // - static/app/utils/extractSlug.tsx
+  const KNOWN_DOMAINS =
+    /(?:\.?)((?:localhost|dev\.getsentry\.net|sentry\.dev)(?:\:\d*)?)$/;
+
+  const extractSlug = (hostname: string) => {
+    const match = hostname.match(KNOWN_DOMAINS);
+    if (!match) {
+      return null;
+    }
+
+    const [
+      matchedExpression, // Expression includes optional leading `.`
+    ] = match;
+
+    const [slug] = hostname.replace(matchedExpression, '').split('.');
+    return slug;
+  };
+
   // Try and load certificates from mkcert if available. Use $ yarn mkcert-localhost
   const certPath = path.join(__dirname, 'config');
   const httpsOptions = !fs.existsSync(path.join(certPath, 'localhost.pem'))
@@ -617,6 +637,10 @@ if (IS_UI_DEV_ONLY) {
           'Document-Policy': 'js-profiling',
         },
         cookieDomainRewrite: {'.sentry.io': 'localhost'},
+        router: ({hostname}) => {
+          const orgSlug = extractSlug(hostname);
+          return orgSlug ? `https://${orgSlug}.sentry.io` : 'https://sentry.io';
+        },
       },
     ],
     historyApiFallback: {


### PR DESCRIPTION
### What
This updates our webpack devServer proxy config so the `target` is dynamic based on the local hostname you're using. So if you're visiting `https://testorg-az.dev.getsentry.net:7999` then the proxy will use `https://testorg-az.sentry.io/` instead of the naked `https://sentry.io/`

Thanks to https://github.com/chimurai/http-proxy-middleware/issues/200#issuecomment-776376844

### Why?

Before we were sending proxy requests to `sentry.io`, which don't have a subdomain in the url. 

Without a subdomain, the [`SubdomainMiddleware`](https://github.com/getsentry/sentry/blob/a6ee2a872617588cd1a2be45fa0c3ff6e823cf69/src/sentry/middleware/subdomain.py#LL41C14-L41C14) couldn't do it's job, because the hostname doesn't end with `.sentry.io`. There's no leading `.` to match.

The outcome is that the `activeorg` wasn't set inside [`CustomerDomainMiddleware`](https://github.com/getsentry/sentry/blob/master/src/sentry/middleware/customer_domain.py#L80-L81) and therefore fields like `lastOrganization` and `customerDomain` inside of `/api/client-config/` were set to incorrect values. 

When `/api/client-config/` has the wrong stuff (`customerDomain`  would be null, and `lastOrganization` would often be some other domain that doesn't related to the current url in the browser) then a fresh pageload under `yarn dev-ui` would cause failures, show an org that doesn't match the url, and generally "just not work".

How to test that:
1. Login to two orgs on sentry.io:
   - https://sentry.sentry.io/issues/
   - https://testorg-az.sentry.io/issues/
2. Run `yarn dev-ui` and login there as well (copy cookies across etc)
   - https://sentry.dev.getsentry.net:7999/api/client-config/
   - https://testorg-az.dev.getsentry.net:7999/api/client-config/

Notice that when you look at the client-config responses:
- `customerDomain` is null
- `lastOrganization` is set to the same thing in in both responses. It will be `sentry` if you visit `https://sentry.sentry.io/issues/` and reload the page, or `testorg-az` of you reload the prod issue page for that org.

When in this state, if you load up /issues/ you'll see data related to whatever `lastOrganization` is set to. The url in the browser doesn't matter :(


The proxy change fixes that, so the url you see: "testorg-az.dev.getsentry.net:7999" matches the data that's loaded.


