### PR TITLE
feat(sourcemaps): Remove bundles with the same bundle_id on upload

### DIFF
--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import IO, Callable, Dict, List, Optional, Tuple
 
 from django.db import models
+from django.db.models.signals import post_delete
 from django.utils import timezone
 from symbolic import SymbolicError, normalize_debug_id
 
@@ -71,6 +72,13 @@ class ArtifactBundle(Model):
             return release_artifact_bundle.release_name, release_artifact_bundle.dist_name
         except IndexError:
             return None, None
+
+
+def delete_file_for_artifact_bundle(instance, **kwargs):
+    instance.file.delete()
+
+
+post_delete.connect(delete_file_for_artifact_bundle, sender=ArtifactBundle)
 
 
 @region_silo_only_model

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -3,7 +3,7 @@ import logging
 from os import path
 from typing import List, Optional, Tuple
 
-from django.db import IntegrityError, router, transaction
+from django.db import IntegrityError, router
 from django.db.models import Q
 from symbolic import SymbolicError, normalize_debug_id
 
@@ -283,10 +283,7 @@ def _extract_debug_ids_from_manifest(
 
 
 def _remove_duplicate_artifact_bundles(except_id: int, bundle_id: str):
-    for artifact_bundle in ArtifactBundle.objects.filter(~Q(id=except_id), bundle_id=bundle_id):
-        with transaction.atomic():
-            artifact_bundle.delete()
-            artifact_bundle.file.delete()
+    ArtifactBundle.objects.filter(~Q(id=except_id), bundle_id=bundle_id).delete()
 
 
 def _create_artifact_bundle(

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -283,6 +283,8 @@ def _extract_debug_ids_from_manifest(
 
 
 def _remove_duplicate_artifact_bundles(except_id: int, bundle_id: str):
+    # Even though we delete via a QuerySet the associated file is also deleted, because django will still
+    # fire the on_delete signal.
     ArtifactBundle.objects.filter(~Q(id=except_id), bundle_id=bundle_id).delete()
 
 

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 
-from sentry.models import FileBlob, FileBlobOwner, ReleaseFile
+from sentry.models import File, FileBlob, FileBlobOwner, ReleaseFile
 from sentry.models.artifactbundle import (
     ArtifactBundle,
     DebugIdArtifactBundle,
@@ -289,6 +289,9 @@ class AssembleArtifactsTest(BaseAssembleTest):
 
         artifact_bundles = ArtifactBundle.objects.filter(bundle_id=bundle_id)
         assert len(artifact_bundles) == 1
+
+        files = File.objects.filter()
+        assert len(files) == 1
 
         debug_id_artifact_bundles = DebugIdArtifactBundle.objects.filter(debug_id=debug_id)
         # We have two entries, since we have multiple files in the artifact bundle.

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -218,7 +218,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
                 org_id=self.organization.id,
                 project_ids=[self.project.id],
                 version=version,
-                dist=version,
+                dist=dist,
                 checksum=total_checksum,
                 chunks=[blob1.checksum],
                 upload_as_artifact_bundle=True,
@@ -266,6 +266,41 @@ class AssembleArtifactsTest(BaseAssembleTest):
             DebugIdArtifactBundle.objects.all().delete()
             ReleaseArtifactBundle.objects.all().delete()
             ProjectArtifactBundle.objects.all().delete()
+
+    def test_upload_multiple_artifact_with_same_bundle_id(self):
+        bundle_file = self.create_artifact_bundle_zip(
+            fixture_path="artifact_bundle_debug_ids", project=self.project.id
+        )
+        blob1 = FileBlob.from_file(ContentFile(bundle_file))
+        total_checksum = sha1(bundle_file).hexdigest()
+        bundle_id = "67429b2f-1d9e-43bb-a626-771a1e37555c"
+        debug_id = "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
+
+        for i in range(0, 3):
+            assemble_artifacts(
+                org_id=self.organization.id,
+                project_ids=[self.project.id],
+                version="1.0",
+                dist="android",
+                checksum=total_checksum,
+                chunks=[blob1.checksum],
+                upload_as_artifact_bundle=True,
+            )
+
+        artifact_bundles = ArtifactBundle.objects.filter(bundle_id=bundle_id)
+        assert len(artifact_bundles) == 1
+
+        debug_id_artifact_bundles = DebugIdArtifactBundle.objects.filter(debug_id=debug_id)
+        # We have two entries, since we have multiple files in the artifact bundle.
+        assert len(debug_id_artifact_bundles) == 2
+
+        release_artifact_bundle = ReleaseArtifactBundle.objects.filter(
+            release_name="1.0", dist_name="android"
+        )
+        assert len(release_artifact_bundle) == 1
+
+        release_artifact_bundle = ProjectArtifactBundle.objects.filter(project_id=self.project.id)
+        assert len(release_artifact_bundle) == 1
 
     def test_artifacts_without_debug_ids(self):
         bundle_file = self.create_artifact_bundle_zip(


### PR DESCRIPTION
This PR adds the logic to remove existing bundles with the same `bundle_id`.