### PR TITLE
feat(replay): use step numbers in favor of checkboxes

### DIFF
--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -8,12 +8,14 @@ import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useOnboardingDocs from 'sentry/components/onboardingWizard/useOnboardingDocs';
+// TODO: should be time to move this
+import {Flex} from 'sentry/components/profiling/flex';
 import useCurrentProjectState from 'sentry/components/replaysOnboarding/useCurrentProjectState';
 import {
   generateDocKeys,
   isPlatformSupported,
 } from 'sentry/components/replaysOnboarding/utils';
-import OnboardingStep from 'sentry/components/sidebar/onboardingStep';
+import {DocumentationWrapper} from 'sentry/components/sidebar/onboardingStep';
 import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
 import {CommonSidebarProps, SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {replayPlatforms} from 'sentry/data/platformCategories';
@@ -184,12 +186,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
         }
         return (
           <div key={index}>
-            <OnboardingStep
-              docContent={docContents[docKey]}
-              docKey={docKey}
-              prefix="replay"
-              project={currentProject}
-            />
+            <OnboardingStepV2 step={index + 1} content={docContents[docKey]} />
             {footer}
           </div>
         );
@@ -198,8 +195,40 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   );
 }
 
+// TODO: we'll have to move this into a folder for common consumption w/ Profiling, Performance etc.
+interface OnboardingStepV2Props {
+  content: string;
+  step: number;
+}
+
+function OnboardingStepV2({step, content}: OnboardingStepV2Props) {
+  return (
+    <Flex>
+      <div>
+        <TaskStepNumber>{step}</TaskStepNumber>
+      </div>
+      <Flex.Item>
+        <DocumentationWrapper dangerouslySetInnerHTML={{__html: content}} />
+      </Flex.Item>
+    </Flex>
+  );
+}
+
+const TaskStepNumber = styled('div')`
+  display: flex;
+  margin-right: ${space(1.5)};
+  background-color: ${p => p.theme.yellow300};
+  border-radius: 50%;
+  font-weight: bold;
+  height: ${space(4)};
+  width: ${space(4)};
+  justify-content: center;
+  align-items: center;
+`;
+
 const TaskSidebarPanel = styled(SidebarPanel)`
-  width: 450px;
+  width: 600px;
+  max-width: 100%;
 `;
 
 const TopRightBackgroundImage = styled('img')`

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -8,8 +8,6 @@ import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useOnboardingDocs from 'sentry/components/onboardingWizard/useOnboardingDocs';
-// TODO: should be time to move this
-import {Flex} from 'sentry/components/profiling/flex';
 import useCurrentProjectState from 'sentry/components/replaysOnboarding/useCurrentProjectState';
 import {
   generateDocKeys,
@@ -203,16 +201,23 @@ interface OnboardingStepV2Props {
 
 function OnboardingStepV2({step, content}: OnboardingStepV2Props) {
   return (
-    <Flex>
+    <OnboardingStepContainer>
       <div>
         <TaskStepNumber>{step}</TaskStepNumber>
       </div>
-      <Flex.Item>
+      <div>
         <DocumentationWrapper dangerouslySetInnerHTML={{__html: content}} />
-      </Flex.Item>
-    </Flex>
+      </div>
+    </OnboardingStepContainer>
   );
 }
+
+const OnboardingStepContainer = styled('div')`
+  display: flex;
+  & > :last-child {
+    overflow: hidden;
+  }
+`;
 
 const TaskStepNumber = styled('div')`
   display: flex;


### PR DESCRIPTION
## Summary
Minor layout changes and removal of the onboarding checkbox, to align to: https://www.figma.com/file/6e0R6eyjmohixOipp7lkq6/Specs%3A-Onboarding-v2?node-id=823-1876&t=N3Rp78p02vCHCV3t-0

Before:
![image](https://user-images.githubusercontent.com/7349258/228570984-4edbc90d-2c9b-4cd7-8992-c5b7f8e23fa6.png)

After:
![image](https://user-images.githubusercontent.com/7349258/228571185-d9ec3b18-81d4-4215-a49b-6e2f5d087955.png)


Relates to: https://github.com/getsentry/sentry/issues/45474