### PR TITLE
chore(2fa): Use OrganizationMember.get_email() when resolving email address for 2FA compliance comms

### DIFF
--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -127,7 +127,7 @@ class TwoFactorComplianceTask(OrganizationComplianceTask):
             type="user.setup_2fa",
             context=email_context,
         )
-        message.send_async([member.email])
+        message.send_async([member.get_email()])
 
 
 @instrumented_task(


### PR DESCRIPTION
Use `OrganizationMember.get_email()` when resolving email address for 2FA compliance comms.

`member.email` could be `None`, so we may want to fallback to the user's email.