### PR TITLE
fix(onboarding) Fix newest-performance-issue alias URL

### DIFF
--- a/src/sentry/web/frontend/newest_performance_issue.py
+++ b/src/sentry/web/frontend/newest_performance_issue.py
@@ -1,7 +1,6 @@
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from rest_framework.request import Request
-from rest_framework.response import Response
 
 from sentry.models.group import Group, GroupStatus
 
@@ -9,7 +8,7 @@ from .react_page import ReactPageView
 
 
 class NewestPerformanceIssueView(ReactPageView):
-    def handle(self, request: Request, organization, **kwargs) -> Response:
+    def handle(self, request: Request, organization, **kwargs) -> HttpResponse:
         group = (
             Group.objects.filter(
                 project_id__in=request.access.accessible_project_ids,
@@ -21,11 +20,8 @@ class NewestPerformanceIssueView(ReactPageView):
             .order_by("-first_seen")
             .first()
         )
-        if group:
-            return HttpResponseRedirect(
-                reverse("sentry-organization-issue", args=[organization.slug, group.id])
-            )
         # if no group, then redirect to the issues page
-        return HttpResponseRedirect(
-            reverse("sentry-organization-issue-list", args=[organization.slug])
-        )
+        url = reverse("sentry-organization-issue-list", args=[organization.slug])
+        if group:
+            url = reverse("sentry-organization-issue", args=[organization.slug, group.id])
+        return HttpResponseRedirect(organization.absolute_url(url))

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -753,6 +753,12 @@ urlpatterns += [
         DisabledMemberView.as_view(),
         name="sentry-customer-domain-organization-disabled-member",
     ),
+    # Newest performance issue
+    url(
+        r"^newest-performance-issue/$",
+        NewestPerformanceIssueView.as_view(),
+        name="sentry-customer-domain-organization-newest-performance-issue",
+    ),
     # Restore organization
     url(
         r"^restore/",

--- a/tests/sentry/web/frontend/test_newest_performance_issue.py
+++ b/tests/sentry/web/frontend/test_newest_performance_issue.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from sentry.event_manager import EventManager
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.performance_issues.event_generators import get_event
 
 
@@ -27,7 +28,7 @@ nplus_one_no_timestamp = {**get_event("n-plus-one-in-django-index-view")}
 del nplus_one_no_timestamp["timestamp"]
 
 
-class DisabledMemberViewTest(TestCase):
+class NewestPerformanceIssueViewTest(TestCase):
     @cached_property
     def path(self):
         return reverse("sentry-organization-newest-performance-issue", args=[self.org.slug])
@@ -75,14 +76,52 @@ class DisabledMemberViewTest(TestCase):
 
         resp = self.client.get(self.path, follow=True)
         assert resp.redirect_chain == [
-            (f"/organizations/{self.org.slug}/issues/{event1.groups[0].id}/", 302)
+            (f"http://testserver/organizations/{self.org.slug}/issues/{event1.groups[0].id}/", 302)
         ]
 
         self.login_as(self.owner)
         resp = self.client.get(self.path, follow=True)
         assert resp.redirect_chain == [
-            (f"/organizations/{self.org.slug}/issues/{event2.groups[0].id}/", 302)
+            (f"http://testserver/organizations/{self.org.slug}/issues/{event2.groups[0].id}/", 302)
         ]
+
+    @override_options({"store.use-ingest-performance-detection-only": 1.0})
+    @override_options({"performance.issues.all.problem-detection": 1.0})
+    @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
+    @with_feature("organizations:customer-domains")
+    def test_simple_customer_domains(self):
+        self.project1.update_option("sentry:performance_issue_creation_rate", 1.0)
+        self.project2.update_option("sentry:performance_issue_creation_rate", 1.0)
+        with mock.patch("sentry_sdk.tracing.Span.containing_transaction"), self.feature(
+            {
+                "projects:performance-suspect-spans-ingestion": True,
+            }
+        ):
+            latest_event_time = time()
+            older_event_time = latest_event_time - 300
+
+            manager = EventManager(make_event(**nplus_one_no_timestamp, timestamp=older_event_time))
+            manager.normalize()
+            event1 = manager.save(self.project1.id)
+
+            manager = EventManager(
+                make_event(**nplus_one_no_timestamp, timestamp=latest_event_time)
+            )
+            manager.normalize()
+            event2 = manager.save(self.project2.id)
+
+            # issue error
+            manager = EventManager(make_event(timestamp=latest_event_time))
+            manager.normalize()
+            manager.save(self.project1.id)
+
+        domain = f"{self.org.slug}.testserver"
+        resp = self.client.get("/newest-performance-issue/", follow=True, SERVER_NAME=domain)
+        assert resp.redirect_chain == [(f"http://{domain}/issues/{event1.groups[0].id}/", 302)]
+
+        self.login_as(self.owner)
+        resp = self.client.get("/newest-performance-issue/", follow=True, SERVER_NAME=domain)
+        assert resp.redirect_chain == [(f"http://{domain}/issues/{event2.groups[0].id}/", 302)]
 
     def test_no_performance_issue(self):
         resp = self.client.get(self.path, follow=True)

--- a/tests/sentry/web/frontend/test_newest_performance_issue.py
+++ b/tests/sentry/web/frontend/test_newest_performance_issue.py
@@ -125,4 +125,6 @@ class NewestPerformanceIssueViewTest(TestCase):
 
     def test_no_performance_issue(self):
         resp = self.client.get(self.path, follow=True)
-        assert resp.redirect_chain == [(f"/organizations/{self.org.slug}/issues/", 302)]
+        assert resp.redirect_chain == [
+            (f"http://testserver/organizations/{self.org.slug}/issues/", 302)
+        ]


### PR DESCRIPTION
- Add missing URL for customer domains.
- Use organization to generate redirect URLs so that we don't also get hit with clientside redirects.
- Add tests and improve existing ones.