### PR TITLE
fix(ui): Do not wrap event ID tooltip

### DIFF
--- a/static/app/components/overlay.tsx
+++ b/static/app/components/overlay.tsx
@@ -136,7 +136,12 @@ const Overlay = styled(
   /* Override z-index from useOverlayPosition */
   z-index: ${p => p.theme.zIndex.dropdown} !important;
   ${p => p.animated && `will-change: transform, opacity;`}
-  ${p => p.overlayStyle as any}
+
+  /* Specificity hack to allow override styles to have higher specificity than
+   * styles provided in any styled components which extend Overlay */
+  :where(*) {
+    ${p => p.overlayStyle as any}
+  }
 `;
 
 interface PositionWrapperProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -120,7 +120,7 @@ export const GroupEventCarousel = ({
         <EventLabelContainer>
           <div>
             <EventIdLabel>Event ID:</EventIdLabel>{' '}
-            <Tooltip title={event.id}>
+            <Tooltip overlayStyle={{maxWidth: 'max-content'}} title={event.id}>
               <Clipboard value={event.id}>
                 <EventId>
                   {getShortEventId(event.id)}


### PR DESCRIPTION
Before
<img width="268" alt="image" src="https://user-images.githubusercontent.com/1421724/226432945-c2e4d030-8d33-40be-abc6-2b8dbe5f3849.png">

After
![image](https://user-images.githubusercontent.com/1421724/226062353-c0f08807-18a5-45f2-bc8e-48f3bd34e0f2.png)
