### PR TITLE
ref: Add new mobile vitals

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -539,6 +539,8 @@ ALL_MEASUREMENT_METRICS = frozenset(
         "d:transactions/measurements.frames_slow@none",
         "d:transactions/measurements.frames_slow_rate@ratio",
         "d:transactions/measurements.frames_total@none",
+        "d:transactions/measurements.time_to_initial_display@millisecond",
+        "d:transactions/measurements.time_to_full_display@millisecond",
         "d:transactions/measurements.stall_count@none",
         "d:transactions/measurements.stall_longest_time@millisecond",
         "d:transactions/measurements.stall_percentage@ratio",

--- a/src/sentry/relay/config/measurements.py
+++ b/src/sentry/relay/config/measurements.py
@@ -43,6 +43,8 @@ BUILTIN_MEASUREMENTS: Sequence[BuiltinMeasurementKey] = [
     {"name": "stall_total_time", "unit": "millisecond"},
     {"name": "ttfb.requesttime", "unit": "millisecond"},
     {"name": "ttfb", "unit": "millisecond"},
+    {"name": "time_to_full_display", "unit": "millisecond"},
+    {"name": "time_to_initial_display", "unit": "millisecond"},
 ]
 
 

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -223,6 +223,8 @@ METRICS_MAP = {
     "measurements.frames_slow": "d:transactions/measurements.frames_slow@none",
     "measurements.frames_total": "d:transactions/measurements.frames_total@none",
     "measurements.lcp": "d:transactions/measurements.lcp@millisecond",
+    "measurements.time_to_initial_display": "d:transactions/measurements.time_to_initial_display@millisecond",
+    "measurements.time_to_full_display": "d:transactions/measurements.time_to_full_display@millisecond",
     "measurements.stall_count": "d:transactions/measurements.stall_count@none",
     "measurements.stall_stall_longest_time": "d:transactions/measurements.stall_longest_time@millisecond",
     "measurements.stall_stall_total_time": "d:transactions/measurements.stall_total_time@millisecond",

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -72,6 +72,8 @@ TRANSACTION_METRICS_NAMES = {
     "d:transactions/breakdowns.span_ops.ops.resource@millisecond": PREFIX + 123,
     "d:transactions/breakdowns.span_ops.ops.ui@millisecond": PREFIX + 124,
     "c:transactions/count_per_root_project@none": PREFIX + 125,
+    "d:transactions/measurements.time_to_initial_display@millisecond": PREFIX + 126,
+    "d:transactions/measurements.time_to_full_display@millisecond": PREFIX + 127,
 }
 
 # 200 - 299

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -96,6 +96,12 @@ class TransactionMRI(Enum):
     MEASUREMENTS_FRAMES_SLOW = "d:transactions/measurements.frames_slow@none"
     MEASUREMENTS_FRAMES_SLOW_RATE = "d:transactions/measurements.frames_slow_rate@ratio"
     MEASUREMENTS_FRAMES_TOTAL = "d:transactions/measurements.frames_total@none"
+    MEASUREMENTS_TIME_TO_INITIAL_DISPLAY = (
+        "d:transactions/measurements.time_to_initial_display@millisecond"
+    )
+    MEASUREMENTS_TIME_TO_FULL_DISPLAY = (
+        "d:transactions/measurements.time_to_full_display@millisecond"
+    )
     MEASUREMENTS_STALL_COUNT = "d:transactions/measurements.stall_count@none"
     MEASUREMENTS_STALL_LONGEST_TIME = "d:transactions/measurements.stall_longest_time@millisecond"
     MEASUREMENTS_STALL_PERCENTAGE = "d:transactions/measurements.stall_percentage@ratio"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -77,6 +77,8 @@ class TransactionMetricKey(Enum):
     MEASUREMENTS_FRAMES_SLOW = "transaction.measurements.frames_slow"
     MEASUREMENTS_FRAMES_SLOW_RATE = "transaction.measurements.frames_slow_rate"
     MEASUREMENTS_FRAMES_TOTAL = "transaction.measurements.frames_total"
+    MEASUREMENTS_TIME_TO_INITIAL_DISPLAY = "transaction.measurements.time_to_initial_display"
+    MEASUREMENTS_TIME_TO_FULL_DISPLAY = "transaction.measurements.time_to_full_display"
     MEASUREMENTS_STALL_COUNT = "transaction.measurements.stall_count"
     MEASUREMENTS_STALL_LONGEST_TIME = "transaction.measurements.stall_longest_time"
     MEASUREMENTS_STALL_PERCENTAGE = "transaction.measurements.stall_percentage"

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1510,6 +1510,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         "measurements.fid": "metrics_distributions",
         "measurements.cls": "metrics_distributions",
         "measurements.frames_frozen_rate": "metrics_distributions",
+        "measurements.time_to_initial_display": "metrics_distributions",
         "spans.http": "metrics_distributions",
         "user": "metrics_sets",
     }

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1515,6 +1515,8 @@ def is_duration_measurement(key):
         "measurements.fid",
         "measurements.ttfb",
         "measurements.ttfb.requesttime",
+        "measurements.time_to_initial_display",
+        "measurements.time_to_full_display",
         "measurements.app_start_cold",
         "measurements.app_start_warm",
     ]

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-03-03T12:37:18.832972Z'
-creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
@@ -122,6 +120,10 @@ config:
     - name: ttfb.requesttime
       unit: millisecond
     - name: ttfb
