### PR TITLE
fix(trace): Include start and end to perf issues

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -224,7 +224,7 @@ class TraceEvent:
                                     if end is None:
                                         end = end_timestamp
                                     else:
-                                        end = min(end, end_timestamp)
+                                        end = max(end, end_timestamp)
                                 except ValueError:
                                     pass
                                 suspect_spans.append(event_span.get("span_id"))

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -187,6 +187,7 @@ class TraceEvent:
                 continue
 
             suspect_spans: List[str] = []
+            start = end = None
             if light:
                 # This value doesn't matter for the light view
                 span = [self.event["trace.span"]]
@@ -207,6 +208,16 @@ class TraceEvent:
                     for event_span in self.nodestore_event.data.get("spans", []):
                         for problem in problems:
                             if event_span.get("span_id") in problem.offender_span_ids:
+                                start = (
+                                    min(start, event_span.get("start_timestamp"))
+                                    if start
+                                    else event_span.get("start_timestamp")
+                                )
+                                end = (
+                                    max(end, event_span.get("timestamp"))
+                                    if end
+                                    else event_span.get("timestamp")
+                                )
                                 suspect_spans.append(event_span.get("span_id"))
                 else:
                     span = [self.event["trace.span"]]
@@ -231,6 +242,8 @@ class TraceEvent:
                     "level": constants.LOG_LEVELS[group.level],
                     "culprit": group.culprit,
                     "type": group.type,
+                    "start": start,
+                    "end": end,
                 }
             )
 


### PR DESCRIPTION
- This adds the min start timestamp and max timestamp of the perf issue suspect spans so they can be rendered in the trace view