### PR TITLE
ref(code mappings): Default `organizations:derive-code-mappings` to `True`

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1040,7 +1040,7 @@ SENTRY_FEATURES = {
     # Enables getting commit sha from git blame for codecov.
     "organizations:codecov-commit-sha-from-git-blame": False,
     # Enables automatically deriving of code mappings
-    "organizations:derive-code-mappings": False,
+    "organizations:derive-code-mappings": True,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -60,6 +60,7 @@ class OrganizationSerializerTest(TestCase):
             "dashboards-edit",
             "discover-basic",
             "discover-query",
+            "derive-code-mappings",
             "event-attachments",
             "integrations-alert-rule",
             "integrations-chat-unfurl",


### PR DESCRIPTION
Because the `derive-code-mappings.general-availability-rollout` option is set to `1.0` in SAAS, code mapping is already happening for all SAAS orgs. In order to enable it for all on-prem users (and in order to simplify the machinery for enabling it), this changes the default value of the corresponding feature flag to `True`. This will then let us remove the feature handler, which is now always returning `True`.

Ref: WOR-2833