### PR TITLE
chore(hybrid-cloud): Remove deprecated admin that won't work in HC world

### DIFF
--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -18,7 +18,6 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
 
 from sentry.models import (
-    ApiKey,
     AuditLogEntry,
     AuthIdentity,
     AuthProvider,
@@ -63,13 +62,6 @@ class ProjectAdmin(admin.ModelAdmin):
 admin.site.register(Project, ProjectAdmin)
 
 
-class OrganizationApiKeyInline(admin.TabularInline):
-    model = ApiKey
-    extra = 1
-    fields = ("label", "key", "status", "allowed_origins", "date_added")
-    raw_id_fields = ("organization",)
-
-
 class OrganizationProjectInline(admin.TabularInline):
     model = Project
     extra = 1
@@ -111,7 +103,6 @@ class OrganizationAdmin(admin.ModelAdmin):
         OrganizationMemberInline,
         OrganizationTeamInline,
         OrganizationProjectInline,
-        OrganizationApiKeyInline,
     )
 
 
@@ -119,9 +110,8 @@ admin.site.register(Organization, OrganizationAdmin)
 
 
 class AuthProviderAdmin(admin.ModelAdmin):
-    list_display = ("organization", "provider", "date_added")
-    search_fields = ("organization__name",)
-    raw_id_fields = ("organization", "default_teams")
+    list_display = ("organization_id", "provider", "date_added")
+    raw_id_fields = ("default_teams",)
     list_filter = ("provider",)
 
 


### PR DESCRIPTION
ApiKey's relationship is more complicated in the HC world -- we can't use the functional relations this admin interface depends on.

BUT it's not clear that we actively use the django admin inteface anymore (`_admin` is powered by our API which we ARE supporting with HC).