### PR TITLE
feat: support collapsing system frames

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -22,6 +22,7 @@ import {
   useCanvasScheduler,
 } from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {collapseSystemFrameStrategy} from 'sentry/utils/profiling/collapseSystemFrameStrategy';
 import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphSearch} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphPreferences';
@@ -138,7 +139,7 @@ export function AggregateFlamegraph(): ReactElement {
       inverted: view === 'bottom up',
       sort: sorting,
       configSpace: undefined,
-      collapseSystemFrames,
+      collapseStrategy: collapseSystemFrames ? collapseSystemFrameStrategy : undefined,
     });
 
     transaction.finish();

--- a/static/app/utils/profiling/collapseSystemFrameStrategy.ts
+++ b/static/app/utils/profiling/collapseSystemFrameStrategy.ts
@@ -1,0 +1,20 @@
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+
+const isSystemFrame = (frame: FlamegraphFrame) => !frame.node.frame.is_application;
+
+export function collapseSystemFrameStrategy(frame: FlamegraphFrame) {
+  const children = frame.children;
+
+  if (children.length === 1) {
+    const [child] = children;
+    if (isSystemFrame(frame) && isSystemFrame(child)) {
+      if (!child.collapsed) {
+        child.collapsed = [];
+      }
+      child.collapsed.push(frame);
+      child.parent = frame.parent;
+      frame = child;
+    }
+  }
+  return frame;
+}

--- a/static/app/utils/profiling/flamegraph.spec.tsx
+++ b/static/app/utils/profiling/flamegraph.spec.tsx
@@ -1,5 +1,6 @@
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
+import {SampledProfile} from 'sentry/utils/profiling/profile/sampledProfile';
 import {createFrameIndex} from 'sentry/utils/profiling/profile/utils';
 import {Rect} from 'sentry/utils/profiling/speedscope';
 
