### PR TITLE
fix(profiling): dont throw in PanelItem when project not found

### DIFF
--- a/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
+++ b/static/app/views/profiling/landing/profilingSlowestTransactionsPanel.tsx
@@ -134,8 +134,8 @@ function SlowestTransactionPanelItem({
     [projects.projects, transaction]
   );
 
-  if (!transactionProject) {
-    throw Error('Cannot find project for slowest transaction');
+  if (!transactionProject && !projects.fetching && projects.projects.length > 0) {
+    return null;
   }
 
   const key: SlowestTransactionsFields = 'p95()';


### PR DESCRIPTION
## Summary

Render null instead of throwing an error in `SlowestTransactionPanelItem`