### PR TITLE
ref(scaling-codeowners): Increase post process issue owners ratelimit

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS))
 
-ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 30
+ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 50
 
 
 class PostProcessJob(TypedDict, total=False):


### PR DESCRIPTION
Increase post process issue owners per project per minute ratelimit from 30 to 50.

30 was initially chosen as a gut call - we are interested in seeing if increasing the ratelimit will improve performance of the `handle_owner_assignment` step in the post process pipeline.