### PR TITLE
test(ui): Remove duplicate test checks in metric edit

### DIFF
--- a/static/app/views/alerts/rules/metric/edit.spec.jsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.jsx
@@ -1,9 +1,6 @@
-import {Fragment} from 'react';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import GlobalModal from 'sentry/components/globalModal';
 import {metric} from 'sentry/utils/analytics';
 import MetricRulesEdit from 'sentry/views/alerts/rules/metric/edit';
 import {AlertRuleTriggerType} from 'sentry/views/alerts/rules/metric/types';
@@ -19,7 +16,7 @@ jest.mock('sentry/utils/analytics', () => ({
 }));
 
 describe('MetricRulesEdit', function () {
-  beforeAll(function () {
+  beforeEach(function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/users/',
       body: [],
@@ -51,6 +48,15 @@ describe('MetricRulesEdit', function () {
         },
       ],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [TestStubs.Member()],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
   });
 
   it('renders and edits trigger', async function () {
@@ -62,11 +68,6 @@ describe('MetricRulesEdit', function () {
       body: rule,
     });
 
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/members/',
-      body: [TestStubs.Member()],
-    });
-
     const editRule = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/project-slug/alert-rules/${rule.id}/`,
       method: 'PUT',
@@ -74,18 +75,15 @@ describe('MetricRulesEdit', function () {
     });
 
     render(
-      <Fragment>
-        <GlobalModal />
-        <MetricRulesEdit
-          params={{
-            projectId: project.slug,
-            ruleId: rule.id,
-          }}
-          organization={organization}
-          onChangeTitle={onChangeTitleMock}
-          project={project}
-        />
-      </Fragment>
+      <MetricRulesEdit
+        params={{
+          projectId: project.slug,
+          ruleId: rule.id,
+        }}
+        organization={organization}
+        onChangeTitle={onChangeTitleMock}
+        project={project}
+      />
     );
 
     // has existing trigger
@@ -97,9 +95,6 @@ describe('MetricRulesEdit', function () {
     // Check correct rule name is called
     expect(onChangeTitleMock).toHaveBeenCalledWith(rule.name);
 
-    await userEvent.clear(screen.getByTestId('warning-threshold'));
-    await userEvent.type(screen.getByTestId('warning-threshold'), '13');
-
     await userEvent.clear(screen.getByTestId('resolve-threshold'));
     await userEvent.type(screen.getByTestId('resolve-threshold'), '12');
 
@@ -110,6 +105,7 @@ describe('MetricRulesEdit', function () {
     await userEvent.click(screen.getByLabelText('Save Rule'));
 
     expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
+
     expect(editRule).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -139,10 +135,6 @@ describe('MetricRulesEdit', function () {
               alertThreshold: 70,
               id: '1',
             }),
-            expect.objectContaining({
-              actions: [],
-              alertThreshold: 13,
-            }),
           ],
         }),
         method: 'PUT',
@@ -152,11 +144,10 @@ describe('MetricRulesEdit', function () {
     // New Trigger should be in list
     // Has correct values
     expect(screen.getByTestId('critical-threshold')).toHaveValue('70');
-    expect(screen.getByTestId('warning-threshold')).toHaveValue('13');
     expect(screen.getByTestId('resolve-threshold')).toHaveValue('12');
   });
 
-  it('clears trigger', async function () {
+  it('removes warning trigger', async function () {
     const {organization, project} = initializeOrg();
     const rule = TestStubs.MetricRule();
     rule.triggers.push({
@@ -166,15 +157,9 @@ describe('MetricRulesEdit', function () {
     });
     rule.resolveThreshold = 12;
 
-    const onChangeTitleMock = jest.fn();
-    const req = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
       body: rule,
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/members/',
-      body: [TestStubs.Member()],
     });
 
     const editRule = MockApiClient.addMockResponse({
@@ -184,19 +169,16 @@ describe('MetricRulesEdit', function () {
     });
 
     render(
-      <Fragment>
-        <GlobalModal />
-        <MetricRulesEdit
-          params={{
-            orgId: organization.slug,
-            projectId: project.slug,
-            ruleId: rule.id,
-          }}
-          organization={organization}
-          onChangeTitle={onChangeTitleMock}
-          project={project}
-        />
-      </Fragment>
+      <MetricRulesEdit
+        params={{
+          orgId: organization.slug,
+          projectId: project.slug,
+          ruleId: rule.id,
+        }}
+        organization={organization}
+        onChangeTitle={() => {}}
+        project={project}
+      />
     );
 
     // has existing trigger
@@ -204,19 +186,9 @@ describe('MetricRulesEdit', function () {
     expect(screen.getByTestId('warning-threshold')).toHaveValue('13');
     expect(screen.getByTestId('resolve-threshold')).toHaveValue('12');
 
-    expect(req).toHaveBeenCalled();
-
-    // Check correct rule name is called
-    expect(onChangeTitleMock).toHaveBeenCalledWith(rule.name);
-
-    await userEvent.click(screen.getByLabelText('Add Action'));
-
     // Clear warning Trigger
     await userEvent.clear(screen.getByTestId('warning-threshold'));
 
-    await waitFor(() => expect(screen.getByLabelText('Save Rule')).toBeEnabled());
-
-    // Save Trigger
     await userEvent.click(screen.getByLabelText('Save Rule'));
 
     expect(editRule).toHaveBeenCalledWith(
@@ -235,15 +207,7 @@ describe('MetricRulesEdit', function () {
           thresholdType: 0,
           triggers: [
             expect.objectContaining({
-              actions: [
-                expect.objectContaining({
-                  integrationId: null,
-                  targetIdentifier: '',
-                  targetType: 'user',
-                  type: 'email',
-                  options: null,
-                }),
-              ],
+              actions: [],
               alertRuleId: '4',
               alertThreshold: 70,
               id: '1',

--- a/static/app/views/alerts/rules/metric/edit.spec.jsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.jsx
@@ -96,7 +96,7 @@ describe('MetricRulesEdit', function () {
     expect(onChangeTitleMock).toHaveBeenCalledWith(rule.name);
 
     await userEvent.clear(screen.getByTestId('resolve-threshold'));
-    await userEvent.type(screen.getByTestId('resolve-threshold'), '12');
+    await userEvent.type(screen.getByTestId('resolve-threshold'), '7');
 
     // Create a new action
     await userEvent.click(screen.getByLabelText('Add Action'));
@@ -119,7 +119,7 @@ describe('MetricRulesEdit', function () {
           status: 0,
           timeWindow: 60,
           thresholdType: 0,
-          resolveThreshold: 12,
+          resolveThreshold: 7,
           triggers: [
             expect.objectContaining({
               actions: [
@@ -144,7 +144,7 @@ describe('MetricRulesEdit', function () {
     // New Trigger should be in list
     // Has correct values
     expect(screen.getByTestId('critical-threshold')).toHaveValue('70');
-    expect(screen.getByTestId('resolve-threshold')).toHaveValue('12');
+    expect(screen.getByTestId('resolve-threshold')).toHaveValue('7');
   });
 
   it('removes warning trigger', async function () {


### PR DESCRIPTION
- Mocks were not being reset between tests
- global modal not being used
- removed some duplicate checks