### PR TITLE
fix(codecov): Change endpoint for has_integration check

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -62,7 +62,7 @@ def has_codecov_integration(organization: Organization) -> Tuple[bool, str | Non
             continue
 
         owner_username, _ = repos[0].get("full_name").split("/")
-        url = CODECOV_REPOS_URL.format(service="gh", owner_username=owner_username)
+        url = CODECOV_REPOS_URL.format(service="github", owner_username=owner_username)
         response = requests.get(url, headers={"Authorization": f"Bearer {codecov_token}"})
         if response.status_code == 200:
             return True, None  # We found a codecov integration, so we can stop looking

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -16,7 +16,7 @@ LineCoverage = Sequence[Tuple[int, int]]
 CODECOV_REPORT_URL = (
     "https://api.codecov.io/api/v2/{service}/{owner_username}/repos/{repo_name}/file_report/{path}"
 )
-CODECOV_REPOS_URL = "https://api.codecov.io/api/v2/{service}/{owner_username}/repos"
+CODECOV_REPOS_URL = "https://api.codecov.io/api/v2/{service}/{owner_username}"
 CODECOV_TIMEOUT = 2
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/tasks/auto_enable_codecov.py
+++ b/src/sentry/tasks/auto_enable_codecov.py
@@ -76,6 +76,6 @@ def enable_for_organization(organization_id: int, dry_run=False) -> None:
         )
     except Exception:
         logger.exception(
-            "Error checking for codecov integration.",
+            "Error checking for Codecov integration",
             extra={"organization_id": organization_id},
         )

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -310,7 +310,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         sentry_options.set("codecov.client-secret", "supersecrettoken")
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit/repos",
+            "https://api.codecov.io/api/v2/github/testgit",
             status=200,
         )
 
@@ -396,7 +396,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
     def test_setting_codecov_without_integration_forbidden(self, mock_get_repositories):
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit/repos",
+            "https://api.codecov.io/api/v2/github/testgit",
             status=404,
         )
         data = {"codecovAccess": True}

--- a/tests/sentry/integrations/utils/test_codecov.py
+++ b/tests/sentry/integrations/utils/test_codecov.py
@@ -40,7 +40,7 @@ class TestCodecovIntegration(APITestCase):
     def test_no_codecov_integration(self, mock_get_repositories):
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit",
+            "https://api.codecov.io/api/v2/github/testgit",
             status=404,
         )
 
@@ -56,7 +56,7 @@ class TestCodecovIntegration(APITestCase):
     def test_has_codecov_integration(self, mock_get_repositories):
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit",
+            "https://api.codecov.io/api/v2/github/testgit",
             status=200,
         )
 

--- a/tests/sentry/integrations/utils/test_codecov.py
+++ b/tests/sentry/integrations/utils/test_codecov.py
@@ -40,7 +40,7 @@ class TestCodecovIntegration(APITestCase):
     def test_no_codecov_integration(self, mock_get_repositories):
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit/repos",
+            "https://api.codecov.io/api/v2/gh/testgit",
             status=404,
         )
 
@@ -56,7 +56,7 @@ class TestCodecovIntegration(APITestCase):
     def test_has_codecov_integration(self, mock_get_repositories):
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit/repos",
+            "https://api.codecov.io/api/v2/gh/testgit",
             status=200,
         )
 

--- a/tests/sentry/tasks/test_auto_enable_codecov.py
+++ b/tests/sentry/tasks/test_auto_enable_codecov.py
@@ -25,13 +25,13 @@ class AutoEnableCodecovTest(TestCase):
 
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit/repos",
+            "https://api.codecov.io/api/v2/gh/testgit",
             status=200,
         )
 
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/fakegit/repos",
+            "https://api.codecov.io/api/v2/gh/fakegit",
             status=404,
         )
 

--- a/tests/sentry/tasks/test_auto_enable_codecov.py
+++ b/tests/sentry/tasks/test_auto_enable_codecov.py
@@ -25,13 +25,13 @@ class AutoEnableCodecovTest(TestCase):
 
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/testgit",
+            "https://api.codecov.io/api/v2/github/testgit",
             status=200,
         )
 
         responses.add(
             responses.GET,
-            "https://api.codecov.io/api/v2/gh/fakegit",
+            "https://api.codecov.io/api/v2/github/fakegit",
             status=404,
         )
 


### PR DESCRIPTION
Switch to using `GET /api/v2/{service}/{org}` to verify whether the Github orgs have a Codecov integration. This will allow us to verify the integration's existence regardless of whether the repo itself is private. 