### PR TITLE
test(ui): Disable emotion sourcemaps for tests

### DIFF
--- a/babel.config.ts
+++ b/babel.config.ts
@@ -54,8 +54,18 @@ const config: TransformOptions = {
       ],
     },
     test: {
-      // Required, see https://github.com/facebook/jest/issues/9430
-      plugins: ['dynamic-import-node'],
+      plugins: [
+        // Required, see https://github.com/facebook/jest/issues/9430
+        'dynamic-import-node',
+        // Disable emotion sourcemaps in tests
+        // Since emotion spends lots of time parsing and inserting sourcemaps
+        [
+          '@emotion/babel-plugin',
+          {
+            sourceMap: false,
+          },
+        ],
+      ],
     },
   },
 };


### PR DESCRIPTION
disables the emotion sourcemaps during tests https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin#sourcemap

emotion spends time inserting the correct sourcemap when serializing styles, this is useful if you're trying to find out where css came from during development as the browser could tell you something like - display flex came from line 94 in this file.

when measuring `static/app/components/events/searchBar.spec.jsx`
the setQuery funciton is a helper that finds the search input clicks it and pastes some text into it.

before - we can see lots of time spent doing serializeStyles mostly because there's an expensive regex
![image](https://user-images.githubusercontent.com/1400464/226725870-4cee38c9-1b87-4a08-8f8c-6767efbba91d.png)

after - we spend less time serializing styles
![image](https://user-images.githubusercontent.com/1400464/226726200-21b64055-9cb2-4c97-bf61-2c44da4af2d2.png)

