### PR TITLE
fix(stats): Use project ids in per-min query for stats page

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -118,6 +118,7 @@ describe('OrganizationStats', function () {
         statsPeriod: '5m',
         interval: '1m',
         groupBy: ['category', 'outcome'],
+        project: [-1],
         field: ['sum(quantity)'],
       },
       UsageStatsProjects: {

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -254,7 +254,7 @@ class UsageStatsOrganization<
   }
 
   get cardMetadata() {
-    const {dataCategory, dataCategoryName, organization} = this.props;
+    const {dataCategory, dataCategoryName, organization, projectIds} = this.props;
     const {total, accepted, dropped, filtered} = this.chartData.cardStats;
 
     const cardMetadata: Record<string, ScoreCardProps> = {
@@ -269,7 +269,11 @@ class UsageStatsOrganization<
         }),
         score: accepted,
         trend: (
-          <UsageStatsPerMin organization={organization} dataCategory={dataCategory} />
+          <UsageStatsPerMin
+            dataCategory={dataCategory}
+            organization={organization}
+            projectIds={projectIds}
+          />
         ),
       },
       filtered: {

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -10,6 +10,7 @@ import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
 type Props = {
   dataCategory: DataCategoryInfo['plural'];
   organization: Organization;
+  projectIds: number[];
 } & AsyncComponent['props'];
 
 type State = {
@@ -37,10 +38,12 @@ class UsageStatsPerMin extends AsyncComponent<Props, State> {
   }
 
   get endpointQuery() {
+    const {projectIds} = this.props;
     return {
       statsPeriod: '5m', // Any value <1h will return current hour's data
       interval: '1m',
       groupBy: ['category', 'outcome'],
+      project: projectIds,
       field: ['sum(quantity)'],
     };
   }


### PR DESCRIPTION
This PR fixes the query being used to calculate the per min data on the stats page to use the projects in state. This will mean that selecting one, none or many projects to filter the rest of the page should carry over to the per min stat.