### PR TITLE
feat(replays): Enable direct-storage blob driver based on configuration

### DIFF
--- a/src/sentry/replays/lib/storage.py
+++ b/src/sentry/replays/lib/storage.py
@@ -101,7 +101,7 @@ class StorageBlob(Blob):
         storage.delete(self.make_key(segment))
 
     @metrics.wraps("replays.lib.storage.StorageBlob.get")
-    def get(self, segment: RecordingSegmentStorageMeta) -> Optional[bytes]:
+    def get(self, segment: RecordingSegmentStorageMeta) -> bytes:
         try:
             storage = get_storage(self._make_storage_options())
             blob = storage.open(self.make_key(segment))
@@ -109,7 +109,7 @@ class StorageBlob(Blob):
             blob.close()
         except Exception:
             logger.exception("Storage GET error.")
-            return None
+            return b"[]"  # Return a default value if the storage does not exist.
         else:
             return result
 

--- a/src/sentry/replays/lib/storage.py
+++ b/src/sentry/replays/lib/storage.py
@@ -101,7 +101,7 @@ class StorageBlob(Blob):
         storage.delete(self.make_key(segment))
 
     @metrics.wraps("replays.lib.storage.StorageBlob.get")
-    def get(self, segment: RecordingSegmentStorageMeta) -> bytes:
+    def get(self, segment: RecordingSegmentStorageMeta) -> Optional[bytes]:
         try:
             storage = get_storage(self._make_storage_options())
             blob = storage.open(self.make_key(segment))
@@ -109,7 +109,7 @@ class StorageBlob(Blob):
             blob.close()
         except Exception:
             logger.exception("Storage GET error.")
-            return b"[]"  # Return a default value if the storage does not exist.
+            return None
         else:
             return result
 

--- a/src/sentry/replays/usecases/ingest.py
+++ b/src/sentry/replays/usecases/ingest.py
@@ -10,10 +10,7 @@ from sentry_sdk.tracing import Span
 from sentry.constants import DataCategory
 from sentry.models.project import Project
 from sentry.replays.cache import RecordingSegmentCache, RecordingSegmentParts
-from sentry.replays.lib.storage import (  # make_storage_driver,
-    FilestoreBlob,
-    RecordingSegmentStorageMeta,
-)
+from sentry.replays.lib.storage import RecordingSegmentStorageMeta, make_storage_driver
 from sentry.replays.models import ReplayRecordingSegment as ReplayRecordingSegmentModel
 from sentry.signals import first_replay_received
 from sentry.utils import json, metrics
@@ -169,13 +166,7 @@ def ingest_recording(message: RecordingIngestMessage, transaction: Span) -> None
 
     # Using a blob driver ingest the recording-segment bytes.  The storage location is unknown
     # within this scope.
-    #
-    # Temporarily commented out write behavior.  We'll continue writing as normal and test that
-    # the read behavior has no regressions.
-    #
-    # driver = make_storage_driver(message.org_id)
-    # driver.set(segment_data, recording_segment)
-    driver = FilestoreBlob()
+    driver = make_storage_driver(message.org_id)
     driver.set(segment_data, recording_segment)
 
     # The first segment records an accepted outcome. This is for billing purposes. Subsequent

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -260,10 +260,8 @@ def download_segment(segment: RecordingSegmentStorageMeta) -> Optional[bytes]:
     """Return the segment blob data."""
     driver = FilestoreBlob() if segment.file_id else StorageBlob()
     result = driver.get(segment)
