### PR TITLE
perf(sentry): Add experimental UI element tag for interaction transactions

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -92,7 +92,7 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     profilesSampleRate: shouldEnableBrowserProfiling ? 1 : 0,
     tracesSampler: context => {
       if (context.transactionContext.op?.startsWith('ui.action')) {
-        return tracesSampleRate; // / 100; TODO: DIVIDE BY 100
+        return tracesSampleRate / 100;
       }
       return tracesSampleRate;
     },

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -7,7 +7,7 @@ import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
 
 import {SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import {Config} from 'sentry/types';
-import {addExtraMeasurements} from 'sentry/utils/performanceForSentry';
+import {addExtraMeasurements, addUIElementTag} from 'sentry/utils/performanceForSentry';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 const SPA_MODE_ALLOW_URLS = [
@@ -92,12 +92,13 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     profilesSampleRate: shouldEnableBrowserProfiling ? 1 : 0,
     tracesSampler: context => {
       if (context.transactionContext.op?.startsWith('ui.action')) {
-        return tracesSampleRate / 100;
+        return tracesSampleRate; // / 100; TODO: DIVIDE BY 100
       }
       return tracesSampleRate;
     },
     beforeSendTransaction(event) {
       addExtraMeasurements(event);
+      addUIElementTag(event);
 
       event.spans = event.spans?.filter(span => {
         // Filter analytic timeout spans.

--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -425,3 +425,24 @@ export const setGroupedEntityTag = (
   groups = [...groups, +Infinity];
   setTag(`${tagName}.grouped`, `<=${groups.find(g => n <= g)}`);
 };
+
+/**
+ * A temporary util function used for interaction transactions that will attach a tag to the transaction, indicating the element
+ * that was interacted with. This will allow for querying for transactions by a specific element. This is a high cardinality tag, but
+ * it is only temporary for an experiment
+ */
+export const addUIElementTag = (transaction: TransactionEvent) => {
+  if (!transaction || transaction.contexts?.trace?.op !== 'ui.action.click') {
+    return;
+  }
+
+  if (!transaction.tags) {
+    return;
+  }
+
+  const interactionSpan = transaction.spans?.find(
+    span => span.op === 'ui.interaction.click'
+  );
+
+  transaction.tags.interactionElement = interactionSpan?.description;
+};


### PR DESCRIPTION
Adds an experimental tag to interaction transactions that contains the element that was interacted with. This will allow us to query and aggregate transactions by a DOM element.

Please note that this is only for experimental purposes and will be removed later on.

Example of what this looks like on a transaction:
![image](https://user-images.githubusercontent.com/16740047/227629658-01df04fc-85a8-4d59-8d41-8c831a133983.png)
