### PR TITLE
chore(hybrid-cloud): Refactor api permissions to better support HC

### DIFF
--- a/src/sentry/api/bases/organization_request_change.py
+++ b/src/sentry/api/bases/organization_request_change.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 from rest_framework.request import Request
 
 from sentry.api.bases import OrganizationPermission
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models import Organization
 
 
 class OrganizationRequestChangeEndpointPermission(OrganizationPermission):
@@ -10,7 +13,9 @@ class OrganizationRequestChangeEndpointPermission(OrganizationPermission):
         "POST": ["org:read"],
     }
 
-    def is_member_disabled_from_limit(self, request: Request, organization):
+    def is_member_disabled_from_limit(
+        self, request: Request, organization_or_id: Organization | int
+    ):
         # disabled members need to be able to make requests
         return False
 

--- a/src/sentry/api/bases/project_request_change.py
+++ b/src/sentry/api/bases/project_request_change.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from rest_framework.request import Request
 
 from sentry.api.bases import ProjectEndpoint, ProjectPermission
+from sentry.services.hybrid_cloud.organization import RpcOrganization, RpcUserOrganizationContext
 
 
 class ProjectRequestChangeEndpointPermission(ProjectPermission):
@@ -9,7 +12,9 @@ class ProjectRequestChangeEndpointPermission(ProjectPermission):
         "POST": ["org:read"],
     }
 
