### PR TITLE
chore(hybrid-cloud): Various outbox fixes

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -258,7 +258,7 @@ class RegionOutbox(OutboxBase):
     __repr__ = sane_repr("shard_scope", "shard_identifier", "category", "object_identifier")
 
 
-# Outboxes bound from region silo -> control silo
+# Outboxes bound from control silo -> region silo
 @control_silo_only_model
 class ControlOutbox(OutboxBase):
     sharding_columns = ("region_name", "shard_scope", "shard_identifier")


### PR DESCRIPTION
The metric counter for `outbox.saved` had the wrong arguments. I fixed that in this pull request.