### PR TITLE
feat(mobile): Hoist device class to the top of tag summary for mobile platforms

### DIFF
--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -258,7 +258,9 @@ class BaseGroupSidebar extends Component<Props, State> {
           groupId={group.id}
           tagKeys={
             isMobilePlatform(project?.platform)
-              ? MOBILE_TAGS
+              ? !organization.features.includes('device-classification')
+                ? MOBILE_TAGS.filter(tag => tag !== 'device.class')
+                : MOBILE_TAGS
               : frontend.some(val => val === project?.platform)
               ? FRONTEND_TAGS
               : backend.some(val => val === project?.platform)

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -16,7 +16,14 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import TagFacetsDistributionMeter from './tagFacetsDistributionMeter';
 
-export const MOBILE_TAGS = ['device', 'os', 'release', 'environment', 'transaction'];
+export const MOBILE_TAGS = [
+  'device',
+  'device.class',
+  'os',
+  'release',
+  'environment',
+  'transaction',
+];
 
 export const FRONTEND_TAGS = ['browser', 'transaction', 'release', 'url', 'environment'];
 


### PR DESCRIPTION
Adds `device.class` to the top of the tag summary in the issue details page for mobile platforms.