### PR TITLE
feat(replay): Reset Network Details when changing filters

### DIFF
--- a/static/app/views/replays/detail/network/networkDetails.tsx
+++ b/static/app/views/replays/detail/network/networkDetails.tsx
@@ -26,7 +26,7 @@ function NetworkRequestDetails({initialHeight = 100, items}: Props) {
     'n_detail_row',
     ''
   );
-  const {getParamValue: getDetailTab} = useUrlParams('n_details_tab', 'request');
+  const {getParamValue: getDetailTab} = useUrlParams('n_detail_tab', 'request');
   const itemIndex = getDetailRow();
 
   const item = itemIndex ? (items[itemIndex] as NetworkSpan) : null;

--- a/static/app/views/replays/detail/network/networkDetailsTabs.tsx
+++ b/static/app/views/replays/detail/network/networkDetailsTabs.tsx
@@ -20,7 +20,7 @@ export type TabKey = keyof typeof TABS;
 
 function NetworkRequestTabs({className, underlined = true}: Props) {
   const {pathname, query} = useLocation();
-  const {getParamValue, setParamValue} = useUrlParams('n_details_tab', 'request');
+  const {getParamValue, setParamValue} = useUrlParams('n_detail_tab', 'request');
   const activeTab = getParamValue();
 
   return (

--- a/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
@@ -207,20 +207,20 @@ describe('useNetworkFilters', () => {
       .mockReturnValueOnce({
         pathname: '/',
         query: {
-          n_detail_row: 0,
+          n_detail_row: '0',
           n_detail_tab: 'response',
         },
       } as Location<FilterFields>)
       .mockReturnValueOnce({
         pathname: '/',
-        query: {f_n_type: TYPE_FILTER, n_detail_row: 0, n_detail_tab: 'response'},
+        query: {f_n_type: TYPE_FILTER, n_detail_row: '0', n_detail_tab: 'response'},
       } as Location<FilterFields>)
       .mockReturnValueOnce({
         pathname: '/',
         query: {
           f_n_type: TYPE_FILTER,
           f_n_status: STATUS_FILTER,
-          n_detail_row: 0,
+          n_detail_row: '0',
           n_detail_tab: 'response',
         },
       } as Location<FilterFields>);

--- a/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
@@ -198,6 +198,69 @@ describe('useNetworkFilters', () => {
     });
   });
 
+  it('should clear details params when setters are called', () => {
+    const TYPE_FILTER = ['resource.fetch'];
+    const STATUS_FILTER = ['200'];
+    const SEARCH_FILTER = 'pikachu';
+
+    mockUseLocation
+      .mockReturnValueOnce({
+        pathname: '/',
+        query: {
+          n_detail_row: 0,
+          n_detail_tab: 'response',
+        },
+      } as Location<FilterFields>)
+      .mockReturnValueOnce({
+        pathname: '/',
+        query: {f_n_type: TYPE_FILTER, n_detail_row: 0, n_detail_tab: 'response'},
+      } as Location<FilterFields>)
+      .mockReturnValueOnce({
+        pathname: '/',
+        query: {
+          f_n_type: TYPE_FILTER,
+          f_n_status: STATUS_FILTER,
+          n_detail_row: 0,
+          n_detail_tab: 'response',
+        },
+      } as Location<FilterFields>);
+
+    const {result, rerender} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {networkSpans},
+    });
+
+    result.current.setType(TYPE_FILTER);
+    expect(browserHistory.push).toHaveBeenLastCalledWith({
+      pathname: '/',
+      query: {
+        f_n_type: TYPE_FILTER,
+      },
+    });
+
+    rerender();
+
+    result.current.setStatus(STATUS_FILTER);
+    expect(browserHistory.push).toHaveBeenLastCalledWith({
+      pathname: '/',
+      query: {
+        f_n_type: TYPE_FILTER,
+        f_n_status: STATUS_FILTER,
+      },
+    });
+
+    rerender();
+
+    result.current.setSearchTerm(SEARCH_FILTER);
+    expect(browserHistory.push).toHaveBeenLastCalledWith({
+      pathname: '/',
+      query: {
+        f_n_type: TYPE_FILTER,
+        f_n_status: STATUS_FILTER,
+        f_n_search: SEARCH_FILTER,
+      },
+    });
+  });
+
   it('should not filter anything when no values are set', () => {
     mockUseLocation.mockReturnValue({
       pathname: '/',

--- a/static/app/views/replays/detail/network/useNetworkFilters.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.tsx
@@ -9,6 +9,8 @@ export type FilterFields = {
   f_n_search: string;
   f_n_status: string[];
   f_n_type: string[];
+  n_detail_row?: string;
+  n_detail_tab?: string;
 };
 
 type Options = {
@@ -48,6 +50,20 @@ function useNetworkFilters({networkSpans}: Options): Return {
   const status = decodeList(query.f_n_status);
   const type = decodeList(query.f_n_type);
   const searchTerm = decodeScalar(query.f_n_search, '').toLowerCase();
+
+  // Need to clear Network Details URL params when we filter, otherwise you can
+  // get into a state where it is trying to load details for a non fetch/xhr
+  // request.
+  const setFilterAndClearDetails = useCallback(
+    arg => {
+      setFilter({
+        ...arg,
+        n_detail_row: undefined,
+        n_detail_tab: undefined,
+      });
+    },
+    [setFilter]
+  );
 
   const items = useMemo(
     () =>
@@ -89,15 +105,19 @@ function useNetworkFilters({networkSpans}: Options): Return {
   );
 
   const setStatus = useCallback(
-    (f_n_status: string[]) => setFilter({f_n_status}),
-    [setFilter]
+    (f_n_status: string[]) => setFilterAndClearDetails({f_n_status}),
+    [setFilterAndClearDetails]
   );
 
-  const setType = useCallback((f_n_type: string[]) => setFilter({f_n_type}), [setFilter]);
+  const setType = useCallback(
+    (f_n_type: string[]) => setFilterAndClearDetails({f_n_type}),
+    [setFilterAndClearDetails]
+  );
 
   const setSearchTerm = useCallback(
-    (f_n_search: string) => setFilter({f_n_search: f_n_search || undefined}),
-    [setFilter]
+    (f_n_search: string) =>
+      setFilterAndClearDetails({f_n_search: f_n_search || undefined}),
+    [setFilterAndClearDetails]
   );
 
   return {


### PR DESCRIPTION
This fixes an issue where you have a filter for fetch requests, view details of first row, clear filter. The URL params for network details persisted through filter changing and so it is trying to view details of the first row in the Network table and will show nothing if it is a non-fetch/xhr row.
