### PR TITLE
feat(notification-actions): Validate the slack/pagerduty integrations

### DIFF
--- a/src/sentry/api/endpoints/notifications/notification_actions.md
+++ b/src/sentry/api/endpoints/notifications/notification_actions.md
@@ -3,8 +3,8 @@
 ## Background
 
 Notification Actions are meant to be a generic abstraction of the actions we fire when alert rules go off.
-The structure of the model for `NotificationAction` was abstracted from `AlertRuleTriggerAction` but is intentionally unrelated to issues/events/incidents.
-Instead, they are meant to help new features fire notifications to integrations instead of through personal notifications. These notifications can be configured across the whole organization/project, rather than per recipient. It was originally designed for Spike Protection, but should be generic enough to apply to any other part of Sentry.
+The structure of the model for `NotificationAction` was abstracted from `AlertRuleTriggerAction` but decouples it from issues/events/incidents.
+Instead, they are meant to help send notifications to third-party integrations rather than individual channels such as email, or personal notifications settings. These notifications can be configured across the whole organization/project, rather than per recipient. It was originally designed for Spike Protection, but should be generic enough to apply to any other part of Sentry.
 
 Some examples of possible notification actions:
 - Receiving audit log entries to a slack channel

--- a/src/sentry/api/endpoints/notifications/notification_actions.md
+++ b/src/sentry/api/endpoints/notifications/notification_actions.md
@@ -1,17 +1,16 @@
-
 # Notification Actions
 
 ## Background
 
 Notification Actions are meant to be a generic abstraction of the actions we fire when alert rules go off.
-In fact the structure of the model for `NotificationAction` was abstracted from `AlertRuleTriggerAction` but is intentionally unrelated to issues/events/incidents.
-Instead, they are meant to help new features of Sentry fire notifications to integrations instead of through personal notifications. You can think of these as organization notifications, which can be configured across the whole organization/project, rather than per recipient.
+The structure of the model for `NotificationAction` was abstracted from `AlertRuleTriggerAction` but is intentionally unrelated to issues/events/incidents.
+Instead, they are meant to help new features fire notifications to integrations instead of through personal notifications. These notifications can be configured across the whole organization/project, rather than per recipient. It was originally designed for Spike Protection, but should be generic enough to apply to any other part of Sentry.
 
 Some examples of possible notification actions:
 - Receiving audit log entries to a slack channel
 - Creating jira tickets from new user feedback items
 - Triggering a GitHub notification whenever a release is created in Sentry
-- Quota notifications or billing updates to
+- Sending quota notifications or billing updates to a specific non-user email
 - Project notifications send to a slack channel instead of the teams/members
 
 ## How they work

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -149,8 +149,8 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
     def validate_slack_channel(self, data: NotificationActionInputData):
         """
         Validates assuming that SPECIFIC targets for SLACK service has the following target data:
-            target_display: Slack channel id (optional)
-            target_identifier: Slack channel name
+            target_display: Slack channel name
+            target_identifier: Slack channel id (optional)
         NOTE: Reaches out to via slack integration to verify channel
         """
         if (

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -150,7 +150,7 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
         self, data: NotificationActionInputData
     ) -> NotificationActionInputData:
         """
-        Validates assuming that SPECIFIC targets for SLACK service has the following target data:
+        Validates that SPECIFIC targets for SLACK service has the following target data:
             target_display: Slack channel name
             target_identifier: Slack channel id (optional)
         NOTE: Reaches out to via slack integration to verify channel
@@ -163,6 +163,11 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
 
         channel_name = data.get("target_display")
         channel_id = data.get("target_identifier")
+
+        if not channel_name:
+            raise serializers.ValidationError(
+                {"target_display": "Did not receive a slack user or channel name."}
+            )
 
         # If we've received a channel and id, verify them against one another
         if channel_name and channel_id:
@@ -178,11 +183,6 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
             return data
 
         # If we've only received a channel name, ask slack for its id
-        if not channel_name:
-            raise serializers.ValidationError(
-                {"target_display": "Did not receive a slack user or channel name."}
-            )
-
         generic_error_message = f"Could not fetch channel id from Slack for '{channel_name}'. Try providing the channel id, or try again later."
         try:
             _prefix, channel_id, timed_out, = get_channel_id(
@@ -209,7 +209,7 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
         self, data: NotificationActionInputData
     ) -> NotificationActionInputData:
         """
