### PR TITLE
ref(snuba): Add referrer_suffix

### DIFF
--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -99,6 +99,7 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
+            referrer_suffix="frequency_snoozes",
         )[self.group_id]
 
         if rate >= self.count:
@@ -120,6 +121,7 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
+            referrer_suffix="user_count_snoozes",
         )[self.group_id]
 
         if rate >= self.user_count:

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -99,7 +99,6 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
-            referrer_suffix="frequency_snoozes",
         )[self.group_id]
 
         if rate >= self.count:
@@ -121,7 +120,6 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
-            referrer_suffix="user_count_snoozes",
         )[self.group_id]
 
         if rate >= self.user_count:

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -364,6 +364,7 @@ class BaseTSDB(Service):
         environment_ids=None,
         use_cache=False,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         """
         To get a range of data for group ID=[1, 2, 3]:
@@ -388,6 +389,7 @@ class BaseTSDB(Service):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         range_set = self.get_range(
             model,
@@ -399,6 +401,7 @@ class BaseTSDB(Service):
             use_cache=use_cache,
             jitter_value=jitter_value,
             tenant_ids=tenant_ids,
+            referrer_suffix=referrer_suffix,
         )
         sum_set = {key: sum(p for _, p in points) for (key, points) in range_set.items()}
         return sum_set
@@ -462,6 +465,7 @@ class BaseTSDB(Service):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         """
         Count distinct items during a time range.

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -32,6 +32,7 @@ class DummyTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         self.validate_arguments([model], environment_ids if environment_ids is not None else [None])
         _, series = self.get_optimal_rollup_series(start, end, rollup)
@@ -58,6 +59,7 @@ class DummyTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         self.validate_arguments([model], [environment_id])
         return {k: 0 for k in keys}

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -139,6 +139,7 @@ class InMemoryTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         self.validate_arguments([model], [environment_id])
 

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -71,6 +71,7 @@ class InMemoryTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         self.validate_arguments([model], environment_ids if environment_ids is not None else [None])
 

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -456,6 +456,7 @@ class RedisTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         """
         Count distinct items during a time range.

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -273,6 +273,7 @@ class RedisTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         """
         To get a range of data for group ID=[1, 2, 3]:

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -463,7 +463,7 @@ class SnubaTSDB(BaseTSDB):
             referrer = f"tsdb-modelid:{model.value}"
 
             if referrer_suffix:
-                referrer += f"{referrer}:{referrer_suffix}"
+                referrer += f".{referrer_suffix}"
 
             query_result = raw_snql_query(snql_request, referrer, use_cache=use_cache)
             if manual_group_on_time:
@@ -599,7 +599,7 @@ class SnubaTSDB(BaseTSDB):
             referrer = f"tsdb-modelid:{model.value}"
 
             if referrer_suffix:
-                referrer += f"{referrer}:{referrer_suffix}"
+                referrer += f".{referrer_suffix}"
 
             query_func_without_selected_columns = functools.partial(
                 snuba.query,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -275,6 +275,7 @@ class SnubaTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids: dict[str, str | int] = None,
+        referrer_suffix: Optional[str] = None,
     ):
         if model in self.non_outcomes_snql_query_settings:
             # no way around having to explicitly map legacy condition format to SnQL since this function
@@ -311,6 +312,7 @@ class SnubaTSDB(BaseTSDB):
                 ),
                 is_grouprelease=(model == TSDBModel.frequent_releases_by_group),
                 tenant_ids=tenant_ids,
+                referrer_suffix=referrer_suffix,
             )
         else:
             return self.__get_data_legacy(
@@ -327,6 +329,7 @@ class SnubaTSDB(BaseTSDB):
                 use_cache,
                 jitter_value,
                 tenant_ids,
+                referrer_suffix,
             )
 
     def __get_data_snql(
@@ -346,6 +349,7 @@ class SnubaTSDB(BaseTSDB):
         manual_group_on_time: bool = False,
         is_grouprelease: bool = False,
         tenant_ids: dict[str, str | int] = None,
+        referrer_suffix: Optional[str] = None,
     ):
         """
         Similar to __get_data_legacy but uses the SnQL format. For future additions, prefer using this impl over
@@ -456,9 +460,12 @@ class SnubaTSDB(BaseTSDB):
                 ),
                 tenant_ids=tenant_ids or dict(),
             )
-            query_result = raw_snql_query(
-                snql_request, f"tsdb-modelid:{model.value}", use_cache=use_cache
-            )
+            referrer = f"tsdb-modelid:{model.value}"
+
+            if referrer_suffix:
+                referrer += f"{referrer}:{referrer_suffix}"
+
+            query_result = raw_snql_query(snql_request, referrer, use_cache=use_cache)
             if manual_group_on_time:
                 translated_results = {"data": query_result["data"]}
             else:
@@ -497,6 +504,7 @@ class SnubaTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         """
         Normalizes all the TSDB parameters and sends a query to snuba.
@@ -588,6 +596,11 @@ class SnubaTSDB(BaseTSDB):
             orderby.append(model_group)
 
         if keys:
+            referrer = f"tsdb-modelid:{model.value}"
+
+            if referrer_suffix:
+                referrer += f"{referrer}:{referrer_suffix}"
+
             query_func_without_selected_columns = functools.partial(
                 snuba.query,
                 dataset=model_dataset,
@@ -600,7 +613,7 @@ class SnubaTSDB(BaseTSDB):
                 rollup=rollup,
                 limit=limit,
                 orderby=orderby,
-                referrer=f"tsdb-modelid:{model.value}",
+                referrer=referrer,
                 is_grouprelease=(model == TSDBModel.frequent_releases_by_group),
                 use_cache=use_cache,
                 tenant_ids=tenant_ids or dict(),
@@ -715,6 +728,7 @@ class SnubaTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         model_query_settings = self.model_query_settings.get(model)
         assert model_query_settings is not None, f"Unsupported TSDBModel: {model.name}"
@@ -774,6 +788,7 @@ class SnubaTSDB(BaseTSDB):
         use_cache=False,
         jitter_value=None,
         tenant_ids=None,
+        referrer_suffix=None,
     ):
         return self.get_data(
             model,
@@ -786,6 +801,7 @@ class SnubaTSDB(BaseTSDB):
             use_cache=use_cache,
             jitter_value=jitter_value,
             tenant_ids=tenant_ids,
+            referrer_suffix=referrer_suffix,
         )
 
     def get_distinct_counts_union(


### PR DESCRIPTION
**context**
When debugging, one way that we can identify where requests are coming from in snuba is by using the `referrer`. This `referrer` is quite helpful when it happens to be the name of an api endpoint, but becomes less helpful when the same referrer covers a lot of different sources. For example, this is the case with the current `tsdb-model:4` referrer 

**referrer_suffix**
I didn't want to change the existing code too much, and I didn't want to change how we use tools to investigate too much. Adding a suffix means we could still search on `tsdb-model:4*` if we wanted/needed to.  

In another PR I will add the specific `referrer_suffix` to places where I think it makes the most sense


