### PR TITLE
fix(onboarding): Fix issue when first error sent

### DIFF
--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -152,9 +152,7 @@ function SetupDocs({search, route, router, location}: Props) {
 
   const {project_id: rawProjectId} = qs.parse(search);
   const rawProjectIndex = projects.findIndex(p => p.id === rawProjectId);
-  const firstProjectNoError = projects.findIndex(
-    p => selectedProjectsSet.has(p.slug) && !checkProjectHasFirstEvent(p)
-  );
+  const firstProjectNoError = projects.findIndex(p => selectedProjectsSet.has(p.slug));
   // Select a project based on search params. If non exist, use the first project without first event.
   const projectIndex = rawProjectIndex >= 0 ? rawProjectIndex : firstProjectNoError;
   const project = projects[projectIndex];


### PR DESCRIPTION
The current logic was making the page render empty content when the first error ist sent. This PR fixes it.


**Before:**

![image](https://user-images.githubusercontent.com/29228205/225250276-390f1755-2c04-4c31-885b-2af922269800.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/225250108-ff5fc046-02cb-4f43-a8cd-3a71925521fa.png)
