### PR TITLE
Hook up the new artifact-lookup API to JS symbolication

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -122,21 +122,24 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
         for file_id in bundle_file_ids:
             found_artifacts.append(
                 {
+                    "id": str(file_id),
                     "type": "bundle",
                     "url": url_constructor.url_for_file_id(file_id),
                 }
             )
 
-        for file in individual_files:
+        for release_file in individual_files:
             found_artifacts.append(
                 {
+                    "id": str(release_file.file.id),
                     "type": "file",
-                    "url": url_constructor.url_for_file_id(file.id),
+                    "url": url_constructor.url_for_file_id(release_file.file.id),
                     # The `name` is the url/abs_path of the file,
                     # as in: `"~/path/to/file.min.js"`.
-                    "abs_path": file.name,
+                    # FIXME: Should this be the `ReleaseFile.name` or `File.name`?
+                    "abs_path": release_file.name,
                     # These headers should ideally include the `Sourcemap` reference
-                    "headers": file.headers,
+                    "headers": release_file.file.headers,
                 }
             )
 
@@ -276,7 +279,7 @@ def collect_legacy_artifact_bundles_containing_urls(
     return list(filter(lambda url: not url_in_any_artifact_index(url), urls))
 
 
-def get_releasefiles_matching_urls(urls: List[str], release: Release) -> Sequence[File]:
+def get_releasefiles_matching_urls(urls: List[str], release: Release) -> Sequence[ReleaseFile]:
     # Exclude files which are also present in archive:
     file_list = (
         ReleaseFile.public_objects.filter(release_id=release.id)
@@ -288,9 +291,7 @@ def get_releasefiles_matching_urls(urls: List[str], release: Release) -> Sequenc
     for url in urls[1:]:
         condition |= Q(name__icontains=url)
     file_list = file_list.filter(condition)
-    file_list = file_list[:MAX_RELEASEFILES_QUERY]
-
-    return map(lambda release_file: release_file.file, file_list)
+    return file_list[:MAX_RELEASEFILES_QUERY]
 
 
 def url_exists_in_manifest(manifest: dict, url: str) -> bool:

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -149,9 +149,9 @@ def get_internal_source(project):
     }
 
 
-def get_internal_release_file_source(project, release):
+def get_internal_artifact_lookup_source(project):
     """
-    Returns the source configuration for a Sentry project's release files.
+    Returns the source configuration for the Sentry artifact-lookup API.
     """
     internal_url_prefix = options.get("system.internal-url-prefix")
     if not internal_url_prefix:
@@ -165,11 +165,10 @@ def get_internal_release_file_source(project, release):
     sentry_source_url = "{}{}".format(
         internal_url_prefix.rstrip("/"),
         reverse(
-            "sentry-api-0-project-release-files",
+            "sentry-api-0-project-artifact-lookup",
             kwargs={
                 "organization_slug": project.organization.slug,
                 "project_slug": project.slug,
-                "version": release,
             },
         ),
     )

--- a/src/sentry/testutils/relay.py
+++ b/src/sentry/testutils/relay.py
@@ -166,7 +166,10 @@ class RelayStoreHelper:
         wait_for_ingest_consumer,
     ):
         self.auth_header = get_auth_header(
-            "TEST_USER_AGENT/0.0.0", self.projectkey.public_key, self.projectkey.secret_key, "7"
+            "TEST_USER_AGENT/0.0.0",
+            self.projectkey.public_key,
+            self.projectkey.secret_key,
+            "7",
         )
 
         self.settings = settings

--- a/tests/sentry/api/endpoints/test_project_artifact_lookup.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_lookup.py
@@ -286,7 +286,7 @@ class ArtifactLookupTest(APITestCase):
 
         assert len(response) == 1
         assert response[0]["type"] == "file"
-        assert response[0]["abs_path"] == "application.js"
+        assert response[0]["abs_path"] == "http://example.com/application.js"
         assert response[0]["headers"] == file_headers
         self.assert_download_matches_file(response[0]["url"], file)
 

