### PR TITLE
feat(view-hierarchy): Add dart symbols to acceptable DIF files

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -31,6 +31,7 @@ CHUNK_UPLOAD_ACCEPT = (
     "bcsymbolmaps",  # BCSymbolMaps and associated PLists/UuidMaps
     "il2cpp",  # Il2cpp LineMappingJson files
     "portablepdbs",  # Portable PDB debug file
+    "dartsymbols",  # JSON file containing obfuscated and deobfuscated Dart symbols
     # TODO: This is currently turned on by a feature flag
     # "artifact_bundles",  # Artifact bundles containing source maps.
 )

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -319,6 +319,7 @@ KNOWN_DIF_FORMATS: Dict[str, str] = {
     "application/x-debugid-map": "uuidmap",
     "application/x-il2cpp-json": "il2cpp",
     "application/x-portable-pdb": "portablepdb",
+    "application/x-dartsymbols-json": "dartsymbols",
 }
 
 NATIVE_UNKNOWN_STRING = "<unknown>"


### PR DESCRIPTION
Allows a new kind of debug file that's outputted when Flutter builds are run with obfuscation enabled. This is a JSON file where the contents are an array with each value alternating between deobfuscated and obfuscated values.

e.g.:
```json
[
  "",
  "",
  "ClassNameA",
  "XYZ",
  "SymbolB",
  "AbC",
  ...
]
```

This will rely on an update to sentry-cli to start allowing these files to be sent.