### PR TITLE
chore(replays): Add blueprints to replays module

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -53,14 +53,17 @@ This document is structured by resource with each resource having actions that c
 
     Additionally, you can filter by these hidden fields.
 
-    | Field                   | Type          | Description                          |
-    | ----------------------- | ------------- | ------------------------------------ |
-    | replay_click.tag        | string        | Valid HTML5 tag name.                |
-    | replay_click.id         | string        | The ID of an HTML element.           |
-    | replay_click.classes    | array[string] | An array of HTML element classes.    |
-    | replay_click.role       | string        | The role of an HTML element.         |
-    | replay_click.aria_label | string        | The aria-label of an HTML element.   |
-    | replay_click.text       | string        | The text-content of an HTML element. |
+    | Field               | Type          | Description                                                    |
+    | --------------------| ------------- | -------------------------------------------------------------- |
+    | replay_click.alt    | string        | The alt attribute of the HTML element.                         |
+    | replay_click.class  | array[string] | An array of HTML element classes.                              |
+    | replay_click.id     | string        | The ID of an HTML element.                                     |
+    | replay_click.label  | string        | The aria-label attribute of an HTML element.                   |
+    | replay_click.role   | string        | The role of an HTML element.                                   |
+    | replay_click.tag    | string        | Valid HTML5 tag name.                                          |
+    | replay_click.testid | string        | The data-testid of an HTML element. (omitted from public docs) |
+    | replay_click.text   | string        | The text-content of an HTML element.                           |
+    | replay_click.title  | string        | The title attribute of an HTML element.                        |
 
 ### Browse Replays [GET]
 

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -53,16 +53,15 @@ This document is structured by resource with each resource having actions that c
 
     Additionally, you can filter by these hidden fields.
 
-    | Field        | Type          | Description                          |
-    | ------------ | ------------- | ------------------------------------ |
-    | action       | enum[string]  | Choices: click                       |
-    | tag          | string        | Valid HTML5 tag name.                |
-    | id           | string        | The ID of an HTML element.           |
-    | classes      | array[string] | An array of HTML element classes.    |
-    | role         | string        | The role of an HTML element.         |
-    | aria-label   | string        | The aria-label of an HTML element.   |
-    | aria-role    | string        | The aria-role of an HTML element.    |
-    | text-content | string        | The text-content of an HTML element. |
+    | Field      | Type          | Description                          |
+    | ---------- | ------------- | ------------------------------------ |
+    | action     | enum[string]  | Choices: click                       |
+    | tag        | string        | Valid HTML5 tag name.                |
+    | id         | string        | The ID of an HTML element.           |
+    | classes    | array[string] | An array of HTML element classes.    |
+    | role       | string        | The role of an HTML element.         |
+    | aria_label | string        | The aria-label of an HTML element.   |
+    | text       | string        | The text-content of an HTML element. |
 
 ### Browse Replays [GET]
 

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -55,7 +55,6 @@ This document is structured by resource with each resource having actions that c
 
     | Field      | Type          | Description                          |
     | ---------- | ------------- | ------------------------------------ |
-    | action     | enum[string]  | Choices: click                       |
     | tag        | string        | Valid HTML5 tag name.                |
     | id         | string        | The ID of an HTML element.           |
     | classes    | array[string] | An array of HTML element classes.    |

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -53,14 +53,14 @@ This document is structured by resource with each resource having actions that c
 
     Additionally, you can filter by these hidden fields.
 
