### PR TITLE
ref(profiling): handle flamegraph emptystate

### DIFF
--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -1,3 +1,4 @@
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
@@ -10,6 +11,8 @@ import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider'
 
 export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
   const {data, isLoading} = useAggregateFlamegraphQuery({transaction});
+
+  const isEmpty = data?.shared.frames.length === 0;
   return (
     <ProfileGroupProvider type="flamegraph" input={data ?? null} traceID="">
       <FlamegraphStateProvider
@@ -25,6 +28,10 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
             <Flex h={400} column justify="center">
               {isLoading ? (
                 <LoadingIndicator>{t('Loading Flamegraph')}</LoadingIndicator>
+              ) : isEmpty ? (
+                <EmptyStateWarning>
+                  <p>{t(`A flamegraph isn't available for your query`)}</p>
+                </EmptyStateWarning>
               ) : (
                 <AggregateFlamegraph />
               )}

--- a/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
+++ b/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
@@ -13,7 +13,7 @@ export function useAggregateFlamegraphQuery({transaction}: {transaction: string}
   const conditions = new MutableSearch([]);
   conditions.setFilterValues('transaction_name', [transaction]);
 
-  return useQuery<Profiling.ProfileInput>(
+  return useQuery<Profiling.Schema>(
     [
       url,
       {


### PR DESCRIPTION
## Summary
Adds empty state to the `aggregateFlamegraph`

![image](https://user-images.githubusercontent.com/7349258/225709533-1f0426e1-a0e3-432f-9dca-a517e398b86b.png)
