### PR TITLE
feat(codecov): walk back 20 commits instead of 10

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -102,7 +102,7 @@ def get_codecov_data(repo: str, service: str, path: str) -> Tuple[LineCoverage |
     with configure_scope() as scope:
         response = requests.get(
             url,
-            params={"walk_back": 10},
+            params={"walk_back": 20},
             headers={"Authorization": f"Bearer {codecov_token}"},
             timeout=CODECOV_TIMEOUT,
         )


### PR DESCRIPTION
There's a chance that some customers may benefit if they commit a lot in a day and may have had few hours of CI outage or bad config.