### PR TITLE
ref(monitors): Use `monitor_config` for upsert during checkin

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -187,7 +187,7 @@ class MonitorCheckInValidator(serializers.Serializer):
         # Support specifying monitor configuration via a check-in
         #
         # NOTE: Most monitor attributes are contextual (project, slug, etc),
-        #       the monitor config is passed in via this checkin searializers
+        #       the monitor config is passed in via this checkin serializer's
         #       monitor_config attribute.
         monitor_config = attrs.get("monitor_config")
         if monitor_config:
@@ -210,7 +210,7 @@ class MonitorCheckInValidator(serializers.Serializer):
             monitor_validator.is_valid(raise_exception=True)
 
             # Drop the `monitor_config` attribute favor in favor of the fully
-            # validate monitor data
+            # validated monitor data
             attrs["monitor"] = monitor_validator.validated_data
             del attrs["monitor_config"]
 

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -179,16 +179,17 @@ class MonitorCheckInValidator(serializers.Serializer):
     )
     duration = EmptyIntegerField(required=False, allow_null=True)
     environment = serializers.CharField(required=False, allow_null=True)
-    config = ObjectField(required=False)
+    monitor_config = ObjectField(required=False)
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
 
         # Support specifying monitor configuration via a check-in
         #
-        # NOTE: Most monitor attributes are contextual, the monitor config is
-        #       passed in via this checkin searializers config attribute.
-        monitor_config = attrs.get("config")
+        # NOTE: Most monitor attributes are contextual (project, slug, etc),
+        #       the monitor config is passed in via this checkin searializers
+        #       monitor_config attribute.
+        monitor_config = attrs.get("monitor_config")
         if monitor_config:
             project = self.context["project"]
 
@@ -207,7 +208,10 @@ class MonitorCheckInValidator(serializers.Serializer):
                 },
             )
             monitor_validator.is_valid(raise_exception=True)
+
+            # Drop the `monitor_config` attribute favor in favor of the fully
+            # validate monitor data
             attrs["monitor"] = monitor_validator.validated_data
-            del attrs["config"]
+            del attrs["monitor_config"]
 
         return attrs

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -169,7 +169,10 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             resp = self.client.post(
                 path,
-                {"status": "ok", "config": {"schedule_type": "crontab", "schedule": "5 * * * *"}},
+                {
+                    "status": "ok",
+                    "monitor_config": {"schedule_type": "crontab", "schedule": "5 * * * *"},
+                },
                 **self.dsn_auth_headers,
             )
             assert resp.status_code == 201, resp.content
@@ -186,7 +189,10 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             resp = self.client.post(
                 path,
-                {"status": "ok", "config": {"schedule_type": "crontab", "schedule": "5 * * * *"}},
+                {
+                    "status": "ok",
+                    "monitor_config": {"schedule_type": "crontab", "schedule": "5 * * * *"},
+                },
                 **self.dsn_auth_headers,
             )
             assert resp.status_code == 201, resp.content
@@ -201,7 +207,10 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             resp = self.client.post(
                 path,
-                {"status": "ok", "config": {"schedule_type": "crontab", "schedule": "5 * * * *"}},
+                {
+                    "status": "ok",
+                    "monitor_config": {"schedule_type": "crontab", "schedule": "5 * * * *"},
+                },
                 **self.dsn_auth_headers,
             )
             assert resp.status_code == 400, resp.content


### PR DESCRIPTION
This is a bit more cleary while being slightly more verbose

**NOTE:** This was NOT yet being used in production. It is a breaking change, but luckily no one was using it :-)