### PR TITLE
fix(code mappings): Handle generic exceptions in `derive_code_mappings`

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -122,6 +122,9 @@ def derive_code_mappings(
         logger.warning("derive_code_mappings.getting_lock_failed", extra=extra)
         # This will cause the auto-retry logic to try again
         raise error
+    except Exception:
+        logger.exception("Unexpected error type while calling `get_trees_for_org()`.", extra=extra)
+        return
 
     if not trees:
         logger.error("The tree is empty. Investigate.")


### PR DESCRIPTION
This adds an `except` branch to `derive_code_mappings` to handle generic exceptions raised by `get_trees_for_org()`.

Ref: WOR-2704