### PR TITLE
fix(snuba): fix referrer attribution

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -549,11 +549,15 @@ TSDBModelReferrer = enum.Enum(
 # specific suffixes that apply to tsdb-modelid referrers, these are optional
 # and are passed around through using `referrer_suffix`.
 TSDB_MODEL_TO_SUFFIXES = {
-    TSDBModel.group: {"frequency_snoozes", "alert_event_frequency", "alert_event_frequency"},
+    TSDBModel.group: {
+        "frequency_snoozes",
+        "alert_event_frequency",
+        "alert_event_frequency_percent",
+    },
     TSDBModel.group_performance: {
         "frequency_snoozes",
         "alert_event_frequency",
-        "alert_event_frequency",
+        "alert_event_frequency_percent",
     },
     TSDBModel.users_affected_by_group: {"user_count_snoozes", "alert_event_uniq_user_frequency"},
     TSDBModel.users_affected_by_perf_group: {

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -751,6 +751,7 @@ class SnubaTSDB(BaseTSDB):
             use_cache=use_cache,
             jitter_value=jitter_value,
             tenant_ids=tenant_ids,
+            referrer_suffix=referrer_suffix,
         )
         # convert
         #    {group:{timestamp:count, ...}}

--- a/tests/snuba/test_referrer.py
+++ b/tests/snuba/test_referrer.py
@@ -20,10 +20,15 @@ class ReferrerTest(TestCase):
         assert warn_log.call_count == 0
 
     @patch("sentry.snuba.referrer.logger.warning")
-    def test_referrer_validate_tsdb_4_model_with_suffix(self, warn_log):
+    def test_referrer_validate_tsdb_model_with_suffix(self, warn_log):
         assert warn_log.call_count == 0
+        validate_referrer("tsdb-modelid:300.user_count_snoozes")
+        assert warn_log.call_count == 0
+        validate_referrer("tsdb-modelid:4.frequency_snoozes")
+        assert warn_log.call_count == 0
+        # tsdb-modelid:4 doesn't use the `user_count_snoozes` suffix
         validate_referrer("tsdb-modelid:4.user_count_snoozes")
-        assert warn_log.call_count == 0
+        assert warn_log.call_count == 1
 
     @patch("sentry.snuba.referrer.logger.warning")
     def test_referrer_validate_base_enum_values(self, warn_log):


### PR DESCRIPTION
**context**
sooo https://github.com/getsentry/sentry/pull/45902 worked great except for two things:
* forgot to pass through the `referrer_suffix` in `get_range`
* `tsdb-modelid:4` is not used for the user queries

So this PR fixes both of those issues
