### PR TITLE
fix(gitlab): Retrieve blame content instead of 404

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -324,7 +324,8 @@ class GitLabApiClient(ApiClient):
         self, repo: Repository, path: str, ref: str, lineno: int
     ) -> Sequence[Mapping[str, Any]]:
         project_id = repo.config["project_id"]
-        request_path = GitLabApiClientPath.blame.format(project=project_id, path=path)
+        encoded_path = quote(path, safe="")
+        request_path = GitLabApiClientPath.blame.format(project=project_id, path=encoded_path)
         contents = self.get(
             request_path, params={"ref": ref, "range[start]": lineno, "range[end]": lineno}
         )

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock, patch
-from urllib.parse import parse_qs, urlencode, urlparse, quote
+from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import responses
 

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock, patch
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, quote
 
 import responses
 
@@ -349,6 +349,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         installation = integration.get_installation(self.organization.id)
 
         filepath = "sentry/tasks.py"
+        encoded_filepath = quote(filepath, safe="")
         ref = "master"
         event_frame = {
             "function": "handle_set_commits",
@@ -361,7 +362,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{filepath}/blame?ref={ref}&range[start]=30&range[end]=30",
+            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{encoded_filepath}/blame?ref={ref}&range%5Bstart%5D=30&range%5Bend%5D=30",
             json=[
                 {
                     "commit": {


### PR DESCRIPTION
This commit aims to URL-encode file paths that are used during API calls to Gitlab. Currently, file paths are not encoded, which result in an unknown Gitlab API path and HTTP 404 response.

Link to the related section in the Gitlab docs:
https://docs.gitlab.com/ee/api/repository_files.html#get-file-blame-from-repository

Related quote from the Gitlab docs page:
"URL-encoded full path to new file, such aslib%2Fclass%2Erb."




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
