### PR TITLE
fix(routes): Fix sentry-api-0-project-filters-details endpoint name

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1898,7 +1898,7 @@ PROJECT_URLS = [
     url(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/filters/(?P<filter_id>[\w-]+)/$",
         ProjectFilterDetailsEndpoint.as_view(),
-        name="sentry-api-0-project-filters",
+        name="sentry-api-0-project-filters-details",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/hooks/$",

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -4,7 +4,7 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test
 class ProjectFilterDetailsTest(APITestCase):
-    endpoint = "sentry-api-0-project-filters"
+    endpoint = "sentry-api-0-project-filters-details"
     method = "put"
 
     def setUp(self):


### PR DESCRIPTION
`sentry-api-0-project-filters` is already taken for `ProjectFiltersEndpoint`. 