--- a/tests/symbolicator/__init__.py
+++ b/tests/symbolicator/__init__.py
@@ -97,15 +97,14 @@ def insta_snapshot_native_stacktrace_data(self, event, **kwargs):
     )
 
 
-def insta_snapshot_javascript_stacktrace_data(self, event, **kwargs):
+def insta_snapshot_javascript_stacktrace_data(insta_snapshot, event):
     # limit amount of data going into a snapshot so that they don't break all
     # the time due to unrelated changes.
-    self.insta_snapshot(
+    insta_snapshot(
         {
             "exception": {"values": [x for x in get_path(event, "exception", "values") or ()]},
             "errors": [e for e in event.get("errors") or () if e.get("name") != "timestamp"],
-        },
-        **kwargs,
+        }
     )
 
 

--- a/tests/symbolicator/snapshots/TestSymbolicatorSourceMapIntegration/test_symbolicator_roundtrip/0.pysnap
+++ b/tests/symbolicator/snapshots/TestSymbolicatorSourceMapIntegration/test_symbolicator_roundtrip/0.pysnap
@@ -1,21 +1,28 @@
 ---
-created: '2023-03-03T15:11:53.219343Z'
+created: '2023-03-22T16:27:13.923183Z'
 creator: sentry
 source: tests/symbolicator/test_sourcemap.py
 ---
-errors: []
+errors:
+- type: js_no_source
+  url: http://example.com/index.html
 exception:
   values:
   - raw_stacktrace:
       frames:
       - abs_path: http://example.com/test.min.js
         colno: 64
