### PR TITLE
chore(profiling): Add feature flag to return the sampled format

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1095,6 +1095,8 @@ SENTRY_FEATURES = {
     "organizations:profiling-span-previews": False,
     # Enable the transactions backed profiling views
     "organizations:profiling-using-transactions": False,
+    # Enable the sentry sample format response
+    "organizations:profiling-sampled-format": False,
     # Whether to enable ingest for profile blocked main thread issues
     "organizations:profile-blocked-main-thread-ingest": False,
     # Whether to enable post process group for profile blocked main thread issues

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -145,6 +145,7 @@ default_manager.add("organizations:profiling-aggregate-flamegraph", Organization
 default_manager.add("organizations:profiling-previews", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:profiling-span-previews", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:profiling-using-transactions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:profiling-sampled-format", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:project-stats", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:related-events", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
We want to eliminate the intermediate transformation from the sampled format to the speedscope format. This will return the raw payload and eliminate an unnecessary step. Only applicable for platforms sending the sampled format, so this excludes android and old iOS sdk versions.