### PR TITLE
chore(hybrid-cloud): Update assert when saving organization member

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -200,7 +200,9 @@ class OrganizationMember(Model):
 
     @transaction.atomic
     def save(self, *args, **kwargs):
-        assert self.user_id or self.email, "Must set user or email"
+        assert (self.user_id is None and self.email) or (
+            self.user_id and self.email is None
+        ), "Must set either user or email"
         if self.token and not self.token_expires_at:
             self.refresh_expires_at()
         super().save(*args, **kwargs)

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -254,13 +254,15 @@ class AuthLoginView(BaseView):
 
                         if settings.SENTRY_SINGLE_ORGANIZATION:
                             om = organization_service.check_membership_by_email(
-                                org_context.organization.id, user.email
+                                organization_id=org_context.organization.id, email=user.email
                             )
+
                             if om is None:
+                                om = organization_service.check_membership_by_id(
+                                    organization_id=org_context.organization.id, user_id=user.id
+                                )
+                            if om is None or om.user_id is None:
                                 request.session.pop("_next", None)
-                            else:
-                                if om.user_id is None:
-                                    request.session.pop("_next", None)
 
                 # On login, redirect to onboarding
                 if self.active_organization:

--- a/tests/apidocs/endpoints/scim/test_member_index.py
+++ b/tests/apidocs/endpoints/scim/test_member_index.py
@@ -39,9 +39,8 @@ class SCIMMemberIndexDocs(APIDocsTestCase, SCIMTestCase):
 
     def test_post_member_exists_but_not_accepted(self):
         self.create_member(
-            user=self.create_user(),
+            user=self.create_user(email="test.user@okta.local"),
             organization=self.organization,
-            email="test.user@okta.local",
             role="member",
             invite_status=1,
         )

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -79,9 +79,7 @@ class AcceptInviteTest(TestCase):
 
     def test_invite_not_pending(self):
         user = self.create_user(email="test@gmail.com")
-        om = Factories.create_member(
-            email="newuser@example.com", token="abc", organization=self.organization, user=user
-        )
+        om = Factories.create_member(token="abc", organization=self.organization, user=user)
         for path in self._get_paths([om.id, om.token]):
             resp = self.client.get(path)
             assert resp.status_code == 400

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -244,7 +244,6 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase):
         sso_member = self.create_member(
             organization=self.organization,
             user=user,
-            email=user.email,
             invite_status=InviteStatus.APPROVED.value,
             flags=OrganizationMember.flags["sso:linked"],
         )
@@ -253,7 +252,8 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase):
             self.organization.slug, qs_params={"query": "ssoLinked:true"}
         )
         assert len(response.data) == 1
-        assert response.data[0]["email"] == sso_member.email
+        assert sso_member.email is None
+        assert response.data[0]["name"] == response.data[0]["user"]["email"] == user.email
 
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": "ssoLinked:false"}
@@ -270,7 +270,6 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase):
         member_2fa = self.create_member(
             organization=self.organization,
             user=user,
-            email=user.email,
             invite_status=InviteStatus.APPROVED.value,
         )
 
@@ -283,7 +282,8 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase):
             self.organization.slug, qs_params={"query": "has2fa:true"}
         )
         assert len(response.data) == 1
