### PR TITLE
feat(ai): Unify loader across dark/light mode

### DIFF
--- a/static/app/views/issueDetails/openAIFixSuggestion/aiLoaderMessage.tsx
+++ b/static/app/views/issueDetails/openAIFixSuggestion/aiLoaderMessage.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
 import shuffle from 'lodash/shuffle';
 
 import {t} from 'sentry/locale';
@@ -40,7 +41,12 @@ export function AiLoaderMessage() {
 
   return (
     <div>
-      <strong>{messages[messageIndex]}…</strong>
+      <Message>{messages[messageIndex]}…</Message>
     </div>
   );
 }
+
+// Hacky way until we have proper darkmode/lightmode ai loaders
+const Message = styled('strong')`
+  color: #3e3446;
+`;

--- a/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionPanel.tsx
+++ b/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionPanel.tsx
@@ -178,7 +178,7 @@ export function OpenAIFixSuggestionPanel({eventID, projectSlug}: Props) {
       </FixSuggestionPanelHeader>
       {expandedSuggestedFix && (
         <Fragment>
-          <PanelBody withPadding>
+          <StyledPanelBody withPadding isLoading={dataIsLoading}>
             {dataIsLoading ? (
               <AiLoaderWrapper>
                 <div className="ai-loader" />
@@ -200,7 +200,7 @@ export function OpenAIFixSuggestionPanel({eventID, projectSlug}: Props) {
                 }}
               />
             )}
-          </PanelBody>
+          </StyledPanelBody>
           {!dataIsLoading && !dataIsError && (
             <PanelFooter>
               <Feedback>
@@ -252,6 +252,10 @@ const FixSuggestionPanel = styled(Panel)`
   margin-top: ${space(1.5)};
   margin-bottom: ${space(1.5)};
   overflow: hidden;
+`;
+
+const StyledPanelBody = styled(PanelBody)<{isLoading: boolean}>`
+  background: ${p => (p.isLoading ? 'white' : undefined)};
 `;
 
 const FixSuggestionPanelHeader = styled(PanelHeader)<{isExpanded: boolean}>`


### PR DESCRIPTION
Until we have a proper light/dark mode SVG loader, this makes the dark mode loader look less broken.