### PR TITLE
fix(issue-platform): process culprit in occurrence consumer

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -161,6 +161,9 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
             if payload.get("event_id"):
                 occurrence_data["event_id"] = UUID(payload["event_id"]).hex
 
+            if payload.get("culprit"):
+                occurrence_data["culprit"] = payload["culprit"]
+
             if "event" in payload:
                 event_payload = payload["event"]
                 if payload["project_id"] != event_payload.get("project_id"):

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -298,3 +298,9 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
             message = deepcopy(get_test_message(self.project.id, True))
             message["event"].update(**case)
             _get_kwargs(message)
+
+    def test_culprit(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        message["culprit"] = "i did it"
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["culprit"] == "i did it"


### PR DESCRIPTION
We weren't passing `culprit` along in the occurrence consumer. We should be doing that.