### PR TITLE
ref(outcomes) Tweak new QueryDefinition constructor

### DIFF
--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -54,7 +54,7 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
                     Outcome.RATE_LIMITED.api_name(),
                 ],
                 group_by=["outcome"],
-                category="error",
+                category=["error"],
                 key_id=key.id,
                 interval=request.GET.get("resolution", "1d"),
             )

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -238,7 +238,7 @@ class QueryDefinition:
         outcome: Optional[List[str]] = None,
         group_by: Optional[List[str]] = None,
         query: Optional[Mapping[str, Any]] = None,
-        category: Optional[str] = None,
+        category: Optional[List[str]] = None,
         reason: Optional[str] = None,
         allow_minute_resolution: bool = True,
     ) -> QueryDefinition:
@@ -258,13 +258,13 @@ class QueryDefinition:
             query_dict.setlist("groupBy", group_by)
         if outcome is not None:
             query_dict.setlist("outcome", outcome)
+        if category is not None:
+            query_dict.setlist("category", category)
 
         if interval is not None:
             query_dict["interval"] = interval
         if reason is not None:
             query_dict["reason"] = reason
-        if category is not None:
-            query_dict["category"] = category
         if query is not None:
             query_dict["query"] = query
         if key_id is not None:


### PR DESCRIPTION
The `category` filter is used as a list in existing tests so the new interface needs to support lists too. With this fixed I'll be able to update outcomes queries in getsentry and then update orgstats as well.