### PR TITLE
ref(derived_code_mappings): Report error when API response is not empty

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -376,6 +376,7 @@ class GitHubClientMixin(ApiClient):  # type: ignore
             resp = self.get(path, params={"per_page": self.page_size})
             logger.info(resp)
             output.extend(resp) if not response_key else output.extend(resp[response_key])
+            next_link = get_next_link(resp)
 
             # XXX: Debugging code; remove afterward
             if (
@@ -386,16 +387,18 @@ class GitHubClientMixin(ApiClient):  # type: ignore
             ):
                 logger.info(f"headers: {resp.headers}")
                 logger.info(f"output: {output}")
+                logger.info(f"next_link: {next_link}")
                 logger.error("No list of repos even when there's some. Investigate.")
 
             # XXX: In order to speed up this function we will need to parallelize this
             # Use ThreadPoolExecutor; see src/sentry/utils/snuba.py#L358
-            while get_next_link(resp) and page_number < page_number_limit:
-                new_path = get_next_link(resp)
-                logger.info(f"Page {page_number}: {new_path}")
-                resp = self.get(new_path)
+            while next_link and page_number < page_number_limit:
+                resp = self.get(next_link)
                 logger.info(resp)
                 output.extend(resp) if not response_key else output.extend(resp[response_key])
+
+                next_link = get_next_link(resp)
+                logger.info(f"Page {page_number}: {next_link}")
                 page_number += 1
             return output
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -178,7 +178,8 @@ class GitHubClientMixin(ApiClient):  # type: ignore
         repositories = self._populate_repositories(gh_org, cache_seconds)
         extra.update({"repos_num": str(len(repositories))})
         trees = self._populate_trees(repositories)
-        logger.info("Using cached trees for Github org.", extra=extra)
+        if trees:
+            logger.info("Using cached trees for Github org.", extra=extra)
 
         try:
             rate_limit = self.get_rate_limit()
@@ -376,11 +377,22 @@ class GitHubClientMixin(ApiClient):  # type: ignore
             logger.info(resp)
             output.extend(resp) if not response_key else output.extend(resp[response_key])
 
+            # XXX: Debugging code; remove afterward
+            if (
+                response_key
+                and response_key == "repositories"
+                and resp["total_count"] > 0
+                and not output
+            ):
+                logger.info(f"headers: {resp.headers}")
+                logger.info(f"output: {output}")
+                logger.error("No list of repos even when there's some. Investigate.")
+
             # XXX: In order to speed up this function we will need to parallelize this
             # Use ThreadPoolExecutor; see src/sentry/utils/snuba.py#L358
             while get_next_link(resp) and page_number < page_number_limit:
                 new_path = get_next_link(resp)
-                logger.info(f"Page {page_number}: {path}")
+                logger.info(f"Page {page_number}: {new_path}")
                 resp = self.get(new_path)
                 logger.info(resp)
                 output.extend(resp) if not response_key else output.extend(resp[response_key])

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -112,8 +112,14 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
     def get_trees_for_org(self, cache_seconds: int = 3600 * 24) -> Dict[str, RepoTree]:
         trees: Dict[str, RepoTree] = {}
-        gh_org = self.model.metadata["domain_name"].split("github.com/")[1]
-        extra = {"gh_org": gh_org, "metadata": self.model.metadata}
+        domain_name = self.model.metadata["domain_name"]
+        extra = {"metadata": self.model.metadata}
+        if domain_name.find("github.com/") == -1:
+            logger.warning("We currently only support github.com domains.", extra=extra)
+            return trees
+
+        gh_org = domain_name.split("github.com/")[1]
+        extra.update({"gh_org": gh_org})
         organization_context = organization_service.get_organization_by_id(
             id=self.org_integration.organization_id, user_id=None
         )

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import calendar
 import datetime
+import logging
 import time
 
 from rest_framework.response import Response
 
 from sentry import options
 from sentry.utils import jwt
+
+logger = logging.getLogger(__name__)
 
 
 def get_jwt(github_id: str | None = None, github_private_key: str | None = None) -> str:
@@ -30,12 +33,15 @@ def get_jwt(github_id: str | None = None, github_private_key: str | None = None)
 
 
 def get_next_link(response: Response) -> str | None:
-    """Github uses a link header to inform pagination.
+    """Github uses a `link` header to inform pagination.
     The relation parameter can be prev, next, first or last
-    e.g. <https://api.github.com/organizations/1396951/repos?per_page=100&page=1>; rel="first"
+
+    Read more here:
+    https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers
     """
     link_option: str | None = response.headers.get("link")
     if link_option is None:
+        logger.info("There are no pages to iterate on.")
         return None
 
     # Should be a comma separated string of links

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -127,7 +127,7 @@ def derive_code_mappings(
         return
 
     if not trees:
-        logger.error("The tree is empty. Investigate.")
+        logger.warning("The trees are empty.")
         return
 
     trees_helper = CodeMappingTreesHelper(trees)

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -178,6 +178,18 @@ class GitHubAppsClientTest(TestCase):
         assert len(responses.calls) == 5
         assert responses.calls[1].response.status_code == 200
 
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_only_one_page(self, get_jwt):
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.client.page_size}"
+
+        # No link in the headers because there are no more pages
+        responses.add(method=responses.GET, url=url, json={}, headers={})
+        self.client.get_with_pagination(f"/repos/{self.repo.name}/assignees")
+        # One call is for getting the token for the installation
+        assert len(responses.calls) == 2
+        assert responses.calls[1].response.status_code == 200
+
     @mock.patch(
         "sentry.integrations.github.integration.GitHubIntegration.check_file",
         return_value=GITHUB_CODEOWNERS["html_url"],

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -231,10 +231,11 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase):
             responses.GET,
             "https://api.github.com/installation/repositories",
             json={
+                "total_count": 2,
                 "repositories": [
                     {"full_name": "getsentry/sentry", "name": "sentry"},
                     {"full_name": "getsentry/other", "name": "other", "archived": True},
-                ]
+                ],
             },
         )
 
@@ -300,7 +301,10 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/installation/repositories",
-            json={"repositories": [{"name": "sentry", "full_name": "getsentry/sentry"}]},
+            json={
+                "total_count": 1,
+                "repositories": [{"name": "sentry", "full_name": "getsentry/sentry"}],
+            },
         )
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
@@ -325,7 +329,10 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/installation/repositories",
-            json={"repositories": [{"name": "sentry", "full_name": "getsentry/sentry"}]},
+            json={
+                "total_count": 1,
+                "repositories": [{"name": "sentry", "full_name": "getsentry/sentry"}],
+            },
         )
         responses.add(
             responses.GET,
@@ -362,7 +369,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/installation/repositories",
-            json={"repositories": []},
+            json={"total_count": 0, "repositories": []},
         )
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
@@ -378,7 +385,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/installation/repositories",
-            json={"repositories": []},
+            json={"total_count": 0, "repositories": []},
         )
         responses.add(
             responses.POST,


### PR DESCRIPTION
Getting repositories sometimes may be empty even if the count of repositories is greater than 0.

This change reduces the number of reported errors to when there's at least a single repository.

This fixes [SENTRY-YKB](https://sentry.sentry.io/issues/3915004865) just because a new error will be produced with a subset of all errors.