### PR TITLE
ref(sourcemaps): Add new date_uploaded field to sorting in endpoint

### DIFF
--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 from django.db import router
 from django.db.models import Q
@@ -15,7 +15,7 @@ from sentry.models import ArtifactBundle, ProjectArtifactBundle, ReleaseArtifact
 from sentry.utils.db import atomic_transaction
 
 
-class InvalidSortBy(SentryAPIException):
+class InvalidSortParameter(SentryAPIException):
     status_code = status.HTTP_400_BAD_REQUEST
     code = "invalid_sort_by"
     message = "You can either sort via 'date_added' or '-date_added'"
@@ -23,7 +23,7 @@ class InvalidSortBy(SentryAPIException):
 
 class ArtifactBundlesMixin:
     @classmethod
-    def derive_order_by(cls, sort_by: str) -> Optional[Union[str, Response]]:
+    def derive_order_by(cls, sort_by: str) -> Optional[str]:
         is_desc = sort_by.startswith("-")
         sort_by = sort_by.strip("-")
 
@@ -31,7 +31,7 @@ class ArtifactBundlesMixin:
             order_by = "date_uploaded"
             return f"-{order_by}" if is_desc else order_by
 
-        raise InvalidSortBy()
+        raise InvalidSortParameter
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -15,9 +15,9 @@ from sentry.models import ArtifactBundle, ProjectArtifactBundle, ReleaseArtifact
 from sentry.utils.db import atomic_transaction
 
 
-class InvalidSortParameter(SentryAPIException):
+class InvalidSortByParameter(SentryAPIException):
     status_code = status.HTTP_400_BAD_REQUEST
-    code = "invalid_sort_by"
+    code = "invalid_sort_by_parameter"
     message = "You can either sort via 'date_added' or '-date_added'"
 
 
@@ -31,7 +31,7 @@ class ArtifactBundlesMixin:
             order_by = "date_uploaded"
             return f"-{order_by}" if is_desc else order_by
 
-        raise InvalidSortParameter
+        raise InvalidSortByParameter
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.db import router
 from django.db.models import Q
 from rest_framework.request import Request
@@ -12,8 +14,21 @@ from sentry.models import ArtifactBundle, ProjectArtifactBundle, ReleaseArtifact
 from sentry.utils.db import atomic_transaction
 
 
+class ArtifactBundlesMixin:
+    @classmethod
+    def derive_order_by(cls, sort_by: str) -> Optional[str]:
+        is_desc = sort_by.startswith("-")
+        sort_by = sort_by.strip("-")
+
+        if sort_by == "date_added":
+            order_by = "date_uploaded"
+            return f"-{order_by}" if is_desc else order_by
+
+        return None
+
+
 @region_silo_endpoint
-class ArtifactBundlesEndpoint(ProjectEndpoint):
+class ArtifactBundlesEndpoint(ProjectEndpoint, ArtifactBundlesMixin):
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project) -> Response:
@@ -31,18 +46,18 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
         query = request.GET.get("query")
 
         try:
-            queryset = ProjectArtifactBundle.objects.filter(
-                organization_id=project.organization_id, project_id=project.id
-            ).select_related("artifact_bundle")
+            queryset = ArtifactBundle.objects.filter(
+                organization_id=project.organization_id,
+                projectartifactbundle__project_id=project.id,
+            )
         except ProjectArtifactBundle.DoesNotExist:
             raise ResourceDoesNotExist
 
         if query:
-            query_q = Q(artifact_bundle__bundle_id__icontains=query)
+            query_q = Q(bundle_id__icontains=query)
             queryset = queryset.filter(query_q)
 
-        def expose_artifact_bundle(debug_id_artifact_bundle, release_dist):
-            artifact_bundle = debug_id_artifact_bundle.artifact_bundle
+        def expose_artifact_bundle(artifact_bundle, release_dist):
             release, dist = release_dist
 
             # TODO(iambriccardo): Use a serializer for this.
@@ -51,12 +66,12 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
                 "release": release if release != "" else None,
                 "dist": dist if dist != "" else None,
                 "fileCount": artifact_bundle.artifact_count,
