### PR TITLE
fix(monitors): 404 when monitor is not found during check-in create

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -146,6 +146,10 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
                     },
                 )
 
+            # Monitor does not exist and we have not created one
+            if not monitor:
+                return self.respond(status=404)
+
             # Update monitor configuration during checkin if config is changed
             if update_monitor and monitor_data["config"] != monitor.config:
                 monitor.update(config=monitor_data["config"])

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -293,6 +293,12 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
         assert resp.status_code == 404
 
+    def test_with_dsn_and_missing_monitor_without_create(self):
+        path = reverse(self.endpoint, args=["my-missing-monitor"])
+        resp = self.client.post(path, {"status": "ok"}, **self.dsn_auth_headers)
+
+        assert resp.status_code == 404
+
     def test_rate_limit(self):
         for path_func in self._get_path_functions():
             monitor = self._create_monitor()


### PR DESCRIPTION
We missed a case in https://github.com/getsentry/sentry/pull/45775

The monitor may be completely missing if we're not sending `config` (we won't create it)