### PR TITLE
feat(issue-platform): Integrate policy layer into issue search

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -37,12 +37,11 @@ from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_types_by_category
 from sentry.issues.search import (
     SEARCH_FILTER_UPDATERS,
-    SEARCH_STRATEGIES,
     IntermediateSearchQueryPartial,
     MergeableRow,
     SearchQueryPartial,
     UnsupportedSearchQuery,
-    _query_params_for_generic,
+    get_search_strategies,
     group_categories_from,
 )
 from sentry.models import Environment, Group, Organization, Project
@@ -277,7 +276,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             ),
         )
 
-        strategy = SEARCH_STRATEGIES.get(group_category, _query_params_for_generic)
+        strategy = get_search_strategies()[group_category]
         snuba_query_params = strategy(
             pinned_query_partial,
             selected_columns,
@@ -359,7 +358,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         if not group_categories:
             group_categories = {
                 gc
-                for gc in SEARCH_STRATEGIES.keys()
+                for gc in get_search_strategies().keys()
                 if gc != GroupCategory.PROFILE.value
                 or features.has("organizations:issue-platform", organization, actor=actor)
             }

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -11,6 +11,7 @@ from sentry.api.issue_search import convert_query_values, issue_search_config, p
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import (
     ErrorGroupType,
+    NoiseConfig,
     PerformanceNPlusOneGroupType,
     PerformanceRenderBlockingAssetSpanGroupType,
 )
@@ -2362,6 +2363,44 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
             )
         assert list(results) == [self.profile_group_1, self.profile_group_2]
 
+    def test_generic_query_perf(self):
+        event_id = uuid.uuid4().hex
+        group_type = PerformanceNPlusOneGroupType
+        self.project.update_option("sentry:performance_issue_create_issue_through_platform", True)
+
+        with self.options(
+            {"performance.issues.create_issues_through_platform": True}
+        ), mock.patch.object(
+            PerformanceNPlusOneGroupType, "noise_config", new=NoiseConfig(0, timedelta(minutes=1))
+        ):
+            with self.feature(group_type.build_ingest_feature_name()):
+                _, group_info = process_event_and_issue_occurrence(
+                    self.build_occurrence_data(
+                        event_id=event_id, type=group_type.type_id, fingerprint=["some perf issue"]
+                    ),
+                    {
+                        "event_id": event_id,
+                        "project_id": self.project.id,
+                        "title": "some problem",
+                        "platform": "python",
+                        "tags": {"my_tag": "2"},
+                        "timestamp": before_now(minutes=1).isoformat(),
+                        "received": before_now(minutes=1).isoformat(),
+                    },
+                )
+
+            results = self.make_query(search_filter_query="issue.category:performance my_tag:2")
+            assert list(results) == []
+            with self.feature(
+                [
+                    "organizations:issue-platform",
+                    group_type.build_visible_feature_name(),
+                    "organizations:performance-issues-search",
+                ]
+            ):
+                results = self.make_query(search_filter_query="issue.category:performance my_tag:2")
+        assert list(results) == [group_info.group]
+
     def test_error_generic_query(self):
         with self.feature("organizations:issue-platform"):
             results = self.make_query(search_filter_query="my_tag:1")
@@ -2393,7 +2432,7 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
             self.error_group_1,
         ]
 
-    def test_cursor_performance_issues(self):
+    def test_cursor_profile_issues(self):
         with self.feature("organizations:issue-platform"):
             results = self.make_query(
                 projects=[self.project],


### PR DESCRIPTION
This adds in the policy layer to the issue search, so that issue types will only appear in search when they're been released.

We'll need to change how issue search works once performance issues are moved over. Issue types that use the same dataset should be grouped into the same query, but at the moment we'll make a separate query for each category.