### PR TITLE
feat(hybrid-cloud): Update invite request endpoint to consume `organizationmember_mapping_service`

### DIFF
--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -75,14 +75,14 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
 
         result = serializer.validated_data
 
+        rpc_org_member = organization_service.add_organization_member(
+            organization=organization,
+            email=result["email"],
+            role=result["role"],
+            inviter_id=request.user.id,
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
         with transaction.atomic():
-            rpc_org_member = organization_service.add_organization_member(
-                organization=organization,
-                email=result["email"],
-                role=result["role"],
-                inviter_id=request.user.id,
-                invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
-            )
             om = OrganizationMember.objects.get(id=rpc_org_member.id)
 
             # Do not set team-roles when inviting a member

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -76,7 +76,8 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
         result = serializer.validated_data
 
         rpc_org_member = organization_service.add_organization_member(
-            organization=organization,
+            organization_id=organization.id,
+            default_org_role=organization.default_role,
             email=result["email"],
             role=result["role"],
             inviter_id=request.user.id,

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -86,6 +86,8 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
                 invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
             )
 
+            organizationmember_mapping_service.create_with_organization_member(om)
+
             # Do not set team-roles when inviting a member
             if "teams" in result or "teamRoles" in result:
                 teams = result.get("teams") or [
@@ -99,14 +101,6 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
                 target_object=om.id,
                 data=om.get_audit_log_data(),
                 event=audit_log.get_event_id("INVITE_REQUEST_ADD"),
-            )
-
-            organizationmember_mapping_service.create(
-                organization_id=organization.id,
-                email=result["email"],
-                role=result["role"],
-                inviter_id=request.user.id,
-                invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
             )
 
             outbox = OrganizationMember.outbox_for_update(

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -13,9 +13,6 @@ from sentry.models import InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import InviteRequestNotification
 from sentry.notifications.utils.tasks import async_send_notification
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.services.hybrid_cloud.organizationmember_mapping import (
-    organizationmember_mapping_service,
-)
 
 from ... import save_team_assignments
 from ...index import OrganizationMemberSerializer

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -304,7 +304,8 @@ class DatabaseBackedAuthService(AuthService):
 
         # Otherwise create a new membership
         om = organization_service.add_organization_member(
-            organization=organization,
+            organization_id=organization.id,
+            default_org_role=organization.default_role,
             role=organization.default_role,
             user=serial_user,
             flags=flags,

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -16,7 +16,6 @@ from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.region import (
     ByOrganizationId,
     ByOrganizationIdAttribute,
-    ByOrganizationObject,
     ByOrganizationSlug,
     UnimplementedRegionResolution,
 )
@@ -266,12 +265,13 @@ class OrganizationService(RpcService):
 
         return self.get_organization_by_id(id=org_id, user_id=user_id)
 
-    @regional_rpc_method(resolve=ByOrganizationObject())
+    @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
     def add_organization_member(
         self,
         *,
-        organization: RpcOrganization,
+        organization_id: int,
+        default_org_role: str,
         user: Optional[RpcUser] = None,
         email: Optional[str] = None,
         flags: Optional[RpcOrganizationMemberFlags] = None,

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -270,12 +270,12 @@ class OrganizationService(RpcService):
         self,
         *,
         organization: RpcOrganization,
-        user: Optional[RpcUser],
-        email: Optional[str],
-        flags: Optional[RpcOrganizationMemberFlags],
-        role: Optional[str],
-        inviter_id: Optional[int],
-        invite_status: Optional[int],
+        user: Optional[RpcUser] = None,
+        email: Optional[str] = None,
+        flags: Optional[RpcOrganizationMemberFlags] = None,
+        role: Optional[str] = None,
+        inviter_id: Optional[int] = None,
+        invite_status: Optional[int] = None,
     ) -> RpcOrganizationMember:
         pass
 

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -277,7 +277,7 @@ class OrganizationService(RpcService):
         flags: Optional[RpcOrganizationMemberFlags] = None,
         role: Optional[str] = None,
         inviter_id: Optional[int] = None,
-        invite_status: Optional[int] = None,
+        invite_status: Optional[int] = InviteStatus.APPROVED.value,
     ) -> RpcOrganizationMember:
         pass
 

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -270,9 +270,12 @@ class OrganizationService(RpcService):
         self,
         *,
         organization: RpcOrganization,
-        user: RpcUser,
+        user: Optional[RpcUser],
+        email: Optional[str],
         flags: Optional[RpcOrganizationMemberFlags],
         role: Optional[str],
+        inviter_id: Optional[int],
+        invite_status: Optional[int],
     ) -> RpcOrganizationMember:
         pass
 

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, List, Mapping, Optional, cast
 from pydantic import Field
 
 from sentry.models.organization import OrganizationStatus
+from sentry.models.organizationmember import InviteStatus
 from sentry.roles import team_roles
 from sentry.roles.manager import TeamRole
 from sentry.services.hybrid_cloud import RpcModel
@@ -97,6 +98,7 @@ class RpcOrganizationMember(RpcOrganizationMemberSummary):
     has_global_access: bool = False
     project_ids: List[int] = Field(default_factory=list)
     scopes: List[str] = Field(default_factory=list)
+    invite_status: int = InviteStatus.APPROVED.value
 
     def get_audit_log_metadata(self, user_email: str) -> Mapping[str, Any]:
         team_ids = [mt.team_id for mt in self.member_teams]
@@ -106,7 +108,7 @@ class RpcOrganizationMember(RpcOrganizationMemberSummary):
             "teams": team_ids,
             "has_global_access": self.has_global_access,
             "role": self.role,
-            "invite_status": None,
+            "invite_status": self.invite_status,
         }
 
 

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -278,7 +278,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def add_organization_member(
         self,
         *,
-        organization: RpcOrganization,
+        organization: RpcOrganization | Organization,
         user: RpcUser | None = None,
         email: str | None = None,
         flags: RpcOrganizationMemberFlags | None = None,

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -69,6 +69,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             has_global_access=member.has_global_access,
             scopes=list(member.get_scopes()),
             flags=cls._serialize_member_flags(member),
+            invite_status=member.invite_status,
         )
 
         omts = OrganizationMemberTeam.objects.filter(

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -286,6 +286,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         inviter_id: int | None = None,
         invite_status: int | None = None,
     ) -> RpcOrganizationMember:
