### PR TITLE
feat(replays): Create a replay-feedkback-button hook for customizaing the feedback strategy

### DIFF
--- a/static/app/components/replays/header/feedbackButton.tsx
+++ b/static/app/components/replays/header/feedbackButton.tsx
@@ -1,0 +1,19 @@
+import {Fragment} from 'react';
+
+import {FeatureFeedback} from 'sentry/components/featureFeedback';
+import HookOrDefault from 'sentry/components/hookOrDefault';
+
+const FeedbackButtonHook = HookOrDefault({
+  hookName: 'component:replay-feedback-button',
+  defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
+});
+
+function FeedbackButton() {
+  return (
+    <FeedbackButtonHook>
+      <FeatureFeedback featureName="replay" buttonProps={{size: 'xs'}} />
+    </FeedbackButtonHook>
+  );
+}
+
+export default FeedbackButton;

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -118,6 +118,7 @@ export type ComponentHooks = {
   'component:member-list-header': () => React.ComponentType<MemberListHeaderProps>;
   'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
   'component:replay-beta-grace-period-alert': () => React.ComponentType<ReplayGracePeriodAlertProps>;
+  'component:replay-feedback-button': () => React.ComponentType<{}>;
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardinCTAProps>;
   'component:superuser-access-category': React.FC<any>;
 };

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -1,10 +1,10 @@
 import {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
-import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import * as Layout from 'sentry/components/layouts/thirds';
 import DeleteButton from 'sentry/components/replays/deleteButton';
 import DetailsPageBreadcrumbs from 'sentry/components/replays/header/detailsPageBreadcrumbs';
+import FeedbackButton from 'sentry/components/replays/header/feedbackButton';
 import ShareButton from 'sentry/components/replays/shareButton';
 import {CrumbWalker} from 'sentry/components/replays/walker/urlWalker';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -33,8 +33,8 @@ function Page({children, crumbs, orgSlug, replayRecord}: Props) {
 
       <ButtonActionsWrapper>
         <ShareButton />
+        <FeedbackButton />
         <DeleteButton />
-        <FeatureFeedback featureName="replay" buttonProps={{size: 'xs'}} />
       </ButtonActionsWrapper>
 
       {replayRecord && crumbs ? (


### PR DESCRIPTION
Wrapping the Give Feedback button, it still renders:
![SCR-20230316-lfp](https://user-images.githubusercontent.com/187460/225766869-f30cb774-a068-450d-b049-347f07ad0f45.png)


Related to https://github.com/getsentry/sentry/issues/44318