### PR TITLE
meta: Move issue-platform adjacent to dnd & snuba

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@
 /src/sentry/utils/snql.py                                @getsentry/owners-snuba
 /src/sentry/tsdb/snuba.py                                @getsentry/owners-snuba
 /src/sentry/tsdb/redissnuba.py                           @getsentry/owners-snuba
-/src/sentry/search/snuba/                                @getsentry/owners-snuba
+/src/sentry/search/snuba/                                @getsentry/owners-snuba @getsentry/issue-platform
 /src/sentry/tagstore/snuba/                              @getsentry/owners-snuba
 /src/sentry/sentry_metrics/                              @getsentry/owners-snuba
 /tests/sentry/sentry_metrics/
@@ -164,7 +164,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/snuba/metrics_performance.py                                    @getsentry/discover-n-dashboards
 /src/sentry/snuba/metrics_enhanced_performance.py                           @getsentry/discover-n-dashboards
 
-/src/sentry/search/events/                                                  @getsentry/discover-n-dashboards
+/src/sentry/search/events/                                                  @getsentry/discover-n-dashboards @getsentry/issue-platform
 /tests/snuba/search/test_backend.py                                         @getsentry/discover-n-dashboards
 /static/app/utils/discover/                                                 @getsentry/discover-n-dashboards
 /static/app/components/charts/                                              @getsentry/discover-n-dashboards
@@ -407,7 +407,6 @@ yarn.lock                                                @getsentry/owners-js-de
 ## Issue Platform
 /src/sentry/event_manager.py                        @getsentry/issue-platform
 /src/sentry/issues/                                 @getsentry/issue-platform
-/src/sentry/search/                                 @getsentry/issue-platform
 /src/sentry/tasks/post_process.py                   @getsentry/issue-platform
 /src/sentry/types/issues.py                         @getsentry/issue-platform
 /tests/sentry/event_manager/test_event_manager.py   @getsentry/issue-platform


### PR DESCRIPTION
- Github Codeowners assigns based on the last rule met, which meant that `src/sentry/search` was overwriting the dnd ownership on `src/sentry/search/events` (and snuba as well i think)
- Moved issue-platform to be on those lines as well so that both teams get assigned