### PR TITLE
Avoid infinite processing loop

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -40,4 +40,6 @@ class SDKCrashDetection:
 
         if self.cocoa_sdk_crash_detector.is_sdk_crash(frames):
             sdk_crash_event = self.event_stripper.strip_event_data(event)
+
+            sdk_crash_event["type"] = "extracted_sdk_crash"
             self.sdk_crash_reporter.report(sdk_crash_event)

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from sentry.eventstore.models import Event
-from sentry.utils.safe import get_path
+from sentry.utils.safe import get_path, set_path
 from sentry.utils.sdk_crashes.event_stripper import EventStripper
 from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector
 
@@ -30,6 +30,10 @@ class SDKCrashDetection:
         if event.get("type", None) != "error" or event.get("platform") != "cocoa":
             return
 
+        context = get_path(event, "contexts", "sdk_crash_detection")
+        if context is not None and context.get("detected", False):
+            return
+
         is_unhandled = get_path(event, "exception", "values", -1, "mechanism", "handled") is False
         if is_unhandled is False:
             return
@@ -41,5 +45,5 @@ class SDKCrashDetection:
         if self.cocoa_sdk_crash_detector.is_sdk_crash(frames):
             sdk_crash_event = self.event_stripper.strip_event_data(event)
 
-            sdk_crash_event["type"] = "extracted_sdk_crash"
+            set_path(sdk_crash_event, "contexts", "sdk_crash_detection", value={"detected": True})
             self.sdk_crash_reporter.report(sdk_crash_event)

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -179,9 +179,16 @@ def test_report_cocoa_sdk_crash_frames(frames, should_be_reported):
 
 def test_sdk_crash_detected_event_is_not_reported():
     event = get_crash_event()
-    event["type"] = "extracted_sdk_crash"
+    event["contexts"]["sdk_crash_detection"] = {"detected": True}
 
     _run_report_test_with_event(event, should_be_reported=False)
+
+
+def test_cocoa_sdk_crash_detection_without_context():
+    event = get_crash_event(function="-[SentryHub getScope]")
+    event["contexts"] = {}
+
+    _run_report_test_with_event(event, True)
 
 
 def given_crash_detector() -> Tuple[SDKCrashDetection, SDKCrashReporter]:
@@ -213,7 +220,7 @@ def assert_sdk_crash_reported(
     crash_reporter.report.assert_called_once_with(expected_event)
 
     reported_event = crash_reporter.report.call_args.args[0]
-    assert reported_event["type"] == "extracted_sdk_crash"
+    assert reported_event["contexts"]["sdk_crash_detection"]["detected"] is True
 
 
 def assert_no_sdk_crash_reported(crash_reporter: SDKCrashReporter):


### PR DESCRIPTION
Detect when an event has the context `sdk_crash_detection`, and skip crash monitoring in that case.

Fixes GH-46173