### PR TITLE
fix: API Docs for dsym endpoint only required project:write

### DIFF
--- a/api-docs/paths/projects/dsyms.json
+++ b/api-docs/paths/projects/dsyms.json
@@ -157,7 +157,7 @@
     },
     "security": [
       {
-        "auth_token": ["project:admin"]
+        "auth_token": ["project:write"]
       }
     ]
   }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/45089

