### PR TITLE
telemetry(replays): wrap consumer code in current_hub

### DIFF
--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 class MessageContext:
     message: Dict[str, Any]
     transaction: Span
+    current_hub: sentry_sdk.Hub
 
     # The message attribute can cause large log messages to be emitted which can pin the CPU
     # to 100.
@@ -74,13 +75,14 @@ def move_chunks_to_cache_or_skip(message: Message[KafkaPayload]) -> MessageConte
         sampled=random.random()
         < getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0),
     )
+    current_hub = sentry_sdk.Hub(sentry_sdk.Hub.current)
 
     message_dict = msgpack.unpackb(message.payload.value)
 
     if message_dict["type"] == "replay_recording_chunk":
-        ingest_chunk(cast(RecordingSegmentChunkMessage, message_dict), transaction)
+        ingest_chunk(cast(RecordingSegmentChunkMessage, message_dict), transaction, current_hub)
 
-    return MessageContext(message_dict, transaction)
+    return MessageContext(message_dict, transaction, current_hub)
 
 
 def is_capstone_message(message: Message[MessageContext]) -> Any:
@@ -96,8 +98,12 @@ def move_replay_to_permanent_storage(message: Message[MessageContext]) -> Any:
     message_type = message_dict["type"]
 
     if message_type == "replay_recording_not_chunked":
-        ingest_recording_not_chunked(cast(RecordingMessage, message_dict), context.transaction)
+        ingest_recording_not_chunked(
+            cast(RecordingMessage, message_dict), context.transaction, context.current_hub
+        )
     elif message_type == "replay_recording":
-        ingest_recording_chunked(cast(RecordingSegmentMessage, message_dict), context.transaction)
+        ingest_recording_chunked(
+            cast(RecordingSegmentMessage, message_dict), context.transaction, context.current_hub
+        )
     else:
         raise ValueError(f"Invalid replays recording message type specified: {message_type}")

--- a/src/sentry/replays/usecases/ingest.py
+++ b/src/sentry/replays/usecases/ingest.py
@@ -208,7 +208,7 @@ def ingest_recording(message: RecordingIngestMessage, transaction: Span) -> None
 
 @metrics.wraps("replays.usecases.ingest.ingest_chunk")
 def ingest_chunk(
-    message_dict: RecordingSegmentChunkMessage, transaction: Span, current_hub
+    message_dict: RecordingSegmentChunkMessage, transaction: Span, current_hub: Hub
 ) -> None:
     """Ingest chunked message part."""
     with current_hub:


### PR DESCRIPTION
- per @untitaker this will let us get breadcrumbs per kafka message instead of per-thread, and should make our auto-instrumentation better