### PR TITLE
feat(replay): Fix key alignment when objects are expanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@react-types/radio": "^3.3.1",
     "@react-types/shared": "^3.8.0",
     "@sentry-internal/global-search": "^0.5.7",
-    "@sentry-internal/react-inspector": "6.0.1-3",
+    "@sentry-internal/react-inspector": "6.0.1-4",
     "@sentry-internal/rrweb": "1.106.0",
     "@sentry-internal/rrweb-player": "1.106.0",
     "@sentry/integrations": "^7.45.0",

--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -29,6 +29,7 @@ function ObjectInspector({data, theme, ...props}: Props) {
       TREENODE_FONT_SIZE: 'inherit',
       TREENODE_LINE_HEIGHT: 'inherit',
       BASE_BACKGROUND_COLOR: 'none',
+      ARROW_FONT_SIZE: '10px',
 
       OBJECT_PREVIEW_OBJECT_MAX_PROPERTIES: 1,
       ...theme,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2275,10 +2275,10 @@
     htmlparser2 "^4.1.0"
     title-case "^3.0.2"
 
-"@sentry-internal/react-inspector@6.0.1-3":
-  version "6.0.1-3"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/react-inspector/-/react-inspector-6.0.1-3.tgz#f9ea0165c876c795e98adffd5b74c8524926c1f5"
-  integrity sha512-X0n+xxL74grDiDo7bo37ShulE4eBfv7Hnc/jp1LfpJp4np8C4zBXmB0v9ztNOB3lJJXP7Yj7VfskDSPVFRmlWA==
+"@sentry-internal/react-inspector@6.0.1-4":
+  version "6.0.1-4"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/react-inspector/-/react-inspector-6.0.1-4.tgz#10758f3461cf2cf48df8c80f0514c55ca18872c5"
+  integrity sha512-uL2RyvW8EqDEchnbo8Hu/c4IpBqM3LLxUpZPHs8o40kynerzPset6bC/m5SU124gEhy4PqjdvJ7DhTYR75NetQ==
 
 "@sentry-internal/rrweb-player@1.106.0":
   version "1.106.0"


### PR DESCRIPTION
This was fixed in the `react-inspector` library [here](https://github.com/getsentry/react-inspector/pull/3)

Fixed:
![image](https://user-images.githubusercontent.com/79684/228568813-4bbb912f-93a2-49eb-ad9b-3453e692c3ec.png)

Closes https://github.com/getsentry/sentry/issues/46409