### PR TITLE
fix(scaling-codeowners): Fix analytics value to ID

### DIFF
--- a/src/sentry/api/endpoints/codeowners/__init__.py
+++ b/src/sentry/api/endpoints/codeowners/__init__.py
@@ -56,7 +56,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
         if len(attrs["raw"]) > max_length and len(existing_raw) <= max_length:
             analytics.record(
                 "codeowners.max_length_exceeded",
-                organization_id=self.context["project"].organization,
+                organization_id=self.context["project"].organization.id,
             )
             raise serializers.ValidationError(
                 {"raw": f"Raw needs to be <= {max_length} characters in length"}

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -137,7 +137,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
 
             mock_record.assert_called_with(
                 "codeowners.max_length_exceeded",
-                organization_id=self.organization,
+                organization_id=self.organization.id,
             )
 
             # Test that we allow this to be modified for existing large rows


### PR DESCRIPTION
Fix bug in scaling codeowners analytics by changing value from `organization` to `organization.id`
