### PR TITLE
fix(domains) Improve devserver + customer domains

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -34,7 +34,13 @@ register("system.maximum-file-size", default=2**31, flags=FLAG_PRIORITIZE_DISK)
 
 # URL configuration
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
-register("system.url-prefix", ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
+register(
+    "system.url-prefix",
+    ttl=60,
+    grace=3600,
+    default=os.environ.get("SENTRY_SYSTEM_URL_PREFIX"),
+    flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK,
+)
 register("system.internal-url-prefix", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 # Base hostname that account domains are subdomains of.
 register(

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -194,6 +194,7 @@ and run `sentry devservices up kafka zookeeper`.
     os.environ["NODE_ENV"] = "production" if environment.startswith("prod") else environment
 
     # Configure URL prefixes for customer-domains.
+    os.environ["SENTRY_SYSTEM_URL_PREFIX"] = f"http://localhost:{port}"
     os.environ["SENTRY_SYSTEM_BASE_HOSTNAME"] = f"localhost:{port}"
     os.environ["SENTRY_ORGANIZATION_BASE_HOSTNAME"] = f"{{slug}}.localhost:{port}"
     os.environ["SENTRY_ORGANIZATION_URL_TEMPLATE"] = "http://{hostname}"


### PR DESCRIPTION
If you have system.url-prefix defined as a domain that includes a customer domain you'll get trapped in a redirect loop when going to `/organizations/new/` as the application will try to remove the customer domain, by redirecting to system.url-prefix.

By setting a default value for the option we can improve the workflow for new devserver environments as they'll have this option pre-configured.