### PR TITLE
fix(issue-platform): Re-raise `ValidationError` when we fail schema validation

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -229,7 +229,7 @@ def _validate_event_data(event_data: Mapping[str, Any]) -> None:
         jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)
     except jsonschema.exceptions.ValidationError:
         metrics.incr("occurrence_ingest.event_payload_invalid")
-        raise InvalidEventPayloadError("Event payload does not match schema")
+        raise
 
 
 def _process_message(

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -2,9 +2,10 @@ import datetime
 import logging
 import uuid
 from copy import deepcopy
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Type
 
 import pytest
+from jsonschema import ValidationError
 
 from sentry import eventstore
 from sentry.eventstore.snuba.backend import SnubaEventStorage
@@ -179,14 +180,17 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
     def run_test(self, message: Dict[str, Any]) -> None:
         _get_kwargs(message)
 
-    def run_invalid_schema_test(self, message: Dict[str, Any]) -> None:
-        with pytest.raises(InvalidEventPayloadError):
+    def run_invalid_schema_test(
+        self, message: Dict[str, Any], expected_error: Type[Exception]
+    ) -> None:
+        with pytest.raises(expected_error):
             self.run_test(message)
 
     def run_invalid_payload_test(
         self,
         remove_event_fields: Optional[Sequence[str]] = None,
         update_event_fields: Optional[Dict[str, Any]] = None,
+        expected_error: Type[Exception] = InvalidEventPayloadError,
     ) -> None:
         message = deepcopy(get_test_message(self.project.id))
         if remove_event_fields:
@@ -194,17 +198,31 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
                 message["event"].pop(field)
         if update_event_fields:
             message["event"].update(update_event_fields)
-        self.run_invalid_schema_test(message)
+        self.run_invalid_schema_test(message, expected_error)
 
     def test_invalid_payload(self) -> None:
-        self.run_invalid_payload_test(remove_event_fields=["project_id"])
-        self.run_invalid_payload_test(remove_event_fields=["timestamp"])
-        self.run_invalid_payload_test(remove_event_fields=["platform"])
-        self.run_invalid_payload_test(remove_event_fields=["tags"])
-        self.run_invalid_payload_test(update_event_fields={"project_id": "p_id"})
-        self.run_invalid_payload_test(update_event_fields={"timestamp": 0000})
-        self.run_invalid_payload_test(update_event_fields={"platform": 0000})
-        self.run_invalid_payload_test(update_event_fields={"tags": "tagged"})
+        self.run_invalid_payload_test(
+            remove_event_fields=["project_id"],
+        )
+        self.run_invalid_payload_test(
+            remove_event_fields=["timestamp"], expected_error=ValidationError
+        )
+        self.run_invalid_payload_test(
+            remove_event_fields=["platform"], expected_error=ValidationError
+        )
+        self.run_invalid_payload_test(remove_event_fields=["tags"], expected_error=ValidationError)
+        self.run_invalid_payload_test(
+            update_event_fields={"project_id": "p_id"}, expected_error=InvalidEventPayloadError
+        )
+        self.run_invalid_payload_test(
+            update_event_fields={"timestamp": 0000}, expected_error=ValidationError
+        )
+        self.run_invalid_payload_test(
+            update_event_fields={"platform": 0000}, expected_error=ValidationError
+        )
+        self.run_invalid_payload_test(
+            update_event_fields={"tags": "tagged"}, expected_error=ValidationError
+        )
 
     def test_valid(self) -> None:
         self.run_test(get_test_message(self.project.id))


### PR DESCRIPTION
Currently, when we get validation errors for the event schema they are all collapsed into a single issue, even though they can be caused by different validation problems. Just re-raising the original `ValidationError` so that we get distinct issues here.

Fixes SENTRY-ZGN




<!-- Describe your PR here. -->