@@ -365,4 +366,100 @@ describe('flamegraph', () => {
   it('Empty', () => {
     expect(Flamegraph.Empty().configSpace.equals(new Rect(0, 0, 1_000, 0))).toBe(true);
   });
+
+  it('collapseSystemFrames', () => {
+    const trace: Profiling.SampledProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      threadID: 0,
+      type: 'sampled',
+      weights: [1, 1, 1],
+      samples: [
+        [0, 1, 2, 2, 3], // -> 0,1,3
+        [0, 2, 2, 1, 2, 3], // ->  0,2,1,3
+        [0, 3, 4, 1], // -> 0,4,1
+      ],
+    };
+
+    const flamegraph = new Flamegraph(
+      SampledProfile.FromProfile(
+        trace,
+        createFrameIndex('mobile', [
+          {
+            name: 'f0',
+          },
+          {name: 'f1', is_application: true},
+          {name: 'f2'},
+          {name: 'f3'},
+          {name: 'f4'},
+        ]),
+        {
+          type: 'flamegraph',
+        }
+      ),
+      0,
+      {
+        sort: 'alphabetical',
+        collapseSystemFrames: true,
+      }
+    );
+
+    expect(flamegraph.root).toMatchObject(
+      expectFrame('sentry root', {
+        children: [
+          expectFrame('f0', {
+            children: [
+              expectFrame('f1', {
+                children: [
+                  expectFrame('f3', {
+                    collapsed: [expectFrame('f2'), expectFrame('f2')],
+                  }),
+                ],
+              }),
+              expectFrame('f2', {
+                collapsed: [expectFrame('f2')],
+                children: [
+                  expectFrame('f1', {
+                    children: [
+                      expectFrame('f3', {
+                        collapsed: [expectFrame('f2')],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+              expectFrame('f4', {
+                collapsed: [expectFrame('f3')],
+              }),
+            ],
+          }),
+        ],
+      })
+    );
+  });
 });
+
+function expectFrame(
+  name: string,
+  {
+    collapsed,
+    children,
+  }: {
+    children?: any[];
+    collapsed?: any[];
+  } = {}
+) {
+  const frame = {
+    frame: expect.objectContaining({
+      name,
+    }),
+    children: children ? expect.arrayContaining(children) : expect.any(Array),
+  };
+  if (collapsed) {
+    // @ts-ignore
+    frame.collapsed = expect.arrayContaining(collapsed);
+  }
+  return expect.objectContaining(frame);
+}

--- a/static/app/utils/profiling/flamegraph.spec.tsx
+++ b/static/app/utils/profiling/flamegraph.spec.tsx
@@ -1,3 +1,4 @@
+import {collapseSystemFrameStrategy} from 'sentry/utils/profiling/collapseSystemFrameStrategy';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
 import {SampledProfile} from 'sentry/utils/profiling/profile/sampledProfile';
@@ -402,7 +403,7 @@ describe('flamegraph', () => {
       0,
       {
         sort: 'alphabetical',
-        collapseSystemFrames: true,
+        collapseStrategy: collapseSystemFrameStrategy,
       }
     );
 

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -369,12 +369,9 @@ export class Flamegraph {
 const isSystemFrame = (frame: FlamegraphFrame) => !frame.node.frame.is_application;
 
 function collapse(frame: FlamegraphFrame) {
-  frame.children = frame.children.reduce((acc, child) => {
-    acc.push(collapse(child));
-    return acc;
-  }, [] as FlamegraphFrame[]);
+  frame.children = frame.children.map(collapse);
 
-  if (!frame.parent) {
+  if (frame.frame.isRoot) {
     return frame;
   }
 
@@ -384,10 +381,9 @@ function collapse(frame: FlamegraphFrame) {
     const [child] = children;
     if (isSystemFrame(frame) && isSystemFrame(child)) {
       if (!child.collapsed) {
-        child.collapsed = 1;
-      } else {
-        child.collapsed++;
+        child.collapsed = [];
       }
+      child.collapsed.push(frame);
       child.parent = frame.parent;
       frame = child;
     }

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -366,6 +366,8 @@ export class Flamegraph {
   }
 }
 
+const isSystemFrame = (frame: FlamegraphFrame) => !frame.node.frame.is_application;
+
 function collapse(frame: FlamegraphFrame) {
   frame.children = frame.children.reduce((acc, child) => {
     acc.push(collapse(child));
@@ -376,13 +378,11 @@ function collapse(frame: FlamegraphFrame) {
     return frame;
   }
 
-  const isSystemFrame = !frame.node.frame.is_application;
-
   const children = frame.children;
 
   if (children.length === 1) {
     const [child] = children;
-    if (isSystemFrame) {
+    if (isSystemFrame(frame) && isSystemFrame(child)) {
       if (!child.collapsed) {
         child.collapsed = 1;
       } else {

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -10,6 +10,7 @@ export interface FlamegraphFrame {
   node: CallTreeNode;
   parent: FlamegraphFrame | null;
   start: number;
+  collapsed?: number;
   processId?: number;
   profileIds?: string[];
   threadId?: number;

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -10,7 +10,7 @@ export interface FlamegraphFrame {
   node: CallTreeNode;
   parent: FlamegraphFrame | null;
   start: number;
-  collapsed?: number;
+  collapsed?: FlamegraphFrame[];
   processId?: number;
   profileIds?: string[];
   threadId?: number;


### PR DESCRIPTION
## Summary
Adds support for collapsing system frames for the `AggregateFlamegraph`.

There are likely some edge edge cases here, but its usable as a first attempt.

I haven't handled the text rendering part yet. There are somethings to consider here, the text renderer truncates text, and the sorting occurs on frame names before they're renamed to something like `system frame +10 collapsed` or `funcName +10 collapsed`etc

As for implementing the new frame name, we either handle it where we render frame names by reading the `collapsed` attr, or we just change the frame name by copying the frame w/ the new name


https://user-images.githubusercontent.com/7349258/228250969-f81c660c-1e80-40db-baf4-76a0e9c82fa8.mov

