### PR TITLE
feat(profiling): associate profileIds to CallTreeNodes

### DIFF
--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -90,6 +90,7 @@ declare namespace Profiling {
   interface SampledProfile extends RawProfileBase {
     weights: number[];
     samples: number[][];
+    samples_profiles?: number[][];
     type: 'sampled';
   }
 
@@ -152,6 +153,7 @@ declare namespace Profiling {
     projectID: number;
     shared: {
       frames: ReadonlyArray<Omit<FrameInfo, 'key'>>;
+      profile_ids?: ReadonlyArray<string>;
     };
     measurements?: {
       screen_frame_rates?: {

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -258,6 +258,7 @@ export class Flamegraph {
         depth: 0,
         start: value,
         end: value,
+        profileIds: profile.callTreeNodeProfileIdMap.get(node),
       };
 
       if (parent) {

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -11,6 +11,7 @@ export interface FlamegraphFrame {
   parent: FlamegraphFrame | null;
   start: number;
   processId?: number;
+  profileIds?: string[];
   threadId?: number;
 }
 

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -44,6 +44,8 @@ export class Profile {
     negativeSamplesCount: 0,
   };
 
+  callTreeNodeProfileIdMap: Map<CallTreeNode, string[]> = new Map();
+
   constructor({
     duration,
     startedAt,

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -229,3 +229,12 @@ export const invertCallTree = (roots: Readonly<FlamegraphFrame[]>): FlamegraphFr
   const reversed = reverseTrail(leafNodes, nodeToParentIndex);
   return reversed;
 };
+
+export function resolveFlamegraphSamplesProfileIds(
+  samplesProfiles: Readonly<number[][]>,
+  profileIds: Readonly<string[]>
+): string[][] {
+  return samplesProfiles.map(profileIdIndices => {
+    return profileIdIndices.map(i => profileIds[i]);
+  });
+}


### PR DESCRIPTION
## Summary
This change adds an association between a `CallTreeNode` and a set of `profileIds` it was sampled in. This is PR will enable linking to specific flamecharts from the aggregate flamegraph component.