### PR TITLE
feat(profiling): Include debug meta in profiles for span waterfall

### DIFF
--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -9,7 +9,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron, IconProfiling} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EventTransaction, Frame, PlatformType} from 'sentry/types/event';
+import {EntryType, EventTransaction, Frame, PlatformType} from 'sentry/types/event';
 import {STACK_VIEW} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {formatPercentage} from 'sentry/utils/formatters';
@@ -40,6 +40,17 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
   const project = projects.find(p => p.id === event.projectID);
 
   const profileGroup = useProfileGroup();
+
+  const processedEvent = useMemo(() => {
+    const entries: EventTransaction['entries'] = [...(event.entries || [])];
+    if (profileGroup.images) {
+      entries.push({
+        data: {images: profileGroup.images},
+        type: EntryType.DEBUGMETA,
+      });
+    }
+    return {...event, entries};
+  }, [event, profileGroup]);
 
   // TODO: Pick another thread if it's more relevant.
   const threadId = useMemo(
@@ -187,7 +198,7 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
         </SpanDetailsItem>
       </SpanDetails>
       <StackTrace
-        event={event}
+        event={processedEvent}
         hasHierarchicalGrouping={false}
         newestFirst
         platform={event.platform || 'other'}

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -720,7 +720,9 @@ export interface EventTransaction
   extends Omit<EventBase, 'entries' | 'type' | 'contexts'> {
   contexts: TraceEventContexts;
   endTimestamp: number;
-  entries: (EntrySpans | EntryRequest)[];
+  // EntryDebugMeta is required for profiles to render in the span
+  // waterfall with the correct symbolication statuses
+  entries: (EntrySpans | EntryRequest | EntryDebugMeta)[];
   startTimestamp: number;
   type: EventOrGroupType.TRANSACTION;
   perfProblem?: PerformanceDetectorData;


### PR DESCRIPTION
Using the sampled format, we now have access to the debug meta. Make sure to extract it into the event so the symbolication statuses are rendered correctly.