### PR TITLE
fix(issue-platform): Allows empty debug_meta in event payload

### DIFF
--- a/src/sentry/issues/json_schemas.py
+++ b/src/sentry/issues/json_schemas.py
@@ -37,7 +37,6 @@ EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
                     },
                 },
             },
-            "required": ["images"],
         },
         "dist": {
             "type": ["object", "null"],

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -59,6 +59,7 @@ def get_test_message(
                 ],
             },
             "tags": {},
+            "debug_meta": {},
             "timestamp": now.isoformat(),
             "received": now.isoformat(),
         }


### PR DESCRIPTION
No longer requires `images` key if dict is sent.

Closes SENTRY-ZGN again