### PR TITLE
fix(domains) Fix route confusion around onboarding

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -271,10 +271,13 @@ _path_patterns: List[Tuple[re.Pattern[str], str]] = [
     ),
     # Move /settings/:orgId/:section -> /settings/:section
     # but not /settings/organization or /settings/projects which is a new URL
-    (re.compile(r"\/?settings\/(?!account)(?!projects)(?!teams)[^\/]+\/(.*)"), r"/settings/\1"),
-    (re.compile(r"\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),
-    (re.compile(r"\/?onboarding\/[^\/]+\/(.*)"), r"/onboarding/\1"),
-    (re.compile(r"\/?[^\/]+\/([^\/]+)\/getting-started\/(.*)"), r"/getting-started/\1/\2"),
+    (re.compile(r"^\/?settings\/(?!account)(?!projects)(?!teams)[^\/]+\/(.*)"), r"/settings/\1"),
+    (re.compile(r"^\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),
+    (re.compile(r"^\/?onboarding\/[^\/]+\/(.*)"), r"/onboarding/\1"),
+    (
+        re.compile(r"\/?(?:[^\/]+(?<!settings))\/([^\/]+)\/getting-started\/(.*)"),
+        r"/getting-started/\1/\2",
+    ),
 ]
 
 

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -31,6 +31,7 @@ describe('normalizeUrl', function () {
       ['/settings/sentry/members/', '/settings/members/'],
       ['/settings/sentry/members/3/', '/settings/members/3/'],
       ['/settings/sentry/teams/peeps/', '/settings/teams/peeps/'],
+      ['/settings/sentry/teams/payments/', '/settings/teams/payments/'],
       ['/settings/sentry/billing/receipts/', '/settings/billing/receipts/'],
       [
         '/settings/acme/developer-settings/release-bot/',
@@ -59,9 +60,18 @@ describe('normalizeUrl', function () {
         '/getting-started/project-slug/python',
       ],
       ['/settings/projects/python/filters/', '/settings/projects/python/filters/'],
+      ['/settings/projects/onboarding/abc123/', '/settings/projects/onboarding/abc123/'],
+      [
+        '/settings/projects/join-request/abc123/',
+        '/settings/projects/join-request/abc123/',
+      ],
       [
         '/settings/projects/python/filters/discarded/',
         '/settings/projects/python/filters/discarded/',
+      ],
+      [
+        '/settings/projects/getting-started/abc123/',
+        '/settings/projects/getting-started/abc123/',
       ],
       // Team settings links in breadcrumbs can be pre-normalized from breadcrumbs
       ['/settings/teams/peeps/', '/settings/teams/peeps/'],

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -11,10 +11,14 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/\/settings\/(?!account)(?!projects)(?!teams)[^\/]+\/?$/, '/settings/organization/'],
   // Move /settings/:orgId/:section -> /settings/:section
   // but not /settings/organization or /settings/projects which is a new URL
-  [/\/?settings\/(?!account)(?!projects)(?!teams)[^\/]+\/(.*)/, '/settings/$1'],
-  [/\/?join-request\/[^\/]+\/?.*/, '/join-request/'],
-  [/\/?onboarding\/[^\/]+\/(.*)/, '/onboarding/$1'],
-  [/\/?[^\/]+\/([^\/]+)\/getting-started\/(.*)/, '/getting-started/$1/$2'],
+  [/^\/?settings\/(?!account)(?!projects)(?!teams)[^\/]+\/(.*)/, '/settings/$1'],
+  [/^\/?join-request\/[^\/]+\/?.*/, '/join-request/'],
+  [/^\/?onboarding\/[^\/]+\/(.*)/, '/onboarding/$1'],
+  // Handles /org-slug/project-slug/getting-started/platform/ -> /getting-started/project-slug/platform/
+  [
+    /\/?(?:[^\/]+(?<!settings))\/([^\/]+)\/getting-started\/(.*)/,
+    '/getting-started/$1/$2',
+  ],
 ];
 
 type LocationTarget = ((location: Location) => LocationDescriptor) | LocationDescriptor;

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -113,9 +113,18 @@ def test_customer_domain_path():
             "/getting-started/project-slug/python",
         ],
         ["/settings/projects/python/filters/", "/settings/projects/python/filters/"],
+        ["/settings/projects/onboarding/abc123/", "/settings/projects/onboarding/abc123/"],
+        [
+            "/settings/projects/join-request/abc123/",
+            "/settings/projects/join-request/abc123/",
+        ],
         [
             "/settings/projects/python/filters/discarded/",
             "/settings/projects/python/filters/discarded/",
+        ],
+        [
+            "/settings/projects/getting-started/abc123/",
+            "/settings/projects/getting-started/abc123/",
         ],
         ["/settings/teams/peeps/", "/settings/teams/peeps/"],
     ]


### PR DESCRIPTION
Refine the patterns used to generate domain aliases to disambiguate how 'onboarding' paths work.

Fixes #46301
