### PR TITLE
feat(discover): adds searchable values for device.class

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -20,7 +20,12 @@ import {
   SPAN_OP_BREAKDOWN_FIELDS,
   TRACING_FIELDS,
 } from 'sentry/utils/discover/fields';
-import {FieldKey, FieldKind} from 'sentry/utils/fields';
+import {
+  DEVICE_CLASS_TAG_VALUES,
+  FieldKey,
+  FieldKind,
+  isDeviceClass,
+} from 'sentry/utils/fields';
 import Measurements from 'sentry/utils/measurements/measurements';
 import useApi from 'sentry/utils/useApi';
 import withTags from 'sentry/utils/withTags';
@@ -158,6 +163,12 @@ function SearchBar(props: SearchBarProps) {
         // We can't really auto suggest values for aggregate fields
         // or measurements, so we simply don't
         return Promise.resolve([]);
+      }
+
+      // device.class is stored as "numbers" in snuba, but we want to suggest high, medium,
+      // and low search filter values because discover maps device.class to these values.
+      if (isDeviceClass(tag.key)) {
+        return Promise.resolve(DEVICE_CLASS_TAG_VALUES);
       }
 
       return fetchTagValues({

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1261,3 +1261,9 @@ export function makeTagCollection(fieldKeys: FieldKey[]): TagCollection {
     ])
   );
 }
+
+export function isDeviceClass(key): boolean {
+  return key === FieldKey.DEVICE_CLASS;
+}
+
+export const DEVICE_CLASS_TAG_VALUES = ['high', 'medium', 'low'];


### PR DESCRIPTION
`device.class` values are stored as "numbers" but we map them to `high, medium, low` in discover. We also need to force the searchable values for `device.class` to `high, medium, low` since the number values are not accepted by the field alias converter in discover.
<img width="519" alt="image" src="https://user-images.githubusercontent.com/83961295/225746468-277098b9-1d94-432d-a0e8-56d17f24b4ca.png">