### PR TITLE
fix(perf): Switch span ops to self time

### DIFF
--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -121,12 +121,15 @@ class OpsBreakdown extends Component<Props> {
     const operationNameIntervals = spans.reduce(
       (intervals: Partial<OperationNameIntervals>, span: RawSpanType) => {
         let startTimestamp = span.start_timestamp;
-        let endTimestamp = span.timestamp;
+        const endTimestamp = span.timestamp;
+
+        if (!span.exclusive_time) {
+          return intervals;
+        }
 
         if (endTimestamp < startTimestamp) {
           // reverse timestamps
           startTimestamp = span.timestamp;
-          endTimestamp = span.start_timestamp;
         }
 
         // invariant: startTimestamp <= endTimestamp
@@ -138,7 +141,10 @@ class OpsBreakdown extends Component<Props> {
           operationName = 'unknown';
         }
 
-        const cover: TimeWindowSpan = [startTimestamp, endTimestamp];
+        const cover: TimeWindowSpan = [
+          startTimestamp,
+          startTimestamp + span.exclusive_time / 1000,
+        ];
 
         const operationNameInterval = intervals[operationName];
 


### PR DESCRIPTION
## Summary
This switches span ops breakdown on _event details_ to self time vs total times so it accurately captures children spans as the highest amount of time spent in a transaction, vs. top level parent spans taking precedence.


## Screenshots
### Before
![Screenshot 2023-03-16 at 4 14 04 PM](https://user-images.githubusercontent.com/6111995/225742280-9e257b12-909e-4d46-ae06-17d7e59c633d.png)
### After
![Screenshot 2023-03-16 at 4 13 58 PM](https://user-images.githubusercontent.com/6111995/225742270-8c5a556f-1715-4c0e-a79a-d5c6809ea5ad.png)


