### PR TITLE
feat(replay): Improve Network table performance, fix scrollbar

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -27,6 +27,12 @@ type Props = {
   startTimestampMs: number;
 };
 
+const cellMeasurer = {
+  defaultHeight: BODY_HEIGHT,
+  defaultWidth: 100,
+  fixedHeight: true,
+};
+
 function NetworkList({networkSpans, startTimestampMs}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
 
@@ -57,11 +63,7 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
   const gridRef = useRef<MultiGrid>(null);
   const {cache, getColumnWidth, onScrollbarPresenceChange, onWrapperResize} =
     useVirtualizedGrid({
-      cellMeasurer: {
-        defaultHeight: BODY_HEIGHT,
-        defaultWidth: 100,
-        fixedHeight: true,
-      },
+      cellMeasurer,
       gridRef,
       columnCount: COLUMN_COUNT,
       dynamicColumnIndex: 1,
@@ -126,8 +128,9 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
                 cellRenderer={cellRenderer}
                 columnCount={COLUMN_COUNT}
                 columnWidth={getColumnWidth(width)}
-                estimatedColumnSize={width}
-                estimatedRowSize={HEADER_HEIGHT + items.length * BODY_HEIGHT}
+                deferredMeasurementCache={cache}
+                estimatedColumnSize={100}
+                estimatedRowSize={BODY_HEIGHT}
                 fixedRowCount={1}
                 height={height}
                 noContentRenderer={() => (

--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -38,7 +38,7 @@ function TimestampButton({
 const StyledButton = styled('button')`
   background: transparent;
   border: none;
-  color: 'inherit';
+  color: inherit;
   font-size: ${p => p.theme.fontSizeSmall};
   font-variant-numeric: tabular-nums;
 


### PR DESCRIPTION
* I think adding `deferredMeasurementCache` is what is doing the work here (at least for initial scrolling)
* the "estimated*" props say it should be *total* size on docs, but from looking at examples and trying it out, it seems to be just a single row/column. This "fixes" the issue with the scrollbar where it seems like there is a lot of data but as you scroll near the actual bottom, the scroll bar turns big (indicating the estimated list was much larger than actual list).

Before:
![image](https://user-images.githubusercontent.com/79684/227062989-308cc754-30ec-47ff-a164-fdc42da1f6cc.png)

After:
![image](https://user-images.githubusercontent.com/79684/227062827-9f618d83-3698-4613-8502-9000171e4ad3.png)
