### PR TITLE
ref(monitors): Split base endpoints

### DIFF
--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -33,16 +33,103 @@ class ProjectMonitorPermission(ProjectPermission):
 
 
 class MonitorEndpoint(Endpoint):
-    permission_classes = (ProjectMonitorPermission,)
+    """
+    Base endpoint class for monitors which will lookup the monitor ID and
+    convert it to a Monitor object.
 
-    # TODO(epurkhiser): This should be vastly simplified to not deal with
-    # missing organization_slug. Only endpoints that extend the
-    # MonitorIngestEndpoint need to deal with that (it should not extend this)
+    Currently this has two strategies for monitor lookup
+
+    1. Via the monitor slug. In this scenario the organization_slug MUST be
+       present, since monitor slugs are unique with the organization_slug
+
+    2. Via the monitor GUID. In this scenario the organization_slug is not
+       required as GUIDs are global to sentry. We will check that the
+       organization resulting from the monitor project
+
+    [!!]: This base endpoint is NOT used for legacy ingestion endpoints, see
+          MonitorIngestEndpoint for that.
+    """
+
+    permission_classes = (ProjectMonitorPermission,)
 
     def convert_args(
         self,
         request: Request,
+        organization_slug: str,
         monitor_id: str,
+        checkin_id: str | None = None,
+        *args,
+        **kwargs,
+    ):
+        try:
+            organization = Organization.objects.get_from_cache(slug=organization_slug)
+        except Organization.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        try:
+            # Try lookup by slug first
+            monitor = Monitor.objects.get(organization_id=organization.id, slug=monitor_id)
+        except Monitor.DoesNotExist:
+            # Try lookup by GUID. We cannot consolidate this into one query as
+            # we need to validate the slug is a GUID before trying to query on
+            # the GUID column, otherwise we'll produce a postgres error
+            try:
+                UUID(monitor_id)
+            except ValueError:
+                # This error is a bit confusing, because this may also mean
+                # that we've failed to lookup their monitor by slug.
+                raise ParameterValidationError("Invalid monitor UUID")
+            try:
+                monitor = Monitor.objects.get(organization_id=organization.id, guid=monitor_id)
+            except Monitor.DoesNotExist:
+                raise ResourceDoesNotExist
+
+        project = Project.objects.get_from_cache(id=monitor.project_id)
+        if project.status != ProjectStatus.VISIBLE:
+            raise ResourceDoesNotExist
+
+        self.check_object_permissions(request, project)
+
+        with configure_scope() as scope:
+            scope.set_tag("project", project.id)
+
+        bind_organization_context(project.organization)
+
+        request._request.organization = project.organization
+
+        kwargs["organization"] = organization
+        kwargs["project"] = project
+        kwargs["monitor"] = monitor
+
+        if checkin_id:
+            checkin = try_checkin_lookup(monitor, checkin_id)
+            kwargs["checkin"] = checkin
+
+        return args, kwargs
+
+
+class MonitorIngestEndpoint(Endpoint):
+    """
+    This type of endpont explicitly only allows for DSN and Token / Key based authentication.
+
+    [!!]: These endpoints support routes which **do not specify the
+          organization slug**! This endpoint is extra careful in those cases to
+          validate
+
+    [!!]: These endpoints are legacy and will be replaced by relay based
+          checkin ingestion in the very near future.
+    """
+
+    authentication_classes = (DSNAuthentication, TokenAuthentication, ApiKeyAuthentication)
+    permission_classes = (ProjectMonitorPermission,)
+
+    # TODO(dcramer): this code needs shared with other endpoints as its security focused
+    # TODO(dcramer): this doesnt handle is_global roles
+    def convert_args(
+        self,
+        request: Request,
+        monitor_id: str,
+        checkin_id: str | None = None,
         organization_slug: str | None = None,
         *args,
         **kwargs,
@@ -82,7 +169,8 @@ class MonitorEndpoint(Endpoint):
         if project.status != ProjectStatus.VISIBLE:
             raise ResourceDoesNotExist
 
-        # Validate that the authenticated project matches the monitor
+        # Validate that the authenticated project matches the monitor. This is
+        # used for DSN style authentication
         if hasattr(request.auth, "project_id") and project.id != request.auth.project_id:
             raise ResourceDoesNotExist
 
@@ -91,6 +179,7 @@ class MonitorEndpoint(Endpoint):
         if organization_slug and project.organization.slug != organization_slug:
             raise ResourceDoesNotExist
 
+        # Check project permission. Required for Token style authentication
         self.check_object_permissions(request, project)
 
         with configure_scope() as scope:
@@ -100,101 +189,36 @@ class MonitorEndpoint(Endpoint):
 
         request._request.organization = project.organization
 
-        kwargs.update({"monitor": monitor, "project": project})
+        kwargs["project"] = project
+        kwargs["monitor"] = monitor
+
+        if checkin_id:
+            checkin = try_checkin_lookup(monitor, checkin_id)
+            kwargs["checkin"] = checkin
+
         return args, kwargs
 
 
-class MonitorCheckInEndpoint(MonitorEndpoint):
-    # TODO(dcramer): this code needs shared with other endpoints as its security focused
-    # TODO(dcramer): this doesnt handle is_global roles
-    def convert_args(
-        self,
-        request: Request,
-        monitor_id: str,
-        checkin_id: str,
-        *args,
-        **kwargs,
-    ):
-        args, kwargs = super().convert_args(request, monitor_id, *args, **kwargs)
+def try_checkin_lookup(monitor: Monitor, checkin_id: str):
+    # we support the magic keyword of "latest" to grab the most recent check-in
+    # which is unfinished (thus still mutable)
+    if checkin_id == "latest":
+        checkin = (
+            MonitorCheckIn.objects.filter(monitor=monitor)
+            .exclude(status__in=CheckInStatus.FINISHED_VALUES)
+            .order_by("-date_added")
+            .first()
+        )
+        if not checkin:
+            raise ResourceDoesNotExist
+        return checkin
 
-        monitor = kwargs["monitor"]
-        # we support the magic keyword of "latest" to grab the most recent check-in
-        # which is unfinished (thus still mutable)
-        if checkin_id == "latest":
-            checkin = (
-                MonitorCheckIn.objects.filter(monitor=monitor)
-                .exclude(status__in=CheckInStatus.FINISHED_VALUES)
-                .order_by("-date_added")
-                .first()
-            )
-            if not checkin:
-                raise ResourceDoesNotExist
-        else:
-            try:
-                UUID(checkin_id)
-            except ValueError:
-                raise ParameterValidationError("Invalid check-in UUID")
+    try:
+        UUID(checkin_id)
+    except ValueError:
+        raise ParameterValidationError("Invalid check-in UUID")
 
-            try:
-                checkin = MonitorCheckIn.objects.get(monitor=monitor, guid=checkin_id)
-            except MonitorCheckIn.DoesNotExist:
-                raise ResourceDoesNotExist
-
-        kwargs.update({"checkin": checkin})
-        return args, kwargs
-
-
-class MonitorIngestEndpoint(MonitorEndpoint):
-    """
-    This type of endpont explicitly only allows for DSN and Token / Key based authentication.
-
-    [!!]: These endpoints are legacy and will be replaced by relay based
-          checkin ingestion in the very near future.
-    """
-
-    # TODO(epurkhiser): This should not extend MonitorEndpoint, that base class
-    # is designed for frontend API endpoints
-
-    authentication_classes = (DSNAuthentication, TokenAuthentication, ApiKeyAuthentication)
-
-    # TODO(dcramer): this code needs shared with other endpoints as its security focused
-    # TODO(dcramer): this doesnt handle is_global roles
-    def convert_args(
-        self,
-        request: Request,
-        monitor_id: str,
-        checkin_id: str | None = None,
-        *args,
-        **kwargs,
-    ):
-        args, kwargs = super().convert_args(request, monitor_id, *args, **kwargs)
-
-        monitor = kwargs["monitor"]
-
-        if checkin_id is None:
-            return args, kwargs
-
-        # we support the magic keyword of "latest" to grab the most recent check-in
-        # which is unfinished (thus still mutable)
-        if checkin_id == "latest":
-            checkin = (
-                MonitorCheckIn.objects.filter(monitor=monitor)
-                .exclude(status__in=CheckInStatus.FINISHED_VALUES)
-                .order_by("-date_added")
-                .first()
-            )
-            if not checkin:
-                raise ResourceDoesNotExist
-        else:
-            try:
-                UUID(checkin_id)
-            except ValueError:
-                raise ParameterValidationError("Invalid check-in UUID")
-
-            try:
-                checkin = MonitorCheckIn.objects.get(monitor=monitor, guid=checkin_id)
-            except MonitorCheckIn.DoesNotExist:
-                raise ResourceDoesNotExist
-
-        kwargs.update({"checkin": checkin})
-        return args, kwargs
+    try:
+        return MonitorCheckIn.objects.get(monitor=monitor, guid=checkin_id)
+    except MonitorCheckIn.DoesNotExist:
+        raise ResourceDoesNotExist

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_attachment.py
@@ -8,7 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.endpoints.event_attachment_details import EventAttachmentDetailsPermission
 from sentry.models import File
 
-from .base import MonitorCheckInEndpoint, ProjectMonitorPermission
+from .base import MonitorEndpoint, ProjectMonitorPermission
 
 
 class MonitorCheckInAttachmentPermission(EventAttachmentDetailsPermission):
@@ -25,7 +25,7 @@ class MonitorCheckInAttachmentPermission(EventAttachmentDetailsPermission):
 
 
 @region_silo_endpoint
-class OrganizationMonitorCheckInAttachmentEndpoint(MonitorCheckInEndpoint):
+class OrganizationMonitorCheckInAttachmentEndpoint(MonitorEndpoint):
     # TODO(davidenwang): Add documentation after uploading feature is complete
     permission_classes = (MonitorCheckInAttachmentPermission,)
 
@@ -40,7 +40,7 @@ class OrganizationMonitorCheckInAttachmentEndpoint(MonitorCheckInEndpoint):
         response["Content-Disposition"] = f"attachment; filename={file.name}"
         return response
 
-    def get(self, request: Request, project, monitor, checkin) -> Response:
+    def get(self, request: Request, organization, project, monitor, checkin) -> Response:
         if checkin.attachment_id:
             return self.download(checkin.attachment_id)
         else:

--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -42,9 +42,7 @@ class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint):
             404: RESPONSE_NOTFOUND,
         },
     )
