### PR TITLE
fix(issues): fixes issue detail page sometimes not passing the correct project to content components

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -661,7 +661,12 @@ class GroupDetails extends Component<Props, State> {
               <StyledLoadingError message={t('Error loading the specified project')} />
             ) : (
               // TODO(ts): Update renderContent function to deal with empty group
-              this.renderContent(projects[0], group!)
+              this.renderContent(
+                (project?.slug
+                  ? projects.find(({slug}) => slug === project?.slug)
+                  : undefined) ?? projects[0],
+                group!
+              )
             )
           ) : (
             <LoadingIndicator />

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -661,6 +661,9 @@ class GroupDetails extends Component<Props, State> {
               <StyledLoadingError message={t('Error loading the specified project')} />
             ) : (
               // TODO(ts): Update renderContent function to deal with empty group
+              // Search for the slug in the projects list if possible. This is because projects
+              // is just a complete list of stored projects and the first element may not be
+              // the expected project.
               this.renderContent(
                 (project?.slug
                   ? projects.find(({slug}) => slug === project?.slug)


### PR DESCRIPTION
The `<Projects>` hoc returns all stored projects, which means it sometimes returns more than one project, ie theres no guarantee that the returned `projects[0]` matches the expected project slug. 

This update attempts to find the expected project slug in the returned `projects` array, rather than just blindly use `projects[0]`.

This fixes a bug where navigating to an issue details page from an issue widget in dashboards ends up in a broken page because of incorrect project state.