### PR TITLE
feat(workflow): Return none for deleted user activities

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -77,7 +77,7 @@ class ActivitySerializer(Serializer):
 
         return {
             item: {
-                "user": users[str(item.user_id)] if item.user_id else None,
+                "user": users.get(str(item.user_id)) if item.user_id else None,
                 "source": groups.get(item.data["source_id"])
                 if item.type == ActivityType.UNMERGE_DESTINATION.value
                 else None,


### PR DESCRIPTION
return none instead of erroring

fixes SENTRY-ZY5
fixes #46432