### PR TITLE
feat(replay): Memoize `getPrevReplayEvent`

### DIFF
--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, memo, useCallback} from 'react';
+import {CSSProperties, memo, useCallback, useMemo} from 'react';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -32,21 +32,29 @@ function BreadcrumbRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props
     [handleMouseLeave, breadcrumb]
   );
 
-  const current = getPrevReplayEvent({
-    items: breadcrumbs,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : undefined;
+      }),
+    [breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : undefined,
+    [breadcrumbs, currentHoverTime, startTimestampMs]
+  );
 
   const isCurrent = breadcrumb.id === current?.id;
   const isHovered = breadcrumb.id === hovered?.id;

--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useCallback} from 'react';
+import {CSSProperties, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -17,11 +17,12 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 type Props = {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
   breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[];
+  index: number;
   startTimestampMs: number;
   style: CSSProperties;
 };
 
-function ConsoleMessage({breadcrumb, breadcrumbs, startTimestampMs, style}: Props) {
+function ConsoleLogRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
 
   const {handleMouseEnter, handleMouseLeave, handleClick} =
@@ -40,21 +41,29 @@ function ConsoleMessage({breadcrumb, breadcrumbs, startTimestampMs, style}: Prop
     [handleMouseLeave, breadcrumb]
   );
 
-  const current = getPrevReplayEvent({
-    items: breadcrumbs,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : undefined;
+      }),
+    [breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : undefined,
+    [breadcrumbs, currentHoverTime, startTimestampMs]
+  );
 
   const hasOccurred =
     currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);
@@ -148,4 +157,4 @@ const Message = styled('div')`
   word-break: break-word;
 `;
 
-export default ConsoleMessage;
+export default ConsoleLogRow;

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useCallback} from 'react';
+import {CSSProperties, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
@@ -43,21 +43,29 @@ function DomMutationRow({mutation, mutations, startTimestampMs, style}: Props) {
   );
 
   const breadcrumbs = mutations.map(({crumb}) => crumb);
-  const current = getPrevReplayEvent({
-    items: breadcrumbs,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : undefined;
+      }),
+    [breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : undefined,
+    [breadcrumbs, currentHoverTime, startTimestampMs]
+  );
 
   const hasOccurred =
     currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useMemo, useRef} from 'react';
 import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
@@ -44,21 +44,29 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
 
-  const current = getPrevReplayEvent({
-    items,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : null;
+      }),
+    [items, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : null,
+    [items, currentHoverTime, startTimestampMs]
+  );
 
   const gridRef = useRef<MultiGrid>(null);
   const {cache, getColumnWidth, onScrollbarPresenceChange, onWrapperResize} =


### PR DESCRIPTION
This is a pretty expensive call, even in our virtualized lists. Memoize the results of these calls to improve performance, especially when scrolling. Though the biggest boost to perf happens when we need to call `updateList` (e.g. in console where we can have lots of messages with dynamic dimensions which need to call `updateList` to sync row heights).