### PR TITLE
ref(profiling): Reword to most frequent stacks

### DIFF
--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -145,7 +145,7 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
     <Fragment>
       <SpanDetails>
         <SpanDetailsItem grow>
-          <SectionHeading>{t('Top Contributors to this Span')}</SectionHeading>
+          <SectionHeading>{t('Most Frequent Stacks in this Span')}</SectionHeading>
         </SpanDetailsItem>
         <SpanDetailsItem>
           <SectionSubtext>


### PR DESCRIPTION
As discussed, we're rewording `Top Contributors` to `Most Frequent Stacks`.