### PR TITLE
feat(ui): Move retention priorities settings higher

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -350,47 +350,6 @@ class ProjectPerformance extends AsyncView<Props, State> {
             )}
           </Access>
         </Form>
-        <Feature features={['organizations:performance-issues-dev']}>
-          <Fragment>
-            <Form
-              saveOnBlur
-              allowUndo
-              initialData={{
-                performanceIssueCreationRate:
-                  this.state.project.performanceIssueCreationRate,
-              }}
-              apiMethod="PUT"
-              apiEndpoint={projectEndpoint}
-            >
-              <Access access={requiredScopes}>
-                {({hasAccess}) => (
-                  <JsonForm
-                    title={t('Performance Issues - All')}
-                    fields={this.performanceIssueFormFields}
-                    disabled={!hasAccess}
-                  />
-                )}
-              </Access>
-            </Form>
-            <Form
-              saveOnBlur
-              allowUndo
-              initialData={this.state.performance_issue_settings}
-              apiMethod="PUT"
-              apiEndpoint={performanceIssuesEndpoint}
-            >
-              <Access access={requiredScopes}>
-                {({hasAccess}) => (
-                  <JsonForm
-                    title={t('Performance Issues - Detector Settings')}
-                    fields={this.performanceIssueDetectorsFormFields}
-                    disabled={!hasAccess}
-                  />
-                )}
-              </Access>
-            </Form>
-          </Fragment>
-        </Feature>
         <Feature features={['organizations:dynamic-sampling']}>
           <Form
             saveOnBlur
@@ -437,6 +396,47 @@ class ProjectPerformance extends AsyncView<Props, State> {
               )}
             </Access>
           </Form>
+        </Feature>
+        <Feature features={['organizations:performance-issues-dev']}>
+          <Fragment>
+            <Form
+              saveOnBlur
+              allowUndo
+              initialData={{
+                performanceIssueCreationRate:
+                  this.state.project.performanceIssueCreationRate,
+              }}
+              apiMethod="PUT"
+              apiEndpoint={projectEndpoint}
+            >
+              <Access access={requiredScopes}>
+                {({hasAccess}) => (
+                  <JsonForm
+                    title={t('Performance Issues - All')}
+                    fields={this.performanceIssueFormFields}
+                    disabled={!hasAccess}
+                  />
+                )}
+              </Access>
+            </Form>
+            <Form
+              saveOnBlur
+              allowUndo
+              initialData={this.state.performance_issue_settings}
+              apiMethod="PUT"
+              apiEndpoint={performanceIssuesEndpoint}
+            >
+              <Access access={requiredScopes}>
+                {({hasAccess}) => (
+                  <JsonForm
+                    title={t('Performance Issues - Detector Settings')}
+                    fields={this.performanceIssueDetectorsFormFields}
+                    disabled={!hasAccess}
+                  />
+                )}
+              </Access>
+            </Form>
+          </Fragment>
         </Feature>
       </Fragment>
     );


### PR DESCRIPTION
The performance issues section is an internal feature for engineers, not meant to be customer-facing. 
Therefore, this PR moves the retention priorities above it so that UI is consistent between feature flags.

## Before
![image](https://user-images.githubusercontent.com/9060071/227197887-cf6a4155-78bb-4445-b238-78c23e1d6eb4.png)

## After
![image](https://user-images.githubusercontent.com/9060071/227197666-1c90f42e-2088-40e2-b167-7d28f9ab4a8f.png)
