### PR TITLE
feat(sourcemaps): Add count of weakly associated artifacts

### DIFF
--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -73,6 +73,9 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
             for pr in project_releases
         ]
 
+        # We want to first check if there are any bundles that are weakly associated with this release, if so we want
+        # to count the artifacts of the newest "ArtifactBundle".
+        weak_artifacts_count = release.count_weakly_associated_artifacts()
         return Response(
             {
                 "version": release.version,
@@ -83,6 +86,10 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "commitCount": release.commit_count,
                 "released": release.date_released or release.date_added,
                 "commitFilesChanged": commit_files_changed,
-                "releaseFileCount": release.count_artifacts(),
+                # In case there is not artifact bundle that is weakly associated with this release, we check if there is
+                # the old "ReleaseFile".
+                "releaseFileCount": release.count_artifacts()
+                if weak_artifacts_count is None
+                else weak_artifacts_count,
             }
         )

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -75,7 +75,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
 
         # We want to first check if there are any bundles that are weakly associated with this release, if so we want
         # to count the artifacts of the newest "ArtifactBundle".
-        weak_artifacts_count = release.count_weakly_associated_artifacts()
+        last_bundle = release.last_weakly_associated_artifact_bundle()
         return Response(
             {
                 "version": release.version,
@@ -87,9 +87,10 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "released": release.date_released or release.date_added,
                 "commitFilesChanged": commit_files_changed,
                 # In case there is not artifact bundle that is weakly associated with this release, we check if there is
-                # the old "ReleaseFile".
+                # the old "ReleaseFile". In case the old "ReleaseFile" is not present, we will return 0.
                 "releaseFileCount": release.count_artifacts()
-                if weak_artifacts_count is None
-                else weak_artifacts_count,
+                if last_bundle is None
+                else last_bundle.artifact_count,
+                "bundleId": None if last_bundle is None else str(last_bundle.bundle_id),
             }
         )

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1203,7 +1203,7 @@ class Release(Model):
         counts = get_artifact_counts([self.id])
         return counts.get(self.id, 0)
 
-    def count_weakly_associated_artifacts(self):
+    def last_weakly_associated_artifact_bundle(self):
         """Counts the number of artifacts in the most recent "ArtifactBundle" that is weakly associated
         with this release.
         """
@@ -1219,7 +1219,7 @@ class Release(Model):
         if len(bundles) == 0:
             return None
 
-        return bundles[0].artifact_count
+        return bundles[0]
 
     def clear_commits(self):
         """

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -34,6 +34,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.locks import locks
 from sentry.models import (
     Activity,
+    ArtifactBundle,
     BaseManager,
     CommitFileChange,
     GroupInbox,
@@ -1201,6 +1202,24 @@ class Release(Model):
         """
         counts = get_artifact_counts([self.id])
         return counts.get(self.id, 0)
+
+    def count_weakly_associated_artifacts(self):
+        """Counts the number of artifacts in the most recent "ArtifactBundle" that is weakly associated
+        with this release.
+        """
+        bundles = (
+            ArtifactBundle.objects.filter(
+                organization_id=self.organization.id,
+                releaseartifactbundle__release_name=self.version,
+            )
+            .order_by("-date_uploaded")
+            .select_related("file")[:1]
+        )
+
+        if len(bundles) == 0:
+            return None
+
+        return bundles[0].artifact_count
 
     def clear_commits(self):
         """

--- a/tests/sentry/api/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_release_meta.py
@@ -116,6 +116,7 @@ class ReleaseMetaTest(APITestCase):
 
         data = json.loads(response.content)
         assert data["releaseFileCount"] == 2
+        assert data["bundleId"] is None
 
     def test_artifact_count_with_weak_existing_association(self):
         user = self.create_user(is_staff=False, is_superuser=False)
@@ -150,3 +151,4 @@ class ReleaseMetaTest(APITestCase):
 
         data = json.loads(response.content)
         assert data["releaseFileCount"] == 10
+        assert data["bundleId"] == str(bundle.bundle_id)


### PR DESCRIPTION
This PR adds the ability to count the number of artifacts of a weakly associated artifact bundle to a specific release.