### PR TITLE
chore(metric alerts): Add logging for v2

### DIFF
--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -164,7 +164,7 @@ def handle_message(
                     # XXX(ahmed): Remove this logic. This was kept here as backwards compat
                     # for subscription updates with schema version `2`. However schema version 3
                     # sends the "entity" in the payload
-                    logger.info("Message value using version 2")
+                    logger.warn("Message value using version 2")
                     entity_regex = r"^(MATCH|match)[ ]*\(([^)]+)\)"
                     entity_match = re.match(entity_regex, contents["request"]["query"])
                     if not entity_match:

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -164,6 +164,7 @@ def handle_message(
                     # XXX(ahmed): Remove this logic. This was kept here as backwards compat
                     # for subscription updates with schema version `2`. However schema version 3
                     # sends the "entity" in the payload
+                    logger.info("Message value using version 2")
                     entity_regex = r"^(MATCH|match)[ ]*\(([^)]+)\)"
                     entity_match = re.match(entity_regex, contents["request"]["query"])
                     if not entity_match:


### PR DESCRIPTION
Add logging to see if we ever hit this code block - based on the comment and [this](https://github.com/getsentry/snuba/blob/1f92bcbe9e6919468546fc8d9194ae2186d89429/snuba/subscriptions/codecs.py#L37) I don't believe we do, and if not, I can remove some special handling. 