### PR TITLE
fix(ecosystem): Adjust stacktrace codecov padding

### DIFF
--- a/static/app/components/events/interfaces/frame/contextLine.tsx
+++ b/static/app/components/events/interfaces/frame/contextLine.tsx
@@ -128,4 +128,5 @@ const padding = space(2);
 const LineContent = styled('div')`
   display: grid;
   grid-template-columns: ${lineNumberWidth} calc(100% - ${lineNumberWidth} - ${padding});
+  gap: ${space(0.5)};
 `;


### PR DESCRIPTION
Code was a bit close to the codecov highlights

before
![image](https://user-images.githubusercontent.com/1400464/227058255-11749f02-3eb2-4fa6-8c91-4dc3f519d044.png)

after
![image](https://user-images.githubusercontent.com/1400464/227058310-e160d071-599d-4637-93d5-71ce699bd418.png)
