### PR TITLE
perf(replay): Improve performance of `getPrevReplayEvent`

### DIFF
--- a/static/app/utils/replays/getReplayEvent.spec.tsx
+++ b/static/app/utils/replays/getReplayEvent.spec.tsx
@@ -141,6 +141,9 @@ describe('getPrevReplayEvent', () => {
   it('should return the previous crumb even if the timestamp is closer to the next crumb', () => {
     const crumbs = createCrumbs();
     const results = getPrevReplayEvent({
+      itemLookup: crumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
       items: crumbs,
       targetTimestampMs: START_TIMESTAMP_SEC * 1000 + CURRENT_TIME_MS,
     });
@@ -150,8 +153,12 @@ describe('getPrevReplayEvent', () => {
 
   it('should return the previous crumb when the list is not sorted', () => {
     const [one, two, three, four, five] = createCrumbs();
+    const items = [one, four, five, three, two];
     const results = getPrevReplayEvent({
-      items: [one, four, five, three, two],
+      itemLookup: items
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
+      items,
       targetTimestampMs: START_TIMESTAMP_SEC * 1000 + CURRENT_TIME_MS,
     });
 
@@ -161,6 +168,9 @@ describe('getPrevReplayEvent', () => {
   it('should return undefined when there are no crumbs', () => {
     const crumbs = [];
     const results = getPrevReplayEvent({
+      itemLookup: crumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
       items: crumbs,
       targetTimestampMs: START_TIMESTAMP_SEC * 1000 + CURRENT_TIME_MS,
     });
@@ -171,6 +181,9 @@ describe('getPrevReplayEvent', () => {
   it('should return undefined when the timestamp is earlier than any crumbs', () => {
     const crumbs = createCrumbs();
     const results = getPrevReplayEvent({
+      itemLookup: crumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
       items: crumbs,
       targetTimestampMs: START_TIMESTAMP_SEC * 1000 - CURRENT_TIME_MS,
     });
@@ -178,24 +191,41 @@ describe('getPrevReplayEvent', () => {
     expect(results).toBeUndefined();
   });
 
-  it('should return the crumb previous when a crumbs timestamp exactly matches', () => {
+  it('should return the last crumb if timestamp is later than any crumb', () => {
     const crumbs = createCrumbs();
-    const exactCrumbTime = 8135;
     const results = getPrevReplayEvent({
+      itemLookup: crumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
       items: crumbs,
-      targetTimestampMs: START_TIMESTAMP_SEC * 1000 + exactCrumbTime,
+      targetTimestampMs: 1652308892002 + 10,
     });
 
-    expect(results?.id).toEqual(3);
+    expect(results?.id).toEqual(0);
   });
 
-  it('should return the crumb if timestamps exactly match and allowExact is enabled', () => {
+  it('should return the last crumb if timestamp is exactly the last crumb', () => {
+    const crumbs = createCrumbs();
+    const results = getPrevReplayEvent({
+      itemLookup: crumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
+      items: crumbs,
+      targetTimestampMs: 1652308892002,
+    });
+
+    expect(results?.id).toEqual(0);
+  });
+
+  it('should return the crumb if timestamps exactly match', () => {
     const crumbs = createCrumbs();
     const exactCrumbTime = 8135;
     const results = getPrevReplayEvent({
+      itemLookup: crumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
       items: crumbs,
       targetTimestampMs: START_TIMESTAMP_SEC * 1000 + exactCrumbTime,
-      allowExact: true,
     });
 
     expect(results?.id).toEqual(4);

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -1,21 +1,25 @@
-import {CSSProperties, memo, useCallback, useMemo} from 'react';
+import {CSSProperties, memo, useCallback} from 'react';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import type {Crumb} from 'sentry/types/breadcrumbs';
-import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 
 interface Props {
   breadcrumb: Crumb;
-  breadcrumbs: Crumb[];
+  isCurrent: boolean;
+  isHovered: boolean;
   startTimestampMs: number;
   style: CSSProperties;
+  breadcrumbIndex?: number[][];
 }
 
-function BreadcrumbRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props) {
-  const {currentTime, currentHoverTime} = useReplayContext();
-
+function BreadcrumbRow({
+  breadcrumb,
+  startTimestampMs,
+  style,
+  isCurrent,
+  isHovered,
+}: Props) {
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
 
@@ -31,33 +35,6 @@ function BreadcrumbRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props
     () => handleMouseLeave(breadcrumb),
     [handleMouseLeave, breadcrumb]
   );
-
-  const current = useMemo(
-    () =>
-      getPrevReplayEvent({
-        items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentTime,
-        allowEqual: true,
-        allowExact: true,
-      }),
-    [breadcrumbs, currentTime, startTimestampMs]
-  );
-
-  const hovered = useMemo(
-    () =>
-      currentHoverTime
-        ? getPrevReplayEvent({
-            items: breadcrumbs,
-            targetTimestampMs: startTimestampMs + currentHoverTime,
-            allowEqual: true,
-            allowExact: true,
-          })
-        : undefined,
-    [breadcrumbs, currentHoverTime, startTimestampMs]
-  );
-
-  const isCurrent = breadcrumb.id === current?.id;
-  const isHovered = breadcrumb.id === hovered?.id;
 
   return (
     <BreadcrumbItem

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, memo, useCallback} from 'react';
+import {CSSProperties, memo, useCallback, useMemo} from 'react';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -32,21 +32,29 @@ function BreadcrumbRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props
     [handleMouseLeave, breadcrumb]
   );
 
-  const current = getPrevReplayEvent({
-    items: breadcrumbs,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : undefined;
+      }),
+    [breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : undefined,
+    [breadcrumbs, currentHoverTime, startTimestampMs]
+  );
 
   const isCurrent = breadcrumb.id === current?.id;
   const isHovered = breadcrumb.id === hovered?.id;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -8,8 +8,10 @@ import {
 import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import type {Crumb} from 'sentry/types/breadcrumbs';
+import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import BreadcrumbRow from 'sentry/views/replays/detail/breadcrumbs/breadcrumbRow';
 import useScrollToCurrentItem from 'sentry/views/replays/detail/breadcrumbs/useScrollToCurrentItem';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
@@ -29,6 +31,7 @@ const cellMeasurer = {
 };
 
 function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
+  const {currentTime, currentHoverTime} = useReplayContext();
   const items = useMemo(
     () =>
       (breadcrumbs || []).filter(crumb => !['console'].includes(crumb.category || '')),
@@ -36,6 +39,40 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
   );
 
   const listRef = useRef<ReactVirtualizedList>(null);
+
+  const itemLookup = useMemo(
+    () =>
+      breadcrumbs &&
+      breadcrumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
+    [breadcrumbs]
+  );
+
+  const current = useMemo(
+    () =>
+      breadcrumbs
+        ? getPrevReplayEvent({
+            itemLookup,
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentTime,
+          })
+        : undefined,
+    [itemLookup, breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime && breadcrumbs
+        ? getPrevReplayEvent({
+            itemLookup,
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+          })
+        : undefined,
+    [itemLookup, breadcrumbs, currentHoverTime, startTimestampMs]
+  );
+
   const {cache, updateList} = useVirtualizedList({
     cellMeasurer,
     ref: listRef,
@@ -60,8 +97,9 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
         rowIndex={index}
       >
         <BreadcrumbRow
+          isCurrent={current?.id === item.id}
+          isHovered={hovered?.id === item.id}
           breadcrumb={item}
-          breadcrumbs={items}
           startTimestampMs={startTimestampMs}
           style={style}
         />

--- a/static/app/views/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useScrollToCurrentItem.tsx
@@ -12,15 +12,23 @@ type Opts = {
 };
 function useScrollToCurrentItem({breadcrumbs, ref, startTimestampMs}: Opts) {
   const {currentTime} = useReplayContext();
+  const itemLookup = useMemo(
+    () =>
+      breadcrumbs &&
+      breadcrumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
+    [breadcrumbs]
+  );
+
   const current = useMemo(
     () =>
       getPrevReplayEvent({
+        itemLookup,
         items: breadcrumbs || [],
         targetTimestampMs: startTimestampMs + currentTime,
-        allowEqual: true,
-        allowExact: true,
       }),
-    [breadcrumbs, currentTime, startTimestampMs]
+    [itemLookup, breadcrumbs, currentTime, startTimestampMs]
   );
 
   useEffect(() => {

--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useCallback} from 'react';
+import {CSSProperties, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -17,11 +17,12 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 type Props = {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
   breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[];
+  index: number;
   startTimestampMs: number;
   style: CSSProperties;
 };
 
-function ConsoleMessage({breadcrumb, breadcrumbs, startTimestampMs, style}: Props) {
+function ConsoleLogRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
 
   const {handleMouseEnter, handleMouseLeave, handleClick} =
@@ -40,21 +41,29 @@ function ConsoleMessage({breadcrumb, breadcrumbs, startTimestampMs, style}: Prop
     [handleMouseLeave, breadcrumb]
   );
 
-  const current = getPrevReplayEvent({
-    items: breadcrumbs,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : undefined;
+      }),
+    [breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : undefined,
+    [breadcrumbs, currentHoverTime, startTimestampMs]
+  );
 
   const hasOccurred =
     currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);
@@ -148,4 +157,4 @@ const Message = styled('div')`
   word-break: break-word;
 `;
 
-export default ConsoleMessage;
+export default ConsoleLogRow;

--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -15,12 +15,10 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 type Props = {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
-  breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[];
   isCurrent: boolean;
   isHovered: boolean;
   startTimestampMs: number;
   style: CSSProperties;
-  breadcrumbIndex?: number[][];
 };
 
 function ConsoleLogRow({

--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useCallback, useMemo} from 'react';
+import {CSSProperties, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -7,7 +7,6 @@ import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {IconFire, IconWarning} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
-import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import MessageFormatter from 'sentry/views/replays/detail/console/messageFormatter';
 import {breadcrumbHasIssue} from 'sentry/views/replays/detail/console/utils';
@@ -17,13 +16,21 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 type Props = {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
   breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[];
-  index: number;
+  isCurrent: boolean;
+  isHovered: boolean;
   startTimestampMs: number;
   style: CSSProperties;
+  breadcrumbIndex?: number[][];
 };
 
-function ConsoleLogRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props) {
-  const {currentTime, currentHoverTime} = useReplayContext();
+function ConsoleLogRow({
+  breadcrumb,
+  isHovered,
+  isCurrent,
+  startTimestampMs,
+  style,
+}: Props) {
+  const {currentTime} = useReplayContext();
 
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
@@ -41,34 +48,8 @@ function ConsoleLogRow({breadcrumb, breadcrumbs, startTimestampMs, style}: Props
     [handleMouseLeave, breadcrumb]
   );
 
-  const current = useMemo(
-    () =>
-      getPrevReplayEvent({
-        items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentTime,
-        allowEqual: true,
-        allowExact: true,
-      }),
-    [breadcrumbs, currentTime, startTimestampMs]
-  );
-
-  const hovered = useMemo(
-    () =>
-      currentHoverTime
-        ? getPrevReplayEvent({
-            items: breadcrumbs,
-            targetTimestampMs: startTimestampMs + currentHoverTime,
-            allowEqual: true,
-            allowExact: true,
-          })
-        : undefined,
-    [breadcrumbs, currentHoverTime, startTimestampMs]
-  );
-
   const hasOccurred =
     currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);
-  const isCurrent = breadcrumb.id === current?.id;
-  const isHovered = breadcrumb.id === hovered?.id;
 
   return (
     <ConsoleLog

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -92,7 +92,6 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
           isCurrent={current?.id === item.id}
           isHovered={hovered?.id === item.id}
           breadcrumb={item}
-          breadcrumbs={items}
           startTimestampMs={startTimestampMs}
           style={style}
         />

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -1,4 +1,4 @@
-import {memo, useRef} from 'react';
+import {memo, useMemo, useRef} from 'react';
 import {
   AutoSizer,
   CellMeasurer,
@@ -8,8 +8,10 @@ import {
 import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
 import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
+import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import ConsoleFilters from 'sentry/views/replays/detail/console/consoleFilters';
 import ConsoleLogRow from 'sentry/views/replays/detail/console/consoleLogRow';
 import useConsoleFilters from 'sentry/views/replays/detail/console/useConsoleFilters';
@@ -33,13 +35,47 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
   const filterProps = useConsoleFilters({breadcrumbs: breadcrumbs || []});
   const {items, setSearchTerm} = filterProps;
   const clearSearchTerm = () => setSearchTerm('');
+  const {currentTime, currentHoverTime} = useReplayContext();
 
   const listRef = useRef<ReactVirtualizedList>(null);
+  const itemLookup = useMemo(
+    () =>
+      breadcrumbs &&
+      breadcrumbs
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
+    [breadcrumbs]
+  );
+
   const {cache, updateList} = useVirtualizedList({
     cellMeasurer,
     ref: listRef,
     deps: [items],
   });
+
+  const current = useMemo(
+    () =>
+      breadcrumbs
+        ? getPrevReplayEvent({
+            itemLookup,
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentTime,
+          })
+        : undefined,
+    [itemLookup, breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime && breadcrumbs
+        ? getPrevReplayEvent({
+            itemLookup,
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+          })
+        : undefined,
+    [itemLookup, breadcrumbs, currentHoverTime, startTimestampMs]
+  );
 
   const renderRow = ({index, key, style, parent}: ListRowProps) => {
     const item = items[index];
@@ -53,6 +89,8 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
         rowIndex={index}
       >
         <ConsoleLogRow
+          isCurrent={current?.id === item.id}
+          isHovered={hovered?.id === item.id}
           breadcrumb={item}
           breadcrumbs={items}
           startTimestampMs={startTimestampMs}

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -17,7 +17,6 @@ type Props = {
   isCurrent: boolean;
   isHovered: boolean;
   mutation: Extraction;
-  mutations: Extraction[];
   startTimestampMs: number;
   style: CSSProperties;
 };

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useCallback, useMemo} from 'react';
+import {CSSProperties, useCallback} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
@@ -8,23 +8,30 @@ import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {space} from 'sentry/styles/space';
-import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import type {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
 import IconWrapper from 'sentry/views/replays/detail/iconWrapper';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 type Props = {
+  isCurrent: boolean;
+  isHovered: boolean;
   mutation: Extraction;
   mutations: Extraction[];
   startTimestampMs: number;
   style: CSSProperties;
 };
 
-function DomMutationRow({mutation, mutations, startTimestampMs, style}: Props) {
+function DomMutationRow({
+  isCurrent,
+  isHovered,
+  mutation,
+  startTimestampMs,
+  style,
+}: Props) {
   const {html, crumb: breadcrumb} = mutation;
 
-  const {currentTime, currentHoverTime} = useReplayContext();
+  const {currentTime} = useReplayContext();
 
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
@@ -42,35 +49,8 @@ function DomMutationRow({mutation, mutations, startTimestampMs, style}: Props) {
     [handleMouseLeave, breadcrumb]
   );
 
-  const breadcrumbs = mutations.map(({crumb}) => crumb);
-  const current = useMemo(
-    () =>
-      getPrevReplayEvent({
-        items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentTime,
-        allowEqual: true,
-        allowExact: true,
-      }),
-    [breadcrumbs, currentTime, startTimestampMs]
-  );
-
-  const hovered = useMemo(
-    () =>
-      currentHoverTime
-        ? getPrevReplayEvent({
-            items: breadcrumbs,
-            targetTimestampMs: startTimestampMs + currentHoverTime,
-            allowEqual: true,
-            allowExact: true,
-          })
-        : undefined,
-    [breadcrumbs, currentHoverTime, startTimestampMs]
-  );
-
   const hasOccurred =
     currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);
-  const isCurrent = breadcrumb.id === current?.id;
-  const isHovered = breadcrumb.id === hovered?.id;
 
   const {title} = getDetails(breadcrumb);
 

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useCallback} from 'react';
+import {CSSProperties, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
@@ -43,21 +43,29 @@ function DomMutationRow({mutation, mutations, startTimestampMs, style}: Props) {
   );
 
   const breadcrumbs = mutations.map(({crumb}) => crumb);
-  const current = getPrevReplayEvent({
-    items: breadcrumbs,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items: breadcrumbs,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : undefined;
+      }),
+    [breadcrumbs, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items: breadcrumbs,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : undefined,
+    [breadcrumbs, currentHoverTime, startTimestampMs]
+  );
 
   const hasOccurred =
     currentTime >= relativeTimeInMs(breadcrumb.timestamp || 0, startTimestampMs);

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -95,7 +95,6 @@ function DomMutations({replay, startTimestampMs}: Props) {
           isCurrent={mutation.crumb.id === current?.id}
           isHovered={mutation.crumb.id === hovered?.id}
           mutation={mutation}
-          mutations={items}
           startTimestampMs={startTimestampMs}
           style={style}
         />

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -44,28 +44,35 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
 
+  const itemLookup = useMemo(
+    () =>
+      items &&
+      items
+        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
+        .sort(([a], [b]) => a - b),
+    [items]
+  );
+
   const current = useMemo(
     () =>
       getPrevReplayEvent({
+        itemLookup,
         items,
         targetTimestampMs: startTimestampMs + currentTime,
-        allowEqual: true,
-        allowExact: true,
       }),
-    [items, currentTime, startTimestampMs]
+    [itemLookup, items, currentTime, startTimestampMs]
   );
 
   const hovered = useMemo(
     () =>
       currentHoverTime
         ? getPrevReplayEvent({
+            itemLookup,
             items,
             targetTimestampMs: startTimestampMs + currentHoverTime,
-            allowEqual: true,
-            allowExact: true,
           })
         : null,
-    [items, currentHoverTime, startTimestampMs]
+    [itemLookup, items, currentHoverTime, startTimestampMs]
   );
 
   const gridRef = useRef<MultiGrid>(null);

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useMemo, useRef} from 'react';
 import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
@@ -44,21 +44,29 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
 
-  const current = getPrevReplayEvent({
-    items,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowEqual: true,
-    allowExact: true,
-  });
-
-  const hovered = currentHoverTime
-    ? getPrevReplayEvent({
+  const current = useMemo(
+    () =>
+      getPrevReplayEvent({
         items,
-        targetTimestampMs: startTimestampMs + currentHoverTime,
+        targetTimestampMs: startTimestampMs + currentTime,
         allowEqual: true,
         allowExact: true,
-      })
-    : null;
+      }),
+    [items, currentTime, startTimestampMs]
+  );
+
+  const hovered = useMemo(
+    () =>
+      currentHoverTime
+        ? getPrevReplayEvent({
+            items,
+            targetTimestampMs: startTimestampMs + currentHoverTime,
+            allowEqual: true,
+            allowExact: true,
+          })
+        : null,
+    [items, currentHoverTime, startTimestampMs]
+  );
 
   const gridRef = useRef<MultiGrid>(null);
   const {cache, getColumnWidth, onScrollbarPresenceChange, onWrapperResize} =


### PR DESCRIPTION
This is a pretty expensive call, even in our virtualized lists, especially when scrolling

* Pull up the current/hovered logic to the table level instead of per row item, this reduces the # of `getPrevReplayEvent` calls to 1.
* Provide a memoized and sorted lookup table to `getReplayEvent` and use a binary search to find previous event.
* Memoize the results of `getPrevReplayEvent`
 
The biggest boost to perf will happen when we need to call `updateList` (e.g. in Console where we can have lots of messages with dynamic dimensions which will need to call `updateList` to sync row heights).


Closes #46260 