### PR TITLE
feat(profiling): link to profile from aggregate flamegraph

### DIFF
--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -11,12 +12,35 @@ import {space} from 'sentry/styles/space';
 import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
 import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 
 export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
   const {data, isLoading} = useAggregateFlamegraphQuery({transaction});
+  const {
+    selection: {projects},
+  } = usePageFilters();
 
   const isEmpty = data?.shared.frames.length === 0;
+
+  const profileGroupInput = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+
+    // TODO: this is a hack and should be coming from `vroom`
+    // without this our contextMenu links don't work
+    const profileGroupWithprofileId: Profiling.Schema = {
+      ...data,
+      metadata: {
+        ...data.metadata,
+        // without this our contextMenu links don't work
+        projectID: projects[0],
+      },
+    };
+
+    return profileGroupWithprofileId;
+  }, [data, projects]);
   return (
     <Flex column gap={space(1)}>
       <Flex align="center" gap={space(0.5)}>
@@ -37,7 +61,7 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
           }
         />
       </Flex>
-      <ProfileGroupProvider type="flamegraph" input={data ?? null} traceID="">
+      <ProfileGroupProvider type="flamegraph" input={profileGroupInput} traceID="">
         <FlamegraphStateProvider
           initialState={{
             preferences: {

--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -1,4 +1,3 @@
-import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -12,35 +11,13 @@ import {space} from 'sentry/styles/space';
 import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
 import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 
 export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
   const {data, isLoading} = useAggregateFlamegraphQuery({transaction});
-  const {
-    selection: {projects},
-  } = usePageFilters();
 
   const isEmpty = data?.shared.frames.length === 0;
 
-  const profileGroupInput = useMemo(() => {
-    if (!data) {
-      return null;
-    }
-
-    // TODO: this is a hack and should be coming from `vroom`
-    // without this our contextMenu links don't work
-    const profileGroupWithprofileId: Profiling.Schema = {
-      ...data,
-      metadata: {
-        ...data.metadata,
-        // without this our contextMenu links don't work
-        projectID: projects[0],
-      },
-    };
-
-    return profileGroupWithprofileId;
-  }, [data, projects]);
   return (
     <Flex column gap={space(1)}>
       <Flex align="center" gap={space(0.5)}>
@@ -61,7 +38,7 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
           }
         />
       </Flex>
-      <ProfileGroupProvider type="flamegraph" input={profileGroupInput} traceID="">
+      <ProfileGroupProvider type="flamegraph" input={data ?? null} traceID="">
         <FlamegraphStateProvider
           initialState={{
             preferences: {

--- a/static/app/components/profiling/profilingContextMenu.tsx
+++ b/static/app/components/profiling/profilingContextMenu.tsx
@@ -24,8 +24,9 @@ const Menu = styled(
   box-shadow: ${p => p.theme.dropShadowHeavy};
   width: auto;
   min-width: 164px;
-  overflow: auto;
   padding-bottom: ${space(0.5)};
+  overflow: auto;
+  overflow-x: hidden;
 `;
 
 export {Menu as ProfilingContextMenu};
@@ -123,7 +124,8 @@ const MenuButton = styled('button')`
   pointer-events: ${p => (p.disabled ? 'none' : undefined)};
   opacity: ${p => (p.disabled ? 0.7 : undefined)};
 
-  &:focus {
+  &:focus,
+  &:hover {
     color: ${p => p.theme.textColor};
     background: ${p => p.theme.hover};
     outline: none;

--- a/static/app/components/profiling/profilingContextMenu.tsx
+++ b/static/app/components/profiling/profilingContextMenu.tsx
@@ -24,9 +24,8 @@ const Menu = styled(
   box-shadow: ${p => p.theme.dropShadowHeavy};
   width: auto;
   min-width: 164px;
-  padding-bottom: ${space(0.5)};
   overflow: auto;
-  overflow-x: hidden;
+  padding-bottom: ${space(0.5)};
 `;
 
 export {Menu as ProfilingContextMenu};
@@ -124,8 +123,7 @@ const MenuButton = styled('button')`
   pointer-events: ${p => (p.disabled ? 'none' : undefined)};
   opacity: ${p => (p.disabled ? 0.7 : undefined)};
 
-  &:focus,
-  &:hover {
+  &:focus {
     color: ${p => p.theme.textColor};
     background: ${p => p.theme.hover};
     outline: none;

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {clamp} from 'sentry/utils/profiling/colors/utils';
 import {Rect} from 'sentry/utils/profiling/speedscope';
@@ -36,6 +36,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
   const [containerCoordinates, setContainerCoordinates] = useState<Rect | null>(null);
 
   const itemProps = useKeyboardNavigation();
+  const subMenuRef = useRef<HTMLElement | null>(null);
 
   // We wrap the setOpen function in a useEffect so that we also clear the keyboard
   // tabIndex when a menu is closed. This prevents tabIndex from being persisted between render
@@ -64,11 +65,17 @@ export function useContextMenu({container}: UseContextMenuOptions) {
   }, [itemProps, wrapSetOpen]);
 
   const getMenuItemProps = useCallback(
-    ({onClick}: {onClick?: () => void} = {}) => {
+    ({onClick, ref}: {onClick?: () => void; ref?: (node: any) => void} = {}) => {
       const menuItemProps = itemProps.getItemProps();
 
       return {
         ...menuItemProps,
+        ref: (node: any) => {
+          if (ref) {
+            ref(node);
+          }
+          menuItemProps.ref(node);
+        },
         onClick: (evt: React.MouseEvent) => {
           evt.preventDefault();
           onClick?.();
@@ -113,7 +120,11 @@ export function useContextMenu({container}: UseContextMenuOptions) {
   useEffect(() => {
     const listener = (event: MouseEvent | TouchEvent) => {
       // Do nothing if clicking ref's element or descendent elements
-      if (!itemProps.menuRef || itemProps.menuRef.contains(event.target as Node)) {
+      if (
+        !itemProps.menuRef ||
+        itemProps.menuRef.contains(event.target as Node) ||
+        (subMenuRef.current && subMenuRef.current?.contains(event.target as Node))
+      ) {
         return;
       }
 
@@ -180,6 +191,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
     containerCoordinates,
     contextMenuCoordinates: position,
     menuRef: itemProps.menuRef,
+    subMenuRef,
     handleContextMenu,
     getMenuProps,
     getMenuItemProps,


### PR DESCRIPTION
## Summary
Adds the ability to click into a flamechart from the flamegraph context menu.


![image](https://user-images.githubusercontent.com/7349258/226989102-6a2e4f4f-6d6a-4331-a2d7-43161415976c.png)

https://user-images.githubusercontent.com/7349258/226989030-f7883bc0-c1a0-415d-a418-b2d9cc95abb5.mov

