### PR TITLE
feat(env): add canary const to server.py

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -92,6 +92,8 @@ IS_DEV = ENVIRONMENT == "development"
 
 DEBUG = IS_DEV
 
+IS_CANARY = False
+
 ADMIN_ENABLED = DEBUG
 
 ADMINS = ()


### PR DESCRIPTION
adds an `IS_CANARY` const to our settings which we'll control in getsentry.