### PR TITLE
feat(replays): Rename user.name field to user.username to be consistent with the rest of Sentry

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -54,7 +54,7 @@ This document is structured by resource with each resource having actions that c
     Additionally, you can filter by these hidden fields.
 
     | Field               | Type          | Description                                                    |
-    | --------------------| ------------- | -------------------------------------------------------------- |
+    | ------------------- | ------------- | -------------------------------------------------------------- |
     | replay_click.alt    | string        | The alt attribute of the HTML element.                         |
     | replay_click.class  | array[string] | An array of HTML element classes.                              |
     | replay_click.id     | string        | The ID of an HTML element.                                     |
@@ -155,7 +155,7 @@ Retrieve a collection of replays.
           "email": "john.doe@example.com",
           "id": "30246326",
           "ip_address": "213.164.1.114",
-          "name": "John Doe"
+          "username": "John Doe"
         }
       }
     ]
@@ -218,7 +218,7 @@ Retrieve a single replay instance.
         "email": "john.doe@example.com",
         "id": "30246326",
         "ip": "213.164.1.114",
-        "name": "John Doe"
+        "username": "John Doe"
       }
     }
   }

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -45,12 +45,12 @@ def generate_normalized_output(
         )
         item["user"] = {
             "id": item.pop("user_id", None),
-            "name": item.pop("user_name", None),
+            "username": item.pop("user_username", None),
             "email": item.pop("user_email", None),
             "ip": item.pop("user_ip", None),
         }
         item["user"]["display_name"] = (
-            item["user"]["name"]
+            item["user"]["username"]
             or item["user"]["email"]
             or item["user"]["id"]
             or item["user"]["ip"]

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -405,7 +405,7 @@ class ReplayQueryConfig(QueryConfig):
     url = ListField(query_alias="urls_sorted")
     user_id = String(field_alias="user.id", query_alias="user_id")
     user_email = String(field_alias="user.email", query_alias="user_email")
-    user_name = String(field_alias="user.name", query_alias="user_name")
+    user_username = String(field_alias="user.username")
     user_ip_address = String(field_alias="user.ip", query_alias="user_ip")
     os_name = String(field_alias="os.name", query_alias="os_name")
     os_version = String(field_alias="os.version", query_alias="os_version")
@@ -420,7 +420,7 @@ class ReplayQueryConfig(QueryConfig):
 
     # These are object-type fields.  User's who query by these fields are likely querying by
     # the "name" value.
-    user = String(field_alias="user", query_alias="user_name")
+    user = String(field_alias="user", query_alias="user_username")
     os = String(field_alias="os", query_alias="os_name")
     browser = String(field_alias="browser", query_alias="browser_name")
     device = String(field_alias="device", query_alias="device_name")
@@ -554,7 +554,7 @@ FIELD_QUERY_ALIAS_MAP: Dict[str, List[str]] = {
     "count_segments": ["count_segments"],
     "is_archived": ["is_archived"],
     "activity": ["activity", "count_errors", "count_urls"],
-    "user": ["user_id", "user_email", "user_name", "user_ip"],
+    "user": ["user_id", "user_email", "user_username", "user_ip"],
     "os": ["os_name", "os_version"],
     "browser": ["browser_name", "browser_version"],
     "device": ["device_name", "device_brand", "device_family", "device_model"],
@@ -563,7 +563,7 @@ FIELD_QUERY_ALIAS_MAP: Dict[str, List[str]] = {
     # Nested fields.  Useful for selecting searchable fields.
     "user.id": ["user_id"],
     "user.email": ["user_email"],
-    "user.name": ["user_name"],
+    "user.username": ["user_username"],
     "user.ip": ["user_ip"],
     "os.name": ["os_name"],
     "os.version": ["os_version"],
@@ -651,7 +651,7 @@ QUERY_ALIAS_COLUMN_MAP = {
     "dist": take_any_from_aggregation(column_name="dist"),
     "user_id": take_any_from_aggregation(column_name="user_id"),
     "user_email": take_any_from_aggregation(column_name="user_email"),
-    "user_name": take_any_from_aggregation(column_name="user_name"),
+    "user_username": take_any_from_aggregation(column_name="user_name", alias="user_username"),
     "user_ip": Function(
         "IPv4NumToString",
         parameters=[take_any_from_aggregation(column_name="ip_address_v4", aliased=False)],

--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -36,7 +36,7 @@ def assert_expected_response(
     """Assert a received response matches what was expected."""
     # Compare the response structure and values to the expected response.
     for key, value in expected_response.items():
-        assert key in response, key
+        assert key in response, f"key: {key}"
         response_value = response.pop(key)
 
         if isinstance(response_value, dict):
@@ -45,7 +45,7 @@ def assert_expected_response(
                 if isinstance(v, list):
                     assert sorted(response_value[k]) == sorted(v)
                 else:
-                    assert response_value[k] == v
+                    assert response_value[k] == v, f"value: {v}, expected: {response_value[k]}"
         elif isinstance(response_value, list):
             assert len(response_value) == len(value), f'"{response_value}" "{value}"'
             for item in response_value:
@@ -105,7 +105,7 @@ def mock_expected_response(
             "id": kwargs.pop("user_id", "123"),
             "display_name": kwargs.pop("user_display_name", "username"),
             "email": kwargs.pop("user_email", "username@example.com"),
-            "name": kwargs.pop("user_name", "username"),
+            "username": kwargs.pop("user_name", "username"),
             "ip": kwargs.pop("user_ip", "127.0.0.1"),
         },
         "tags": kwargs.pop("tags", {}),

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -153,7 +153,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
 
             assert len(response_data["data"][0]["user"]) == 5
             assert "id" in response_data["data"][0]["user"]
-            assert "name" in response_data["data"][0]["user"]
+            assert "username" in response_data["data"][0]["user"]
             assert "email" in response_data["data"][0]["user"]
             assert "ip" in response_data["data"][0]["user"]
             assert "display_name" in response_data["data"][0]["user"]
@@ -512,7 +512,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "duration:>15",
                 "user.id:123",
                 "user:username123",
-                "user.name:username123",
+                "user.username:username123",
                 "user.email:username@example.com",
                 "user.email:*@example.com",
                 "user.ip:127.0.0.1",
@@ -727,7 +727,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "device.family",
                 "device.model",
                 "user.id",
-                "user.name",
+                "user.username",
                 "user.email",
                 "activity",
             ]


### PR DESCRIPTION
Related: https://github.com/getsentry/replay-backend/issues/282