### PR TITLE
ref(source-maps): Update artifacts header and breadcrumbs

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -526,7 +526,7 @@ function buildRoutes() {
           })}
         >
           <Route
-            name={t('Artifact Bundle')}
+            name={t('Debug ID Bundle')}
             path=":bundleId/"
             component={make(async () => {
               const {ProjectSourceMapsContainer} = await import(
@@ -551,7 +551,7 @@ function buildRoutes() {
           })}
         >
           <Route
-            name={t('Artifact Bundle')}
+            name={t('Release Bundle')}
             path=":bundleId/"
             component={make(async () => {
               const {ProjectSourceMapsContainer} = await import(

--- a/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
@@ -94,7 +94,7 @@ describe('ProjectSourceMapsArtifacts', function () {
       );
 
       // Title
-      expect(screen.getByRole('heading')).toHaveTextContent('Artifact Bundle');
+      expect(screen.getByRole('heading')).toHaveTextContent('Release Bundle');
       // Subtitle
       expect(screen.getByText('bea7335dfaebc0ca6e65a057')).toBeInTheDocument();
 
@@ -202,7 +202,7 @@ describe('ProjectSourceMapsArtifacts', function () {
       );
 
       // Title
-      expect(screen.getByRole('heading')).toHaveTextContent('Artifact Bundle');
+      expect(screen.getByRole('heading')).toHaveTextContent('Debug ID Bundle');
       // Subtitle
       expect(
         screen.getByText('7227e105-744e-4066-8c69-3e5e344723fc')

--- a/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.tsx
@@ -183,7 +183,7 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
   return (
     <Fragment>
       <SettingsPageHeader
-        title={t('Artifact Bundle')}
+        title={tabDebugIdBundlesActive ? t('Debug ID Bundle') : t('Release Bundle')}
         subtitle={
           <VersionAndDetails>
             {params.bundleId}


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/29228205/228163988-2cbbbbeb-dbd9-4e8f-ba96-2edd38a00048.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/228163933-6360a62c-39a5-4961-a396-ff08bb7eff03.png)


same happens for `Debug Bundle Ids` . Now instead of "Artifact Bundle" we display "Debug Bundle Id"
