### PR TITLE
fix(profiling): Typo in format name sampled vs sample

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -83,7 +83,7 @@ class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
             return Response(status=404)
 
         preferred_format = (
-            "sampled"
+            "sample"
             if features.has(
                 "organizations:profiling-sampled-format", project.organization, actor=request.user
             )


### PR DESCRIPTION
The format name should be sample, not sampled (no -d).