### PR TITLE
feat(metrics): add histogram to our metrics api

### DIFF
--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -28,3 +28,6 @@ class MetricsBackend(local):
 
     def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
         raise NotImplementedError
+
+    def histogram(self, key, value, instance=None, tags=None, sample_rate=1):
+        raise NotImplementedError

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -70,3 +70,16 @@ class DatadogMetricsBackend(MetricsBackend):
         self.stats.gauge(
             self._get_key(key), value, sample_rate=sample_rate, tags=tags, host=self.host
         )
+
+    def histogram(self, key, value, instance=None, tags=None, sample_rate=1):
+        if tags is None:
+            tags = {}
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+        if tags:
+            tags = [f"{k}:{v}" for k, v in tags.items()]
+        self.stats.histogram(
+            self._get_key(key), value, sample_rate=sample_rate, tags=tags, host=self.host
+        )

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -44,3 +44,14 @@ class DogStatsdMetricsBackend(MetricsBackend):
         if tags:
             tags = [f"{k}:{v}" for k, v in tags.items()]
         statsd.gauge(self._get_key(key), value, sample_rate=sample_rate, tags=tags)
+
+    def histogram(self, key, value, instance=None, tags=None, sample_rate=1):
+        if tags is None:
+            tags = {}
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+        if tags:
+            tags = [f"{k}:{v}" for k, v in tags.items()]
+        statsd.histogram(self._get_key(key), value, sample_rate=sample_rate, tags=tags)

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -12,3 +12,6 @@ class DummyMetricsBackend(MetricsBackend):
 
     def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
         pass
+
+    def histogram(self, key, value, instance=None, tags=None, sample_rate=1):
+        pass

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -16,3 +16,6 @@ class LoggingBackend(MetricsBackend):
 
     def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})
+
+    def histogram(self, key, value, instance=None, tags=None, sample_rate=1):
+        logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -23,3 +23,7 @@ class StatsdMetricsBackend(MetricsBackend):
 
     def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
         self.client.gauge(self._full_key(self._get_key(key)), value, sample_rate)
+
+    def histogram(self, key, value, instance=None, tags=None, sample_rate=1):
+        # our statsd client does not support histogram
+        pass

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -284,6 +284,25 @@ def timing(
         logger.exception("Unable to record backend metric")
 
 
+def histogram(
+    key: str,
+    value: Union[int, float],
+    instance: Optional[str] = None,
+    tags: Optional[Tags] = None,
+    sample_rate: float = settings.SENTRY_METRICS_SAMPLE_RATE,
+) -> None:
+    current_tags = _get_current_global_tags()
+    if tags is not None:
+        current_tags.update(tags)
+    current_tags = _filter_tags(key, current_tags)
+
+    try:
+        backend.histogram(key, value, instance, current_tags, sample_rate)
+    except Exception:
+        logger = logging.getLogger("sentry.errors")
+        logger.exception("Unable to record backend metric")
+
+
 @contextmanager
 def timer(
     key: str,

--- a/tests/sentry/metrics/test_datadog.py
+++ b/tests/sentry/metrics/test_datadog.py
@@ -30,3 +30,10 @@ class DatadogMetricsBackendTest(TestCase):
         mock_gauge.assert_called_once_with(
             "sentrytest.foo", 5, sample_rate=1, tags=["instance:bar"], host=get_hostname()
         )
+
+    @patch("datadog.threadstats.base.ThreadStats.histogram")
+    def test_histogram(self, mock_histogram):
+        self.backend.histogram("foo", 5, instance="bar")
+        mock_histogram.assert_called_once_with(
+            "sentrytest.foo", 5, sample_rate=1, tags=["instance:bar"], host=get_hostname()
+        )


### PR DESCRIPTION
- see https://docs.datadoghq.com/metrics/types/?tab=histogram#metric-types

motivation: for replays we'd like to collect histogram metrics about the filesize of replays in our consumer.