-        assert response.data[0]["email"] == member_2fa.email
+        assert member_2fa.email is None
+        assert response.data[0]["name"] == response.data[0]["user"]["email"] == user.email
 
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": "has2fa:false"}

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -335,7 +335,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
 
     def test_user_details_set_inactive(self):
         member = self.create_member(
-            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+            user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         AuthIdentity.objects.create(
             user=member.user, auth_provider=self.auth_provider, ident="test_ident"
@@ -360,7 +360,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
 
     def test_user_details_set_inactive_dict(self):
         member = self.create_member(
-            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+            user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         AuthIdentity.objects.create(
             user=member.user, auth_provider=self.auth_provider, ident="test_ident"
@@ -385,7 +385,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
 
     def test_user_details_set_inactive_with_bool_string(self):
         member = self.create_member(
-            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+            user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         AuthIdentity.objects.create(
             user=member.user, auth_provider=self.auth_provider, ident="test_ident"
@@ -410,7 +410,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
 
     def test_user_details_set_inactive_with_dict_bool_string(self):
         member = self.create_member(
-            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+            user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         AuthIdentity.objects.create(
             user=member.user, auth_provider=self.auth_provider, ident="test_ident"
@@ -435,7 +435,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
 
     def test_invalid_patch_op(self):
         member = self.create_member(
-            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+            user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         AuthIdentity.objects.create(
             user=member.user, auth_provider=self.auth_provider, ident="test_ident"
@@ -454,7 +454,7 @@ class SCIMMemberDetailsTests(SCIMTestCase):
 
     def test_invalid_patch_op_value(self):
         member = self.create_member(
-            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+            user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         AuthIdentity.objects.create(
             user=member.user, auth_provider=self.auth_provider, ident="test_ident"

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -65,7 +65,7 @@ class SCIMMemberIndexTests(SCIMTestCase):
     def test_post_users_already_exists(self):
         # test that response 409s if member already exists (by email)
         member = self.create_member(
-            user=self.create_user(), organization=self.organization, email="test.user@okta.local"
+            user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
         url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
         response = self.client.post(url, CREATE_USER_POST_DATA)

--- a/tests/sentry/api/endpoints/test_team_members.py
+++ b/tests/sentry/api/endpoints/test_team_members.py
@@ -50,12 +50,11 @@ class TeamMembersTest(APITestCase):
         assert response.data[1]["id"] == str(pending_invite.id)
 
     def test_team_members_list_does_not_include_inactive_users(self):
-        inactive_user = self.create_user()
+        inactive_user = self.create_user(email="inactive@example.com")
         inactive_user.is_active = False
         inactive_user.save()
 
         inactive_member = self.create_member(
-            email="inactive@example.com",
             organization=self.org,
             user=inactive_user,
             teams=[self.team],

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -221,7 +221,6 @@ class SlackIntegrationPostInstallTest(APITestCase):
         self.user2 = self.create_user("foo@example.com")
         self.member = self.create_member(
             user=self.user2,
-            email="foo@example.com",
             organization=self.organization,
             role="manager",
             teams=[self.team],
@@ -229,7 +228,6 @@ class SlackIntegrationPostInstallTest(APITestCase):
         self.user3 = self.create_user("hellboy@example.com")
         self.member = self.create_member(
             user=self.user3,
-            email="hellboy@example.com",
             organization=self.organization,
             role="manager",
             teams=[self.team],
@@ -237,7 +235,6 @@ class SlackIntegrationPostInstallTest(APITestCase):
         self.user4 = self.create_user("ialreadyexist@example.com")
         self.member = self.create_member(
             user=self.user4,
-            email="ialreadyexist@example.com",
             organization=self.organization,
             role="manager",
             teams=[self.team],

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -75,11 +75,9 @@ class SubscribeTest(TestCase):
     def test_actor_team(self):
         org = self.create_organization()
         group = self.create_group()
-        user = self.create_user()
+        user = self.create_user(email="bar@example.com")
         team = self.create_team(organization=org)
-        self.create_member(
-            user=user, email="bar@example.com", organization=org, role="owner", teams=[team]
-        )
+        self.create_member(user=user, organization=org, role="owner", teams=[team])
 
         GroupSubscription.objects.subscribe_actor(group=group, actor=team)
 

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -1,6 +1,5 @@
 import copy
 from unittest import mock
-from uuid import uuid4
 
 import pytest
 from django.core import mail

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -311,15 +311,11 @@ class Require2fa(TestCase):
             return self.create_user("")
         return self.create_user()
 
-    def _create_user_and_member(self, has_2fa=False, has_user_email=True, has_member_email=False):
+    def _create_user_and_member(self, has_2fa=False, has_user_email=True):
         user = self._create_user(has_email=has_user_email)
         if has_2fa:
             TotpInterface().enroll(user)
-        if has_member_email:
-            email = uuid4().hex
-            member = self.create_member(organization=self.org, user=user, email=email)
-        else:
-            member = self.create_member(organization=self.org, user=user)
+        member = self.create_member(organization=self.org, user=user)
         return user, member
 
     def is_organization_member(self, user_id, member_id):
@@ -331,7 +327,8 @@ class Require2fa(TestCase):
 
     def is_pending_organization_member(self, user_id, member_id, was_booted=True):
         member = OrganizationMember.objects.get(id=member_id)
-        assert User.objects.filter(id=user_id).exists()
+        if user_id:
+            assert User.objects.filter(id=user_id).exists()
         assert member.is_pending
         assert member.email
         if was_booted:
@@ -402,13 +399,12 @@ class Require2fa(TestCase):
         ).count() == len(non_compliant)
 
     def test_handle_2fa_required__pending_member__ok(self):
-        user, member = self._create_user_and_member(has_member_email=True)
-        member.user = None
-        member.save()
+        member = self.create_member(organization=self.org, email="bob@zombo.com")
+        assert not member.user
 
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
             self.org.handle_2fa_required(self.request)
-        self.is_pending_organization_member(user.id, member.id, was_booted=False)
+        self.is_pending_organization_member(user_id=None, member_id=member.id, was_booted=False)
 
         assert len(mail.outbox) == 0
         assert not AuditLogEntry.objects.filter(
@@ -418,28 +414,9 @@ class Require2fa(TestCase):
         ).exists()
 
     @mock.patch("sentry.tasks.auth.logger")
-    def test_handle_2fa_required__no_user_email__ok(self, auth_log):
-        user, member = self._create_user_and_member(has_user_email=False, has_member_email=True)
-        assert not user.email
-        assert member.email
-
-        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            self.org.handle_2fa_required(self.request)
-
-        self.is_pending_organization_member(user.id, member.id)
-
-        assert len(mail.outbox) == 1
-        assert mail.outbox[0].to == [member.email]
-
-        assert not auth_log.warning.called
-        auth_log.info.assert_called_with(
-            "2FA noncompliant user removed from org",
-            extra={"organization_id": self.org.id, "user_id": user.id, "member_id": member.id},
-        )
-
-    @mock.patch("sentry.tasks.auth.logger")
     def test_handle_2fa_required__no_email__warning(self, auth_log):
         user, member = self._create_user_and_member(has_user_email=False)
+        assert not user.has_2fa()
         assert not user.email
         assert not member.email
 

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -189,7 +189,6 @@ class OrganizationMemberTest(TestCase):
             organization=self.organization,
             role="member",
             user=user,
-            email="test@example.com",
             token="abc-def",
             token_expires_at="2018-01-01 10:00:00",
         )

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -880,17 +880,13 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
     def test_basic_auth_flow_as_user_with_confirmed_membership(self):
         user = self.create_user("foor@example.com")
         self.create_member(organization=self.organization, user=user)
-        member = OrganizationMember.objects.get(organization=self.organization, user=user)
-        member.email = "foor@example.com"
-        member.save()
 
         self.session["_next"] = reverse(
             "sentry-organization-settings", args=[self.organization.slug]
         )
         self.save_session()
-
         resp = self.client.post(
-            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+            self.path, {"username": user.username, "password": "admin", "op": "login"}, follow=True
         )
         assert resp.redirect_chain == [
             (reverse("sentry-organization-settings", args=[self.organization.slug]), 302),
@@ -1022,9 +1018,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         TotpInterface().enroll(user)
 
         self.create_member(organization=self.organization, user=user)
-        member = OrganizationMember.objects.get(organization=self.organization, user=user)
-        member.email = "foor@example.com"
-        member.save()
 
         resp = self.client.post(
             self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
@@ -1039,9 +1032,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         TotpInterface().enroll(user)
 
         self.create_member(organization=self.organization, user=user)
-        member = OrganizationMember.objects.get(organization=self.organization, user=user)
-        member.email = "foor@example.com"
-        member.save()
 
         resp = self.client.post(
             self.path, {"username": user, "password": "admin", "op": "login"}, follow=True


### PR DESCRIPTION
Update assert to be an exclusive or logical operation. 

For an `OrganizationMember`, we expect either user or email to be set, but not both.