### PR TITLE
ref(replays): <FluidHeight> should default to height:100%

### DIFF
--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -14,11 +14,9 @@ function ReplayView({toggleFullscreen}: Props) {
   return (
     <Fragment>
       <ReplayCurrentUrl />
-      <FluidHeight>
-        <Panel>
-          <ReplayPlayer />
-        </Panel>
-      </FluidHeight>
+      <Panel>
+        <ReplayPlayer />
+      </Panel>
       <ReplayController toggleFullscreen={toggleFullscreen} />
     </Fragment>
   );

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -59,7 +59,7 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
   };
 
   return (
-    <ConsoleContainer>
+    <FluidHeight>
       <ConsoleFilters breadcrumbs={breadcrumbs} {...filterProps} />
       <ConsoleLogContainer>
         {breadcrumbs ? (
@@ -89,13 +89,9 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
           <Placeholder height="100%" />
         )}
       </ConsoleLogContainer>
-    </ConsoleContainer>
+    </FluidHeight>
   );
 }
-
-const ConsoleContainer = styled(FluidHeight)`
-  height: 100%;
-`;
 
 const ConsoleLogContainer = styled('div')`
   position: relative;

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -62,7 +62,7 @@ function DomMutations({replay, startTimestampMs}: Props) {
   };
 
   return (
-    <MutationContainer>
+    <FluidHeight>
       <DomFilters actions={actions} {...filterProps} />
       <MutationItemContainer>
         {isLoading || !actions ? (
@@ -92,13 +92,9 @@ function DomMutations({replay, startTimestampMs}: Props) {
           </AutoSizer>
         )}
       </MutationItemContainer>
-    </MutationContainer>
+    </FluidHeight>
   );
 }
-
-const MutationContainer = styled(FluidHeight)`
-  height: 100%;
-`;
 
 const MutationItemContainer = styled('div')`
   position: relative;

--- a/static/app/views/replays/detail/layout/fluidHeight.tsx
+++ b/static/app/views/replays/detail/layout/fluidHeight.tsx
@@ -6,6 +6,7 @@ const FluidHeight = styled('div')`
   flex-wrap: nowrap;
   flex-grow: 1;
   overflow: hidden;
+  height: 100%;
 `;
 
 export default FluidHeight;

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -191,8 +191,6 @@ const SmallMarginSideTabs = styled(SideTabs)`
 `;
 
 const VideoSection = styled(FluidHeight)`
-  height: 100%;
-
   background: ${p => p.theme.background};
   gap: ${space(1)};
 

--- a/static/app/views/replays/detail/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryChart.tsx
@@ -44,9 +44,9 @@ function MemoryChart({
 
   if (!memorySpans) {
     return (
-      <MemoryLoadingWrapper>
+      <MemoryChartWrapper>
         <Placeholder height="100%" />
-      </MemoryLoadingWrapper>
+      </MemoryChartWrapper>
     );
   }
 
@@ -227,10 +227,6 @@ const MemoryChartWrapper = styled(FluidHeight)`
   margin-bottom: ${space(3)};
   border-radius: ${space(0.5)};
   border: 1px solid ${p => p.theme.border};
-`;
-
-const MemoryLoadingWrapper = styled(MemoryChartWrapper)`
-  height: 100%;
 `;
 
 const MemoizedMemoryChart = memo(

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -115,7 +115,7 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
   };
 
   return (
-    <NetworkContainer>
+    <FluidHeight>
       <NetworkFilters networkSpans={networkSpans} {...filterProps} />
       <NetworkTable>
         {networkSpans ? (
@@ -151,13 +151,9 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
           <Placeholder height="100%" />
         )}
       </NetworkTable>
-    </NetworkContainer>
+    </FluidHeight>
   );
 }
-
-const NetworkContainer = styled(FluidHeight)`
-  height: 100%;
-`;
 
 const NetworkTable = styled('div')`
   position: relative;


### PR DESCRIPTION
The only callsite that has a change in ui is the Replay Details > Memory tab

| Before (border not 100% tall) | After (full border) |
| --- | --- |
| <img width="714" alt="SCR-20230319-mu4" src="https://user-images.githubusercontent.com/187460/226216683-1950640c-018a-48ce-a8f0-b6a642eaee2e.png"> | <img width="720" alt="SCR-20230319-mty" src="https://user-images.githubusercontent.com/187460/226216727-31f103f1-e658-4ab0-9a75-701748868d07.png"> |


All other callsites render the same:
- Replay Preview (on Issue Details for example) has `height:100%` added, but still has `max-height:448px` which sets the limit
- Replay View/Player didn't need the extra wrapper. `<Panel>` overrides `<FluidHeight>` already. Resizing panels appears to work fine with just the one.
- Console/Network/DOM tabs as well as VideoSection in layout.tsx no longer need their overrides. 