### PR TITLE
feat(perf-issues): Initialize UI for consecutive http

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -81,6 +81,7 @@ export function SpanEvidenceKeyValueList({
       [IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES]: ConsecutiveDBQueriesSpanEvidence,
       [IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET]: RenderBlockingAssetSpanEvidence,
       [IssueType.PERFORMANCE_UNCOMPRESSED_ASSET]: UncompressedAssetSpanEvidence,
+      [IssueType.PERFORMANCE_CONSECUTIVE_HTTP]: ConsecutiveHTTPSpanEvidence,
     }[performanceProblem.issueType] ?? DefaultSpanEvidence;
 
   return (
@@ -113,6 +114,25 @@ const ConsecutiveDBQueriesSpanEvidence = ({
         makeRow(
           t('Duration Impact'),
           getDurationImpact(event, getConsecutiveDbTimeSaved(causeSpans, offendingSpans))
+        ),
+      ].filter(Boolean) as KeyValueListData
+    }
+  />
+);
+
+const ConsecutiveHTTPSpanEvidence = ({
+  event,
+  offendingSpans,
+  orgSlug,
+  projectSlug,
+}: SpanEvidenceKeyValueListProps) => (
+  <PresortedKeyValueList
+    data={
+      [
+        makeTransactionNameRow(event, orgSlug, projectSlug),
+        makeRow(
+          'Offending Spans',
+          offendingSpans.map(span => span.description)
         ),
       ].filter(Boolean) as KeyValueListData
     }

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -61,6 +61,7 @@ export enum IssueType {
 
   // Performance
   PERFORMANCE_CONSECUTIVE_DB_QUERIES = 'performance_consecutive_db_queries',
+  PERFORMANCE_CONSECUTIVE_HTTP = 'performance_consecutive_http',
   PERFORMANCE_FILE_IO_MAIN_THREAD = 'performance_file_io_main_thread',
   PERFORMANCE_N_PLUS_ONE_API_CALLS = 'performance_n_plus_one_api_calls',
   PERFORMANCE_N_PLUS_ONE_DB_QUERIES = 'performance_n_plus_one_db_queries',

--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -44,6 +44,20 @@ const performanceConfig: IssueCategoryConfigMapping = {
       linksByPlatform: {},
     },
   },
+  [IssueType.PERFORMANCE_CONSECUTIVE_HTTP]: {
+    resources: {
+      description: t(
+        'A Consecutive HTTP issue occurs when X number of consecutive HTTP calls occur sequentially, each taking Y amount of time'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: Consecutive HTTP'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/consecutive-http/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
   [IssueType.PERFORMANCE_FILE_IO_MAIN_THREAD]: {
     resources: {
       description: t('File IO operations on your main thread may lead to app hangs.'),

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -258,6 +258,14 @@ function GroupHeader({
         >
           <StyledShortId shortId={group.shortId} />
         </Tooltip>
+        {group.issueType === IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES && (
+          <FeatureBadge
+            type="alpha"
+            title={t(
+              'Consecutive HTTP Performance Issues are in active development and may change'
+            )}
+          />
+        )}
         {group.issueType === IssueType.PERFORMANCE_SLOW_DB_QUERY && (
           <FeatureBadge
             type="alpha"


### PR DESCRIPTION
Creates an initial UI for consecutive http, not final by any means, but it's enough for an internal release.