### PR TITLE
ref(perf): Add VCD to more perf views

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -117,7 +117,7 @@ export class PerformanceInteraction {
   }
 }
 
-export const CustomerProfiler = ({id, children}: {children: ReactNode; id: string}) => {
+export const CustomProfiler = ({id, children}: {children: ReactNode; id: string}) => {
   return (
     <Profiler id={id} onRender={onRenderCallback}>
       {children}

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -23,6 +23,7 @@ import {createFuzzySearch, Fuse} from 'sentry/utils/fuzzySearch';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {TraceFullDetailed, TraceMeta} from 'sentry/utils/performance/quickTrace/types';
 import {filterTrace, reduceTrace} from 'sentry/utils/performance/quickTrace/utils';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 import {MetaData} from 'sentry/views/performance/transactionDetails/styles';
 
@@ -303,16 +304,21 @@ class TraceDetailsContent extends Component<Props, State> {
         {this.renderTraceHeader(traceInfo)}
         {this.renderSearchBar()}
         <Margin>
-          <TraceView
-            filteredTransactionIds={this.state.filteredTransactionIds}
-            traceInfo={traceInfo}
-            location={location}
-            organization={organization}
-            traceEventView={traceEventView}
-            traceSlug={traceSlug}
-            traces={traces}
-            meta={meta}
-          />
+          <VisuallyCompleteWithData
+            id="PerformanceDetails-TraceView"
+            hasData={!!traces.length}
+          >
+            <TraceView
+              filteredTransactionIds={this.state.filteredTransactionIds}
+              traceInfo={traceInfo}
+              location={location}
+              organization={organization}
+              traceEventView={traceEventView}
+              traceSlug={traceSlug}
+              traces={traces}
+              meta={meta}
+            />
+          </VisuallyCompleteWithData>
         </Margin>
       </Fragment>
     );

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -29,7 +29,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
-import {CustomerProfiler} from 'sentry/utils/performanceForSentry';
+import {CustomProfiler} from 'sentry/utils/performanceForSentry';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -287,7 +287,7 @@ class TransactionDetail extends Component<Props> {
 
   render() {
     return (
-      <CustomerProfiler id="TransactionDetail">
+      <CustomProfiler id="TransactionDetail">
         <TransactionDetailsContainer
           onClick={event => {
             // prevent toggling the transaction detail
@@ -297,7 +297,7 @@ class TransactionDetail extends Component<Props> {
           {this.renderTransactionErrors()}
           {this.renderTransactionDetail()}
         </TransactionDetailsContainer>
-      </CustomerProfiler>
+      </CustomProfiler>
     );
   }
 }

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -33,6 +33,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import ViewReplayLink from 'sentry/utils/discover/viewReplayLink';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import {TableColumn} from 'sentry/views/discover/table/types';
 
@@ -476,24 +477,29 @@ class EventsTable extends Component<Props, State> {
                       organization={organization}
                       replayIds={replayIds}
                     >
-                      <GridEditable
-                        isLoading={
-                          isTotalEventsLoading ||
-                          isDiscoverQueryLoading ||
-                          shouldFetchAttachments
-                        }
-                        data={tableData?.data ?? []}
-                        columnOrder={columnOrder}
-                        columnSortBy={eventView.getSorts()}
-                        grid={{
-                          onResizeColumn: this.handleResizeColumn,
-                          renderHeadCell: this.renderHeadCellWithMeta(
-                            tableData?.meta
-                          ) as any,
-                          renderBodyCell: this.renderBodyCellWithData(tableData) as any,
-                        }}
-                        location={location}
-                      />
+                      <VisuallyCompleteWithData
+                        id="TransactionEvents-EventsTable"
+                        hasData={!!tableData?.data?.length}
+                      >
+                        <GridEditable
+                          isLoading={
+                            isTotalEventsLoading ||
+                            isDiscoverQueryLoading ||
+                            shouldFetchAttachments
+                          }
+                          data={tableData?.data ?? []}
+                          columnOrder={columnOrder}
+                          columnSortBy={eventView.getSorts()}
+                          grid={{
+                            onResizeColumn: this.handleResizeColumn,
+                            renderHeadCell: this.renderHeadCellWithMeta(
+                              tableData?.meta
+                            ) as any,
+                            renderBodyCell: this.renderBodyCellWithData(tableData) as any,
+                          }}
+                          location={location}
+                        />
+                      </VisuallyCompleteWithData>
                       <Pagination
                         disabled={isDiscoverQueryLoading}
                         caption={paginationCaption}

--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -19,6 +19,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import SuspectSpansQuery from 'sentry/utils/performance/suspectSpans/suspectSpansQuery';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useProjects from 'sentry/utils/useProjects';
 
@@ -149,16 +150,21 @@ function SpansContent(props: Props) {
             >
               {({suspectSpans, isLoading, pageLinks}) => (
                 <Fragment>
-                  <SuspectSpansTable
-                    location={location}
-                    organization={organization}
-                    transactionName={transactionName}
-                    project={projects.find(p => p.id === projectId)}
-                    isLoading={isLoading}
-                    suspectSpans={suspectSpans ?? []}
-                    totals={totals}
-                    sort={sort.field}
-                  />
+                  <VisuallyCompleteWithData
+                    id="TransactionSpans-SuspectSpansTable"
+                    hasData={!!suspectSpans?.length}
+                  >
+                    <SuspectSpansTable
+                      location={location}
+                      organization={organization}
+                      transactionName={transactionName}
+                      project={projects.find(p => p.id === projectId)}
+                      isLoading={isLoading}
+                      suspectSpans={suspectSpans ?? []}
+                      totals={totals}
+                      sort={sort.field}
+                    />
+                  </VisuallyCompleteWithData>
                   <Pagination pageLinks={pageLinks ?? null} />
                 </Fragment>
               )}

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/spanDetailsTable.tsx
@@ -24,6 +24,7 @@ import {
   ExampleTransaction,
   SuspectSpan,
 } from 'sentry/utils/performance/suspectSpans/types';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 
 import {generateTransactionLink} from '../../utils';
 
@@ -89,22 +90,24 @@ export default function SpanTable(props: Props) {
 
   return (
     <Fragment>
-      <GridEditable
-        isLoading={isLoading}
-        data={data}
-        columnOrder={SPANS_TABLE_COLUMN_ORDER}
-        columnSortBy={[]}
-        grid={{
-          renderHeadCell,
-          renderBodyCell: renderBodyCellWithMeta(
-            location,
-            organization,
-            transactionName,
-            suspectSpan
-          ),
-        }}
-        location={location}
-      />
+      <VisuallyCompleteWithData id="SpanDetails-SpanDetailsTable" hasData={!!data.length}>
+        <GridEditable
+          isLoading={isLoading}
+          data={data}
+          columnOrder={SPANS_TABLE_COLUMN_ORDER}
+          columnSortBy={[]}
+          grid={{
+            renderHeadCell,
+            renderBodyCell: renderBodyCellWithMeta(
+              location,
+              organization,
+              transactionName,
+              suspectSpan
+            ),
+          }}
+          location={location}
+        />
+      </VisuallyCompleteWithData>
       <Pagination pageLinks={pageLinks ?? null} />
     </Fragment>
   );

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -23,6 +23,7 @@ import {
   TableData,
   TableDataRow,
 } from 'sentry/utils/performance/segmentExplorer/segmentExplorerQuery';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
@@ -303,22 +304,27 @@ export class TagValueTable extends Component<Props, State> {
 
     return (
       <StyledPanelTable>
-        <GridEditable
-          isLoading={isLoading}
-          data={tableData && tableData.data ? tableData.data : []}
-          columnOrder={newColumns}
-          columnSortBy={[]}
-          grid={{
-            renderHeadCell: this.renderHeadCellWithMeta(
-              eventView,
-              tableData ? tableData.meta : {},
-              newColumns
-            ) as any,
-            renderBodyCell: this.renderBodyCellWithData(this.props) as any,
-            onResizeColumn: this.handleResizeColumn,
-          }}
-          location={location}
-        />
+        <VisuallyCompleteWithData
+          id="TransactionTags-TagValueTable"
+          hasData={!!tableData?.data?.length}
+        >
+          <GridEditable
+            isLoading={isLoading}
+            data={tableData && tableData.data ? tableData.data : []}
+            columnOrder={newColumns}
+            columnSortBy={[]}
+            grid={{
+              renderHeadCell: this.renderHeadCellWithMeta(
+                eventView,
+                tableData ? tableData.meta : {},
+                newColumns
+              ) as any,
+              renderBodyCell: this.renderBodyCellWithData(this.props) as any,
+              onResizeColumn: this.handleResizeColumn,
+            }}
+            location={location}
+          />
+        </VisuallyCompleteWithData>
 
         <Pagination pageLinks={pageLinks} onCursor={onCursor} size="sm" />
       </StyledPanelTable>


### PR DESCRIPTION
### Summary
This wraps adds VCD to a lot more of our perf views, wrapping the main list/table actionable component (usually a list with links).

Other:
- For some reason the profiling component was called `CustomerProfiler`... 