### PR TITLE
fix(ecosystem): Only show unique codeowners error banners

### DIFF
--- a/static/app/views/settings/project/projectOwnership/codeownerErrors.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeownerErrors.spec.tsx
@@ -34,4 +34,29 @@ describe('CodeownerErrors', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('@getsentry/something')).toBeInTheDocument();
   });
+
+  it('should deduplicate errors', () => {
+    const codeowner = TestStubs.CodeOwner({
+      errors: {
+        missing_user_emails: ['santry@example.com'],
+        missing_external_users: [],
+        missing_external_teams: ['@getsentry/something'],
+        teams_without_access: ['#snuba'],
+        users_without_access: [],
+      },
+    });
+    render(
+      <CodeOwnerErrors
+        codeowners={[codeowner, {...codeowner, id: '123'}]}
+        projectSlug={project.slug}
+        orgSlug={org.slug}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'There were 3 ownership issues within Sentry on the latest sync with the CODEOWNERS file'
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/settings/project/projectOwnership/codeownerErrors.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeownerErrors.tsx
@@ -1,5 +1,6 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
+import uniqBy from 'lodash/uniqBy';
 
 import {Alert} from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -75,6 +76,16 @@ export function CodeOwnerErrors({
   orgSlug,
   projectSlug,
 }: CodeOwnerErrorsProps) {
+  const filteredCodeowners = useMemo(() => {
+    const owners = codeowners.filter(({errors}) => {
+      // Remove codeowners files with no errors
+      return Object.values(errors).some(values => values.length);
+    });
+
+    // Uniq errors
+    return uniqBy(owners, codeowner => JSON.stringify(codeowner.errors));
+  }, [codeowners]);
+
   const errMessage = (
     codeMapping: RepositoryProjectPathConfig,
     type: CodeOwnerErrorKeys,
@@ -138,35 +149,33 @@ export function CodeOwnerErrors({
 
   return (
     <Fragment>
-      {codeowners
-        .filter(({errors}) => Object.values(errors).some(values => values.length))
-        .map(({id, codeMapping, errors}) => {
-          const errorPairs = Object.entries(errors).filter(
-            ([_, values]) => values.length
-          ) as Array<[CodeOwnerErrorKeys, string[]]>;
-          const errorCount = errorPairs.reduce(
-            (acc, [_, values]) => acc + values.length,
-            0
-          );
-          return (
-            <Alert
-              key={id}
-              type="error"
-              showIcon
-              expand={
-                <AlertContentContainer key="container">
-                  {errorPairs.map(([type, values]) => (
-                    <ErrorContainer key={`${id}-${type}`}>
-                      {errMessage(codeMapping!, type, values)}
-                    </ErrorContainer>
-                  ))}
-                </AlertContentContainer>
-              }
-            >
-              {`There were ${errorCount} ownership issues within Sentry on the latest sync with the CODEOWNERS file`}
-            </Alert>
-          );
-        })}
+      {filteredCodeowners.map(({id, codeMapping, errors}) => {
+        const errorPairs = Object.entries(errors).filter(
+          ([_, values]) => values.length
+        ) as Array<[CodeOwnerErrorKeys, string[]]>;
+        const errorCount = errorPairs.reduce(
+          (acc, [_, values]) => acc + values.length,
+          0
+        );
+        return (
+          <Alert
+            key={id}
+            type="error"
+            showIcon
+            expand={
+              <AlertContentContainer key="container">
+                {errorPairs.map(([type, values]) => (
+                  <ErrorContainer key={`${id}-${type}`}>
+                    {errMessage(codeMapping!, type, values)}
+                  </ErrorContainer>
+                ))}
+              </AlertContentContainer>
+            }
+          >
+            {`There were ${errorCount} ownership issues within Sentry on the latest sync with the CODEOWNERS file`}
+          </Alert>
+        );
+      })}
     </Fragment>
   );
 }


### PR DESCRIPTION
We sometimes have duplicates because of how codeowners is duplicated for each code mapping
