### PR TITLE
feat(discover): Discover Top N requests using mep + feature flag

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -300,7 +300,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             fields_meta = meta.get("fields", {})
 
             if standard_meta:
-                isMetricsData = meta.pop("isMetricsData", False)
+                isMetricsData = meta.get("isMetricsData", False)
                 fields, units = self.handle_unit_meta(fields_meta)
                 meta = {
                     "fields": fields,

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -180,7 +180,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             comparison_delta: Optional[datetime],
         ) -> SnubaTSResult:
             if top_events > 0:
-                return discover.top_events_timeseries(
+                can_use_metrics_for_top_n = self.get_features(organization, request).get(
+                    "organizations:discover-mep-top-n", False
+                )
+                return (dataset if can_use_metrics_for_top_n else discover).top_events_timeseries(
                     timeseries_columns=query_columns,
                     selected_columns=self.get_field_list(organization, request),
                     equations=self.get_equation_list(organization, request),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1063,6 +1063,8 @@ SENTRY_FEATURES = {
     "organizations:discover": False,
     # Enables events endpoint rate limit
     "organizations:discover-events-rate-limit": False,
+    # Enable mep for top n queries in discover
+    "organizations:discover-mep-top-n": False,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": True,
     # Allow organizations to configure all symbol sources.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -73,6 +73,7 @@ default_manager.add("organizations:dashboards-rh-widget", OrganizationFeature, F
 default_manager.add("organizations:dashboards-template", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:discover-events-rate-limit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:discover-mep-top-n", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:ds-prioritise-by-project-bias", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:ds-prioritise-by-transaction-bias", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/search/events/builder/__init__.py
+++ b/src/sentry/search/events/builder/__init__.py
@@ -11,6 +11,7 @@ from .metrics import (  # NOQA
     HistogramMetricQueryBuilder,
     MetricsQueryBuilder,
     TimeseriesMetricQueryBuilder,
+    TopEventsMetricQueryBuilder,
 )
 from .profile_functions import (  # NOQA
     ProfileFunctionsQueryBuilder,
@@ -34,6 +35,7 @@ __all__ = [
     "HistogramMetricQueryBuilder",
     "MetricsQueryBuilder",
     "TimeseriesMetricQueryBuilder",
+    "TopEventsMetricQueryBuilder",
     "ProfilesQueryBuilder",
     "ProfilesTimeseriesQueryBuilder",
     "ProfileFunctionsQueryBuilder",

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -390,6 +390,7 @@ def top_events_timeseries(
                     "discover.top-events.timeseries.key-mismatch",
                     extra={"result_key": result_key, "top_event_keys": list(results.keys())},
                 )
+        result["meta"]["isMetricsData"] = True
         for key, item in results.items():
             results[key] = SnubaTSResult(
                 {
@@ -400,6 +401,7 @@ def top_events_timeseries(
                     else item["data"],
                     "order": item["order"],
                     "isMetricsData": True,
+                    "meta": result["meta"],
                 },
                 params["start"],
                 params["end"],

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -601,6 +601,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
     def setUp(self):
         super().setUp()
         self.features["organizations:use-metrics-layer"] = True
+        self.features["organizations:discover-mep-top-n"] = True
 
     def create_top_metrics(self):
         environments = ["prod", "staging"]


### PR DESCRIPTION
Adds support for using mep for Top N events-stats requests.
Also adds a feature flag to gate this feature for now.

Some notes:
- Only works using the metrics layer
- Top N requests with more than 1 groupby column does not generate an `Other` series (because the metrics layer transform doesn't allow `Or` conditions and I haven't done a workaround yet)