### PR TITLE
ref(py): Get your ruby out of my python

### DIFF
--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -48,10 +48,10 @@ class ExternalActorSerializer(Serializer):  # type: ignore
         # each actor id maps to an object
         resolved_actors: MutableMapping[int, Any] = {}
         for type_str, type_id in ACTOR_TYPES.items():
-            klass = actor_type_to_class(type_id)
+            cls = actor_type_to_class(type_id)
             actor_ids = actor_ids_by_type[type_str]
 
-            for model in fetch_actors_by_actor_ids(klass, actor_ids):
+            for model in fetch_actors_by_actor_ids(cls, actor_ids):
                 resolved_actors[model.actor_id] = {type_str: model}
 
         # create a mapping of external actor to a set of attributes. Those attributes are either {"user": User} or {"team": Team}.

--- a/src/sentry/auth/password_validation.py
+++ b/src/sentry/auth/password_validation.py
@@ -21,11 +21,11 @@ def get_password_validators(validator_config):
     validators = []
     for validator in validator_config:
         try:
-            klass = import_string(validator["NAME"])
+            cls = import_string(validator["NAME"])
         except ImportError:
             msg = "The module in NAME could not be imported: %s. Check your AUTH_PASSWORD_VALIDATORS setting."
             raise ImproperlyConfigured(msg % validator["NAME"])
-        validators.append(klass(**validator.get("OPTIONS", {})))
+        validators.append(cls(**validator.get("OPTIONS", {})))
 
     return validators
 

--- a/src/sentry/integrations/msteams/notifications.py
+++ b/src/sentry/integrations/msteams/notifications.py
@@ -60,8 +60,8 @@ def is_supported_notification_type(notification: BaseNotification) -> bool:
 def get_notification_card(
     notification: BaseNotification, context: Mapping[str, Any], recipient: User | Team
 ) -> AdaptiveCard:
-    klass = MESSAGE_BUILDERS[notification.message_builder]
-    return klass(notification, context, recipient).build_notification_card()
+    cls = MESSAGE_BUILDERS[notification.message_builder]
+    return cls(notification, context, recipient).build_notification_card()
 
 
 @register_notification_provider(ExternalProviders.MSTEAMS)

--- a/src/sentry/integrations/slack/message_builder/notifications/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/__init__.py
@@ -5,13 +5,13 @@ from .digest import DigestNotificationMessageBuilder
 from .issues import IssueNotificationMessageBuilder
 
 
-def get_message_builder(klass: str) -> type[SlackNotificationsMessageBuilder]:
+def get_message_builder(class_name: str) -> type[SlackNotificationsMessageBuilder]:
     """TODO(mgaeta): HACK to get around circular imports."""
     return {
         "DigestNotificationMessageBuilder": DigestNotificationMessageBuilder,
         "IssueNotificationMessageBuilder": IssueNotificationMessageBuilder,
         "SlackNotificationsMessageBuilder": SlackNotificationsMessageBuilder,
-    }[klass]
+    }[class_name]
 
 
 __all__ = (

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -51,8 +51,8 @@ def get_attachments(
 ) -> List[SlackAttachment]:
     extra_context = (extra_context_by_actor_id or {}).get(recipient.actor_id, {})
     context = get_context(notification, recipient, shared_context, extra_context)
-    klass = get_message_builder(notification.message_builder)
-    attachments = klass(notification, context, recipient).build()
+    cls = get_message_builder(notification.message_builder)
+    attachments = cls(notification, context, recipient).build()
     if isinstance(attachments, List):
         return attachments
     return [attachments]

--- a/src/sentry/mediators/param.py
+++ b/src/sentry/mediators/param.py
@@ -137,8 +137,8 @@ class Param:
             >>> self._eval_string_type()
             sentry.models.project.Project
         """
-        mod, klass = self._type.rsplit(".", 1)
-        return getattr(sys.modules[mod], klass)
+        mod, cls = self._type.rsplit(".", 1)
+        return getattr(sys.modules[mod], cls)
 
     def _missing_value(self, value):
         return self.is_required and value is None and not self.has_default


### PR DESCRIPTION
hot takes

See https://peps.python.org/pep-0008/#designing-for-inheritance

> If your public attribute name collides with a reserved keyword, append a single trailing underscore to your attribute name. This is preferable to an abbreviation or corrupted spelling. (However, notwithstanding this rule, ‘cls’ is the preferred spelling for any variable or argument which is known to be a class, especially the first argument to a class method.)
