### PR TITLE
fix(issue-platform): Allow perf issues coming via the issue platform to successfully make it through process in post process group

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -186,10 +186,15 @@ class SnubaEventStorage(EventStorage):
 
         return []
 
-    def get_event_by_id(self, project_id, event_id, group_id=None):
+    def get_event_by_id(
+        self, project_id, event_id, group_id=None, skip_transaction_groupevent=False
+    ):
         """
         Get an event given a project ID and event ID
         Returns None if an event cannot be found
+
+        skip_transaction_groupevent: Temporary hack parameter to skip converting a transaction
+        event into a `GroupEvent`. Used as part of `post_process_group`.
         """
 
         event_id = normalize_event_id(event_id)
@@ -205,7 +210,7 @@ class SnubaEventStorage(EventStorage):
 
         if group_id is not None and event.get_event_type() != "generic":
             # Set passed group_id if not a transaction
-            if event.get_event_type() == "transaction":
+            if event.get_event_type() == "transaction" and not skip_transaction_groupevent:
                 logger.warning("eventstore.passed-group-id-for-transaction")
                 return event.for_group(Group.objects.get(id=group_id))
             else:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -466,7 +466,9 @@ def post_process_group(
                 return
             # Issue platform events don't use `event_processing_store`. Fetch from eventstore
             # instead.
-            event = eventstore.get_event_by_id(project_id, occurrence.event_id, group_id=group_id)
+            event = eventstore.get_event_by_id(
+                project_id, occurrence.event_id, group_id=group_id, skip_transaction_groupevent=True
+            )
 
         set_current_event_project(event.project_id)
 


### PR DESCRIPTION
Currently the use of `get_event_by_id` converts the event into a `GroupEvent` when we have a transaction, which breaks the flow of post process group.

This adds in a temporary flag to prevent that in this one case - we want to return `GroupEvent`s elsewhere for now. Once perf issues are fully migrated, we can move away from having the `.groups` property in general and make use of `GroupEvent` more broadly.

