### PR TITLE
fix(codecov-v2): Remove token from request

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -44,13 +44,6 @@ def has_codecov_integration(organization: Organization) -> Tuple[bool, str | Non
 
     Returns a tuple of (has_codecov_integration, error_message)
     """
-    codecov_token = options.get("codecov.client-secret")
-    if not codecov_token:
-        logger.info(
-            "codecov.get_token", extra={"error": "Missing codecov token", "org_id": organization.id}
-        )
-        return False, CodecovIntegrationError.MISSING_TOKEN.value
-
     integrations = Integration.objects.filter(organizations=organization.id, provider="github")
     if not integrations.exists():
         logger.info(

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -70,7 +70,7 @@ def has_codecov_integration(organization: Organization) -> Tuple[bool, str | Non
 
         owner_username, _ = repos[0].get("full_name").split("/")
         url = CODECOV_REPOS_URL.format(service="github", owner_username=owner_username)
-        response = requests.get(url, headers={"Authorization": f"Bearer {codecov_token}"})
+        response = requests.get(url)
         if response.status_code == 200:
             logger.info(
                 "codecov.check_integration_success",

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -307,7 +307,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.create_integration(
             organization=self.organization, provider="github", external_id="extid"
         )
-        sentry_options.set("codecov.client-secret", "supersecrettoken")
         responses.add(
             responses.GET,
             "https://api.codecov.io/api/v2/github/testgit",

--- a/tests/sentry/tasks/test_auto_enable_codecov.py
+++ b/tests/sentry/tasks/test_auto_enable_codecov.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import responses
 
-from sentry import audit_log, options
+from sentry import audit_log
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organization import Organization
 from sentry.tasks.auto_enable_codecov import enable_for_organization, schedule_organizations
@@ -21,7 +21,6 @@ class AutoEnableCodecovTest(TestCase):
             provider="github",
             external_id="id",
         )
-        options.set("codecov.client-secret", "supersecrettoken")
 
         responses.add(
             responses.GET,


### PR DESCRIPTION
Remove the supertoken from requests to Codecov's `GET /api/v2/github/{org}` endpoint. This should fix the 401s we're seeing.