-    | Field      | Type          | Description                          |
-    | ---------- | ------------- | ------------------------------------ |
-    | tag        | string        | Valid HTML5 tag name.                |
-    | id         | string        | The ID of an HTML element.           |
-    | classes    | array[string] | An array of HTML element classes.    |
-    | role       | string        | The role of an HTML element.         |
-    | aria_label | string        | The aria-label of an HTML element.   |
-    | text       | string        | The text-content of an HTML element. |
+    | Field                   | Type          | Description                          |
+    | ----------------------- | ------------- | ------------------------------------ |
+    | replay_click.tag        | string        | Valid HTML5 tag name.                |
+    | replay_click.id         | string        | The ID of an HTML element.           |
+    | replay_click.classes    | array[string] | An array of HTML element classes.    |
+    | replay_click.role       | string        | The role of an HTML element.         |
+    | replay_click.aria_label | string        | The aria-label of an HTML element.   |
+    | replay_click.text       | string        | The text-content of an HTML element. |
 
 ### Browse Replays [GET]
 

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -51,6 +51,19 @@ This document is structured by resource with each resource having actions that c
     | `trace_ids`    | `trace` & `trace_id` |
     | `urls`         | `url`                |
 
+    Additionally, you can filter by these hidden fields.
+
+    | Field        | Type          | Description                          |
+    | ------------ | ------------- | ------------------------------------ |
+    | action       | enum[string]  | Choices: click                       |
+    | tag          | string        | Valid HTML5 tag name.                |
+    | id           | string        | The ID of an HTML element.           |
+    | classes      | array[string] | An array of HTML element classes.    |
+    | role         | string        | The role of an HTML element.         |
+    | aria-label   | string        | The aria-label of an HTML element.   |
+    | aria-role    | string        | The aria-role of an HTML element.    |
+    | text-content | string        | The text-content of an HTML element. |
+
 ### Browse Replays [GET]
 
 Retrieve a collection of replays.

