### PR TITLE
chore(hybrid-cloud): Remove User.get_short_name

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -257,9 +257,6 @@ class User(BaseModel, AbstractBaseUser):
     def get_full_name(self):
         return self.name
 
-    def get_short_name(self):
-        return self.username
-
     def get_salutation_name(self):
         name = self.name or self.username.split("@", 1)[0].split(".", 1)[0]
         first_name = name.split(" ", 1)[0]

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -83,9 +83,6 @@ class RpcUser:
     def get_full_name(self) -> str:
         return self.name
 
-    def get_short_name(self) -> str:
-        return self.username
-
     def get_avatar_type(self) -> str:
         if self.avatar is not None:
             return self.avatar.avatar_type

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -63,6 +63,10 @@ class UserTest(TestCase):
         projects = user.get_projects()
         assert {_.id for _ in projects} == {project.id}
 
+    def test_get_full_name(self):
+        user = self.create_user(name="foo bar")
+        assert user.name == user.get_full_name() == "foo bar"
+
 
 @control_silo_test
 class UserDetailsTest(TestCase):


### PR DESCRIPTION
I did a brief audit on the `User` model:

- Remove `User.get_short_name`, which is un-used in either `sentry` and `getsentry`. I removed the related method for `RpcUser` as well.
- Add test coverage for `User.get_full_name`.