### PR TITLE
ref: Consume error mappings from symbolicator sourcemap response

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -98,8 +98,8 @@ def map_symbolicator_process_js_errors(errors):
             mapped_errors.append(
                 {
                     "type": EventError.JS_INVALID_SOURCEMAP_LOCATION,
-                    "column": error["column"],
-                    "row": error["row"],
+                    "column": error["col"],
+                    "row": error["line"],
                     "source": error["abs_path"],
                 }
             )
@@ -140,7 +140,9 @@ def process_payload(data):
     if not _handle_response_status(data, response):
         return data
 
-    data.setdefault("errors", []).extend(map_symbolicator_process_js_errors(response.get("errors")))
+    processing_errors = response.get("errors", [])
+    if len(processing_errors) > 0:
+        data.setdefault("errors", []).extend(map_symbolicator_process_js_errors(processing_errors))
 
     # TODO: should this really be a hard assert? Or rather an internal log?
     assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -442,13 +442,9 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         event = self.post_and_retrieve_event(data)
 
-        # FIXME: Unify this assertion once we add error mapping.
-        if process_with_symbolicator:
-            assert "errors" not in event.data
-        else:
-            assert event.data["errors"] == [
-                {"type": "js_no_source", "url": "http//example.com/index.html"}
-            ]
+        assert event.data["errors"] == [
+            {"type": "js_no_source", "url": "http//example.com/index.html"}
+        ]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames
@@ -540,13 +536,9 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         event = self.post_and_retrieve_event(data)
 
-        # FIXME: Unify this assertion once we add error mapping.
-        if process_with_symbolicator:
-            assert "errors" not in event.data
-        else:
-            assert event.data["errors"] == [
-                {"type": "js_no_source", "url": "http//example.com/index.html"}
-            ]
+        assert event.data["errors"] == [
+            {"type": "js_no_source", "url": "http//example.com/index.html"}
+        ]
 
         exception = event.interfaces["exception"]
         frame_list = exception.values[0].stacktrace.frames


### PR DESCRIPTION
Only a few basic errors for now, but it allows us to confirm via integration tests that the roundtrip works as expected.