### PR TITLE
ref(perf): Change name of visually complete metric

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -354,7 +354,7 @@ const customMeasurements: Record<
    *
    * This should replace LCP as a 'load' metric when it's present, since it also works on navigations.
    */
-  visually_complete_data: ({transaction, transactionStart}) => {
+  visually_complete_with_data: ({transaction, transactionStart}) => {
     const vcdSpan = getVCDSpan(transaction);
     if (!vcdSpan?.endTimestamp) {
       return undefined;


### PR DESCRIPTION
### Summary
This changes the name to 'visually_complete_with_data' instead of the confusing term it was before. Doing this before this measurement name is hard to change when people start using it.

