### PR TITLE
feat(replay): Use `<ObjectInspector>` for breadcrumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -101,6 +101,10 @@ function BreadcrumbItem({
             data={description}
             expandPaths={expandPaths}
             onExpand={handleDimensionChange}
+            theme={{
+              TREENODE_FONT_SIZE: '0.7rem',
+              ARROW_FONT_SIZE: '0.5rem',
+            }}
           />
         )}
       </CrumbDetails>

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -13,24 +13,36 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 type MouseCallback = (crumb: Crumb, e: React.MouseEvent<HTMLElement>) => void;
 
-interface Props {
+interface BaseProps {
   crumb: Crumb;
-  index: number;
   isCurrent: boolean;
   isHovered: boolean;
   onClick: null | MouseCallback;
   startTimestampMs: number;
   expandPaths?: string[];
-  onDimensionChange?: (
+  onMouseEnter?: MouseCallback;
+  onMouseLeave?: MouseCallback;
+  style?: CSSProperties;
+}
+interface NoDimensionChangeProps extends BaseProps {
+  index?: undefined;
+  onDimensionChange?: undefined;
+}
+
+interface WithDimensionChangeProps extends BaseProps {
+  /**
+   * Only required if onDimensionChange is used
+   */
+  index: number;
+  onDimensionChange: (
     index: number,
     path: string,
     expandedState: Record<string, boolean>,
     event: MouseEvent<HTMLDivElement>
   ) => void;
-  onMouseEnter?: MouseCallback;
-  onMouseLeave?: MouseCallback;
-  style?: CSSProperties;
 }
+
+type Props = NoDimensionChangeProps | WithDimensionChangeProps;
 
 function BreadcrumbItem({
   crumb,

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -109,20 +109,26 @@ function BreadcrumbItem({
             {description}
           </Description>
         ) : (
-          <ObjectInspector
-            data={description}
-            expandPaths={expandPaths}
-            onExpand={handleDimensionChange}
-            theme={{
-              TREENODE_FONT_SIZE: '0.7rem',
-              ARROW_FONT_SIZE: '0.5rem',
-            }}
-          />
+          <InspectorWrapper>
+            <ObjectInspector
+              data={description}
+              expandPaths={expandPaths}
+              onExpand={handleDimensionChange}
+              theme={{
+                TREENODE_FONT_SIZE: '0.7rem',
+                ARROW_FONT_SIZE: '0.5rem',
+              }}
+            />
+          </InspectorWrapper>
         )}
       </CrumbDetails>
     </CrumbItem>
   );
 }
+
+const InspectorWrapper = styled('div')`
+  font-family: ${p => p.theme.text.familyMono};
+`;
 
 const CrumbDetails = styled('div')`
   display: flex;

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,7 +1,8 @@
-import {CSSProperties, memo, useCallback} from 'react';
+import {CSSProperties, memo, MouseEvent, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
+import ObjectInspector from 'sentry/components/objectInspector';
 import {PanelItem} from 'sentry/components/panels';
 import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -14,10 +15,18 @@ type MouseCallback = (crumb: Crumb, e: React.MouseEvent<HTMLElement>) => void;
 
 interface Props {
   crumb: Crumb;
+  index: number;
   isCurrent: boolean;
   isHovered: boolean;
   onClick: null | MouseCallback;
   startTimestampMs: number;
+  expandPaths?: string[];
+  onDimensionChange?: (
+    index: number,
+    path: string,
+    expandedState: Record<string, boolean>,
+    event: MouseEvent<HTMLDivElement>
+  ) => void;
   onMouseEnter?: MouseCallback;
   onMouseLeave?: MouseCallback;
   style?: CSSProperties;
@@ -25,9 +34,12 @@ interface Props {
 
 function BreadcrumbItem({
   crumb,
+  expandPaths,
+  index,
   isCurrent,
   isHovered,
   onClick,
+  onDimensionChange,
   onMouseEnter,
   onMouseLeave,
   startTimestampMs,
@@ -48,6 +60,11 @@ function BreadcrumbItem({
       onClick?.(crumb, e);
     },
     [crumb, onClick]
+  );
+  const handleDimensionChange = useCallback(
+    (path, expandedState, e) =>
+      onDimensionChange && onDimensionChange(index, path, expandedState, e),
+    [index, onDimensionChange]
   );
 
   return (
@@ -75,9 +92,17 @@ function BreadcrumbItem({
           ) : null}
         </TitleContainer>
 
-        <Description title={description} showOnlyOnOverflow>
-          {description}
-        </Description>
+        {typeof description === 'string' ? (
+          <Description title={description} showOnlyOnOverflow>
+            {description}
+          </Description>
+        ) : (
+          <ObjectInspector
+            data={description}
+            expandPaths={expandPaths}
+            onExpand={handleDimensionChange}
+          />
+        )}
       </CrumbDetails>
     </CrumbItem>
   );

--- a/static/app/components/replays/breadcrumbs/utils.tsx
+++ b/static/app/components/replays/breadcrumbs/utils.tsx
@@ -1,4 +1,3 @@
-import ObjectInspector from 'sentry/components/objectInspector';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -50,7 +49,7 @@ export function getDescription(crumb: Crumb) {
     case BreadcrumbType.NAVIGATION:
       return `${crumbData?.to ?? ''}`;
     case BreadcrumbType.DEFAULT:
-      return <ObjectInspector data={crumbData} />;
+      return crumbData;
     default:
       return crumb.message || '';
   }

--- a/static/app/components/replays/breadcrumbs/utils.tsx
+++ b/static/app/components/replays/breadcrumbs/utils.tsx
@@ -1,3 +1,4 @@
+import ObjectInspector from 'sentry/components/objectInspector';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -49,7 +50,7 @@ export function getDescription(crumb: Crumb) {
     case BreadcrumbType.NAVIGATION:
       return `${crumbData?.to ?? ''}`;
     case BreadcrumbType.DEFAULT:
-      return JSON.stringify(crumbData);
+      return <ObjectInspector data={crumbData} />;
     default:
       return crumb.message || '';
   }

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, memo, useCallback} from 'react';
+import {CSSProperties, memo, MouseEvent, useCallback} from 'react';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
 import type {Crumb} from 'sentry/types/breadcrumbs';
@@ -6,19 +6,30 @@ import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 
 interface Props {
   breadcrumb: Crumb;
+  index: number;
   isCurrent: boolean;
   isHovered: boolean;
   startTimestampMs: number;
   style: CSSProperties;
   breadcrumbIndex?: number[][];
+  expandPaths?: string[];
+  onDimensionChange?: (
+    index: number,
+    path: string,
+    expandedState: Record<string, boolean>,
+    event: MouseEvent<HTMLDivElement>
+  ) => void;
 }
 
 function BreadcrumbRow({
   breadcrumb,
+  expandPaths,
+  index,
+  isCurrent,
+  onDimensionChange,
+  isHovered,
   startTimestampMs,
   style,
-  isCurrent,
-  isHovered,
 }: Props) {
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
@@ -38,6 +49,7 @@ function BreadcrumbRow({
 
   return (
     <BreadcrumbItem
+      index={index}
       crumb={breadcrumb}
       isCurrent={isCurrent}
       isHovered={isHovered}
@@ -46,6 +58,8 @@ function BreadcrumbRow({
       onMouseLeave={onMouseLeave}
       startTimestampMs={startTimestampMs}
       style={style}
+      expandPaths={expandPaths}
+      onDimensionChange={onDimensionChange}
     />
   );
 }

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -9,16 +9,16 @@ interface Props {
   index: number;
   isCurrent: boolean;
   isHovered: boolean;
-  startTimestampMs: number;
-  style: CSSProperties;
-  breadcrumbIndex?: number[][];
-  expandPaths?: string[];
-  onDimensionChange?: (
+  onDimensionChange: (
     index: number,
     path: string,
     expandedState: Record<string, boolean>,
     event: MouseEvent<HTMLDivElement>
   ) => void;
+  startTimestampMs: number;
+  style: CSSProperties;
+  breadcrumbIndex?: number[][];
+  expandPaths?: string[];
 }
 
 function BreadcrumbRow({

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import {memo, useMemo, useRef} from 'react';
+import {memo, MouseEvent, useCallback, useMemo, useRef} from 'react';
 import {
   AutoSizer,
   CellMeasurer,
@@ -32,6 +32,7 @@ const cellMeasurer = {
 
 function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
+  const expandPaths = useRef(new Map<number, Set<string>>());
   const items = useMemo(
     () =>
       (breadcrumbs || []).filter(crumb => !['console'].includes(crumb.category || '')),
@@ -80,6 +81,29 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
     deps,
   });
 
+  const handleDimensionChange = useCallback(
+    (
+      index: number,
+      path: string,
+      expandedState: Record<string, boolean>,
+      event: MouseEvent<HTMLDivElement>
+    ) => {
+      const rowState = expandPaths.current.get(index) || new Set();
+      if (expandedState[path]) {
+        rowState.add(path);
+      } else {
+        // Collapsed, i.e. its default state, so no need to store state
+        rowState.delete(path);
+      }
+      expandPaths.current.set(index, rowState);
+      cache.clear(index, 0);
+      listRef.current?.recomputeGridSize({rowIndex: index});
+      listRef.current?.forceUpdateGrid();
+      event.stopPropagation();
+    },
+    [cache, expandPaths, listRef]
+  );
+
   useScrollToCurrentItem({
     breadcrumbs,
     ref: listRef,
@@ -98,11 +122,14 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
         rowIndex={index}
       >
         <BreadcrumbRow
+          index={index}
           isCurrent={current?.id === item.id}
           isHovered={hovered?.id === item.id}
           breadcrumb={item}
           startTimestampMs={startTimestampMs}
           style={style}
+          expandPaths={Array.from(expandPaths.current.get(index) || [])}
+          onDimensionChange={handleDimensionChange}
         />
       </CellMeasurer>
     );


### PR DESCRIPTION
Adds object inspection to Replay breadcrumbs.



Before:
![image](https://user-images.githubusercontent.com/79684/228534424-487027f3-8e1d-4e20-a2a1-b24928b4955a.png)


After:
![image](https://user-images.githubusercontent.com/79684/228556530-8db30b70-be02-4e11-a6af-1d357db34260.png)