### PR TITLE
ref(sourcemaps): Add deletion to debug id bundles - [TET-785]

### DIFF
--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
@@ -50,7 +50,12 @@ function renderDebugIdBundlesMockRequests({
     body: empty ? [] : TestStubs.SourceMapsDebugIDBundles(),
   });
 
-  return {artifactBundles};
+  const artifactBundlesDeletion = MockApiClient.addMockResponse({
+    url: `/projects/${orgSlug}/${projectSlug}/files/artifact-bundles/`,
+    method: 'DELETE',
+  });
+
+  return {artifactBundles, artifactBundlesDeletion};
 }
 
 describe('ProjectSourceMaps', function () {
@@ -291,7 +296,17 @@ describe('ProjectSourceMaps', function () {
         )
       ).toBeInTheDocument();
       // Close modal
-      await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+      await waitFor(() => {
+        expect(mockRequests.artifactBundlesDeletion).toHaveBeenLastCalledWith(
+          '/projects/org-slug/project-slug/files/artifact-bundles/',
+          expect.objectContaining({
+            query: expect.objectContaining({
+              bundleId: 'b916a646-2c6b-4e45-af4c-409830a44e0e',
+            }),
+          })
+        );
+      });
 
       // Switch tab
       await userEvent.click(screen.getByRole('link', {name: 'Release Bundles'}));

--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -195,10 +195,13 @@ export function ProjectSourceMaps({location, router, project}: Props) {
     async (name: string) => {
       addLoadingMessage(t('Removing artifacts\u2026'));
       try {
-        await api.requestPromise(sourceMapsEndpoint, {
-          method: 'DELETE',
-          query: {name},
-        });
+        await api.requestPromise(
+          tabDebugIdBundlesActive ? debugIdBundlesEndpoint : sourceMapsEndpoint,
+          {
+            method: 'DELETE',
+            query: tabDebugIdBundlesActive ? {bundleId: name} : {name},
+          }
+        );
         tabDebugIdBundlesActive ? debugIdBundlesRefetch() : archivesRefetch();
         addSuccessMessage(t('Artifacts removed.'));
       } catch {
@@ -211,6 +214,7 @@ export function ProjectSourceMaps({location, router, project}: Props) {
       tabDebugIdBundlesActive,
       debugIdBundlesRefetch,
       archivesRefetch,
+      debugIdBundlesEndpoint,
     ]
   );
 


### PR DESCRIPTION
Updates the `handleDelete` covering `Debug Id Bundles` too 