### PR TITLE
chore(crons): Bump sentry-sdk to 1.17.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -56,7 +56,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.7.1
 sentry-relay>=0.8.19
-sentry-sdk>=1.16.0
+sentry-sdk>=1.17.0
 snuba-sdk>=1.0.5
 simplejson>=3.17.6
 statsd>=3.3

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -157,7 +157,7 @@ selenium==4.3.0
 sentry-arroyo==2.7.1
 sentry-cli==2.14.4
 sentry-relay==0.8.19
-sentry-sdk==1.16.0
+sentry-sdk==1.17.0
 simplejson==3.17.6
 six==1.16.0
 sniffio==1.2.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -109,7 +109,7 @@ s3transfer==0.5.2
 selenium==4.3.0
 sentry-arroyo==2.7.1
 sentry-relay==0.8.19
-sentry-sdk==1.16.0
+sentry-sdk==1.17.0
 simplejson==3.17.6
 six==1.16.0
 sniffio==1.2.0


### PR DESCRIPTION
Bump sentry-sdk to 1.17.0 for newest crons changes.