### PR TITLE
chore(proguard): Add span to all proguard mapping open

### DIFF
--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -33,7 +33,7 @@ def get_proguard_images(event: Event):
 
 
 def get_proguard_mapper(uuid: str, project: Project):
-    with sentry_sdk.start_span(op="proguard.get_proguard_mapper") as span:
+    with sentry_sdk.start_span(op="proguard.fetch_debug_files") as span:
         dif_paths = ProjectDebugFile.difcache.fetch_difs(project, [uuid], features=["mapping"])
         debug_file_path = dif_paths.get(uuid)
         if debug_file_path is None:
@@ -46,7 +46,9 @@ def get_proguard_mapper(uuid: str, project: Project):
             sentry_sdk.capture_exception(exc)
             return
 
+    with sentry_sdk.start_span(op="proguard.open"):
         mapper = ProguardMapper.open(debug_file_path)
+
     if not mapper.has_line_info:
         return
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -469,7 +469,7 @@ def _deobfuscate(profile: Profile, project: Project) -> None:
     if debug_file_id is None or debug_file_id == "":
         return
 
-    with sentry_sdk.start_span(op="task.profiling.deobfuscate.fetch_difs"):
+    with sentry_sdk.start_span(op="proguard.fetch_debug_files"):
         dif_paths = ProjectDebugFile.difcache.fetch_difs(
             project, [debug_file_id], features=["mapping"]
         )
@@ -477,12 +477,12 @@ def _deobfuscate(profile: Profile, project: Project) -> None:
         if debug_file_path is None:
             return
 
-    with sentry_sdk.start_span(op="task.profiling.deobfuscate.open_mapper"):
+    with sentry_sdk.start_span(op="proguard.open"):
         mapper = ProguardMapper.open(debug_file_path)
         if not mapper.has_line_info:
             return
 
-    with sentry_sdk.start_span(op="task.profiling.deobfuscate.remap"):
+    with sentry_sdk.start_span(op="proguard.remap"):
         for method in profile["profile"]["methods"]:
             mapped = mapper.remap_frame(
                 method["class_name"], method["name"], method["source_line"] or 0


### PR DESCRIPTION
We're looking to establish a baseline for existing proguard mapping calls. This adds a span to all the calls to `ProguardMapper.open` in preparation for getsentry/rust-proguard#26 which aims to improve the performance by 15-30%.