### PR TITLE
feat(pytest): Add `it.only` equivalent to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ markers = [
     "snuba: test requires access to snuba",
     "sentry_metrics: test requires access to sentry metrics",
     "symbolicator: test requires access to symbolicator",
+    "only: if this appears on any test in a file, only run tests with this marker",
 ]
 selenium_driver = "chrome"
 filterwarnings = [


### PR DESCRIPTION
This adds a custom marker to pytest which mimics the [functionality of jest's `it.only`](https://jestjs.io/docs/api#testonlyname-fn-timeout). When a test is decorated with the `@pytest.mark.only` decorator, it will cause all other tests to be skipped. 

Though this works across the codebase (in other words, marking one test as an `only` will cause the other 16K tests in the repo to be skipped if a bare `pytest` command is used), it works better (a.k.a., way faster) when tests are already being restricted to a particular file (in other words, if pytest is being run as `pytest path/to/some/test/file.py`).

It also adds a flake8 rule to ensure that no instances of the new marker make it into production.

### Screenshots:

The marker in use:

![image](https://user-images.githubusercontent.com/14812505/226263282-aa2a7457-0718-4908-9427-ea3bdb7564b5.png)

The flake8 rule triggering in the linter:

![image](https://user-images.githubusercontent.com/14812505/226262698-b2ac9491-b65b-4559-aa24-36955780442a.png)

The flake8 rule triggering in the pre-commit hook:

![image](https://user-images.githubusercontent.com/14812505/226262561-65b8412c-5a82-41e0-b6da-b213b50e407e.png)
