### PR TITLE
fix(codeowners): Parse url path in codeowners suggestions

### DIFF
--- a/static/app/views/settings/project/projectOwnership/modal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.spec.tsx
@@ -98,7 +98,7 @@ describe('Project Ownership', () => {
       screen.getByText(`path:raven/base.py ${user.email}`, {exact: false})
     ).toBeInTheDocument();
     expect(
-      screen.getByText(`url:https://example.com/path ${user.email}`, {exact: false})
+      screen.getByText(`url:*/path ${user.email}`, {exact: false})
     ).toBeInTheDocument();
 
     // Rule builder hidden TODO: remove when streamline-targeting-context is GA

--- a/static/app/views/settings/project/projectOwnership/modal.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.tsx
@@ -52,6 +52,22 @@ function getFrameSuggestions(eventData?: Event) {
   return uniq(frames.map(frame => frame.filename || frame.absPath || ''));
 }
 
+/**
+ * Attempt to remove the origin from a URL
+ */
+function getUrlPath(maybeUrl?: string) {
+  if (!maybeUrl) {
+    return '';
+  }
+
+  try {
+    const url = new URL(maybeUrl);
+    return `*${url.pathname}`;
+  } catch {
+    return maybeUrl;
+  }
+}
+
 function OwnershipSuggestions({
   paths,
   urls,
@@ -67,7 +83,7 @@ function OwnershipSuggestions({
   }
 
   const pathSuggestion = paths.length ? `path:${paths[0]} ${email}` : null;
-  const urlSuggestion = urls.length ? `url:${urls[0]} ${email}` : null;
+  const urlSuggestion = urls.length ? `url:${getUrlPath(urls[0])} ${email}` : null;
 
   const transactionTag = eventData?.tags?.find(({key}) => key === 'transaction');
   const transactionSuggestion = transactionTag


### PR DESCRIPTION
Just parses the path suggestion from `https://example.com/something/123` to `*/something/123`

WOR-2795