### PR TITLE
fix(sourcemaps): Show url in files

### DIFF
--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -94,7 +94,7 @@ class ProjectArtifactBundleFilesEndpoint(ProjectEndpoint):
                 "id": base64.urlsafe_b64encode(bytes(file_path.encode("utf-8"))).decode("utf-8"),
                 # In case the file type string was invalid, we return the sentinel value INVALID_SOURCE_FILE_TYPE.
                 "fileType": file_type.value if file_type is not None else INVALID_SOURCE_FILE_TYPE,
-                "filePath": file_path,
+                "filePath": archive.get_file_url_by_file_path(file_path),
                 "fileSize": file_info.file_size if file_info is not None else None,
                 "debugId": debug_id,
             }
@@ -120,7 +120,7 @@ class ProjectArtifactBundleFilesEndpoint(ProjectEndpoint):
         try:
             return self.paginate(
                 request=request,
-                sources=[ArtifactBundleSource(archive.get_files_by_file_path_or_debug_id(query))],
+                sources=[ArtifactBundleSource(archive.get_files_by_url_or_debug_id(query))],
                 paginator_cls=ChainPaginator,
                 max_offset=MAX_ARTIFACT_BUNDLE_FILES_OFFSET,
                 on_results=serialize_results,

--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -225,14 +225,14 @@ class ArtifactBundleArchive:
 
         return results
 
-    def get_files_by_file_path_or_debug_id(self, query: Optional[str]) -> Dict[str, dict]:
-        def filter_function(file_path: str, info: dict) -> bool:
+    def get_files_by_url_or_debug_id(self, query: Optional[str]) -> Dict[str, dict]:
+        def filter_function(_: str, info: dict) -> bool:
             if query is None:
                 return True
 
             normalized_query = query.lower()
 
-            if normalized_query in file_path.lower():
+            if normalized_query in info.get("url", "").lower():
                 return True
 
             headers = self.normalize_headers(info.get("headers", {}))
@@ -258,3 +258,8 @@ class ArtifactBundleArchive:
             return entry[1]
 
         return None
+
+    def get_file_url_by_file_path(self, file_path):
+        files = self.manifest.get("files", {})
+        file_info = files.get(file_path, {})
+        return file_info.get("url")

--- a/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
@@ -223,7 +223,7 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
             "files": [
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/bundle1.js",
+                    "filePath": "~/bundle1.js",
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                     "fileSize": 71,
                     "fileType": 0,
@@ -242,21 +242,21 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
             "files": [
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/bundle1.js",
+                    "filePath": "~/bundle1.js",
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                     "fileSize": 71,
                     "fileType": 0,
                 },
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/bundle1.min.js",
+                    "filePath": "~/bundle1.min.js",
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpz",
                     "fileSize": 63,
                     "fileType": 2,
                 },
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/bundle1.min.js.map",
+                    "filePath": "~/bundle1.min.js.map",
                     "fileSize": 139,
                     "fileType": 0,
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpzLm1hcA==",
@@ -275,14 +275,14 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
             "files": [
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
-                    "filePath": "files/_/_/index.js.map",
+                    "filePath": "~/index.js.map",
                     "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                     "fileSize": 1804,
                     "fileType": 3,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
-                    "filePath": "files/_/_/index.min.js",
+                    "filePath": "~/index.min.js",
                     "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                     "fileSize": 1676,
                     "fileType": 2,

--- a/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
@@ -47,42 +47,42 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
             "files": [
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/bundle1.js",
+                    "filePath": "~/bundle1.js",
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                     "fileSize": 71,
                     "fileType": 0,
                 },
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/bundle1.min.js",
+                    "filePath": "~/bundle1.min.js",
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpz",
                     "fileSize": 63,
                     "fileType": 2,
                 },
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/bundle1.min.js.map",
+                    "filePath": "~/bundle1.min.js.map",
                     "fileSize": 139,
                     "fileType": 0,
                     "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpzLm1hcA==",
                 },
                 {
                     "debugId": None,
-                    "filePath": "files/_/_/index.js",
+                    "filePath": "~/index.js",
                     "id": "ZmlsZXMvXy9fL2luZGV4Lmpz",
                     "fileSize": 3706,
                     "fileType": 1,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
-                    "filePath": "files/_/_/index.js.map",
+                    "filePath": "~/index.js.map",
                     "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                     "fileSize": 1804,
                     "fileType": 3,
                 },
                 {
                     "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
-                    "filePath": "files/_/_/index.min.js",
+                    "filePath": "~/index.min.js",
                     "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                     "fileSize": 1676,
                     "fileType": 2,
@@ -124,14 +124,14 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                 "files": [
                     {
                         "debugId": None,
-                        "filePath": "files/_/_/bundle1.js",
+                        "filePath": "~/bundle1.js",
                         "id": "ZmlsZXMvXy9fL2J1bmRsZTEuanM=",
                         "fileSize": 71,
                         "fileType": 0,
                     },
                     {
                         "debugId": None,
-                        "filePath": "files/_/_/bundle1.min.js",
+                        "filePath": "~/bundle1.min.js",
                         "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpz",
                         "fileSize": 63,
                         "fileType": 2,
@@ -145,14 +145,14 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                 "files": [
                     {
                         "debugId": None,
-                        "filePath": "files/_/_/bundle1.min.js.map",
+                        "filePath": "~/bundle1.min.js.map",
                         "fileSize": 139,
                         "fileType": 0,
                         "id": "ZmlsZXMvXy9fL2J1bmRsZTEubWluLmpzLm1hcA==",
                     },
                     {
                         "debugId": None,
-                        "filePath": "files/_/_/index.js",
+                        "filePath": "~/index.js",
                         "id": "ZmlsZXMvXy9fL2luZGV4Lmpz",
                         "fileSize": 3706,
                         "fileType": 1,
@@ -166,14 +166,14 @@ class ProjectArtifactBundleFilesEndpointTest(APITestCase):
                 "files": [
                     {
                         "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
-                        "filePath": "files/_/_/index.js.map",
+                        "filePath": "~/index.js.map",
                         "id": "ZmlsZXMvXy9fL2luZGV4LmpzLm1hcA==",
                         "fileSize": 1804,
                         "fileType": 3,
                     },
                     {
                         "debugId": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b",
-                        "filePath": "files/_/_/index.min.js",
+                        "filePath": "~/index.min.js",
                         "id": "ZmlsZXMvXy9fL2luZGV4Lm1pbi5qcw==",
                         "fileSize": 1676,
                         "fileType": 2,


### PR DESCRIPTION
This PR changes the results of the artifact bundle files endpoint to return the `url` instead of `file_path`.