### PR TITLE
fix(codecov): Switch codecov flag to internal handler

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -234,7 +234,7 @@ default_manager.add("organizations:source-maps-cta", OrganizationFeature, Featur
 default_manager.add("organizations:source-maps-debug-ids", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:team-insights", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:derive-code-mappings", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:codecov-stacktrace-integration", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:codecov-stacktrace-integration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:codecov-stacktrace-integration-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:codecov-integration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
Switching the organizations:codecov-stacktrace-integration flag to an internal handler to use it in a cron task.

Related PR https://github.com/getsentry/getsentry/pull/10005