### PR TITLE
fix(config): Remove note about installing `python-memcached` from default `sentry.conf.py`

### DIFF
--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -42,10 +42,7 @@ DEBUG = %(debug_flag)s
 # Sentry currently utilizes two separate mechanisms. While CACHES is not a
 # requirement, it will optimize several high throughput patterns.
 
-# If you wish to use memcached, install the dependencies and adjust the config
-# as shown:
-#
-#   pip install python-memcached
+# If you wish to use memcached, uncomment the following:
 #
 # CACHES = {
 #     'default': {


### PR DESCRIPTION
Given that `python-memcached` is [listed in our core requirements](https://github.com/getsentry/sentry/blob/28d3d0e274e014ccf07f98dffbf4bc6026b9a456/requirements-base.txt#L43), we don't need to tell people to install it separately.