--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -1,0 +1,353 @@
+# Replays API
+
+Host: https://sentry.io/api/0
+
+**Authors.**
+
+@cmanallen
+@joshferge
+
+**How to read this document.**
+
+This document is structured by resource with each resource having actions that can be performed against it. Every action that either accepts a request or returns a response WILL document the full interchange format. Clients may opt to restrict response data or provide a subset of the request data. The API may or may not accept partial payloads.
+
+## Replays [/organizations/<organization_slug>/replays/]
+
+- Parameters
+
+  - field (optional, string)
+  - environment (optional, string)
+  - project (optional, string)
+  - sort (optional, string)
+    Default: -startedAt
+    Members: + projectId + -projectId + startedAt + -startedAt + finishedAt + -finishedAt + duration + -duration + countErrors + -countErrors
+  - statsPeriod (optional, string) - A positive integer suffixed with a unit type.
+    Default: 7d
+    Members: + s + m + h + d + w
+  - start (optional, string) - ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`)
+  - end (optional, string) - ISO 8601 format. Required if `start` is set.
+  - limit (optional, number)
+    Default: 10
+  - offset (optional, number)
+    Default: 0
+  - query (optional, string) - Search query with space-separated field/value pairs. ie: `?query=count_errors:>2 AND duration:<1h`.
+
+    Some fields in the API response have their own dedicated parameters, or are otherwide not supported in the `query` param. They are:
+
+    | Response Field      | Parameter       |
+    | ------------------- | --------------- |
+    | `environment`       | `?environment=` |
+    | `project_id`        | `?project=`     |
+    | `started_at`        | `?start=`       |
+    | `finished_at`       | `?end=`         |
+    | `user.display_name` | -               |
+
+    You can use the following aliases to query for fields that are plural in the API response:
+
+    | Response Field | Search Alias         |
+    | -------------- | -------------------- |
+    | `error_ids`    | `error_id`           |
+    | `releases`     | `release`            |
+    | `trace_ids`    | `trace` & `trace_id` |
+    | `urls`         | `url`                |
+
+### Browse Replays [GET]
+
+Retrieve a collection of replays.
+
+**Attributes**
+
+| Column            | Type                          | Description                                            |
+| ----------------- | ----------------------------- | ------------------------------------------------------ |
+| activity          | number                        | -                                                      |
+| browser.name      | optional[string]              | -                                                      |
+| browser.version   | optional[string]              | -                                                      |
+| count_errors      | number                        | The number of errors associated with the replay.       |
+| count_segments    | number                        | The number of segments that make up the replay.        |
+| count_urls        | number                        | The number of urls visited in the replay.              |
+| device.brand      | optional[string]              | -                                                      |
+| device.family     | optional[string]              | -                                                      |
+| device.model_id   | optional[string]              | Same search field as Events                            |
+| device.name       | optional[string]              | -                                                      |
+| dist              | optional[string]              | -                                                      |
+| duration          | number                        | Difference of `finishedAt` and `startedAt` in seconds. |
+| environment       | optional[string]              | -                                                      |
+| error_ids         | array[string]                 | -                                                      |
+| finished_at       | string                        | The **latest** timestamp received.                     |
+| id                | string                        | The ID of the Replay instance.                         |
+| os.name           | optional[string]              | -                                                      |
+| os.version        | optional[string]              | -                                                      |
+| platform          | string                        | -                                                      |
+| project_id        | string                        | -                                                      |
+| releases          | array[string]                 | Same search field as Events                            |
+| sdk.name          | string                        | -                                                      |
+| sdk.version       | string                        | -                                                      |
+| started_at        | string                        | The **earliest** replay_start_timestamp received.      |
+| tags              | object[string, array[string]] | -                                                      |
+| trace_ids         | array[string]                 | Same search field as Events                            |
+| urls              | array[string]                 | -                                                      |
+| user.display_name | optional[string]              | -                                                      |
+| user.email        | optional[string]              | -                                                      |
+| user.id           | optional[string]              | -                                                      |
+| user.ip           | optional[string]              | Same search field as Events                            |
+| user.username     | optional[string]              | -                                                      |
+
+- Response 200
+
+  ```json
+  {
+    "data": [
+      {
+        "activity": 5,
+        "browser": {
+          "name": "Chome",
+          "version": "103.0.38"
+        },
+        "count_errors": 1,
+        "count_segments": 0,
+        "count_urls": 1,
+        "device": {
+          "brand": "Apple",
+          "family": "iPhone",
+          "model_id": "11",
+          "name": "iPhone 11"
+        },
+        "dist": null,
+        "duration": 576,
+        "environment": "production",
+        "error_ids": ["7e07485f-12f9-416b-8b14-26260799b51f"],
+        "finished_at": "2022-07-07T14:15:33.201019",
+        "id": "7e07485f-12f9-416b-8b14-26260799b51f",
+        "os": {
+          "name": "iOS",
+          "version": "16.2"
+        },
+        "platform": "Sentry",
+        "project_dd": "639195",
+        "releases": ["version@1.4"],
+        "sdk": {
+          "name": "Thundercat",
+          "version": "27.1"
+        },
+        "started_at": "2022-07-07T14:05:57.909921",
+        "tags": {
+          "hello": ["world", "Lionel Richie"]
+        },
+        "title": "My cool replay",
+        "trace_ids": ["7e07485f-12f9-416b-8b14-26260799b51f"],
+        "urls": ["/organizations/abc123/issues"],
+        "user": {
+          "display_name": "John Doe",
+          "email": "john.doe@example.com",
+          "id": "30246326",
+          "ip_address": "213.164.1.114",
+          "name": "John Doe"
+        }
+      }
+    ]
+  }
+  ```
+
+## Replay [/projects/<organization_slug>/<project_slug>/replays/<replay_id>/]
+
+- Parameters
+  - field (optional, string)
+
+### Fetch Replay [GET]
+
+Retrieve a single replay instance.
+
+- Response 200
+
+  ```json
+  {
+    "data": {
+      "activity": 5,
+      "browser": {
+        "name": "Chome",
+        "version": "103.0.38"
+      },
+      "count_errors": 1,
+      "count_segments": 0,
+      "count_urls": 1,
+      "device": {
+        "brand": "Apple",
+        "family": "iPhone",
+        "model_id": "11",
+        "name": "iPhone 11"
+      },
+      "dist": null,
+      "duration": 576,
+      "environment": "production",
+      "error_ids": ["7e07485f-12f9-416b-8b14-26260799b51f"],
+      "finished_at": "2022-07-07T14:15:33.201019",
+      "id": "7e07485f-12f9-416b-8b14-26260799b51f",
+      "os": {
+        "name": "iOS",
+        "version": "16.2"
+      },
+      "platform": "Sentry",
+      "project_id": "639195",
+      "releases": ["version@1.4"],
+      "sdk": {
+        "name": "Thundercat",
+        "version": "27.1"
+      },
+      "started_at": "2022-07-07T14:05:57.909921",
+      "tags": {
+        "hello": ["world", "Lionel Richie"]
+      },
+      "trace_ids": ["7e07485f-12f9-416b-8b14-26260799b51f"],
+      "urls": ["/organizations/abc123/issues"],
+      "user": {
+        "display_name": "John Doe",
+        "email": "john.doe@example.com",
+        "id": "30246326",
+        "ip": "213.164.1.114",
+        "name": "John Doe"
+      }
+    }
+  }
+  ```
+
+### Delete Replay [DELETE]
+
+Deletes a replay instance.
+
+- Response 204
+
+## Replay Recording Segments [/projects/<organization_slug>/<project_slug>/replays/<replay_id>/recording-segments/]
+
+- Parameters
+  - per_page
+  - cursor
+  - download - Instruct the API to return a streaming json response
+
+### Browse Replay Recording Segments [GET]
+
+Retrieve a collection of replay recording-segments.
+
+| Column    | Type   | Description |
+| --------- | ------ | ----------- |
+| replayId  | string | -           |
+| segmentId | number | -           |
+| projectId | string | -           |
+| dateAdded | string | -           |
+
+Without download query argument
+
+- Response 200
+
+  ```json
+  {
+    "data": [
+      {
+        "replayId": "7e07485f-12f9-416b-8b14-26260799b51f",
+        "segmentId": 0,
+        "projectId": "409512",
+        "dateAdded": "2022-07-07T14:15:33.201019"
+      }
+    ]
+  }
+  ```
+
+With download query argument, rrweb events JSON
+
+- Response 200
+  Content-Type application/json
+
+  ```json
+  [
+    [
+      {"type":4, "data":{"href":"https://example.com", "width":1500, "height":1200}},
+      {...}
+    ],
+    [
+      {...}
+    ]
+  ]
+  ```
+
+## Replay Recording Segment [/projects/<organization_slug>/<project_slug>/replays/<replay_id>/recording-segments/<segment_id>/]
+
+- Parameters
+  - download - Instruct the API to return a streaming bytes response.
+
+### Fetch Replay Recording Segment [GET]
+
+Retrieve a single replay recording-segment.
+
+Without download query argument.
+
+- Response 200
+
+  ```json
+  {
+    "data": {
+      "replayId": "7e07485f-12f9-416b-8b14-26260799b51f",
+      "segmentId": 0,
+      "projectId": 409512,
+      "dateAdded": "2022-07-07T14:15:33.201019"
+    }
+  }
+  ```
+
+With download query argument.
+
+- Response 200
+
+  Content-Type application/octet-stream
+
+## Replay Tag Keys [/projects/<organization_slug>/<project_slug>/replays/tags/]
+
+### Fetch Tag Keys [GET]
+
+Retrieve a collection of tag keys associated with the replays dataset.
+
+| Column      | Type   | Description |
+| ----------- | ------ | ----------- |
+| key         | string | -           |
+| name        | string | -           |
+| totalValues | number | -           |
+
+- Response 200
+
+  ```json
+  [
+    {
+      "key": "plan.total_members",
+      "name": "Plan.Total Members",
+      "totalValues": 630661
+    }
+  ]
+  ```
+
+## Replay Tag Values [/projects/<organization_slug>/<project_slug>/replays/tags/<key>/values/]
+
+### Fetch Tag Values [GET]
+
+Retrieve a collection of tag values associated with a tag key on the replays dataset.
+
+| Column    | Type   | Description |
+| --------- | ------ | ----------- |
+| key       | string | -           |
+| name      | string | -           |
+| value     | string | -           |
+| count     | number | -           |
+| lastSeen  | string | -           |
+| firstSeen | string | -           |
+
+- Response 200
+
+  ```json
+  [
+    {
+      "key": "plan",
+      "name": "am1_team",
+      "value": "am1_team",
+      "count": 66880,
+      "lastSeen": "2022-12-09T19:39:53Z",
+      "firstSeen": "2022-11-25T19:40:39Z"
+    }
+  ]
+  ```

--- a/src/sentry/replays/blueprints/recording_consumer.md
+++ b/src/sentry/replays/blueprints/recording_consumer.md
@@ -1,0 +1,89 @@
+# Replays SDK Event
+
+This file defines the contract between the recording consumer and its producers. All messages are transmitted as `msgpack` encoded bytes. Messages smaller than 1MB in size are processed as one message. Their structure is defined in the "Small Recordings" section. All other message types are defined in the "Large Recordings" section.
+
+**Authors:**
+@cmanallen
+
+## Small Recordings
+
+### Replay Recording Not Chunked
+
+| Column     | Type         | Description                                       |
+| ---------- | ------------ | ------------------------------------------------- |
+| type       | string       | Literal: replay_recording_not_chunked             |
+| replay_id  | string       | -                                                 |
+| key_id     | Optonal[int] | -                                                 |
+| org_id     | int          | -                                                 |
+| project_id | int          | -                                                 |
+| received   | int          | Unix timestamp of when the event was received     |
+| payload    | bytes        | JSON encoded headers are prefixed to the payload. |
+
+- Request (application/octet-stream)
+
+  ```python
+  {
+    "type": "replay_recording_not_chunked",
+    "replay_id": "515539018c9b4260a6f999572f1661ee",
+    "key_id": 1,
+    "org_id": 132,
+    "project_id": 10459681,
+    "received": 1342632621,
+    "payload": b"{'segment_id': 0}\n\x14ftypqt\x00\x00\x00\x00qt\x00\x00x08wide\x03\xbdd\x11mdat"
+  }
+  ```
+
+## Large Recordings
+
+### Replay Recording Chunk
+
+| Column      | Type   | Description                     |
+| ----------- | ------ | ------------------------------- |
+| type        | string | Literal: replay_recording_chunk |
+| replay_id   | string | -                               |
+| project_id  | int    | -                               |
+| chunk_index | int    | -                               |
+| id          | string | -                               |
+| payload     | bytes  | -                               |
+
+- Request (application/octet-stream)
+
+  ```python
+  {
+    "type": "replay_recording_chunk",
+    "replay_id": "515539018c9b4260a6f999572f1661ee",
+    "project_id": 1,
+    "chunk_index": 10,
+    "id": "e4a28052c54743a286be419c9d168ef5",
+    "payload": b"\x14ftypqt\x00\x00\x00\x00qt\x00\x00x08wide\x03\xbdd\x11mdat"
+  }
+  ```
+
+### Replay Recording
+
+| Column           | Type         | Description                                           |
+| ---------------- | ------------ | ----------------------------------------------------- |
+| type             | string       | Literal: replay_recording                             |
+| replay_id        | string       | -                                                     |
+| key_id           | Optonal[int] | -                                                     |
+| org_id           | int          | -                                                     |
+| project_id       | int          | -                                                     |
+| received         | int          | Unix timestamp of when the event was received         |
+| replay_recording | dict         | Contains the number of chunks and a unique identifier |
+
+- Request (application/octet-stream)
+
+  ```python
+  {
+    "type": "replay_recording",
+    "replay_id": "515539018c9b4260a6f999572f1661ee",
+    "key_id": 1,
+    "org_id": 132,
+    "project_id": 10459681,
+    "received": 1342632621,
+    "replay_recording": {
+        "id": "e4a28052c54743a286be419c9d168ef5",
+        "chunks": 5
+    }
+  }
+  ```

--- a/src/sentry/replays/blueprints/relay.md
+++ b/src/sentry/replays/blueprints/relay.md
@@ -1,0 +1,101 @@
+# Replays SDK Event
+
+**Authors:**
+@cmanallen
+
+### Replay Event
+
+**Replay SDK Event**
+
+| Column                              | Type         | Description                            |
+| ----------------------------------- | ------------ | -------------------------------------- |
+| type                                | string       | -                                      |
+| replay_id                           | string       | -                                      |
+| replay_type                         | enum[string] | "error", "session"                     |
+| event_id                            | string       | Unique ID specific to the event.       |
+| segment_id                          | number       | -                                      |
+| timestamp                           | number       | -                                      |
+| replay_start_timestamp              | number       | -                                      |
+| urls                                | list[string] | A list of URLs in order of visitation. |
+| error_ids                           | list[string] | -                                      |
+| trace_ids                           | list[string] | -                                      |
+| contexts.replay.error_sample_rate   | float        | -                                      |
+| contexts.replay.session_sample_rate | float        | -                                      |
+
+**Base SDK Event**
+
+| Column                     | Type   | Description |
+| -------------------------- | ------ | ----------- |
+| dist                       | string | -           |
+| platform                   | string | -           |
+| environment                | string | -           |
+| release                    | string | -           |
+| user.id                    | string | -           |
+| user.username              | string | -           |
+| user.email                 | string | -           |
+| user.ip_address            | string | -           |
+| sdk.name                   | string | -           |
+| sdk.version                | string | -           |
+| request.headers.User-Agent | string | -           |
+
+- Request (ContentType: application/json)
+
+  ```json
+  {
+    "type": "replay_event",
+    "replay_type": "session",
+    "replay_id": "515539018c9b4260a6f999572f1661ee",
+    "event_id": "e4a28052c54743a286be419c9d168ef5",
+    "segment_id": 0,
+    "timestamp": 161657652454,
+    "replay_start_timestamp": 160006562825,
+    "urls": ["https://www.sentry.io", "https://www.sentry.io/login"],
+    "error_ids": [],
+    "trace_ids": [],
+    "dist": "abc123",
+    "platform": "javascript",
+    "environment": "production",
+    "release": "version@1.3",
+    "user": {
+      "id": "123",
+      "username": "username",
+      "email": "username@example.com",
+      "ip_address": "127.0.0.1"
+    },
+    "sdk": {
+      "name": "sentry.javascript.react",
+      "version": "6.18.1"
+    },
+    "tags": {
+      "customtag": "is_set",
+      "transaction": "Title"
+    },
+    "contexts": {
+      "replay": {
+        "error_sample_rate": 0.2,
+        "session_sample_rate": 0.5
+      },
+      "trace": {
+        "op": "pageload",
+        "span_id": "affa5649681a1eeb",
+        "trace_id": "23eda6cd4b174ef8a51f0096df3bfdd1"
+      }
+    },
+    "request": {
+      "url": "http://localhost:3000/",
+      "headers": {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
+      }
+    },
+    "extra": {}
+  }
+  ```
+
+### Replay Recording Segment Event
+
+- Request (application/octet-stream)
+
+  ```bytes
+  {"segment_id": 0}
+  \x00\x00\x00\x14ftypqt  \x00\x00\x00\x00qt  \x00\x00\x00\x08wide\x03\xbdd\x11mdat
+  ```

--- a/src/sentry/replays/blueprints/snuba_consumer.md
+++ b/src/sentry/replays/blueprints/snuba_consumer.md
@@ -1,0 +1,91 @@
+- Replay Event
+
+```json
+{
+  "type": "replay_event",
+  "start_time": 1678478346.735299,
+  "replay_id": "e5e062bf2e1d4afd96fd2f90b6770431",
+  "project_id": 1,
+  "retention_days": 30,
+  "payload": {
+    "type": "replay_event",
+    "replay_id": "e5e062bf2e1d4afd96fd2f90b6770431",
+    "replay_type": "session",
+    "segment_id": 0,
+    "event_hash": "8bea4461d8b944f393c15a3cb1c4169a",
+    "urls": ["https:://www.sentry.io", "https:://www.sentry.io/login"],
+    "is_archived": false,
+    "trace_ids": ["36e980a9c6024cde9f5d089f15b83b5f", "8bea4461d8b944f393c15a3cb1c4169a"],
+    "error_ids": ["36e980a9c6024cde9f5d089f15b83b5f"],
+    "dist": "",
+    "platform": "javascript",
+    "timestamp": 1678478346,
+    "replay_start_timestamp": 1678478346,
+    "environment": "prod",
+    "release": "34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a",
+    "user": {
+      "id": "101",
+      "username": "sentaur",
+      "email": "sentaur@sentry.io",
+      "ip_address": "127.0.0.1"
+    },
+    "sdk": {
+      "name": "sentry.javascript",
+      "version": "7.41.0"
+    },
+    "tags": {
+      "customtag": "is_set",
+      "transaction": "/organizations/:orgId/issues/"
+    },
+    "contexts": {
+      "trace": {
+        "op": "pageload",
+        "span_id": "affa5649681a1eeb",
+        "trace_id": "23eda6cd4b174ef8a51f0096df3bfdd1"
+      },
+      "replay": {
+        "error_sample_rate": 0.5,
+        "session_sample_rate": 0.5
+      },
+      "os": {
+        "name": "iOS",
+        "version": "16.2"
+      },
+      "browser": {
+        "name": "Firefox",
+        "version": "110.0"
+      },
+      "device": {
+        "name": "iPhone 11",
+        "brand": "Apple",
+        "family": "iPhone",
+        "model": "iPhone"
+      }
+    },
+    "request": {
+      "url": "https:://www.sentry.io",
+      "headers": {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/110.0"
+      }
+    }
+  }
+}
+```
+
+- Replay Actions Event
+
+```json
+{
+  "type": "replay_event",
+  "start_time": 1678478346.735299,
+  "replay_id": "e5e062bf2e1d4afd96fd2f90b6770431",
+  "project_id": 1,
+  "retention_days": 30,
+  "payload": {
+    "type": "replay_actions",
+    "replay_id": "e5e062bf2e1d4afd96fd2f90b6770431",
+    "segment_id": 0,
+    "actions": []
+  }
+}
+```

--- a/src/sentry/replays/blueprints/snuba_consumer.md
+++ b/src/sentry/replays/blueprints/snuba_consumer.md
@@ -1,4 +1,6 @@
-- Replay Event
+# Replays Snuba Consumer
+
+## Replay Event
 
 ```json
 {
@@ -72,7 +74,7 @@
 }
 ```
 
-- Replay Actions Event
+## Replay Actions Event
 
 ```json
 {
@@ -85,7 +87,21 @@
     "type": "replay_actions",
     "replay_id": "e5e062bf2e1d4afd96fd2f90b6770431",
     "segment_id": 0,
-    "actions": []
+    "actions": [
+      {
+        "dom_action": "click",
+        "dom_element": "div",
+        "dom_id": "id",
+        "dom_classes": ["class1", "class2"],
+        "dom_aria_label": "test",
+        "dom_aria_role": "aria-button",
+        "dom_role": "button",
+        "dom_text_content": "text",
+        "dom_node_id": 59,
+        "timestamp": 1678478346,
+        "event_hash": "df3c3aa2daae465e89f1169e49139827"
+      }
+    ]
   }
 }
 ```


### PR DESCRIPTION
Add blueprints documenting the schemas for Replays related inter-process communications.

This PR ports blueprints from https://github.com/getsentry/replay-backend/ while adding new things, related to the DOM search feature: https://github.com/getsentry/sentry/issues/45524