### PR TITLE
fix(issues): Adjust max width of filter bar on issue stream

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -44,7 +44,7 @@ const SearchContainer = styled('div')`
 const StyledPageFilterBar = styled(PageFilterBar)`
   flex: 0 1 0;
   width: 100%;
-  max-width: 35rem;
+  max-width: 45rem;
 
   > div > button {
     width: 100%;


### PR DESCRIPTION
The filter bar's max width was not large enough to accomodate projects with long titles. This PR fixes this simply by adjusting the max width

### Before
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/16740047/228663547-f4d621de-8541-47c2-88ff-313b91487bb2.png">

### After
<img width="1340" alt="image" src="https://user-images.githubusercontent.com/16740047/228663668-9ccdaade-0045-4f62-96b8-547ed36169b3.png">
