### PR TITLE
feat(ecosystem): Add codeowners file modal, link to file

### DIFF
--- a/fixtures/js-stubs/codeOwner.js
+++ b/fixtures/js-stubs/codeOwner.js
@@ -17,6 +17,7 @@ export function CodeOwner({
     codeMappingId: '11',
     provider: 'github',
     codeMapping: RepositoryProjectPathConfig({project, repo, integration}),
+    codeOwnersUrl: 'https://github.com/getsentry/sentry/blob/master/.github/CODEOWNERS',
     ownershipSyntax: '',
     errors: {
       missing_user_emails: [],

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -519,6 +519,11 @@ export type ServiceHook = {
  */
 export type CodeOwner = {
   codeMappingId: string;
+  /**
+   * Link to the CODEOWNERS file in source control
+   * 'unknown' if the api fails to fetch the file
+   */
+  codeOwnersUrl: string | 'unknown';
   dateCreated: string;
   dateUpdated: string;
   errors: {

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -10,12 +10,14 @@ import {
   IconGithub,
   IconGitlab,
   IconJira,
+  IconSentry,
   IconVsts,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
-import {
+import type {
   AppOrProviderOrPlugin,
+  CodeOwner,
   DocIntegration,
   ExternalActorMapping,
   ExternalActorMappingOrSuggestion,
@@ -224,6 +226,20 @@ export const getIntegrationIcon = (
       return <IconGeneric size={iconSize} />;
   }
 };
+
+export function getCodeOwnerIcon(
+  provider: CodeOwner['provider'],
+  iconSize: IconSize = 'md'
+) {
+  switch (provider ?? '') {
+    case 'github':
+      return <IconGithub size={iconSize} />;
+    case 'gitlab':
+      return <IconGitlab size={iconSize} />;
+    default:
+      return <IconSentry size={iconSize} />;
+  }
+}
 
 // used for project creation and onboarding
 // determines what integration maps to what project platform

--- a/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -8,11 +8,11 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 type Props = {
-  'data-test-id': string;
   dateUpdated: string | null;
   raw: string;
   type: 'codeowners' | 'issueowners';
   controls?: React.ReactNode[];
+  'data-test-id'?: string;
   placeholder?: string;
   provider?: string;
   repoName?: string;

--- a/static/app/views/settings/project/projectOwnership/viewCodeOwnerModal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/viewCodeOwnerModal.spec.tsx
@@ -1,0 +1,23 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ViewCodeOwnerModal from './viewCodeOwnerModal';
+
+describe('ViewCodeOwnerModal', () => {
+  const mockComponent: any = ({children}) => <div>{children}</div>;
+
+  it('should display parsed codeowners file', () => {
+    const ownershipSyntax = `codeowners:/src/sentry/migrations/ #developer-infrastructure\n`;
+    render(
+      <ViewCodeOwnerModal
+        codeowner={TestStubs.CodeOwner({ownershipSyntax})}
+        closeModal={jest.fn()}
+        Header={mockComponent}
+        Footer={mockComponent}
+        Body={mockComponent}
+        CloseButton={mockComponent}
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue(ownershipSyntax);
+  });
+});

--- a/static/app/views/settings/project/projectOwnership/viewCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/viewCodeOwnerModal.tsx
@@ -11,11 +11,11 @@ import {getCodeOwnerIcon} from 'sentry/utils/integrationUtil';
 import theme from 'sentry/utils/theme';
 import RulesPanel from 'sentry/views/settings/project/projectOwnership/rulesPanel';
 
-interface Props extends ModalRenderProps {
+interface ViewCodeOwnerModalProps extends ModalRenderProps {
   codeowner: CodeOwner;
 }
 
-function ViewCodeOwnerModal({Body, Header, codeowner}: Props) {
+function ViewCodeOwnerModal({Body, Header, codeowner}: ViewCodeOwnerModalProps) {
   return (
     <Fragment>
       <Header closeButton>

--- a/static/app/views/settings/project/projectOwnership/viewCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/viewCodeOwnerModal.tsx
@@ -1,0 +1,72 @@
+import {Fragment} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {SectionHeading} from 'sentry/components/charts/styles';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {CodeOwner} from 'sentry/types';
+import {getCodeOwnerIcon} from 'sentry/utils/integrationUtil';
+import theme from 'sentry/utils/theme';
+import RulesPanel from 'sentry/views/settings/project/projectOwnership/rulesPanel';
+
+interface Props extends ModalRenderProps {
+  codeowner: CodeOwner;
+}
+
+function ViewCodeOwnerModal({Body, Header, codeowner}: Props) {
+  return (
+    <Fragment>
+      <Header closeButton>
+        <HeaderContainer>
+          {getCodeOwnerIcon(codeowner.provider)}
+          <h4>{codeowner.codeMapping?.repoName}</h4>
+        </HeaderContainer>
+      </Header>
+      <Body>
+        <BodyContainer>
+          <div>
+            <div>
+              <SectionHeading>{t('Code Mapping:')}</SectionHeading>
+            </div>
+            {t('Stack Trace Root -')} <code>{codeowner.codeMapping?.stackRoot}</code>
+            <br />
+            {t('Source Code Root -')} <code>{codeowner.codeMapping?.sourceRoot}</code>
+          </div>
+
+          <RulesPanel
+            data-test-id="issueowners-panel"
+            type="codeowners"
+            provider={codeowner.provider}
+            raw={codeowner.ownershipSyntax || ''}
+            dateUpdated={codeowner.dateUpdated}
+          />
+        </BodyContainer>
+      </Body>
+    </Fragment>
+  );
+}
+
+const HeaderContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const BodyContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+`;
+
+export const modalCss = css`
+  @media (min-width: ${theme.breakpoints.small}) {
+    width: 80%;
+  }
+  [role='document'] {
+    overflow: initial;
+  }
+`;
+
+export default ViewCodeOwnerModal;


### PR DESCRIPTION
- Adds code mappings and a link to the codeowners file on github
- Adds a modal where you can view the parsed codeowners file like you could before on the ownership rules page.

table update
![image](https://user-images.githubusercontent.com/1400464/225767506-5d40c3a0-299c-4cd3-aeb3-ef816bd827ea.png)

new modal
![image](https://user-images.githubusercontent.com/1400464/225767673-f96add27-277f-4881-a43f-54533ff890e6.png)
