### PR TITLE
telemetry(replays): add histograms for req/res body sizes

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -139,29 +139,30 @@ def get_user_actions(
         # look for request / response breadcrumbs and report metrics on them
         if event.get("type") == 5 and event.get("data", {}).get("tag") == "performanceSpan":
             if event["data"].get("payload", {}).get("op") in ("resource.fetch", "resource.xhr"):
+                event_payload_data = event["data"]["payload"]["data"]
 
                 # these first two cover SDKs 7.44 and 7.45
-                if event["data"]["payload"]["data"].get("requestBodySize"):
+                if event_payload_data.get("requestBodySize"):
                     metrics.timing(
                         "replays.usecases.ingest.request_body_size",
-                        event["data"]["payload"]["data"]["requestBodySize"],
+                        event_payload_data["requestBodySize"],
                     )
-                if event["data"]["payload"]["data"].get("responseBodySize"):
+                if event_payload_data.get("responseBodySize"):
                     metrics.timing(
                         "replays.usecases.ingest.response_body_size",
-                        event["data"]["payload"]["data"]["responseBodySize"],
+                        event_payload_data["responseBodySize"],
                     )
 
                 # what the most recent SDKs send:
-                if event["data"]["payload"]["data"].get("request", {}).get("size"):
+                if event_payload_data.get("request", {}).get("size"):
                     metrics.timing(
                         "replays.usecases.ingest.request_body_size",
-                        event["data"]["payload"]["data"]["request"]["size"],
+                        event_payload_data["request"]["size"],
                     )
-                if event["data"]["payload"]["data"].get("response", {}).get("size"):
+                if event_payload_data.get("response", {}).get("size"):
                     metrics.timing(
                         "replays.usecases.ingest.response_body_size",
-                        event["data"]["payload"]["data"]["response"]["size"],
+                        event_payload_data["response"]["size"],
                     )
 
     return result

--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -136,6 +136,15 @@ def get_user_actions(
                     }
                 )
 
+        # look for request / response breadcrumbs and report metrics on them
+        if event.get("type") == 5 and event.get("data", {}).get("tag") == "performanceSpan":
+            if event["data"].get("payload", {}).get("op") == "resource.fetch":
+                # we can assume if the op matches the rest of the keys are defined
+                request_size = event["data"]["payload"]["data"]["request"]["size"]
+                response_size = event["data"]["payload"]["data"]["response"]["size"]
+                metrics.timing("replays.usecases.ingest.request_body_size", request_size)
+                metrics.timing("replays.usecases.ingest.response_body_size", response_size)
+
     return result
 
 

--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -138,12 +138,31 @@ def get_user_actions(
 
         # look for request / response breadcrumbs and report metrics on them
         if event.get("type") == 5 and event.get("data", {}).get("tag") == "performanceSpan":
-            if event["data"].get("payload", {}).get("op") == "resource.fetch":
-                # we can assume if the op matches the rest of the keys are defined
-                request_size = event["data"]["payload"]["data"]["request"]["size"]
-                response_size = event["data"]["payload"]["data"]["response"]["size"]
-                metrics.timing("replays.usecases.ingest.request_body_size", request_size)
-                metrics.timing("replays.usecases.ingest.response_body_size", response_size)
+            if event["data"].get("payload", {}).get("op") in ("resource.fetch", "resource.xhr"):
+
+                # these first two cover SDKs 7.44 and 7.45
+                if event["data"]["payload"]["data"].get("requestBodySize"):
+                    metrics.timing(
+                        "replays.usecases.ingest.request_body_size",
+                        event["data"]["payload"]["data"]["requestBodySize"],
+                    )
+                if event["data"]["payload"]["data"].get("responseBodySize"):
+                    metrics.timing(
+                        "replays.usecases.ingest.response_body_size",
+                        event["data"]["payload"]["data"]["responseBodySize"],
+                    )
+
+                # what the most recent SDKs send:
+                if event["data"]["payload"]["data"].get("request", {}).get("size"):
+                    metrics.timing(
+                        "replays.usecases.ingest.request_body_size",
+                        event["data"]["payload"]["data"]["request"]["size"],
+                    )
+                if event["data"]["payload"]["data"].get("response", {}).get("size"):
+                    metrics.timing(
+                        "replays.usecases.ingest.response_body_size",
+                        event["data"]["payload"]["data"]["response"]["size"],
+                    )
 
     return result
 

--- a/tests/sentry/replays/unit/test_ingest_dom_index.py
+++ b/tests/sentry/replays/unit/test_ingest_dom_index.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 from sentry.utils import json
 from src.sentry.replays.usecases.ingest.dom_index import (
@@ -126,3 +127,48 @@ def test_encode_as_uuid():
     b = encode_as_uuid("hello,world!")
     assert a == b
     assert isinstance(uuid.UUID(a), uuid.UUID)
+
+
+def test_parse_request_response():
+    events = [
+        {
+            "type": 5,
+            "timestamp": 1680009712.507,
+            "data": {
+                "tag": "performanceSpan",
+                "payload": {
+                    "op": "resource.fetch",
+                    "description": "https://api2.amplitude.com/2/httpapi",
+                    "startTimestamp": 1680009712.507,
+                    "endTimestamp": 1680009712.671,
+                    "data": {
+                        "method": "POST",
+                        "statusCode": 200,
+                        "request": {
+                            "size": 2949,
+                            "body": {
+                                "api_key": "foobar",
+                                "events": "[...]",
+                                "options": {"min_id_length": 1},
+                            },
+                        },
+                        "response": {
+                            "size": 94,
+                            "body": {
+                                "code": 200,
+                                "server_upload_time": 1680009712652,
+                                "payload_size_bytes": 2949,
+                                "events_ingested": 5,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    ]
+    with mock.patch("sentry.utils.metrics.timing") as timing:
+        parse_replay_actions(1, "1", 30, events)
+        assert timing.call_args_list == [
+            mock.call("replays.usecases.ingest.request_body_size", 2949),
+            mock.call("replays.usecases.ingest.response_body_size", 94),
+        ]


### PR DESCRIPTION
While parsing the replay, also take a look at  `perfomanceSpan` > `resource.fetch` and emit a metric for their respective sizes.

questions for SDK folks:

1. once the `op` type is confirmed to be `resource.fetch`, is the rest of the schema as i'm grabbing it guaranteed to be there?
2. is `resource.fetch` the only op type to look at? is there a separate one for `xhr`?
