### PR TITLE
ref(dynamic-sampling): Add onboarding experiement to the ds page (temp test) - [TET-778]

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -23,6 +23,12 @@ export const experimentList: {
     parameter: 'exposed',
     assignments: [0, 1],
   },
+  {
+    key: 'OnboardingNewFooterExperiment',
+    type: ExperimentType.Organization,
+    parameter: 'scenario',
+    assignments: [0, 1, 2],
+  },
 ];
 
 export const experimentConfig = experimentList.reduce(

--- a/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
+++ b/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
@@ -19,6 +19,7 @@ import {DynamicSamplingBias, DynamicSamplingBiasType} from 'sentry/types/samplin
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -61,12 +62,26 @@ export const knowDynamicSamplingBiases = {
 export function DynamicSampling({project}: Props) {
   const organization = useOrganization();
   const api = useApi();
+  const {logExperiment, experimentAssignment} = useExperiment(
+    'OnboardingNewFooterExperiment',
+    {
+      logExperimentOnMount: false,
+    }
+  );
 
   const hasTransactionNamePriorityFlag = organization.features.includes(
     'dynamic-sampling-transaction-name-priority'
   );
   const hasAccess = organization.access.includes('project:write');
   const biases = project.dynamicSamplingBiases ?? [];
+
+  // log experiment on mount if feature enabled
+  useEffect(() => {
+    // we are testing this on the dynamic sampling page but it will be removed soon
+    if (organization?.features.includes('onboarding-heartbeat-footer')) {
+      logExperiment();
+    }
+  }, [logExperiment, organization?.features]);
 
   useEffect(() => {
     trackAdvancedAnalyticsEvent('dynamic_sampling_settings.viewed', {
@@ -126,6 +141,16 @@ export function DynamicSampling({project}: Props) {
   return (
     <SentryDocumentTitle title={t('Dynamic Sampling')}>
       <Fragment>
+        {organization?.features.includes('onboarding-heartbeat-footer') && (
+          <div>
+            The Heartbeat is active and you are participating in the experiment: &nbsp;
+            {experimentAssignment === 0
+              ? '(Baseline) No change'
+              : experimentAssignment === 1
+              ? '(Variant 1) New design with “Explore Sentry“ button disabled while “waiting for error“'
+              : '(Variant 2) New design with existing “View Sample Error“ button instead while “waiting for error“'}
+          </div>
+        )}
         <SettingsPageHeader
           title={
             <Fragment>


### PR DESCRIPTION
Just to test if the A/B test we want to do in the onboarding is properly working we are using the dynamic sampling page for it... Naturally, everything is behind a feature flag and only available for us... the code will be moved to the onboarding as soon as we confirm that it works.

related to https://github.com/getsentry/getsentry/pull/9820