### PR TITLE
fix(scopes): role check for sentry:events_member_admin

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -674,7 +674,7 @@ class Organization(Model, SnowflakeIdMixin):
         return "".join(parts)
 
     def get_scopes(self, role: Role) -> FrozenSet[str]:
-        if role.priority > 0:
+        if role.id != "member":
             return role.scopes
 
         scopes = set(role.scopes)


### PR DESCRIPTION
The old code was checking `role.priority > 0` before removing the related scopes, because it assumes that the lowest role via priority is `member`. In getsentry, the `priority` for an org role of `member` is actually `1` because we add a different role as the lowest role. So the tests pass in sentry, but the behavior is incorrect. Changed it to explicitly check that `role.id = "member"`.