### PR TITLE
ref(actions): Add alert rule id to pagerduty and slack logs

### DIFF
--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -36,7 +36,7 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
             a for a in super().get_integrations() if a.metadata.get("installation_type") != "tenant"
         ]
 
-    def after(self, event, state):
+    def after(self, event, state, rule):
         channel = self.get_option("channel_id")
 
         integration = self.get_integration()

--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -34,7 +34,7 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
     def _get_service(self):
         return PagerDutyService.objects.get(id=self.get_option("service"))
 
-    def after(self, event, state):
+    def after(self, event, state, rule):
         integration = self.get_integration()
         if not integration:
             logger.exception("Integration removed, however, the rule still refers to it.")

--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -60,6 +60,7 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
                         "service_id": service.id,
                         "project_id": event.project_id,
                         "event_id": event.event_id,
+                        "rule_id": rule.id,
                     },
                 )
                 raise e
@@ -74,6 +75,7 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
                     "event_id": event.event_id,
                     "service_name": service.service_name,
                     "service_id": service.id,
+                    "rule_id": rule.id,
                 },
             )
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -80,6 +80,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                         "project_id": event.project_id,
                         "event_id": event.event_id,
                         "channel_name": self.get_option("channel"),
+                        "rule_id": rule.id,
                     },
                 )
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -7,7 +7,7 @@ from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.issues import build_group_attachment
 from sentry.integrations.slack.utils import get_channel_id
-from sentry.models import Integration
+from sentry.models import Integration, Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.rules import EventState
 from sentry.rules.actions import IntegrationEventAction
@@ -38,7 +38,9 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "tags": {"type": "string", "placeholder": "i.e environment,user,my_tag"},
         }
 
-    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(
+        self, event: GroupEvent, state: EventState, rule: Rule
+    ) -> Generator[CallbackFuture, None, None]:
         channel = self.get_option("channel_id")
         tags = set(self.get_tags_list())
 

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -34,7 +34,7 @@ class NotifyEmailAction(EventAction):
             self.data["fallthroughType"] = FallthroughChoiceType.ACTIVE_MEMBERS.value
         return self.label.format(**self.data)
 
-    def after(self, event, state):
+    def after(self, event, state, rule):
         group = event.group
         extra = {"event_id": event.event_id, "group_id": group.id}
         group = event.group

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -5,6 +5,7 @@ import logging
 from typing import Generator
 
 from sentry.eventstore.models import GroupEvent
+from sentry.models import Rule
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
 
 logger = logging.getLogger("sentry.rules")
@@ -14,7 +15,9 @@ class EventAction(RuleBase, abc.ABC):
     rule_type = "action/event"
 
     @abc.abstractmethod
