### PR TITLE
feat(replay): Add new body size field to Network table

### DIFF
--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -78,7 +78,9 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       ref,
       style,
     };
-    const size = span.data.size ?? span.data.responseBodySize;
+
+    // `data.responseBodySize` is from SDK version 7.44-7.45
+    const size = span.data.size ?? span.data.response?.size ?? span.data.responseBodySize;
 
     const renderFns = [
       () => (


### PR DESCRIPTION
We moved the size field in the sdk in https://github.com/getsentry/sentry-javascript/pull/7589

Note that this field is for XHR/fetch and reflects the decoded body size whereas the other `data.size` fields are *transfer* size (i.e. over the network). We may want to consider changing to show decoded body size for all, though that was only recently added to the SDK.
