### PR TITLE
ref(snuba): name referrer suffixes for tsdb-modelid:4

### DIFF
--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -99,6 +99,7 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
+            referrer_suffix="frequency_snoozes",
         )[self.group_id]
 
         if rate >= self.count:
@@ -120,6 +121,7 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
+            referrer_suffix="user_count_snoozes",
         )[self.group_id]
 
         if rate >= self.user_count:

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -99,7 +99,6 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
-            referrer_suffix="frequency_snoozes",
         )[self.group_id]
 
         if rate >= self.count:
@@ -121,7 +120,6 @@ class GroupSnooze(Model):
             start=start,
             end=end,
             tenant_ids={"organization_id": self.group.project.organization_id},
-            referrer_suffix="user_count_snoozes",
         )[self.group_id]
 
         if rate >= self.user_count:

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -236,6 +236,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
             use_cache=True,
             jitter_value=event.group_id,
             tenant_ids={"organization_id": event.group.project.organization_id},
+            referrer_suffix="alert_event_frequency",
         )
         return sums[event.group_id]
 
@@ -259,6 +260,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
             use_cache=True,
             jitter_value=event.group_id,
             tenant_ids={"organization_id": event.group.project.organization_id},
+            referrer_suffix="alert_event_uniq_user_frequency",
         )
         return totals[event.group_id]
 
@@ -367,6 +369,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                 use_cache=True,
                 jitter_value=event.group_id,
                 tenant_ids={"organization_id": event.group.project.organization_id},
+                referrer_suffix="alert_event_frequency_percent",
             )[event.group_id]
             if issue_count > avg_sessions_in_interval:
                 # We want to better understand when and why this is happening, so we're logging it for now

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -549,6 +549,7 @@ TSDBModelReferrer = enum.Enum(
 # specific suffixes that apply to tsdb-modelid:4 referrers, these are optional
 # and are passed around through using `referrer_suffix`
 TSDB_4_SUFFIXES = {
+    "frequency_snoozes",
     "user_count_snoozes",
     "alert_event_frequency",
     "alert_event_uniq_user_frequency",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -555,14 +555,15 @@ TSDB_4_SUFFIXES = {
     "alert_event_frequency_percent",
 }
 
-TSDBModelReferrer = enum.Enum(
-    "TSDBModelReferrer",
+TSDBModel4Referrer = enum.Enum(
+    "TSDBModel4Referrer",
     {f"TSDB_MODELID_4_{suffix}": f"tsdb-modelid:4.{suffix}" for suffix in TSDB_4_SUFFIXES},
 )
 
 
 Referrer = enum.Enum(
-    "Referrer", [(i.name, i.value) for i in chain(ReferrerBase, TSDBModelReferrer)]
+    "Referrer",
+    [(i.name, i.value) for i in chain(ReferrerBase, TSDBModelReferrer, TSDBModel4Referrer)],
 )
 
 

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -546,6 +546,21 @@ TSDBModelReferrer = enum.Enum(
     {f"TSDB_MODELID_{model.value}": f"tsdb-modelid:{model.value}" for model in TSDBModel},
 )
 
+# specific suffixes that apply to tsdb-modelid:4 referrers, these are optional
+# and are passed around through using `referrer_suffix`
+TSDB_4_SUFFIXES = {
+    "user_count_snoozes",
+    "alert_event_frequency",
+    "alert_event_uniq_user_frequency",
+    "alert_event_frequency_percent",
+}
+
+TSDBModelReferrer = enum.Enum(
+    "TSDBModelReferrer",
+    {f"TSDB_MODELID_4_{suffix}": f"tsdb-modelid:4.{suffix}" for suffix in TSDB_4_SUFFIXES},
+)
+
+
 Referrer = enum.Enum(
     "Referrer", [(i.name, i.value) for i in chain(ReferrerBase, TSDBModelReferrer)]
 )

--- a/tests/snuba/test_referrer.py
+++ b/tests/snuba/test_referrer.py
@@ -20,6 +20,12 @@ class ReferrerTest(TestCase):
         assert warn_log.call_count == 0
 
     @patch("sentry.snuba.referrer.logger.warning")
+    def test_referrer_validate_tsdb_4_model_with_suffix(self, warn_log):
+        assert warn_log.call_count == 0
+        validate_referrer("tsdb-modelid:4.user_count_snoozes")
+        assert warn_log.call_count == 0
+
+    @patch("sentry.snuba.referrer.logger.warning")
     def test_referrer_validate_base_enum_values(self, warn_log):
         assert warn_log.call_count == 0
         for i in ReferrerBase:


### PR DESCRIPTION
Needs https://github.com/getsentry/sentry/pull/45854 first.

Adds the `referrer_suffix` for different `tsdb-modelid:4` referrers. These should make it easier to tell if load is coming from issue alert rules, snoozes, etc