### PR TITLE
feat(profiling): Pass profile format preference to vroom

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -82,18 +82,26 @@ class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
         if not features.has("organizations:profiling", project.organization, actor=request.user):
             return Response(status=404)
 
+        preferred_format = (
+            "sampled" if features.has("organizations:profiling-sampled-format") else "speedscope"
+        )
+
         response = get_from_profiling_service(
             "GET",
             f"/organizations/{project.organization_id}/projects/{project.id}/profiles/{profile_id}",
+            params={"format": preferred_format},
         )
 
         if response.status == 200:
             profile = json.loads(response.data)
 
-            # make sure to remove the version from the metadata
-            # we're going to replace it with the release here
-            version = profile.get("metadata", {}).pop("version")
-            profile["metadata"]["release"] = get_release(project, version)
+            if "release" in profile:
+                profile["release"] = get_release(project, profile["release"])
+            else:
+                # make sure to remove the version from the metadata
+                # we're going to replace it with the release here
+                version = profile.get("metadata", {}).pop("version")
+                profile["metadata"]["release"] = get_release(project, version)
 
             return Response(profile)
 

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -83,7 +83,11 @@ class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
             return Response(status=404)
 
         preferred_format = (
-            "sampled" if features.has("organizations:profiling-sampled-format") else "speedscope"
+            "sampled"
+            if features.has(
+                "organizations:profiling-sampled-format", project.organization, actor=request.user
+            )
+            else "speedscope"
         )
 
         response = get_from_profiling_service(


### PR DESCRIPTION
To transition over to directly using the sampled format, this passes a param to vroom to indicate the preferred format to receive the response in. Vroom will try to use the indicated format where possible but for platforms like android, it will ignore it as it does not have the sampled format available.
