### PR TITLE
chore(view-hierarchy): Remove frontend feature flags

### DIFF
--- a/static/app/components/events/eventViewHierarchy.spec.tsx
+++ b/static/app/components/events/eventViewHierarchy.spec.tsx
@@ -43,7 +43,7 @@ const MOCK_DATA = JSON.stringify({
 });
 
 const organization = TestStubs.Organization({
-  features: ['event-attachments', 'mobile-view-hierarchies'],
+  features: ['event-attachments'],
 });
 const event = TestStubs.Event();
 

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -96,10 +96,7 @@ function EventViewHierarchyContent({event, project}: Props) {
 function EventViewHierarchy(props: Props) {
   const organization = useOrganization();
 
-  if (
-    !organization.features?.includes('mobile-view-hierarchies') ||
-    !organization.features.includes('event-attachments')
-  ) {
+  if (!organization.features.includes('event-attachments')) {
     return null;
   }
 

--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -53,7 +53,6 @@ const optionsAvailable = [
   'profile.issues.blocked_main_thread-ppg.la-rollout',
   'profile.issues.blocked_main_thread-ppg.ea-rollout',
   'profile.issues.blocked_main_thread-ppg.ga-rollout',
-  'processing.view-hierarchies-deobfuscation-general-availability',
 ];
 
 type Field = ReturnType<typeof getOption>;
@@ -206,7 +205,6 @@ export default class AdminSettings extends AsyncView<{}, State> {
           <Feature features={['organizations:view-hierarchies-options-dev']}>
             <Panel>
               <PanelHeader>View Hierarchy</PanelHeader>
-              {fields['processing.view-hierarchies-deobfuscation-general-availability']}
             </Panel>
           </Feature>
         </Form>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -557,15 +557,6 @@ const definitions: Field[] = [
     component: BooleanField,
     defaultValue: () => false,
   },
-  {
-    key: 'processing.view-hierarchies-deobfuscation-general-availability',
-    label: t('View Hierarchies Deobfuscation GA'),
-    defaultValue: () => 0.0,
-    component: NumberField,
-    min: 0.0,
-    max: 1.0,
-    step: 0.0001,
-  },
   ...performanceOptionDefinitions,
 ];
 


### PR DESCRIPTION
Removes the frontend feature flags for view hierarchies. Also includes removing the options UI for the ProGuard deobfuscation since it's been in GA for a while and we can always roll it back through Ops. I _will_ be removing it shortly after this PR deploys through #45768

I'm keeping around the options panel for View Hierarchies because with the Flutter iOS work, I'll probably want to roll that out through options as well.