### PR TITLE
fix(ui) Don't use lookbehinds because of safari

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -275,7 +275,7 @@ _path_patterns: List[Tuple[re.Pattern[str], str]] = [
     (re.compile(r"^\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),
     (re.compile(r"^\/?onboarding\/[^\/]+\/(.*)"), r"/onboarding/\1"),
     (
-        re.compile(r"\/?(?:[^\/]+(?<!settings))\/([^\/]+)\/getting-started\/(.*)"),
+        re.compile(r"^\/?(?!settings)[^\/]+\/([^\/]+)\/getting-started\/(.*)"),
         r"/getting-started/\1/\2",
     ),
 ]

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -15,10 +15,7 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/^\/?join-request\/[^\/]+\/?.*/, '/join-request/'],
   [/^\/?onboarding\/[^\/]+\/(.*)/, '/onboarding/$1'],
   // Handles /org-slug/project-slug/getting-started/platform/ -> /getting-started/project-slug/platform/
-  [
-    /\/?(?:[^\/]+(?<!settings))\/([^\/]+)\/getting-started\/(.*)/,
-    '/getting-started/$1/$2',
-  ],
+  [/^\/?(?!settings)[^\/]+\/([^\/]+)\/getting-started\/(.*)/, '/getting-started/$1/$2'],
 ];
 
 type LocationTarget = ((location: Location) => LocationDescriptor) | LocationDescriptor;


### PR DESCRIPTION
Safari *still* doesn't support lookbehinds. Rework the pattern to use a lookahead which safari does support.