-    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(
+        self, event: GroupEvent, state: EventState, rule: Rule
+    ) -> Generator[CallbackFuture, None, None]:
         """
         Executed after a Rule matches.
 
@@ -26,7 +29,7 @@ class EventAction(RuleBase, abc.ABC):
         Does not need to handle group state (e.g. is resolved or not)
         Caller will handle state
 
-        >>> def after(self, event, state):
+        >>> def after(self, event, state, rule):
         >>>     yield self.future(self.print_results)
         >>>
         >>> def print_results(self, event, futures):

--- a/src/sentry/rules/actions/integrations/create_ticket/base.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/base.py
@@ -4,6 +4,7 @@ import abc
 from typing import Any, Generator, Mapping
 
 from sentry.eventstore.models import GroupEvent
+from sentry.models import Rule
 from sentry.rules.actions.integrations.base import IntegrationEventAction
 from sentry.rules.actions.integrations.create_ticket.form import IntegrationNotifyServiceForm
 from sentry.rules.actions.integrations.create_ticket.utils import create_issue
@@ -80,7 +81,9 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
     def generate_footer(self, rule_url: str) -> str:
         pass
 
-    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(
+        self, event: GroupEvent, state: EventState, rule: Rule
+    ) -> Generator[CallbackFuture, None, None]:
         integration_id = self.get_integration_id()
         key = f"{self.provider}:{integration_id}"
         yield self.future(

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -1,6 +1,7 @@
 from typing import Generator, Sequence
 
 from sentry.eventstore.models import GroupEvent
+from sentry.models import Rule
 from sentry.plugins.base import plugins
 from sentry.rules import EventState
 from sentry.rules.actions.base import EventAction
@@ -32,7 +33,9 @@ class NotifyEventAction(EventAction):
 
         return results
 
-    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(
+        self, event: GroupEvent, state: EventState, rule: Rule
+    ) -> Generator[CallbackFuture, None, None]:
         group = event.group
 
         for plugin_ in self.get_plugins():

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -18,7 +18,7 @@ from sentry.incidents.models import (
     IncidentStatus,
 )
 from sentry.integrations.metric_alerts import incident_attachment_info
-from sentry.models import SentryApp, SentryAppInstallation
+from sentry.models import Rule, SentryApp, SentryAppInstallation
 from sentry.plugins.base import plugins
 from sentry.rules import EventState
 from sentry.rules.actions.base import EventAction
@@ -173,7 +173,9 @@ class NotifyEventServiceAction(EventAction):
             return f"(Legacy) {title}"
         return title
 
-    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(
+        self, event: GroupEvent, state: EventState, rule: Rule
+    ) -> Generator[CallbackFuture, None, None]:
         service = self.get_option("service")
 
         extra = {"event_id": event.event_id}

--- a/src/sentry/rules/actions/sentry_apps/notify_event.py
+++ b/src/sentry/rules/actions/sentry_apps/notify_event.py
@@ -5,7 +5,7 @@ from typing import Any, Generator, Mapping, Sequence
 from rest_framework import serializers
 
 from sentry.eventstore.models import GroupEvent
-from sentry.models import Project
+from sentry.models import Project, Rule
 from sentry.rules import EventState
 from sentry.rules.actions.sentry_apps import SentryAppEventAction
 from sentry.rules.base import CallbackFuture
@@ -140,7 +140,9 @@ class NotifyEventSentryAppAction(SentryAppEventAction):
                 f"Unexpected setting(s) '{extra_keys_string}' configured for {sentry_app.name}"
             )
 
-    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(
+        self, event: GroupEvent, state: EventState, rule: Rule
+    ) -> Generator[CallbackFuture, None, None]:
         sentry_app = self._get_sentry_app(event)
         yield self.future(
             notify_sentry_app,

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -240,7 +240,7 @@ class RuleProcessor:
 
             action_inst = action_cls(self.project, data=action, rule=rule)
             results = safe_execute(
-                action_inst.after, event=self.event, state=state, _with_transaction=False
+                action_inst.after, event=self.event, state=state, _with_transaction=False, rule=rule
             )
             if results is None:
                 self.logger.warning("Action %s did not return any futures", action["id"])

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -76,7 +76,9 @@ class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
             content_type="application/json",
         )
 
-        results = list(self.jira_rule.after(event=event, state=self.get_state()))
+        results = list(
+            self.jira_rule.after(event=event, state=self.get_state(), rule=self.jira_rule.rule)
+        )
         assert len(results) == 1
 
         # Trigger rule callback
@@ -156,7 +158,9 @@ class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
             data={"provider": self.integration.provider},
         )
 
-        results = list(self.jira_rule.after(event=event, state=self.get_state()))
+        results = list(
+            self.jira_rule.after(event=event, state=self.get_state(), rule=self.jira_rule.rule)
+        )
         assert len(results) == 1
         results[0].callback(event, futures=[])
 

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -42,7 +42,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
             data={"team": self.integration.id, "channel": "Naboo", "channel_id": "nb"}
         )
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(
@@ -81,7 +81,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         rule = self.get_rule(
             data={"team": self.integration.id, "channel": "Hellboy", "channel_id": "nb"}
         )
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(
@@ -114,7 +114,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         rule = self.get_rule(
             data={"team": self.integration.id, "channel": "Naboo", "channel_id": "nb"}
         )
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -53,7 +53,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         rule = self.get_rule(data={"account": self.integration.id, "service": self.service.id})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(
@@ -76,7 +76,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
     def test_applies_correctly_performance_issue(self):
         event = self.create_performance_issue()
         rule = self.get_rule(data={"account": self.integration.id, "service": self.service.id})
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(
@@ -111,7 +111,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         event.occurrence = occurrence
 
         rule = self.get_rule(data={"account": self.integration.id, "service": self.service.id})
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(
@@ -203,7 +203,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         rule = self.get_rule(data={"account": integration.id, "service": service.id})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -38,7 +38,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(
@@ -360,7 +360,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 0
 
     @responses.activate
@@ -370,7 +370,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
         responses.add(
@@ -402,5 +402,5 @@ class SlackNotifyActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -41,7 +41,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
     def trigger(self, event, rule_object):
         action = rule_object.data.get("actions", ())[0]
         action_inst = self.get_rule(data=action, rule=rule_object)
-        results = list(action_inst.after(event=event, state=self.get_state()))
+        results = list(action_inst.after(event=event, state=self.get_state(), rule=rule_object))
         assert len(results) == 1
 
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -59,7 +59,9 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
             content_type="application/json",
         )
 
-        after_res = azuredevops_rule.after(event=event, state=self.get_state())
+        after_res = azuredevops_rule.after(
+            event=event, state=self.get_state(), rule=azuredevops_rule.rule
+        )
         results = list(after_res)
         assert len(results) == 1
 
@@ -112,7 +114,9 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         )
         azuredevops_rule.rule = Rule.objects.create(project=self.project, label="test rule")
 
-        results = list(azuredevops_rule.after(event=event, state=self.get_state()))
+        results = list(
+            azuredevops_rule.after(event=event, state=self.get_state(), rule=azuredevops_rule.rule)
+        )
         assert len(results) == 1
         results[0].callback(event, futures=[])
         assert len(responses.calls) == 0

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -123,7 +123,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase):
         rule = self.get_rule(data={"targetType": "IssueOwners"})
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(results) == 1
 
     def test_full_integration(self):

--- a/tests/sentry/rules/actions/test_notify_event.py
+++ b/tests/sentry/rules/actions/test_notify_event.py
@@ -17,7 +17,7 @@ class NotifyEventActionTest(RuleTestCase):
         rule = self.get_rule()
         rule.get_plugins = lambda: (LegacyPluginService(plugin),)
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
 
         assert len(results) == 1
         assert plugin.should_notify.call_count == 1

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -47,7 +47,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
 
         assert rule.id == SENTRY_APP_ALERT_ACTION
 
-        futures = list(rule.after(event=event, state=self.get_state()))
+        futures = list(rule.after(event=event, state=self.get_state(), rule=rule))
         assert len(futures) == 1
         assert futures[0].callback is notify_sentry_app
         assert futures[0].kwargs["sentry_app"].id == self.app.id

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -24,7 +24,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
         with patch("sentry.plugins.base.plugins.get") as get_plugin:
             get_plugin.return_value = plugin
 
-            results = list(rule.after(event=event, state=self.get_state()))
+            results = list(rule.after(event=event, state=self.get_state(), rule=rule))
 
         assert len(results) == 1
         assert plugin.should_notify.call_count == 1
@@ -39,7 +39,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"service": "test-application"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event, state=self.get_state(), rule=rule))
 
         assert len(results) == 1
         assert results[0].callback is notify_sentry_app
@@ -58,7 +58,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
         with patch("sentry.plugins.base.plugins.get") as get_plugin:
             get_plugin.return_value = plugin
 
-            results = list(rule.after(event=event, state=self.get_state()))
+            results = list(rule.after(event=event, state=self.get_state(), rule=rule))
 
         assert len(results) == 2
         assert plugin.should_notify.call_count == 1


### PR DESCRIPTION
_WIP pending being able to manually test this. Currently I can't get PagerDuty running locally. Will leave as draft for now._

----------------

This adds the id of the triggering alert rule to the logging we do when sending PagerDuty and Slack notifications. In order to enable this, `EventAction.after()` now takes a new keyword arg, `rule`.

Ref: FEEDBACK-1771
