### PR TITLE
chore(hybrid-cloud): Add outbox_runner to outbox tests

### DIFF
--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -19,7 +19,8 @@ from sentry.models import (
 from sentry.silo import SiloMode
 from sentry.tasks.deliver_from_outbox import enqueue_outbox_jobs
 from sentry.testutils.factories import Factories
-from sentry.testutils.silo import control_silo_test, region_silo_test
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits, region_silo_test
 from sentry.types.region import MONOLITH_REGION_NAME
 
 
@@ -29,6 +30,11 @@ def test_creating_org_outboxes():
     Organization.outbox_for_update(10).save()
     OrganizationMember.outbox_for_update(12, 15).save()
     assert RegionOutbox.objects.count() == 2
+
+    with exempt_from_silo_limits(), outbox_runner():
+        # drain outboxes
+        pass
+    assert RegionOutbox.objects.count() == 0
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
I've updated the outbox test for the **region** silo to ensure that `outbox_runner()` does drain the outboxes.

I'm unable to add a similar assert for the **control** silo test.