### PR TITLE
fix(dynamic-sampling): Adjust query interval for collecting transactions counts

### DIFF
--- a/src/sentry/dynamic_sampling/prioritise_transactions.py
+++ b/src/sentry/dynamic_sampling/prioritise_transactions.py
@@ -28,6 +28,8 @@ from sentry.utils.snuba import raw_snql_query
 logger = logging.getLogger(__name__)
 MAX_SECONDS = 60
 CHUNK_SIZE = 9998  # Snuba's limit is 10000 and we fetch CHUNK_SIZE+1
+# Controls the time range on which data is collected
+QUERY_TIME_INTERVAL = timedelta(hours=1)
 
 
 class ProjectTransactions(TypedDict, total=True):
@@ -62,7 +64,7 @@ def get_orgs_with_project_counts(max_orgs: int, max_projects: int) -> Iterator[L
                 ],
                 where=[
                     Condition(Function("modulo", [Column("org_id"), 100]), Op.LT, load_rate),
-                    Condition(Column("timestamp"), Op.GTE, datetime.utcnow() - timedelta(hours=6)),
+                    Condition(Column("timestamp"), Op.GTE, datetime.utcnow() - QUERY_TIME_INTERVAL),
                     Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
                     Condition(Column("metric_id"), Op.EQ, metric_id),
                 ],
@@ -151,7 +153,7 @@ def fetch_transactions_with_total_volumes(
                     AliasedExpression(Column(transaction_tag), "transaction_name"),
                 ],
                 where=[
-                    Condition(Column("timestamp"), Op.GTE, datetime.utcnow() - timedelta(hours=6)),
+                    Condition(Column("timestamp"), Op.GTE, datetime.utcnow() - QUERY_TIME_INTERVAL),
                     Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
                     Condition(Column("metric_id"), Op.EQ, metric_id),
                     Condition(Column("org_id"), Op.IN, org_ids),

--- a/tests/sentry/dynamic_sampling/test_prioritise_transactions.py
+++ b/tests/sentry/dynamic_sampling/test_prioritise_transactions.py
@@ -40,7 +40,7 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
                     self.store_performance_metric(
                         name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
                         tags={"transaction": name},
-                        hours_before_now=1,
+                        minutes_before_now=30,
                         value=num_transactions,
                         project_id=p.id,
                         org_id=org.id,

--- a/tests/sentry/dynamic_sampling/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/test_tasks.py
@@ -108,7 +108,7 @@ class TestPrioritiseTransactionsTask(BaseMetricsLayerTestCase, TestCase, SnubaTe
                     self.store_performance_metric(
                         name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
                         tags={"transaction": name},
-                        hours_before_now=1,
+                        minutes_before_now=30,
                         value=num_transactions,
                         project_id=p.id,
                         org_id=org.id,


### PR DESCRIPTION
Changes the interval for which we collect transactions count to 1h