### PR TITLE
feat(codecov-v2): Serialize processing organizations for codecov auto-enablement

### DIFF
--- a/src/sentry/tasks/auto_enable_codecov.py
+++ b/src/sentry/tasks/auto_enable_codecov.py
@@ -25,25 +25,31 @@ def schedule_organizations(dry_run=False) -> None:
     logger.info("Starting task for sentry.tasks.auto_enable_codecov.schedule_organizations")
 
     organizations = Organization.objects.filter(status=OrganizationStatus.ACTIVE)
-    logger.info(f"Processing {len(organizations)} organizations for codecov auto-enable")
+    logger.info(
+        "Processing organizations for codecov auto-enable", extra={"count": len(organizations)}
+    )
     for _, organization in enumerate(
         RangeQuerySetWrapper(organizations, step=1000, result_value_getter=lambda item: item.id)
     ):
-        if not features.has("organizations:codecov-stacktrace-integration", organization):
+        codecov_enabled = features.has("organizations:codecov-stacktrace-integration", organization)
+        should_auto_enable = features.has("organizations:auto-enable-codecov", organization)
+        if codecov_enabled and should_auto_enable:
             logger.warning(
-                f"Skipping {organizations.id}: organizations:codecov-stacktrace-integration is False"
+                "Processing organization",
+                extra={
+                    "organization_id": organization.id,
+                },
             )
-            continue
-
-        if not features.has("organizations:auto-enable-codecov", organization):
+            enable_for_organization(organization.id)
+        else:
             logger.warning(
-                f"Processing {len(organizations)}: organizations:auto-enable-codecov is False"
+                "Skipping organization: feature flag is False",
+                extra={
+                    "organization_id": organization.id,
+                    "codecov_integration_enabled": codecov_enabled,
+                    "should_auto_enable": should_auto_enable,
+                },
             )
-            continue
-
-        # Create a celery task per organization
-        logger.info(f"Queuing organization for codecov access {organization.id}")
-        enable_for_organization.delay(organization.id)
 
 
 @instrumented_task(  # type: ignore

--- a/src/sentry/tasks/auto_enable_codecov.py
+++ b/src/sentry/tasks/auto_enable_codecov.py
@@ -7,7 +7,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.query import RangeQuerySetWrapper
 
-logger = logging.getLogger("sentry.tasks.auto_enable_codecov")
+logger = logging.getLogger(__name__)
 
 
 @instrumented_task(

--- a/tests/sentry/tasks/test_auto_enable_codecov.py
+++ b/tests/sentry/tasks/test_auto_enable_codecov.py
@@ -69,7 +69,7 @@ class AutoEnableCodecovTest(TestCase):
         org = Organization.objects.get(id=self.org_1.id)
         assert not org.flags.codecov_access.is_set
 
-    @patch("sentry.tasks.auto_enable_codecov.enable_for_organization.delay")
+    @patch("sentry.tasks.auto_enable_codecov.enable_for_organization")
     def test_schedules_for_orgs(self, mock_enable_for_organization):
         schedule_organizations()
 


### PR DESCRIPTION
Replaces `enable_for_organization.delay` with `enable_for_organization` and refactors the feature flag logic to improve logging.

If this works, I'll reintroduce `enable_for_organization.delay` to see if that's where our logs and requests are getting lost.