### PR TITLE
ref(monitors): Only support lookup on slug in most endpoints

### DIFF
--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from rest_framework.request import Request
 
-from sentry.api.authentication import DSNAuthentication, TokenAuthentication
+from sentry.api.authentication import ApiKeyAuthentication, DSNAuthentication, TokenAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases.project import ProjectPermission
@@ -34,17 +34,8 @@ class ProjectMonitorPermission(ProjectPermission):
 
 class MonitorEndpoint(Endpoint):
     """
-    Base endpoint class for monitors which will lookup the monitor ID and
+    Base endpoint class for monitors which will lookup the monitor and
     convert it to a Monitor object.
-
-    Currently this has two strategies for monitor lookup
-
-    1. Via the monitor slug. In this scenario the organization_slug MUST be
-       present, since monitor slugs are unique with the organization_slug
-
-    2. Via the monitor GUID. In this scenario the organization_slug is not
-       required as GUIDs are global to sentry. We will check that the
-       organization resulting from the monitor project
 
     [!!]: This base endpoint is NOT used for legacy ingestion endpoints, see
           MonitorIngestEndpoint for that.
@@ -67,22 +58,9 @@ class MonitorEndpoint(Endpoint):
             raise ResourceDoesNotExist
 
         try:
-            # Try lookup by slug first
             monitor = Monitor.objects.get(organization_id=organization.id, slug=monitor_id)
         except Monitor.DoesNotExist:
-            # Try lookup by GUID. We cannot consolidate this into one query as
-            # we need to validate the slug is a GUID before trying to query on
-            # the GUID column, otherwise we'll produce a postgres error
-            try:
-                UUID(monitor_id)
-            except ValueError:
-                # This error is a bit confusing, because this may also mean
-                # that we've failed to lookup their monitor by slug.
-                raise ParameterValidationError("Invalid monitor UUID")
-            try:
-                monitor = Monitor.objects.get(organization_id=organization.id, guid=monitor_id)
-            except Monitor.DoesNotExist:
-                raise ResourceDoesNotExist
+            raise ResourceDoesNotExist
 
         project = Project.objects.get_from_cache(id=monitor.project_id)
         if project.status != ProjectStatus.VISIBLE:
@@ -112,15 +90,19 @@ class MonitorIngestEndpoint(Endpoint):
     """
     This type of endpont explicitly only allows for DSN and Token / Key based authentication.
 
+    [!!]: These endpoints are legacy and will be replaced by relay based
+          checkin ingestion in the very near future.
+
     [!!]: These endpoints support routes which **do not specify the
           organization slug**! This endpoint is extra careful in those cases to
           validate
 