+        assert (user is None and email) or (user and email is None), "Must set either user or email"
         with transaction.atomic():
             org_member: OrganizationMember = OrganizationMember.objects.create(
                 organization_id=organization.id,

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -299,9 +299,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 inviter_id=inviter_id,
                 invite_status=invite_status,
             )
-            region_outbox = org_member.outbox_for_update(
-                org_id=organization.id, org_member_id=org_member.id
-            )
+            region_outbox = org_member.outbox_for_update()
             region_outbox.save()
         region_outbox.drain_shard(max_updates_to_drain=1000)
         return self.serialize_member(org_member)

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -303,7 +303,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 org_id=organization.id, org_member_id=org_member.id
             )
             region_outbox.save()
-            region_outbox.drain_shard(max_updates_to_drain=1000)
+        region_outbox.drain_shard(max_updates_to_drain=1000)
         return self.serialize_member(org_member)
 
     def add_team_member(self, *, team_id: int, organization_member: RpcOrganizationMember) -> None:

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -280,7 +280,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def add_organization_member(
         self,
         *,
-        organization: RpcOrganization | Organization,
+        organization_id: int,
+        default_org_role: str,
         user: RpcUser | None = None,
         email: str | None = None,
         flags: RpcOrganizationMemberFlags | None = None,
@@ -291,11 +292,11 @@ class DatabaseBackedOrganizationService(OrganizationService):
         assert (user is None and email) or (user and email is None), "Must set either user or email"
         with transaction.atomic():
             org_member: OrganizationMember = OrganizationMember.objects.create(
-                organization_id=organization.id,
+                organization_id=organization_id,
                 user_id=user.id if user else None,
                 email=email,
                 flags=self._deserialize_member_flags(flags) if flags else 0,
-                role=role or organization.default_role,
+                role=role or default_org_role,
                 inviter_id=inviter_id,
                 invite_status=invite_status,
             )

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -17,6 +17,7 @@ from sentry.models import (
     Team,
     TeamStatus,
 )
+from sentry.models.organizationmember import InviteStatus
 from sentry.services.hybrid_cloud import logger
 from sentry.services.hybrid_cloud.organization import (
     OrganizationService,
@@ -285,7 +286,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         flags: RpcOrganizationMemberFlags | None = None,
         role: str | None = None,
         inviter_id: int | None = None,
-        invite_status: int | None = None,
+        invite_status: int | None = InviteStatus.APPROVED.value,
     ) -> RpcOrganizationMember:
         assert (user is None and email) or (user and email is None), "Must set either user or email"
         with transaction.atomic():

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -302,7 +302,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             )
             region_outbox = org_member.outbox_for_update()
             region_outbox.save()
