### PR TITLE
fix(profiling): Take inner most frames for stacktrace

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -170,7 +170,7 @@ class Content extends Component<Props, State> {
       lastFrameIdx = (data.frames ?? []).length - 1;
     }
 
-    const frames: React.ReactElement[] = [];
+    let frames: React.ReactElement[] = [];
     let nRepeats = 0;
 
     const maxLengthOfAllRelativeAddresses = (data.frames ?? []).reduce(
@@ -263,7 +263,7 @@ class Content extends Component<Props, State> {
     }
 
     if (defined(maxDepth)) {
-      frames.splice(maxDepth);
+      frames = frames.slice(-maxDepth);
     }
 
     if (newestFirst) {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -155,7 +155,7 @@ function Content({
       0
     );
 
-    const convertedFrames = frames
+    let convertedFrames = frames
       .map((frame, frameIndex) => {
         const prevFrame = frames[frameIndex - 1];
         const nextFrame = frames[frameIndex + 1];
@@ -241,7 +241,7 @@ function Content({
     }
 
     if (defined(maxDepth)) {
-      convertedFrames.splice(maxDepth);
+      convertedFrames = convertedFrames.slice(-maxDepth);
     }
 
     if (!newestFirst) {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -137,7 +137,7 @@ function Content({
     0
   );
 
-  const convertedFrames = frames
+  let convertedFrames = frames
     .map((frame, frameIndex) => {
       const prevFrame = frames[frameIndex - 1];
       const nextFrame = frames[frameIndex + 1];
@@ -226,7 +226,7 @@ function Content({
   }
 
   if (defined(maxDepth)) {
-    convertedFrames.splice(maxDepth);
+    convertedFrames = convertedFrames.slice(-maxDepth);
   }
 
   return (


### PR DESCRIPTION
Profiling stacks were previously reversed. Now that they're the right order, make sure to take the last N elements for the maxDepth to show more relevant stacks.