### PR TITLE
ref(profiling): Fix webpack dsn

### DIFF
--- a/build-utils/sentry-instrumentation.ts
+++ b/build-utils/sentry-instrumentation.ts
@@ -50,7 +50,7 @@ class SentryInstrumentation {
     const {ProfilingIntegration} = require('@sentry/profiling-node');
 
     sentry.init({
-      dsn: 'https://2eec505f93aa4a8da5222be7f01d0133@o1137848.ingest.sentry.io/4504872101150720',
+      dsn: 'https://3d282d186d924374800aa47006227ce9@sentry.io/2053674',
       environment: IS_CI ? 'ci' : 'local',
       tracesSampleRate: 1.0,
       integrations: [new ProfilingIntegration()],


### PR DESCRIPTION
Accidentally changed it in the previous PR, switching it back to sentry org.