### PR TITLE
ci: remove visual snapshots from CI

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -119,12 +119,6 @@ jobs:
         env:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
 
-      - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@ea663f1be8b73c86b18081d714423ce52352e934
-        with:
-          save-only: true
-          snapshot-path: .artifacts/visual-snapshots
-
       # This job runs when FE or BE changes happen, however, we only upload coverage data for
       # BE changes since it conflicts with codecov's carry forward functionality
       # Upload coverage data even if running the tests step fails since
@@ -149,13 +143,3 @@ jobs:
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
-
-      - name: Diff snapshots
-        uses: getsentry/action-visual-snapshot@ea663f1be8b73c86b18081d714423ce52352e934
-        # Run this step only if there are acceptance related code changes
-        # Forks are handled in visual-diff.yml
-        if: needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
-        with:
-          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
-          gcs-bucket: 'sentry-visual-snapshots'
-          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -193,13 +193,6 @@ jobs:
           base-path: .artifacts/visual-snapshots/jest
           css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
 
-      - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@ea663f1be8b73c86b18081d714423ce52352e934
-        with:
-          artifact-name: frontend-snapshots
-          save-only: true
-          snapshot-path: .artifacts/visual-snapshots
-
       # We only upload coverage data for FE changes since it conflicts with
       # codecov's carry forward functionality.
       # Upload coverage data even if running the tests step fails since
@@ -210,23 +203,6 @@ jobs:
         with:
           files: .artifacts/coverage/*
           type: frontend
-
-  frontend-visual-diff:
-    needs: [frontend-browser-tests]
-    name: Visual diff
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    if: github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
-    steps:
-      - name: Diff snapshots
-        uses: getsentry/action-visual-snapshot@ea663f1be8b73c86b18081d714423ce52352e934
-        with:
-          action-name: 'Visual Snapshot: Frontend'
-          artifact-name: 'frontend-snapshots'
-          base-branch: 'master'
-          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
-          gcs-bucket: 'sentry-visual-snapshots'
-          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
   # This check runs once all dependant jobs have passed
   # It symbolizes that all required Frontend checks have succesfully passed (Or skipped)


### PR DESCRIPTION
Visual snapshots can be executed by adding 'Trigger: Visual Snapshot' on a PR




<!-- Describe your PR here. -->