### PR TITLE
feat(mobile): Update event serializer to map device.class tag values

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -765,7 +765,7 @@ DEVICE_CLASS = {
 }
 
 
-def map_device_class_level(device_class: str) -> str:
+def map_device_class_level(device_class: str) -> Optional[str]:
     for key, value in DEVICE_CLASS.items():
         if device_class in value:
             return key

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -763,3 +763,10 @@ DEVICE_CLASS = {
     "medium": {"2"},
     "high": {"3"},
 }
+
+
+def map_device_class_level(device_class: str) -> str:
+    for key, value in DEVICE_CLASS.items():
+        if device_class in value:
+            return key
+    return None

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -283,3 +283,47 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         assert len(top_values) == 2
         assert top_values[0]["value"] == "android"
         assert top_values[1]["value"] == "iOS"
+
+    def test_device_class(self):
+        for _ in range(3):
+            self.store_event(
+                data={
+                    "fingerprint": ["group-1"],
+                    "tags": {"device.class": "1"},
+                    "timestamp": iso_format(before_now(minutes=1)),
+                },
+                project_id=self.project.id,
+            )
+        for _ in range(2):
+            self.store_event(
+                data={
+                    "fingerprint": ["group-1"],
+                    "tags": {"device.class": "2"},
+                    "timestamp": iso_format(before_now(minutes=1)),
+                },
+                project_id=self.project.id,
+            )
+        event = self.store_event(
+            data={
+                "fingerprint": ["group-1"],
+                "tags": {"device.class": "3"},
+                "timestamp": iso_format(before_now(minutes=1)),
+            },
+            project_id=self.project.id,
+        )
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{event.group.id}/tags/?limit=3&key=device.class"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["key"] == "device.class"
+        assert response.data[0]["totalValues"] == 6
+
+        top_values = sorted(response.data[0]["topValues"], key=lambda r: r["value"])
+        assert len(top_values) == 3
+        assert top_values[0]["value"] == "high"
+        assert top_values[1]["value"] == "low"
+        assert top_values[2]["value"] == "medium"


### PR DESCRIPTION
Updates event serializers to map `device.class` tags in the event to `high, medium, low`.
This update affects endpoints like `/events` used in the issue details page.

![image](https://user-images.githubusercontent.com/83961295/224824514-34a3f4a2-7259-49ca-b6f1-3cadca3f71b1.png)