-        region_outbox.drain_shard(max_updates_to_drain=1000)
+        region_outbox.drain_shard(max_updates_to_drain=10)
         return self.serialize_member(org_member)
 
     def add_team_member(self, *, team_id: int, organization_member: RpcOrganizationMember) -> None:

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -290,9 +290,12 @@ class DatabaseBackedOrganizationService(OrganizationService):
         with transaction.atomic():
             org_member: OrganizationMember = OrganizationMember.objects.create(
                 organization_id=organization.id,
-                user_id=user.id,
+                user_id=user.id if user else None,
+                email=email,
                 flags=self._deserialize_member_flags(flags) if flags else 0,
                 role=role or organization.default_role,
+                inviter_id=inviter_id,
+                invite_status=invite_status,
             )
             region_outbox = org_member.outbox_for_update(
                 org_id=organization.id, org_member_id=org_member.id

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -279,9 +279,12 @@ class DatabaseBackedOrganizationService(OrganizationService):
         self,
         *,
         organization: RpcOrganization,
-        user: RpcUser,
-        flags: RpcOrganizationMemberFlags | None,
-        role: str | None,
+        user: RpcUser | None = None,
+        email: str | None = None,
+        flags: RpcOrganizationMemberFlags | None = None,
+        role: str | None = None,
+        inviter_id: int | None = None,
+        invite_status: int | None = None,
     ) -> RpcOrganizationMember:
         with transaction.atomic():
             org_member: OrganizationMember = OrganizationMember.objects.create(

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -5,8 +5,6 @@ import functools
 from types import TracebackType
 from typing import Any, Callable, Generator, List, Mapping, Optional, Sequence, Tuple, Type, cast
 
-from django.db.models import Q
-
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.services.hybrid_cloud import DelegatedBySiloMode, InterfaceWithLifecycle, hc_test_stub
@@ -119,10 +117,10 @@ class HybridCloudTestMixin:
 
         assert (
             OrganizationMember.objects.filter(
-                Q(email=email) | Q(user_id=user_id),
-            )
-            .filter(organization_id=org_member.organization_id)
-            .count()
+                organization_id=org_member.organization_id,
+                user_id=user_id,
+                email=email,
+            ).count()
             == 1
         )
 

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -5,8 +5,11 @@ import functools
 from types import TracebackType
 from typing import Any, Callable, Generator, List, Mapping, Optional, Sequence, Tuple, Type, cast
 
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.services.hybrid_cloud import DelegatedBySiloMode, InterfaceWithLifecycle, hc_test_stub
 from sentry.silo import SiloMode
+from sentry.testutils.silo import exempt_from_silo_limits
 
 
 class use_real_service:
@@ -93,3 +96,41 @@ def enforce_inter_silo_max_calls(max_calls: int) -> Generator[None, None, None]:
         yield
     finally:
         hc_test_stub.cb = None
