### PR TITLE
feat(replay): Display fetch/xhr response body sizes in Network table

### DIFF
--- a/static/app/views/replays/detail/network/networkHeaderCell.tsx
+++ b/static/app/views/replays/detail/network/networkHeaderCell.tsx
@@ -1,7 +1,8 @@
-import {CSSProperties, forwardRef} from 'react';
+import {CSSProperties, forwardRef, Fragment, ReactNode} from 'react';
 import styled from '@emotion/styled';
 
-import {IconArrow} from 'sentry/icons';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconArrow, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useSortNetwork from 'sentry/views/replays/detail/network/useSortNetwork';
@@ -14,14 +15,33 @@ type Props = {
   style: CSSProperties;
 };
 
+// `block` so that it's vertically centered :lolsob:
+const SizeInfo = styled(IconInfo)`
+  display: block;
+`;
+
 const COLUMNS: {
   field: SortConfig['by'];
-  label: string;
+  label: ReactNode;
 }[] = [
   {field: 'status', label: t('Status')},
   {field: 'description', label: t('Path')},
   {field: 'op', label: t('Type')},
-  {field: 'size', label: t('Size')},
+  {
+    field: 'size',
+    label: (
+      <Fragment>
+        {t('Size')}
+        <Tooltip
+          title={t(
+            'The number used for fetch/xhr is the response body size. It is possible the network transfer size is smaller due to compression.'
+          )}
+        >
+          <SizeInfo size="xs" />
+        </Tooltip>
+      </Fragment>
+    ),
+  },
   {field: 'duration', label: t('Duration')},
   {field: 'startTimestamp', label: t('Timestamp')},
 ];

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -61,6 +61,7 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       style,
       ref,
     };
+    const size = span.data.size ?? span.data.responseBodySize;
 
     const renderFns = [
       () => (
@@ -94,11 +95,7 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       () => (
         <Cell {...columnProps} numeric>
           <Text>
-            {span.data.size === undefined ? (
-              EMPTY_CELL
-            ) : (
-              <FileSize bytes={span.data.size} />
-            )}
+            {size === undefined ? EMPTY_CELL : <FileSize base={10} bytes={size} />}
           </Text>
         </Cell>
       ),


### PR DESCRIPTION
Added a tooltip to explain the size:
![image](https://user-images.githubusercontent.com/79684/226467308-c57e38b4-b9a8-4de3-b398-dae521ebbd0f.png)


Closes #46051
