### PR TITLE
fix(issue-stream): Fix ignore icon alignment

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -182,15 +182,6 @@ const Title = styled('div')<{hasGroupingTreeUI: boolean; size: Size}>`
     font-weight: 300;
     color: ${p => p.theme.subText};
   }
-  ${p =>
-    !p.hasGroupingTreeUI
-      ? ''
-      : css`
-          > a:first-child {
-            display: inline-flex;
-            min-height: ${space(3)};
-          }
-        `}
 `;
 
 const LocationWrapper = styled('div')`

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -230,7 +230,6 @@ const Message = styled('div')`
 
 const IconWrapper = styled('span')`
   position: relative;
-  display: flex;
   margin-right: 5px;
 `;
 

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -109,7 +109,7 @@ function EventOrGroupHeader({
 
     if (includeLink) {
       return (
-        <GlobalSelectionLink
+        <TitleWithLink
           {...commonEleProps}
           to={{
             pathname: `/organizations/${orgId}/issues/${eventID ? groupID : id}/${
@@ -133,11 +133,11 @@ function EventOrGroupHeader({
           onClick={onClick}
         >
           {getTitleChildren()}
-        </GlobalSelectionLink>
+        </TitleWithLink>
       );
     }
 
-    return <span {...commonEleProps}>{getTitleChildren()}</span>;
+    return <TitleWithoutLink {...commonEleProps}>{getTitleChildren()}</TitleWithoutLink>;
   }
 
   const eventLocation = getLocation(data);
@@ -184,9 +184,7 @@ const Title = styled('div')<{hasGroupingTreeUI: boolean; size: Size}>`
   }
   ${p =>
     !p.hasGroupingTreeUI
-      ? css`
-          ${truncateStyles}
-        `
+      ? ''
       : css`
           > a:first-child {
             display: inline-flex;
@@ -241,6 +239,13 @@ const GroupLevel = styled('div')<{level: Level}>`
   border-radius: 0 3px 3px 0;
 
   background-color: ${p => p.theme.level[p.level] ?? p.theme.level.default};
+`;
+
+const TitleWithLink = styled(GlobalSelectionLink)`
+  display: flex;
+`;
+const TitleWithoutLink = styled('span')`
+  display: flex;
 `;
 
 export default withOrganization(EventOrGroupHeader);


### PR DESCRIPTION
When orgs do not have the flag `grouping-tree-ui`, the icon appears on its own line.

Before:

![CleanShot 2023-03-13 at 15 44 37](https://user-images.githubusercontent.com/10888943/224849085-76c97432-6359-49cb-a917-6029f23ee9c2.png)

After:

![CleanShot 2023-03-13 at 15 44 20](https://user-images.githubusercontent.com/10888943/224849095-1c6283f8-06f0-4780-9f51-46d9a08e511c.png)
 

