### PR TITLE
fix(breadcrumbs): Apply breadcrumb meta highlighting to correct breadcrumbs when sorting/filtering

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
@@ -1,3 +1,4 @@
+import {BreadcrumbMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {Organization} from 'sentry/types';
 import {BreadcrumbType, RawCrumb} from 'sentry/types/breadcrumbs';
 import {Event} from 'sentry/types/event';
@@ -11,7 +12,7 @@ type Props = {
   event: Event;
   organization: Organization;
   searchTerm: string;
-  meta?: Record<any, any>;
+  meta?: BreadcrumbMeta;
 };
 
 export function Data({breadcrumb, event, organization, searchTerm, meta}: Props) {

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -8,13 +8,12 @@ import {
 } from 'react-virtualized';
 import styled from '@emotion/styled';
 
+import {BreadcrumbWithMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {PanelTable} from 'sentry/components/panels';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EntryType} from 'sentry/types';
-import {Crumb} from 'sentry/types/breadcrumbs';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
 import {Breadcrumb} from './breadcrumb';
@@ -31,7 +30,7 @@ type Props = Pick<
   React.ComponentProps<typeof Breadcrumb>,
   'event' | 'organization' | 'searchTerm' | 'relativeTime' | 'displayRelativeTime'
 > & {
-  breadcrumbs: Crumb[];
+  breadcrumbs: BreadcrumbWithMeta[];
   emptyMessage: Pick<
     React.ComponentProps<typeof PanelTable>,
     'emptyMessage' | 'emptyAction'
@@ -50,9 +49,6 @@ function Breadcrumbs({
   emptyMessage,
 }: Props) {
   const [scrollbarSize, setScrollbarSize] = useState(0);
-  const entryIndex = event.entries.findIndex(
-    entry => entry.type === EntryType.BREADCRUMBS
-  );
 
   const listRef = useRef<List>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -81,8 +77,8 @@ function Breadcrumbs({
   });
 
   function renderRow({index, key, parent, style}: ListRowProps) {
-    const breadcrumb = breadcrumbs[index];
-    const isLastItem = breadcrumbs[0].id === breadcrumb.id;
+    const {breadcrumb, meta} = breadcrumbs[index];
+    const isLastItem = index === breadcrumbs.length - 1;
     const {height} = style;
     return (
       <CellMeasurer
@@ -100,7 +96,7 @@ function Breadcrumbs({
             organization={organization}
             searchTerm={searchTerm}
             breadcrumb={breadcrumb}
-            meta={event._meta?.entries?.[entryIndex]?.data?.values?.[index]}
+            meta={meta}
             event={event}
             relativeTime={relativeTime}
             displayRelativeTime={displayRelativeTime}

--- a/static/app/components/events/interfaces/breadcrumbs/types.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/types.tsx
@@ -1,6 +1,6 @@
 import {Crumb} from 'sentry/types/breadcrumbs';
 
-export type BreadcrumbMeta = Record<any, any>;
+export type BreadcrumbMeta = Record<string, any>;
 
 export type BreadcrumbWithMeta = {
   breadcrumb: Crumb;

--- a/static/app/components/events/interfaces/breadcrumbs/types.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/types.tsx
@@ -1,0 +1,8 @@
+import {Crumb} from 'sentry/types/breadcrumbs';
+
+export type BreadcrumbMeta = Record<any, any>;
+
+export type BreadcrumbWithMeta = {
+  breadcrumb: Crumb;
+  meta: BreadcrumbMeta;
+};


### PR DESCRIPTION
The breadcrumb items were matching to the incorrect `meta` data which resulted in the wrong items getting highlighted. This change ties the item up with the meta before any sorts/filters are applied to prevent that from happening.

Before:

<img width="936" alt="CleanShot 2023-03-29 at 09 39 03@2x" src="https://user-images.githubusercontent.com/10888943/228608506-f6e26997-1a7a-4397-b141-4c940de5a6f5.png">

After:

<img width="868" alt="CleanShot 2023-03-29 at 09 39 39@2x" src="https://user-images.githubusercontent.com/10888943/228608571-0c8d202c-4b0d-4859-ae9a-df54c39b0d89.png">
