### PR TITLE
fix(onboarding): Update are you sure button logic

### DIFF
--- a/static/app/views/onboarding/components/changeRouteModal.tsx
+++ b/static/app/views/onboarding/components/changeRouteModal.tsx
@@ -55,8 +55,8 @@ export function ChangeRouteModal({
       </Body>
       <Footer>
         <ButtonBar gap={1}>
-          <Button onClick={handleSetUpLater}>{t('On second thought\u2026')}</Button>
-          <Button priority="primary" onClick={closeModal}>
+          <Button onClick={closeModal}>{t('On second thought\u2026')}</Button>
+          <Button priority="primary" onClick={handleSetUpLater}>
             {t('Go away')}
           </Button>
         </ButtonBar>

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -186,7 +186,7 @@ function Onboarding(props: Props) {
     });
 
     // from selected platform to welcome
-    if (onboardingSteps[stepIndex].id === 'welcome') {
+    if (onboardingSteps[stepIndex].id === 'select-platform') {
       setClientState({
         platformToProjectIdMap: clientState?.platformToProjectIdMap ?? {},
         selectedPlatforms: [],


### PR DESCRIPTION
According to the last design spec, the actions shall be inverted, in other words, "go away" means skip onboarding, and "one-second thought" means dismiss the modal and stay. This PR fixes it and also a minor redirect issue.