### PR TITLE
feat(codecov-v2): GA V2 frontend for codecov integration

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -264,7 +264,7 @@ describe('StacktraceLink', function () {
     ));
     const organization = {
       ...org,
-      features: ['codecov-integration', 'codecov-stacktrace-integration-v2'],
+      features: ['codecov-integration'],
       codecovAccess: false,
     };
     MockApiClient.addMockResponse({

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -131,9 +131,7 @@ function shouldShowCodecovPrompt(
   match: StacktraceLinkResult
 ) {
   const enabled =
-    organization.features.includes('codecov-integration') &&
-    organization.features.includes('codecov-stacktrace-integration-v2') &&
-    !organization.codecovAccess;
+    organization.features.includes('codecov-integration') && !organization.codecovAccess;
 
   return enabled && match.config?.provider.key === 'github';
 }


### PR DESCRIPTION
GA the CTA and V2 improvements for codecov stacktrace integration. Backend changes in https://github.com/getsentry/sentry/pull/46420