### PR TITLE
feat(mobile): Adds device-class-synthesis flag and exposes to relay

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1321,6 +1321,8 @@ SENTRY_FEATURES = {
     "organizations:anr-improvements": False,
     # Enable device.class as a selectable column
     "organizations:device-classification": False,
+    # Enables synthesis of device.class in ingest
+    "organizations:device-class-synthesis": False,
     # Enable the onboarding heartbeat footer on the sdk setup page
     "organizations:onboarding-heartbeat-footer": False,
     # Enable product selection in the setup-docs page. The docs reflects the selected products.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -108,6 +108,7 @@ default_manager.add("organizations:view-hierarchies-options-dev", OrganizationFe
 default_manager.add("organizations:anr-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:anr-rate", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:device-classification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:monitors", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:native-stack-trace-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:new-weekly-report", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -49,6 +49,7 @@ EXPOSABLE_FEATURES = [
     "organizations:profiling",
     "organizations:session-replay",
     "organizations:session-replay-recording-scrubbing",
+    "organizations:device-class-synthesis",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
Creates and exposes a `organizations:device-class-synthesis` flag to be used in relay to control `device.class` tag synthesis for users.