### PR TITLE
ref(processing-issues): Remove block with processingissues/fix instructions from the UI

### DIFF
--- a/static/app/views/settings/project/projectProcessingIssues.tsx
+++ b/static/app/views/settings/project/projectProcessingIssues.tsx
@@ -13,16 +13,9 @@ import JsonForm from 'sentry/components/forms/jsonForm';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {
-  Panel,
-  PanelAlert,
-  PanelBody,
-  PanelHeader,
-  PanelTable,
-} from 'sentry/components/panels';
+import {Panel, PanelAlert, PanelTable} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Tag from 'sentry/components/tag';
-import TextCopyInput from 'sentry/components/textCopyInput';
 import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import formGroups from 'sentry/data/forms/processingIssues';
@@ -362,27 +355,6 @@ class ProjectProcessingIssues extends Component<Props, State> {
 
   renderResults() {
     const {processingIssues} = this.state;
-    const fixLink = processingIssues ? processingIssues.signedLink : false;
-
-    let fixLinkBlock: React.ReactNode = null;
-
-    if (fixLink) {
-      fixLinkBlock = (
-        <Panel>
-          <PanelHeader>
-            {t('Having trouble uploading debug informations? We can help!')}
-          </PanelHeader>
-          <PanelBody withPadding>
-            <label>
-              {t(
-                "Paste this command into your shell and we'll attempt to upload the missing symbols from your machine:"
-              )}
-            </label>
-            <TextCopyInput monospace>{`curl -sL "${fixLink}" | bash`}</TextCopyInput>
-          </PanelBody>
-        </Panel>
-      );
-    }
 
     let processingRow: React.ReactNode = null;
     if (processingIssues && processingIssues.issuesProcessing > 0) {
@@ -399,7 +371,6 @@ class ProjectProcessingIssues extends Component<Props, State> {
 
     return (
       <Fragment>
-        {fixLinkBlock}
         <h3>
           {t('Pending Issues')}
           <Access access={['project:write']}>


### PR DESCRIPTION
This feature has been broken for 5 years now due to incorrectly used sentry-cli command (`--uuid` instead of `--id` flag which was changed in https://github.com/getsentry/sentry-cli/commit/e8965f8c7d32c67af22b4a5bb267911a45371ee3).

We will remove it from the UI first, and corresponding API removal will follow.

API change: https://github.com/getsentry/sentry/pull/46496