### PR TITLE
chore(code mappings): Remove unused options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -672,8 +672,4 @@ register("dynamic-sampling.prioritise_transactions.load_rate", default=0.0)
 register("dynamic-sampling.prioritise_transactions.num_explicit_large_transactions", 30)
 # the number of large transactions to retrieve from Snuba for transaction re-balancing
 register("dynamic-sampling.prioritise_transactions.num_explicit_small_transactions", 0)
-# Killswitch for deriving code mappings
-register("post_process.derive-code-mappings", default=True)
-# Allows adjusting the GA percentage
-register("derive-code-mappings.general-availability-rollout", default=0.0)
 register("hybrid_cloud.outbox_rate", default=0.0)


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/getsentry/pull/9905, which removes `DeriveCodeMappingsFeatureHandler`. Now that it no longer exists, nothing is checking the two options relevant to automatic code mapping derivation. (It's now solely controlled by a feature flag.) The options can therefore be removed.

Ref: WOR-2833