### PR TITLE
ref(compactSelect): Always render options in DOM

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -374,11 +374,7 @@ export function Control({
             {triggerLabel}
           </DropdownButton>
         )}
-        <StyledPositionWrapper
-          zIndex={theme.zIndex.tooltip}
-          visible={overlayIsOpen}
-          {...overlayProps}
-        >
+        <StyledPositionWrapper zIndex={theme.zIndex.tooltip} {...overlayProps}>
           <StyledOverlay
             width={menuWidth ?? menuFullWidth}
             maxWidth={maxMenuWidth}
@@ -387,6 +383,10 @@ export function Control({
             data-menu-has-header={!!menuTitle || clearable}
             data-menu-has-search={searchable}
             data-menu-has-footer={!!menuFooter}
+            // Control visibility directly via the style attribute, instead of an
+            // emotion style prop, to ensure that RTL's .toBeVisible() assertions will
+            // work correctly.
+            style={{display: overlayIsOpen ? 'block' : 'none'}}
           >
             <FocusScope contain={overlayIsOpen}>
               {(menuTitle || clearable) && (
@@ -556,11 +556,8 @@ const StyledOverlay = styled(Overlay, {
       : withUnits(p.maxHeightProp)};
 `;
 
-const StyledPositionWrapper = styled(PositionWrapper, {
-  shouldForwardProp: prop => isPropValid(prop),
-})<{visible?: boolean}>`
+const StyledPositionWrapper = styled(PositionWrapper)`
   min-width: 100%;
-  display: ${p => (p.visible ? 'block' : 'none')};
 `;
 
 const OptionsWrap = styled('div')`

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -341,6 +341,20 @@ export function Control({
     },
   });
 
+  const positionWrapperProps = useMemo(
+    () => ({
+      ...overlayProps,
+      style: {
+        ...overlayProps.style,
+        // Control the menu's visibility directly via the style attribute, instead of an
+        // emotion style prop, to ensure that RTL's .toBeVisible() assertions will
+        // function correctly.
+        display: overlayIsOpen ? 'block' : 'none',
+      },
+    }),
+    [overlayIsOpen, overlayProps]
+  );
+
   const contextValue = useMemo(
     () => ({
       registerListState,
@@ -374,7 +388,7 @@ export function Control({
             {triggerLabel}
           </DropdownButton>
         )}
-        <StyledPositionWrapper zIndex={theme.zIndex.tooltip} {...overlayProps}>
+        <StyledPositionWrapper zIndex={theme.zIndex.tooltip} {...positionWrapperProps}>
           <StyledOverlay
             width={menuWidth ?? menuFullWidth}
             maxWidth={maxMenuWidth}
@@ -383,10 +397,6 @@ export function Control({
             data-menu-has-header={!!menuTitle || clearable}
             data-menu-has-search={searchable}
             data-menu-has-footer={!!menuFooter}
-            // Control visibility directly via the style attribute, instead of an
-            // emotion style prop, to ensure that RTL's .toBeVisible() assertions will
-            // work correctly.
-            style={{display: overlayIsOpen ? 'block' : 'none'}}
           >
             <FocusScope contain={overlayIsOpen}>
               {(menuTitle || clearable) && (

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -28,7 +28,6 @@ export interface SelectContextValue {
    * automatically updated based on the current search string.
    */
   filterOption: (opt: SelectOption<React.Key>) => boolean;
-  overlayIsOpen: boolean;
   /**
    * Function to be called once when a list is initialized, to register its state in
    * SelectContext. In composite selectors, where there can be multiple lists, the
@@ -56,7 +55,6 @@ export const SelectContext = createContext<SelectContextValue>({
   registerListState: () => {},
   saveSelectedOptions: () => {},
   filterOption: () => true,
-  overlayIsOpen: false,
 });
 
 export interface ControlProps extends UseOverlayProps {
@@ -360,10 +358,9 @@ export function Control({
       registerListState,
       saveSelectedOptions,
       overlayState,
-      overlayIsOpen,
       filterOption,
     }),
-    [registerListState, saveSelectedOptions, overlayState, overlayIsOpen, filterOption]
+    [registerListState, saveSelectedOptions, overlayState, filterOption]
   );
 
   const theme = useTheme();

--- a/static/app/components/compactSelect/gridList/index.tsx
+++ b/static/app/components/compactSelect/gridList/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useContext, useRef} from 'react';
+import {Fragment, useCallback, useRef} from 'react';
 import {AriaGridListOptions, useGridList} from '@react-aria/gridlist';
 import {mergeProps} from '@react-aria/utils';
 import {ListState} from '@react-stately/list';
@@ -7,7 +7,6 @@ import {Node} from '@react-types/shared';
 import domId from 'sentry/utils/domId';
 import {FormSize} from 'sentry/utils/theme';
 
-import {SelectContext} from '../control';
 import {ListLabel, ListSeparator, ListWrap} from '../styles';
 
 import {GridListOption} from './option';
@@ -77,34 +76,32 @@ function GridList({
     [keyDownHandler, gridProps]
   );
 
-  const {overlayIsOpen} = useContext(SelectContext);
   return (
     <Fragment>
       {listItems.length !== 0 && <ListSeparator role="separator" />}
       {listItems.length !== 0 && label && <ListLabel id={labelId}>{label}</ListLabel>}
       <ListWrap {...mergeProps(gridProps, props)} onKeyDown={onKeyDown} ref={ref}>
-        {overlayIsOpen &&
-          listItems.map(item => {
-            if (item.type === 'section') {
-              return (
-                <GridListSection
-                  key={item.key}
-                  node={item}
-                  listState={listState}
-                  size={size}
-                />
-              );
-            }
-
+        {listItems.map(item => {
+          if (item.type === 'section') {
             return (
-              <GridListOption
+              <GridListSection
                 key={item.key}
                 node={item}
                 listState={listState}
                 size={size}
               />
             );
-          })}
+          }
+
+          return (
+            <GridListOption
+              key={item.key}
+              node={item}
+              listState={listState}
+              size={size}
+            />
+          );
+        })}
       </ListWrap>
     </Fragment>
   );

--- a/static/app/components/compactSelect/index.spec.tsx
+++ b/static/app/components/compactSelect/index.spec.tsx
@@ -439,7 +439,7 @@ describe('CompactSelect', function () {
       );
 
       // click on the trigger button
-      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByRole('button', {expanded: false}));
       await waitFor(() =>
         expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus()
       );

--- a/static/app/components/compactSelect/listBox/index.tsx
+++ b/static/app/components/compactSelect/listBox/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useContext, useRef} from 'react';
+import {Fragment, useCallback, useRef} from 'react';
 import {AriaListBoxOptions, useListBox} from '@react-aria/listbox';
 import {mergeProps} from '@react-aria/utils';
 import {ListState} from '@react-stately/list';
@@ -6,7 +6,6 @@ import {Node} from '@react-types/shared';
 
 import {FormSize} from 'sentry/utils/theme';
 
-import {SelectContext} from '../control';
 import {ListLabel, ListSeparator, ListWrap} from '../styles';
 
 import {ListBoxOption} from './option';
@@ -88,34 +87,27 @@ function ListBox({
     [keyDownHandler, listBoxProps]
   );
 
-  const {overlayIsOpen} = useContext(SelectContext);
   return (
     <Fragment>
       {listItems.length !== 0 && <ListSeparator role="separator" />}
       {listItems.length !== 0 && label && <ListLabel {...labelProps}>{label}</ListLabel>}
       <ListWrap {...mergeProps(listBoxProps, props)} onKeyDown={onKeyDown} ref={ref}>
-        {overlayIsOpen &&
-          listItems.map(item => {
-            if (item.type === 'section') {
-              return (
-                <ListBoxSection
-                  key={item.key}
-                  item={item}
-                  listState={listState}
-                  size={size}
-                />
-              );
-            }
-
+        {listItems.map(item => {
+          if (item.type === 'section') {
             return (
-              <ListBoxOption
+              <ListBoxSection
                 key={item.key}
                 item={item}
                 listState={listState}
                 size={size}
               />
             );
-          })}
+          }
+
+          return (
+            <ListBoxOption key={item.key} item={item} listState={listState} size={size} />
+          );
+        })}
       </ListWrap>
     </Fragment>
   );

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -143,7 +143,7 @@ describe('Breadcrumbs', () => {
 
       // breadcrumbs + filter item
       // TODO(Priscila): Filter should not render in the dom if not open
-      expect(screen.getAllByText(textWithMarkupMatcher('Warning'))).toHaveLength(5);
+      expect(screen.getAllByText(textWithMarkupMatcher('Warning'))).toHaveLength(6);
     });
 
     it('should filter crumbs based on crumb category', async function () {
@@ -324,7 +324,7 @@ describe('Breadcrumbs', () => {
       expect(within(breadcrumbsBefore[2]).getByText('hey')).toBeInTheDocument();
       expect(within(breadcrumbsBefore[3]).getByText('sup')).toBeInTheDocument();
 
-      await selectEvent.select(screen.getByText(/newest/i), /oldest/i);
+      await selectEvent.select(screen.getByRole('button', {name: /newest/i}), /oldest/i);
 
       // Now should be sorted oldest -> newest
       const breadcrumbsAfter = screen.getAllByTestId(/crumb/i);

--- a/static/app/components/events/interfaces/threadsV2.spec.tsx
+++ b/static/app/components/events/interfaces/threadsV2.spec.tsx
@@ -253,16 +253,16 @@ describe('ThreadsV2', function () {
         ).toBeInTheDocument();
 
         // Sort by options
-        expect(screen.getByText('Newest')).toBeInTheDocument();
-        expect(screen.queryByText('Oldest')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Newest'})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Oldest'})).not.toBeInTheDocument();
 
         // Switch to recent last
-        await userEvent.click(screen.getByText('Newest'));
-        await userEvent.click(screen.getByText('Oldest'));
+        await userEvent.click(screen.getByRole('button', {name: 'Newest'}));
+        await userEvent.click(screen.getByRole('option', {name: 'Oldest'}));
 
         // Recent last is checked
-        expect(screen.getByText('Oldest')).toBeInTheDocument();
-        expect(screen.queryByText('Newest')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Oldest'})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Newest'})).not.toBeInTheDocument();
 
         // Last frame is the first on the list
         expect(
@@ -272,8 +272,8 @@ describe('ThreadsV2', function () {
         ).toBeInTheDocument();
 
         // Click on recent first
-        await userEvent.click(screen.getByText('Oldest'));
-        await userEvent.click(screen.getByText('Newest'));
+        await userEvent.click(screen.getByRole('button', {name: 'Oldest'}));
+        await userEvent.click(screen.getByRole('option', {name: 'Newest'}));
 
         // First frame is the first on the list
         expect(
@@ -292,11 +292,11 @@ describe('ThreadsV2', function () {
 
         Object.entries(displayOptions).forEach(([key, value]) => {
           if (key === 'minified' || key === 'raw-stack-trace') {
-            expect(screen.getByText(value)).toBeInTheDocument();
+            expect(screen.getByRole('option', {name: value})).toBeInTheDocument();
             return;
           }
 
-          expect(screen.queryByText(value)).not.toBeInTheDocument();
+          expect(screen.queryByRole('option', {name: value})).not.toBeInTheDocument();
         });
 
         // Hover over the Minified option
@@ -1014,8 +1014,8 @@ describe('ThreadsV2', function () {
         await userEvent.click(screen.getByRole('button', {name: 'Newest'}));
 
         // Sort by options
-        expect(screen.getAllByText('Newest')).toHaveLength(2);
-        expect(screen.getByText('Oldest')).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'Newest'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'Oldest'})).toBeInTheDocument();
 
         // Recent first is checked by default
         expect(screen.getByRole('option', {name: 'Newest'})).toHaveAttribute(
@@ -1024,11 +1024,11 @@ describe('ThreadsV2', function () {
         );
 
         // Click on recent last
-        await userEvent.click(screen.getByText('Oldest'));
+        await userEvent.click(screen.getByRole('option', {name: 'Oldest'}));
 
         // Recent last is enabled
-        expect(screen.queryByText('Newest')).not.toBeInTheDocument();
-        expect(screen.getByText('Oldest')).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Newest'})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Oldest'})).toBeInTheDocument();
 
         // Last frame is the first on the list
         expect(
@@ -1037,7 +1037,7 @@ describe('ThreadsV2', function () {
 
         // Switch back to recent first
         await userEvent.click(screen.getByRole('button', {name: 'Oldest'}));
-        await userEvent.click(screen.getByText('Newest'));
+        await userEvent.click(screen.getByRole('option', {name: 'Newest'}));
 
         // First frame is the first on the list
         expect(

--- a/static/app/views/alerts/list/rules/index.spec.jsx
+++ b/static/app/views/alerts/list/rules/index.spec.jsx
@@ -124,15 +124,19 @@ describe('AlertRulesList', () => {
   it('displays team dropdown context if unassigned', async () => {
     createWrapper();
     const assignee = (await screen.findAllByTestId('alert-row-assignee'))[0];
-    const btn = within(assignee).getAllByRole('button')[0];
+    const btn = within(assignee).getByRole('button', {expanded: false});
 
     expect(assignee).toBeInTheDocument();
     expect(btn).toBeInTheDocument();
 
     await userEvent.click(btn, {skipHover: true});
 
-    expect(screen.getByText('#team-slug')).toBeInTheDocument();
-    expect(within(assignee).getByText('Unassigned')).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: 'team slug #team-slug'})
+    ).toBeInTheDocument();
+    expect(
+      within(assignee).getByRole('option', {name: 'Unassigned'})
+    ).toBeInTheDocument();
   });
 
   it('assigns rule to team from unassigned', async () => {
@@ -143,13 +147,13 @@ describe('AlertRulesList', () => {
     });
     createWrapper();
     const assignee = (await screen.findAllByTestId('alert-row-assignee'))[0];
-    const btn = within(assignee).getAllByRole('button')[0];
+    const btn = within(assignee).getByRole('button', {expanded: false});
 
     expect(assignee).toBeInTheDocument();
     expect(btn).toBeInTheDocument();
 
     await userEvent.click(btn, {skipHover: true});
-    await userEvent.click(screen.getByText('#team-slug'));
+    await userEvent.click(screen.getByRole('option', {name: 'team slug #team-slug'}));
 
     expect(assignMock).toHaveBeenCalledWith(
       '/projects/org-slug/earth/rules/123/',

--- a/static/app/views/dashboards/detail.spec.jsx
+++ b/static/app/views/dashboards/detail.spec.jsx
@@ -447,20 +447,23 @@ describe('Dashboards > Detail', function () {
     });
 
     it('shows add widget option', async function () {
-      render(
-        <OrganizationContext.Provider value={initialData.organization}>
-          <ViewEditDashboard
-            organization={initialData.organization}
-            params={{orgId: 'org-slug', dashboardId: '1'}}
-            router={initialData.router}
-            location={initialData.router.location}
-          />
-        </OrganizationContext.Provider>,
-        {context: initialData.routerContext}
-      );
+      await act(async () => {
+        render(
+          <OrganizationContext.Provider value={initialData.organization}>
+            <ViewEditDashboard
+              organization={initialData.organization}
+              params={{orgId: 'org-slug', dashboardId: '1'}}
+              router={initialData.router}
+              location={initialData.router.location}
+            />
+          </OrganizationContext.Provider>,
+          {context: initialData.routerContext}
+        );
 
-      // Enter edit mode.
-      await userEvent.click(screen.getByRole('button', {name: 'Edit Dashboard'}));
+        // Enter edit mode.
+        await userEvent.click(screen.getByRole('button', {name: 'Edit Dashboard'}));
+      });
+
       expect(await screen.findByRole('button', {name: 'Add widget'})).toBeInTheDocument();
     });
 
@@ -882,21 +885,25 @@ describe('Dashboards > Detail', function () {
           }),
         ],
       });
-      render(
-        <CreateDashboard
-          organization={initialData.organization}
-          params={{orgId: 'org-slug', templateId: 'default-template'}}
-          router={initialData.router}
-          location={initialData.router.location}
-        />,
-        {
-          context: initialData.routerContext,
-          organization: initialData.organization,
-        }
-      );
 
-      await userEvent.click(await screen.findByText('24H'));
-      await userEvent.click(screen.getByText('Last 7 days'));
+      await act(async () => {
+        render(
+          <CreateDashboard
+            organization={initialData.organization}
+            params={{orgId: 'org-slug', templateId: 'default-template'}}
+            router={initialData.router}
+            location={initialData.router.location}
+          />,
+          {
+            context: initialData.routerContext,
+            organization: initialData.organization,
+          }
+        );
+
+        await userEvent.click(await screen.findByText('24H'));
+        await userEvent.click(screen.getByText('Last 7 days'));
+      });
+
       await screen.findByText('7D');
 
       expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
@@ -1003,9 +1010,11 @@ describe('Dashboards > Detail', function () {
       );
 
       await screen.findByText('7D');
-      await userEvent.click(await screen.findByText('sentry-android-shop@1.2.0'));
-      await userEvent.click(screen.getByText('Clear'));
-      screen.getByText('All Releases');
+      await userEvent.click(
+        screen.getByRole('button', {name: 'sentry-android-shop@1.2.0'})
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'Clear'}));
+      screen.getByRole('button', {name: 'All Releases'});
       await userEvent.click(document.body);
 
       expect(browserHistory.push).toHaveBeenCalledWith(
@@ -1253,7 +1262,7 @@ describe('Dashboards > Detail', function () {
         {context: testData.routerContext, organization: testData.organization}
       );
 
-      await screen.findByText(/not-selected-1/);
+      await screen.findByRole('button', {name: /not-selected-1/});
       screen.getByText('Save');
       screen.getByText('Cancel');
     });
@@ -1297,7 +1306,7 @@ describe('Dashboards > Detail', function () {
         {context: testData.routerContext, organization: testData.organization}
       );
 
-      await screen.findByText(/not-selected-1/);
+      await screen.findByRole('button', {name: /not-selected-1/});
       await userEvent.click(screen.getByText('Cancel'));
 
       // release isn't used in the redirect
@@ -1398,19 +1407,20 @@ describe('Dashboards > Detail', function () {
           location: TestStubs.location(),
         },
       });
-      render(
-        <ViewEditDashboard
-          organization={testData.organization}
-          params={{orgId: 'org-slug', dashboardId: '1'}}
-          router={testData.router}
-          location={testData.router.location}
-        />,
-        {context: testData.routerContext, organization: testData.organization}
-      );
 
-      await userEvent.click(await screen.findByText('All Releases'));
-      await userEvent.type(screen.getByPlaceholderText('Search\u2026'), 's');
       await act(async () => {
+        render(
+          <ViewEditDashboard
+            organization={testData.organization}
+            params={{orgId: 'org-slug', dashboardId: '1'}}
+            router={testData.router}
+            location={testData.router.location}
+          />,
+          {context: testData.routerContext, organization: testData.organization}
+        );
+
+        await userEvent.click(await screen.findByText('All Releases'));
+        await userEvent.type(screen.getByPlaceholderText('Search\u2026'), 's');
         await userEvent.click(await screen.findByRole('option', {name: 'search-result'}));
       });
 

--- a/static/app/views/dashboards/releasesSelectControl.spec.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.spec.tsx
@@ -47,31 +47,40 @@ describe('Dashboards > ReleasesSelectControl', function () {
   it('updates menu title with selection', async function () {
     renderReleasesSelect({});
 
-    expect(screen.getByText('All Releases')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'All Releases'})).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('All Releases'));
-    expect(screen.getByText('Latest Release(s)')).toBeInTheDocument();
-    await userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
+    await userEvent.click(screen.getByRole('button', {name: 'All Releases'}));
+    expect(screen.getByRole('option', {name: 'Latest Release(s)'})).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('option', {name: 'sentry-android-shop@1.2.0'})
+    );
 
     await userEvent.click(document.body);
 
-    expect(screen.getByText('sentry-android-shop@1.2.0')).toBeInTheDocument();
-    expect(screen.queryByText('+1')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'sentry-android-shop@1.2.0'})
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /\+1/})).not.toBeInTheDocument();
   });
 
   it('updates menu title with multiple selections', async function () {
     renderReleasesSelect({});
 
-    expect(screen.getByText('All Releases')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'All Releases'})).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('All Releases'));
-    await userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
-    await userEvent.click(screen.getByText('sentry-android-shop@1.4.0'));
+    await userEvent.click(screen.getByRole('button', {name: 'All Releases'}));
+    await userEvent.click(
+      screen.getByRole('option', {name: 'sentry-android-shop@1.2.0'})
+    );
+    await userEvent.click(
+      screen.getByRole('option', {name: 'sentry-android-shop@1.4.0'})
+    );
 
     await userEvent.click(document.body);
 
-    expect(screen.getByText('sentry-android-shop@1.2.0')).toBeInTheDocument();
-    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'sentry-android-shop@1.2.0 +1'})
+    ).toBeInTheDocument();
   });
 
   it('calls onSearch when filtering by releases', async function () {

--- a/static/app/views/discover/chartFooter.spec.tsx
+++ b/static/app/views/discover/chartFooter.spec.tsx
@@ -123,8 +123,8 @@ describe('Discover > ChartFooter', function () {
 
     render(chartFooter);
 
-    await userEvent.click(screen.getByText('count()'));
-    await userEvent.click(screen.getByText('failure_count()'));
+    await userEvent.click(screen.getByRole('button', {name: 'Y-Axis count()'}));
+    await userEvent.click(screen.getByRole('option', {name: 'failure_count()'}));
     expect(yAxis).toEqual(['count()', 'failure_count()']);
   });
 });

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -115,7 +115,7 @@ describe('Discover > Homepage', () => {
 
     // Only the environment field
     expect(screen.getAllByTestId('grid-head-cell').length).toEqual(1);
-    screen.getByText('Previous Period');
+    screen.getByRole('button', {name: 'Display Previous Period'});
     screen.getByText('event.type:error');
   });
 

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -1230,8 +1230,8 @@ describe('Results', function () {
       await userEvent.click(screen.getByText('Set as Default'));
       expect(await screen.findByText('Remove Default')).toBeInTheDocument();
 
-      await userEvent.click(screen.getByText('Total Period'));
-      await userEvent.click(screen.getByText('Previous Period'));
+      await userEvent.click(screen.getByRole('button', {name: 'Display Total Period'}));
+      await userEvent.click(screen.getByRole('option', {name: 'Previous Period'}));
 
       const rerenderData = initializeOrg({
         ...initializeOrg(),
@@ -1250,7 +1250,7 @@ describe('Results', function () {
           router={rerenderData.router}
         />
       );
-      screen.getByText('Previous Period');
+      screen.getByRole('button', {name: 'Display Previous Period'});
       expect(await screen.findByText('Set as Default')).toBeInTheDocument();
     });
 
@@ -1298,8 +1298,8 @@ describe('Results', function () {
       await userEvent.click(screen.getByText('Set as Default'));
       expect(await screen.findByText('Remove Default')).toBeInTheDocument();
 
-      await userEvent.click(screen.getByText('Total Period'));
-      await userEvent.click(screen.getByText('Previous Period'));
+      await userEvent.click(screen.getByRole('button', {name: 'Display Total Period'}));
+      await userEvent.click(screen.getByRole('option', {name: 'Previous Period'}));
       const rerenderData = initializeOrg({
         ...initializeOrg(),
         organization,
@@ -1317,7 +1317,7 @@ describe('Results', function () {
           setSavedQuery={jest.fn()}
         />
       );
-      screen.getByText('Previous Period');
+      screen.getByRole('button', {name: 'Display Previous Period'});
       expect(await screen.findByText('Set as Default')).toBeInTheDocument();
     });
 

--- a/static/app/views/discover/resultsChart.spec.tsx
+++ b/static/app/views/discover/resultsChart.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import EventView from 'sentry/utils/discover/eventView';
 import {DISPLAY_MODE_OPTIONS, DisplayModes} from 'sentry/utils/discover/types';
@@ -125,11 +125,14 @@ describe('Discover > ResultsChart', function () {
       {context: initialData.routerContext}
     );
 
-    await userEvent.click(await screen.findByText(/Y-Axis/));
+    await userEvent.click(await screen.findByRole('button', {name: /Y-Axis/}));
 
-    expect(screen.getAllByRole('option')).toHaveLength(2);
+    const listBox = screen.getByRole('listbox', {name: /Y-Axis/});
+    expect(within(listBox).getAllByRole('option')).toHaveLength(2);
 
-    expect(screen.getByRole('option', {name: 'count()'})).toBeEnabled();
-    expect(screen.getByRole('option', {name: 'count_unique(user)'})).toBeEnabled();
+    expect(within(listBox).getByRole('option', {name: 'count()'})).toBeEnabled();
+    expect(
+      within(listBox).getByRole('option', {name: 'count_unique(user)'})
+    ).toBeEnabled();
   });
 });

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import ProjectPageFilter from 'sentry/components/projectPageFilter';
+import {ProjectPageFilter} from 'sentry/components/projectPageFilterV2';
 import {space} from 'sentry/styles/space';
 import {IssueSearchWithSavedSearches} from 'sentry/views/issueList/issueSearchWithSavedSearches';
 

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/projectPageFilterV2';
+import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {space} from 'sentry/styles/space';
 import {IssueSearchWithSavedSearches} from 'sentry/views/issueList/issueSearchWithSavedSearches';
 

--- a/static/app/views/issueList/overview.spec.jsx
+++ b/static/app/views/issueList/overview.spec.jsx
@@ -210,7 +210,7 @@ describe('IssueList', function () {
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
       expect(savedSearchesRequest).toHaveBeenCalledTimes(1);
 
-      await userEvent.click(await screen.findByRole('textbox'));
+      await userEvent.click(await screen.findByDisplayValue('is:unresolved'));
 
       // auxillary requests being made
       expect(recentSearchesRequest).toHaveBeenCalledTimes(1);
@@ -225,8 +225,6 @@ describe('IssueList', function () {
           data: expect.stringContaining('is%3Aunresolved'),
         })
       );
-
-      expect(screen.getByRole('textbox')).toHaveValue('is:unresolved ');
 
       expect(screen.getByRole('button', {name: /custom search/i})).toBeInTheDocument();
     });
@@ -263,7 +261,7 @@ describe('IssueList', function () {
         );
       });
 
-      expect(screen.getByRole('textbox')).toHaveValue('level:foo ');
+      expect(screen.getByDisplayValue('level:foo')).toBeInTheDocument();
 
       // Tab shows "custom search"
       expect(screen.getByRole('button', {name: 'Custom Search'})).toBeInTheDocument();
@@ -298,7 +296,7 @@ describe('IssueList', function () {
         );
       });
 
-      expect(screen.getByRole('textbox')).toHaveValue('is:resolved ');
+      expect(screen.getByDisplayValue('is:resolved')).toBeInTheDocument();
 
       // Organization saved search selector should have default saved search selected
       expect(screen.getByRole('button', {name: 'My Default Search'})).toBeInTheDocument();
@@ -343,7 +341,7 @@ describe('IssueList', function () {
         );
       });
 
-      expect(screen.getByRole('textbox')).toHaveValue('assigned:me ');
+      expect(screen.getByDisplayValue('assigned:me')).toBeInTheDocument();
 
       // Organization saved search selector should have default saved search selected
       expect(screen.getByRole('button', {name: 'Assigned to Me'})).toBeInTheDocument();
@@ -385,7 +383,7 @@ describe('IssueList', function () {
         );
       });
 
-      expect(screen.getByRole('textbox')).toHaveValue('level:error ');
+      expect(screen.getByDisplayValue('level:error')).toBeInTheDocument();
 
       // Organization saved search selector should have default saved search selected
       expect(screen.getByRole('button', {name: 'Custom Search'})).toBeInTheDocument();
@@ -423,7 +421,7 @@ describe('IssueList', function () {
         );
       });
 
-      expect(screen.getByRole('textbox')).toHaveValue('is:resolved ');
+      expect(screen.getByDisplayValue('is:resolved')).toBeInTheDocument();
 
       // Organization saved search selector should have default saved search selected
       expect(screen.getByRole('button', {name: 'My Default Search'})).toBeInTheDocument();
@@ -473,8 +471,9 @@ describe('IssueList', function () {
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
 
-      await userEvent.clear(screen.getByRole('textbox'));
-      await userEvent.type(screen.getByRole('textbox'), 'dogs{enter}');
+      const textbox = screen.getByDisplayValue('is:resolved');
+      await userEvent.clear(textbox);
+      await userEvent.type(textbox, 'dogs{enter}');
 
       expect(browserHistory.push).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -511,8 +510,9 @@ describe('IssueList', function () {
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
 
-      await userEvent.clear(screen.getByRole('textbox'));
-      await userEvent.type(screen.getByRole('textbox'), 'assigned:me level:fatal{enter}');
+      const textbox = screen.getByDisplayValue('is:unresolved');
+      await userEvent.clear(textbox);
+      await userEvent.type(textbox, 'assigned:me level:fatal{enter}');
 
       expect(browserHistory.push.mock.calls[0][0]).toEqual(
         expect.objectContaining({
@@ -928,8 +928,9 @@ describe('IssueList', function () {
         context: routerContext,
       });
 
-      await userEvent.clear(screen.getByRole('textbox'));
-      await userEvent.type(screen.getByRole('textbox'), 'is:ignored{enter}');
+      const textbox = screen.getByDisplayValue('is:unresolved');
+      await userEvent.clear(textbox);
+      await userEvent.type(textbox, 'is:ignored{enter}');
 
       expect(browserHistory.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/issues/',
@@ -1082,7 +1083,10 @@ describe('IssueList', function () {
 
       render(<IssueListOverview {...routerProps} {...props} />, {context: routerContext});
 
-      await userEvent.type(screen.getByRole('textbox'), ' level:error{enter}');
+      await userEvent.type(
+        screen.getByDisplayValue('is:unresolved'),
+        ' level:error{enter}'
+      );
 
       expect(
         await screen.findByText(/We couldn't find any issues that matched your filters/i)

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -171,16 +171,16 @@ describe('OrganizationStats', function () {
   it('pushes state changes to the route', async () => {
     render(<OrganizationStats {...defaultProps} />, {context: routerContext});
 
-    await userEvent.click(screen.getByText('Category'));
-    await userEvent.click(screen.getByText('Attachments'));
+    await userEvent.click(screen.getByRole('button', {name: 'Category Errors'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Attachments'}));
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {dataCategory: DATA_CATEGORY_INFO.attachment.plural},
       })
     );
 
-    await userEvent.click(screen.getByText('Periodic'));
-    await userEvent.click(screen.getByText('Cumulative'));
+    await userEvent.click(screen.getByRole('button', {name: 'Type Periodic'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Cumulative'}));
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {transform: ChartDataTransform.CUMULATIVE},

--- a/static/app/views/projectDetail/projectCharts.spec.tsx
+++ b/static/app/views/projectDetail/projectCharts.spec.tsx
@@ -74,8 +74,10 @@ describe('ProjectDetail > ProjectCharts', () => {
       screen.getByRole('button', {name: 'Display Crash Free Sessions'})
     );
 
-    expect(screen.queryByText('Foreground ANR Rate')).not.toBeInTheDocument();
-    expect(screen.queryByText('ANR Rate')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {name: 'Foreground ANR Rate'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'ANR Rate'})).not.toBeInTheDocument();
   });
 
   it('makes the right ANR sessions request', async () => {
@@ -117,7 +119,7 @@ describe('ProjectDetail > ProjectCharts', () => {
       body: responseBody,
     });
     renderProjectCharts(['anr-rate'], 'android', 'anr_rate');
-    expect(screen.getByText('ANR Rate')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Display ANR Rate'})).toBeInTheDocument();
 
     await waitFor(() =>
       expect(mockSessions).toHaveBeenCalledWith(

--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
@@ -34,7 +34,11 @@ describe('OwnershipRulesTable', () => {
 
     expect(screen.getByText('path')).toBeInTheDocument();
     expect(screen.getByText('pattern')).toBeInTheDocument();
-    expect(screen.getByText(user1.name)).toBeInTheDocument();
+
+    // First result is a filter option — it should be invisible as the menu is not open
+    expect(screen.getAllByText(user1.name)[0]).not.toBeVisible();
+    // Second result is what we're looking for in the Owner column, user1.name
+    expect(screen.getAllByText(user1.name)[1]).toBeVisible();
   });
 
   it('should render multiple project owners', () => {
@@ -53,7 +57,11 @@ describe('OwnershipRulesTable', () => {
     expect(screen.getByText('path')).toBeInTheDocument();
     expect(screen.getByText('pattern')).toBeInTheDocument();
     expect(screen.getByText(`${user1.name} and 1 other`)).toBeInTheDocument();
-    expect(screen.queryByText(user2.name)).not.toBeInTheDocument();
+
+    // First result is a filter option — it should be invisible as the menu is not open
+    expect(screen.queryAllByText(user2.name)[0]).not.toBeVisible();
+    // There should be no other result (i.e. no user2.name in the Owner column)
+    expect(screen.queryAllByText(user2.name).length).toEqual(1);
   });
 
   it('should filter by rule type and pattern', async () => {


### PR DESCRIPTION
Rather than mounting and unmounting select options when the menu opens/closes, it's more efficient to always have the options mounted in the DOM and instead control the menu's visibility via a `display` style attribute.

**Before —** opening the menu causes a 43ms rendering spike
<img width="143" alt="Screenshot 2023-03-27 at 1 47 36 PM" src="https://user-images.githubusercontent.com/44172267/228062877-3048103f-0d98-410e-95c1-208b01982360.png">

**After —** there is no spike when the menu opens, all renders take around 4-8ms
<img width="143" alt="Screenshot 2023-03-27 at 1 47 16 PM" src="https://user-images.githubusercontent.com/44172267/228062801-8bbeb2a5-aec4-408d-a1b3-fd15a7412c24.png">
