### PR TITLE
feat(tx-clusterer): Skip projects without enough transactions

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -66,7 +66,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 if len(tx_names) < redis.MAX_SET_SIZE:
                     return
                 clusterer = TreeClusterer(merge_threshold=MERGE_THRESHOLD)
-                clusterer.add_input(iter(tx_names))
+                clusterer.add_input(tx_names)
                 new_rules = clusterer.get_rules()
                 rules.update_rules(project, new_rules)
 

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -62,8 +62,11 @@ def cluster_projects(projects: Sequence[Project]) -> None:
         if features.has("organizations:transaction-name-clusterer", project.organization):
             with sentry_sdk.start_span(op="txcluster_project") as span:
                 span.set_data("project_id", project.id)
+                tx_names = redis.get_transaction_names(project)
+                if len(list(tx_names)) < redis.MAX_SET_SIZE:
+                    return
                 clusterer = TreeClusterer(merge_threshold=MERGE_THRESHOLD)
-                clusterer.add_input(redis.get_transaction_names(project))
+                clusterer.add_input(tx_names)
                 new_rules = clusterer.get_rules()
                 rules.update_rules(project, new_rules)
 

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -62,11 +62,11 @@ def cluster_projects(projects: Sequence[Project]) -> None:
         if features.has("organizations:transaction-name-clusterer", project.organization):
             with sentry_sdk.start_span(op="txcluster_project") as span:
                 span.set_data("project_id", project.id)
-                tx_names = redis.get_transaction_names(project)
-                if len(list(tx_names)) < redis.MAX_SET_SIZE:
+                tx_names = list(redis.get_transaction_names(project))
+                if len(tx_names) < redis.MAX_SET_SIZE:
                     return
                 clusterer = TreeClusterer(merge_threshold=MERGE_THRESHOLD)
-                clusterer.add_input(tx_names)
+                clusterer.add_input(iter(tx_names))
                 new_rules = clusterer.get_rules()
                 rules.update_rules(project, new_rules)
 

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -242,9 +242,7 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
 @mock.patch("sentry.ingest.transaction_clusterer.rules.update_rules")
 @pytest.mark.django_db
-def test_clusterer_only_runs_when_enough_transactions(
-    mock_update_rules, default_organization, task_runner
-):
+def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default_organization):
     project = Project(id=123, name="test_project", organization_id=default_organization.id)
 
     _store_transaction_name(project, "/transaction/number/1")


### PR DESCRIPTION
The transaction name clusterer has two thresholds: the merge threshold and the set size threshold. The goal of these thresholds is to ensure a certain ratio is met to generate proper rules. At the moment, the clusterer runs even if there's a single transaction ingested, which may produce low-quality rules degrading the renaming and user experience. This PR addressed that problem by not running the clusterer if not enough rules have been ingested.