+      unit: millisecond
+    - name: time_to_full_display
+      unit: millisecond
+    - name: time_to_initial_display
       unit: millisecond
     maxCustomMeasurements: 10
   piiConfig:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-03-03T12:37:18.951044Z'
-creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
@@ -122,6 +120,10 @@ config:
     - name: ttfb.requesttime
       unit: millisecond
     - name: ttfb
+      unit: millisecond
+    - name: time_to_full_display
+      unit: millisecond
+    - name: time_to_initial_display
       unit: millisecond
     maxCustomMeasurements: 10
   piiConfig:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/MONOLITH.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-02-28T15:22:32.843604Z'
-creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
@@ -50,6 +48,10 @@ config:
     - name: ttfb.requesttime
       unit: millisecond
     - name: ttfb
+      unit: millisecond
+    - name: time_to_full_display
+      unit: millisecond
+    - name: time_to_initial_display
       unit: millisecond
     maxCustomMeasurements: 10
   piiConfig:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/slim_config/REGION.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-02-28T15:22:32.652661Z'
-creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
@@ -50,6 +48,10 @@ config:
     - name: ttfb.requesttime
       unit: millisecond
     - name: ttfb
+      unit: millisecond
+    - name: time_to_full_display
+      unit: millisecond
+    - name: time_to_initial_display
       unit: millisecond
     maxCustomMeasurements: 10
   piiConfig:

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/MONOLITH/with_metrics.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-02-28T14:42:11.964248Z'
-creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 breakdownsV2:
@@ -944,6 +942,8 @@ transactionMetrics:
   - d:transactions/measurements.stall_longest_time@millisecond
   - d:transactions/measurements.stall_percentage@ratio
   - d:transactions/measurements.stall_total_time@millisecond
+  - d:transactions/measurements.time_to_full_display@millisecond
+  - d:transactions/measurements.time_to_initial_display@millisecond
   - d:transactions/measurements.ttfb.requesttime@millisecond
   - d:transactions/measurements.ttfb@millisecond
   - s:transactions/user@none

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/REGION/with_metrics.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2023-02-28T14:42:11.608258Z'
-creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 breakdownsV2:
@@ -944,6 +942,8 @@ transactionMetrics:
   - d:transactions/measurements.stall_longest_time@millisecond
   - d:transactions/measurements.stall_percentage@ratio
   - d:transactions/measurements.stall_total_time@millisecond
+  - d:transactions/measurements.time_to_full_display@millisecond
+  - d:transactions/measurements.time_to_initial_display@millisecond
   - d:transactions/measurements.ttfb.requesttime@millisecond
   - d:transactions/measurements.ttfb@millisecond
   - s:transactions/user@none


### PR DESCRIPTION
- Adds the new time to full and initial display to all the backend lists. wow there's too many of these
- Closes #45879