### PR TITLE
styles(profiling): Additional styles for inlining stacktrace component

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -18,8 +18,8 @@ type Props = {
   platform: PlatformType;
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
-  hideIcon?: boolean;
   includeSystemFrames?: boolean;
+  inlined?: boolean;
   isHoverPreviewed?: boolean;
   maxDepth?: number;
   meta?: Record<any, any>;
@@ -32,6 +32,7 @@ function Content({
   event,
   newestFirst,
   isHoverPreviewed,
+  inlined,
   groupingCurrentLevel,
   includeSystemFrames = true,
   expandFirstFrame = true,
@@ -171,7 +172,9 @@ function Content({
           prevFrame,
           nextFrame,
           isExpanded: expandFirstFrame && lastFrameIndex === frameIndex,
-          emptySourceNotation: lastFrameIndex === frameIndex && frameIndex === 0,
+          emptySourceNotation: inlined
+            ? false
+            : lastFrameIndex === frameIndex && frameIndex === 0,
           platform,
           timesRepeated: nRepeats,
           showingAbsoluteAddress: showingAbsoluteAddresses,
@@ -231,7 +234,11 @@ function Content({
 
   return (
     <Wrapper className={className}>
-      <Frames isHoverPreviewed={isHoverPreviewed} data-test-id="stack-trace">
+      <Frames
+        isHoverPreviewed={isHoverPreviewed}
+        inlined={inlined}
+        data-test-id="stack-trace"
+      >
         {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
       </Frames>
     </Wrapper>
@@ -248,7 +255,7 @@ const Wrapper = styled(Panel)`
   }
 `;
 
-const Frames = styled('ul')<{isHoverPreviewed?: boolean}>`
+export const Frames = styled('ul')<{inlined?: boolean; isHoverPreviewed?: boolean}>`
   background: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px ${p => 'solid ' + p.theme.border};
@@ -267,5 +274,13 @@ const Frames = styled('ul')<{isHoverPreviewed?: boolean}>`
       border-radius: 0;
       box-shadow: none;
       margin-bottom: 0;
+    `}
+
+  ${p =>
+    p.inlined &&
+    `
+      border-radius: 0;
+      border-left: 0;
+      border-right: 0;
     `}
 `;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -58,7 +58,6 @@ function StackTrace({
           newestFirst={newestFirst}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
-          hideIcon={inlined}
           inlined={inlined}
           maxDepth={maxDepth}
         />

--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -437,6 +437,7 @@ const LeftLineTitle = styled('div')`
 
 const RepeatedContent = styled(LeftLineTitle)`
   justify-content: center;
+  margin-right: ${space(1)};
 `;
 
 const NativeLineContent = styled('div')<{isFrameAfterLastNonApp: boolean}>`

--- a/static/app/components/events/interfaces/frame/lineV2/default.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/default.tsx
@@ -126,6 +126,7 @@ const Title = styled('div')`
 
 const RepeatedContent = styled(VertCenterWrapper)`
   justify-content: center;
+  margin-right: ${space(1)};
 `;
 
 const RepeatedFrames = styled('div')`


### PR DESCRIPTION
This adds addition styles for the stacktrace component when inlined for profiling use cases. This includes
- removing the border from native stacktraces
- adds some space between the recursion icon and the in app/system badge

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/228014803-8a614a89-fbe1-4f64-a0ac-4efe6efdc2eb.png)

## After

![image](https://user-images.githubusercontent.com/10239353/228014580-ce4ea41c-362e-45eb-be0c-c364500761ee.png)
