### PR TITLE
fix(replays): make platform empty string in deletion

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -45,7 +45,7 @@ def archive_replay(project_id: int, replay_id: str) -> None:
         "urls": [],
         "timestamp": time.time(),
         "is_archived": True,
-        "platform": None,
+        "platform": "",
     }
 
     publisher = _initialize_publisher()


### PR DESCRIPTION
Another clickhouse 20 bug. 

resolves https://github.com/getsentry/self-hosted/issues/2042