### PR TITLE
fix(ecosystem): Adjust codeowners copy and primary button

### DIFF
--- a/static/app/views/settings/project/projectOwnership/codeownerErrors.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeownerErrors.spec.tsx
@@ -30,9 +30,7 @@ describe('CodeownerErrors', () => {
       )
     );
     expect(
-      screen.getByText(
-        `The following teams do not have an association in the organization: ${org.slug}`
-      )
+      screen.getByText(`There’s a problem linking teams and members from an integration`)
     ).toBeInTheDocument();
     expect(screen.getByText('@getsentry/something')).toBeInTheDocument();
   });

--- a/static/app/views/settings/project/projectOwnership/codeownerErrors.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeownerErrors.tsx
@@ -84,7 +84,7 @@ export function CodeOwnerErrors({
       case 'missing_external_teams':
         return (
           <ErrorMessage
-            message={`The following teams do not have an association in the organization: ${orgSlug}`}
+            message="There’s a problem linking teams and members from an integration"
             values={values}
             link={`/settings/${orgSlug}/integrations/${codeMapping?.provider?.slug}/${codeMapping?.integrationId}/?tab=teamMappings`}
             linkValue="Configure Team Mappings"

--- a/static/app/views/settings/project/projectOwnership/index.spec.jsx
+++ b/static/app/views/settings/project/projectOwnership/index.spec.jsx
@@ -97,10 +97,10 @@ describe('Project Ownership', () => {
       );
 
       // Renders button
-      expect(screen.getByRole('button', {name: 'Add CODEOWNERS'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Import CODEOWNERS'})).toBeInTheDocument();
 
       // Opens modal
-      userEvent.click(screen.getByRole('button', {name: 'Add CODEOWNERS'}));
+      userEvent.click(screen.getByRole('button', {name: 'Import CODEOWNERS'}));
       expect(openModal).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Adjusts some copy and re-arranges the buttons with edit rules becoming the primary action.

![image](https://user-images.githubusercontent.com/1400464/225174791-053c9f35-4e97-44dc-bf31-d37f88bdd615.png)
