### PR TITLE
ref(api): Scope the slugify_instance locks

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -188,7 +188,9 @@ class Project(Model, PendingDeletionMixin, SnowflakeIdMixin):
 
     def save(self, *args, **kwargs):
         if not self.slug:
-            lock = locks.get("slug:project", duration=5, name="project_slug")
+            lock = locks.get(
+                f"slug:project:{self.organization_id}", duration=5, name="project_slug"
+            )
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_instance(
                     self,

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -175,7 +175,7 @@ class Team(Model):
 
     def save(self, *args, **kwargs):
         if not self.slug:
-            lock = locks.get("slug:team", duration=5, name="team_slug")
+            lock = locks.get(f"slug:team:{self.organization_id}", duration=5, name="team_slug")
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_instance(self, self.name, organization=self.organization)
         super().save(*args, **kwargs)


### PR DESCRIPTION
These are unique to organization_id, there's no reason they need to lock against all of sentry