### PR TITLE
feat(workflow): Track emails that did not send

### DIFF
--- a/src/sentry/utils/email/send.py
+++ b/src/sentry/utils/email/send.py
@@ -16,7 +16,11 @@ def send_messages(messages: Sequence[EmailMultiAlternatives], fail_silently: boo
     connection = get_connection(fail_silently=fail_silently)
     # Explicitly typing to satisfy mypy.
     sent: int = connection.send_messages(messages)
-    metrics.incr("email.sent", len(messages), skip_internal=False)
+    metrics.incr("email.sent", sent, skip_internal=False, tags={"success": True})
+    failed = len(messages) - sent
+    if failed:
+        metrics.incr("email.sent", failed, skip_internal=False, tags={"success": False})
+
     for message in messages:
         extra = {
             "message_id": message.extra_headers["Message-Id"],

--- a/src/sentry/utils/email/send.py
+++ b/src/sentry/utils/email/send.py
@@ -18,7 +18,7 @@ def send_messages(messages: Sequence[EmailMultiAlternatives], fail_silently: boo
     sent: int = connection.send_messages(messages)
     metrics.incr("email.sent", sent, skip_internal=False, tags={"success": True})
     failed = len(messages) - sent
-    if failed:
+    if failed > 0:
         metrics.incr("email.sent", failed, skip_internal=False, tags={"success": False})
 
     for message in messages:


### PR DESCRIPTION
Attempting to track the number of emails sent for our SLO. I'm assuming the sent is the number of emails that sent successfully and len(messages) is the number of emails we attempted to send.

[WOR-2854](https://getsentry.atlassian.net/browse/WOR-2854)

[WOR-2854]: https://getsentry.atlassian.net/browse/WOR-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