### PR TITLE
feat(codecov): Redesign codecov setting

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -155,6 +155,7 @@ export type AnalyticsHooks = {
 export type FeatureDisabledHooks = {
   'feature-disabled:alert-wizard-performance': FeatureDisabledHook;
   'feature-disabled:alerts-page': FeatureDisabledHook;
+  'feature-disabled:codecov-integration-setting': FeatureDisabledHook;
   'feature-disabled:custom-inbound-filters': FeatureDisabledHook;
   'feature-disabled:dashboards-edit': FeatureDisabledHook;
   'feature-disabled:dashboards-page': FeatureDisabledHook;

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -60,7 +60,10 @@ describe('OrganizationGeneralSettings', function () {
   });
 
   it('can enable "codecov access"', async function () {
-    defaultProps.organization.features.push('codecov-stacktrace-integration');
+    defaultProps.organization.features.push(
+      'codecov-stacktrace-integration',
+      'codecov-integration'
+    );
     organization.codecovAccess = false;
     render(<OrganizationGeneralSettings {...defaultProps} />);
     const mock = MockApiClient.addMockResponse({

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.jsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.jsx
@@ -124,4 +124,41 @@ describe('OrganizationSettingsForm', function () {
       })
     );
   });
+
+  it('can enable codecov', function () {
+    putMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      method: 'PUT',
+      body: {...organization, codecovAccess: true},
+    });
+
+    render(
+      <OrganizationSettingsForm
+        location={TestStubs.location()}
+        orgId={organization.slug}
+        access={new Set(['org:write'])}
+        initialData={TestStubs.Organization({codecovAccess: false})}
+        onSave={onSave}
+      />,
+      {
+        organization: {
+          ...organization,
+          features: ['codecov-stacktrace-integration', 'codecov-integration'],
+        },
+      }
+    );
+
+    userEvent.click(
+      screen.getByRole('checkbox', {name: /Enable Code Coverage Insights/})
+    );
+
+    expect(putMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/',
+      expect.objectContaining({
+        data: {
+          codecovAccess: true,
+        },
+      })
+    );
+  });
 });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -1,15 +1,23 @@
 import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 import {Location} from 'history';
 import cloneDeep from 'lodash/cloneDeep';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {updateOrganization} from 'sentry/actionCreators/organizations';
+import Feature from 'sentry/components/acl/feature';
+import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import AvatarChooser from 'sentry/components/avatarChooser';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
+import {Hovercard} from 'sentry/components/hovercard';
+import ExternalLink from 'sentry/components/links/externalLink';
+import Tag from 'sentry/components/tag';
 import organizationSettingsFields from 'sentry/data/forms/organizationGeneralSettings';
+import {IconCodecov, IconLock} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {Organization, Scope} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -51,8 +59,45 @@ class OrganizationSettingsForm extends AsyncComponent<Props, State> {
         {
           name: 'codecovAccess',
           type: 'boolean',
-          label: t('Enable Code Coverage Insights - powered by Codecov'),
-          help: t('Opt-in to connect your codecov account'),
+          disabled: !organization.features.includes('codecov-integration'),
+          label: (
+            <PoweredByCodecov>
+              {t('Enable Code Coverage Insights')}{' '}
+              <Feature
+                hookName="feature-disabled:codecov-integration-setting"
+                renderDisabled={p => (
+                  <Hovercard
+                    body={
+                      <FeatureDisabled
+                        features={p.features}
+                        hideHelpToggle
+                        featureName={t('Codecov Coverage')}
+                      />
+                    }
+                  >
+                    <Tag role="status" icon={<IconLock isSolid />}>
+                      {t('disabled')}
+                    </Tag>
+                  </Hovercard>
+                )}
+                features={['organizations:codecov-integration']}
+              >
+                {() => null}
+              </Feature>
+            </PoweredByCodecov>
+          ),
+          formatMessageValue: (value: boolean) => {
+            const onOff = value ? t('on') : t('off');
+            return t('Codecov access was turned %s', onOff);
+          },
+          help: (
+            <PoweredByCodecov>
+              {t('powered by')} <IconCodecov /> Codecov{' '}
+              <ExternalLink href="https://about.codecov.io/sign-up-sentry-codecov/">
+                {t('Learn More')}
+              </ExternalLink>
+            </PoweredByCodecov>
+          ),
         },
       ];
     }
@@ -88,3 +133,14 @@ class OrganizationSettingsForm extends AsyncComponent<Props, State> {
 }
 
 export default withOrganization(OrganizationSettingsForm);
+
+const PoweredByCodecov = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+
+  & > span {
+    display: flex;
+    align-items: center;
+  }
+`;


### PR DESCRIPTION
- adds an upsell
- changes copy in toast when activating
- redesign setting to look like new figma w/ "Learn More" link

it won't say "unavailable" in prod, but it looks like this
![Screenshot 2023-03-13 at 4 42 10 PM](https://user-images.githubusercontent.com/1400464/224857870-d1394ece-b8d8-4cca-bc7d-a751a72661e0.png)

[WOR-2793](https://getsentry.atlassian.net/browse/WOR-2793)

[WOR-2793]: https://getsentry.atlassian.net/browse/WOR-2793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