### PR TITLE
fix(discover): Always use group_id as a tag when queried

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -630,11 +630,19 @@ class QueryBuilder(BaseQueryBuilder):
         for column in stripped_columns:
             if column == "":
                 continue
-            # need to make sure the column is resolved with the appropriate alias
-            # because the resolved snuba name may be different
-            resolved_column = self.resolve_column(column, alias=True)
-            if resolved_column not in self.columns:
-                resolved_columns.append(resolved_column)
+            elif column == "group_id":
+                # We don't expose group_id publically, so if a user requests it,
+                # we expect it to be a custom tag, so we convert it to tags[group_id]
+                # to ensure it resolves as a tag
+                self.tag_to_prefixed_map["group_id"] = "tags[group_id]"
+                self.prefixed_to_tag_map["tags[group_id]"] = "group_id"
+                resolved_columns.append(self.resolve_column("tags[group_id]", alias=True))
+            else:
+                # need to make sure the column is resolved with the appropriate alias
+                # because the resolved snuba name may be different
+                resolved_column = self.resolve_column(column, alias=True)
+                if resolved_column not in self.columns:
+                    resolved_columns.append(resolved_column)
 
         # Happens after resolving columns to check if there any aggregates
         if self.auto_fields:

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -632,8 +632,10 @@ class QueryBuilder(BaseQueryBuilder):
                 continue
             elif column == "group_id":
                 # We don't expose group_id publically, so if a user requests it,
-                # we expect it to be a custom tag, so we convert it to tags[group_id]
-                # to ensure it resolves as a tag
+                # we expect it is a custom tag, so we convert it to tags[group_id]
+                # and ensure it queries tag data
+                # These maps are updated so the response can be mapped back to group_id
+                # in the response
                 self.tag_to_prefixed_map["group_id"] = "tags[group_id]"
                 self.prefixed_to_tag_map["tags[group_id]"] = "group_id"
                 resolved_column = self.resolve_column("tags[group_id]", alias=True)

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -636,13 +636,14 @@ class QueryBuilder(BaseQueryBuilder):
                 # to ensure it resolves as a tag
                 self.tag_to_prefixed_map["group_id"] = "tags[group_id]"
                 self.prefixed_to_tag_map["tags[group_id]"] = "group_id"
-                resolved_columns.append(self.resolve_column("tags[group_id]", alias=True))
+                resolved_column = self.resolve_column("tags[group_id]", alias=True)
             else:
                 # need to make sure the column is resolved with the appropriate alias
                 # because the resolved snuba name may be different
                 resolved_column = self.resolve_column(column, alias=True)
-                if resolved_column not in self.columns:
-                    resolved_columns.append(resolved_column)
+
+            if resolved_column not in self.columns:
+                resolved_columns.append(resolved_column)
 
         # Happens after resolving columns to check if there any aggregates
         if self.auto_fields:

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -657,11 +657,10 @@ class QueryBuilder(BaseQueryBuilder):
         field = tag_match.group("tag") if tag_match else raw_field
 
         if field == "group_id":
-            # We don't expose group_id publically, so if a user requests it,
-            # we expect it is a custom tag, so we convert it to tags[group_id]
+            # We don't expose group_id publicly, so if a user requests it
+            # we expect it is a custom tag. Convert it to tags[group_id]
             # and ensure it queries tag data
             # These maps are updated so the response can be mapped back to group_id
-            # in the response
             self.tag_to_prefixed_map["group_id"] = "tags[group_id]"
             self.prefixed_to_tag_map["tags[group_id]"] = "group_id"
             raw_field = "tags[group_id]"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1078,7 +1078,7 @@ def resolve_column(dataset) -> Callable[[str], str]:
 
         # Some dataset specific logic:
         if dataset == Dataset.Discover:
-            if isinstance(col, (list, tuple)) or col in ("project_id", "group_id"):
+            if isinstance(col, (list, tuple)) or col == "project_id":
                 return col
         else:
             if (

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1078,7 +1078,7 @@ def resolve_column(dataset) -> Callable[[str], str]:
 
         # Some dataset specific logic:
         if dataset == Dataset.Discover:
-            if isinstance(col, (list, tuple)) or col == "project_id":
+            if isinstance(col, (list, tuple)) or col in ("project_id", "group_id"):
                 return col
         else:
             if (

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6006,3 +6006,25 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["count()"] == 1
+
+    def test_group_id_as_custom_tag(self):
+        project1 = self.create_project()
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "poof",
+                "timestamp": self.ten_mins_ago_iso,
+                "user": {"email": self.user.email},
+                "tags": {"group_id": "this should just get returned"},
+            },
+            project_id=project1.id,
+        )
+        query = {
+            "field": ["group_id"],
+            "query": "",
+            "orderby": "group_id",
+            "statsPeriod": "24h",
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert response.data["data"][0]["group_id"] == "this should just get returned"

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1057,7 +1057,6 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             event_data["data"]["event_id"] = f"a{i}" * 16
             self.store_event(event_data["data"], project_id=event_data["project"].id)
 
-        # Query for count and count()
         data = {
             "start": iso_format(self.day_ago),
             "end": iso_format(self.day_ago + timedelta(hours=2)),
@@ -1065,17 +1064,16 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             "yAxis": "count()",
             "orderby": ["-count()"],
             "field": ["count()", "group_id"],
-            "topEvents": 5,
             "partial": 1,
         }
         response = self.client.get(self.url, data, format="json")
         assert response.status_code == 200
-        assert response.data["testing"]["data"][0][1] == [{"count": 7}]
+        assert response.data["data"][0][1] == [{"count": 8}]
 
         data["query"] = "group_id:testing"
         response = self.client.get(self.url, data, format="json")
         assert response.status_code == 200
-        assert response.data["testing"]["data"][0][1] == [{"count": 7}]
+        assert response.data["data"][0][1] == [{"count": 7}]
 
         data["query"] = "group_id:abc"
         response = self.client.get(self.url, data, format="json")


### PR DESCRIPTION
Fixes a problem in discover where a user with a custom group_id tag would not query for the tag, but rather the issue ID
