### PR TITLE
ref(onboarding): Add amplitude experiment to the onboarding - [TET-778]

### DIFF
--- a/static/app/components/onboarding/footer.tsx
+++ b/static/app/components/onboarding/footer.tsx
@@ -123,7 +123,8 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
     trackAdvancedAnalyticsEvent('onboarding.first_error_received', {
       organization,
       new_organization: !!newOrg,
-      project_slug: projectSlug,
+      project_id: projectId,
+      platform: selectedProject?.platform ?? 'other',
     });
 
     onboardingContext.setProjectData({
@@ -141,6 +142,7 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
     projectData,
     onboardingContext,
     projectSlug,
+    selectedProject,
   ]);
 
   useEffect(() => {
@@ -159,7 +161,8 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
     trackAdvancedAnalyticsEvent('onboarding.first_error_processed', {
       organization,
       new_organization: !!newOrg,
-      project_slug: projectSlug,
+      project_id: projectId,
+      platform: selectedProject?.platform ?? 'other',
     });
 
     onboardingContext.setProjectData({
@@ -178,6 +181,7 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
     projectId,
     onboardingContext,
     projectSlug,
+    selectedProject,
   ]);
 
   // The explore button is only showed if Sentry has not yet received any errors OR the issue is still being processed
@@ -192,7 +196,8 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
 
     trackAdvancedAnalyticsEvent('onboarding.explore_sentry_button_clicked', {
       organization,
-      project_slug: projectSlug,
+      project_id: projectId,
+      platform: selectedProject?.platform ?? 'other',
     });
 
     if (clientState) {
@@ -213,7 +218,7 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
     clientState,
     router,
     setClientState,
-    projectSlug,
+    selectedProject,
   ]);
 
   const handleSkipOnboarding = useCallback(() => {
@@ -264,7 +269,8 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
     trackAdvancedAnalyticsEvent('onboarding.view_error_button_clicked', {
       organization,
       new_organization: !!newOrg,
-      project_slug: projectSlug,
+      project_id: projectId,
+      platform: selectedProject?.platform ?? 'other',
     });
 
     if (clientState) {
@@ -286,7 +292,7 @@ export function Footer({projectSlug, projectId, router, newOrg}: Props) {
     setClientState,
     onboardingContext,
     projectId,
-    projectSlug,
+    selectedProject,
   ]);
 
   return (

--- a/static/app/components/onboarding/footerWithViewSampleErrorButton.tsx
+++ b/static/app/components/onboarding/footerWithViewSampleErrorButton.tsx
@@ -129,7 +129,8 @@ export function FooterWithViewSampleErrorButton({
     trackAdvancedAnalyticsEvent('onboarding.first_error_received', {
       organization,
       new_organization: !!newOrg,
-      project_slug: projectSlug,
+      project_id: projectId,
+      platform: selectedProject?.platform ?? 'other',
     });
 
     onboardingContext.setProjectData({
@@ -147,6 +148,7 @@ export function FooterWithViewSampleErrorButton({
     projectData,
     onboardingContext,
     projectSlug,
+    selectedProject,
   ]);
 
   useEffect(() => {
@@ -165,7 +167,8 @@ export function FooterWithViewSampleErrorButton({
     trackAdvancedAnalyticsEvent('onboarding.first_error_processed', {
       organization,
       new_organization: !!newOrg,
-      project_slug: projectSlug,
+      project_id: projectId,
+      platform: selectedProject?.platform ?? 'other',
     });
 
     onboardingContext.setProjectData({
@@ -184,6 +187,7 @@ export function FooterWithViewSampleErrorButton({
     projectId,
     onboardingContext,
     projectSlug,
+    selectedProject,
   ]);
 
   const handleSkipOnboarding = useCallback(() => {
@@ -234,7 +238,8 @@ export function FooterWithViewSampleErrorButton({
     trackAdvancedAnalyticsEvent('onboarding.view_error_button_clicked', {
       organization,
       new_organization: !!newOrg,
-      project_slug: projectSlug,
+      project_id: projectId,
+      platform: selectedProject?.platform ?? 'other',
     });
 
     if (clientState) {
@@ -256,7 +261,7 @@ export function FooterWithViewSampleErrorButton({
     setClientState,
     onboardingContext,
     projectId,
-    projectSlug,
+    selectedProject,
   ]);
 
   return (
@@ -297,9 +302,13 @@ export function FooterWithViewSampleErrorButton({
             source="targted-onboarding-heartbeat-footer"
             priority="primary"
             onCreateSampleGroup={() => {
+              if (!projectId) {
+                return;
+              }
               trackAdvancedAnalyticsEvent('onboarding.view_sample_error_button_clicked', {
                 new_organization: !!newOrg,
-                project_slug: projectSlug,
+                project_id: projectId,
+                platform: selectedProject?.platform ?? 'other',
                 organization,
               });
             }}

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -4,23 +4,28 @@ export type OnboardingEventParameters = {
     to: string;
   };
   'onboarding.explore_sentry_button_clicked': {
-    project_slug: string;
+    platform: string;
+    project_id: string;
   };
   'onboarding.first_error_processed': {
     new_organization: boolean;
-    project_slug: string;
+    platform: string;
+    project_id: string;
   };
   'onboarding.first_error_received': {
     new_organization: boolean;
-    project_slug: string;
+    platform: string;
+    project_id: string;
   };
   'onboarding.view_error_button_clicked': {
     new_organization: boolean;
-    project_slug: string;
+    platform: string;
+    project_id: string;
   };
   'onboarding.view_sample_error_button_clicked': {
     new_organization: boolean;
-    project_slug: string;
+    platform: string;
+    project_id: string;
   };
 };
 

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -202,14 +202,6 @@ function SetupDocs({search, route, router, location}: Props) {
 
   // log experiment on mount if feature enabled
   useEffect(() => {
-    // we are testing this on the dynamic sampling page but it will be removed soon
-    if (organization?.features.includes('onboarding-heartbeat-footer')) {
-      logExperiment();
-    }
-  }, [logExperiment, organization?.features]);
-
-  // log experiment on mount if feature enabled
-  useEffect(() => {
     logExperiment();
   }, [logExperiment]);
 

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -10,6 +10,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import {DocumentationWrapper} from 'sentry/components/onboarding/documentationWrapper';
 import {Footer} from 'sentry/components/onboarding/footer';
+import {FooterWithViewSampleErrorButton} from 'sentry/components/onboarding/footerWithViewSampleErrorButton';
 import {PlatformKey} from 'sentry/data/platformCategories';
 import platforms from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
@@ -19,6 +20,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {platformToIntegrationMap} from 'sentry/utils/integrationUtil';
 import useApi from 'sentry/utils/useApi';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
@@ -28,7 +30,6 @@ import ProjectSidebarSection from './components/projectSidebarSection';
 import IntegrationSetup from './integrationSetup';
 import {StepProps} from './types';
 import {usePersistedOnboardingState} from './utils';
-
 /**
  * The documentation will include the following string should it be missing the
  * verification example, which currently a lot of docs are.
@@ -111,9 +112,11 @@ function SetupDocs({search, route, router, location}: Props) {
   const organization = useOrganization();
   const {projects: rawProjects} = useProjects();
   const [clientState, setClientState] = usePersistedOnboardingState();
-
-  const heartbeatFooter = !!organization?.features.includes(
-    'onboarding-heartbeat-footer'
+  const {logExperiment, experimentAssignment} = useExperiment(
+    'OnboardingNewFooterExperiment',
+    {
+      logExperimentOnMount: false,
+    }
   );
 
   const singleSelectPlatform = !!organization?.features.includes(
@@ -197,6 +200,19 @@ function SetupDocs({search, route, router, location}: Props) {
     fetchData();
   }, [fetchData]);
 
+  // log experiment on mount if feature enabled
+  useEffect(() => {
+    // we are testing this on the dynamic sampling page but it will be removed soon
+    if (organization?.features.includes('onboarding-heartbeat-footer')) {
+      logExperiment();
+    }
+  }, [logExperiment, organization?.features]);
+
+  // log experiment on mount if feature enabled
+  useEffect(() => {
+    logExperiment();
+  }, [logExperiment]);
+
   if (!project) {
     return null;
   }
@@ -267,53 +283,61 @@ function SetupDocs({search, route, router, location}: Props) {
         </MainContent>
       </Wrapper>
 
-      {project &&
-        (heartbeatFooter ? (
-          <Footer
-            projectSlug={project.slug}
-            projectId={project.id}
-            route={route}
-            router={router}
-            location={location}
-            newOrg
-          />
-        ) : (
-          <FirstEventFooter
-            project={project}
-            organization={organization}
-            isLast={!nextProject}
-            hasFirstEvent={checkProjectHasFirstEvent(project)}
-            onClickSetupLater={() => {
-              const orgIssuesURL = `/organizations/${organization.slug}/issues/?project=${project.id}&referrer=onboarding-setup-docs`;
-              trackAdvancedAnalyticsEvent(
-                'growth.onboarding_clicked_setup_platform_later',
-                {
-                  organization,
-                  platform: currentPlatform,
-                  project_index: projectIndex,
-                }
-              );
-              if (!project.platform || !clientState) {
-                browserHistory.push(orgIssuesURL);
-                return;
+      {experimentAssignment === 'variant2' ? (
+        <FooterWithViewSampleErrorButton
+          projectSlug={project.slug}
+          projectId={project.id}
+          route={route}
+          router={router}
+          location={location}
+          newOrg
+        />
+      ) : experimentAssignment === 'variant1' ? (
+        <Footer
+          projectSlug={project.slug}
+          projectId={project.id}
+          route={route}
+          router={router}
+          location={location}
+          newOrg
+        />
+      ) : (
+        <FirstEventFooter
+          project={project}
+          organization={organization}
+          isLast={!nextProject}
+          hasFirstEvent={checkProjectHasFirstEvent(project)}
+          onClickSetupLater={() => {
+            const orgIssuesURL = `/organizations/${organization.slug}/issues/?project=${project.id}&referrer=onboarding-setup-docs`;
+            trackAdvancedAnalyticsEvent(
+              'growth.onboarding_clicked_setup_platform_later',
+              {
+                organization,
+                platform: currentPlatform,
+                project_index: projectIndex,
               }
-              // if we have a next project, switch to that
-              if (nextProject) {
-                setNewProject(nextProject.id);
-              } else {
-                setClientState({
-                  ...clientState,
-                  state: 'finished',
-                });
-                browserHistory.push(orgIssuesURL);
-              }
-            }}
-            handleFirstIssueReceived={() => {
-              const newHasFirstEventMap = {...hasFirstEventMap, [project.id]: true};
-              setHasFirstEventMap(newHasFirstEventMap);
-            }}
-          />
-        ))}
+            );
+            if (!project.platform || !clientState) {
+              browserHistory.push(orgIssuesURL);
+              return;
+            }
+            // if we have a next project, switch to that
+            if (nextProject) {
+              setNewProject(nextProject.id);
+            } else {
+              setClientState({
+                ...clientState,
+                state: 'finished',
+              });
+              browserHistory.push(orgIssuesURL);
+            }
+          }}
+          handleFirstIssueReceived={() => {
+            const newHasFirstEventMap = {...hasFirstEventMap, [project.id]: true};
+            setHasFirstEventMap(newHasFirstEventMap);
+          }}
+        />
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
+++ b/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
@@ -19,7 +19,6 @@ import {DynamicSamplingBias, DynamicSamplingBiasType} from 'sentry/types/samplin
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
-import {useExperiment} from 'sentry/utils/useExperiment';
 import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -62,26 +61,12 @@ export const knowDynamicSamplingBiases = {
 export function DynamicSampling({project}: Props) {
   const organization = useOrganization();
   const api = useApi();
-  const {logExperiment, experimentAssignment} = useExperiment(
-    'OnboardingNewFooterExperiment',
-    {
-      logExperimentOnMount: false,
-    }
-  );
 
   const hasTransactionNamePriorityFlag = organization.features.includes(
     'dynamic-sampling-transaction-name-priority'
   );
   const hasAccess = organization.access.includes('project:write');
   const biases = project.dynamicSamplingBiases ?? [];
-
-  // log experiment on mount if feature enabled
-  useEffect(() => {
-    // we are testing this on the dynamic sampling page but it will be removed soon
-    if (organization?.features.includes('onboarding-heartbeat-footer')) {
-      logExperiment();
-    }
-  }, [logExperiment, organization?.features]);
 
   useEffect(() => {
     trackAdvancedAnalyticsEvent('dynamic_sampling_settings.viewed', {
@@ -141,16 +126,6 @@ export function DynamicSampling({project}: Props) {
   return (
     <SentryDocumentTitle title={t('Dynamic Sampling')}>
       <Fragment>
-        {organization?.features.includes('onboarding-heartbeat-footer') && (
-          <div>
-            The Heartbeat is active and you are participating in the experiment: &nbsp;
-            {experimentAssignment === 'baseline'
-              ? '(Baseline) No change'
-              : experimentAssignment === 'variant1'
-              ? '(Variant 1) New design with “Explore Sentry“ button disabled while “waiting for error“'
-              : '(Variant 2) New design with existing “View Sample Error“ button instead while “waiting for error“'}
-          </div>
-        )}
         <SettingsPageHeader
           title={
             <Fragment>


### PR DESCRIPTION
- Removes the amplitude experiment code from the dynamic sampling page
- Adds the amplitude experiment code to the onboarding page 
- Create a new footer only with the "View Sample Error" button