### PR TITLE
feat(replay): Change font CSS to match Chrome Dev Tools

### DIFF
--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -142,8 +142,8 @@ function Icon({level}: {level: Extract<Crumb, BreadcrumbTypeDefault>['level']}) 
 }
 
 const Message = styled('div')`
-  font-family: ${p => p.theme.text.familyMono};
-  font-size: ${p => p.theme.fontSizeSmall};
+  font-family: 'Menlo', monospace; /* match Chrome dev tools */
+  font-size: ${p => p.theme.fontSizeExtraSmall};
   white-space: pre-wrap;
   word-break: break-word;
 `;


### PR DESCRIPTION
* Decrease font size from 12px -> 11px
* Change font family to `Menlo`

Our previous text styling was a bit too big IMO, this brings it to be the same size and font as Chrome dev tools to make it a bit more familiar feeling.

Old:
![image](https://user-images.githubusercontent.com/79684/227064714-f8eb1137-5aba-4ecd-99b3-baa38c799dc3.png)


New:
![image](https://user-images.githubusercontent.com/79684/227064719-84b7db26-8eca-4fb8-b142-c0794205a1c0.png)
