### PR TITLE
fix(ecosystem): Preserve codeowners filters on update

### DIFF
--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
@@ -104,6 +104,40 @@ describe('OwnershipRulesTable', () => {
     expect(screen.queryByText('mytag')).toBeInTheDocument();
   });
 
+  it('preserves selected teams when rules are updated', () => {
+    const rules: ParsedOwnershipRule[] = [
+      {
+        matcher: {pattern: 'filepath', type: 'path'},
+        owners: [{type: 'user', id: user1.id, name: user1.name}],
+      },
+      {
+        matcher: {pattern: 'anotherpath', type: 'path'},
+        owners: [{type: 'user', id: user2.id, name: user2.name}],
+      },
+    ];
+
+    const {rerender} = render(
+      <OwnershipRulesTable projectRules={rules} codeowners={[]} />
+    );
+
+    // Clear the filter
+    userEvent.click(screen.getByRole('button', {name: 'My Teams'}));
+    userEvent.click(screen.getByRole('button', {name: 'Clear'}));
+    expect(screen.getAllByText('path')).toHaveLength(2);
+
+    const newRules: ParsedOwnershipRule[] = [
+      ...rules,
+      {
+        matcher: {pattern: 'thirdpath', type: 'path'},
+        owners: [{type: 'user', id: user2.id, name: user2.name}],
+      },
+    ];
+
+    rerender(<OwnershipRulesTable projectRules={newRules} codeowners={[]} />);
+    expect(screen.getAllByText('path')).toHaveLength(3);
+    expect(screen.getByRole('button', {name: 'Everyone'})).toBeInTheDocument();
+  });
+
   it('should paginate results', () => {
     const owners: Actor[] = [{type: 'user', id: user1.id, name: user1.name}];
     const rules: ParsedOwnershipRule[] = Array(100)


### PR DESCRIPTION
After update ownership rules, the filters were being reset. Preserve them once they've been changed.

