### PR TITLE
feat(CapMan): Replays queries now have `tenant_ids`

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -233,6 +233,7 @@ class SnubaEventStorage(EventStorage):
                     filter_keys={"project_id": [project_id], "event_id": [event_id]},
                     limit=1,
                     referrer="eventstore.get_event_by_id_nodestore",
+                    tenant_ids={"organization_id": event.project.organization_id},
                     **raw_query_kwargs,
                 )
             except snuba.QueryOutsideRetentionError:
@@ -338,6 +339,7 @@ class SnubaEventStorage(EventStorage):
                 referrer="eventstore.get_next_or_prev_event_id",
                 orderby=orderby,
                 dataset=dataset,
+                tenant_ids=tenant_ids,
             )
         except (snuba.QueryOutsideRetentionError, snuba.QueryOutsideGroupActivityError):
             # This can happen when the date conditions for paging

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -65,6 +65,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
             start=snuba_params.start,
             end=snuba_params.end,
             replay_ids=list(replay_ids_mapping.keys()),
+            tenant_ids={"organization_id": organization.id},
         )
 
         if request.GET.get("returnIds"):

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -61,6 +61,7 @@ class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
                 limit=limit,
                 offset=offset,
                 search_filters=search_filters,
+                tenant_ids={"organization_id": organization.id},
             )
 
         return self.paginate(

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -45,6 +45,7 @@ class ProjectReplayDetailsEndpoint(ProjectEndpoint):
             replay_id=replay_id,
             start=filter_params["start"],
             end=filter_params["end"],
+            tenant_ids={"organization_id": project.organization_id},
         )
 
         response = process_raw_response(

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -52,7 +52,7 @@ def query_replays_collection(
     limit: Optional[str],
     offset: Optional[str],
     search_filters: List[SearchFilter],
-    tenant_ids: dict[str, Any],
+    tenant_ids: dict[str, Any] | None = None,
 ) -> dict:
     """Query aggregated replay collection."""
     conditions = []

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -162,8 +162,8 @@ def query_replays_dataset(
             groupby=[Column("project_id"), Column("replay_id")],
             granularity=Granularity(3600),
             **query_options,
-            tenant_ids=tenant_ids,
         ),
+        tenant_ids=tenant_ids,
     )
     return raw_snql_query(snuba_request, "replays.query.query_replays_dataset")
 

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -116,7 +116,7 @@ def query_replays_dataset(
     sorting: List[OrderBy],
     pagination: Optional[Paginators],
     search_filters: List[SearchFilter],
-    tenant_ids: dict[str, Any],
+    tenant_ids: dict[str, Any] | None = None,
 ):
     query_options = {}
 

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -265,8 +265,8 @@ def query_replays_dataset_tagkey_values(
             groupby=[grouped_column],
             granularity=Granularity(3600),
             limit=Limit(1000),
-            tenant_ids=tenant_ids,
         ),
+        tenant_ids=tenant_ids,
     )
     return raw_snql_query(
         snuba_request, referrer="replays.query.query_replays_dataset_tagkey_values", use_cache=True

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -52,6 +52,7 @@ def query_replays_collection(
     limit: Optional[str],
     offset: Optional[str],
     search_filters: List[SearchFilter],
+    tenant_ids: dict[str, Any],
 ) -> dict:
     """Query aggregated replay collection."""
     conditions = []
@@ -75,6 +76,7 @@ def query_replays_collection(
         sorting=sort_ordering,
         pagination=paginators,
         search_filters=search_filters,
+        tenant_ids=tenant_ids,
     )
     return response["data"]
 
@@ -84,6 +86,7 @@ def query_replay_instance(
     replay_id: str,
     start: datetime,
     end: datetime,
+    tenant_ids: dict[str, Any],
 ):
     """Query aggregated replay instance."""
     response = query_replays_dataset(
@@ -98,6 +101,7 @@ def query_replay_instance(
         sorting=[],
         pagination=None,
         search_filters=[],
+        tenant_ids=tenant_ids,
     )
     return response["data"]
 
@@ -112,6 +116,7 @@ def query_replays_dataset(
     sorting: List[OrderBy],
     pagination: Optional[Paginators],
     search_filters: List[SearchFilter],
+    tenant_ids: dict[str, Any],
 ):
     query_options = {}
 
@@ -157,6 +162,7 @@ def query_replays_dataset(
             groupby=[Column("project_id"), Column("replay_id")],
             granularity=Granularity(3600),
             **query_options,
+            tenant_ids=tenant_ids,
         ),
     )
     return raw_snql_query(snuba_request, "replays.query.query_replays_dataset")
@@ -167,6 +173,7 @@ def query_replays_count(
     start: datetime,
     end: datetime,
     replay_ids: List[str],
+    tenant_ids: dict[str, Any],
 ):
 
     snuba_request = Request(
@@ -198,6 +205,7 @@ def query_replays_count(
             groupby=[Column("replay_id")],
             granularity=Granularity(3600),
         ),
+        tenant_ids=tenant_ids,
     )
     return raw_snql_query(
         snuba_request, referrer="replays.query.query_replays_count", use_cache=True
@@ -210,6 +218,7 @@ def query_replays_dataset_tagkey_values(
     end: datetime,
     environment: str | None,
     tag_key: str,
+    tenant_ids: dict[str, Any] | None,
 ):
     """Query replay tagkey values. Like our other tag functionality, aggregates do not work here."""
 
@@ -256,6 +265,7 @@ def query_replays_dataset_tagkey_values(
             groupby=[grouped_column],
             granularity=Granularity(3600),
             limit=Limit(1000),
+            tenant_ids=tenant_ids,
         ),
     )
     return raw_snql_query(

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1404,6 +1404,7 @@ class SnubaTagStorage(TagStorage):
                 end=end,
                 environment=filters.get("environment"),
                 tag_key=key,
+                tenant_ids=tenant_ids,
             )
             results = {
                 d["tag_value"]: {


### PR DESCRIPTION
### Overview
- Added org ID per Snuba request for Replays queries
- More context #44788