### PR TITLE
fix(migrations): Adds exception handling + testing for MonitorCheckIn backfill

### DIFF
--- a/src/sentry/migrations/0386_backfill_monitor_env_checkins.py
+++ b/src/sentry/migrations/0386_backfill_monitor_env_checkins.py
@@ -43,7 +43,10 @@ def backfill_monitor_checkins(apps, schema_editor):
         if monitor_environment_id:
             continue
 
-        monitor_environment_id = monitor_mappings[monitor_id]
+        try:
+            monitor_environment_id = monitor_mappings[monitor_id]
+        except KeyError:
+            continue
 
         batch.append((monitor_checkin_id, monitor_environment_id))
         if len(batch) >= BATCH_SIZE:


### PR DESCRIPTION
`MonitorCheckIns` can be orphaned if a project is deleted as the project deletion task only deletes the top level `Monitor` object. Test will need to be fixed/updated when the project deletion task is properly fixed 