### PR TITLE
fix(perf): Handle stat range overflow

### DIFF
--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -116,7 +116,7 @@ def parse_stats_period(period: str) -> Optional[timedelta]:
             }
         )
     except OverflowError:
-        return None
+        return timedelta.max
 
 
 def get_interval_from_range(date_range: timedelta, high_fidelity: bool) -> str:

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -107,9 +107,16 @@ def parse_stats_period(period: str) -> Optional[timedelta]:
     value = int(value)
     if not unit:
         unit = "s"
-    return timedelta(
-        **{{"h": "hours", "d": "days", "m": "minutes", "s": "seconds", "w": "weeks"}[unit]: value}
-    )
+    try:
+        return timedelta(
+            **{
+                {"h": "hours", "d": "days", "m": "minutes", "s": "seconds", "w": "weeks"}[
+                    unit
+                ]: value
+            }
+        )
+    except OverflowError:
+        return None
 
 
 def get_interval_from_range(date_range: timedelta, high_fidelity: bool) -> str:

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -19,4 +19,4 @@ def test_parse_stats_period():
     assert parse_stats_period("20f") is None
     assert parse_stats_period("-1s") is None
     assert parse_stats_period("4w") == datetime.timedelta(weeks=4)
-    assert parse_stats_period("900000000000d") is None
+    assert parse_stats_period("900000000000d") is datetime.timedelta.max

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -19,3 +19,4 @@ def test_parse_stats_period():
     assert parse_stats_period("20f") is None
     assert parse_stats_period("-1s") is None
     assert parse_stats_period("4w") == datetime.timedelta(weeks=4)
+    assert parse_stats_period("900000000000d") is None


### PR DESCRIPTION
Closes SENTRY-103T. The longest `timedelta` is 999999999 days, and someone's asking for 900000000000. I initially fell back to `None`, but decided to fall down to `timedelta.max` instead, which IMO will do the thing that users actually _want_. You tell me though, maybe that clamping behaviour belongs elsewhere.
