### PR TITLE
ref(crons): Use circle add icon for Add Monitor button

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -119,7 +119,7 @@ class Monitors extends AsyncView<Props, State> {
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
               <CronsFeedbackButton />
-              <NewMonitorButton size="sm" icon={<IconAdd size="xs" />}>
+              <NewMonitorButton size="sm" icon={<IconAdd isCircled size="xs" />}>
                 {t('Add Monitor')}
               </NewMonitorButton>
             </ButtonBar>


### PR DESCRIPTION
Misunderstood from before, and previously removed in this [PR](https://github.com/getsentry/sentry/pull/45738), but this should indeed be a circle add icon

<img width="312" alt="image" src="https://user-images.githubusercontent.com/9372512/225446569-33eea2bf-eb40-45e2-ac32-2b09e96028ea.png">