-    [!!]: These endpoints are legacy and will be replaced by relay based
-          checkin ingestion in the very near future.
+    [!!]: This type of endpoint supports lookup of monitors by slug AND by
+          GUID. However slug lookup is **ONLY** supported when the organization
+          slug is part of the URL parameters.
     """
 
-    authentication_classes = (DSNAuthentication, TokenAuthentication)
+    authentication_classes = (DSNAuthentication, TokenAuthentication, ApiKeyAuthentication)
     permission_classes = (ProjectMonitorPermission,)
 
     allow_auto_create_monitors = False

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
@@ -16,7 +16,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(MonitorIngestTestCase):
     endpoint = "sentry-api-0-organization-monitor-check-in-attachment"
 
     def get_path(self, monitor, checkin):
-        return reverse(self.endpoint, args=[self.organization.slug, monitor.guid, checkin.guid])
+        return reverse(self.endpoint, args=[self.organization.slug, monitor.slug, checkin.guid])
 
     def _create_monitor(self):
         return Monitor.objects.create(

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -61,11 +61,11 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
     @patch("sentry.analytics.record")
     def test_passing(self, mock_record):
-        first_monitor_id = None
+        tested_monitors = []
+
         for path_func in self._get_path_functions():
             monitor = self._create_monitor()
-            if not first_monitor_id:
-                first_monitor_id = str(monitor.guid)
+            tested_monitors.append(monitor)
 
             path = path_func(monitor.guid)
 
@@ -95,7 +95,7 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             user_id=self.user.id,
-            monitor_id=first_monitor_id,
+            monitor_id=str(tested_monitors[0].guid),
         )
 
     def test_failing(self):

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -15,28 +15,12 @@ class OrganizationMonitorDetailsTest(MonitorTestCase):
     def test_simple(self):
         monitor = self._create_monitor()
 
-        resp = self.get_success_response(self.organization.slug, monitor.guid)
-        assert resp.data["id"] == str(monitor.guid)
-
-    def test_simple_slug(self):
-        monitor = self._create_monitor(slug="my-monitor")
-
         resp = self.get_success_response(self.organization.slug, monitor.slug)
-        assert resp.data["id"] == str(monitor.guid)
-        assert resp.data["slug"] == "my-monitor"
-
-        # GUID based lookup also works
-        resp = self.get_success_response(self.organization.slug, monitor.guid)
-        assert resp.data["id"] == str(monitor.guid)
-        assert resp.data["slug"] == "my-monitor"
+        assert resp.data["slug"] == monitor.slug
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        self.get_error_response("asdf", monitor.guid, status_code=404)
-
-    def test_invalid_monitor_id(self):
-        self._create_monitor()
-        self.get_error_response(self.organization.slug, "bad-guid", status_code=400)
+        self.get_error_response("asdf", monitor.slug, status_code=404)
 
 
 @region_silo_test(stable=True)
@@ -50,9 +34,9 @@ class UpdateMonitorTest(MonitorTestCase):
     def test_name(self):
         monitor = self._create_monitor()
         resp = self.get_success_response(
-            self.organization.slug, monitor.guid, method="PUT", **{"name": "Monitor Name"}
+            self.organization.slug, monitor.slug, method="PUT", **{"name": "Monitor Name"}
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.name == "Monitor Name"
@@ -60,7 +44,7 @@ class UpdateMonitorTest(MonitorTestCase):
     def test_slug(self):
         monitor = self._create_monitor()
         resp = self.get_success_response(
-            self.organization.slug, monitor.guid, method="PUT", **{"slug": "my-monitor"}
+            self.organization.slug, monitor.slug, method="PUT", **{"slug": "my-monitor"}
         )
         assert resp.data["id"] == str(monitor.guid)
 
@@ -69,18 +53,18 @@ class UpdateMonitorTest(MonitorTestCase):
 
         # Validate error cases jsut to be safe
         self.get_error_response(
-            self.organization.slug, monitor.guid, method="PUT", status_code=400, **{"slug": ""}
+            self.organization.slug, monitor.slug, method="PUT", status_code=400, **{"slug": ""}
         )
         self.get_error_response(
-            self.organization.slug, monitor.guid, method="PUT", status_code=400, **{"slug": None}
+            self.organization.slug, monitor.slug, method="PUT", status_code=400, **{"slug": None}
         )
 
     def test_can_disable(self):
         monitor = self._create_monitor()
         resp = self.get_success_response(
-            self.organization.slug, monitor.guid, method="PUT", **{"status": "disabled"}
+            self.organization.slug, monitor.slug, method="PUT", **{"status": "disabled"}
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.status == MonitorStatus.DISABLED
@@ -91,9 +75,9 @@ class UpdateMonitorTest(MonitorTestCase):
         monitor.update(status=MonitorStatus.DISABLED)
 
         resp = self.get_success_response(
-            self.organization.slug, monitor.guid, method="PUT", **{"status": "active"}
+            self.organization.slug, monitor.slug, method="PUT", **{"status": "active"}
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.status == MonitorStatus.ACTIVE
@@ -104,9 +88,9 @@ class UpdateMonitorTest(MonitorTestCase):
         monitor.update(status=MonitorStatus.OK)
 
         resp = self.get_success_response(
-            self.organization.slug, monitor.guid, method="PUT", **{"status": "active"}
+            self.organization.slug, monitor.slug, method="PUT", **{"status": "active"}
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.status == MonitorStatus.OK
@@ -116,11 +100,11 @@ class UpdateMonitorTest(MonitorTestCase):
 
         resp = self.get_success_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             **{"config": {"timezone": "America/Los_Angeles"}},
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["timezone"] == "America/Los_Angeles"
@@ -130,11 +114,11 @@ class UpdateMonitorTest(MonitorTestCase):
 
         resp = self.get_success_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             **{"config": {"checkin_margin": 30}},
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["checkin_margin"] == 30
@@ -143,9 +127,9 @@ class UpdateMonitorTest(MonitorTestCase):
         monitor = self._create_monitor()
 
         resp = self.get_success_response(
-            self.organization.slug, monitor.guid, method="PUT", **{"config": {"max_runtime": 30}}
+            self.organization.slug, monitor.slug, method="PUT", **{"config": {"max_runtime": 30}}
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["max_runtime"] == 30
@@ -154,9 +138,9 @@ class UpdateMonitorTest(MonitorTestCase):
         monitor = self._create_monitor()
 
         resp = self.get_success_response(
-            self.organization.slug, monitor.guid, method="PUT", **{"config": {"invalid": True}}
+            self.organization.slug, monitor.slug, method="PUT", **{"config": {"invalid": True}}
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert "invalid" not in monitor.config
@@ -166,11 +150,11 @@ class UpdateMonitorTest(MonitorTestCase):
 
         resp = self.get_success_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             **{"config": {"schedule": "*/5 * * * *"}},
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["schedule_type"] == ScheduleType.CRONTAB
@@ -191,11 +175,11 @@ class UpdateMonitorTest(MonitorTestCase):
 
         resp = self.get_success_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             **{"config": {"schedule": "@monthly"}},
         )
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["schedule_type"] == ScheduleType.CRONTAB
@@ -206,14 +190,14 @@ class UpdateMonitorTest(MonitorTestCase):
 
         self.get_error_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             status_code=400,
             **{"config": {"schedule": "*/0.5 * * * *"}},
         )
         self.get_error_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             status_code=400,
             **{"config": {"schedule": "* * * *"}},
@@ -224,12 +208,12 @@ class UpdateMonitorTest(MonitorTestCase):
 
         resp = self.get_success_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             **{"config": {"schedule_type": "interval", "schedule": [1, "month"]}},
         )
 
-        assert resp.data["id"] == str(monitor.guid)
+        assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["schedule_type"] == ScheduleType.INTERVAL
@@ -240,7 +224,7 @@ class UpdateMonitorTest(MonitorTestCase):
 
         self.get_error_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             status_code=400,
             **{"config": {"schedule_type": "interval", "schedule": [1, "decade"]}},
@@ -248,7 +232,7 @@ class UpdateMonitorTest(MonitorTestCase):
 
         self.get_error_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             status_code=400,
             **{"config": {"schedule_type": "interval", "schedule": ["foo", "month"]}},
@@ -256,7 +240,7 @@ class UpdateMonitorTest(MonitorTestCase):
 
         self.get_error_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             status_code=400,
             **{"config": {"schedule_type": "interval", "schedule": "bar"}},
@@ -267,7 +251,7 @@ class UpdateMonitorTest(MonitorTestCase):
 
         self.get_error_response(
             "asdf",
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             status_code=404,
             **{"config": {"schedule_type": "interval", "schedule": [1, "month"]}},
@@ -279,7 +263,7 @@ class UpdateMonitorTest(MonitorTestCase):
         project2 = self.create_project()
         resp = self.get_error_response(
             self.organization.slug,
-            monitor.guid,
+            monitor.slug,
             method="PUT",
             status_code=400,
             **{"project": project2.slug},
@@ -302,7 +286,7 @@ class DeleteMonitorTest(MonitorTestCase):
         monitor = self._create_monitor()
 
         self.get_success_response(
-            self.organization.slug, monitor.guid, method="DELETE", status_code=202
+            self.organization.slug, monitor.slug, method="DELETE", status_code=202
         )
 
         monitor = Monitor.objects.get(id=monitor.id)
@@ -312,4 +296,4 @@ class DeleteMonitorTest(MonitorTestCase):
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()
-        self.get_error_response("asdf", monitor.guid, status_code=404)
+        self.get_error_response("asdf", monitor.slug, status_code=404)

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -17,8 +17,8 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         self.login_as(self.user)
 
     def check_valid_response(self, response, expected_monitors):
-        assert [str(monitor.guid) for monitor in expected_monitors] == [
-            str(monitor_resp["id"]) for monitor_resp in response.data
+        assert [monitor.slug for monitor in expected_monitors] == [
+            monitor_resp["slug"] for monitor_resp in response.data
         ]
 
     def test_simple(self):
@@ -78,9 +78,7 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         }
         response = self.get_success_response(self.organization.slug, **data)
 
-        assert response.data["id"]
-
-        monitor = Monitor.objects.get(guid=response.data["id"])
+        monitor = Monitor.objects.get(slug=response.data["slug"])
         assert monitor.organization_id == self.organization.id
         assert monitor.project_id == self.project.id
         assert monitor.name == "My Monitor"
@@ -113,5 +111,4 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         }
         response = self.get_success_response(self.organization.slug, **data)
 
-        assert response.data["id"]
         assert response.data["slug"] == "my-monitor"


### PR DESCRIPTION
Legacy ingest still explicitly only uses slugs