### PR TITLE
feat(onboarding): Add feature flag to control the View Sample Error button - [TET-778]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1307,6 +1307,8 @@ SENTRY_FEATURES = {
     "organizations:view-hierarchies-options-dev": False,
     # Enable the onboarding heartbeat footer on the sdk setup page
     "organizations:onboarding-heartbeat-footer": False,
+    # Enable the onboarding heartbeat footer on the sdk setup page with the view sample error button
+    "organizations:onboarding-heartbeat-footer-with-view-sample-error": False,
     # Enable a new behavior for deleting the freshly created project,
     # if the user clicks on the back button in the onboarding for new orgs
     "organizations:onboarding-project-deletion-on-back-click": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -215,6 +215,7 @@ default_manager.add("organizations:integrations-issue-sync", OrganizationFeature
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature)
 default_manager.add("organizations:onboarding-heartbeat-footer", OrganizationFeature, True)
+default_manager.add("organizations:onboarding-heartbeat-footer-with-view-sample-error", OrganizationFeature, True)
 default_manager.add("organizations:onboarding-project-deletion-on-back-click", OrganizationFeature, True)
 default_manager.add("organizations:onboarding-remove-multiselect-platform", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)


### PR DESCRIPTION
We would like to do an A/B Test of the new onboarding footer with and without the View Sample Error button when Sentry is still awaiting the first error. This PR adds a feature flag that is going to be controlled by flagr so we can roll out it for a certain amount of users.