### PR TITLE
feat(db-issue): Add db docs to UI

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -63,6 +63,7 @@ export enum IssueType {
   PERFORMANCE_CONSECUTIVE_DB_QUERIES = 'performance_consecutive_db_queries',
   PERFORMANCE_CONSECUTIVE_HTTP = 'performance_consecutive_http',
   PERFORMANCE_FILE_IO_MAIN_THREAD = 'performance_file_io_main_thread',
+  PERFORMANCE_DB_MAIN_THREAD = 'performance_db_main_thread',
   PERFORMANCE_N_PLUS_ONE_API_CALLS = 'performance_n_plus_one_api_calls',
   PERFORMANCE_N_PLUS_ONE_DB_QUERIES = 'performance_n_plus_one_db_queries',
   PERFORMANCE_SLOW_DB_QUERY = 'performance_slow_db_query',

--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -63,8 +63,20 @@ const performanceConfig: IssueCategoryConfigMapping = {
       description: t('File IO operations on your main thread may lead to app hangs.'),
       links: [
         {
-          text: t('Sentry Docs: File IO on the Main Thread'),
-          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/main-thread-io/',
+          text: t('Sentry Docs: file IO on the Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/file-io-main-thread-io/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PERFORMANCE_DB_MAIN_THREAD]: {
+    resources: {
+      description: t('Database operations on your main thread may lead to app hangs.'),
+      links: [
+        {
+          text: t('Sentry Docs: database on the Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/db-main-thread-io/',
         },
       ],
       linksByPlatform: {},


### PR DESCRIPTION
- This adds database on main thread doc links to the UI
- Also updates the file io docs, since they'll be moving
- do not merge until https://github.com/getsentry/sentry-docs/pull/6507 is in
- Closes #46045 