### PR TITLE
fix(issue-platform): Explicitly pass `culprit` as part of the occurrence, and store `subtitle` correctly

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -94,10 +94,8 @@ def _create_issue_kwargs(
         # TODO: Figure out what message should be. Or maybe we just implement a platform event and
         # define it in `search_message` there.
         "message": event.search_message,
-        # TODO: Not sure what to put here
-        # "logger": job["logger_name"],
         "level": LOG_LEVELS_MAP.get(occurrence.level),
-        "culprit": occurrence.subtitle,
+        "culprit": occurrence.culprit,
         "last_seen": event.datetime,
         "first_seen": event.datetime,
         "active_at": event.datetime,
@@ -114,6 +112,7 @@ class OccurrenceMetadata(TypedDict):
     culprit: str
     metadata: Mapping[str, Any]
     title: str
+    value: str
     location: Optional[str]
     last_received: datetime
 
@@ -130,10 +129,10 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
 
     return {
         "type": event_type.key,
-        # Not totally sure if this makes sense?
-        "culprit": occurrence.subtitle,
-        "metadata": event_metadata,
         "title": occurrence.issue_title,
+        "value": occurrence.subtitle,
+        "culprit": occurrence.culprit,
+        "metadata": event_metadata,
         "location": event.location,
         "last_received": event.datetime,
     }

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -112,7 +112,6 @@ class OccurrenceMetadata(TypedDict):
     culprit: str
     metadata: Mapping[str, Any]
     title: str
-    value: str
     location: Optional[str]
     last_received: datetime
 

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -126,11 +126,11 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
     event_metadata = dict(event_type.get_metadata(event.data))
     event_metadata = dict(event_metadata)
     event_metadata["title"] = occurrence.issue_title
+    event_metadata["value"] = occurrence.subtitle
 
     return {
         "type": event_type.key,
         "title": occurrence.issue_title,
-        "value": occurrence.subtitle,
         "culprit": occurrence.culprit,
         "metadata": event_metadata,
         "location": event.location,

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -33,6 +33,7 @@ class IssueOccurrenceData(TypedDict):
     type: int
     detection_time: float
     level: Optional[str]
+    culprit: Optional[str]
 
 
 @dataclass(frozen=True)
@@ -83,6 +84,7 @@ class IssueOccurrence:
     type: Type[GroupType]
     detection_time: datetime
     level: str
+    culprit: str
 
     def __post_init__(self) -> None:
         if not is_aware(self.detection_time):
@@ -104,6 +106,7 @@ class IssueOccurrence:
             "type": self.type.type_id,
             "detection_time": self.detection_time.timestamp(),
             "level": self.level,
+            "culprit": self.culprit,
         }
 
     @classmethod
@@ -112,6 +115,9 @@ class IssueOccurrence:
         level = data.get("level")
         if not level:
             level = DEFAULT_LEVEL
+        culprit = data.get("culprit")
+        if not culprit:
+            culprit = ""
         return cls(
             data["id"],
             data["project_id"],
@@ -129,6 +135,7 @@ class IssueOccurrence:
             get_group_type_by_type_id(data["type"]),
             cast(datetime, parse_timestamp(data["detection_time"])),
             level,
+            culprit,
         )
 
     @property

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -140,6 +140,12 @@ class AlertRuleNotification(ProjectNotification):
                     "subtitle": get_performance_issue_alert_subtitle(self.event),
                 },
             )
+
+        if getattr(self.event, "occurrence", None):
+            context["issue_title"] = self.event.occurrence.issue_title
+            context["subtitle"] = self.event.occurrence.subtitle
+            context["culprit"] = self.event.occurrence.culprit
+
         if self.group.issue_category not in GROUP_CATEGORIES_CUSTOM_EMAIL:
             generic_issue_data_html = get_generic_data(self.event)
             if generic_issue_data_html:

--- a/src/sentry/templates/sentry/emails/_group.html
+++ b/src/sentry/templates/sentry/emails/_group.html
@@ -52,11 +52,14 @@
         {% else %}
           <a href="{{group.get_absolute_url}}">{{group.title|truncatechars:40}}</a>
         {% endif %}
-        <br />
         {% if transaction %}
           <span class="event-subtitle">{{ transaction }}</span>
         {% endif %}
-      </h3>
+        <br />
+        {% if metadata.value %}
+          <small>{{ metadata.value|truncatechars:100|soft_break:40 }}</small>
+        {% endif %}
+     </h3>
     </div>
   {% endif %}
 </div>

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -141,7 +141,9 @@
                       {% else %}
                       <a href="{% absolute_uri link %}">{{ event.title|truncatechars:40 }}</a>
                       {% endif %}
-                      {% if transaction %}
+                      {% if culprit %}
+                        <span class="event-subtitle">{{ culprit }}</span>
+                      {% elif transaction %}
                         <span class="event-subtitle">{{ transaction }}</span>
                       {% endif %}
                       <br />

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -87,4 +87,5 @@ TEST_ISSUE_OCCURRENCE = IssueOccurrence(
     ProfileFileIOGroupType,
     ensure_aware(datetime.now()),
     "info",
+    "/api/123/",
 )

