### PR TITLE
feat(group-hash): Add a timeout for group hash associations

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2983,6 +2983,14 @@ SENTRY_METRICS_INDEXER_REDIS_CLUSTER = "default"
 # Value is in milliseconds. Set to `None` to disable.
 SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT = 1000
 
+# Statement timeout for group hash association.
+# In case of contention around group hash association this times out the statement
+# which has the effect that some groups end up orphaned.  This can cause groups to
+# be over-created however has the advantage that we are not contending on those
+# locks.
+# Value is in milliseconds. Set to `None` to disable.
+SENTRY_GROUP_HASH_ASSOCIATION_STATEMENT_TIMEOUT = 1000
+
 # Implemented in getsentry to run additional devserver workers.
 SENTRY_EXTRA_WORKERS = None
 


### PR DESCRIPTION
This addresses the impact of INC-377 by adding a statement timeout on the group hashes association. I am not entirely sure if this is going to address the problem. The impact of this is also not entirely clear to me.

The assumption is that the change in #45600 make this worse, but I'm not convinced. While it's likely that hierarchical grouping made this problem less bad by associating fewer hashes, the behavior of the base grouping already used to associate all hashes so this just brings us back to baseline.