### PR TITLE
feat(replays): onboarding-v2 unsupported/supported project CTA states

### DIFF
--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -88,7 +88,10 @@ export default function ReplayOnboardingPanel() {
               action: primaryAction === 'create' ? t('Create') : t('Select'),
               projectMsg: (
                 <strong>
-                  {t(`Session Replay isn't available for %s.`, selectedProjects[0].slug)}
+                  {t(
+                    `Session Replay isn't available for project %s.`,
+                    selectedProjects[0].slug
+                  )}
                 </strong>
               ),
               link: (

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -87,10 +87,10 @@ export default function ReplayOnboardingPanel() {
         <Feature
           features={['session-replay-ga']}
           organization={organization}
-          renderDisabled={() => <SetupReplaysCTA />}
+          renderDisabled={() => <SetupReplaysCTA disableSetup={allProjectsUnsupported} />}
         >
           <OnboardingCTAHook organization={organization}>
-            <SetupReplaysCTA />
+            <SetupReplaysCTA disableSetup={allProjectsUnsupported} />
           </OnboardingCTAHook>
         </Feature>
       </OnboardingPanel>
@@ -98,7 +98,7 @@ export default function ReplayOnboardingPanel() {
   );
 }
 
-function SetupReplaysCTA() {
+function SetupReplaysCTA({disableSetup}: {disableSetup: boolean}) {
   const {activateSidebar} = useReplayOnboardingSidebarPanel();
 
   return (
@@ -110,7 +110,7 @@ function SetupReplaysCTA() {
         )}
       </p>
       <ButtonList gap={1}>
-        <Button onClick={activateSidebar} priority="primary">
+        <Button onClick={activateSidebar} priority="primary" disabled={disableSetup}>
           {t('Set Up Replays')}
         </Button>
         <Button

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -44,6 +44,8 @@ export default function ReplayOnboardingPanel() {
     pageFilters.selection.projects.includes(Number(p.id))
   );
 
+  const hasSelectedProjects = selectedProjects.length > 0;
+
   const allProjectsUnsupported = projects.projects.every(
     p => !replayPlatforms.includes(p.platform!)
   );
@@ -58,7 +60,9 @@ export default function ReplayOnboardingPanel() {
   // disable "create" if the user has insufficient permissions
   // disable "setup" if the current selected pageFilters are not supported
   const primaryActionDisabled =
-    primaryAction === 'create' ? !canCreateProjects : allSelectedProjectsUnsupported;
+    primaryAction === 'create'
+      ? !canCreateProjects
+      : allSelectedProjectsUnsupported && hasSelectedProjects;
 
   const breakpoints = preferences.collapsed
     ? {
@@ -76,14 +80,14 @@ export default function ReplayOnboardingPanel() {
 
   return (
     <Fragment>
-      {allSelectedProjectsUnsupported && (
+      {hasSelectedProjects && allSelectedProjectsUnsupported && (
         <Alert icon={<IconInfo />}>
           {tct(
             `[projectMsg] Select a project using our [link], or equivalent framework SDK.`,
             {
               projectMsg: (
                 <strong>
-                  {t(`Session Replay isn't available for %s.`, selectedProjects[0]?.slug)}
+                  {t(`Session Replay isn't available for %s.`, selectedProjects[0].slug)}
                 </strong>
               ),
               link: (

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -83,8 +83,9 @@ export default function ReplayOnboardingPanel() {
       {hasSelectedProjects && allSelectedProjectsUnsupported && (
         <Alert icon={<IconInfo />}>
           {tct(
-            `[projectMsg] Select a project using our [link], or equivalent framework SDK.`,
+            `[projectMsg] [action] a project using our [link], or equivalent framework SDK.`,
             {
+              action: primaryAction === 'create' ? t('Create') : t('Select'),
               projectMsg: (
                 <strong>
                   {t(`Session Replay isn't available for %s.`, selectedProjects[0].slug)}

--- a/static/app/views/replays/list/setupReplaysCTA.spec.tsx
+++ b/static/app/views/replays/list/setupReplaysCTA.spec.tsx
@@ -1,0 +1,33 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SetupReplaysCTA} from 'sentry/views/replays/list/replayOnboardingPanel';
+
+describe('SetupReplaysCTA', () => {
+  it('renders setup replay', () => {
+    render(<SetupReplaysCTA primaryAction="setup" orgSlug="foo" />);
+    expect(screen.getByTestId('setup-replays-btn')).toBeInTheDocument();
+  });
+
+  it('renders setup replay w/ disabled state including tooltip', async () => {
+    render(<SetupReplaysCTA primaryAction="setup" orgSlug="foo" disabled />);
+    const setupBtn = screen.getByTestId('setup-replays-btn');
+    await userEvent.hover(setupBtn);
+    await waitFor(() => screen.getByTestId('setup-replays-tooltip'));
+    expect(screen.getByTestId('setup-replays-tooltip')).toBeInTheDocument();
+  });
+
+  it('create project', () => {
+    render(<SetupReplaysCTA primaryAction="create" orgSlug="foo" />);
+    const createBtn = screen.getByTestId('create-project-btn');
+    expect(createBtn).toBeInTheDocument();
+    expect(createBtn).toHaveAttribute('href', `/organizations/foo/projects/new/`);
+  });
+
+  it('create project w/ disabled state including tooltip', async () => {
+    render(<SetupReplaysCTA primaryAction="create" orgSlug="foo" disabled />);
+    const createBtn = screen.getByTestId('create-project-btn');
+    await userEvent.hover(createBtn);
+    await waitFor(() => screen.getByTestId('create-project-tooltip'));
+    expect(screen.getByTestId('create-project-tooltip')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds the following:
- alert banner if select project does not support replay
- new CTA states
  - if all projects don't support replay
    -  Create project (disabled if no permission)
  - if selected projects don't support replay
    - Disable button   


All _selected_ Projects don't support replay:
![image](https://user-images.githubusercontent.com/7349258/228635977-6575cebc-5eed-41bd-a602-224f6f4d48d7.png)


All projects don't support replay:
![image](https://user-images.githubusercontent.com/7349258/228636593-7287c4a8-7153-456f-ad24-ab7053f55af9.png)


All projects don't support replay, w/o create permissions:
![image](https://user-images.githubusercontent.com/7349258/228636882-9eabd491-f745-46cd-bf18-6670005f6b27.png)


Relates to: https://github.com/getsentry/sentry/issues/45474#event-8866165824