### PR TITLE
chore(vsts): Add logs for permission errors

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -453,6 +453,14 @@ class VstsIntegrationProvider(IntegrationProvider):  # type: ignore
             auth_codes = (400, 401, 403)
             permission_error = "permission" in str(e) or "not authorized" in str(e)
             if e.code in auth_codes or permission_error:
+                logger.info(
+                    "vsts.create_subscription_permission_error",
+                    extra={
+                        "organization_id": self.pipeline.organization.id,
+                        "error_message": str(e),
+                        "error_code": e.code,
+                    },
+                )
                 raise IntegrationProviderError(
                     "You do not have sufficient account access to create webhooks\n"
                     "on the selected Azure DevOps organization.\n"

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -199,7 +199,9 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
         }
 
         integration = VstsIntegrationProvider()
-
+        pipeline = Mock()
+        pipeline.organization = self.organization
+        integration.set_pipeline(pipeline)
         with pytest.raises(IntegrationProviderError) as err:
             integration.build_integration(state)
         assert "sufficient account access to create webhooks" in str(err)
@@ -232,7 +234,9 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
         }
 
         integration = VstsIntegrationProvider()
-
+        pipeline = Mock()
+        pipeline.organization = self.organization
+        integration.set_pipeline(pipeline)
         with pytest.raises(IntegrationProviderError) as err:
             integration.build_integration(state)
         assert "sufficient account access to create webhooks" in str(err)


### PR DESCRIPTION
## Objective:
Adding some visibility into the exact error we receive from VSTS, so that we can point customers in the right direction.