### PR TITLE
fix(profiling): disable call order sorting for aggFlamegraph

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -399,6 +399,7 @@ export function AggregateFlamegraph(): ReactElement {
         disablePanX
         disableZoom
         disableGrid
+        disableCallOrderSort
       />
       <AggregateFlamegraphToolbar>
         <Button size="xs" onClick={() => scheduler.dispatch('reset zoom')}>

--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -36,7 +36,11 @@ const FLAMEGRAPH_COLOR_CODINGS: FlamegraphColorCodings = [
   'by frequency',
 ];
 const FLAMEGRAPH_VIEW_OPTIONS: FlamegraphViewOptions[] = ['top down', 'bottom up'];
-const FLAMEGRAPH_SORTING_OPTIONS: FlamegraphSorting[] = ['left heavy', 'call order'];
+const FLAMEGRAPH_SORTING_OPTIONS: FlamegraphSorting[] = [
+  'alphabetical',
+  'left heavy',
+  'call order',
+];
 
 interface FlamegraphContextMenuProps {
   contextMenu: ReturnType<typeof useContextMenu>;
@@ -45,6 +49,7 @@ interface FlamegraphContextMenuProps {
   onCopyFunctionNameClick: () => void;
   onHighlightAllOccurencesClick: () => void;
   profileGroup: ProfileGroup | null;
+  disableCallOrderSort?: boolean;
 }
 
 function isSupportedPlatformForGitHubLink(platform: string | undefined): boolean {
@@ -221,18 +226,23 @@ export function FlamegraphContextMenu(props: FlamegraphContextMenuProps) {
         </ProfilingContextMenuGroup>
         <ProfilingContextMenuGroup>
           <ProfilingContextMenuHeading>{t('Sorting')}</ProfilingContextMenuHeading>
-          {FLAMEGRAPH_SORTING_OPTIONS.map((sorting, idx) => (
-            <ProfilingContextMenuItemCheckbox
-              key={idx}
-              {...props.contextMenu.getMenuItemProps({
-                onClick: () => dispatch({type: 'set sorting', payload: sorting}),
-              })}
-              onClick={() => dispatch({type: 'set sorting', payload: sorting})}
-              checked={preferences.sorting === sorting}
-            >
-              {sorting}
-            </ProfilingContextMenuItemCheckbox>
-          ))}
+          {FLAMEGRAPH_SORTING_OPTIONS.map((sorting, idx) => {
+            if (props.disableCallOrderSort && sorting === 'call order') {
+              return null;
+            }
+            return (
+              <ProfilingContextMenuItemCheckbox
+                key={idx}
+                {...props.contextMenu.getMenuItemProps({
+                  onClick: () => dispatch({type: 'set sorting', payload: sorting}),
+                })}
+                onClick={() => dispatch({type: 'set sorting', payload: sorting})}
+                checked={preferences.sorting === sorting}
+              >
+                {sorting}
+              </ProfilingContextMenuItemCheckbox>
+            );
+          })}
         </ProfilingContextMenuGroup>
       </ProfilingContextMenu>
     </Fragment>

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -69,6 +69,7 @@ interface FlamegraphZoomViewProps {
   setFlamegraphOverlayCanvasRef: React.Dispatch<
     React.SetStateAction<HTMLCanvasElement | null>
   >;
+  disableCallOrderSort?: boolean;
   disableGrid?: boolean;
   disablePanX?: boolean;
   disableZoom?: boolean;
@@ -88,6 +89,7 @@ function FlamegraphZoomView({
   disablePanX = false,
   disableZoom = false,
   disableGrid = false,
+  disableCallOrderSort = false,
 }: FlamegraphZoomViewProps): React.ReactElement {
   const flamegraphTheme = useFlamegraphTheme();
   const profileGroup = useProfileGroup();
@@ -641,6 +643,7 @@ function FlamegraphZoomView({
         isHighlightingAllOccurences={highlightingAllOccurences}
         onCopyFunctionNameClick={handleCopyFunctionName}
         onHighlightAllOccurencesClick={handleHighlightAllFramesClick}
+        disableCallOrderSort={disableCallOrderSort}
       />
       {flamegraphCanvas &&
       flamegraphRenderer &&


### PR DESCRIPTION
## Summary
Disables call order sorting via the context menu for the aggregate flamegraph.

Attempting to sort would previously throw an error

![image](https://user-images.githubusercontent.com/7349258/225716157-f205d790-708d-40be-9052-41816e13d62c.png)
