### PR TITLE
Revert "feat: adds ab test for apm"

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -36,7 +36,6 @@ import {Organization} from 'sentry/types';
 import {isDemoWalkthrough} from 'sentry/utils/demoMode';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import theme from 'sentry/utils/theme';
-import {useExperiment} from 'sentry/utils/useExperiment';
 import useMedia from 'sentry/utils/useMedia';
 
 import {ProfilingOnboardingSidebar} from '../profiling/ProfilingOnboarding/profilingOnboardingSidebar';
@@ -73,9 +72,6 @@ function Sidebar({location, organization}: Props) {
 
   const collapsed = !!preferences.collapsed;
   const horizontal = useMedia(`(max-width: ${theme.breakpoints.medium})`);
-  const {logExperiment, experimentAssignment} = useExperiment('APMSidebarExperiment', {
-    logExperimentOnMount: false,
-  });
 
   const toggleCollapse = () => {
     const action = collapsed ? showSidebar : hideSidebar;
@@ -86,13 +82,6 @@ function Sidebar({location, organization}: Props) {
 
   // Close panel on any navigation
   useEffect(() => void hidePanel(), [location?.pathname]);
-
-  // log experiment on mount if feature enabled
-  useEffect(() => {
-    if (organization?.features.includes('performance-view')) {
-      logExperiment();
-    }
-  }, [logExperiment, organization?.features]);
 
   // Add classname to body
   useEffect(() => {
@@ -191,11 +180,7 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconLightning size="md" />}
-        label={
-          <GuideAnchor target="performance">
-            {experimentAssignment === 1 ? t('APM') : t('Performance')}
-          </GuideAnchor>
-        }
+        label={<GuideAnchor target="performance">{t('Performance')}</GuideAnchor>}
         to={`/organizations/${organization.slug}/performance/`}
         id="performance"
       />

--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -23,12 +23,6 @@ export const experimentList: {
     parameter: 'scenario',
     assignments: ['baseline', 'variant1', 'variant2'],
   },
-  {
-    key: 'APMSidebarExperiment',
-    type: ExperimentType.Organization,
-    parameter: 'exposed',
-    assignments: [0, 1],
-  },
 ];
 
 export const experimentConfig = experimentList.reduce(


### PR DESCRIPTION
Reverts getsentry/sentry#45805

CTR is worse with `APM`  than with `Performance` so we will revert