+
+
+class HybridCloudTestMixin:
+    @exempt_from_silo_limits()
+    def assert_org_member_mapping(self, org_member: OrganizationMember, expected=None):
+        org_member_mapping = OrganizationMemberMapping.objects.get(
+            organization_id=org_member.organization_id,
+            email=org_member.email,
+            user_id=org_member.user_id,
+        )
+
+        email = org_member_mapping.email
+        user_id = org_member_mapping.user_id
+        # only either user_id or email should have a value, but not both.
+        assert (email is None and user_id) or (email and user_id is None)
+
+        assert org_member_mapping.role == org_member.role
+        if org_member.inviter:
+            assert org_member_mapping.inviter_id == org_member.inviter.id
+        else:
+            assert org_member_mapping.inviter_id is None
+        assert org_member_mapping.invite_status == org_member.invite_status
+        if expected:
+            for key, expected_value in expected.items():
+                assert getattr(org_member_mapping, key) == expected_value
+
+    @exempt_from_silo_limits()
+    def assert_org_member_mapping_not_exists(self, org_member: OrganizationMember):
+        email = org_member.email
+        user_id = org_member.user_id
+        # only either user_id or email should have a value, but not both.
+        assert (email is None and user_id) or (email and user_id is None)
+
+        assert not OrganizationMemberMapping.objects.filter(
+            organization_id=org_member.organization_id,
+            email=org_member.email,
+            user_id=org_member.user_id,
+        ).exists()

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -10,13 +10,12 @@ from sentry.models import (
     OrganizationMemberTeam,
     OrganizationOption,
 )
-from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.models.outbox import OutboxCategory, RegionOutbox
 from sentry.testutils import APITestCase
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment_no_text
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
+from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
@@ -68,7 +67,9 @@ class OrganizationInviteRequestListTest(APITestCase):
 
 
 @region_silo_test(stable=True)
-class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotificationTest):
+class OrganizationInviteRequestCreateTest(
+    APITestCase, SlackActivityNotificationTest, HybridCloudTestMixin
+):
     endpoint = "sentry-api-0-organization-invite-request-index"
     method = "post"
 
@@ -97,14 +98,6 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
     def test_simple(self):
         self.login_as(user=self.user)
 
-        with exempt_from_silo_limits():
-            assert (
-                RegionOutbox.objects.filter(
-                    category=OutboxCategory.ORGANIZATION_MEMBER_UPDATE
-                ).count()
-                == 0
-            )
-
         with self.tasks(), outbox_runner():
             response = self.client.post(
                 self.url, {"email": "eric@localhost", "role": "member", "teams": [self.team.slug]}
@@ -128,23 +121,7 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
         assert len(teams) == 1
         assert teams[0].team_id == self.team.id
 
-        with exempt_from_silo_limits():
-            assert (
-                RegionOutbox.objects.filter(
-                    category=OutboxCategory.ORGANIZATION_MEMBER_UPDATE
-                ).count()
-                == 0
-            )
-
-            org_member_mapping = OrganizationMemberMapping.objects.get(
-                organization_id=self.organization.id,
-                email="eric@localhost",
-            )
-            assert org_member_mapping.role == "member"
-            assert org_member_mapping.user_id is None
-            assert org_member_mapping.email == "eric@localhost"
-            assert org_member_mapping.inviter_id == self.user.id
-            assert org_member_mapping.invite_status == InviteStatus.REQUESTED_TO_BE_INVITED.value
+        self.assert_org_member_mapping(org_member=member)
 
     def test_higher_role(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -15,6 +15,7 @@ from sentry.models.outbox import OutboxCategory, RegionOutbox
 from sentry.testutils import APITestCase
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment_no_text
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils import json
 
@@ -104,7 +105,7 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
                 == 0
             )
 
-        with self.tasks():
+        with self.tasks(), outbox_runner():
             response = self.client.post(
                 self.url, {"email": "eric@localhost", "role": "member", "teams": [self.team.slug]}
             )
@@ -132,7 +133,7 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
                 RegionOutbox.objects.filter(
                     category=OutboxCategory.ORGANIZATION_MEMBER_UPDATE
                 ).count()
-                == 1
+                == 0
             )
 
             org_member_mapping = OrganizationMemberMapping.objects.get(

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -10,10 +10,12 @@ from sentry.models import (
     OrganizationMemberTeam,
     OrganizationOption,
 )
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
+from sentry.models.outbox import OutboxCategory, RegionOutbox
 from sentry.testutils import APITestCase
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment_no_text
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils import json
 
 
@@ -64,7 +66,7 @@ class OrganizationInviteRequestListTest(APITestCase):
         assert resp.data[0]["inviteStatus"] == "requested_to_be_invited"
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotificationTest):
     endpoint = "sentry-api-0-organization-invite-request-index"
     method = "post"
