### PR TITLE
perf(replays): Increase pending task queue size

### DIFF
--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -51,7 +51,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         step = RunTaskInThreads(
             processing_function=move_replay_to_permanent_storage,
             concurrency=4,
-            max_pending_futures=16,
+            max_pending_futures=50,
             next_step=CommitOffsets(commit),
         )
 


### PR DESCRIPTION
Not sure if it makes all that much difference - but try to prevent the consumer getting paused as frequently
