### PR TITLE
fix(perf-issues): Accept sanitized span descriptions

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -187,8 +187,10 @@ def get_url_from_span(span: Span) -> str:
         return url
 
     if type(url_data) is str:
-        # But usually the URL is a regular string, and so is the query. If
-        # `http.query` is absent, `url` contains the query
+        # Usually the URL is a regular string, and so is the query. This
+        # is the standardized format for all SDKs, and is the preferred
+        # format going forward. Otherwise, if `http.query` is absent, `url`
+        # contains the query.
         url = url_data
         query_data = data.get("http.query")
         if type(query_data) is str and len(query_data) > 0:

--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -167,19 +167,44 @@ def get_duration_between_spans(first_span: Span, second_span: Span):
 
 
 def get_url_from_span(span: Span) -> str:
+    """
+    Parses the span data and pulls out the URL. Accounts for different SDKs and
+    different versions of SDKs formatting and parsing the URL contents
+    differently.
+    """
+
     data = span.get("data") or {}
-    url = data.get("url") or ""
-    if not url:
-        # If data is missing, fall back to description
-        description = span.get("description") or ""
-        parts = description.split(" ", 1)
-        if len(parts) == 2:
-            url = parts[1]
 
-    if type(url) is dict:
-        url = url.get("pathname") or ""
+    # The most modern and version is to provide URL information in the span
+    # data
+    url_data = data.get("url")
 
-    return url
+    if type(url_data) is dict:
+        # Some transactions mysteriously provide the URL as a dict that looks
+        # like JavaScript's URL object
+        url = url_data.get("pathname") or ""
+        url += url_data.get("search") or ""
+        return url
+
+    if type(url_data) is str:
+        # But usually the URL is a regular string, and so is the query. If
+        # `http.query` is absent, `url` contains the query
+        url = url_data
+        query_data = data.get("http.query")
+        if type(query_data) is str and len(query_data) > 0:
+            url += f"?{query_data}"
+
+        return url
+
+    # Attempt to parse the full URL from the span description, in case
+    # the previous approaches did not yield a good result
+    description = span.get("description") or ""
+    parts = description.split(" ", 1)
+    if len(parts) == 2:
+        url = parts[1]
+        return url
+
+    return ""
 
 
 def fingerprint_spans(spans: List[Span], unique_only: bool = False):

--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -175,7 +175,7 @@ def get_url_from_span(span: Span) -> str:
 
     data = span.get("data") or {}
 
-    # The most modern and version is to provide URL information in the span
+    # The most modern version is to provide URL information in the span
     # data
     url_data = data.get("url")
 

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -157,10 +157,12 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if description.strip()[:3].upper() != "GET":
             return False
 
+        url = get_url_from_span(span)
+
         # GraphQL URLs have complicated queries in them. Until we parse those
         # queries to check for what's duplicated, we can't tell what is being
         # duplicated. Ignore them for now
-        if "graphql" in description:
+        if "graphql" in url:
             return False
 
         # Next.js infixes its data URLs with a build ID. (e.g.,
@@ -168,10 +170,8 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         # explosion, since every deploy would change this ID and create new
         # fingerprints. Since we're not parameterizing URLs yet, we need to
         # exclude them
-        if "_next/data" in description:
+        if "_next/data" in url:
             return False
-
-        url = get_url_from_span(span)
 
         # Next.js error pages cause an N+1 API Call that isn't useful to anyone
         if "__nextjs_original-stack-frame" in url:
@@ -180,6 +180,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if not url:
             return False
 
+        # Once most users update their SDKs to use the latest standard, we
+        # won't have to do this, since the URLs will be sent in as `span.data`
+        # in a parsed format
         parsed_url = urlparse(str(url))
 
         if parsed_url.netloc in cls.HOST_DENYLIST:

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -343,7 +343,7 @@ def test_allows_eligible_spans(span):
         {
             "span_id": "a",
             "op": "http.client",
-            "description": "GET http://service.io/resource",
+            "description": "GET /resource.js",
             "hash": "a",
             "data": {"url": "/resource.js"},
         },
@@ -360,7 +360,7 @@ def test_allows_eligible_spans(span):
             "hash": "a",
             "data": {
                 "http.query": "graphql=somequery",
-                "url": "http://service.io",
+                "url": "http://service.io/resource",
             },
         },
         {

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -356,6 +356,16 @@ def test_allows_eligible_spans(span):
         {
             "span_id": "a",
             "op": "http.client",
+            "description": "GET http://service.io/resource",  # New JS SDK removes query string from description
+            "hash": "a",
+            "data": {
+                "http.query": "graphql=somequery",
+                "url": "http://service.io",
+            },
+        },
+        {
+            "span_id": "a",
+            "op": "http.client",
             "hash": "b",
             "description": "GET /_next/data/LjdprRSkUtLP0bMUoWLur/items.json?collection=hello",
         },


### PR DESCRIPTION
As of https://github.com/getsentry/sentry-javascript/pull/7206 the Node.js SDK will not append search parameters to the span's description or the URL. Instead, the search parameters will be in the `http.query` key. e.g.,

```json
{
  "span_id": "a",
  "op": "http.client",
  "description": "GET /service",
  "http.query": "id=223"
}
```

This improves our URL handling to anticipate this case on the backend.
