### PR TITLE
test(ui): Use `queryBy` in wait for element to be removed

### DIFF
--- a/static/app/components/dropdownLink.spec.tsx
+++ b/static/app/components/dropdownLink.spec.tsx
@@ -83,7 +83,7 @@ describe('DropdownLink', function () {
         // Click outside
         await userEvent.click(screen.getByTestId('outside-element'), {delay: null});
 
-        await waitForElementToBeRemoved(() => screen.getByText('hi'));
+        await waitForElementToBeRemoved(() => screen.queryByText('hi'));
       });
 
       it('closes when dropdown actor button is clicked', async function () {

--- a/static/app/views/issueDetails/groupMerged/index.spec.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.spec.tsx
@@ -95,7 +95,7 @@ describe('Issues -> Merged View', function () {
       {context: routerContext}
     );
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(container).toSnapshot();
   });

--- a/static/app/views/issueList/savedIssueSearches.spec.tsx
+++ b/static/app/views/issueList/savedIssueSearches.spec.tsx
@@ -260,7 +260,7 @@ describe('SavedIssueSearches', function () {
     render(<SavedIssueSearches {...defaultProps} />);
     renderGlobalModal();
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     await userEvent.click(
       screen.getByRole('button', {name: /create a new saved search/i})
@@ -288,6 +288,6 @@ describe('SavedIssueSearches', function () {
     });
 
     // Modal should close
-    await waitForElementToBeRemoved(() => screen.getByRole('dialog'));
+    await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
   });
 });

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -317,7 +317,7 @@ describe('Performance > Landing > Index', function () {
 
       render(<WrappedComponent data={data} withStaticFilters />, data.routerContext);
 
-      await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+      await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
       await userEvent.type(screen.getByPlaceholderText('Search Transactions'), '{enter}');
       expect(searchHandlerMock).toHaveBeenCalledWith('', 'transactionsOnly');
     });

--- a/static/app/views/settings/project/projectKeys/list/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.jsx
@@ -100,7 +100,7 @@ describe('ProjectKeys', function () {
     await userEvent.click(screen.getByRole('button', {name: 'Disable'}));
     await userEvent.click(screen.getByTestId('confirm-button'));
 
-    await waitForElementToBeRemoved(() => screen.getByRole('dialog'));
+    await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
 
     expect(enableMock).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -122,7 +122,7 @@ function renderGlobalModal(options?: Options) {
    * wait for the modal to be removed to avoid any act warnings.
    */
   function waitForModalToHide() {
-    return rtl.waitForElementToBeRemoved(() => rtl.screen.getByRole('dialog'));
+    return rtl.waitForElementToBeRemoved(() => rtl.screen.queryByRole('dialog'));
   }
 
   return {...result, waitForModalToHide};


### PR DESCRIPTION
This prevents some flakes because getBy throws an error if the element doesn't exist. 
For example - Loading indicators may have already disappeared causing the getBy to error.

example https://github.com/getsentry/sentry/actions/runs/4494022966/jobs/7905991074?pr=46220