-    def is_member_disabled_from_limit(self, request: Request, organization):
+    def is_member_disabled_from_limit(
+        self, request: Request, organization: RpcOrganization | RpcUserOrganizationContext
+    ):
         # disabled members need to be able to make requests
         return False
 

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -49,6 +49,7 @@ from sentry.models.group import STATUS_UPDATE_CHOICES
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.models.groupinbox import GroupInboxRemoveAction, add_group_to_inbox
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
+from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.signals import (
     issue_ignored,
@@ -88,7 +89,7 @@ def handle_discard(
             try:
                 tombstone = GroupTombstone.objects.create(
                     previous_group_id=group.id,
-                    actor_id=user.id if user else None,
+                    actor_id=coerce_id_from(user),
                     **{name: getattr(group, name) for name in TOMBSTONE_FIELDS_FROM_GROUP},
                 )
             except IntegrityError:

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -193,7 +193,7 @@ class ApiInviteHelper:
             return None
 
         try:
-            provider = AuthProvider.objects.get(organization=om.organization)
+            provider = AuthProvider.objects.get(organization_id=om.organization.id)
         except AuthProvider.DoesNotExist:
             provider = None
 

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -14,7 +14,12 @@ from sentry.api.exceptions import (
 from sentry.auth import access
 from sentry.auth.superuser import Superuser, is_active_superuser
 from sentry.auth.system import is_system_auth
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud import extract_id_from
+from sentry.services.hybrid_cloud.organization import (
+    RpcOrganization,
+    RpcUserOrganizationContext,
+    organization_service,
+)
 from sentry.utils import auth
 
 if TYPE_CHECKING:
@@ -79,21 +84,39 @@ class SuperuserPermission(permissions.BasePermission):  # type: ignore[misc]
 
 
 class SentryPermission(ScopedPermission):
-    def is_not_2fa_compliant(self, request: Request, organization: Organization) -> bool:
+    def is_not_2fa_compliant(
+        self, request: Request, organization: RpcOrganization | Organization
+    ) -> bool:
         return False
 
-    def needs_sso(self, request: Request, organization: Organization) -> bool:
+    def needs_sso(self, request: Request, organization: Organization | RpcOrganization) -> bool:
         return False
 
-    def is_member_disabled_from_limit(self, request: Request, organization: Organization) -> bool:
+    def is_member_disabled_from_limit(
+        self,
+        request: Request,
+        organization: RpcUserOrganizationContext | RpcOrganization | Organization,
+    ) -> bool:
         return False
 
-    def determine_access(self, request: Request, organization: Organization) -> None:
+    # This wide typing on organization gives us a lot of flexibility as we move forward with hybrid cloud.
+    # Once we have fully encircled all call sites (which are MANY!) we can collapse the typing around a single
+    # usage (likely the RpcUserOrganizationContext, which is necessary for access and organization details).
+    # For now, this wide typing allows incremental rollout of those changes.  Be mindful how you use
+    # organization in this method to stay compatible with all 3 paths.
+    def determine_access(
+        self, request: Request, organization: RpcUserOrganizationContext | Organization | int
+    ) -> None:
         from sentry.api.base import logger
 
-        org_context = organization_service.get_organization_by_id(
-            id=organization.id, user_id=request.user.id if request.user else None
-        )
+        org_context: RpcUserOrganizationContext | None
+        if isinstance(organization, RpcUserOrganizationContext):
+            org_context = organization
+        else:
+            org_context = organization_service.get_organization_by_id(
+                id=extract_id_from(organization), user_id=request.user.id if request.user else None
+            )
+
         if org_context is None:
             assert False, "Failed to fetch organization in determine_access"
 
@@ -116,7 +139,7 @@ class SentryPermission(ScopedPermission):
             rpc_user_org_context=org_context,
         )
 
-        extra = {"organization_id": organization.id, "user_id": request.user.id}
+        extra = {"organization_id": extract_id_from(organization), "user_id": request.user.id}
 
         if auth.is_user_signed_request(request):
             # if the user comes from a signed request
@@ -127,7 +150,7 @@ class SentryPermission(ScopedPermission):
             )
         elif request.user.is_authenticated:
             # session auth needs to confirm various permissions
-            if self.needs_sso(request, organization):
+            if self.needs_sso(request, org_context.organization):
 
                 logger.info(
                     "access.must-sso",
@@ -142,17 +165,17 @@ class SentryPermission(ScopedPermission):
 
                 raise SsoRequired(organization, after_login_redirect=after_login_redirect)
 
-            if self.is_not_2fa_compliant(request, organization):
+            if self.is_not_2fa_compliant(request, org_context.organization):
                 logger.info(
                     "access.not-2fa-compliant",
                     extra=extra,
                 )
-                if request.user.is_superuser and organization.id != Superuser.org_id:
+                if request.user.is_superuser and extract_id_from(organization) != Superuser.org_id:
                     raise SuperuserRequired()
 
                 raise TwoFactorRequired()
 
-            if self.is_member_disabled_from_limit(request, organization):
+            if self.is_member_disabled_from_limit(request, org_context):
                 logger.info(
                     "access.member-disabled-from-limit",
                     extra=extra,

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -19,7 +19,13 @@ from sentry.auth.access import get_cached_organization_member  # noqa
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.organization import Organization
 from sentry.search.utils import InvalidQuery, parse_datetime_string
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud import extract_id_from
+from sentry.services.hybrid_cloud.organization import (
+    RpcOrganization,
+    RpcOrganizationMember,
+    RpcUserOrganizationContext,
+    organization_service,
+)
 from sentry.utils.dates import parse_stats_period
 
 logger = logging.getLogger(__name__)
@@ -196,7 +202,12 @@ def get_date_range_from_stats_period(
     return start, end
 
 
-def is_member_disabled_from_limit(request: Request, organization: Organization) -> bool:
+# The wide typing allows us to move towards RpcUserOrganizationContext in the future to save RPC calls.
+# If you can use the wider more correct type, please do.
+def is_member_disabled_from_limit(
+    request: Request,
+    organization: RpcUserOrganizationContext | RpcOrganization | Organization | int,
+) -> bool:
     user = request.user
 
     # never limit sentry apps
@@ -208,9 +219,14 @@ def is_member_disabled_from_limit(request: Request, organization: Organization) 
         return False
 
     # must be a simple user at this point
-    member = organization_service.check_membership_by_id(
-        organization_id=organization.id, user_id=user.id
-    )
+
+    member: RpcOrganizationMember | None
+    if isinstance(organization, RpcUserOrganizationContext):
+        member = organization.member
+    else:
+        member = organization_service.check_membership_by_id(
+            organization_id=extract_id_from(organization), user_id=user.id
+        )
     if member is None:
         return False
     else:

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -5,6 +5,7 @@ from typing import Any, List, Mapping
 from sentry import features
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.models import Group, GroupAssignee, Organization, SentryFunction, Team, User
+from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation, app_service
 from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.signals import (
@@ -77,7 +78,7 @@ def send_comment_webhooks(organization, issue, user, event, data=None):
             installation_id=install.id,
             issue_id=issue.id,
             type=event,
-            user_id=(user.id if user else None),
+            user_id=coerce_id_from(user),
             data=data,
         )
     if features.has("organizations:sentry-functions", organization, actor=user):
@@ -103,7 +104,7 @@ def send_workflow_webhooks(
             installation_id=install.id,
             issue_id=issue.id,
             type=event.split(".")[-1],
-            user_id=(user.id if user else None),
+            user_id=coerce_id_from(user),
             data=data,
         )
     if features.has("organizations:sentry-functions", organization, actor=user):

--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -263,3 +263,21 @@ class RpcPaginationResult:
             next=RpcCursorState.from_cursor(cursor_result.next),
             prev=RpcCursorState.from_cursor(cursor_result.prev),
         )
+
+
+def coerce_id_from(m: object | int | None) -> int | None:
+    if m is None:
+        return None
+    if isinstance(m, int):
+        return m
+    if hasattr(m, "id"):
+        return m.id  # type: ignore
+    raise ValueError(f"Cannot coerce {m!r} into id!")
+
+
+def extract_id_from(m: object | int) -> int:
+    if isinstance(m, int):
+        return m
+    if hasattr(m, "id"):
+        return m.id  # type: ignore
+    raise ValueError(f"Cannot extract {m!r} from id!")

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -19,6 +19,7 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
 from sentry.models import AuthProvider, Organization, OrganizationMember, OrganizationStatus
+from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.signals import join_request_link_viewed, user_signup
 from sentry.utils import auth, json, metrics
@@ -77,7 +78,7 @@ class AuthLoginView(BaseView):
             return None
 
         try:
-            auth_provider = AuthProvider.objects.get(organization=organization)
+            auth_provider = AuthProvider.objects.get(organization_id=organization.id)
         except AuthProvider.DoesNotExist:
             return None
 
@@ -125,7 +126,7 @@ class AuthLoginView(BaseView):
         return self.respond("sentry/login.html", context)
 
     def _handle_login(self, request: Request, user, organization: Optional[Organization]):
-        login(request, user, organization_id=organization.id if organization else None)
+        login(request, user, organization_id=coerce_id_from(organization))
         self.determine_active_organization(request)
 
     def handle_basic_auth(self, request: Request, **kwargs):

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -65,7 +65,7 @@ class AuthOrganizationLoginView(AuthLoginView):
             initiate_login(request, next_uri)
 
         try:
-            auth_provider = AuthProvider.objects.get(organization=organization)
+            auth_provider = AuthProvider.objects.get(organization_id=organization.id)
         except AuthProvider.DoesNotExist:
             auth_provider = None
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -159,7 +159,9 @@ class OrganizationMixin:
             organization_slug = request.subdomain
         return organization_slug  # type: ignore[no-any-return]
 
-    def is_not_2fa_compliant(self, request: Request, organization: RpcOrganization) -> bool:
+    def is_not_2fa_compliant(
+        self, request: Request, organization: RpcOrganization | Organization
+    ) -> bool:
         return (
             organization.flags.require_2fa
             and not request.user.has_2fa()
@@ -167,7 +169,7 @@ class OrganizationMixin:
         )
 
     def is_member_disabled_from_limit(
-        self, request: Request, organization: RpcOrganization
+        self, request: Request, organization: RpcUserOrganizationContext | RpcOrganization
     ) -> bool:
         return is_member_disabled_from_limit(request, organization)
 

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.models import Commit, CommitAuthor, CommitFileChange, Integration, Repository, User
 from sentry.plugins.providers import RepositoryProvider
+from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.shared_integrations.exceptions import ApiError
 from sentry_plugins.github.client import GitHubClient
 
@@ -16,14 +17,14 @@ logger = logging.getLogger("sentry.webhooks")
 
 
 class PushEventWebhook(Webhook):
-    def _handle(self, event, organization, is_apps):
+    def _handle(self, event, organization_id, is_apps):
         authors = {}
 
         gh_username_cache = {}
 
         try:
             repo = Repository.objects.get(
-                organization_id=organization.id,
+                organization_id=organization_id,
                 provider="github_apps" if is_apps else "github",
                 external_id=str(event["repository"]["id"]),
             )
@@ -57,7 +58,7 @@ class PushEventWebhook(Webhook):
                     else:
                         try:
                             commit_author = CommitAuthor.objects.get(
-                                external_id=external_id, organization_id=organization.id
+                                external_id=external_id, organization_id=organization_id
                             )
                         except CommitAuthor.DoesNotExist:
                             commit_author = None
@@ -81,7 +82,7 @@ class PushEventWebhook(Webhook):
                                     user = User.objects.filter(
                                         social_auth__provider="github",
                                         social_auth__uid=gh_user["id"],
-                                        org_memberships=organization,
+                                        org_memberships=organization_id,
                                     )[0]
                                 except IndexError:
                                     pass
@@ -106,7 +107,7 @@ class PushEventWebhook(Webhook):
                 author = None
             elif author_email not in authors:
                 authors[author_email] = author = CommitAuthor.objects.get_or_create(
-                    organization_id=organization.id,
+                    organization_id=organization_id,
                     email=author_email,
                     defaults={"name": commit["author"]["name"][:128]},
                 )[0]
@@ -135,7 +136,7 @@ class PushEventWebhook(Webhook):
                 with transaction.atomic():
                     c = Commit.objects.create(
                         repository_id=repo.id,
-                        organization_id=organization.id,
+                        organization_id=organization_id,
                         key=commit["id"],
                         message=commit["message"],
                         author=author,
@@ -143,15 +144,15 @@ class PushEventWebhook(Webhook):
                     )
                     for fname in commit["added"]:
                         CommitFileChange.objects.create(
-                            organization_id=organization.id, commit=c, filename=fname, type="A"
+                            organization_id=organization_id, commit=c, filename=fname, type="A"
                         )
                     for fname in commit["removed"]:
                         CommitFileChange.objects.create(
-                            organization_id=organization.id, commit=c, filename=fname, type="D"
+                            organization_id=organization_id, commit=c, filename=fname, type="D"
                         )
                     for fname in commit["modified"]:
                         CommitFileChange.objects.create(
-                            organization_id=organization.id, commit=c, filename=fname, type="M"
+                            organization_id=organization_id, commit=c, filename=fname, type="M"
                         )
             except IntegrityError:
                 pass
@@ -166,9 +167,11 @@ class PushEventWebhook(Webhook):
             integration = Integration.objects.get(
                 external_id=event["installation"]["id"], provider="github_apps"
             )
-            organizations = list(integration.organizations.all())
+            organizations = list(
+                integration.organizationintegrations.values_list("organization_id", flat=True)
+            )
         else:
-            organizations = [organization]
+            organizations = [coerce_id_from(organization)]
 
-        for org in organizations:
-            self._handle(event, org, is_apps)
+        for org_id in organizations:
+            self._handle(event, org_id, is_apps)

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -168,7 +168,7 @@ class PushEventWebhook(Webhook):
                 external_id=event["installation"]["id"], provider="github_apps"
             )
             organizations = list(
-                integration.organizationintegrations.values_list("organization_id", flat=True)
+                integration.organizationintegration_set.values_list("organization_id", flat=True)
             )
         else:
             organizations = [coerce_id_from(organization)]

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -144,7 +144,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             sentry_options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 52 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 54
+        expected_queries = 48 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 50
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)


### PR DESCRIPTION
Introduces `extract_id_from` and `coerce_id_from` to help replace instances where we need to support things of the form `organization_or_id`.

Refactors `permissions.py` to better support a HC world where we won't have direct relatioship access to the orm Organization object.  Right now the, the typing has to be broad because the call to `determine_access` ends up being used in pretty far and wide places -- sometimes, it can be called directly with enough information that an additional RPC is not necessary, but  as https://github.com/getsentry/sentry/pull/45528/files reveals, we will have call sites where we will only have `organization_id` to pass in.  It may be possible in a future world to fully encapsulate all organization api endpoints such that this can be preloaded and consistent typing, but the path of least resistant for incremental, but meaningful changes, is to widen the type.

I aimed for consistent and meaningful handling of the widened type.  I believe I landed somewhere that is comprehensible and easy to understand, while making this interface WAY easier to build HC for.