### PR TITLE
feat: add flamegraph tooltip header

### DIFF
--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -24,9 +24,6 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
         <QuestionTooltip
           size="sm"
           position="right"
-          overlayStyle={{
-            textAlign: 'unset',
-          }}
           isHoverable
           title={
             <TooltipContent>
@@ -77,6 +74,9 @@ export const HeaderTitle = styled('span')`
 `;
 
 export const TooltipContent = styled('div')`
+  & p {
+    text-align: left;
+  }
   & p:last-child {
     margin-bottom: 0;
   }

--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -5,7 +5,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
 import {Flex} from 'sentry/components/profiling/flex';
-import {Tooltip} from 'sentry/components/tooltip';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
@@ -19,27 +19,27 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
   const isEmpty = data?.shared.frames.length === 0;
   return (
     <Flex column gap={space(1)}>
-      <Flex.Item>
-        <Tooltip
-          showUnderline
+      <Flex align="center" gap={space(0.5)}>
+        <HeaderTitle>{t('Flamegraph')}</HeaderTitle>
+        <QuestionTooltip
+          size="sm"
+          position="right"
           overlayStyle={{
             textAlign: 'unset',
           }}
           isHoverable
           title={
-            <div>
+            <TooltipContent>
               <p>{t('An aggregate of profiles for this transaction.')}</p>
               <p>
                 {t(
                   'Navigate the flamegraph by scrolling and by double clicking a frame to zoom.'
                 )}
               </p>
-            </div>
+            </TooltipContent>
           }
-        >
-          <HeaderTitle>{t('Flamegraph (?)')}</HeaderTitle>
-        </Tooltip>
-      </Flex.Item>
+        />
+      </Flex>
       <ProfileGroupProvider type="flamegraph" input={data ?? null} traceID="">
         <FlamegraphStateProvider
           initialState={{
@@ -70,11 +70,14 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
   );
 }
 
-export const HeaderTitle = styled('div')`
+export const HeaderTitle = styled('span')`
   ${p => p.theme.text.cardTitle};
   color: ${p => p.theme.headingColor};
-  font-size: ${p => p.theme.fontSizeSmall};
-  /* text-decoration: underline dotted; */
-  /* text-underline-offset: ${space(0.25)}; */
-  cursor: pointer;
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+export const TooltipContent = styled('div')`
+  & p:last-child {
+    margin-bottom: 0;
+  }
 `;

--- a/static/app/components/profiling/aggregateFlamegraphPanel.tsx
+++ b/static/app/components/profiling/aggregateFlamegraphPanel.tsx
@@ -1,9 +1,13 @@
+import styled from '@emotion/styled';
+
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels';
 import {AggregateFlamegraph} from 'sentry/components/profiling/flamegraph/aggregateFlamegraph';
 import {Flex} from 'sentry/components/profiling/flex';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {FlamegraphStateProvider} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider';
 import {FlamegraphThemeProvider} from 'sentry/utils/profiling/flamegraph/flamegraphThemeProvider';
 import {useAggregateFlamegraphQuery} from 'sentry/utils/profiling/hooks/useAggregateFlamegraphQuery';
@@ -14,31 +18,63 @@ export function AggregateFlamegraphPanel({transaction}: {transaction: string}) {
 
   const isEmpty = data?.shared.frames.length === 0;
   return (
-    <ProfileGroupProvider type="flamegraph" input={data ?? null} traceID="">
-      <FlamegraphStateProvider
-        initialState={{
-          preferences: {
-            sorting: 'alphabetical',
-            view: 'bottom up',
-          },
-        }}
-      >
-        <FlamegraphThemeProvider>
-          <Panel>
-            <Flex h={400} column justify="center">
-              {isLoading ? (
-                <LoadingIndicator>{t('Loading Flamegraph')}</LoadingIndicator>
-              ) : isEmpty ? (
-                <EmptyStateWarning>
-                  <p>{t(`A flamegraph isn't available for your query`)}</p>
-                </EmptyStateWarning>
-              ) : (
-                <AggregateFlamegraph />
-              )}
-            </Flex>
-          </Panel>
-        </FlamegraphThemeProvider>
-      </FlamegraphStateProvider>
-    </ProfileGroupProvider>
+    <Flex column gap={space(1)}>
+      <Flex.Item>
+        <Tooltip
+          showUnderline
+          overlayStyle={{
+            textAlign: 'unset',
+          }}
+          isHoverable
+          title={
+            <div>
+              <p>{t('An aggregate of profiles for this transaction.')}</p>
+              <p>
+                {t(
+                  'Navigate the flamegraph by scrolling and by double clicking a frame to zoom.'
+                )}
+              </p>
+            </div>
+          }
+        >
+          <HeaderTitle>{t('Flamegraph (?)')}</HeaderTitle>
+        </Tooltip>
+      </Flex.Item>
+      <ProfileGroupProvider type="flamegraph" input={data ?? null} traceID="">
+        <FlamegraphStateProvider
+          initialState={{
+            preferences: {
+              sorting: 'alphabetical',
+              view: 'bottom up',
+            },
+          }}
+        >
+          <FlamegraphThemeProvider>
+            <Panel>
+              <Flex h={400} column justify="center">
+                {isLoading ? (
+                  <LoadingIndicator>{t('Loading Flamegraph')}</LoadingIndicator>
+                ) : isEmpty ? (
+                  <EmptyStateWarning>
+                    <p>{t(`A flamegraph isn't available for your query`)}</p>
+                  </EmptyStateWarning>
+                ) : (
+                  <AggregateFlamegraph />
+                )}
+              </Flex>
+            </Panel>
+          </FlamegraphThemeProvider>
+        </FlamegraphStateProvider>
+      </ProfileGroupProvider>
+    </Flex>
   );
 }
+
+export const HeaderTitle = styled('div')`
+  ${p => p.theme.text.cardTitle};
+  color: ${p => p.theme.headingColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  /* text-decoration: underline dotted; */
+  /* text-underline-offset: ${space(0.25)}; */
+  cursor: pointer;
+`;


### PR DESCRIPTION
# Summary

Adds a flamegraph tooltip header. 
Closes: https://github.com/getsentry/sentry/pull/46216 

![image](https://user-images.githubusercontent.com/7349258/227029273-d3b41104-0b76-46e5-b10c-ae1335bf7ba9.png)


I recommend reviewing this one w/ whitespace hidden 
![image](https://user-images.githubusercontent.com/7349258/227007849-5e565a3a-fbb5-44f4-9f5b-222f598fbb97.png)