--- a/src/sentry/web/frontend/debug/debug_generic_issue.py
+++ b/src/sentry/web/frontend/debug/debug_generic_issue.py
@@ -39,6 +39,7 @@ class DebugGenericIssueEmailView(View):
                 "project_label": project.slug,
                 "commits": json.loads(COMMIT_EXAMPLE),
                 "issue_title": event.occurrence.issue_title,
-                "subtitle": event.title,
+                "subtitle": event.occurrence.subtitle,
+                "culprit": event.occurrence.culprit,
             },
         ).render(request)

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -129,8 +129,9 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignor
         assert group.active_at == event.datetime
         assert group.issue_type == occurrence.type
         assert group.first_release is None
-        assert group.data["culprit"] == occurrence.subtitle
-        assert group.data["title"] == occurrence.issue_title
+        assert group.title == occurrence.issue_title
+        assert group.data["value"] == occurrence.subtitle
+        assert group.culprit == occurrence.culprit
         assert group.location() == event.location
 
     def test_existing_group(self) -> None:
@@ -150,8 +151,9 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignor
         assert updated_group_info.group.id == updated_group.id
         assert not updated_group_info.is_new
         assert not updated_group_info.is_regression
-        assert updated_group.culprit == new_occurrence.subtitle
         assert updated_group.title == new_occurrence.issue_title
+        assert updated_group.data["value"] == new_occurrence.subtitle
+        assert updated_group.culprit == new_occurrence.culprit
         assert updated_group.location() == event.location
         assert updated_group.times_seen == 2
 
@@ -199,7 +201,7 @@ class CreateIssueKwargsTest(OccurrenceTestMixin, TestCase):  # type: ignore
             "platform": event.platform,
             "message": event.search_message,
             "level": LOG_LEVELS_MAP.get(occurrence.level),
-            "culprit": occurrence.subtitle,
+            "culprit": occurrence.culprit,
             "last_seen": event.datetime,
             "first_seen": event.datetime,
             "active_at": event.datetime,
@@ -215,8 +217,8 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):  # type: ignore
         event = self.store_event(data={}, project_id=self.project.id)
         assert materialize_metadata(occurrence, event) == {
             "type": "default",
-            # Not totally sure if this makes sense?
-            "culprit": occurrence.subtitle,
+            "value": occurrence.subtitle,
+            "culprit": occurrence.culprit,
             "metadata": {"title": occurrence.issue_title},
             "title": occurrence.issue_title,
             "location": event.location,

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -130,7 +130,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignor
         assert group.issue_type == occurrence.type
         assert group.first_release is None
         assert group.title == occurrence.issue_title
-        assert group.data["value"] == occurrence.subtitle
+        assert group.data["metadata"]["value"] == occurrence.subtitle
         assert group.culprit == occurrence.culprit
         assert group.location() == event.location
 
@@ -152,7 +152,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignor
         assert not updated_group_info.is_new
         assert not updated_group_info.is_regression
         assert updated_group.title == new_occurrence.issue_title
-        assert updated_group.data["value"] == new_occurrence.subtitle
+        assert updated_group.data["metadata"]["value"] == new_occurrence.subtitle
         assert updated_group.culprit == new_occurrence.culprit
         assert updated_group.location() == event.location
         assert updated_group.times_seen == 2
@@ -217,9 +217,8 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):  # type: ignore
         event = self.store_event(data={}, project_id=self.project.id)
         assert materialize_metadata(occurrence, event) == {
             "type": "default",
-            "value": occurrence.subtitle,
             "culprit": occurrence.culprit,
-            "metadata": {"title": occurrence.issue_title},
+            "metadata": {"title": occurrence.issue_title, "value": occurrence.subtitle},
             "title": occurrence.issue_title,
             "location": event.location,
             "last_received": event.datetime,

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -37,6 +37,7 @@ class OccurrenceTestMixin:
             "fingerprint": ["some-fingerprint"],
             "issue_title": "something bad happened",
             "subtitle": "it was bad",
+            "culprit": "api/123",
             "resource_id": "1234",
             "evidence_data": {"Test": 123},
             "evidence_display": [

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -205,6 +205,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             ProfileFileIOGroupType,
             ensure_aware(datetime.now()),
             "info",
+            "/api/123",
         )
         occurrence.save()
         event.occurrence = occurrence
@@ -254,6 +255,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             ProfileFileIOGroupType,
             ensure_aware(datetime.now()),
             "info",
+            "/api/123",
         )
         occurrence.save()
         event.occurrence = occurrence


### PR DESCRIPTION
Updating the occurrences model to properly map to how we use fields in the ui

<img width="629" alt="225149172-015bbd99-bc7d-4908-8ac5-00507b8d1659" src="https://user-images.githubusercontent.com/6288560/225165614-aa3a6379-14e2-48c2-a93c-49081ee6b577.png">

This adds `culprit` to the occurrence payload, and changes how we map data to the group as follows:
 - `title` - `group.data["title"]`
 - `subtitle` - `group.data["value"]`
 - `culprit` - `group.culprit`

Also make sure that the generic issue alert email and digests are using these fields as expected.