### PR TITLE
chore(hybrid-cloud): Consolidate key lengths as constants for region names and idempotency keys

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -39,6 +39,7 @@ from sentry.models import (
     ScheduledDeletion,
     UserEmail,
 )
+from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
 from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMappingUpdate,
     organization_mapping_service,
@@ -428,7 +429,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
 class OwnerOrganizationSerializer(OrganizationSerializer):
     defaultRole = serializers.ChoiceField(choices=roles.get_choices())
     cancelDeletion = serializers.BooleanField(required=False)
-    idempotencyKey = serializers.CharField(max_length=32, required=False)
+    idempotencyKey = serializers.CharField(max_length=IDEMPOTENCY_KEY_LENGTH, required=False)
 
     def save(self, *args, **kwargs):
         org = self.context["organization"]

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -23,6 +23,7 @@ from sentry.models import (
     ProjectPlatform,
 )
 from sentry.search.utils import tokenize_query
+from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
 from sentry.signals import org_setup_complete, terms_accepted
 
@@ -30,7 +31,7 @@ from sentry.signals import org_setup_complete, terms_accepted
 class OrganizationSerializer(BaseOrganizationSerializer):
     defaultTeam = serializers.BooleanField(required=False)
     agreeTerms = serializers.BooleanField(required=True)
-    idempotencyKey = serializers.CharField(max_length=32, required=False)
+    idempotencyKey = serializers.CharField(max_length=IDEMPOTENCY_KEY_LENGTH, required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sentry/models/organizationmapping.py
+++ b/src/sentry/models/organizationmapping.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from sentry.db.models import BoundedBigIntegerField, Model, sane_repr
 from sentry.db.models.base import control_silo_only_model
+from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH, REGION_NAME_LENGTH
 
 
 @control_silo_only_model
@@ -26,8 +27,8 @@ class OrganizationMapping(Model):
     verified = models.BooleanField(default=False)
     # If a record already exists with the same slug, the organization_id can only be
     # updated IF the idempotency key is identical.
-    idempotency_key = models.CharField(max_length=48)
-    region_name = models.CharField(max_length=48)
+    idempotency_key = models.CharField(max_length=IDEMPOTENCY_KEY_LENGTH)
+    region_name = models.CharField(max_length=REGION_NAME_LENGTH)
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -21,6 +21,7 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
+from sentry.services.hybrid_cloud import REGION_NAME_LENGTH
 from sentry.silo import SiloMode
 from sentry.utils import metrics
 
@@ -270,7 +271,7 @@ class ControlOutbox(OutboxBase):
         "object_identifier",
     )
 
-    region_name = models.CharField(max_length=48)
+    region_name = models.CharField(max_length=REGION_NAME_LENGTH)
 
     def send_signal(self):
         process_control_outbox.send(

--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
     from sentry.api.base import Endpoint
 T = TypeVar("T")
 
+IDEMPOTENCY_KEY_LENGTH = 48
+REGION_NAME_LENGTH = 48
+
 
 class InterfaceWithLifecycle(ABC):
     @abstractmethod


### PR DESCRIPTION
This should help avoid the magic constant issue across hybrid cloud code.