-        Validates assuming that SPECIFIC targets for PAGERDUTY service has the following target data:
+        Validates that SPECIFIC targets for PAGERDUTY service has the following target data:
             target_display: PagerDutyService.service_name
             target_identifier: PagerDutyService.id
         """

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -146,7 +146,9 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
             )
         registration.validate_action(data=data)
 
-    def validate_slack_channel(self, data: NotificationActionInputData):
+    def validate_slack_channel(
+        self, data: NotificationActionInputData
+    ) -> NotificationActionInputData:
         """
         Validates assuming that SPECIFIC targets for SLACK service has the following target data:
             target_display: Slack channel name
@@ -203,7 +205,9 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
         data["target_identifier"] = channel_id
         return data
 
-    def validate_pagerduty_service(self, data: NotificationActionInputData):
+    def validate_pagerduty_service(
+        self, data: NotificationActionInputData
+    ) -> NotificationActionInputData:
         """
         Validates assuming that SPECIFIC targets for PAGERDUTY service has the following target data:
             target_display: PagerDutyService.service_name

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -6,6 +6,8 @@ from rest_framework import serializers
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.constants import SentryAppInstallationStatus
+from sentry.integrations.slack.utils.channel import get_channel_id, validate_channel_id
+from sentry.models.integrations.pagerduty_service import PagerDutyService
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.notificationaction import ActionService, ActionTarget, NotificationAction
 from sentry.models.project import Project
@@ -47,9 +49,10 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
 
     service_type = serializers.CharField()
     target_type = serializers.CharField()
-    target_identifier = serializers.CharField()
-    target_display = serializers.CharField()
     trigger_type = serializers.CharField()
+
+    target_identifier = serializers.CharField(required=False)
+    target_display = serializers.CharField(required=False)
 
     def validate_integration_id(self, integration_id: int) -> int:
         organization_integration = integration_service.get_organization_integration(
@@ -117,6 +120,7 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
                     "integration_id": f"Integration of provider '{integration.provider}' does not match service type of '{service_provider}'"
                 }
             )
+        self.integration = integration
 
     def validate_sentry_app_and_service(self, data: NotificationActionInputData):
         if (
@@ -142,10 +146,113 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
             )
         registration.validate_action(data=data)
 
+    def validate_slack_channel(self, data: NotificationActionInputData):
+        """
+        Validates assuming that SPECIFIC targets for SLACK service has the following target data:
+            target_display: Slack channel id (optional)
+            target_identifier: Slack channel name
+        NOTE: Reaches out to via slack integration to verify channel
+        """
+        if (
+            data["service_type"] != ActionService.SLACK.value
+            or data["target_type"] != ActionTarget.SPECIFIC.value
+        ):
+            return data
+
+        channel_name = data.get("target_display")
+        channel_id = data.get("target_identifier")
+
+        # If we've received a channel and id, verify them against one another
+        if channel_name and channel_id:
+            try:
+                validate_channel_id(
+                    name=channel_name,
+                    integration_id=self.integration.id,
+                    input_channel_id=channel_id,
+                )
+            except Exception as e:
+                # validate_channel_id raises user friendly validation errors!
+                raise serializers.ValidationError({"target_display": str(e)})
+            return data
+
+        # If we've only received a channel name, ask slack for its id
+        if not channel_name:
+            raise serializers.ValidationError(
+                {"target_display": "Did not receive a slack user or channel name."}
+            )
+        try:
+            _prefix, channel_id, timed_out, = get_channel_id(
+                organization=self.context["organization"],
+                integration=self.integration,
+                channel_name=channel_name,
+            )
+        except Exception:
+            raise serializers.ValidationError(
+                {
+                    "target_display": f"Could not fetch channel id from Slack for {channel_name}. Try providing the channel id, or try again later."
+                }
+            )
+        if timed_out:
+            raise serializers.ValidationError(
+                {
+                    "target_identifier": "Please provide a slack channel id, we encountered a timeout searching for it via the channel name."
+                }
+            )
+        data["target_identifier"] = channel_id
+        return data
+
+    def validate_pagerduty_service(self, data: NotificationActionInputData):
+        """
+        Validates assuming that SPECIFIC targets for PAGERDUTY service has the following target data:
+            target_display: PagerDutyService.service_name
+            target_identifier: PagerDutyService.id
+        """
+        if (
+            data["service_type"] != ActionService.PAGERDUTY.value
+            or data["target_type"] != ActionTarget.SPECIFIC.value
+        ):
+            return data
+
+        service_id = data.get("target_identifier")
+
+        if not service_id:
+            pd_service_options = [
+                f"{pds['id']} ({pds['service_name']})"
+                for pds in PagerDutyService.objects.filter(
+                    organization_integration__organization_id=self.context["organization"].id,
+                    organization_integration__integration_id=self.integration.id,
+                ).values("id", "service_name")
+            ]
+
+            raise serializers.ValidationError(
+                {
+                    "target_identifier": f" Did not recieve PagerDuty service id for the '{self.integration.name}' account, Choose from {oxfordize_list(pd_service_options)}"
+                }
+            )
+
+        try:
+            pds = PagerDutyService.objects.get(
+                id=service_id,
+                organization_integration__organization_id=self.context["organization"].id,
+                organization_integration__integration_id=self.integration.id,
+            ).values("id", "service_name")
+        except PagerDutyService.DoesNotExist:
+            raise serializers.ValidationError(
+                {
+                    "target_identifier": f"Could not find associated PagerDuty service for the '{self.integration.name}' account. If it exists, ensure Sentry has access."
+                }
+            )
+        data["target_display"] = pds["service_name"]
+        data["target_identifier"] = pds["id"]
+
     def validate(self, data: NotificationActionInputData) -> NotificationActionInputData:
         self.validate_integration_and_service(data)
         self.validate_sentry_app_and_service(data)
         self.validate_with_registry(data)
+
+        data = self.validate_slack_channel(data)
+        data = self.validate_pagerduty_service(data)
+
         return data
 
     class Meta:

--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -16,6 +16,7 @@ from sentry.models import (
     Team,
     User,
 )
+from sentry.testutils.silo import exempt_from_silo_limits
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json
 
@@ -30,6 +31,7 @@ def get_response_text(data: SlackBody) -> str:
     )
 
 
+@exempt_from_silo_limits()
 def install_slack(organization: Organization, workspace_id: str = "TXXXXXXX1") -> Integration:
     integration = Integration.objects.create(
         external_id=workspace_id,

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
@@ -1,8 +1,10 @@
 from unittest.mock import MagicMock, patch
 
+import responses
 from rest_framework import serializers, status
 
 from sentry.api.serializers.base import serialize
+from sentry.models.integrations.pagerduty_service import PagerDutyService
 from sentry.models.notificationaction import (
     ActionRegistration,
     ActionService,
@@ -12,6 +14,7 @@ from sentry.models.notificationaction import (
     NotificationActionProject,
 )
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import region_silo_test
 
 NOTIFICATION_ACTION_FEATURE = ["organizations:notification-actions"]
@@ -40,6 +43,11 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             "targetDisplay": "@pyke",
             "targetIdentifier": "555",
         }
+        self.mock_register = lambda data: NotificationAction.register_action(
+            trigger_type=ActionTrigger.get_value(data["triggerType"]),
+            service_type=ActionService.get_value(data["serviceType"]),
+            target_type=ActionTarget.get_value(data["targetType"]),
+        )
         self.login_as(user=self.user)
 
     def test_requires_feature(self):
@@ -100,7 +108,7 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             )
 
     def test_put_missing_fields(self):
-        required_fields = self.base_data.keys()
+        required_fields = ["serviceType", "triggerType", "targetType"]
         with self.feature(NOTIFICATION_ACTION_FEATURE):
             response = self.get_error_response(
                 self.organization.slug,
@@ -225,20 +233,127 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             assert error_message in str(response.data)
 
     @patch.dict(NotificationAction._registry, {})
+    @responses.activate
+    def test_post_with_slack_validation(self):
+        class MockActionRegistration(ActionRegistration):
+            pass
+
+        channel_name = "journal"
+        channel_id = "CABC123"
+
+        integration = install_slack(organization=self.organization)
+        data = {
+            "triggerType": "audit-log",
+            "targetType": "specific",
+            "serviceType": "slack",
+            "integrationId": integration.id,
+            "targetDisplay": f"#{channel_name}",
+        }
+
+        self.mock_register(data)(MockActionRegistration)
+        with self.feature(NOTIFICATION_ACTION_FEATURE):
+            # Can't find slack channel
+            responses.add(
+                method=responses.GET,
+                url="https://slack.com/api/conversations.list",
+                status=500,
+            )
+            self.get_error_response(
+                self.organization.slug,
+                self.notif_action.id,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                method="PUT",
+                **data,
+            )
+            # Successful search for channel
+            responses.add(
+                method=responses.GET,
+                url="https://slack.com/api/conversations.list",
+                status=200,
+                json={"ok": True, "channels": [{"name": channel_name, "id": channel_id}]},
+            )
+            response = self.get_success_response(
+                self.organization.slug,
+                self.notif_action.id,
+                status_code=status.HTTP_202_ACCEPTED,
+                method="PUT",
+                **data,
+            )
+            assert response.data["targetIdentifier"] == channel_id
+
+    @patch.dict(NotificationAction._registry, {})
+    def test_PUT_with_pagerduty_validation(self):
+        class MockActionRegistration(ActionRegistration):
+            pass
+
+        service_name = "palace"
+
+        integration = self.create_integration(
+            organization=self.organization, external_id="pd-id", provider="pagerduty", name="dream"
+        )
+        second_integration = self.create_integration(
+            organization=self.organization, external_id="pd-id-2", provider="pagerduty", name="nail"
+        )
+
+        data = {
+            "triggerType": "audit-log",
+            "targetType": "specific",
+            "serviceType": "pagerduty",
+            "integrationId": integration.id,
+            "targetDisplay": "incorrect_service_name",
+        }
+
+        self.mock_register(data)(MockActionRegistration)
+        with self.feature(NOTIFICATION_ACTION_FEATURE):
+            # Didn't provide a targetIdentifier key
+            response = self.get_error_response(
+                self.organization.slug,
+                self.notif_action.id,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                method="PUT",
+                **data,
+            )
+            assert "Did not recieve PagerDuty service id" in str(response.data["targetIdentifier"])
+            service = PagerDutyService.objects.create(
+                service_name=service_name,
+                integration_key="abc",
+                organization_integration=second_integration.organizationintegration_set.first(),
+            )
+            data["targetIdentifier"] = service.id
+            response = self.get_error_response(
+                self.organization.slug,
+                self.notif_action.id,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                method="PUT",
+                **data,
+            )
+            assert "ensure Sentry has access" in str(response.data["targetIdentifier"])
+            service = PagerDutyService.objects.create(
+                service_name=service_name,
+                integration_key="def",
+                organization_integration=integration.organizationintegration_set.first(),
+            )
+            data["targetIdentifier"] = service.id
+            response = self.get_success_response(
+                self.organization.slug,
+                self.notif_action.id,
+                status_code=status.HTTP_202_ACCEPTED,
+                method="PUT",
+                **data,
+            )
+            assert response.data["targetIdentifier"] == service.id
+            assert response.data["targetDisplay"] == service.service_name
+
+    @patch.dict(NotificationAction._registry, {})
     def test_put_simple(self):
         class MockActionRegistration(ActionRegistration):
             validate_action = MagicMock()
 
-        registration = MockActionRegistration
-        NotificationAction.register_action(
-            trigger_type=ActionTrigger.get_value(self.base_data["triggerType"]),
-            service_type=ActionService.get_value(self.base_data["serviceType"]),
-            target_type=ActionTarget.get_value(self.base_data["targetType"]),
-        )(registration)
+        self.mock_register(self.base_data)(MockActionRegistration)
 
         data = {**self.base_data}
         with self.feature(NOTIFICATION_ACTION_FEATURE):
-            assert not registration.validate_action.called
+            assert not MockActionRegistration.validate_action.called
             response = self.get_success_response(
                 self.organization.slug,
                 self.notif_action.id,
@@ -249,7 +364,7 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             # Response contains input data
             assert data.items() <= response.data.items()
             # Database reflects changes
-            assert registration.validate_action.called
+            assert MockActionRegistration.validate_action.called
             self.notif_action.refresh_from_db()
             assert response.data == serialize(self.notif_action)
             # Relation table has been updated

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
@@ -1,8 +1,10 @@
 from unittest.mock import MagicMock, patch
 
+import responses
 from rest_framework import serializers, status
 
 from sentry.api.serializers.base import serialize
+from sentry.models.integrations.pagerduty_service import PagerDutyService
 from sentry.models.notificationaction import (
     ActionRegistration,
     ActionService,
@@ -12,6 +14,7 @@ from sentry.models.notificationaction import (
     NotificationActionProject,
 )
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import region_silo_test
 
 NOTIFICATION_ACTION_FEATURE = ["organizations:notification-actions"]
@@ -26,7 +29,6 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         self.user = self.create_user("thepaleking@hk.com")
         self.organization = self.create_organization(name="hallownest", owner=self.user)
         self.other_organization = self.create_organization(name="pharloom", owner=self.user)
-        # self.integration = install_slack(organization=self.organization)
         self.team = self.create_team(
             name="pale beings", organization=self.organization, members=[self.user]
         )
@@ -41,10 +43,10 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             "targetDisplay": "@hollowknight",
             "targetIdentifier": "THK",
         }
-        self.mock_register = NotificationAction.register_action(
-            trigger_type=ActionTrigger.get_value(self.base_data["triggerType"]),
-            service_type=ActionService.get_value(self.base_data["serviceType"]),
-            target_type=ActionTarget.get_value(self.base_data["targetType"]),
+        self.mock_register = lambda data: NotificationAction.register_action(
+            trigger_type=ActionTrigger.get_value(data["triggerType"]),
+            service_type=ActionService.get_value(data["serviceType"]),
+            target_type=ActionTarget.get_value(data["targetType"]),
         )
         self.login_as(user=self.user)
 
@@ -145,7 +147,7 @@ class NotificationActionsIndexEndpointTest(APITestCase):
                     assert serialize(action) in response.data
 
     def test_post_missing_fields(self):
-        required_fields = self.base_data.keys()
+        required_fields = ["serviceType", "triggerType", "targetType"]
         with self.feature(NOTIFICATION_ACTION_FEATURE):
             response = self.get_error_response(
                 self.organization.slug,
@@ -245,8 +247,7 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         class MockActionRegistration(ActionRegistration):
             validate_action = MagicMock(side_effect=serializers.ValidationError(error_message))
 
-        registration = MockActionRegistration
-        self.mock_register(registration)
+        self.mock_register(self.base_data)(MockActionRegistration)
 
         with self.feature(NOTIFICATION_ACTION_FEATURE):
             response = self.get_error_response(
@@ -256,6 +257,113 @@ class NotificationActionsIndexEndpointTest(APITestCase):
                 **self.base_data,
             )
             assert error_message in str(response.data)
+
+    @patch.dict(NotificationAction._registry, {})
+    @responses.activate
+    def test_post_with_slack_validation(self):
+        class MockActionRegistration(ActionRegistration):
+            pass
+
+        channel_name = "journal"
+        channel_id = "CABC123"
+
+        integration = install_slack(organization=self.organization)
+        data = {
+            "triggerType": "audit-log",
+            "targetType": "specific",
+            "serviceType": "slack",
+            "integrationId": integration.id,
+            "targetDisplay": f"#{channel_name}",
+        }
+
+        self.mock_register(data)(MockActionRegistration)
+        with self.feature(NOTIFICATION_ACTION_FEATURE):
+            # Can't find slack channel
+            responses.add(
+                method=responses.GET,
+                url="https://slack.com/api/conversations.list",
+                status=500,
+            )
+            self.get_error_response(
+                self.organization.slug,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                method="POST",
+                **data,
+            )
+            # Successful search for channel
+            responses.add(
+                method=responses.GET,
+                url="https://slack.com/api/conversations.list",
+                status=200,
+                json={"ok": True, "channels": [{"name": channel_name, "id": channel_id}]},
+            )
+            response = self.get_success_response(
+                self.organization.slug,
+                status_code=status.HTTP_201_CREATED,
+                method="POST",
+                **data,
+            )
+            assert response.data["targetIdentifier"] == channel_id
+
+    @patch.dict(NotificationAction._registry, {})
+    def test_post_with_pagerduty_validation(self):
+        class MockActionRegistration(ActionRegistration):
+            pass
+
+        service_name = "palace"
+
+        integration = self.create_integration(
+            organization=self.organization, external_id="pd-id", provider="pagerduty", name="dream"
+        )
+        second_integration = self.create_integration(
+            organization=self.organization, external_id="pd-id-2", provider="pagerduty", name="nail"
+        )
+
+        data = {
+            "triggerType": "audit-log",
+            "targetType": "specific",
+            "serviceType": "pagerduty",
+            "integrationId": integration.id,
+            "targetDisplay": "incorrect_service_name",
+        }
+
+        self.mock_register(data)(MockActionRegistration)
+        with self.feature(NOTIFICATION_ACTION_FEATURE):
+            # Didn't provide a targetIdentifier key
+            response = self.get_error_response(
+                self.organization.slug,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                method="POST",
+                **data,
+            )
+            assert "Did not recieve PagerDuty service id" in str(response.data["targetIdentifier"])
+            service = PagerDutyService.objects.create(
+                service_name=service_name,
+                integration_key="abc",
+                organization_integration=second_integration.organizationintegration_set.first(),
+            )
+            data["targetIdentifier"] = service.id
+            response = self.get_error_response(
+                self.organization.slug,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                method="POST",
+                **data,
+            )
+            assert "ensure Sentry has access" in str(response.data["targetIdentifier"])
+            service = PagerDutyService.objects.create(
+                service_name=service_name,
+                integration_key="def",
+                organization_integration=integration.organizationintegration_set.first(),
+            )
+            data["targetIdentifier"] = service.id
+            response = self.get_success_response(
+                self.organization.slug,
+                status_code=status.HTTP_201_CREATED,
+                method="POST",
+                **data,
+            )
+            assert response.data["targetIdentifier"] == service.id
+            assert response.data["targetDisplay"] == service.service_name
 
     @patch.dict(NotificationAction._registry, {})
     def test_post_simple(self):


### PR DESCRIPTION
This PR adds validation for slack and pagerduty to make sure the `targetIdentifier` and `targetDisplay` keys are valid, especially since they're not required now. 

- For slack, this'll allow submitting just a slack channel, and we'll search for the ID before saving
- For pagerduty, this'll double check that the service ID matches the integration, and belongs to your organization (as well as saving the name and id correctly)