-    def get(
-        self, request: Request, project, monitor, organization_slug: str | None = None
-    ) -> Response:
+    def get(self, request: Request, organization, project, monitor) -> Response:
         """
         Retrieve a list of check-ins for a monitor
         """

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -44,9 +44,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
             404: RESPONSE_NOTFOUND,
         },
     )
-    def get(
-        self, request: Request, project, monitor, organization_slug: str | None = None
-    ) -> Response:
+    def get(self, request: Request, organization, project, monitor) -> Response:
         """
         Retrieves details for a monitor.
         """
@@ -67,9 +65,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
             404: RESPONSE_NOTFOUND,
         },
     )
-    def put(
-        self, request: Request, project, monitor, organization_slug: str | None = None
-    ) -> Response:
+    def put(self, request: Request, organization, project, monitor) -> Response:
         """
         Update a monitor.
         """
@@ -83,7 +79,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
                 "config": monitor.config,
                 "project": project,
             },
-            context={"organization": project.organization, "access": request.access},
+            context={"organization": organization, "access": request.access},
         )
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
@@ -110,7 +106,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
             monitor.update(**params)
             self.create_audit_entry(
                 request=request,
-                organization=project.organization,
+                organization=organization,
                 target_object=monitor.id,
                 event=audit_log.get_event_id("MONITOR_EDIT"),
                 data=monitor.get_audit_log_data(),
@@ -132,9 +128,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
             404: RESPONSE_NOTFOUND,
         },
     )