-                "date": debug_id_artifact_bundle.date_added.isoformat()[:19] + "Z",
+                "date": artifact_bundle.date_uploaded.isoformat()[:19] + "Z",
             }
 
         def serialize_results(results):
             release_artifact_bundles = ReleaseArtifactBundle.objects.filter(
-                artifact_bundle_id__in=[r.artifact_bundle_id for r in results]
+                artifact_bundle_id__in=[r.id for r in results]
             )
             release_artifact_bundles = {
                 release.artifact_bundle_id: (release.release_name, release.dist_name)
@@ -67,18 +82,16 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
             return serialize(
                 [
                     expose_artifact_bundle(
-                        debug_id_artifact_bundle=r,
-                        release_dist=release_artifact_bundles.get(
-                            r.artifact_bundle_id, (None, None)
-                        ),
+                        artifact_bundle=r,
+                        release_dist=release_artifact_bundles.get(r.id, (None, None)),
                     )
                     for r in results
                 ],
                 request.user,
             )
 
-        sort_by = request.GET.get("sortBy", "-date_added")
-        if sort_by not in {"-date_added", "date_added"}:
+        order_by = self.derive_order_by(sort_by=request.GET.get("sortBy", "-date_added"))
+        if order_by is None:
             return Response(
                 {"error": "You can either sort via 'date_added' or '-date_added'"}, status=400
             )
@@ -86,7 +99,7 @@ class ArtifactBundlesEndpoint(ProjectEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
-            order_by=sort_by,
+            order_by=order_by,
             paginator_cls=OffsetPaginator,
             default_per_page=10,
             on_results=serialize_results,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -543,8 +543,11 @@ class Factories:
     @classmethod
     @exempt_from_silo_limits()
     def create_artifact_bundle(
-        cls, org, artifact_count=0, fixture_path="artifact_bundle_debug_ids"
+        cls, org, artifact_count=0, fixture_path="artifact_bundle_debug_ids", date_uploaded=None
     ):
+        if date_uploaded is None:
+            date_uploaded = timezone.now()
+
         bundle = cls.create_artifact_bundle_zip(org.slug, fixture_path=fixture_path)
         file_ = File.objects.create(name="artifact-bundle.zip")
         file_.putfile(ContentFile(bundle))
@@ -555,6 +558,7 @@ class Factories:
             bundle_id=uuid4(),
             file=file_,
             artifact_count=artifact_count,
+            date_uploaded=date_uploaded,
         )
         return artifact_bundle
 

--- a/tests/sentry/api/endpoints/test_artifact_bundles.py
+++ b/tests/sentry/api/endpoints/test_artifact_bundles.py
@@ -14,20 +14,22 @@ class ArtifactBundlesEndpointTest(APITestCase):
     def test_get_artifact_bundles_with_multiple_bundles(self):
         project = self.create_project(name="foo")
 
-        artifact_bundle_1 = self.create_artifact_bundle(self.organization, artifact_count=2)
+        artifact_bundle_1 = self.create_artifact_bundle(
+            self.organization, artifact_count=2, date_uploaded=datetime.now()
+        )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
             project_id=project.id,
             artifact_bundle=artifact_bundle_1,
-            date_added=datetime.now(),
         )
 
-        artifact_bundle_2 = self.create_artifact_bundle(self.organization, artifact_count=2)
+        artifact_bundle_2 = self.create_artifact_bundle(
+            self.organization, artifact_count=2, date_uploaded=datetime.now() + timedelta(hours=1)
+        )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
             project_id=project.id,
             artifact_bundle=artifact_bundle_2,
-            date_added=datetime.now() + timedelta(hours=1),
         )
         ReleaseArtifactBundle.objects.create(
             organization_id=self.organization.id,
@@ -36,12 +38,13 @@ class ArtifactBundlesEndpointTest(APITestCase):
             artifact_bundle=artifact_bundle_2,
         )
 
-        artifact_bundle_3 = self.create_artifact_bundle(self.organization, artifact_count=2)
+        artifact_bundle_3 = self.create_artifact_bundle(
+            self.organization, artifact_count=2, date_uploaded=datetime.now() + timedelta(hours=2)
+        )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
             project_id=project.id,
             artifact_bundle=artifact_bundle_3,
-            date_added=datetime.now() + timedelta(hours=2),
         )
         ReleaseArtifactBundle.objects.create(
             organization_id=self.organization.id,
@@ -117,12 +120,15 @@ class ArtifactBundlesEndpointTest(APITestCase):
     def test_get_artifact_bundles_pagination(self):
         project = self.create_project(name="foo")
         for index in range(0, 15):
-            artifact_bundle = self.create_artifact_bundle(self.organization, artifact_count=2)
+            artifact_bundle = self.create_artifact_bundle(
+                self.organization,
+                artifact_count=2,
+                date_uploaded=datetime.now() + timedelta(hours=index),
+            )
             ProjectArtifactBundle.objects.create(
                 organization_id=self.organization.id,
                 project_id=project.id,
                 artifact_bundle=artifact_bundle,
-                date_added=datetime.now() + timedelta(hours=index),
             )
 
         for cursor, expected in [("10:0:1", 10), ("10:1:0", 5)]:
@@ -143,13 +149,16 @@ class ArtifactBundlesEndpointTest(APITestCase):
         project = self.create_project(name="foo")
         bundle_ids = []
         for index in range(0, 5):
-            artifact_bundle = self.create_artifact_bundle(self.organization, artifact_count=2)
+            artifact_bundle = self.create_artifact_bundle(
+                self.organization,
+                artifact_count=2,
+                date_uploaded=datetime.now() + timedelta(hours=index),
+            )
             bundle_ids.append(str(artifact_bundle.bundle_id))
             ProjectArtifactBundle.objects.create(
                 organization_id=self.organization.id,
                 project_id=project.id,
                 artifact_bundle=artifact_bundle,
-                date_added=datetime.now() + timedelta(hours=index),
             )
 
         url = reverse(

--- a/tests/sentry/api/endpoints/test_artifact_bundles.py
+++ b/tests/sentry/api/endpoints/test_artifact_bundles.py
@@ -179,7 +179,10 @@ class ArtifactBundlesEndpointTest(APITestCase):
         self.login_as(user=self.user)
         response = self.client.get(url + "?sortBy=bundleId")
         assert response.status_code == 400
-        assert response.data["error"] == "You can either sort via 'date_added' or '-date_added'"
+        assert (
+            response.data["detail"]["message"]
+            == "You can either sort via 'date_added' or '-date_added'"
+        )
 
     def test_delete_artifact_bundles(self):
         project = self.create_project(name="foo")


### PR DESCRIPTION
This PR adds the support for sorting by the `date_uploaded` field introduced in the `ArtifactBundle` model.