### PR TITLE
fix(test): Fix @with_feature decorator

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -565,7 +565,7 @@ class RpcBackedAccess(Access):
             return True
 
         if self.rpc_user_organization_context.member and features.has(
-            "organizations:team-roles", self.rpc_user_organization_context.organization.id
+            "organizations:team-roles", self.rpc_user_organization_context.organization
         ):
             memberships = self.rpc_user_organization_context.member.member_teams
             for membership in memberships:

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -1,5 +1,6 @@
 __all__ = ["Feature", "with_feature", "apply_feature_flag_on_cls"]
 
+import functools
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -114,6 +115,7 @@ def with_feature(feature):
             with Feature(feature):
                 return func(self, *args, **kwargs)
 
+        functools.update_wrapper(wrapped, func)
         return wrapped
 
     return decorator

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -10,7 +10,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test(stable=True)
+@region_silo_test
 class OrganizationRelayHistoryTest(APITestCase):
     endpoint = "sentry-api-0-organization-relay-usage"
 


### PR DESCRIPTION
`test_access.py` was not running all tests in all silo modes thanks to interaction with `@with_feature`.
Fix is simple: all decorators need to set the `__name__` correctly, usually through `update_wrapper`