### PR TITLE
fix(codecov): Decrease timeout for coverage requests

### DIFF
--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -17,7 +17,7 @@ CODECOV_REPORT_URL = (
     "https://api.codecov.io/api/v2/{service}/{owner_username}/repos/{repo_name}/file_report/{path}"
 )
 CODECOV_REPOS_URL = "https://api.codecov.io/api/v2/{service}/{owner_username}"
-CODECOV_TIMEOUT = 10
+CODECOV_TIMEOUT = 5
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Decreasing the timeout to 5s - this shouldn't impact performance greatly and it ensures users aren't waiting a long time for the stacktrace links to appear. 