@@ -93,6 +95,15 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
 
     def test_simple(self):
         self.login_as(user=self.user)
+
+        with exempt_from_silo_limits():
+            assert (
+                RegionOutbox.objects.filter(
+                    category=OutboxCategory.ORGANIZATION_MEMBER_UPDATE
+                ).count()
+                == 0
+            )
+
         with self.tasks():
             response = self.client.post(
                 self.url, {"email": "eric@localhost", "role": "member", "teams": [self.team.slug]}
@@ -115,6 +126,24 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
 
         assert len(teams) == 1
         assert teams[0].team_id == self.team.id
+
+        with exempt_from_silo_limits():
+            assert (
+                RegionOutbox.objects.filter(
+                    category=OutboxCategory.ORGANIZATION_MEMBER_UPDATE
+                ).count()
+                == 1
+            )
+
+            org_member_mapping = OrganizationMemberMapping.objects.get(
+                organization_id=self.organization.id,
+                email="eric@localhost",
+            )
+            assert org_member_mapping.role == "member"
+            assert org_member_mapping.user_id is None
+            assert org_member_mapping.email == "eric@localhost"
+            assert org_member_mapping.inviter_id == self.user.id
+            assert org_member_mapping.invite_status == InviteStatus.REQUESTED_TO_BE_INVITED.value
 
     def test_higher_role(self):
         self.login_as(user=self.user)

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -41,7 +41,8 @@ class RpcServiceTest(TestCase):
         service = OrganizationService.create_delegation()
         with override_regions(regions), override_settings(SILO_MODE=SiloMode.CONTROL):
             service.add_organization_member(
-                organization=serial_org,
+                organization_id=serial_org.id,
+                default_org_role=serial_org.default_role,
                 user=serial_user,
                 flags=RpcOrganizationMemberFlags(),
                 role=None,
@@ -57,8 +58,17 @@ class RpcServiceTest(TestCase):
         assert region == target_region
         assert service_name == OrganizationService.key
         assert method_name == "add_organization_member"
-        assert serial_arguments.keys() == {"flags", "organization", "role", "user"}
-        assert serial_arguments["organization"]["id"] == organization.id
+        assert serial_arguments.keys() == {
+            "organization_id",
+            "default_org_role",
+            "user",
+            "email",
+            "flags",
+            "role",
+            "inviter_id",
+            "invite_status",
+        }
+        assert serial_arguments["organization_id"] == organization.id
 
     @mock.patch("sentry.services.hybrid_cloud.report_pydantic_type_validation_error")
     def test_models_tolerate_invalid_types(self, mock_report):
@@ -83,7 +93,8 @@ class RpcServiceTest(TestCase):
         serial_user = RpcUser(id=user.id)
         serial_org = DatabaseBackedOrganizationService.serialize_organization(organization)
         serial_arguments = dict(
-            organization=serial_org.dict(),
+            organization_id=serial_org.id,
+            default_org_role=serial_org.default_role,
             user=serial_user.dict(),
             flags=RpcOrganizationMemberFlags().dict(),
             role=None,


### PR DESCRIPTION
This pull request updates the invite request endpoint to consume the `organizationmember_mapping_service` (introduced in https://github.com/getsentry/sentry/pull/45867).

Depends on https://github.com/getsentry/sentry/pull/45867.