### PR TITLE
fix(api): Ensure that project users endpoint works with multiple email results

### DIFF
--- a/src/sentry/api/endpoints/project_users.py
+++ b/src/sentry/api/endpoints/project_users.py
@@ -1,4 +1,3 @@
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -31,27 +30,12 @@ class ProjectUsersEndpoint(ProjectEndpoint):
         if request.GET.get("query"):
             try:
                 field, identifier = request.GET["query"].strip().split(":", 1)
-            except ValueError:
-                return Response([])
-            # username and ip can return multiple eventuser objects
-            if field in ("ip", "username"):
                 queryset = queryset.filter(
                     project_id=project.id,
                     **{EventUser.attr_from_keyword(field): identifier},
                 )
-            else:
-                try:
-                    queryset = [
-                        queryset.get(
-                            project_id=project.id,
-                            **{EventUser.attr_from_keyword(field): identifier},
-                        )
-                    ]
-                except EventUser.DoesNotExist:
-                    return Response(status=status.HTTP_404_NOT_FOUND)
-                except KeyError:
-                    return Response([])
-                return Response(serialize(queryset, request.user))
+            except (ValueError, KeyError):
+                return Response([])
 
         return self.paginate(
             request=request,

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -79,7 +79,8 @@ class ProjectUsersTest(APITestCase):
 
         response = self.client.get(f"{self.path}?query=email:@example.com", format="json")
 
-        assert response.status_code == 404, response.content
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
 
     def test_id_search(self):
         self.login_as(user=self.user)
@@ -92,7 +93,8 @@ class ProjectUsersTest(APITestCase):
 
         response = self.client.get(f"{self.path}?query=id:3", format="json")
 
-        assert response.status_code == 404, response.content
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
 
     def test_ip_search(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Since this is using a `.get` when querying with `email:email@example.com`, it will fail when there are multiple objects with that email, which is a possibility ([sentry issue here](https://sentry.sentry.io/issues/4046874288/?project=1&referrer=performance-related-issues-issue-stream&statsPeriod=14d)).

I _believe_ this is only used in the admin console, but correct me if I'm wrong. I've verified that it works as intended there.