### PR TITLE
feat(killswitch): Add killswitch to disable retrieval of last deploy for projects

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -48,6 +48,7 @@ from sentry.constants import (
     SCRAPE_JAVASCRIPT_DEFAULT,
     SENSITIVE_FIELDS_DEFAULT,
 )
+from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models import (
     Organization,
@@ -571,7 +572,10 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
     def serialize(  # type: ignore
         self, obj: Organization, attrs: Mapping[str, Any], user: User, access: Access
     ) -> DetailedOrganizationSerializerWithProjectsAndTeamsResponse:
-        from sentry.api.serializers.models.project import ProjectSummarySerializer
+        from sentry.api.serializers.models.project import (
+            LATEST_DEPLOYS_KEY,
+            ProjectSummarySerializer,
+        )
         from sentry.api.serializers.models.team import TeamSerializer
 
         context = cast(
@@ -583,6 +587,18 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         project_list = self._project_list(obj, access)
 
         context["teams"] = serialize(team_list, user, TeamSerializer(access=access))
-        context["projects"] = serialize(project_list, user, ProjectSummarySerializer(access=access))
+
+        collapse_projects = {}
+        if killswitch_matches_context(
+            "api.organization.disable-last-deploys",
+            {
+                "organization_id": obj.id,
+            },
+        ):
+            collapse_projects = {LATEST_DEPLOYS_KEY}
+
+        context["projects"] = serialize(
+            project_list, user, ProjectSummarySerializer(access=access, collapse=collapse_projects)
+        )
 
         return context

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -10,6 +10,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union,
     cast,
@@ -588,7 +589,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
 
         context["teams"] = serialize(team_list, user, TeamSerializer(access=access))
 
-        collapse_projects = {}
+        collapse_projects: Set[str] = set()
         if killswitch_matches_context(
             "api.organization.disable-last-deploys",
             {

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -198,6 +198,15 @@ ALL_KILLSWITCH_OPTIONS = {
             _update_project_configs, "Trigger invalidation tasks for projects"
         ),
     ),
+    "api.organization.disable-last-deploys": KillswitchInfo(
+        description="""
+        Do not retrieve last deploys for projects in organization.
+
+        To protect database against suboptimal queries for organizations with huge number of
+        projects. This works by adding collapse argument to the serializer.
+        """,
+        fields={"organization_id": "An organization ID to disable last deploys for."},
+    ),
 }
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -431,6 +431,7 @@ register("store.load-shed-symbolicate-event-projects", type=Any, default=[])
 register("store.symbolicate-event-lpq-never", type=Sequence, default=[])
 register("store.symbolicate-event-lpq-always", type=Sequence, default=[])
 register("post_process.get-autoassign-owners", type=Sequence, default=[])
+register("api.organization.disable-last-deploys", type=Sequence, default=[])
 
 # Switch for more performant project counter incr
 register("store.projectcounter-modern-upsert-sample-rate", default=0.0)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -162,7 +162,7 @@ class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):
         assert len(result["teams"]) == 1
         assert len(result["projects"]) == 1
 
-    def test_disalbe_last_deploys_killswitch(self):
+    def test_disable_last_deploys_killswitch(self):
         self.team
         self.project
         self.release = self.create_release(self.project)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -1,9 +1,10 @@
+import datetime
 from unittest import mock
 
 from django.conf import settings
 from django.utils import timezone
 
-from sentry import features
+from sentry import features, killswitches, options
 from sentry.api.serializers import (
     DetailedOrganizationSerializer,
     DetailedOrganizationSerializerWithProjectsAndTeams,
@@ -13,7 +14,7 @@ from sentry.api.serializers import (
 from sentry.api.serializers.models.organization import ORGANIZATION_OPTIONS_AS_FEATURES
 from sentry.auth import access
 from sentry.features.base import OrganizationFeature
-from sentry.models import OrganizationOnboardingTask
+from sentry.models import Deploy, Environment, OrganizationOnboardingTask, ReleaseProjectEnvironment
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingTaskStatus
 from sentry.testutils import TestCase
@@ -160,6 +161,45 @@ class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):
         assert result["relayPiiConfig"] is None
         assert len(result["teams"]) == 1
         assert len(result["projects"]) == 1
+
+    def test_disalbe_last_deploys_killswitch(self):
+        self.team
+        self.project
+        self.release = self.create_release(self.project)
+        self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc)
+        self.environment_1 = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+        self.environment_1.add_project(self.project)
+        self.environment_1.save()
+        deploy = Deploy.objects.create(
+            environment_id=self.environment_1.id,
+            organization_id=self.organization.id,
+            release=self.release,
+            date_finished=self.date,
+        )
+        ReleaseProjectEnvironment.objects.create(
+            project_id=self.project.id,
+            release_id=self.release.id,
+            environment_id=self.environment_1.id,
+            last_deploy_id=deploy.id,
+        )
+        acc = access.from_user(self.user, self.organization)
+        serializer = DetailedOrganizationSerializerWithProjectsAndTeams()
+        result = serialize(self.organization, self.user, serializer, access=acc)
+
+        assert result["projects"][0]["latestDeploys"]
+
+        opt_val = killswitches.validate_user_input(
+            "api.organization.disable-last-deploys", [{"organization_id": self.organization.id}]
+        )
+        options.set("api.organization.disable-last-deploys", opt_val)
+
+        result = serialize(self.organization, self.user, serializer, access=acc)
+        assert not result["projects"][0].get("latestDeploys")
+
+        opt_val = killswitches.validate_user_input("api.organization.disable-last-deploys", [])
+        options.set("api.organization.disable-last-deploys", opt_val)
 
 
 class OnboardingTasksSerializerTest(TestCase):


### PR DESCRIPTION
Adding killswitch to Organization API serializer to prevent resolution of last deploys for organizations with a huge number of projects until we find a better way to do this without killing Postgres.