### PR TITLE
fix(profiling): Properly cap profiling stack to 16 frames

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {Frame, Organization, PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
+import {defined} from 'sentry/utils';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import Line from '../../frame/line';
@@ -28,6 +29,7 @@ type Props = {
   debugFrames?: StacktraceFilenameQuery[];
   hideIcon?: boolean;
   isHoverPreviewed?: boolean;
+  maxDepth?: number;
   meta?: Record<any, any>;
   newestFirst?: boolean;
   organization?: Organization;
@@ -140,6 +142,7 @@ class Content extends Component<Props, State> {
       platform,
       includeSystemFrames,
       isHoverPreviewed,
+      maxDepth,
       meta,
       debugFrames,
       hideIcon,
@@ -257,6 +260,10 @@ class Content extends Component<Props, State> {
       frames[lastFrame] = cloneElement(frames[lastFrame], {
         registers: data.registers,
       });
+    }
+
+    if (defined(maxDepth)) {
+      frames.splice(maxDepth);
     }
 
     if (newestFirst) {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {Frame, Group, PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
+import {defined} from 'sentry/utils';
 
 import Line from '../../frame/lineV2';
 import {getImageRange, parseAddress, stackTracePlatformIcon} from '../../utils';
@@ -26,6 +27,7 @@ type Props = {
   hideIcon?: boolean;
   includeSystemFrames?: boolean;
   isHoverPreviewed?: boolean;
+  maxDepth?: number;
   meta?: Record<any, any>;
   newestFirst?: boolean;
 };
@@ -39,6 +41,7 @@ function Content({
   className,
   isHoverPreviewed,
   groupingCurrentLevel,
+  maxDepth,
   meta,
   hideIcon,
   includeSystemFrames = true,
@@ -235,12 +238,10 @@ function Content({
       convertedFrames[lastFrame] = cloneElement(convertedFrames[lastFrame], {
         registers,
       });
+    }
 
-      if (!newestFirst) {
-        return convertedFrames;
-      }
-
-      return [...convertedFrames].reverse();
+    if (defined(maxDepth)) {
+      convertedFrames.splice(maxDepth);
     }
 
     if (!newestFirst) {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -7,6 +7,7 @@ import {space} from 'sentry/styles/space';
 import {Frame, Group, PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
+import {defined} from 'sentry/utils';
 
 import NativeFrame from '../../nativeFrame';
 import {getImageRange, parseAddress} from '../../utils';
@@ -20,6 +21,7 @@ type Props = {
   hideIcon?: boolean;
   includeSystemFrames?: boolean;
   isHoverPreviewed?: boolean;
+  maxDepth?: number;
   meta?: Record<any, any>;
   newestFirst?: boolean;
 };
@@ -33,6 +35,7 @@ function Content({
   groupingCurrentLevel,
   includeSystemFrames = true,
   expandFirstFrame = true,
+  maxDepth,
   meta,
 }: Props) {
   const [showingAbsoluteAddresses, setShowingAbsoluteAddresses] = useState(false);
@@ -220,14 +223,10 @@ function Content({
     convertedFrames[lastFrame] = cloneElement(convertedFrames[lastFrame], {
       registers,
     });
+  }
 
-    return (
-      <Wrapper className={className}>
-        <Frames isHoverPreviewed={isHoverPreviewed} data-test-id="stack-trace">
-          {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
-        </Frames>
-      </Wrapper>
-    );
+  if (defined(maxDepth)) {
+    convertedFrames.splice(maxDepth);
   }
 
   return (

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -18,6 +18,7 @@ type Props = Pick<React.ComponentProps<typeof ContentV2>, 'groupingCurrentLevel'
   platform: PlatformType;
   stacktrace: StacktraceType;
   inlined?: boolean;
+  maxDepth?: number;
   meta?: Record<any, any>;
   nativeV2?: boolean;
   stackView?: STACK_VIEW;
@@ -32,6 +33,7 @@ function StackTrace({
   hasHierarchicalGrouping,
   groupingCurrentLevel,
   nativeV2,
+  maxDepth,
   meta,
   inlined,
 }: Props) {
@@ -58,6 +60,7 @@ function StackTrace({
           meta={meta}
           hideIcon={inlined}
           inlined={inlined}
+          maxDepth={maxDepth}
         />
       </ErrorBoundary>
     );
@@ -77,6 +80,7 @@ function StackTrace({
           meta={meta}
           hideIcon={inlined}
           inlined={inlined}
+          maxDepth={maxDepth}
         />
       </ErrorBoundary>
     );
@@ -94,6 +98,7 @@ function StackTrace({
         meta={meta}
         hideIcon={inlined}
         inlined={inlined}
+        maxDepth={maxDepth}
       />
     </ErrorBoundary>
   );

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -200,6 +200,7 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
         stackView={STACK_VIEW.APP}
         nativeV2
         inlined
+        maxDepth={MAX_STACK_DEPTH}
       />
     </Fragment>
   );
@@ -285,10 +286,7 @@ function sortByCount(a: CallTreeNode, b: CallTreeNode) {
 function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame[] {
   const frames: Frame[] = [];
 
-  let framesCount = 0;
-  let prevFrame: ProfilingFrame | null = null;
-
-  while (framesCount < MAX_STACK_DEPTH && node && !node.isRoot()) {
+  while (node && !node.isRoot()) {
     const frame = {
       absPath: node.frame.path ?? null,
       colNo: node.frame.column ?? null,
@@ -310,24 +308,7 @@ function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame
       vars: null,
     };
 
-    if (
-      // Recursive frames get collapsed into 1, so only count the
-      // entire recursive group once.
-      node.frame !== prevFrame &&
-      // In app frames are not collapsed so count it.
-      (node.frame.is_application ||
-        // Only count non in app frames if the previous frame is in app.
-        // This is because a group of non in app frames will be collapsed
-        // into a single frame, so we only count the entire group once.
-        prevFrame?.is_application)
-    ) {
-      framesCount += 1;
-    }
-
     frames.push(frame);
-
-    prevFrame = node.frame;
-
     node = node.parent;
   }
 


### PR DESCRIPTION
Instead of preprocessing the frames and doing all this counting, the stacktrace component already implements this collapsing. So we opt to add a max depth component to trim the excess frames.