### PR TITLE
ref: Reuse internal_artifact_lookup_source_url as base for artifact files

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -149,9 +149,9 @@ def get_internal_source(project):
     }
 
 
-def get_internal_artifact_lookup_source(project):
+def get_internal_artifact_lookup_source_url(project):
     """
-    Returns the source configuration for the Sentry artifact-lookup API.
+    Returns the url used as a part of source configuration for the Sentry artifact-lookup API.
     """
     internal_url_prefix = options.get("system.internal-url-prefix")
     if not internal_url_prefix:
@@ -162,7 +162,7 @@ def get_internal_artifact_lookup_source(project):
             ).replace("127.0.0.1", "host.docker.internal")
 
     assert internal_url_prefix
-    sentry_source_url = "{}{}".format(
+    return "{}{}".format(
         internal_url_prefix.rstrip("/"),
         reverse(
             "sentry-api-0-project-artifact-lookup",
@@ -173,10 +173,15 @@ def get_internal_artifact_lookup_source(project):
         ),
     )
 
+
+def get_internal_artifact_lookup_source(project):
+    """
+    Returns the source configuration for the Sentry artifact-lookup API.
+    """
     return {
         "type": "sentry",
         "id": INTERNAL_SOURCE_NAME,
-        "url": sentry_source_url,
+        "url": get_internal_artifact_lookup_source_url(project),
         "token": get_system_token(),
     }
 

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -456,7 +456,7 @@ def django_cache():
 # to `system.internal-url-prefix` or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`.
 @pytest.fixture(ids=["without_symbolicator", "with_symbolicator"], params=[0, 1])
 def process_with_symbolicator(request, set_sentry_option, live_server):
-    with set_sentry_option("system.internal-url-prefix", live_server.url), set_sentry_option(
+    with set_sentry_option("system.url-prefix", live_server.url), set_sentry_option(
         "symbolicator.sourcemaps-processing-sample-rate", request.param
     ):
         # Run test case

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -456,7 +456,7 @@ def django_cache():
 # to `system.internal-url-prefix` or add `127.0.0.1 host.docker.internal` entry to your `/etc/hosts`.
 @pytest.fixture(ids=["without_symbolicator", "with_symbolicator"], params=[0, 1])
 def process_with_symbolicator(request, set_sentry_option, live_server):
-    with set_sentry_option("system.url-prefix", live_server.url), set_sentry_option(
+    with set_sentry_option("system.internal-url-prefix", live_server.url), set_sentry_option(
         "symbolicator.sourcemaps-processing-sample-rate", request.param
     ):
         # Run test case


### PR DESCRIPTION
With this change, we can be certain, that the artifact lookup endpoint will return a list of files, which URLs always point to the same source as the list originated from.