### PR TITLE
ref(forms): Allow onSubmit hook to return data

### DIFF
--- a/static/app/components/forms/apiForm.tsx
+++ b/static/app/components/forms/apiForm.tsx
@@ -8,7 +8,7 @@ import useApi from 'sentry/utils/useApi';
 type Props = FormProps & {
   apiEndpoint: string;
   apiMethod: string;
-  onSubmit?: (data: Record<string, any>) => void;
+  onSubmit?: (data: Record<string, any>) => any | void;
 };
 
 function ApiForm({onSubmit, apiMethod, apiEndpoint, ...otherProps}: Props) {
@@ -20,11 +20,11 @@ function ApiForm({onSubmit, apiMethod, apiEndpoint, ...otherProps}: Props) {
       onSuccess: (response: Record<string, any>) => void,
       onError: (error: any) => void
     ) => {
-      onSubmit?.(data);
+      const transformed = onSubmit?.(data);
       addLoadingMessage(t('Saving changes\u2026'));
       api.request(apiEndpoint, {
         method: apiMethod,
-        data,
+        data: transformed ?? data,
         success: response => {
           clearIndicators();
           onSuccess(response);


### PR DESCRIPTION
### Summary
We don't always want to in-situ modify data in 'onSubmit', this also allows it to return and have that return value used instead. This is helpful if an endpoint only takes an array instead of an object bundle.

Needed for https://github.com/getsentry/getsentry/pull/9838.


