### PR TITLE
test(ui): Set environment on master branch + CI

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -278,7 +278,7 @@ const config: Config.InitialOptions = {
       init: {
         // jest project under Sentry organization (dev productivity team)
         dsn: 'https://3fe1dce93e3a4267979ebad67f3de327@sentry.io/4857230',
-        // Use production env to reduce sampling on production branch
+        // Use production env to reduce sampling of commits on master
         environment: CI ? (IS_MASTER_BRANCH ? 'production' : 'ci') : 'local',
         tracesSampleRate: CI ? 1 : 0.5,
         profilesSampleRate: 0.1,

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,6 +19,8 @@ const {
   GITHUB_RUN_ATTEMPT,
 } = process.env;
 
+const IS_MASTER_BRANCH = GITHUB_PR_REF === 'refs/heads/master';
+
 const BALANCE_RESULTS_PATH = path.resolve(
   __dirname,
   'tests',
@@ -276,8 +278,9 @@ const config: Config.InitialOptions = {
       init: {
         // jest project under Sentry organization (dev productivity team)
         dsn: 'https://3fe1dce93e3a4267979ebad67f3de327@sentry.io/4857230',
-        environment: CI ? 'ci' : 'local',
-        tracesSampleRate: 1,
+        // Use production env to reduce sampling on production branch
+        environment: CI ? (IS_MASTER_BRANCH ? 'production' : 'ci') : 'local',
+        tracesSampleRate: CI ? 1 : 0.5,
         profilesSampleRate: 0.1,
         transportOptions: {keepAlive: true},
       },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -279,7 +279,7 @@ const config: Config.InitialOptions = {
         // jest project under Sentry organization (dev productivity team)
         dsn: 'https://3fe1dce93e3a4267979ebad67f3de327@sentry.io/4857230',
         // Use production env to reduce sampling of commits on master
-        environment: CI ? (IS_MASTER_BRANCH ? 'production' : 'ci') : 'local',
+        environment: CI ? (IS_MASTER_BRANCH ? 'ci:master' : 'ci:pull_request') : 'local',
         tracesSampleRate: CI ? 1 : 0.5,
         profilesSampleRate: 0.1,
         transportOptions: {keepAlive: true},


### PR DESCRIPTION
CI data can be messy since it includes everyone's PR's that may or may not be up to date. Filtering by branch samples the data.

This would reduce sampling for the master branch by setting the environment to production and reducing the sample rate for the dev environment.
