### PR TITLE
fix(perf): Update mapping between platform type and performance tab

### DIFF
--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -111,31 +111,27 @@ export function platformToPerformanceType(
     return PROJECT_PERFORMANCE_TYPE.ANY;
   }
 
-  if (
-    selectedProjects.every(project =>
-      FRONTEND_PLATFORMS.includes(project.platform as string)
-    )
-  ) {
-    return PROJECT_PERFORMANCE_TYPE.FRONTEND;
-  }
+  const projectPerformanceTypes = new Set<PROJECT_PERFORMANCE_TYPE>();
 
-  if (
-    selectedProjects.every(project =>
-      BACKEND_PLATFORMS.includes(project.platform as string)
-    )
-  ) {
-    return PROJECT_PERFORMANCE_TYPE.BACKEND;
-  }
+  selectedProjects.forEach(project => {
+    if (FRONTEND_PLATFORMS.includes(project.platform ?? '')) {
+      projectPerformanceTypes.add(PROJECT_PERFORMANCE_TYPE.FRONTEND);
+    }
+    if (BACKEND_PLATFORMS.includes(project.platform ?? '')) {
+      projectPerformanceTypes.add(PROJECT_PERFORMANCE_TYPE.BACKEND);
+    }
+    if (MOBILE_PLATFORMS.includes(project.platform ?? '')) {
+      projectPerformanceTypes.add(PROJECT_PERFORMANCE_TYPE.MOBILE);
+    }
+  });
 
-  if (
-    selectedProjects.every(project =>
-      MOBILE_PLATFORMS.includes(project.platform as string)
-    )
-  ) {
-    return PROJECT_PERFORMANCE_TYPE.MOBILE;
-  }
+  const uniquePerformanceTypeCount = projectPerformanceTypes.size;
 
-  return PROJECT_PERFORMANCE_TYPE.ANY;
+  if (!uniquePerformanceTypeCount || uniquePerformanceTypeCount > 1) {
+    return PROJECT_PERFORMANCE_TYPE.ANY;
+  }
+  const [platformType] = projectPerformanceTypes;
+  return platformType;
 }
 
 /**


### PR DESCRIPTION
The motivation for this PR is to update the mapping between a certain platform type like `react` to which tab it defaults to in performance, like `web vitals`.

Previously if a platform was marked as multiple categories like `frontend` and `mobile` we would return `frontend` and always take them to `web vitals`. This was the case for `unity`.

This doesn't make too much sense imo, and now we just return `any` which will take the user to `all transactions.