### PR TITLE
fix(sourcemaps): Change date formatting and add search

### DIFF
--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -44,7 +44,9 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
         def expose_artifact_bundle(debug_id_artifact_bundle):
             artifact_bundle = debug_id_artifact_bundle.artifact_bundle
 
+            # TODO(iambriccardo): Use a serializer for this.
             return {
+                "id": artifact_bundle.id,
                 "type": "artifact_bundle",
                 "name": str(artifact_bundle.bundle_id),
                 "date": debug_id_artifact_bundle.date_added.isoformat()[:19] + "Z",

--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -41,32 +41,21 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
             query_q = Q(artifact_bundle__bundle_id__icontains=query)
             queryset = queryset.filter(query_q)
 
-        def expose_artifact_bundle(artifact_bundle, artifact_bundle_meta):
-            bundle_id, artifact_count = artifact_bundle_meta
+        def expose_artifact_bundle(debug_id_artifact_bundle):
+            artifact_bundle = debug_id_artifact_bundle.artifact_bundle
 
             return {
                 "type": "artifact_bundle",
-                "name": str(bundle_id),
-                "date": artifact_bundle["date_added"].isoformat()[:19] + "Z",
-                "fileCount": artifact_count,
+                "name": str(artifact_bundle.bundle_id),
+                "date": debug_id_artifact_bundle.date_added.isoformat()[:19] + "Z",
+                "fileCount": artifact_bundle.artifact_count,
             }
 
         def serialize_results(results):
-            artifact_bundle_counts = ArtifactBundle.get_artifact_counts(
-                [r["artifact_bundle_id"] for r in results]
-            )
-
             # We want to maintain the -date_added ordering, thus we index the metadata by using the id fetched with the
             # first query.
             return serialize(
-                [
-                    expose_artifact_bundle(
-                        artifact_bundle=r,
-                        artifact_bundle_meta=artifact_bundle_counts[r["artifact_bundle_id"]],
-                    )
-                    for r in results
-                    if r["artifact_bundle_id"] in artifact_bundle_counts
-                ],
+                [expose_artifact_bundle(debug_id_artifact_bundle=r) for r in results],
                 request.user,
             )
 

--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -40,7 +40,7 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
             return {
                 "type": "artifact_bundle",
                 "bundleId": str(bundle_id),
-                "dateCreated": artifact_bundle["date_added"].isoformat().replace("+00:00", "Z"),
+                "dateCreated": artifact_bundle["date_added"].strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "fileCount": artifact_count,
             }
 

--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -40,7 +40,7 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
             return {
                 "type": "artifact_bundle",
                 "bundleId": str(bundle_id),
-                "date": artifact_bundle["date_added"],
+                "dateCreated": artifact_bundle["date_added"].isoformat().replace("+00:00", "Z"),
                 "fileCount": artifact_count,
             }
 

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -1,7 +1,6 @@
 import zipfile
 from enum import Enum
-from typing import IO, Dict, List, Optional, Tuple
-from uuid import UUID
+from typing import IO, List, Optional, Tuple
 
 from django.db import models
 from django.utils import timezone
@@ -53,18 +52,6 @@ class ArtifactBundle(Model):
         db_table = "sentry_artifactbundle"
 
         unique_together = (("organization_id", "bundle_id"),)
-
-    @classmethod
-    def get_artifact_counts(cls, artifact_bundle_ids: List[int]) -> Dict[int, Tuple[UUID, int]]:
-        artifact_bundles = ArtifactBundle.objects.filter(id__in=artifact_bundle_ids)
-        bundles_with_counts = {}
-        for artifact_bundle in artifact_bundles:
-            bundles_with_counts[artifact_bundle.id] = (
-                artifact_bundle.bundle_id,
-                artifact_bundle.artifact_count,
-            )
-
-        return bundles_with_counts
 
 
 @region_silo_only_model

--- a/tests/sentry/api/endpoints/test_artifact_bundles.py
+++ b/tests/sentry/api/endpoints/test_artifact_bundles.py
@@ -35,25 +35,42 @@ class ArtifactBundlesEndpointTest(APITestCase):
             kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
         )
 
