### PR TITLE
Make `lookup-artifact` URLs usable externally

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -12,6 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.endpoints.debug_files import has_download_permission
 from sentry.api.serializers import serialize
+from sentry.auth.system import is_system_auth
 from sentry.lang.native.sources import get_internal_artifact_lookup_source_url
 from sentry.models import DebugIdArtifactBundle, Distribution, File, Release, ReleaseFile
 from sentry.models.artifactbundle import ArtifactBundleArchive, ReleaseArtifactBundle
@@ -117,7 +118,7 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
         individual_files = try_resolve_urls(urls, project, release_name, dist_name, bundle_file_ids)
 
         # Then: Construct our response
-        url_constructor = UrlConstructor(project)
+        url_constructor = UrlConstructor(request, project)
 
         found_artifacts = []
         for file_id in bundle_file_ids:
@@ -326,8 +327,11 @@ def find_file_in_archive_index(archive_index: dict, url: str) -> Optional[File]:
 
 
 class UrlConstructor:
-    def __init__(self, project: Project):
-        self.base_url = get_internal_artifact_lookup_source_url(project)
+    def __init__(self, request: Request, project: Project):
+        if is_system_auth(request.auth):
+            self.base_url = get_internal_artifact_lookup_source_url(project)
+        else:
+            self.base_url = request.build_absolute_uri(request.path)
 
     def url_for_file_id(self, file_id: int) -> str:
         # NOTE: Returning a self-route that requires authentication (via Bearer token)

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -120,9 +120,10 @@ class InvalidSourcesError(Exception):
     pass
 
 
-def get_internal_source(project):
+def get_internal_url_prefix() -> str:
     """
-    Returns the source configuration for a Sentry project.
+    Returns the `internal-url-prefix` normalized in such a way that it works in local
+    development environments.
     """
     internal_url_prefix = options.get("system.internal-url-prefix")
     if not internal_url_prefix:
@@ -133,8 +134,15 @@ def get_internal_source(project):
             ).replace("127.0.0.1", "host.docker.internal")
 
     assert internal_url_prefix
+    return internal_url_prefix.rstrip("/")
+
+
+def get_internal_source(project):
+    """
+    Returns the source configuration for a Sentry project.
+    """
     sentry_source_url = "{}{}".format(
-        internal_url_prefix.rstrip("/"),
+        get_internal_url_prefix(),
         reverse(
             "sentry-api-0-dsym-files",
             kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
@@ -153,17 +161,8 @@ def get_internal_artifact_lookup_source_url(project):
     """
     Returns the url used as a part of source configuration for the Sentry artifact-lookup API.
     """
-    internal_url_prefix = options.get("system.internal-url-prefix")
-    if not internal_url_prefix:
-        internal_url_prefix = options.get("system.url-prefix")
-        if sys.platform == "darwin":
-            internal_url_prefix = internal_url_prefix.replace(
-                "localhost", "host.docker.internal"
-            ).replace("127.0.0.1", "host.docker.internal")
-
-    assert internal_url_prefix
     return "{}{}".format(
-        internal_url_prefix.rstrip("/"),
+        get_internal_url_prefix(),
         reverse(
             "sentry-api-0-project-artifact-lookup",
             kwargs={


### PR DESCRIPTION
Depending on the authentication, this will use the `internal-url-prefix` for Sentry-Symbolicator requests, or the `request` url for external requests, so that end-users can download the linked files directly from their browser.