### PR TITLE
feat(replay): Show all `user` attributes in Replay tags, add `replayType`

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -73,6 +73,11 @@ export const getBreadcrumbsByCategory = (breadcrumbs: Crumb[], categories: strin
 
 export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
   // Marshal special fields into tags
+  const user = Object.fromEntries(
+    Object.entries(apiResponse.user)
+      .filter(([key, value]) => key !== 'display_name' && value)
+      .map(([key, value]) => [`user.${key}`, [value]])
+  );
   const unorderedTags: ReplayRecord['tags'] = {
     ...apiResponse.tags,
     ...(apiResponse.browser?.name ? {'browser.name': [apiResponse.browser.name]} : {}),
@@ -87,11 +92,12 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...(apiResponse.device?.name ? {'device.name': [apiResponse.device.name]} : {}),
     ...(apiResponse.platform ? {platform: [apiResponse.platform]} : {}),
     ...(apiResponse.releases ? {releases: [...apiResponse.releases]} : {}),
+    ...(apiResponse.replay_type ? {replayType: [apiResponse.replay_type]} : {}),
     ...(apiResponse.os?.name ? {'os.name': [apiResponse.os.name]} : {}),
     ...(apiResponse.os?.version ? {'os.version': [apiResponse.os.version]} : {}),
     ...(apiResponse.sdk?.name ? {'sdk.name': [apiResponse.sdk.name]} : {}),
     ...(apiResponse.sdk?.version ? {'sdk.version': [apiResponse.sdk.version]} : {}),
-    ...(apiResponse.user?.ip ? {'user.ip': [apiResponse.user.ip]} : {}),
+    ...user,
   };
 
   // Sort the tags by key

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -22,10 +22,16 @@ const notTags = [
   'device.name',
   'platform',
   'releases',
+  'replayType',
   'os.name',
   'os.version',
   'sdk.name',
   'sdk.version',
+  'user.email',
+  'user.username',
+  // TODO(replay): Remove this when backend changes `name` -> `username`
+  'user.name',
+  'user.id',
   'user.ip',
 ];
 


### PR DESCRIPTION
This will now show all user attributes in Replay tag panel instead of only `user.ip`. Also add `replayType`.
