### PR TITLE
ref(perf): Change nextjs default view

### DIFF
--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -89,7 +89,9 @@ export enum PROJECT_PERFORMANCE_TYPE {
 
 // The native SDK is equally used on clients and end-devices as on
 // backend, the default view should be "All Transactions".
-const FRONTEND_PLATFORMS: string[] = [...frontend];
+const FRONTEND_PLATFORMS: string[] = [...frontend].filter(
+  platform => platform !== 'javascript-nextjs' // Next has both frontend and backend transactions.
+);
 const BACKEND_PLATFORMS: string[] = backend.filter(platform => platform !== 'native');
 const MOBILE_PLATFORMS: string[] = [...mobile];
 


### PR DESCRIPTION
### Summary
This removes nextjs from the 'default to frontend' list so users should be hitting 'all transactions' from now on.

Other:
- We don't have a great experience for 'mixed' projects since we have a built-in assumption for platform->project type, but since the web vitals view currently adds filters omitting data, we definitely can't use it for next at the moment.

