### PR TITLE
fix(inbound-filters): Ensure legacy browser subfilters are always a set

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -33,8 +33,12 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             return Response(serializer.errors, status=400)
 
         current_state = inbound_filters.get_filter_state(filter_id, project)
+        if type(current_state) is list:
+            current_state = set(current_state)
 
         new_state = inbound_filters.set_filter_state(filter_id, project, serializer.validated_data)
+        if type(new_state) is list:
+            new_state = set(new_state)
         audit_log_state = audit_log.get_event_id("PROJECT_ENABLE")
 
         returned_state = None

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -33,11 +33,11 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             return Response(serializer.errors, status=400)
 
         current_state = inbound_filters.get_filter_state(filter_id, project)
-        if type(current_state) is list:
+        if isinstance(current_state, list):
             current_state = set(current_state)
 
         new_state = inbound_filters.set_filter_state(filter_id, project, serializer.validated_data)
-        if type(new_state) is list:
+        if isinstance(new_state, list):
             new_state = set(new_state)
         audit_log_state = audit_log.get_event_id("PROJECT_ENABLE")
 

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -22,3 +22,40 @@ class ProjectFilterDetailsTest(APITestCase):
         )
 
         assert project.get_option("filters:browser-extensions") == "1"
+
+    def test_put_legacy_browsers(self):
+        org = self.create_organization(name="baz", slug="1", owner=self.user)
+        team = self.create_team(organization=org, name="foo", slug="foo")
+        project = self.create_project(name="Bar", slug="bar", teams=[team])
+
+        project.update_option(
+            "filters:legacy-browsers",
+            [
+                "ie10",
+                "ie9",
+                "android_pre_4",
+                "ie_pre_9",
+                "opera_pre_15",
+                "safari_pre_6",
+                "ie11",
+                "opera_mini_pre_8",
+            ],
+        )
+
+        new_subfilters = [
+            "safari_pre_6",
+            "opera_mini_pre_8",
+            "ie10",
+            "ie11",
+            "opera_pre_15",
+        ]
+
+        self.get_success_response(
+            org.slug,
+            project.slug,
+            "legacy-browsers",
+            subfilters=new_subfilters,
+            status_code=201,
+        )
+
+        assert set(project.get_option("filters:legacy-browsers")) == set(new_subfilters)


### PR DESCRIPTION
Fixes SENTRY-ZZ5