### PR TITLE
fix(weekly_email): Do not fail if user is not specified

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -770,7 +770,10 @@ def render_template_context(ctx, user):
             if ctx.organization.slug == "sentry":
                 logger.info(
                     "render_template_context.all_key_errors.num_projects",
-                    extra={"user_id": user.id, "num_user_projects": len(user_projects)},
+                    extra={
+                        "user_id": user.id if user else "",
+                        "num_user_projects": len(user_projects),
+                    },
                 )
             for project_ctx in user_projects:
                 if ctx.organization.slug == "sentry":


### PR DESCRIPTION
The _admin interface allows scheduling the weekly email report for a user that would have access to all reports, thus, a specific `user` is not set.

Fixes [SENTRY-ZN8](https://sentry.sentry.io/issues/4011905281)