### PR TITLE
perf(replays): strip dashes post query for replay counts

### DIFF
--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -27,6 +27,10 @@ def _strip_dashes(field: str) -> str:
     return field
 
 
+def normalize_output_count_query(response: list[dict[str, Any]]) -> list[str]:
+    return [_strip_dashes(item["replay_id"]) for item in response["data"]]
+
+
 def generate_normalized_output(response: list[dict[str, Any]]) -> Iterator[dict[str, Any]]:
     """For each payload in the response strip "agg_" prefixes."""
     for item in response:

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -27,7 +27,7 @@ def _strip_dashes(field: str) -> str:
     return field
 
 
-def normalize_output_count_query(response: list[dict[str, Any]]) -> list[str]:
+def normalize_output_count_query(response: dict[str, Any]) -> list[str]:
     return [_strip_dashes(item["replay_id"]) for item in response["data"]]
 
 

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -182,7 +182,7 @@ def query_replays_count(
         query=Query(
             match=Entity("replays"),
             select=[
-                _strip_uuid_dashes("replay_id", Column("replay_id")),
+                Column("replay_id"),
                 Function(
                     "notEmpty",
                     parameters=[Function("groupArray", parameters=[Column("is_archived")])],


### PR DESCRIPTION
in #45715 we fixed this field for our replays index query, but didn't do so for counts. This PR addresses that. small refactors as we have to strip the dash in post and there wasn't a post_process func for this snuba query.