### PR TITLE
fix(stacktrace): Fixes styling missing frame context in mobile traces

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -129,10 +129,10 @@ const Context = ({
 
   if (!hasContextSource && !hasContextVars && !hasContextRegisters && !hasAssembly) {
     return emptySourceNotation ? (
-      <div className="empty-context">
+      <EmptyContext>
         <StyledIconFlag size="xs" />
-        <p>{t('No additional details are available for this frame.')}</p>
-      </div>
+        {t('No additional details are available for this frame.')}
+      </EmptyContext>
     ) : null;
   }
 
@@ -229,4 +229,13 @@ const Wrapper = styled('ol')<{startLineNo: number}>`
   && {
     border-radius: 0 !important;
   }
+`;
+
+const EmptyContext = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  padding: 20px;
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;

--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -451,22 +451,6 @@ div.traceback > ul {
       color: inherit;
     }
 
-    .empty-context {
-      padding: 20px;
-      color: @gray;
-
-      p {
-        display: inline-block;
-        margin-bottom: 0;
-      }
-
-      .icon {
-        opacity: 0.45;
-        margin-right: 10px;
-        font-size: 0.85em;
-      }
-    }
-
     .context {
       display: none;
       background: #fff;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/46472

In some stacktraces, the class `.empty-context` wasn't being applied. So I removed it and replaced with emotion styles. 

Before:

![CleanShot 2023-03-29 at 14 49 28](https://user-images.githubusercontent.com/10888943/228675503-2df4f630-5bcf-4f75-baa6-9f4fe7c6344d.png)

After:

![CleanShot 2023-03-29 at 14 50 13](https://user-images.githubusercontent.com/10888943/228675657-5ac245dd-8d17-4258-b419-9a339269d51d.png)

