### PR TITLE
fix(display-timings): full & initial display are duration

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1517,6 +1517,8 @@ def is_duration_measurement(key):
         "measurements.ttfb.requesttime",
         "measurements.app_start_cold",
         "measurements.app_start_warm",
+        "measurements.time_to_full_display",
+        "measurements.time_to_initial_display",
     ]
 
 


### PR DESCRIPTION
- Missed a spot for these values, need to be here too so that the saerch syntax treats them as durations, and not just numbers