### PR TITLE
fix(workflow): Ignore sample event if unmounted

### DIFF
--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -73,6 +73,12 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
     });
   }
 
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  private _isMounted = true;
+
   recordAnalytics({eventCreated, retries, duration}) {
     const {organization, project, source} = this.props;
 
@@ -134,6 +140,12 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
     // before redirecting.
     const t0 = performance.now();
     const {eventCreated, retries} = await latestEventAvailable(api, eventData.groupID);
+
+    // Navigated away before event was created
+    if (!this._isMounted) {
+      return;
+    }
+
     const t1 = performance.now();
 
     clearIndicators();

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -141,7 +141,8 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
     const t0 = performance.now();
     const {eventCreated, retries} = await latestEventAvailable(api, eventData.groupID);
 
-    // Navigated away before event was created
+    // Navigated away before event was created - skip analytics and error messages
+    // latestEventAvailable will succeed even if the request was cancelled
     if (!this._isMounted) {
       return;
     }


### PR DESCRIPTION
The sample event can take up to 30 seconds, sometimes people get tired of waiting and have already navigated away. 
