### PR TITLE
fix(replays): handle 429s from gcs

### DIFF
--- a/src/sentry/replays/lib/storage.py
+++ b/src/sentry/replays/lib/storage.py
@@ -121,6 +121,7 @@ class StorageBlob(Blob):
             storage.save(self.make_key(segment), BytesIO(value))
         except TooManyRequests:
             # if we 429 because of a dupe segment problem, ignore it
+            metrics.incr("replays.lib.storage.TooManyRequests")
             pass
 
     def make_key(self, segment: RecordingSegmentStorageMeta) -> str:


### PR DESCRIPTION
- if we write to GCS and have a duplicate segment problem, our storage driver can rate limit and this crashes the consumer.


This PR simply handles the exception for now. We should make it storage agnostic and I can follow up to do that.

Fixes https://sentry.sentry.io/issues/4028634220/?project=1&query=is%3Aunresolved+server_name%3Agetsentry-consumer-ingest-replay-recordings%2A&referrer=issue-stream&statsPeriod=14d