### PR TITLE
fix(commit-context): Add cache to integrations check

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -807,13 +807,22 @@ def process_commits(job: PostProcessJob) -> None:
                 event_frames = get_frame_paths(event)
                 sdk_name = get_sdk_name(event.data)
 
-                integrations = Integration.objects.filter(
-                    organizations=event.project.organization,
-                    provider__in=["github", "gitlab"],
+                integration_cache_key = (
+                    f"commit-context-scm-integration:{event.project.organization_id}"
                 )
+                has_integrations = cache.get(integration_cache_key)
+                if has_integrations is None:
+                    integrations = Integration.objects.filter(
+                        organizations=event.project.organization,
+                        provider__in=["github", "gitlab"],
+                    )
+                    has_integrations = integrations.exists()
+                    # Cache the integrations check for 4 hours
+                    cache.set(integration_cache_key, has_integrations, 14400)
+
                 if (
                     features.has("organizations:commit-context", event.project.organization)
-                    and integrations.exists()
+                    and has_integrations
                 ):
                     cache_key = DEBOUNCE_CACHE_KEY(event.group_id)
                     if cache.get(cache_key):

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -995,6 +995,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             f"issue_owner_assignment_ratelimiter:{self.project.id}",
             (set(range(0, ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT * 10, 10)), datetime.now()),
         )
+        cache.set(f"commit-context-scm-integration:{self.project.organization_id}", True, 60)
         event = self.create_event(
             data={
                 "message": "oh no",


### PR DESCRIPTION
Cache the SCM integrations check so we aren't hitting the db with each event