### PR TITLE
fix(mep): Remove os name

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -125,6 +125,8 @@ class MetricsQueryBuilder(QueryBuilder):
         if col.startswith("tags["):
             tag_match = constants.TAG_KEY_RE.search(col)
             col = tag_match.group("tag") if tag_match else col
+        if col in constants.METRIC_UNAVAILBLE_COLUMNS:
+            raise IncompatibleMetricsQuery(f"{col} is unavailable")
 
         if self.use_metrics_layer:
             if col in ["project_id", "timestamp"]:

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -249,6 +249,8 @@ METRIC_TOLERATED_TAG_VALUE = "tolerated"
 METRIC_SATISFIED_TAG_VALUE = "satisfied"
 METRIC_FRUSTRATED_TAG_VALUE = "frustrated"
 METRIC_SATISFACTION_TAG_KEY = "satisfaction"
+# These strings will be resolved by the indexer, but aren't available in the dataset
+METRIC_UNAVAILBLE_COLUMNS = {"os.name"}
 
 # Only the metrics that are on the distributions & are in milliseconds
 METRIC_DURATION_COLUMNS = {

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2122,6 +2122,47 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
         assert meta["isMetricsData"]
 
+    def test_os_name_incompatible(self):
+        self.store_transaction_metric(
+            1,
+            tags={"transaction": "foo_transaction", "transaction.status": "foobar"},
+            timestamp=self.min_ago,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "os.name",
+                    "p90()",
+                ],
+                "query": "transaction:foo_transaction",
+                "dataset": "metrics",
+            }
+        )
+        assert response.status_code == 400, response.content
+        assert response.data["detail"] == "os.name is unavailable"
+
+    def test_os_name_falls_back(self):
+        self.store_transaction_metric(
+            1,
+            tags={"transaction": "foo_transaction", "transaction.status": "foobar"},
+            timestamp=self.min_ago,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "os.name",
+                    "p75()",
+                ],
+                "query": "transaction:foo_transaction",
+                "dataset": "metricsEnhanced",
+            }
+        )
+        assert response.status_code == 200, response.content
+        meta = response.data["meta"]
+        assert not meta["isMetricsData"]
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
- This removes os.name from the metrics query builder since its not actually being collected
- There maybe the possibility of more columns to add to `METRIC_UNAVAILBLE_COLUMNS` later
- Closes ﻿#46055 