-    def delete(
-        self, request: Request, project, monitor, organization_slug: str | None = None
-    ) -> Response:
+    def delete(self, request: Request, organization, project, monitor) -> Response:
         """
         Delete a monitor.
         """

--- a/src/sentry/monitors/endpoints/organization_monitor_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_stats.py
@@ -13,9 +13,7 @@ from .base import MonitorEndpoint
 @region_silo_endpoint
 class OrganizationMonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
     # TODO(dcramer): probably convert to tsdb
-    def get(
-        self, request: Request, project, monitor, organization_slug: str | None = None
-    ) -> Response:
+    def get(self, request: Request, organization, project, monitor) -> Response:
         args = self._parse_args(request)
 
         stats = {}


### PR DESCRIPTION
* MonitorEndpoint is simplified quite a bit now that it will always have a organization_slug in the parameters

 * MonitorCheckInEndpoint has been removed. MonitorEndpoint will lookup the checkin if a checkin_id is present.

 * MonitorIngestEndpoint no longer extends MonitorEndpoint and now handles all of the complicated moniotr lookup logic separately from MonitorEndpoint, since these endpoints allow for orgless routes.

   This will make it simply to remove this base endpoint once we've fully deprecated the API ingest endpoints in favor of relay ingestion of monitor checkins

This is a follow up to https://github.com/getsentry/sentry/pull/45678