### PR TITLE
feat(ui): Surface release in processing issues

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -550,6 +550,8 @@ export type ProcessingIssueItem = {
     image_arch: string;
     image_path: string;
     image_uuid: string;
+    dist?: string;
+    release?: string;
   };
   id: string;
   lastSeen: string;

--- a/static/app/views/settings/project/projectProcessingIssues.tsx
+++ b/static/app/views/settings/project/projectProcessingIssues.tsx
@@ -21,8 +21,10 @@ import {
   PanelTable,
 } from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import Tag from 'sentry/components/tag';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import TimeSince from 'sentry/components/timeSince';
+import Version from 'sentry/components/version';
 import formGroups from 'sentry/data/forms/processingIssues';
 import {IconQuestion} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -299,6 +301,7 @@ class ProjectProcessingIssues extends Component<Props, State> {
   }
 
   renderDetails(item: ProcessingIssueItem) {
+    const {release, dist} = item.data;
     let dsymUUID: React.ReactNode = null;
     let dsymName: React.ReactNode = null;
     let dsymArch: React.ReactNode = null;
@@ -320,6 +323,14 @@ class ProjectProcessingIssues extends Component<Props, State> {
         {dsymUUID && <span> {dsymUUID}</span>}
         {dsymArch && <span> {dsymArch}</span>}
         {dsymName && <span> (for {dsymName})</span>}
+        {(release || dist) && (
+          <div>
+            <Tag tooltipText={t('Latest Release')}>
+              {release ? <Version version={release} /> : t('none')}
+            </Tag>{' '}
+            <Tag tooltipText={t('Latest Distribution')}>{dist || t('none')}</Tag>
+          </div>
+        )}
       </span>
     );
   }

--- a/static/app/views/settings/project/projectProcessingIssues.tsx
+++ b/static/app/views/settings/project/projectProcessingIssues.tsx
@@ -328,7 +328,7 @@ class ProjectProcessingIssues extends Component<Props, State> {
             <Tag tooltipText={t('Latest Release Observed with Issue')}>
               {release ? <Version version={release} /> : t('none')}
             </Tag>{' '}
-            <Tag tooltipText={t('Latest Distribution')}>{dist || t('none')}</Tag>
+            <Tag tooltipText={t('Latest Distribution Observed with Issue')}>{dist || t('none')}</Tag>
           </div>
         )}
       </span>

--- a/static/app/views/settings/project/projectProcessingIssues.tsx
+++ b/static/app/views/settings/project/projectProcessingIssues.tsx
@@ -328,7 +328,9 @@ class ProjectProcessingIssues extends Component<Props, State> {
             <Tag tooltipText={t('Latest Release Observed with Issue')}>
               {release ? <Version version={release} /> : t('none')}
             </Tag>{' '}
-            <Tag tooltipText={t('Latest Distribution Observed with Issue')}>{dist || t('none')}</Tag>
+            <Tag tooltipText={t('Latest Distribution Observed with Issue')}>
+              {dist || t('none')}
+            </Tag>
           </div>
         )}
       </span>

--- a/static/app/views/settings/project/projectProcessingIssues.tsx
+++ b/static/app/views/settings/project/projectProcessingIssues.tsx
@@ -325,7 +325,7 @@ class ProjectProcessingIssues extends Component<Props, State> {
         {dsymName && <span> (for {dsymName})</span>}
         {(release || dist) && (
           <div>
-            <Tag tooltipText={t('Latest Release')}>
+            <Tag tooltipText={t('Latest Release Observed with Issue')}>
               {release ? <Version version={release} /> : t('none')}
             </Tag>{' '}
             <Tag tooltipText={t('Latest Distribution')}>{dist || t('none')}</Tag>


### PR DESCRIPTION
This PR surfaces `release` and `distribution` in processing issues' UI.

![image](https://user-images.githubusercontent.com/9060071/227970232-abb233c4-f620-42ba-b53e-bee9a3d76474.png)

Backend is being worked on here: https://github.com/getsentry/sentry/pull/46250