### PR TITLE
feat(discover): add device.class as field to front end and feature flag device.class in generateFieldOptions

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -504,7 +504,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   [FieldKey.DEVICE_CLASS]: {
     desc: t('The estimated performance level of the device, graded low, medium, or high'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.BOOLEAN,
+    valueType: FieldValueType.STRING,
   },
   [FieldKey.DEVICE_FAMILY]: {
     desc: t('Model name across generations'),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -24,6 +24,7 @@ export enum FieldKey {
   DEVICE_BATTERY_LEVEL = 'device.battery_level',
   DEVICE_BRAND = 'device.brand',
   DEVICE_CHARGING = 'device.charging',
+  DEVICE_CLASS = 'device.class',
   DEVICE_FAMILY = 'device.family',
   DEVICE_LOCALE = 'device.locale',
   DEVICE_MODEL_ID = 'device.model_id',
@@ -497,6 +498,11 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   },
   [FieldKey.DEVICE_CHARGING]: {
     desc: t('Charging at the time of the event'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
+  [FieldKey.DEVICE_CLASS]: {
+    desc: t('The estimated performance level of the device, graded low, medium, or high'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.BOOLEAN,
   },
@@ -1063,6 +1069,7 @@ export const DISCOVER_FIELDS = [
   FieldKey.DEVICE_SIMULATOR,
   FieldKey.DEVICE_ONLINE,
   FieldKey.DEVICE_CHARGING,
+  FieldKey.DEVICE_CLASS,
   FieldKey.GEO_COUNTRY_CODE,
   FieldKey.GEO_REGION,
   FieldKey.GEO_CITY,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -490,6 +490,11 @@ export function generateFieldOptions({
     fieldKeys = fieldKeys.filter(item => !PROFILING_FIELDS.includes(item));
   }
 
+  // Strip device.class if the org doesn't have access.
+  if (!organization.features.includes('device-classification')) {
+    fieldKeys = fieldKeys.filter(item => item !== 'device.class');
+  }
+
   const fieldOptions: Record<string, SelectValue<FieldValue>> = {};
 
   // Index items by prefixed keys as custom tags can overlap both fields and


### PR DESCRIPTION
Allows `device.class` to be selectable in column selectors in places like discover and dashboards. Also adds a description for the smart search bar and adds a feature flag check.