### PR TITLE
feat(sourcemaps): hide sourcemap not found error

### DIFF
--- a/static/app/components/events/eventErrors.spec.tsx
+++ b/static/app/components/events/eventErrors.spec.tsx
@@ -56,38 +56,20 @@ describe('EventErrors', () => {
     ).toBeInTheDocument();
   });
 
-  describe('release artifacts', () => {
-    it('displays extra error info when event dist does not match file dist', async () => {
-      const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/releases/release-version/files/',
-        body: [{name: 'dist-1'}],
-      });
-
-      const eventWithDifferentDist = TestStubs.Event({
-        release: {
-          version: 'release-version',
-        },
-        errors: [
-          {
-            type: JavascriptProcessingErrors.JS_MISSING_SOURCE,
-            data: {
-              url: 'https://place.com/dist-2',
-            },
+  it('hides source map not found error', () => {
+    const eventWithDifferentDist = TestStubs.Event({
+      errors: [
+        {
+          type: JavascriptProcessingErrors.JS_MISSING_SOURCE,
+          data: {
+            url: 'https://place.com/dist-2',
           },
-        ],
-      });
-
-      render(<EventErrors {...defaultProps} event={eventWithDifferentDist} />);
-
-      await userEvent.click(
-        screen.getByText(/there was 1 problem processing this event/i)
-      );
-
-      expect(mock).toHaveBeenCalled();
-      await screen.findByText(
-        /Source code was not found because the distribution did not match/i
-      );
+        },
+      ],
     });
+
+    render(<EventErrors {...defaultProps} event={eventWithDifferentDist} />);
+    expect(screen.queryByText(/problem processing this event/i)).not.toBeInTheDocument();
   });
 
   describe('proguard errors', () => {

--- a/static/app/components/events/eventErrors.spec.tsx
+++ b/static/app/components/events/eventErrors.spec.tsx
@@ -61,9 +61,6 @@ describe('EventErrors', () => {
       errors: [
         {
           type: JavascriptProcessingErrors.JS_MISSING_SOURCE,
-          data: {
-            url: 'https://place.com/dist-2',
-          },
         },
       ],
     });

--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -11,9 +11,9 @@ import getThreadException from 'sentry/components/events/interfaces/threads/thre
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import {JavascriptProcessingErrors} from 'sentry/constants/eventErrors';
-import {t, tct, tn} from 'sentry/locale';
+import {tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Artifact, Project} from 'sentry/types';
+import {Project} from 'sentry/types';
 import {DebugFile} from 'sentry/types/debugFiles';
 import {Image} from 'sentry/types/debugImage';
 import {EntryType, Event, ExceptionValue, Thread} from 'sentry/types/event';
@@ -24,6 +24,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {projectProcessingIssuesMessages} from 'sentry/views/settings/project/projectProcessingIssues';
 
 import {DataSection} from './styles';
+
+const ERRORS_TO_HIDE = [JavascriptProcessingErrors.JS_MISSING_SOURCE];
 
 const MAX_ERRORS = 100;
 const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH =
@@ -42,14 +44,6 @@ function isDataMinified(str: string | null) {
 
   return !![...str.matchAll(MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH)].length;
 }
-
-const getURLPathname = (url: string) => {
-  try {
-    return new URL(url).pathname;
-  } catch {
-    return undefined;
-  }
-};
 
 const hasThreadOrExceptionMinifiedFrameData = (
   definedEvent: Event,
@@ -189,28 +183,6 @@ const useFetchProguardMappingFiles = ({
   };
 };
 
-const useFetchReleaseArtifacts = ({event, project}: {event: Event; project: Project}) => {
-  const organization = useOrganization();
-  const releaseVersion = event.release?.version;
-  const pathNames = (event.errors ?? [])
-    .filter(
-      error =>
-        error.type === 'js_no_source' && error.data.url && getURLPathname(error.data.url)
-    )
-    .map(sourceCodeError => getURLPathname(sourceCodeError.data.url));
-  const {data: releaseArtifacts} = useQuery<Artifact[]>(
-    [
-      `/projects/${organization.slug}/${project.slug}/releases/${encodeURIComponent(
-        releaseVersion ?? ''
-      )}/files/`,
-      {query: {query: pathNames}},
-    ],
-    {staleTime: Infinity, enabled: pathNames.length > 0 && defined(releaseVersion)}
-  );
-
-  return releaseArtifacts;
-};
-
 const useRecordAnalyticsEvent = ({event, project}: {event: Event; project: Project}) => {
   const organization = useOrganization();
 
@@ -239,7 +211,6 @@ const useRecordAnalyticsEvent = ({event, project}: {event: Event; project: Proje
 export const EventErrors = ({event, project, isShare}: EventErrorsProps) => {
   const organization = useOrganization();
   useRecordAnalyticsEvent({event, project});
-  const releaseArtifacts = useFetchReleaseArtifacts({event, project});
   const {proguardErrorsLoading, proguardErrors} = useFetchProguardMappingFiles({
     event,
     project,
@@ -272,13 +243,15 @@ export const EventErrors = ({event, project, isShare}: EventErrorsProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const {dist: eventDistribution, errors: eventErrors = [], _meta} = event;
+  const {errors: eventErrors = [], _meta} = event;
 
   // XXX: uniqWith returns unique errors and is not performant with large datasets
   const otherErrors: Array<EventErrorData> =
     eventErrors.length > MAX_ERRORS ? eventErrors : uniqWith(eventErrors, isEqual);
 
-  const errors = [...otherErrors, ...proguardErrors];
+  const errors = [...otherErrors, ...proguardErrors].filter(
+    error => !ERRORS_TO_HIDE.includes(error.type as JavascriptProcessingErrors)
+  );
 
   if (proguardErrorsLoading) {
     // XXX: This is necessary for acceptance tests to wait until removal since there is
@@ -301,37 +274,6 @@ export const EventErrors = ({event, project, isShare}: EventErrorsProps) => {
             {errors.map((error, errorIdx) => {
               const data = error.data ?? {};
               const meta = _meta?.errors?.[errorIdx];
-
-              if (
-                error.type === JavascriptProcessingErrors.JS_MISSING_SOURCE &&
-                data.url &&
-                !!releaseArtifacts?.length
-              ) {
-                const releaseArtifact = releaseArtifacts.find(releaseArt => {
-                  const pathname = data.url ? getURLPathname(data.url) : undefined;
-
-                  if (pathname) {
-                    return releaseArt.name.includes(pathname);
-                  }
-                  return false;
-                });
-
-                const releaseArtifactDistribution = releaseArtifact?.dist ?? null;
-
-                // Neither event nor file have dist -> matching
-                // Event has dist, file doesn’t -> not matching
-                // File has dist, event doesn’t -> not matching
-                // Both have dist, same value -> matching
-                // Both have dist, different values -> not matching
-                if (releaseArtifactDistribution !== eventDistribution) {
-                  error.message = t(
-                    'Source code was not found because the distribution did not match'
-                  );
-                  data['expected-distribution'] = eventDistribution;
-                  data['current-distribution'] = releaseArtifactDistribution;
-                }
-              }
-
               return <ErrorItem key={errorIdx} error={{...error, data}} meta={meta} />;
             })}
           </ErrorList>


### PR DESCRIPTION
Now that we have the in-app source map debugging, we can hide the source map file not found error. Note there are other possible source map errors that we don't hide because they do provide additional information on top of the in-app source map debugging. But this is just a temporary state until we start using the debug ID strategy for sourcemaps. Once we have that in place, we will overhaul the instructions and hide more errors related to sourcemaps. 
![Screen Shot 2023-03-21 at 2 33 02 PM](https://user-images.githubusercontent.com/8533851/226746066-f42e553c-ad09-4990-aa37-119f6f15c121.png)
