### PR TITLE
feat(anr-improvements): Add culprit and short group id to trace

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -98,6 +98,7 @@ class TracePerformanceIssue(TypedDict):
     title: str
     level: str
     culprit: str
+    type: int
 
 
 LightResponse = TypedDict(
@@ -222,6 +223,7 @@ class TraceEvent:
                     "title": group.title,
                     "level": constants.LOG_LEVELS[group.level],
                     "culprit": group.culprit,
+                    "type": group.type,
                 }
             )
 

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -90,12 +90,14 @@ class TraceError(TypedDict):
 class TracePerformanceIssue(TypedDict):
     event_id: str
     issue_id: int
+    short_issue_id: str
     span: List[str]
     suspect_spans: List[str]
     project_id: int
     project_slug: str
     title: str
     level: str
+    culprit: str
 
 
 LightResponse = TypedDict(
@@ -212,12 +214,14 @@ class TraceEvent:
                 {
                     "event_id": self.event["id"],
                     "issue_id": group_id,
+                    "issue_short_id": group.qualified_short_id,
                     "span": span,
                     "suspect_spans": suspect_spans,
                     "project_id": self.event["project.id"],
                     "project_slug": self.event["project"],
                     "title": group.title,
                     "level": constants.LOG_LEVELS[group.level],
+                    "culprit": group.culprit,
                 }
             )
 

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -90,7 +90,7 @@ class TraceError(TypedDict):
 class TracePerformanceIssue(TypedDict):
     event_id: str
     issue_id: int
-    short_issue_id: str
+    issue_short_id: str
     span: List[str]
     suspect_spans: List[str]
     project_id: int

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -32,7 +32,7 @@ from sentry.eventstore.models import Event
 from sentry.models import Group, Organization
 from sentry.search.events.builder import QueryBuilder
 from sentry.snuba import discover
-from sentry.utils.numbers import format_grouped_length
+from sentry.utils.numbers import base32_encode, format_grouped_length
 from sentry.utils.performance_issues.performance_detection import EventPerformanceProblem
 from sentry.utils.sdk import set_measurement
 from sentry.utils.snuba import Dataset, bulk_snql_query
@@ -90,7 +90,7 @@ class TraceError(TypedDict):
 class TracePerformanceIssue(TypedDict):
     event_id: str
     issue_id: int
-    issue_short_id: str
+    issue_short_id: Optional[str]
     span: List[str]
     suspect_spans: List[str]
     project_id: int
@@ -211,11 +211,18 @@ class TraceEvent:
                 else:
                     span = [self.event["trace.span"]]
 
+            # Logic for qualified_short_id is copied from property on the Group model
+            # to prevent an N+1 query from accessing project.slug everytime
+            qualified_short_id = None
+            project_slug = self.event["project"]
+            if group.short_id is not None:
+                qualified_short_id = f"{project_slug.upper()}-{base32_encode(group.short_id)}"
+
             self.performance_issues.append(
                 {
                     "event_id": self.event["id"],
                     "issue_id": group_id,
-                    "issue_short_id": group.qualified_short_id,
+                    "issue_short_id": qualified_short_id,
                     "span": span,
                     "suspect_spans": suspect_spans,
                     "project_id": self.event["project.id"],

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -5,6 +5,7 @@ import pytest
 from django.urls import NoReverseMatch, reverse
 
 from sentry import options
+from sentry.issues.grouptype import PerformanceFileIOMainThreadGroupType
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -737,6 +738,10 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert root["measurements"]["fcp"]["value"] == 750
         assert "issue_short_id" in response.data[0]["performance_issues"][0]
         assert response.data[0]["performance_issues"][0]["culprit"] == "/country_by_code/"
+        assert (
+            response.data[0]["performance_issues"][0]["type"]
+            == PerformanceFileIOMainThreadGroupType.type_id
+        )
 
     def test_detailed_trace_with_bad_tags(self):
         """Basically test that we're actually using the event serializer's method for tags"""

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -735,6 +735,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
                 assert root_tags[key[7:]] == value, f"tags - {key}"
         assert root["measurements"]["lcp"]["value"] == 1000
         assert root["measurements"]["fcp"]["value"] == 750
+        assert "issue_short_id" in response.data[0]["performance_issues"][0]
+        assert response.data[0]["performance_issues"][0]["culprit"] == "/country_by_code/"
 
     def test_detailed_trace_with_bad_tags(self):
         """Basically test that we're actually using the event serializer's method for tags"""


### PR DESCRIPTION
This is so we don't need to make additional api calls to get
this data when we show potential root causes for ANRs.

