### PR TITLE
fix(perf): Use MutableSearch for queries on the landing page

### DIFF
--- a/static/app/components/performance/searchBar.spec.tsx
+++ b/static/app/components/performance/searchBar.spec.tsx
@@ -190,4 +190,28 @@ describe('SearchBar', () => {
     userEvent.click(screen.getByTestId('some-div'));
     expect(screen.queryByTestId('smart-search-dropdown')).not.toBeInTheDocument();
   });
+
+  it('wraps queries with quotes if they contain a space', async () => {
+    const onSearch = jest.fn();
+    eventsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [{transaction: 'GET /my-endpoint'}],
+      },
+    });
+
+    render(<SearchBar {...testProps} onSearch={onSearch} />);
+
+    userEvent.type(screen.getByRole('textbox'), 'GET /my-endpoint');
+    expect(screen.getByRole('textbox')).toHaveValue('GET /my-endpoint');
+
+    act(jest.runAllTimers);
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+
+    userEvent.keyboard('{Enter}');
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith('"GET /my-endpoint"');
+  });
 });

--- a/static/app/components/performance/searchBar.spec.tsx
+++ b/static/app/components/performance/searchBar.spec.tsx
@@ -136,7 +136,7 @@ describe('SearchBar', () => {
 
     expect(screen.queryByTestId('smart-search-dropdown')).not.toBeInTheDocument();
     expect(onSearch).toHaveBeenCalledTimes(1);
-    expect(onSearch).toHaveBeenCalledWith('transaction:clients.fetch');
+    expect(onSearch).toHaveBeenCalledWith('transaction:"clients.fetch"');
   });
 
   it('Submits wildcard searches as raw text searches', async () => {
@@ -191,7 +191,7 @@ describe('SearchBar', () => {
     expect(screen.queryByTestId('smart-search-dropdown')).not.toBeInTheDocument();
   });
 
-  it('wraps queries with quotes if they contain a space', async () => {
+  it('properly formats transaction queries that include a space', async () => {
     const onSearch = jest.fn();
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -209,9 +209,10 @@ describe('SearchBar', () => {
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
 
+    userEvent.keyboard('{Down}');
     userEvent.keyboard('{Enter}');
 
     expect(onSearch).toHaveBeenCalledTimes(1);
-    expect(onSearch).toHaveBeenCalledWith('"GET /my-endpoint"');
+    expect(onSearch).toHaveBeenCalledWith('transaction:"GET /my-endpoint"');
   });
 });

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -193,13 +193,9 @@ function SearchBar(props: SearchBarProps) {
   const handleSearch = (query: string, asRawText: boolean) => {
     setSearchResults([]);
     setSearchString(query);
+    query = new MutableSearch(query).formatString();
 
-    // Transactions with a space must be wrapped in quotes
-    if (query.includes(' ')) {
-      query = `"${query}"`;
-    }
-
-    const fullQuery = asRawText ? query : `transaction:${query}`;
+    const fullQuery = asRawText ? query : `transaction:"${query}"`;
     onSearch(query ? fullQuery : '');
     closeDropdown();
   };

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -193,6 +193,12 @@ function SearchBar(props: SearchBarProps) {
   const handleSearch = (query: string, asRawText: boolean) => {
     setSearchResults([]);
     setSearchString(query);
+
+    // Transactions with a space must be wrapped in quotes
+    if (query.includes(' ')) {
+      query = `"${query}"`;
+    }
+
     const fullQuery = asRawText ? query : `transaction:${query}`;
     onSearch(query ? fullQuery : '');
     closeDropdown();


### PR DESCRIPTION
Fixes a bug with the Performance landing page's transaction search bar, where it would fail to fetch the results of transactions that have a space in them.

This was happening because when searching for a transaction with a space, Discover is not able to properly parse the query string.

### Before
![image](https://user-images.githubusercontent.com/16740047/225104712-cf2d248e-beb0-4024-a57e-8d155438a9f1.png)


### After
![image](https://user-images.githubusercontent.com/16740047/225105348-57c57c90-4212-42ab-861d-69ae80816c3f.png)
