### PR TITLE
fix(replays): Fix alignment of OS & Browser icons in Replay Details header

### DIFF
--- a/static/app/components/replays/contextIcon.tsx
+++ b/static/app/components/replays/contextIcon.tsx
@@ -17,21 +17,38 @@ const LazyContextIcon = lazy(
 );
 
 const ContextIcon = styled(({className, name, version}: Props) => {
-  const icon = generateIconName(name, version ?? undefined);
+  const icon = generateIconName(name, version);
+
+  const title = (
+    <CountTooltipContent>
+      <dt>Name:</dt>
+      <dd>{name}</dd>
+      {version ? <dt>Version:</dt> : null}
+      {version ? <dd>{version}</dd> : null}
+    </CountTooltipContent>
+  );
   return (
-    <div className={className}>
-      <Tooltip title={name}>
-        <Suspense fallback={<LoadingMask />}>
-          <LazyContextIcon name={icon} size="sm" />
-        </Suspense>
-      </Tooltip>
-      {version ? <div>{version}</div> : null}
-    </div>
+    <Tooltip title={title} className={className}>
+      <Suspense fallback={<LoadingMask />}>
+        <LazyContextIcon name={icon} size="sm" />
+      </Suspense>
+      {version ? version : null}
+    </Tooltip>
   );
 })`
   display: flex;
   gap: ${space(1)};
   font-variant-numeric: tabular-nums;
+  align-items: center;
+`;
+
+const CountTooltipContent = styled('dl')`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  gap: ${space(1)} ${space(3)};
+  text-align: left;
+  align-items: center;
+  margin-bottom: 0;
 `;
 
 export default ContextIcon;


### PR DESCRIPTION
Corrected the icon alignment, and along the way improved the tooltip content. 
Also, the tooltip change helped make the alignment fix easier.

**Before:**
Alignment was messed up on the Details page
![Image](https://user-images.githubusercontent.com/187460/226713132-3c0c31e6-d8e2-4f44-a0db-2f26a2f59fb3.png)



**After:**
Details alignment is fixed, list page still looks good.
![SCR-20230321-jg2](https://user-images.githubusercontent.com/187460/226739951-332a0f1b-0a83-45d4-94f2-374000f6731f.png)
![SCR-20230321-jfx](https://user-images.githubusercontent.com/187460/226739954-c6f24837-6692-44ab-830f-ff9a46e524bc.png)



Fixes #46139
