### PR TITLE
fix(ai): Change error status code from 401 to 403

### DIFF
--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -223,7 +223,7 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
             return HttpResponse(
                 json.dumps({"restriction": policy_failure}),
                 content_type="application/json",
-                status=401,
+                status=403,
             )
 
         # Cache the suggestion for a certain amount by primary hash, so even when new events

--- a/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
+++ b/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
@@ -69,7 +69,7 @@ def test_consent(client, default_project, test_event, openai_policy):
 
     openai_policy["result"] = "individual_consent"
     response = client.get(path)
-    assert response.status_code == 401
+    assert response.status_code == 403
     assert response.json() == {"restriction": "individual_consent"}
     response = client.get(path + "?consent=yes")
     assert response.status_code == 200
@@ -77,7 +77,7 @@ def test_consent(client, default_project, test_event, openai_policy):
 
     openai_policy["result"] = "subprocessor"
     response = client.get(path)
-    assert response.status_code == 401
+    assert response.status_code == 403
     assert response.json() == {"restriction": "subprocessor"}
 
     openai_policy["result"] = "allowed"


### PR DESCRIPTION
Changing from 401 to 403 so that we don't have to deal with our global API interceptors on frontend that cause a full page reload.