### PR TITLE
fix(api): OrganizationMemberDetail returns errors

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -152,7 +152,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         )
 
         if not serializer.is_valid():
-            return Response(status=400)
+            return Response(serializer.errors, status=400)
 
         try:
             auth_provider = AuthProvider.objects.get(organization=organization)


### PR DESCRIPTION
PUT requests to `/api/0/organizations/{organization_slug}/members/{member_id}/` would previously not give any detail on why the request was unsuccessful, only a lone 400 status code. This starts returning the actual errors.

This was discovered while using the terraform provider https://github.com/jianyuan/terraform-provider-sentry and applying changes with the [`sentry_organization_member` resource](https://registry.terraform.io/providers/jianyuan/sentry/latest/docs/resources/organization_member).

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
