### PR TITLE
fix(profiling): Disable hierarchical grouping for profile stacks

### DIFF
--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -188,8 +188,8 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
       </SpanDetails>
       <StackTrace
         event={event}
-        hasHierarchicalGrouping
-        newestFirst={false}
+        hasHierarchicalGrouping={false}
+        newestFirst
         platform={event.platform || 'other'}
         stacktrace={{
           framesOmitted: null,
@@ -312,7 +312,10 @@ function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame
     node = node.parent;
   }
 
-  return frames;
+  // Profile stacks start from the inner most frame, while error stacks
+  // start from the outer most frame. Reverse the order here to match
+  // the convention on errors.
+  return frames.reverse();
 }
 
 const SpanDetails = styled('div')`


### PR DESCRIPTION
We want to use the non hierarchical grouping version of the stack trace as that renders the in app/system badges inline.