### PR TITLE
ref(profiling): remove methods

### DIFF
--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -218,14 +218,14 @@ function getTopNodes(profile: Profile, startTimestamp, stopTimestamp): CallTreeN
 
     duration += profile.weights[i];
 
-    if (sample.isRoot() || !inRange) {
+    if (sample.isRoot || !inRange) {
       continue;
     }
 
     const stack: CallTreeNode[] = [sample];
     let node: CallTreeNode | null = sample;
 
-    while (node && !node.isRoot()) {
+    while (node && !node.isRoot) {
       stack.push(node);
       node = node.parent;
     }
@@ -286,7 +286,7 @@ function sortByCount(a: CallTreeNode, b: CallTreeNode) {
 function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame[] {
   const frames: Frame[] = [];
 
-  while (node && !node.isRoot()) {
+  while (node && !node.isRoot) {
     const frame = {
       absPath: node.frame.path ?? null,
       colNo: node.frame.column ?? null,

--- a/static/app/utils/profiling/callTreeNode.tsx
+++ b/static/app/utils/profiling/callTreeNode.tsx
@@ -5,34 +5,21 @@ export class CallTreeNode {
 
   private locked = false;
   count: number = 0;
+  isRoot: boolean;
 
-  parent: CallTreeNode | null;
-  recursive: CallTreeNode | null;
+  parent: CallTreeNode | null = null;
+  recursive: CallTreeNode | null = null;
   children: CallTreeNode[] = [];
 
   totalWeight: number = 0;
   selfWeight: number = 0;
 
+  static readonly Root = new CallTreeNode(Frame.Root, null);
+
   constructor(frame: Frame, parent: CallTreeNode | null) {
-    this.recursive = null;
     this.parent = parent;
     this.frame = frame;
-  }
-
-  setParent(parent: CallTreeNode): void {
-    this.parent = parent;
-  }
-
-  setRecursiveThroughNode(node: CallTreeNode): void {
-    this.recursive = node;
-  }
-
-  incrementCount(): void {
-    this.count++;
-  }
-
-  isRecursive(): boolean {
-    return !!this.recursive;
+    this.isRoot = Frame.Root.name === this.frame.name;
   }
 
   isDirectRecursive(): boolean {
@@ -49,10 +36,4 @@ export class CallTreeNode {
   lock(): void {
     this.locked = true;
   }
-
-  isRoot(): boolean {
-    return Frame.Root.name === this.frame.name;
-  }
-
-  static readonly Root = new CallTreeNode(Frame.Root, null);
 }

--- a/static/app/utils/profiling/colors/utils.spec.tsx
+++ b/static/app/utils/profiling/colors/utils.spec.tsx
@@ -145,8 +145,8 @@ describe('makeColorMap', () => {
     // Reverse order to ensure we actually sort
     const frames = [f(0, 'aaa'), f(1, 'aaa'), f(2, 'aaa'), f(3, 'c')];
 
-    frames[1]!.node.setRecursiveThroughNode(frames[0]!.node);
-    frames[2]!.node.setRecursiveThroughNode(frames[1]!.node);
+    frames[1]!.node.recursive = frames[0]!.node;
+    frames[2]!.node.recursive = frames[1]!.node;
 
     const map = makeColorMapByRecursion(frames, makeColorBucketTheme(LCH_LIGHT));
 

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -178,10 +178,10 @@ export function makeColorMapByRecursion(
   const colorCache = new Map<FlamegraphFrame['frame']['key'], ColorChannels>();
 
   const sortedFrames = [...frames].sort(defaultFrameSort);
-  const uniqueCount = uniqueCountBy(sortedFrames, t => t.node.isRecursive());
+  const uniqueCount = uniqueCountBy(sortedFrames, t => !!t.node.recursive);
 
   for (let i = 0; i < sortedFrames.length; i++) {
-    if (!sortedFrames[i].node.isRecursive()) {
+    if (!sortedFrames[i].node.recursive) {
       continue;
     }
     const frame = sortedFrames[i]!;

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -286,7 +286,7 @@ export class Flamegraph {
     };
 
     function visit(node: CallTreeNode, start: number) {
-      if (!node.frame.isRoot()) {
+      if (!node.frame.isRoot) {
         openFrame(node, start);
       }
 
@@ -297,7 +297,7 @@ export class Flamegraph {
         childTime += child.totalWeight;
       });
 
-      if (!node.frame.isRoot()) {
+      if (!node.frame.isRoot) {
         closeFrame(node, start + node.totalWeight);
       }
     }

--- a/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.spec.ts
+++ b/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.spec.ts
@@ -10,9 +10,7 @@ function createFlamegraphFrame(frame?: DeepPartial<FlamegraphFrame>) {
     parent = null,
     children = [],
     frame: _frame = {
-      isRoot() {
-        return false;
-      },
+      isRoot: false,
     },
   } = frame ?? {};
   return {
@@ -117,9 +115,7 @@ describe('selectNearestFrame', () => {
   it('does not allow selection of the "sentry root" virtual root node', () => {
     const root = createFlamegraphFrame({
       frame: {
-        isRoot() {
-          return true;
-        },
+        isRoot: true,
       },
     });
     const leftChild = addChildrenToDepth(root, 1);

--- a/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
+++ b/static/app/utils/profiling/flamegraph/flamegraphKeyboardNavigation.ts
@@ -12,7 +12,7 @@ export function selectNearestFrame(frame: FlamegraphFrame, direction: Direction)
     const parent = frame.parent;
 
     // sentry root is a virtual root that should not be selectable
-    if (parent?.frame.isRoot()) {
+    if (parent?.frame.isRoot) {
       return frame;
     }
 

--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -1,6 +1,7 @@
 import type {SymbolicatorStatus} from 'sentry/components/events/interfaces/types';
 import {t} from 'sentry/locale';
 
+const ROOT_KEY = 'sentry root';
 export class Frame {
   readonly key: string | number;
   readonly name: string;
@@ -19,13 +20,15 @@ export class Frame {
   readonly symbolAddr?: string;
   readonly symbolicatorStatus?: SymbolicatorStatus;
 
+  readonly isRoot: boolean;
+
   totalWeight: number = 0;
   selfWeight: number = 0;
 
   static Root = new Frame(
     {
-      key: 'sentry root',
-      name: 'sentry root',
+      key: ROOT_KEY,
+      name: ROOT_KEY,
       is_application: false,
     },
     'mobile'
@@ -47,6 +50,7 @@ export class Frame {
     this.symbol = frameInfo.symbol;
     this.symbolAddr = frameInfo.symbolAddr;
     this.symbolicatorStatus = frameInfo.symbolicatorStatus;
+    this.isRoot = this.key === ROOT_KEY;
 
     // We are remapping some of the keys as they differ between platforms.
     // This is a temporary solution until we adopt a unified format.
@@ -131,9 +135,5 @@ export class Frame {
     if (!this.name) {
       this.name = t('<unknown>');
     }
-  }
-
-  isRoot(): boolean {
-    return this.name === Frame.Root.name;
   }
 }

--- a/static/app/utils/profiling/profile/eventedProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.spec.tsx
@@ -162,7 +162,7 @@ describe('EventedProfile', () => {
       {type: 'flamechart'}
     );
 
-    expect(firstCallee(firstCallee(profile.callTree)).isRecursive()).toBe(true);
+    expect(!!firstCallee(firstCallee(profile.callTree)).recursive).toBe(true);
   });
 
   it('marks indirect recursion', () => {
@@ -189,7 +189,7 @@ describe('EventedProfile', () => {
       {type: 'flamechart'}
     );
 
-    expect(firstCallee(firstCallee(firstCallee(profile.callTree))).isRecursive()).toBe(
+    expect(!!firstCallee(firstCallee(firstCallee(profile.callTree))).recursive).toBe(
       true
     );
   });

--- a/static/app/utils/profiling/profile/eventedProfile.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.tsx
@@ -172,8 +172,8 @@ export class EventedProfile extends Profile {
       while (start >= 0) {
         if (this.calltree[start].frame === node.frame) {
           // The recursion edge is bidirectional
-          this.calltree[start].setRecursiveThroughNode(node);
-          node.setRecursiveThroughNode(this.calltree[start]);
+          this.calltree[start].recursive = node;
+          node.recursive = this.calltree[start];
           break;
         }
         start--;

--- a/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
@@ -260,7 +260,7 @@ describe('jsSelfProfile', () => {
       {type: 'flamechart'}
     );
 
-    expect(firstCallee(firstCallee(profile.callTree)).isRecursive()).toBe(true);
+    expect(!!firstCallee(firstCallee(profile.callTree)).recursive).toBe(true);
   });
 
   it('marks indirect recursion', () => {
@@ -293,7 +293,7 @@ describe('jsSelfProfile', () => {
       {type: 'flamechart'}
     );
 
-    expect(firstCallee(firstCallee(firstCallee(profile.callTree))).isRecursive()).toBe(
+    expect(!!firstCallee(firstCallee(firstCallee(profile.callTree))).recursive).toBe(
       true
     );
   });

--- a/static/app/utils/profiling/profile/jsSelfProfile.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.tsx
@@ -135,8 +135,8 @@ export class JSSelfProfile extends Profile {
       while (stackHeight >= 0) {
         if (framesInStack[stackHeight].frame === node.frame) {
           // The recursion edge is bidirectional
-          framesInStack[stackHeight].setRecursiveThroughNode(node);
-          node.setRecursiveThroughNode(framesInStack[stackHeight]);
+          framesInStack[stackHeight].recursive = node;
+          node.recursive = framesInStack[stackHeight];
           break;
         }
         stackHeight--;
@@ -162,7 +162,7 @@ export class JSSelfProfile extends Profile {
 
     for (const stackNode of framesInStack) {
       stackNode.frame.totalWeight += weight;
-      stackNode.incrementCount();
+      stackNode.count++;
     }
 
     // If node is the same as the previous sample, add the weight to the previous sample

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -107,7 +107,7 @@ export class Profile {
     for (const stackTop of this.samples) {
       let top: CallTreeNode | null = stackTop;
 
-      while (top && !top.isRoot() && prevStack.indexOf(top) === -1) {
+      while (top && !top.isRoot && prevStack.indexOf(top) === -1) {
         top = top.parent;
       }
 
@@ -120,7 +120,7 @@ export class Profile {
 
       let node: CallTreeNode | null = stackTop;
 
-      while (node && !node.isRoot() && node !== top) {
+      while (node && !node.isRoot && node !== top) {
         toOpen.push(node);
         node = node.parent;
       }

--- a/static/app/utils/profiling/profile/sampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.spec.tsx
@@ -148,7 +148,7 @@ describe('SampledProfile', () => {
       {type: 'flamechart'}
     );
 
-    expect(firstCallee(firstCallee(profile.callTree)).isRecursive()).toBe(true);
+    expect(!!firstCallee(firstCallee(profile.callTree)).recursive).toBe(true);
   });
 
   it('marks indirect recursion', () => {
@@ -169,7 +169,7 @@ describe('SampledProfile', () => {
       {type: 'flamechart'}
     );
 
-    expect(firstCallee(firstCallee(firstCallee(profile.callTree))).isRecursive()).toBe(
+    expect(!!firstCallee(firstCallee(firstCallee(profile.callTree))).recursive).toBe(
       true
     );
   });

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -227,8 +227,8 @@ export class SampledProfile extends Profile {
       while (start >= 0) {
         if (framesInStack[start].frame === node.frame) {
           // The recursion edge is bidirectional
-          framesInStack[start].setRecursiveThroughNode(node);
-          node.setRecursiveThroughNode(framesInStack[start]);
+          framesInStack[start].recursive = node;
+          node.recursive = framesInStack[start];
           break;
         }
         start--;
@@ -251,7 +251,7 @@ export class SampledProfile extends Profile {
 
     for (const stackNode of framesInStack) {
       stackNode.frame.totalWeight += weight;
-      stackNode.incrementCount();
+      stackNode.count++;
     }
 
     // If node is the same as the previous sample, add the weight to the previous sample

--- a/static/app/utils/profiling/profile/sentrySampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.tsx
@@ -110,8 +110,8 @@ export class SentrySampledProfile extends Profile {
       while (start >= 0) {
         if (framesInStack[start].frame === node.frame) {
           // The recursion edge is bidirectional
-          framesInStack[start].setRecursiveThroughNode(node);
-          node.setRecursiveThroughNode(framesInStack[start]);
+          framesInStack[start].recursive = node;
+          node.recursive = framesInStack[start];
           break;
         }
         start--;
@@ -134,7 +134,7 @@ export class SentrySampledProfile extends Profile {
 
     for (const stackNode of framesInStack) {
       stackNode.frame.totalWeight += weight;
-      stackNode.incrementCount();
+      stackNode.count++;
     }
 
     // If node is the same as the previous sample, add the weight to the previous sample


### PR DESCRIPTION
Substitute call tree node methods for properties, we really shouldn't need to call a method to access a public boolean...