### PR TITLE
ref(features): add new feature flag enum and shim

### DIFF
--- a/src/sentry/features/base.py
+++ b/src/sentry/features/base.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from enum import Enum
+
 __all__ = [
     "Feature",
     "OrganizationFeature",
     "ProjectFeature",
     "ProjectPluginFeature",
     "UserFeature",
+    "FeatureHandlerStrategy",
 ]
 
 import abc
@@ -62,3 +65,16 @@ class UserFeature(Feature):
 
     def get_subject(self) -> User:
         return self.user
+
+
+class FeatureHandlerStrategy(Enum):
+    """
+    This controls whether the feature flag is evaluated statically,
+    or if it's managed by a remote feature flag service.
+    See https://develop.sentry.dev/feature-flags/
+    """
+
+    INTERNAL = 1
+    """Handle the feature using a constant or logic within python"""
+    REMOTE = 2
+    """Handle the feature using a remote flag management service"""

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -266,7 +266,9 @@ class FeatureManager(RegisteredFeatureManager):
             return None
 
     @staticmethod
-    def _shim_feature_strategy(entity_feature_strategy: bool | FeatureHandlerStrategy):
+    def _shim_feature_strategy(
+        entity_feature_strategy: bool | FeatureHandlerStrategy,
+    ) -> FeatureHandlerStrategy:
         """
         Shim layer for old API to register a feature until all the features have been converted
         """

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -22,7 +22,7 @@ from typing import (
 import sentry_sdk
 from django.conf import settings
 
-from .base import Feature
+from .base import Feature, FeatureHandlerStrategy
 from .exceptions import FeatureNotRegistered
 
 if TYPE_CHECKING:
@@ -144,7 +144,12 @@ class FeatureManager(RegisteredFeatureManager):
         """
         return {k: v for k, v in self._feature_registry.items() if v == feature_type}
 
-    def add(self, name: str, cls: Type[Feature] = Feature, entity_feature: bool = False) -> None:
+    def add(
+        self,
+        name: str,
+        cls: Type[Feature] = Feature,
+        entity_feature_strategy: bool | FeatureHandlerStrategy = False,
+    ) -> None:
         """
         Register a feature.
 
@@ -153,7 +158,9 @@ class FeatureManager(RegisteredFeatureManager):
 
         >>> FeatureManager.has('my:feature', actor=request.user)
         """
-        if entity_feature:
+        entity_feature_strategy = self._shim_feature_strategy(entity_feature_strategy)
+
+        if entity_feature_strategy == FeatureHandlerStrategy.REMOTE:
             if name.startswith("users:"):
                 raise NotImplementedError("User flags not allowed with entity_feature=True")
             self.entity_features.add(name)
@@ -257,6 +264,17 @@ class FeatureManager(RegisteredFeatureManager):
             )
         else:
             return None
+
+    @staticmethod
+    def _shim_feature_strategy(entity_feature_strategy: bool | FeatureHandlerStrategy):
+        """
+        Shim layer for old API to register a feature until all the features have been converted
+        """
+        if entity_feature_strategy is True:
+            return FeatureHandlerStrategy.REMOTE
+        elif entity_feature_strategy is False:
+            return FeatureHandlerStrategy.INTERNAL
+        return entity_feature_strategy
 
 
 class FeatureCheckBatch:


### PR DESCRIPTION
Adds a new enum to eventually replace the magic boolean for registering feature flag handlers. this is the same code as https://github.com/getsentry/sentry/pull/45545, except its the flag enum only. I've added a test to confirm shim behavior. I'll be following up with PRs that change the flags.

The original PR was reverted before deployment as I wasn't confident in the changes without better tests.

also: check out that inline editor documentation w/ a variable docstring 🔥 
<img width="532" alt="Screenshot 2023-03-16 at 5 43 35 PM" src="https://user-images.githubusercontent.com/1976777/225783059-64593316-f899-41a5-87e9-1ff352d78838.png">