-    if result is None:
-        return None
-
-    return decompress(result)
+    if result is not None:
+        return decompress(result)
 
 
 def decompress(buffer: bytes) -> bytes:

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -4,7 +4,7 @@ import uuid
 import zlib
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
-from typing import Iterator, List, Optional
+from typing import Iterator, List
 
 from django.db.models import Prefetch
 from snuba_sdk import (
@@ -245,23 +245,17 @@ def download_segments(segments: List[RecordingSegmentStorageMeta]) -> Iterator[b
     yield b"["
 
     for i, result in enumerate(results):
-        if result is None:
-            yield b"[]"
-        else:
-            yield result
-
+        yield result
         if i < len(segments) - 1:
             yield b","
 
     yield b"]"
 
 
-def download_segment(segment: RecordingSegmentStorageMeta) -> Optional[bytes]:
+def download_segment(segment: RecordingSegmentStorageMeta) -> bytes:
     """Return the segment blob data."""
     driver = FilestoreBlob() if segment.file_id else StorageBlob()
-    result = driver.get(segment)
-    if result is not None:
-        return decompress(result)
+    return decompress(driver.get(segment))
 
 
 def decompress(buffer: bytes) -> bytes:

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -9,11 +9,11 @@ import msgpack
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
-# from sentry import options
+from sentry import options
 from sentry.models import File
 from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingTaskStatus
 from sentry.replays.consumers.recording import ProcessReplayRecordingStrategyFactory
-from sentry.replays.lib.storage import FilestoreBlob, RecordingSegmentStorageMeta
+from sentry.replays.lib.storage import FilestoreBlob, RecordingSegmentStorageMeta, StorageBlob
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.testutils import TransactionTestCase
 
@@ -246,31 +246,31 @@ class FilestoreRecordingTestCase(RecordingTestCaseMixin, TransactionTestCase):
         return FilestoreBlob().get(recording_segment)
 
 
-# class StorageRecordingTestCase(RecordingTestCaseMixin, TransactionTestCase):
-#     def setUp(self):
-#         self.replay_id = uuid.uuid4().hex
-#         self.replay_recording_id = uuid.uuid4().hex
-#         options.set("replay.storage.direct-storage-sample-rate", 100)
+class StorageRecordingTestCase(RecordingTestCaseMixin, TransactionTestCase):
+    def setUp(self):
+        self.replay_id = uuid.uuid4().hex
+        self.replay_recording_id = uuid.uuid4().hex
+        options.set("replay.storage.direct-storage-sample-rate", 100)
 
-#     def assert_replay_recording_segment(self, segment_id: int, compressed: bool):
-#         # Assert no recording segment is written for direct-storage.  Direct-storage does not
-#         # use a metadata database.
-#         recording_segment = ReplayRecordingSegment.objects.first()
-#         assert recording_segment is None
+    def assert_replay_recording_segment(self, segment_id: int, compressed: bool):
+        # Assert no recording segment is written for direct-storage.  Direct-storage does not
+        # use a metadata database.
+        recording_segment = ReplayRecordingSegment.objects.first()
+        assert recording_segment is None
 
-#         bytes = self.get_recording_data(segment_id)
+        bytes = self.get_recording_data(segment_id)
 
-#         # Assert (depending on compression) that the bytes are equal to our default mock value.
-#         if compressed:
-#             assert zlib.decompress(bytes) == b'[{"hello":"world"}]'
-#         else:
-#             assert bytes == b'[{"hello":"world"}]'
+        # Assert (depending on compression) that the bytes are equal to our default mock value.
+        if compressed:
+            assert zlib.decompress(bytes) == b'[{"hello":"world"}]'
+        else:
+            assert bytes == b'[{"hello":"world"}]'
 
-#     def get_recording_data(self, segment_id):
-#         recording_segment = RecordingSegmentStorageMeta(
-#             project_id=self.project.id,
-#             replay_id=self.replay_id,
-#             segment_id=segment_id,
-#             retention_days=30,
-#         )
-#         return StorageBlob().get(recording_segment)
+    def get_recording_data(self, segment_id):
+        recording_segment = RecordingSegmentStorageMeta(
+            project_id=self.project.id,
+            replay_id=self.replay_id,
+            segment_id=segment_id,
+            retention_days=30,
+        )
+        return StorageBlob().get(recording_segment)

--- a/tests/sentry/replays/unit/test_storage.py
+++ b/tests/sentry/replays/unit/test_storage.py
@@ -1,0 +1,69 @@
+from django.conf import settings
+
+from sentry import options
+from sentry.replays.lib.storage import (
+    FilestoreBlob,
+    StorageBlob,
+    _make_storage_driver,
+    make_storage_driver,
+)
+
+
+def test_make_storage_driver_allow_list():
+    """Test building storage driver instance from allow-list."""
+    # Organization exists in the allow-list.
+    assert isinstance(_make_storage_driver(1, 0, [1]), StorageBlob)
+
+    # Organization does not exist in the allow-list.
+    assert isinstance(_make_storage_driver(1, 0, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(1, 0, [2]), FilestoreBlob)
+
+
+def test_make_storage_driver_sample_rate():
+    """Test building storage driver instance from sample rate."""
+    # organization_id = 50
+    # organization_id % 100 == 50
+    # 50% is the sample-rate threshold before this org is allowed to participate.
+    assert isinstance(_make_storage_driver(50, 0, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(50, 10, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(50, 20, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(50, 30, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(50, 40, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(50, 49, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(50, 50, []), FilestoreBlob)
+    assert isinstance(_make_storage_driver(50, 51, []), StorageBlob)
+    assert isinstance(_make_storage_driver(50, 60, []), StorageBlob)
+    assert isinstance(_make_storage_driver(50, 70, []), StorageBlob)
+    assert isinstance(_make_storage_driver(50, 80, []), StorageBlob)
+    assert isinstance(_make_storage_driver(50, 90, []), StorageBlob)
+    assert isinstance(_make_storage_driver(50, 100, []), StorageBlob)
+
+    # 0% sample rate means no org should ever be allowed to participate.
+    assert isinstance(_make_storage_driver(0, 0, []), FilestoreBlob)
+
+
+def test_direct_storage_sample_rate_default_value():
+    """Test "replay.storage.direct-storage-sample-rate" default value."""
+    result = options.get("replay.storage.direct-storage-sample-rate")
+    assert result == 0
+
+
+def test_sentry_replays_storage_allow_list_default_value():
+    """Test "SENTRY_REPLAYS_STORAGE_ALLOWLIST" default value."""
+    allow_list = settings.SENTRY_REPLAYS_STORAGE_ALLOWLIST
+    assert allow_list == []
+
+
+def test_make_storage_driver():
+    """Test "make_storage_driver" returns FilestoreBlob without further configuration."""
+    assert isinstance(make_storage_driver(0), FilestoreBlob)
+    assert isinstance(make_storage_driver(10), FilestoreBlob)
+    assert isinstance(make_storage_driver(20), FilestoreBlob)
+    assert isinstance(make_storage_driver(30), FilestoreBlob)
+    assert isinstance(make_storage_driver(40), FilestoreBlob)
+    assert isinstance(make_storage_driver(50), FilestoreBlob)
+    assert isinstance(make_storage_driver(60), FilestoreBlob)
+    assert isinstance(make_storage_driver(70), FilestoreBlob)
+    assert isinstance(make_storage_driver(80), FilestoreBlob)
+    assert isinstance(make_storage_driver(90), FilestoreBlob)
+    assert isinstance(make_storage_driver(100), FilestoreBlob)


### PR DESCRIPTION
Enable direct-storage blob driver based on configuration.  Currently, we default to the `FilestoreBlob`.  This pull allows configuration driven driver selection. 

- Re-enables driver based test coverage.
- Adds driver based storage driver selection during ingest.
- Adds unit coverage for configuration based driver selection. 