### PR TITLE
fix(ghe): Disable tests running against real host

### DIFF
--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
 from django.utils import timezone
 
 from fixtures.github_enterprise import (
@@ -101,6 +102,7 @@ class WebhookTest(APITestCase):
 
 @region_silo_test
 class PushEventWebhookTest(APITestCase):
+    @pytest.mark.skip(reason="Host has been taken down")
     @patch("sentry.integrations.github_enterprise.client.get_jwt")
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_simple(self, mock_get_installation_metadata, mock_get_jwt):
@@ -251,6 +253,7 @@ class PushEventWebhookTest(APITestCase):
         assert commit.author.email == "baxterthehacker@example.com"
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
+    @pytest.mark.skip(reason="Host has been taken down")
     @patch("sentry.integrations.github_enterprise.client.get_jwt")
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_multiple_orgs(self, mock_get_installation_metadata, mock_get_jwt):


### PR DESCRIPTION
Ops turned off a host the tests were running against.

We can re-enable them when we mock them.