### PR TITLE
ci(jest): Quiet down failing tests

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -171,6 +171,12 @@ jobs:
           #      wouldn't be correct.
           CI_NODE_TOTAL: 4
           CI_NODE_INDEX: ${{ matrix.instance }}
+          # Disable testing-library from printing out any of of the DOM to
+          # stdout. No one actually looks through this in CI, they're just
+          # going to run it locally.
+          #
+          # This quites up the logs quite a bit.
+          DEBUG_PRINT_LIMIT: 0
         run: |
           SENTRY_PROFILER_LOGGING_MODE=eager JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -175,7 +175,7 @@ jobs:
           # stdout. No one actually looks through this in CI, they're just
           # going to run it locally.
           #
-          # This quites up the logs quite a bit.
+          # This quiets up the logs quite a bit.
           DEBUG_PRINT_LIMIT: 0
         run: |
           SENTRY_PROFILER_LOGGING_MODE=eager JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit


### PR DESCRIPTION
Do not print any of the DOM when tests fail