### PR TITLE
fix(dynamic-sampling):Set low volume transaction boost default to True

### DIFF
--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -49,7 +49,7 @@ DEFAULT_BIASES: List[ActivatableBias] = [
     },
     {"id": RuleType.IGNORE_HEALTH_CHECKS_RULE.value, "active": True},
     {"id": RuleType.BOOST_KEY_TRANSACTIONS_RULE.value, "active": True},
-    {"id": RuleType.BOOST_LOW_VOLUME_TRANSACTIONS.value, "active": False},
+    {"id": RuleType.BOOST_LOW_VOLUME_TRANSACTIONS.value, "active": True},
 ]
 RESERVED_IDS = {
     RuleType.UNIFORM_RULE: 1000,

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1336,7 +1336,7 @@ class TestProjectDetailsDynamicSamplingBiases(TestProjectDetailsDynamicSamplingB
                 },
                 {"id": "ignoreHealthChecks", "active": True},
                 {"id": "boostKeyTransactions", "active": True},
-                {"id": "boostLowVolumeTransactions", "active": False},
+                {"id": "boostLowVolumeTransactions", "active": True},
             ]
 
     def test_get_dynamic_sampling_biases_with_previously_assigned_biases(self):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1363,7 +1363,7 @@ class TestProjectDetailsDynamicSamplingBiases(TestProjectDetailsDynamicSamplingB
                 },
                 {"id": "ignoreHealthChecks", "active": True},
                 {"id": "boostKeyTransactions", "active": True},
-                {"id": "boostLowVolumeTransactions", "active": False},
+                {"id": "boostLowVolumeTransactions", "active": True},
             ]
 
     def test_dynamic_sampling_bias_activation(self):


### PR DESCRIPTION

This PR sets the default for low volume transaction boosting to True