### PR TITLE
ref(metric alerts): Remove use-arroyo-consumer Option

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -472,12 +472,6 @@ def post_process_forwarder(**options):
     type=click.Choice(["earliest", "latest"]),
     help="Force subscriptions to start from a particular offset",
 )
-@click.option(
-    "--use-arroyo-consumer",
-    default=True,
-    is_flag=True,
-    help="Switches to the new arroyo consumer implementation.",
-)
 @strict_offset_reset_option()
 @log_options()
 @configuration


### PR DESCRIPTION
Now that the option isn't being used in the ops repo anymore (https://github.com/getsentry/ops/pull/6432) it can be removed entirely.