### PR TITLE
ref(replays): Refactor replayTimestamps() to handle huge arrays

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -246,6 +246,17 @@ export function spansFactory(spans: ReplaySpan[]) {
     }));
 }
 
+/**
+ * Calculate min/max of an array simultaniously.
+ * This prevents two things:
+ * - Avoid extra allocations and iterations, just loop through once.
+ * - Avoid `Maximum call stack size exceeded` when the array is too large
+ *   `Math.min()` & `Math.max()` will throw after about ~10⁷ which is A LOT of items.
+ *   See: https://stackoverflow.com/a/52613386
+ *
+ * `lodash.min()` & `lodash.max()` are also options, they use a while-loop as here,
+ * but that also includes a comparator function
+ */
 function getMinMax(arr) {
   let len = arr.length;
   let min = Infinity;
@@ -272,21 +283,17 @@ export function replayTimestamps(
   rawSpanData: ReplaySpan[]
 ) {
   const rrwebTimestamps = rrwebEvents.map(event => event.timestamp).filter(Boolean);
-  const breadcrumbTimestamps = (
-    rawCrumbs.map(rawCrumb => rawCrumb.timestamp).filter(Boolean) as number[]
-  )
-    .map(timestamp => +new Date(timestamp * 1000))
+  const breadcrumbTimestamps = rawCrumbs
+    .map(rawCrumb => rawCrumb.timestamp)
     .filter(Boolean);
   const rawSpanDataFiltered = rawSpanData.filter(
     ({op}) => op !== 'largest-contentful-paint'
   );
-  const spanStartTimestamps = rawSpanDataFiltered.map(span => span.startTimestamp * 1000);
-  const spanEndTimestamps = rawSpanDataFiltered.map(span => span.endTimestamp * 1000);
+  const spanStartTimestamps = rawSpanDataFiltered.map(span => span.startTimestamp);
+  const spanEndTimestamps = rawSpanDataFiltered.map(span => span.endTimestamp);
 
-  // Calculate min/max of each array individually. This prevents two things:
-  // - Avoid extra array allocations
-  // - Avoid `Maximum call stack size exceeded` when the array is too large for Math.min\Math.max
-  //   See: https://stackoverflow.com/a/52613386
+  // Calculate min/max of each array individually, to prevent extra allocations.
+  // Also using `getMinMax()` so we can handle any huge arrays.
   const {min: minRRWeb, max: maxRRWeb} = getMinMax(rrwebTimestamps);
   const {min: minCrumbs, max: maxCrumbs} = getMinMax(breadcrumbTimestamps);
   const {min: minSpanStarts} = getMinMax(spanStartTimestamps);
@@ -296,14 +303,14 @@ export function replayTimestamps(
     startTimestampMs: Math.min(
       replayRecord.started_at.getTime(),
       minRRWeb,
-      minCrumbs,
-      minSpanStarts
+      minCrumbs * 1000,
+      minSpanStarts * 1000
     ),
     endTimestampMs: Math.max(
       replayRecord.finished_at.getTime(),
       maxRRWeb,
-      maxCrumbs,
-      maxSpanEnds
+      maxCrumbs * 1000,
+      maxSpanEnds * 1000
     ),
   };
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/46084