+        context_line: var makeAFailure=function(){function n(n){}function e(n){throw
+          new Error("failed!")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}
+          {snip}
         data:
           orig_in_app: -1
         filename: test.min.js
         function: e
         in_app: false
         lineno: 1
+        post_context:
+        - //# sourceMappingURL=test.map
       - abs_path: http://example.com/test.min.js
         colno: 136
         context_line: '{snip} row new Error("failed!")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function
@@ -42,61 +49,47 @@ exception:
         - //# sourceMappingURL=test.map
       - abs_path: http://example.com/index.html
         colno: 7
-        context_line: var makeAFailure=function(){function n(n){}function e(n){throw
-          new Error("failed!")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}
-          {snip}
         data:
           orig_in_app: -1
         filename: index.html
         function: produceStack
         in_app: false
         lineno: 6
-        post_context:
-        - //# sourceMappingURL=test.map
     stacktrace:
       frames:
-      - abs_path: http://example.com/index.html
-        colno: 7
+      - abs_path: http://example.com/test.js
+        colno: 11
+        context_line: '    throw new Error(''failed!'');'
         data:
           orig_in_app: -1
-          symbolicator_status: missing_sourcemap
-        filename: index.html
-        function: produceStack
-        in_app: false
-        lineno: 6
-        module: index
-      - abs_path: test.js
-        colno: 5
-        context_line: '    invoke(data);'
-        data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
+          sourcemap: http://example.com/test.map
         filename: test.js
-        function: test
+        function: onFailure
         in_app: false
-        lineno: 20
+        lineno: 5
+        module: test
         post_context:
         - '  }'
         - ''
-        - '  return test;'
-        - '})();'
-        - ''
+        - '  function invoke(data) {'
+        - '    var cb = null;'
+        - '    if (data.failed) {'
         pre_context:
-        - '    cb(data);'
-        - '  }'
+        - var makeAFailure = (function() {
+        - '  function onSuccess(data) {}'
         - ''
-        - '  function test() {'
-        - '    var data = {failed: true, value: 42};'
-      - abs_path: test.js
+        - '  function onFailure(data) {'
+      - abs_path: http://example.com/test.js
         colno: 5
         context_line: '    cb(data);'
         data:
           orig_in_app: -1
-          symbolicator_status: symbolicated
+          sourcemap: http://example.com/test.map
         filename: test.js
         function: invoke
         in_app: false
         lineno: 15
+        module: test
         post_context:
         - '  }'
         - ''
@@ -109,25 +102,36 @@ exception:
         - '    } else {'
         - '      cb = onSuccess;'
         - '    }'
-      - abs_path: test.js
-        colno: 11
-        context_line: '    throw new Error(''failed!'');'
+      - abs_path: http://example.com/test.js
+        colno: 5
+        context_line: '    invoke(data);'
         data:
           orig_in_app: -1
-          symbolicator_status: symbolicated
+          sourcemap: http://example.com/test.map
         filename: test.js
-        function: onFailure
+        function: test
         in_app: false
-        lineno: 5
+        lineno: 20
+        module: test
         post_context:
         - '  }'
         - ''
-        - '  function invoke(data) {'
-        - '    var cb = null;'
-        - '    if (data.failed) {'
-        pre_context:
-        - var makeAFailure = (function() {
-        - '  function onSuccess(data) {}'
+        - '  return test;'
+        - '})();'
         - ''
-        - '  function onFailure(data) {'
+        pre_context:
+        - '    cb(data);'
+        - '  }'
+        - ''
+        - '  function test() {'
+        - '    var data = {failed: true, value: 42};'
+      - abs_path: http://example.com/index.html
+        colno: 7
+        data:
+          orig_in_app: -1
+        filename: index.html
+        function: produceStack
+        in_app: false
+        lineno: 6
+        module: index
     type: Error

--- a/tests/symbolicator/snapshots/TestSymbolicatorSourceMapIntegration/test_symbolicator_roundtrip/1.pysnap
+++ b/tests/symbolicator/snapshots/TestSymbolicatorSourceMapIntegration/test_symbolicator_roundtrip/1.pysnap
@@ -1,0 +1,132 @@
+---
+created: '2023-03-22T16:27:18.884198Z'
+creator: sentry
+source: tests/symbolicator/test_sourcemap.py
+---
+errors: []
+exception:
+  values:
+  - raw_stacktrace:
+      frames:
+      - abs_path: http://example.com/test.min.js
+        colno: 64
+        context_line: var makeAFailure=function(){function n(n){}function e(n){throw
+          new Error("failed!")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}
+          {snip}
+        data:
+          orig_in_app: -1
+        filename: test.min.js
+        function: e
+        in_app: false
+        lineno: 1
+        post_context:
+        - //# sourceMappingURL=test.map
+      - abs_path: http://example.com/test.min.js
+        colno: 136
+        context_line: '{snip} row new Error("failed!")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function
+          i(){var n={failed:true,value:42};r(n)}return i}();'
+        data:
+          orig_in_app: -1
+        filename: test.min.js
+        function: r
+        in_app: false
+        lineno: 1
+        post_context:
+        - //# sourceMappingURL=test.map
+      - abs_path: http://example.com/test.min.js
+        colno: 183
+        context_line: '{snip} row new Error("failed!")}function r(r){var i=null;if(r.failed){i=e}else{i=n}i(r)}function
+          i(){var n={failed:true,value:42};r(n)}return i}();'
+        data:
+          orig_in_app: -1
+        filename: test.min.js
+        function: i
+        in_app: false
+        lineno: 1
+        post_context:
+        - //# sourceMappingURL=test.map
+      - abs_path: http://example.com/index.html
+        colno: 7
+        data:
+          orig_in_app: -1
+        filename: index.html
+        function: produceStack
+        in_app: false
+        lineno: 6
+    stacktrace:
+      frames:
+      - abs_path: test.js
+        colno: 11
+        context_line: '    throw new Error(''failed!'');'
+        data:
+          orig_in_app: -1
+          symbolicator_status: symbolicated
+        filename: test.js
+        function: onFailure
+        in_app: false
+        lineno: 5
+        post_context:
+        - '  }'
+        - ''
+        - '  function invoke(data) {'
+        - '    var cb = null;'
+        - '    if (data.failed) {'
+        pre_context:
+        - var makeAFailure = (function() {
+        - '  function onSuccess(data) {}'
+        - ''
+        - '  function onFailure(data) {'
+      - abs_path: test.js
+        colno: 5
+        context_line: '    cb(data);'
+        data:
+          orig_in_app: -1
+          symbolicator_status: symbolicated
+        filename: test.js
+        function: invoke
+        in_app: false
+        lineno: 15
+        post_context:
+        - '  }'
+        - ''
+        - '  function test() {'
+        - '    var data = {failed: true, value: 42};'
+        - '    invoke(data);'
+        pre_context:
+        - '    if (data.failed) {'
+        - '      cb = onFailure;'
+        - '    } else {'
+        - '      cb = onSuccess;'
+        - '    }'
+      - abs_path: test.js
+        colno: 5
+        context_line: '    invoke(data);'
+        data:
+          orig_in_app: -1
+          symbolicator_status: symbolicated
+        filename: test.js
+        function: test
+        in_app: false
+        lineno: 20
+        post_context:
+        - '  }'
+        - ''
+        - '  return test;'
+        - '})();'
+        pre_context:
+        - '    cb(data);'
+        - '  }'
+        - ''
+        - '  function test() {'
+        - '    var data = {failed: true, value: 42};'
+      - abs_path: http://example.com/index.html
+        colno: 7
+        data:
+          orig_in_app: -1
+          symbolicator_status: missing_sourcemap
+        filename: index.html
+        function: produceStack
+        in_app: false
+        lineno: 6
+        module: index
+    type: Error

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -16,8 +16,13 @@ from sentry.utils.safe import get_path
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
 
 # IMPORTANT:
-# For these tests to run, write `symbolicator.enabled: true` into your
-# `~/.sentry/config.yml` and run `sentry devservices up`
+#
+# This test suite requires Symbolicator in order to run correctly.
+# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `sentry devservices up`
+#
+# If you are using a local instance of Symbolicator, you need to
+# either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,
+# or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
 @pytest.mark.snuba
@@ -25,14 +30,11 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
     @pytest.fixture(autouse=True)
     def initialize(self, live_server, reset_snuba):
         self.project.update_option("sentry:builtin_symbol_sources", [])
-        new_prefix = live_server.url
 
         with patch("sentry.auth.system.is_internal_ip", return_value=True), self.options(
-            # Do not change to internal-url-prefix, otherwise tests break on docker for mac
-            {"system.url-prefix": new_prefix}
+            {"system.url-prefix": live_server.url}
         ):
-
-            # Run test case:
+            # Run test case
             yield
 
     def upload_symbols(self):

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -14,8 +14,13 @@ from sentry.utils.safe import get_path
 from tests.symbolicator import normalize_native_exception
 
 # IMPORTANT:
-# For these tests to run, write `symbolicator.enabled: true` into your
-# `~/.sentry/config.yml` and run `sentry devservices up`
+#
+# This test suite requires Symbolicator in order to run correctly.
+# Set `symbolicator.enabled: true` in your `~/.sentry/config.yml` and run `sentry devservices up`
+#
+# If you are using a local instance of Symbolicator, you need to
+# either change `system.url-prefix` option override inside `initialize` fixture to `system.internal-url-prefix`,
+# or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`
 
 
 def get_unreal_crash_file():
@@ -27,21 +32,14 @@ def get_unreal_crash_apple_file():
 
 
 class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
-    # For these tests to run, write `symbolicator.enabled: true` into your
-    # `~/.sentry/config.yml` and run `sentry devservices up`
-    # Also running locally, it might be necessary to set the
-    # `system.internal-url-prefix` option instead of `system.url-prefix`.
-
     @pytest.fixture(autouse=True)
     def initialize(self, live_server):
         self.project.update_option("sentry:builtin_symbol_sources", [])
-        new_prefix = live_server.url
 
         with patch("sentry.auth.system.is_internal_ip", return_value=True), self.options(
-            {"system.url-prefix": new_prefix}
+            {"system.url-prefix": live_server.url}
         ):
-
-            # Run test case:
+            # Run test case
             yield
 
     def upload_symbols(self):


### PR DESCRIPTION
Includes a couple of fixes for the recently added `lookup-artifact` API, and hooks that up to JS symbolication.
It also fixes some things in the JS symbolication processor and turns on some tests for the whole end-to-end processing.