### PR TITLE
fix(perf): Fix custom perf measurement units

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -342,7 +342,7 @@ const customMeasurements: Record<
       return undefined;
     }
     return {
-      value: (span?.endTimestamp - span?.startTimestamp) / 1000,
+      value: (span?.endTimestamp - span?.startTimestamp) * 1000,
       unit: 'millisecond',
     };
   },
@@ -359,7 +359,7 @@ const customMeasurements: Record<
     if (!vcdSpan?.endTimestamp) {
       return undefined;
     }
-    const value = (vcdSpan?.endTimestamp - transactionStart) / 1000;
+    const value = (vcdSpan?.endTimestamp - transactionStart) * 1000;
     return {
       value,
       unit: 'millisecond',
@@ -382,7 +382,7 @@ const customMeasurements: Record<
     }
     const timestamp = bundleSpan?.endTimestamp || 0; // Default to 0 so this works for navigations.
     return {
-      value: (vcdSpan.endTimestamp - timestamp) / 1000,
+      value: (vcdSpan.endTimestamp - timestamp) * 1000,
       unit: 'millisecond',
     };
   },


### PR DESCRIPTION
### Summary
This should be multiplying to get milliseconds, not dividing.


