### PR TITLE
ref(code mappings): Use cache if too many connection errors are hit

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -22,6 +22,10 @@ FILE_PATH_PREFIX_LENGTH = {
     "./": 2,
 }
 
+# We want tasks which hit the GH API multiple times to give up if they hit too many
+# "can't reach GitHub"-type errors.
+MAX_CONNECTION_ERRORS = 10
+
 
 class Repo(NamedTuple):
     name: str

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -742,3 +742,75 @@ class GitHubIntegrationTest(IntegrationTestCase):
                 ("baz", "master", []),
             ]
         )
+
+    @responses.activate
+    def test_get_trees_for_org_makes_API_requests_before_MAX_CONNECTION_ERRORS_is_hit(self):
+        """
+        If some requests fail, but `MAX_CONNECTION_ERRORS` isn't hit, requests will continue
+        to be made to the API.
+        """
+        installation = self.get_installation_helper()
+        self.set_rate_limit()
+
+        # Given that below we mock MAX_CONNECTION_ERRORS to be 2, the error we hit here
+        # should NOT force the remaining repos to pull from the cache.
+        responses.replace(
+            responses.GET,
+            f"{self.base_url}/repos/Test-Organization/xyz/git/trees/master?recursive=1",
+            body=ApiError("Server Error"),
+        )
+
+        # Clear the cache so we can tell when we're pulling from it rather than from an
+        # API call
+        cache.clear()
+
+        with patch(
+            "sentry.integrations.github.client.MAX_CONNECTION_ERRORS",
+            new=2,
+        ):
+
+            trees = installation.get_trees_for_org()
+            assert trees == self._expected_trees(
+                [
+                    # xyz is missing because its request errors
+                    # foo has data because its API request is made in spite of xyz's error
+                    ("foo", "master", ["src/sentry/api/endpoints/auth_login.py"]),
+                    # bar and baz are missing because their API requests throw errors for
+                    # other reasons in the default mock responses
+                ]
+            )
+
+    @responses.activate
+    def test_get_trees_for_org_falls_back_to_cache_once_MAX_CONNECTION_ERRORS_is_hit(self):
+        """Once `MAX_CONNECTION_ERRORS` requests fail, the rest will grab from the cache."""
+        installation = self.get_installation_helper()
+        self.set_rate_limit()
+
+        # Given that below we mock MAX_CONNECTION_ERRORS to be 1, the error we hit here
+        # should force the remaining repos to pull from the cache.
+        responses.replace(
+            responses.GET,
+            f"{self.base_url}/repos/Test-Organization/xyz/git/trees/master?recursive=1",
+            body=ApiError("Server Error"),
+        )
+
+        # Clear the cache so we can tell when we're pulling from it rather than from an
+        # API call
+        cache.clear()
+
+        with patch(
+            "sentry.integrations.github.client.MAX_CONNECTION_ERRORS",
+            new=1,
+        ):
+
+            trees = installation.get_trees_for_org()
+            assert trees == self._expected_trees(
+                [
+                    # xyz isn't here because the request errors out.
+                    # foo, bar, and baz are here but have no files, because xyz's error
+                    # caused us to pull from the empty cache
+                    ("foo", "master", []),
+                    ("bar", "main", []),
+                    ("baz", "master", []),
+                ]
+            )


### PR DESCRIPTION
When fetching file trees from GH, we need to make a separate request to the GH API for each repo. Currently the requests are independent, in that an error in one has no effect on the others. (Put another way, encountering an error with one request doesn't cause us to give up on trying the rest of the requests.) This makes sense if the error encountered is repo-specific (the repo being empty, for example), but doesn't make sense if the problem is something which will affect the entire process. Indeed, when the error is that the whole org is blocked, we [immediately raise an error](https://github.com/getsentry/sentry/blob/d0b78525d56722f5b58076855a8845c5148dbd51/src/sentry/integrations/github/client.py#L218-L221) (which ultimately kills the whole task) rather than just logging the problem and continuing on.

Another place we should reconsider continuing to make requests is if the GH API is down, or if for whatever reason we're unable to connect to it across the board. Though we don't have a direct signal for this, encountering connection-type API errors multiple times in a row is a good hint that something's wrong and we might as well stop trying (for now). Watching for that situation (and giving up and falling back to the cache if it happens) will allow us to finish potentially fruitless tasks more quickly, freeing up resources for other work.

Ref: WOR-2704