### PR TITLE
chore(hybrid-cloud): Add address validation for Region type

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -236,12 +236,13 @@ def generate_organization_url(org_slug: str) -> str:
     return org_url_template.replace("{hostname}", generate_organization_hostname(org_slug))
 
 
-def generate_region_url() -> str:
-    region_url_template: str = options.get("system.region-api-url-template")
-    region = options.get("system.region") or None
-    if not region_url_template or not region:
+def generate_region_url(region_name: str | None = None) -> str:
+    region_url_template: str | None = options.get("system.region-api-url-template")
+    if region_name is None:
+        region_name = options.get("system.region") or None
+    if not region_url_template or not region_name:
         return options.get("system.url-prefix")  # type: ignore[no-any-return]
-    return region_url_template.replace("{region}", region)
+    return region_url_template.replace("{region}", region_name)
 
 
 _path_patterns: List[Tuple[re.Pattern[str], str]] = [

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -22,8 +22,8 @@ from sentry.types.region import Region, RegionCategory
 TestMethod = Callable[..., None]
 
 region_map = [
-    Region("north_america", 1, "na.sentry.io", RegionCategory.MULTI_TENANT),
-    Region("europe", 2, "eu.sentry.io", RegionCategory.MULTI_TENANT),
+    Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+    Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
     Region("acme-single-tenant", 3, "acme.my.sentry.io", RegionCategory.SINGLE_TENANT),
 ]
 
@@ -70,7 +70,7 @@ class SiloModeTest:
                 ):
                     with override_regions(region_map):
                         if mode == SiloMode.REGION:
-                            with override_settings(SENTRY_REGION="north_america"):
+                            with override_settings(SENTRY_REGION="na"):
                                 test_method(*args, **kwargs)
                         else:
                             test_method(*args, **kwargs)
@@ -112,7 +112,7 @@ class SiloModeTest:
             with override_settings(SILO_MODE=silo_mode):
                 with override_regions(region_map):
                     if silo_mode == SiloMode.REGION:
-                        with override_settings(SENTRY_REGION="north_america"):
+                        with override_settings(SENTRY_REGION="na"):
                             test_method(*args, **kwargs)
                     else:
                         test_method(*args, **kwargs)

--- a/tests/sentry/middleware/integrations/parsers/test_base.py
+++ b/tests/sentry/middleware/integrations/parsers/test_base.py
@@ -19,8 +19,8 @@ def error_regions(region: Region, invalid_region_names: Iterable[str]):
 class BaseRequestParserTest(TestCase):
     response_handler = MagicMock()
     region_config = (
-        Region("na", 1, "https://na.sentry.io", RegionCategory.MULTI_TENANT),
-        Region("eu", 2, "https://eu.sentry.io", RegionCategory.MULTI_TENANT),
+        Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT),
+        Region("eu", 2, "https://eu.testserver", RegionCategory.MULTI_TENANT),
     )
     factory = RequestFactory()
 

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -9,7 +9,7 @@ from sentry.types.region import Region, RegionCategory, RegionResolutionError
 
 
 class SiloClientTest(TestCase):
-    dummy_address = "https://region.sentry.io"
+    dummy_address = "http://eu.testserver"
     region = Region("eu", 1, dummy_address, RegionCategory.MULTI_TENANT)
     region_config = (region,)
 
@@ -34,7 +34,7 @@ class SiloClientTest(TestCase):
             RegionSiloClient("atlantis")
 
         with raises(RegionResolutionError):
-            region = Region("atlantis", 2, self.dummy_address, RegionCategory.MULTI_TENANT)
+            region = Region("eu", 2, self.dummy_address, RegionCategory.MULTI_TENANT)
             RegionSiloClient(region)
 
         client = RegionSiloClient(self.region)

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -20,13 +20,13 @@ from sentry.types.region import (
 class RegionMappingTest(TestCase):
     def test_region_mapping(self):
         regions = [
-            Region("north_america", 1, "na.sentry.io", RegionCategory.MULTI_TENANT),
-            Region("europe", 2, "eu.sentry.io", RegionCategory.MULTI_TENANT),
+            Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+            Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
             Region("acme-single-tenant", 3, "acme.my.sentry.io", RegionCategory.SINGLE_TENANT),
         ]
         with override_regions(regions):
             assert get_region_by_id(1) == regions[0]
-            assert get_region_by_name("europe") == regions[1]
+            assert get_region_by_name("eu") == regions[1]
 
             with pytest.raises(RegionResolutionError):
                 get_region_by_id(4)
@@ -41,12 +41,12 @@ class RegionMappingTest(TestCase):
 
     def test_get_local_region(self):
         regions = [
-            Region("north_america", 1, "na.sentry.io", RegionCategory.MULTI_TENANT),
-            Region("europe", 2, "eu.sentry.io", RegionCategory.MULTI_TENANT),
+            Region("na", 1, "http://na.testserver", RegionCategory.MULTI_TENANT),
+            Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
         ]
 
         with override_regions(regions):
-            with override_settings(SILO_MODE=SiloMode.REGION, SENTRY_REGION="north_america"):
+            with override_settings(SILO_MODE=SiloMode.REGION, SENTRY_REGION="na"):
                 assert get_local_region() == regions[0]
 
             with override_settings(SILO_MODE=SiloMode.MONOLITH):


### PR DESCRIPTION
This adds region address validation for the `Region` type; and validates region addresses with respect to `system.region-api-url-template`.

This validation occurs for:
- multi-tenant mode and,
- in non-monolith silo modes.