### PR TITLE
feat(issues): Wait for project to be loaded before loading issue details content

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -637,7 +637,7 @@ class GroupDetails extends Component<Props, State> {
 
   renderPageContent() {
     const {error: isError, group, project, loading} = this.state;
-    const isLoading = loading || (!group && !isError);
+    const isLoading = loading || (!group && !isError) || !project;
 
     if (isLoading) {
       return <LoadingIndicator />;


### PR DESCRIPTION
A lot of issue details content relies on the project slug to exist in order to generate valid api urls.
Because the project is loaded asynchronously on this component, the project slug is not always available, which causes dependant components to break. This update makes issue details wait for the project to be loaded before proceeding to render content in order to avoid this issue.

<img width="539" alt="image" src="https://user-images.githubusercontent.com/83961295/226728193-f20ed69a-fc11-4740-9504-0c38268841ad.png">
