### PR TITLE
test(ui): Prevent click hover flake in `stream/group.spec.jsx`

### DIFF
--- a/static/app/components/stream/group.spec.jsx
+++ b/static/app/components/stream/group.spec.jsx
@@ -94,7 +94,8 @@ describe('StreamGroup', function () {
       {context: routerContext, organization}
     );
 
-    await userEvent.click(screen.getByText('RequestError'));
+    // skipHover - Prevent stacktrace preview from being rendered
+    await userEvent.click(screen.getByText('RequestError'), {skipHover: true});
     expect(trackAdvancedAnalyticsEvent).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Skip hover in the click action

prevents `No mocked response found for request: GET /issues/1337/events/latest/?collapse=stacktraceOnly` https://github.com/getsentry/sentry/actions/runs/4491256351/jobs/7899476334
