### PR TITLE
fix(profiling): Fix profile stacktrace styles to align with styles

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
@@ -15,7 +17,7 @@ type Props = Pick<React.ComponentProps<typeof ContentV2>, 'groupingCurrentLevel'
   newestFirst: boolean;
   platform: PlatformType;
   stacktrace: StacktraceType;
-  hideIcon?: boolean;
+  inlined?: boolean;
   meta?: Record<any, any>;
   nativeV2?: boolean;
   stackView?: STACK_VIEW;
@@ -31,7 +33,7 @@ function StackTrace({
   groupingCurrentLevel,
   nativeV2,
   meta,
-  hideIcon,
+  inlined,
 }: Props) {
   if (stackView === STACK_VIEW.RAW) {
     return (
@@ -46,7 +48,7 @@ function StackTrace({
   if (nativeV2 && isNativePlatform(platform)) {
     return (
       <ErrorBoundary mini>
-        <ContentV3
+        <StyledContentV3
           data={stacktrace}
           includeSystemFrames={stackView === STACK_VIEW.FULL}
           platform={platform}
@@ -54,7 +56,8 @@ function StackTrace({
           newestFirst={newestFirst}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
-          hideIcon={hideIcon}
+          hideIcon={inlined}
+          inlined={inlined}
         />
       </ErrorBoundary>
     );
@@ -63,7 +66,7 @@ function StackTrace({
   if (hasHierarchicalGrouping) {
     return (
       <ErrorBoundary mini>
-        <ContentV2
+        <StyledContentV2
           data={stacktrace}
           className="no-exception"
           includeSystemFrames={stackView === STACK_VIEW.FULL}
@@ -72,7 +75,8 @@ function StackTrace({
           newestFirst={newestFirst}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
-          hideIcon={hideIcon}
+          hideIcon={inlined}
+          inlined={inlined}
         />
       </ErrorBoundary>
     );
@@ -80,7 +84,7 @@ function StackTrace({
 
   return (
     <ErrorBoundary mini>
-      <Content
+      <StyledContent
         data={stacktrace}
         className="no-exception"
         includeSystemFrames={stackView === STACK_VIEW.FULL}
@@ -88,10 +92,29 @@ function StackTrace({
         event={event}
         newestFirst={newestFirst}
         meta={meta}
-        hideIcon={hideIcon}
+        hideIcon={inlined}
+        inlined={inlined}
       />
     </ErrorBoundary>
   );
 }
+
+const inlinedStyles = `
+  border-radius: 0;
+  border-left: 0;
+  border-right: 0;
+`;
+
+const StyledContentV3 = styled(ContentV3)<{inlined?: boolean}>`
+  ${p => p.inlined && inlinedStyles}
+`;
+
+const StyledContentV2 = styled(ContentV2)<{inlined?: boolean}>`
+  ${p => p.inlined && inlinedStyles}
+`;
+
+const StyledContent = styled(Content)<{inlined?: boolean}>`
+  ${p => p.inlined && inlinedStyles}
+`;
 
 export default StackTrace;

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -197,9 +197,9 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
           registers: null,
           frames,
         }}
-        nativeV2
         stackView={STACK_VIEW.APP}
-        hideIcon
+        nativeV2
+        inlined
       />
     </Fragment>
   );


### PR DESCRIPTION
The stacktrace component was originally made to be a standalone panel so we need to apply some styles to better match this inlined use case.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/225429710-ba37e29d-1541-442c-87a2-a35fd6613de4.png)

## After

![image](https://user-images.githubusercontent.com/10239353/225429521-10a618e0-563c-4e6b-9bb9-8347ff3e4291.png)
