### PR TITLE
feat(crons): Explain crontab syntax in monitor form

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
 
@@ -25,6 +25,7 @@ import {SelectValue} from 'sentry/types';
 import commonTheme from 'sentry/utils/theme';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {crontabAsText} from 'sentry/views/monitors/utils';
 
 import {
   IntervalConfig,
@@ -104,6 +105,11 @@ function MonitorForm({
   const form = useRef(new FormModel({transformData}));
   const {projects} = useProjects();
   const {selection} = usePageFilters();
+  const [crontabInput, setCrontabInput] = useState(
+    monitor?.config.schedule_type === ScheduleType.CRONTAB
+      ? monitor?.config.schedule
+      : null
+  );
 
   function formDataFromConfig(type: MonitorType, config: MonitorConfig) {
     const rv = {};
@@ -133,6 +139,8 @@ function MonitorForm({
   const selectedProject = selectedProjectId
     ? projects.find(p => p.id === selectedProjectId + '')
     : null;
+
+  const parsedSchedule = crontabAsText(crontabInput);
 
   return (
     <Form
@@ -235,6 +243,7 @@ function MonitorForm({
                       css={{input: {fontFamily: commonTheme.text.familyMono}}}
                       required
                       stacked
+                      onChange={setCrontabInput}
                       inline={false}
                     />
                     <StyledSelectField
@@ -245,6 +254,7 @@ function MonitorForm({
                       stacked
                       inline={false}
                     />
+                    {parsedSchedule && <CronstrueText>"{parsedSchedule}"</CronstrueText>}
                   </ScheduleGroupInputs>
                 );
               }
@@ -376,4 +386,11 @@ const LabeledInputs = styled('div')`
 
 const ScheduleGroupInputs = styled(LabeledInputs)<{interval?: boolean}>`
   grid-template-columns: ${p => p.interval && 'auto'} 1fr 2fr;
+`;
+
+const CronstrueText = styled(LabelText)`
+  font-weight: normal;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  font-family: ${p => p.theme.text.familyMono};
+  grid-column: auto / span 2;
 `;

--- a/static/app/views/monitors/row.tsx
+++ b/static/app/views/monitors/row.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import cronstrue from 'cronstrue';
 
 import {deleteMonitor} from 'sentry/actionCreators/monitors';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -13,9 +12,9 @@ import {IconEllipsis} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import {shouldUse24Hours} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {crontabAsText} from 'sentry/views/monitors/utils';
 
 import {MonitorBadge} from './components/monitorBadge';
 import {Monitor, MonitorConfig, MonitorStatus, ScheduleType} from './types';
@@ -29,11 +28,8 @@ interface MonitorRowProps {
 function scheduleAsText(config: MonitorConfig) {
   // Crontab format uses cronstrue
   if (config.schedule_type === ScheduleType.CRONTAB) {
-    return cronstrue.toString(config.schedule, {
-      verbose: true,
-      throwExceptionOnParseError: false,
-      use24HourTimeFormat: shouldUse24Hours(),
-    });
+    const parsedSchedule = crontabAsText(config.schedule);
+    return parsedSchedule || t('Unknown schedule');
   }
 
   // Interval format is simpler

--- a/static/app/views/monitors/row.tsx
+++ b/static/app/views/monitors/row.tsx
@@ -29,7 +29,7 @@ function scheduleAsText(config: MonitorConfig) {
   // Crontab format uses cronstrue
   if (config.schedule_type === ScheduleType.CRONTAB) {
     const parsedSchedule = crontabAsText(config.schedule);
-    return parsedSchedule || t('Unknown schedule');
+    return parsedSchedule ?? t('Unknown schedule');
   }
 
   // Interval format is simpler

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -1,0 +1,20 @@
+import cronstrue from 'cronstrue';
+
+import {shouldUse24Hours} from 'sentry/utils/dates';
+
+export function crontabAsText(crontabInput: string | null): string | null {
+  if (!crontabInput) {
+    return null;
+  }
+  let parsedSchedule: string;
+  try {
+    parsedSchedule = cronstrue.toString(crontabInput, {
+      verbose: true,
+      use24HourTimeFormat: shouldUse24Hours(),
+    });
+  } catch (_e) {
+    return null;
+  }
+
+  return parsedSchedule;
+}


### PR DESCRIPTION
Adds explanation text to bottom of crontab input in monitor creation form

Before:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/9372512/225155717-b6f0390b-02a0-4c47-87bf-9a205b55a643.png">

After:
<img width="620" alt="image" src="https://user-images.githubusercontent.com/9372512/225155550-c0f0e115-2276-4c2a-bea9-917c8731f92c.png">
