### PR TITLE
fix(replay): Fix missing user name when no user and ip is scrubbed

### DIFF
--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -10,6 +10,7 @@ import HeaderPlaceholder from 'sentry/components/replays/header/headerPlaceholde
 import ShareButton from 'sentry/components/replays/shareButton';
 import {CrumbWalker} from 'sentry/components/replays/walker/urlWalker';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import ReplayMetaData from 'sentry/views/replays/detail/replayMetaData';
@@ -41,7 +42,9 @@ function Page({children, crumbs, orgSlug, replayRecord}: Props) {
         <UserBadge
           avatarSize={32}
           displayName={
-            <Layout.Title>{replayRecord.user.display_name || ''}</Layout.Title>
+            <Layout.Title>
+              {replayRecord.user.display_name || t('Unknown User')}
+            </Layout.Title>
           }
           user={{
             name: replayRecord.user.display_name || '',

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -12,7 +12,7 @@ import ScoreBar from 'sentry/components/scoreBar';
 import TimeSince from 'sentry/components/timeSince';
 import CHART_PALETTE from 'sentry/constants/chartPalette';
 import {IconCalendar, IconLocation} from 'sentry/icons';
-import {tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {space, ValidSize} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
@@ -83,7 +83,9 @@ export function ReplayCell({
       <UserBadgeFullWidth
         avatarSize={24}
         displayName={
-          <MainLink to={replayDetails}>{replay.user.display_name || ''}</MainLink>
+          <MainLink to={replayDetails}>
+            {replay.user.display_name || t('Unknown User')}
+          </MainLink>
         }
         user={{
           username: replay.user.display_name || '',


### PR DESCRIPTION
We were showing an empty user string instead of a placeholder text indicating that there is no user information due to IP address scrubbing. Instead let's show `Unknown User` which is consistent with what we show in Issue Details when there is no user.