### PR TITLE
feat(sourcemaps): Add sorting to old source maps endpoint

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -443,10 +443,16 @@ class SourceMapsEndpoint(ProjectEndpoint):
                 [expose_release(r, file_count_map.get(r["id"], 0)) for r in results], request.user
             )
 
+        sort_by = request.GET.get("sortBy", "-date_added")
+        if sort_by not in {"-date_added", "date_added"}:
+            return Response(
+                {"error": "You can either sort via 'date_added' or '-date_added'"}, status=400
+            )
+
         return self.paginate(
             request=request,
             queryset=queryset,
-            order_by="-date_added",
+            order_by=sort_by,
             paginator_cls=OffsetPaginator,
             default_per_page=10,
             on_results=serialize_results,

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -360,6 +360,10 @@ class DebugFilesUploadTest(APITestCase):
         assert response.status_code == 200, response.content
         assert list(map(lambda value: value["id"], response.data)) == release_ids[::-1]
 
+        response = self.client.get(url + "?sortBy=invalid")
+        assert response.status_code == 400
+        assert response.data["error"] == "You can either sort via 'date_added' or '-date_added'"
+
     def test_source_maps_delete_archive(self):
         project = self.create_project(name="foo")
 


### PR DESCRIPTION
This PR adds sorting to the endpoint for listing the release files.