### PR TITLE
ref(metric alerts): Use new consumer

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -429,7 +429,7 @@ def post_process_forwarder(**options):
 )
 @click.option(
     "--use-arroyo-consumer",
-    default=False,
+    default=True,
     is_flag=True,
     help="Switches to the new arroyo consumer implementation.",
 )


### PR DESCRIPTION
We've been using the new consumer on the transaction subscriptions for a couple days (PR here: https://github.com/getsentry/ops/pull/6362) without issue, so now we can use it everywhere. 

Next steps:
* Stop passing the option in the ops repo
* Delete all the old consumer code
* [Create kafka schema](https://github.com/getsentry/sentry-kafka-schemas/pull/49)
* [Use the kafka schema for message validation](https://github.com/getsentry/sentry/pull/46296)