### PR TITLE
fix(logging): Add clarifying comments

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -921,6 +921,9 @@ LOGGING = {
     "handlers": {
         "null": {"class": "logging.NullHandler"},
         "console": {"class": "sentry.logging.handlers.StructLogHandler"},
+        # This `internal` logger is separate from the `Logging` integration in the SDK. Since
+        # we have this to record events, in `sdk.py` we set the integration's `event_level` to
+        # None, so that it records breadcrumbs for all log calls but doesn't send any events.
         "internal": {"level": "ERROR", "class": "sentry_sdk.integrations.logging.EventHandler"},
         "metrics": {
             "level": "WARNING",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -409,6 +409,10 @@ def configure_sdk():
             DjangoAtomicIntegration(),
             DjangoIntegration(),
             CeleryIntegration(),
+            # This makes it so all levels of logging are recorded as breadcrumbs,
+            # but none are captured as events (that's handled by the `internal`
+            # logger defined in `server.py`, which ignores the levels set
+            # in the integration and goes straight to the underlying handler class).
             LoggingIntegration(event_level=None),
             RustInfoIntegration(),
             RedisIntegration(),


### PR DESCRIPTION
This adds comments to both our `internal` logger and our backend SDK config, clarifying the differences in what each one handles. See also https://github.com/getsentry/develop/pull/883 in our dev docs.