### PR TITLE
fix(issue-platform): restrict the occurrence_type when querying search_issues

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -219,7 +219,9 @@ def _query_params_for_generic(
         if group_ids:
             filters = {
                 "group_id": sorted(group_ids),
-                "occurrence_type_id": get_group_types_by_category(GroupCategory.PROFILE.value),
+                "occurrence_type_id": list(
+                    get_group_types_by_category(GroupCategory.PROFILE.value)
+                ),
                 **filters,
             }
 

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -217,7 +217,11 @@ def _query_params_for_generic(
         "organizations:issue-platform", organization=organization, actor=actor
     ):
         if group_ids:
-            filters = {"group_id": sorted(group_ids), **filters}
+            filters = {
+                "group_id": sorted(group_ids),
+                "occurrence_type_id": get_group_types_by_category(GroupCategory.PROFILE.value),
+                **filters,
+            }
 
         params = query_partial(
             dataset=snuba.Dataset.IssuePlatform,
@@ -256,14 +260,6 @@ def _update_profiling_search_filters(
             )
         else:
             updated_filters.append(sf)
-
-    updated_filters.append(
-        SearchFilter(
-            SearchKey("occurrence_type_id"),
-            "IN",
-            SearchValue(raw_value=get_group_types_by_category(GroupCategory.PROFILE.value)),
-        )
-    )
 
     return updated_filters
 

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -6,7 +6,12 @@ from typing import Any, Callable, Mapping, Optional, Protocol, Sequence, Set, Ty
 
 from sentry import features
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
-from sentry.issues.grouptype import GroupCategory, get_all_group_type_ids, get_group_type_by_type_id
+from sentry.issues.grouptype import (
+    GroupCategory,
+    get_all_group_type_ids,
+    get_group_type_by_type_id,
+    get_group_types_by_category,
+)
 from sentry.models import Environment, Organization
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.utils import snuba
@@ -251,6 +256,14 @@ def _update_profiling_search_filters(
             )
         else:
             updated_filters.append(sf)
+
+    updated_filters.append(
+        SearchFilter(
+            SearchKey("occurrence_type_id"),
+            "IN",
+            SearchValue(raw_value=get_group_types_by_category(GroupCategory.PROFILE.value)),
+        )
+    )
 
     return updated_filters
 


### PR DESCRIPTION
This is needed before we start ingesting performance issues into issue platform since our search_issues dataset used to only hold profiling occurrences. But when `search_issues` begins to have different types, we need to add a filter to search on the correct type.