### PR TITLE
feat(ai): Added hook for OpenAI consent policy

### DIFF
--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 import openai
 from django.conf import settings
+from django.dispatch import Signal
 from django.http import HttpResponse
 
 from sentry import eventstore, features
@@ -20,6 +21,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 openai.api_key = settings.OPENAI_API_KEY
+
+openai_policy_check = Signal()
 
 FUN_PROMPT_CHOICES = [
     "[haiku about the error]",
@@ -101,6 +104,17 @@ BLOCKED_TAGS = frozenset(
         "otel",
     ]
 )
+
+
+def get_openai_policy(organization):
+    """Uses a signal to determine what the policy for OpenAI should be."""
+    results = openai_policy_check.send(
+        sender=EventAiSuggestedFixEndpoint, organization=organization
+    )
+    for _, result in results:
+        if result is not None:
+            return result
+    return "allowed"
 
 
 def describe_event_for_ai(event):
@@ -187,6 +201,26 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
         event = eventstore.get_event_by_id(project.id, event_id)
         if event is None:
             raise ResourceDoesNotExist
+
+        # Check the OpenAI access policy
+        policy = get_openai_policy(request.organization)
+        policy_failure = None
+        if policy == "subprocessor":
+            policy_failure = "subprocessor"
+        elif policy == "individual_consent":
+            if request.GET.get("consent") != "yes":
+                policy_failure = "individual_consent"
+        elif policy == "allowed":
+            pass
+        else:
+            logger.warning("Unknown OpenAI policy state")
+
+        if policy_failure is not None:
+            return HttpResponse(
+                json.dumps({"restriction": policy_failure}),
+                content_type="application/json",
+                status=401,
+            )
 
         # Cache the suggestion for a certain amount by primary hash, so even when new events
         # come into the group, we are sharing the same response.

--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -111,10 +111,14 @@ def get_openai_policy(organization):
     results = openai_policy_check.send(
         sender=EventAiSuggestedFixEndpoint, organization=organization
     )
-    for _, result in results:
-        if result is not None:
-            return result
-    return "allowed"
+    result = "allowed"
+
+    # Last one wins
+    for _, new_result in results:
+        if new_result is not None:
+            result = new_result
+
+    return result
 
 
 def describe_event_for_ai(event):

--- a/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
+++ b/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
@@ -17,7 +17,7 @@ def auto_login(client, default_user):
     assert client.login(username=default_user.username, password="admin")
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def openai_mock(monkeypatch):
     def dummy_response(*a, **kw):
         return {"choices": [{"message": {"content": "AI generated response"}}]}
@@ -57,7 +57,7 @@ def openai_policy():
 
 
 @pytest.mark.django_db
-def test_consent(client, default_project, test_event, openai_mock, openai_policy):
+def test_consent(client, default_project, test_event, openai_policy):
     path = reverse(
         "sentry-api-0-event-ai-fix-suggest",
         kwargs={

--- a/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
+++ b/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
@@ -1,0 +1,86 @@
+import pytest
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from sentry.testutils.helpers import Feature
+
+
+@pytest.fixture(autouse=True)
+def openai_features():
+    with Feature({"organizations:open-ai-suggestion": True}):
+        with override_settings(OPENAI_API_KEY="X"):
+            yield
+
+
+@pytest.fixture(autouse=True)
+def auto_login(client, default_user):
+    assert client.login(username=default_user.username, password="admin")
+
+
+@pytest.fixture
+def openai_mock(monkeypatch):
+    def dummy_response(*a, **kw):
+        return {"choices": [{"message": {"content": "AI generated response"}}]}
+
+    monkeypatch.setattr("openai.ChatCompletion.create", dummy_response)
+
+
+@pytest.fixture
+def test_event(default_project, factories):
+    event_data = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ZeroDivisionError",
+                    "stacktrace": {"frames": [{"function": f} for f in ["a", "b"]]},
+                }
+            ]
+        }
+    }
+    return factories.store_event(data=event_data, project_id=default_project.id)
+
+
+@pytest.fixture
+def openai_policy():
+    from sentry.api.endpoints.event_ai_suggested_fix import openai_policy_check
+
+    data = {"result": "allowed"}
+
+    def policy(sender, **kwargs):
+        return data["result"]
+
+    try:
+        openai_policy_check.connect(policy)
+        yield data
+    finally:
+        openai_policy_check.disconnect(policy)
+
+
+@pytest.mark.django_db
+def test_consent(client, default_project, test_event, openai_mock, openai_policy):
+    path = reverse(
+        "sentry-api-0-event-ai-fix-suggest",
+        kwargs={
+            "organization_slug": default_project.organization.slug,
+            "project_slug": default_project.slug,
+            "event_id": test_event.event_id,
+        },
+    )
+
+    openai_policy["result"] = "individual_consent"
+    response = client.get(path)
+    assert response.status_code == 401
+    assert response.json() == {"restriction": "individual_consent"}
+    response = client.get(path + "?consent=yes")
+    assert response.status_code == 200
+    assert response.json() == {"suggestion": "AI generated response"}
+
+    openai_policy["result"] = "subprocessor"
+    response = client.get(path)
+    assert response.status_code == 401
+    assert response.json() == {"restriction": "subprocessor"}
+
+    openai_policy["result"] = "allowed"
+    response = client.get(path)
+    assert response.status_code == 200
+    assert response.json() == {"suggestion": "AI generated response"}


### PR DESCRIPTION
This is a hacky way to gate the OpenAI endpoint based on a signal from getsentry. A signal can override the access policy to the AI feature.

Possible results for the signal:

* `subprocessor`: a subprocessor agreement needs to be signed, but was not signed yet
* `individual_consent`: individual consent from the user has to be supplied
* `allowed`: access to the feature is available

When `individual_consent` is returned, the UI needs to resubmit the request with `?consent=yes`.