### PR TITLE
fix(discover) Fix unfurls not failing for discover

### DIFF
--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -18,6 +18,7 @@ from sentry.db.models import (
 )
 from sentry.db.models.utils import slugify_instance
 from sentry.locks import locks
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils.retries import TimedRetryPolicy
 
 if TYPE_CHECKING:
@@ -28,7 +29,7 @@ class TeamManager(BaseManager):
     def get_for_user(
         self,
         organization: "Organization",
-        user: "User",
+        user: Union["User", RpcUser],
         scope: Optional[str] = None,
         with_projects: bool = False,
     ) -> Union[Sequence["Team"], Sequence[Tuple["Team", Sequence["Project"]]]]:
@@ -53,7 +54,7 @@ class TeamManager(BaseManager):
             team_list = list(base_team_qs)
         else:
             try:
-                om = OrganizationMember.objects.get(user=user, organization=organization)
+                om = OrganizationMember.objects.get(user_id=user.id, organization=organization)
             except OrganizationMember.DoesNotExist:
                 # User is not a member of the organization at all
                 return []

--- a/tests/sentry/manager/test_team_manager.py
+++ b/tests/sentry/manager/test_team_manager.py
@@ -1,4 +1,5 @@
 from sentry.models import Team, User
+from sentry.services.hybrid_cloud.user import user_service
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -10,6 +11,15 @@ class TeamManagerTest(TestCase):
         org = self.create_organization()
         team = self.create_team(organization=org, name="Test")
         self.create_member(organization=org, user=user, teams=[team])
+
+        result = Team.objects.get_for_user(organization=org, user=user)
+        assert result == [team]
+
+    def test_simple_with_rpc_user(self):
+        user = user_service.get_user(User.objects.create(username="foo").id)
+        org = self.create_organization()
+        team = self.create_team(organization=org, name="Test")
+        self.create_member(organization=org, user_id=user.id, teams=[team])
 
         result = Team.objects.get_for_user(organization=org, user=user)
         assert result == [team]


### PR DESCRIPTION
Discover query unfurls were not working because they were being passed an RpcUser instead of an ORM user.

Fixes SENTRY-YB2
Fixes SENTRY-XZ3
