### PR TITLE
fix(perf-issues): enable issue creation for project consecutive http

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -136,4 +136,4 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         )
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:
-        return False
+        return True


### PR DESCRIPTION
is_issue_creation_for_project needs to be true to create any issues. 
setting this to always be true, as we are only looking to set issue creation by org for now.