+        # We test without search.
         self.login_as(user=self.user)
-        response = self.client.get(url + f"?query={artifact_bundle_2.bundle_id}")
+        response = self.client.get(url)
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
         # By default we return the most recent bundle.
         assert response.data == [
             {
-                "bundleId": str(artifact_bundle_2.bundle_id),
-                "dateCreated": "2023-03-15T01:00:00Z",
+                "name": str(artifact_bundle_2.bundle_id),
+                "date": "2023-03-15T01:00:00Z",
                 "fileCount": 2,
                 "type": "artifact_bundle",
             },
             {
-                "bundleId": str(artifact_bundle_1.bundle_id),
-                "dateCreated": "2023-03-15T00:00:00Z",
+                "name": str(artifact_bundle_1.bundle_id),
+                "date": "2023-03-15T00:00:00Z",
                 "fileCount": 2,
                 "type": "artifact_bundle",
             },
+        ]
+
+        # We test the search with a full bundle id.
+        self.login_as(user=self.user)
+        response = self.client.get(url + f"?query={artifact_bundle_2.bundle_id}")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        # By default we return the most recent bundle.
+        assert response.data == [
+            {
+                "name": str(artifact_bundle_2.bundle_id),
+                "date": "2023-03-15T01:00:00Z",
+                "fileCount": 2,
+                "type": "artifact_bundle",
+            }
         ]
 
     def test_get_artifact_bundles_with_no_bundles(self):
@@ -116,12 +133,12 @@ class ArtifactBundlesEndpointTest(APITestCase):
         self.login_as(user=self.user)
         response = self.client.get(url + "?sortBy=date_added")
         assert response.status_code == 200, response.content
-        assert list(map(lambda value: value["bundleId"], response.data)) == bundle_ids
+        assert list(map(lambda value: value["name"], response.data)) == bundle_ids
 
         self.login_as(user=self.user)
         response = self.client.get(url + "?sortBy=-date_added")
         assert response.status_code == 200, response.content
-        assert list(map(lambda value: value["bundleId"], response.data)) == bundle_ids[::-1]
+        assert list(map(lambda value: value["name"], response.data)) == bundle_ids[::-1]
 
         self.login_as(user=self.user)
         response = self.client.get(url + "?sortBy=name")

--- a/tests/sentry/api/endpoints/test_artifact_bundles.py
+++ b/tests/sentry/api/endpoints/test_artifact_bundles.py
@@ -48,12 +48,14 @@ class ArtifactBundlesEndpointTest(APITestCase):
                 "date": "2023-03-15T01:00:00Z",
                 "fileCount": 2,
                 "type": "artifact_bundle",
+                "id": artifact_bundle_2.id,
             },
             {
                 "name": str(artifact_bundle_1.bundle_id),
                 "date": "2023-03-15T00:00:00Z",
                 "fileCount": 2,
                 "type": "artifact_bundle",
+                "id": artifact_bundle_1.id,
             },
         ]
 
@@ -70,6 +72,7 @@ class ArtifactBundlesEndpointTest(APITestCase):
                 "date": "2023-03-15T01:00:00Z",
                 "fileCount": 2,
                 "type": "artifact_bundle",
+                "id": artifact_bundle_2.id,
             }
         ]
 

--- a/tests/sentry/api/endpoints/test_artifact_bundles.py
+++ b/tests/sentry/api/endpoints/test_artifact_bundles.py
@@ -36,7 +36,7 @@ class ArtifactBundlesEndpointTest(APITestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.client.get(url)
+        response = self.client.get(url + f"?query={artifact_bundle_2.bundle_id}")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2


### PR DESCRIPTION
This PR changes the date formatting for the artifact bundles endpoint which is now using the ISO format `2023-03-15T00:00:00Z`. The previous endpoint version was returning the DateTime object which was serialized with the default python string serialization `DateTime(2023-03-15 00:00:00)`. In addition, it adds search via `bundle_id`.