### PR TITLE
fix(n1-api-call): Properly parse sanitized span descriptions

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -385,10 +385,10 @@ describe('SpanEvidenceKeyValueList', () => {
           extractSpanURLString({
             span_id: 'a',
             data: {
-              url: 'http://service.io',
+              url: 'http://service.io?id=2543',
             },
           })?.toString()
-        ).toEqual('http://service.io/');
+        ).toEqual('http://service.io/?id=2543');
       });
 
       it('Pulls out a relative URL if a base is provided', () => {
@@ -403,6 +403,19 @@ describe('SpanEvidenceKeyValueList', () => {
             'http://service.io'
           )?.toString()
         ).toEqual('http://service.io/item');
+      });
+
+      it('Fetches the query string from the span data if available', () => {
+        expect(
+          extractSpanURLString({
+            span_id: 'a',
+            description: 'GET http://service.io/item',
+            data: {
+              url: 'http://service.io/item',
+              'http.query': 'id=153',
+            },
+          })?.toString()
+        ).toEqual('http://service.io/item?id=153');
       });
 
       it('Falls back to span description if URL is faulty', () => {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -477,13 +477,23 @@ function formatChangingQueryParameters(spans: Span[], baseURL?: string): string[
   return pairs;
 }
 
+/** Parses the span data and pulls out the URL. Accounts for different SDKs and
+     different versions of SDKs formatting and parsing the URL contents
+     differently. Mirror of `get_url_from_span`. Ideally, this should not exist,
+     and instead it should use the data provided by the backend */
 export const extractSpanURLString = (span: Span, baseURL?: string): URL | null => {
   let URLString;
 
   URLString = span?.data?.url;
   if (URLString) {
     try {
-      return new URL(span?.data?.url, baseURL);
+      let url = span?.data?.url ?? '';
+      const query = span?.data?.['http.query'];
+      if (query) {
+        url += `?${query}`;
+      }
+
+      return new URL(url, baseURL);
     } catch (e) {
       // Ignore error
     }


### PR DESCRIPTION
This is an FE aspect of #46187. For N+1 API Call performance issues, we need to parse the URLs and extract the query parameters. With newer SDK versions, the query parameters might be in a separate key in span data called `http.query`, rather than being appended to the description or the `url` key in span data. Related to https://github.com/getsentry/sentry-javascript/pull/7206. Updates the URL parsing helper to anticipate this situation.
