### PR TITLE
fix(transaction-details): Render gap span description

### DIFF
--- a/static/app/components/events/interfaces/spans/utils.spec.tsx
+++ b/static/app/components/events/interfaces/spans/utils.spec.tsx
@@ -64,6 +64,18 @@ describe('formatSpanTreeLabel', () => {
       } as RawSpanType)
     ).toBe('GET /items?query=hello world');
   });
+
+  it('returns the description for gap spans', () => {
+    expect(
+      formatSpanTreeLabel({
+        isOrphan: false,
+        start_timestamp: 0,
+        timestamp: 0,
+        type: 'gap',
+        description: 'Missing instrumentation',
+      })
+    ).toBe('Missing instrumentation');
+  });
 });
 
 describe('getCumulativeAlertLevelFromErrors', () => {

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -286,17 +286,15 @@ export function getSpanParentSpanID(span: ProcessedSpanType): string | undefined
 }
 
 export function formatSpanTreeLabel(span: ProcessedSpanType): string | undefined {
-  if (isGapSpan(span)) {
-    return undefined;
-  }
-
   const label = span?.description ?? getSpanID(span);
 
-  if (span.op === 'http.client') {
-    try {
-      return decodeURIComponent(label);
-    } catch {
-      // Do nothing
+  if (!isGapSpan(span)) {
+    if (span.op === 'http.client') {
+      try {
+        return decodeURIComponent(label);
+      } catch {
+        // Do nothing
+      }
     }
   }
 


### PR DESCRIPTION
For gap spans, we should render it's description, otherwise they appear in the span waterfall with no labels at all. Specifically, it should show `Missing instrumentation` and not blank.