### PR TITLE
fix(heroku): Fix release creation

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -75,7 +75,7 @@ class HerokuReleaseHook(ReleaseHook):
 
         commit = slug.get("commit")
         app_name = data.get("app", {}).get("name")
-        if data.get("action") == "update":
+        if body.get("action") == "update":
             if app_name:
                 self.finish_release(
                     version=commit,

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -139,8 +139,8 @@ class HookHandleTest(TestCase):
                 "user": {"email": user.email},
                 "slug": {"commit": "abcd123"},
                 "app": {"name": "example"},
-                "action": "update",
-            }
+            },
+            "action": "update",
         }
         req.body = bytes(json.dumps(body), "utf-8")
         hook.handle(req)
@@ -161,8 +161,8 @@ class HookHandleTest(TestCase):
                 "user": {"email": user.email},
                 "slug": {"commit": "abcd123"},
                 "app": {"name": "example"},
-                "action": "create",
-            }
+            },
+            "action": "create",
         }
         req.body = bytes(json.dumps(body), "utf-8")
         hook.handle(req)
@@ -183,8 +183,8 @@ class HookHandleTest(TestCase):
                 "actor": {"email": user.email},
                 "slug": {"commit": "abcd123"},
                 "app": {"name": "example"},
-                "action": "update",
-            }
+            },
+            "action": "update",
         }
         req.body = bytes(json.dumps(body), "utf-8")
         hook.handle(req)
@@ -204,8 +204,8 @@ class HookHandleTest(TestCase):
                 "user": {"email": "wrong@example.com"},
                 "slug": {"commit": "v999"},
                 "app": {"name": "example"},
-                "action": "update",
-            }
+            },
+            "action": "update",
         }
         req.body = bytes(json.dumps(body), "utf-8")
         hook.handle(req)
@@ -223,8 +223,8 @@ class HookHandleTest(TestCase):
                 "actor": {"email": user.email},
                 "slug": {"commit": ""},
                 "app": {"name": "example"},
-                "action": "update",
-            }
+            },
+            "action": "update",
         }
         req.body = bytes(json.dumps(body), "utf-8")
         with pytest.raises(HookValidationError):


### PR DESCRIPTION
Grab the `action` from the request body, not the data. 

Fixes https://github.com/getsentry/sentry/pull/45721