### PR TITLE
chore(hybrid-cloud): Mark CatchallEndpoint as all_silo_endpoint

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -602,3 +602,6 @@ region_silo_endpoint = EndpointSiloLimit(SiloMode.REGION)
 # that the test will fail if a new endpoint is added with no decorator at all.
 # Eventually we should replace all instances of this decorator and delete it.
 pending_silo_endpoint = EndpointSiloLimit()
+
+# This should be rarely used, but this should be used for any endpoints that exist in any silo mode.
+all_silo_endpoint = EndpointSiloLimit(SiloMode.CONTROL, SiloMode.REGION, SiloMode.MONOLITH)

--- a/src/sentry/api/endpoints/catchall.py
+++ b/src/sentry/api/endpoints/catchall.py
@@ -2,10 +2,10 @@ from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
-from sentry.api.base import Endpoint, pending_silo_endpoint
+from sentry.api.base import Endpoint, all_silo_endpoint
 
 
-@pending_silo_endpoint
+@all_silo_endpoint
 class CatchallEndpoint(Endpoint):
     permission_classes = ()
 

--- a/tests/sentry/api/endpoints/test_catchall.py
+++ b/tests/sentry/api/endpoints/test_catchall.py
@@ -2,10 +2,10 @@ from rest_framework import status
 
 from sentry.testutils import APITestCase
 from sentry.testutils.asserts import assert_status_code
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import all_silo_test
 
 
-@control_silo_test
+@all_silo_test(stable=True)
 class CatchallTestCase(APITestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
- Adds `@all_silo_endpoint` decorator; which should be rarely used, but this should be used for any endpoints that exist in any silo mode.
- Mark `CatchallEndpoint` with `all_silo_endpoint`.