### PR TITLE
Add secret scanning pre-commit step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,12 @@ repos:
       require_serial: true
       additional_dependencies: [ "pyright@1.1.186" ]
       args: [ '--project', 'pyrightconfig-commithook.json' ]
+    - id: trufflehog
+      name: TruffleHog
+      description: Detect secrets in your data.
+      entry: bash -c 'trufflehog git file://. --since-commit HEAD --fail'
+      language: system
+      stages: [ "commit", "push" ]
 
 -   repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.21.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
       additional_dependencies: [ "pyright@1.1.186" ]
       args: [ '--project', 'pyrightconfig-commithook.json' ]
     - id: trufflehog
-      name: TruffleHog
+      name: check-for-secrets
       description: Detect secrets in your data.
       entry: bash -c 'trufflehog git file://. --since-commit HEAD --fail'
       language: system

--- a/Brewfile
+++ b/Brewfile
@@ -18,3 +18,7 @@ tap 'homebrew/cask'
 
 # required for acceptance testing
 cask 'chromedriver'
+
+
+# required for secret checks
+brew 'trufflesecurity/trufflehog/trufflehog'


### PR DESCRIPTION
Adds [trufflehog](https://github.com/trufflesecurity/trufflehog) to our pre-commit steps to help prevent uploads of accidental hardcoded secrets.