### PR TITLE
chore(hybrid-cloud): Add default_factory for date_created field in RpcOrganizationMapping

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, TypedDict
 
@@ -22,7 +22,7 @@ class RpcOrganizationMapping:
     slug: str = ""
     name: str = ""
     region_name: str = ""
-    date_created: datetime = timezone.now()
+    date_created: datetime = field(default_factory=lambda: timezone.now())
     verified: bool = False
     customer_id: Optional[str] = None
 

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -22,7 +22,7 @@ class RpcOrganizationMapping:
     slug: str = ""
     name: str = ""
     region_name: str = ""
-    date_created: datetime = field(default_factory=lambda: timezone.now())
+    date_created: datetime = field(default_factory=timezone.now)
     verified: bool = False
     customer_id: Optional[str] = None
 


### PR DESCRIPTION
This avoids instantiating `timezone.now()` statically for the `RpcOrganizationMapping` dataclass.