### PR TITLE
feat(onboarding): Show JS Loader in onboarding

### DIFF
--- a/static/app/components/onboarding/documentationWrapper.tsx
+++ b/static/app/components/onboarding/documentationWrapper.tsx
@@ -37,6 +37,7 @@ export const DocumentationWrapper = styled('div')`
   blockquote,
   hr,
   pre,
+  pre[class*='language-'],
   div[data-language] {
     margin-top: 1em;
     margin-bottom: 1em;

--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -28,8 +28,11 @@ describe('Onboarding Product Selection', function () {
 
     // Introduction
     expect(
-      screen.getByText(textWithMarkupMatcher(/In this quick guide you’ll use/))
+      screen.getByText(
+        textWithMarkupMatcher(/In this quick guide you’ll use npm or yarn/)
+      )
     ).toBeInTheDocument();
+    expect(screen.queryByText('Prefer to set up Sentry using')).not.toBeInTheDocument();
 
     // Error monitoring shall be checked and disabled by default
     const errorMonitoring = screen.getByTestId(
@@ -80,5 +83,39 @@ describe('Onboarding Product Selection', function () {
     // Tooltip with explanation shall be displayed on hover
     await userEvent.hover(within(sessionReplay).getByTestId('more-information'));
     expect(await screen.findByRole('link', {name: 'Read the Docs'})).toBeInTheDocument();
+  });
+
+  it('renders for Loader Script', async function () {
+    const {routerContext} = initializeOrg({
+      ...initializeOrg(),
+      router: {
+        location: {
+          query: {product: ['performance-monitoring', 'session-replay']},
+        },
+        params: {},
+      },
+    });
+
+    const skipLazyLoader = jest.fn();
+
+    render(<ProductSelection lazyLoader skipLazyLoader={skipLazyLoader} />, {
+      context: routerContext,
+    });
+
+    // Introduction
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/In this quick guide you’ll use our Loader Script/)
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/Prefer to set up Sentry using npm or yarn\?/)
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Go here'));
+
+    expect(skipLazyLoader).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -149,13 +149,11 @@ export function ProductSelection({
       </Products>
       {lazyLoader && (
         <AlternativeInstallationAlert type="info" showIcon>
-          {tct('Prefer to set up Sentry using [npm] or [yarn]? [goHere].', {
-            npm: <strong>npm</strong>,
-            yarn: <strong>yarn</strong>,
+          {tct('Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere:Go here].', {
+            npm: <strong />,
+            yarn: <strong />,
             goHere: (
-              <Button onClick={skipLazyLoader} priority="link">
-                {t('Go here')}
-              </Button>
+              <Button onClick={skipLazyLoader} priority="link" />
             ),
           })}
         </AlternativeInstallationAlert>

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -21,14 +21,14 @@ export enum PRODUCT {
 
 type Props = {
   defaultSelectedProducts?: PRODUCT[];
-  dontUseLazyLoader?: () => void;
   lazyLoader?: boolean;
+  skipLazyLoader?: () => void;
 };
 
 export function ProductSelection({
   defaultSelectedProducts,
   lazyLoader,
-  dontUseLazyLoader,
+  skipLazyLoader,
 }: Props) {
   const router = useRouter();
   const products = decodeList(router.location.query.product);
@@ -153,7 +153,7 @@ export function ProductSelection({
             npm: <strong>npm</strong>,
             yarn: <strong>yarn</strong>,
             goHere: (
-              <Button onClick={dontUseLazyLoader} priority="link">
+              <Button onClick={skipLazyLoader} priority="link">
                 {t('Go here')}
               </Button>
             ),

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -2,6 +2,8 @@ import {Fragment, useCallback, useEffect} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Alert} from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import Checkbox from 'sentry/components/checkbox';
 import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -19,9 +21,15 @@ export enum PRODUCT {
 
 type Props = {
   defaultSelectedProducts?: PRODUCT[];
+  dontUseLazyLoader?: () => void;
+  lazyLoader?: boolean;
 };
 
-export function ProductSelection({defaultSelectedProducts}: Props) {
+export function ProductSelection({
+  defaultSelectedProducts,
+  lazyLoader,
+  dontUseLazyLoader,
+}: Props) {
   const router = useRouter();
   const products = decodeList(router.location.query.product);
 
@@ -57,10 +65,14 @@ export function ProductSelection({defaultSelectedProducts}: Props) {
   return (
     <Fragment>
       <TextBlock>
-        {tct('In this quick guide you’ll use [npm] or [yarn] to set up:', {
-          npm: <strong>npm</strong>,
-          yarn: <strong>yarn</strong>,
-        })}
+        {lazyLoader
+          ? tct('In this quick guide you’ll use our [loaderScript] to set up:', {
+              loaderScript: <strong>Loader Script</strong>,
+            })
+          : tct('In this quick guide you’ll use [npm] or [yarn] to set up:', {
+              npm: <strong>npm</strong>,
+              yarn: <strong>yarn</strong>,
+            })}
       </TextBlock>
       <Products>
         <Product
@@ -135,6 +147,19 @@ export function ProductSelection({defaultSelectedProducts}: Props) {
           />
         </Product>
       </Products>
+      {lazyLoader && (
+        <AlternativeInstallationAlert type="info" showIcon>
+          {tct('Prefer to set up Sentry using [npm] or [yarn]? [goHere].', {
+            npm: <strong>npm</strong>,
+            yarn: <strong>yarn</strong>,
+            goHere: (
+              <Button onClick={dontUseLazyLoader} priority="link">
+                {t('Go here')}
+              </Button>
+            ),
+          })}
+        </AlternativeInstallationAlert>
+      )}
       <Divider />
     </Fragment>
   );
@@ -175,4 +200,8 @@ const TooltipDescription = styled('div')`
   gap: ${space(0.5)};
   justify-content: flex-start;
   text-align: left;
+`;
+
+const AlternativeInstallationAlert = styled(Alert)`
+  margin-top: ${space(3)};
 `;

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -149,14 +149,15 @@ export function ProductSelection({
       </Products>
       {lazyLoader && (
         <AlternativeInstallationAlert type="info" showIcon>
-          {tct(
-            'Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere:Go here].',
-            {
-              npm: <strong />,
-              yarn: <strong />,
-              goHere: <Button onClick={skipLazyLoader} priority="link" />,
-            }
-          )}
+          {tct('Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere].', {
+            npm: <strong />,
+            yarn: <strong />,
+            goHere: (
+              <Button onClick={skipLazyLoader} priority="link">
+                {t('Go here')}
+              </Button>
+            ),
+          })}
         </AlternativeInstallationAlert>
       )}
       <Divider />

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -149,13 +149,14 @@ export function ProductSelection({
       </Products>
       {lazyLoader && (
         <AlternativeInstallationAlert type="info" showIcon>
-          {tct('Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere:Go here].', {
-            npm: <strong />,
-            yarn: <strong />,
-            goHere: (
-              <Button onClick={skipLazyLoader} priority="link" />
-            ),
-          })}
+          {tct(
+            'Prefer to set up Sentry using [npm:npm] or [yarn:yarn]? [goHere:Go here].',
+            {
+              npm: <strong />,
+              yarn: <strong />,
+              goHere: <Button onClick={skipLazyLoader} priority="link" />,
+            }
+          )}
         </AlternativeInstallationAlert>
       )}
       <Divider />

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -535,7 +535,7 @@ describe('Onboarding Setup Docs', function () {
       router.location.query = {
         product: [PRODUCT.SESSION_REPLAY],
       };
-      await rerender(
+      rerender(
         <PersistedStoreContext.Provider
           value={[
             {

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -10,6 +10,8 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {Organization, Project} from 'sentry/types';
 import SetupDocs from 'sentry/views/onboarding/setupDocs';
 
+const PROJECT_KEY = TestStubs.ProjectKeys()[0];
+
 function renderMockRequests({
   project,
   orgSlug,
@@ -23,6 +25,13 @@ function renderMockRequests({
     url: `/projects/${orgSlug}/${project.slug}/`,
     body: project,
   });
+
+  if (project.slug === 'javascript-browser') {
+    MockApiClient.addMockResponse({
+      url: `/projects/${orgSlug}/${project.slug}/keys/`,
+      body: [PROJECT_KEY],
+    });
+  }
 
   MockApiClient.addMockResponse({
     url: `/projects/${orgSlug}/${project.slug}/issues/`,
@@ -423,6 +432,154 @@ describe('Onboarding Setup Docs', function () {
       expect(
         await screen.findByText(ReactDocVariant.ErrorMonitoring)
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('JS Loader Script', function () {
+    it('renders Loader Script setup', async function () {
+      const {router, route, routerContext, organization, project} = initializeOrg({
+        ...initializeOrg(),
+        organization: {
+          ...initializeOrg().organization,
+          features: [
+            'onboarding-remove-multiselect-platform',
+            'onboarding-docs-with-product-selection',
+            'onboarding-project-loader',
+            'js-sdk-dynamic-loader',
+          ],
+        },
+        router: {
+          location: {
+            query: {product: [PRODUCT.PERFORMANCE_MONITORING, PRODUCT.SESSION_REPLAY]},
+          },
+        },
+        projects: [
+          {
+            ...initializeOrg().project,
+            slug: 'javascript-browser',
+            platform: 'javascript',
+          },
+        ],
+      });
+
+      const updateLoaderMock = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/keys/${PROJECT_KEY.id}/`,
+        method: 'PUT',
+        body: PROJECT_KEY,
+      });
+
+      ProjectsStore.init();
+      ProjectsStore.loadInitialData([project]);
+
+      renderMockRequests({
+        project,
+        orgSlug: organization.slug,
+        location: router.location,
+      });
+
+      const {rerender} = render(
+        <PersistedStoreContext.Provider
+          value={[
+            {
+              onboarding: {
+                selectedPlatforms: ['javascript'],
+                platformToProjectIdMap: {
+                  javascript: 'javascript-browser',
+                },
+              },
+            },
+            jest.fn(),
+          ]}
+        >
+          <SetupDocs
+            active
+            onComplete={() => {}}
+            stepIndex={2}
+            router={router}
+            route={route}
+            location={router.location}
+            genSkipOnboardingLink={() => ''}
+            orgId={organization.slug}
+            jumpToSetupProject={() => {}}
+            search=""
+          />
+        </PersistedStoreContext.Provider>,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
+
+      expect(
+        await screen.findByRole('heading', {name: 'Configure JavaScript SDK'})
+      ).toBeInTheDocument();
+
+      expect(updateLoaderMock).toHaveBeenCalledTimes(1);
+      expect(updateLoaderMock).toHaveBeenCalledWith(
+        expect.any(String), // The URL
+        {
+          data: {
+            dynamicSdkLoaderOptions: {
+              hasDebug: false,
+              hasPerformance: true,
+              hasReplay: true,
+            },
+          },
+          error: expect.any(Function),
+          method: 'PUT',
+          success: expect.any(Function),
+        }
+      );
+
+      // update query in URL
+      router.location.query = {
+        product: [PRODUCT.SESSION_REPLAY],
+      };
+      await rerender(
+        <PersistedStoreContext.Provider
+          value={[
+            {
+              onboarding: {
+                selectedPlatforms: ['javascript'],
+                platformToProjectIdMap: {
+                  javascript: 'javascript-browser',
+                },
+              },
+            },
+            jest.fn(),
+          ]}
+        >
+          <SetupDocs
+            active
+            onComplete={() => {}}
+            stepIndex={2}
+            router={router}
+            route={route}
+            location={router.location}
+            genSkipOnboardingLink={() => ''}
+            orgId={organization.slug}
+            jumpToSetupProject={() => {}}
+            search=""
+          />
+        </PersistedStoreContext.Provider>
+      );
+
+      expect(updateLoaderMock).toHaveBeenCalledTimes(2);
+      expect(updateLoaderMock).toHaveBeenLastCalledWith(
+        expect.any(String), // The URL
+        {
+          data: {
+            dynamicSdkLoaderOptions: {
+              hasDebug: false,
+              hasPerformance: false,
+              hasReplay: true,
+            },
+          },
+          error: expect.any(Function),
+          method: 'PUT',
+          success: expect.any(Function),
+        }
+      );
     });
   });
 });

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -26,6 +26,7 @@ import {useExperiment} from 'sentry/utils/useExperiment';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import SetupIntroduction from 'sentry/views/onboarding/components/setupIntroduction';
+import {SetupDocsLoader} from 'sentry/views/onboarding/setupDocsLoader';
 
 import FirstEventFooter from './components/firstEventFooter';
 import ProjectSidebarSection from './components/projectSidebarSection';
@@ -263,9 +264,13 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
     'onboarding-heartbeat-footer'
   );
 
-  const docsWithProductSelection = organization.features?.includes(
+  const docsWithProductSelection = !!organization.features?.includes(
     'onboarding-docs-with-product-selection'
   );
+
+  const loaderOnboarding = !!organization.features?.includes('onboarding-project-loader');
+
+  const jsDynamicLoader = !!organization.features?.includes('js-sdk-dynamic-loader');
 
   const selectedPlatforms = clientState?.selectedPlatforms || [];
   const platformToProjectIdMap = clientState?.platformToProjectIdMap || {};
@@ -315,6 +320,10 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
 
   const currentPlatform = loadedPlatform ?? project?.platform ?? 'other';
 
+  const [showLoaderOnboarding, setShowLoaderOnboarding] = useState(
+    loaderOnboarding && jsDynamicLoader && currentPlatform === 'javascript'
+  );
+
   const fetchData = useCallback(async () => {
     // TODO: add better error handling logic
     if (!project?.platform) {
@@ -323,6 +332,11 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
 
     // this will be fetched in the SetupDocsReact component
     if (project.platform === 'javascript-react' && docsWithProductSelection) {
+      return;
+    }
+
+    // Show loader setup for base javascript platform
+    if (showLoaderOnboarding) {
       return;
     }
 
@@ -355,6 +369,7 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
     integrationSlug,
     integrationUseManualSetup,
     docsWithProductSelection,
+    showLoaderOnboarding,
   ]);
 
   useEffect(() => {
@@ -431,6 +446,14 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
               organization={organization}
               project={project}
               location={location}
+            />
+          ) : showLoaderOnboarding ? (
+            <SetupDocsLoader
+              organization={organization}
+              project={project}
+              location={location}
+              platform={loadedPlatform}
+              close={() => setShowLoaderOnboarding(false)}
             />
           ) : (
             <ProjectDocs

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -126,7 +126,7 @@ export function SetupDocsLoader({
       <ProductSelection
         defaultSelectedProducts={[PRODUCT.PERFORMANCE_MONITORING, PRODUCT.SESSION_REPLAY]}
         lazyLoader
-        dontUseLazyLoader={close}
+        skipLazyLoader={close}
       />
 
       {projectKeyUpdateError && (

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -156,14 +156,23 @@ function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
 
   const loaderLink = projectKey.dsn.cdn;
 
-  const configCodeSnippet = beautify.js(
-    `Sentry.onLoad(function() {
+  const configCodeSnippet = beautify.html(
+    `<script>
+Sentry.onLoad(function() {
   Sentry.init({
     // No need to configure DSN here, it is already configured in the loader script
     // You can add any additional configuration here
     sampleRate: 0.5,
-  })
-})`,
+  });
+});
+</script>`,
+    {indent_size: 2}
+  );
+
+  const verifyCodeSnippet = beautify.html(
+    `<script>
+  myUndefinedFunction();
+</script>`,
     {indent_size: 2}
   );
 
@@ -200,7 +209,7 @@ function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
                 "Initialise Sentry as early as possible in your application's lifecycle."
               )}
             </p>
-            <CodeSnippet dark language="js">
+            <CodeSnippet dark language="html">
               {configCodeSnippet}
             </CodeSnippet>
           </div>
@@ -212,8 +221,8 @@ function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
             "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
           )}
         </p>
-        <CodeSnippet dark language="js">
-          myUndefinedFunction();
+        <CodeSnippet dark language="html">
+          {verifyCodeSnippet}
         </CodeSnippet>
 
         <hr />

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -1,0 +1,240 @@
+import {Fragment, useCallback, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+import {Location} from 'history';
+import beautify from 'js-beautify';
+
+import {Button} from 'sentry/components/button';
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
+import {DocumentationWrapper} from 'sentry/components/onboarding/documentationWrapper';
+import {PRODUCT, ProductSelection} from 'sentry/components/onboarding/productSelection';
+import {PlatformKey} from 'sentry/data/platformCategories';
+import platforms from 'sentry/data/platforms';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {Organization, Project, ProjectKey} from 'sentry/types';
+import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import useApi from 'sentry/utils/useApi';
+import SetupIntroduction from 'sentry/views/onboarding/components/setupIntroduction';
+import {DynamicSDKLoaderOption} from 'sentry/views/settings/project/projectKeys/details/keySettings';
+
+export function SetupDocsLoader({
+  organization,
+  location,
+  project,
+  platform,
+  close,
+}: {
+  close: () => void;
+  location: Location;
+  organization: Organization;
+  platform: PlatformKey | null;
+  project: Project;
+}) {
+  const api = useApi();
+  const currentPlatform = platform ?? project?.platform ?? 'other';
+  const [projectKey, setProjectKey] = useState<ProjectKey | null>(null);
+  const [hasLoadingError, setHasLoadingError] = useState(false);
+  const [projectKeyUpdateError, setProjectKeyUpdateError] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    const keysApiUrl = `/projects/${organization.slug}/${project.slug}/keys/`;
+
+    try {
+      const loadedKeys = await api.requestPromise(keysApiUrl);
+
+      if (loadedKeys.length === 0) {
+        setHasLoadingError(true);
+        return;
+      }
+
+      setProjectKey(loadedKeys[0]);
+      setHasLoadingError(false);
+    } catch (error) {
+      setHasLoadingError(error);
+      throw error;
+    }
+  }, [api, organization.slug, project.slug]);
+
+  // Automatically update the products on the project key when the user changes the product selection
+  // Note that on initial visit, this will also update the project key with the default products (=all products)
+  // This DOES NOT take into account any initial products that may already be set on the project key - they will always be overwritten!
+  const updateSelectedProducts = useCallback(async () => {
+    const productsQuery =
+      (location.query.product as PRODUCT | PRODUCT[] | undefined) ?? [];
+    const products = typeof productsQuery === 'string' ? [productsQuery] : productsQuery;
+
+    const keyId = projectKey?.id;
+
+    if (!keyId) {
+      return;
+    }
+
+    const apiEndpoint = `/projects/${organization.slug}/${project.slug}/keys/${keyId}/`;
+
+    const newDynamicSdkLoaderOptions: Record<DynamicSDKLoaderOption, boolean> = {
+      [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+      [DynamicSDKLoaderOption.HAS_REPLAY]: false,
+      [DynamicSDKLoaderOption.HAS_DEBUG]: false,
+    };
+    products.forEach(product => {
+      // eslint-disable-next-line default-case
+      switch (product) {
+        case PRODUCT.PERFORMANCE_MONITORING:
+          newDynamicSdkLoaderOptions[DynamicSDKLoaderOption.HAS_PERFORMANCE] = true;
+          break;
+        case PRODUCT.SESSION_REPLAY:
+          newDynamicSdkLoaderOptions[DynamicSDKLoaderOption.HAS_REPLAY] = true;
+          break;
+      }
+    });
+
+    try {
+      await api.requestPromise(apiEndpoint, {
+        method: 'PUT',
+        data: {
+          dynamicSdkLoaderOptions: newDynamicSdkLoaderOptions,
+        },
+      });
+      setProjectKeyUpdateError(false);
+    } catch (error) {
+      const message = t('Unable to updated dynamic SDK loader configuration');
+      handleXhrErrorResponse(message)(error);
+      setProjectKeyUpdateError(true);
+    }
+  }, [api, location.query.product, organization.slug, project.slug, projectKey?.id]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData, organization.slug, project.slug]);
+
+  useEffect(() => {
+    updateSelectedProducts();
+  }, [updateSelectedProducts, location.query.product]);
+
+  return (
+    <Fragment>
+      <SetupIntroduction
+        stepHeaderText={t(
+          'Configure %s SDK',
+          platforms.find(p => p.id === currentPlatform)?.name ?? ''
+        )}
+        platform={currentPlatform}
+      />
+      <ProductSelection
+        defaultSelectedProducts={[PRODUCT.PERFORMANCE_MONITORING, PRODUCT.SESSION_REPLAY]}
+        lazyLoader
+        dontUseLazyLoader={close}
+      />
+
+      {projectKeyUpdateError && (
+        <LoadingError
+          message={t('Failed to update the project key with the selected products.')}
+          onRetry={() => updateSelectedProducts()}
+        />
+      )}
+
+      {!hasLoadingError ? (
+        projectKey !== null && <ProjectKeyInfo projectKey={projectKey} />
+      ) : (
+        <LoadingError
+          message={t('Failed to load Client Keys for the project.')}
+          onRetry={() => fetchData()}
+        />
+      )}
+    </Fragment>
+  );
+}
+
+function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
+  const [showOptionalConfig, setShowOptionalConfig] = useState(false);
+
+  const loaderLink = projectKey.dsn.cdn;
+
+  const configCodeSnippet = beautify.js(
+    `Sentry.onLoad(function() {
+  Sentry.init({
+    // No need to configure DSN here, it is already configured in the loader script
+    // You can add any additional configuration here
+    sampleRate: 0.5,
+  })
+})`,
+    {indent_size: 2}
+  );
+
+  return (
+    <DocsWrapper>
+      <DocumentationWrapper>
+        <h2>{t('Install')}</h2>
+        <p>
+          {t(
+            'After including this script tag to a page, we’ll send a test error to make sure Sentry is set up correctly.'
+          )}
+        </p>
+
+        <CodeSnippet dark language="html" onCopy={() => {}}>
+          {beautify.html(
+            `<script src="${loaderLink}" crossorigin="anonymous"></script>`,
+            {indent_size: 2, wrap_attributes: 'force-expand-multiline'}
+          )}
+        </CodeSnippet>
+
+        <hr />
+        <OptionalConfigWrapper>
+          <ToggleButton
+            priority="link"
+            borderless
+            size="zero"
+            icon={<IconChevron direction={showOptionalConfig ? 'down' : 'right'} />}
+            aria-label={t('Toggle optional configuration')}
+            onClick={() => setShowOptionalConfig(!showOptionalConfig)}
+          />
+          <h2 onClick={() => setShowOptionalConfig(!showOptionalConfig)}>
+            {t('Configuration (Optional)')}
+          </h2>
+        </OptionalConfigWrapper>
+        {showOptionalConfig && (
+          <div>
+            <CodeSnippet dark language="js" onCopy={() => {}}>
+              {configCodeSnippet}
+            </CodeSnippet>
+          </div>
+        )}
+        <hr />
+        <h2>{t('Next Steps')}</h2>
+        <ul>
+          <li>
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/sourcemaps/">
+              {t('Source Maps')}
+            </ExternalLink>
+            {': '}
+            {t('Learn how to enable readable stack traces in your Sentry errors.')}
+          </li>
+          <li>
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/configuration/">
+              {t('SDK Configuration')}
+            </ExternalLink>
+            {': '}
+            {t('Learn how to configure your SDK using our Loader Script')}
+          </li>
+        </ul>
+      </DocumentationWrapper>
+    </DocsWrapper>
+  );
+}
+
+const DocsWrapper = styled(motion.div)``;
+
+const OptionalConfigWrapper = styled('div')`
+  display: flex;
+  cursor: pointer;
+`;
+
+const ToggleButton = styled(Button)`
+  &,
+  :hover {
+    color: ${p => p.theme.gray500};
+  }
+`;

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -144,7 +144,7 @@ export function SetupDocsLoader({
       ) : (
         <LoadingError
           message={t('Failed to load Client Keys for the project.')}
-          onRetry={() => fetchData()}
+          onRetry={fetchData}
         />
       )}
     </Fragment>

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -180,7 +180,6 @@ function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
           )}
         </CodeSnippet>
 
-        <hr />
         <OptionalConfigWrapper>
           <ToggleButton
             priority="link"
@@ -196,22 +195,27 @@ function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
         </OptionalConfigWrapper>
         {showOptionalConfig && (
           <div>
+            <p>
+              {t(
+                "Initialise Sentry as early as possible in your application's lifecycle."
+              )}
+            </p>
             <CodeSnippet dark language="js">
               {configCodeSnippet}
             </CodeSnippet>
           </div>
         )}
-        <hr />
 
+        <h2>{t('Verify')}</h2>
         <p>
           {t(
-            'Then create an intentional error, so you can test that everything is working:'
+            "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
           )}
         </p>
-
         <CodeSnippet dark language="js">
           myUndefinedFunction();
         </CodeSnippet>
+
         <hr />
 
         <h2>{t('Next Steps')}</h2>

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -171,11 +171,7 @@ function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
     <DocsWrapper>
       <DocumentationWrapper>
         <h2>{t('Install')}</h2>
-        <p>
-          {t(
-            'After including this script tag to a page, we’ll send a test error to make sure Sentry is set up correctly.'
-          )}
-        </p>
+        <p>{t('Add this script tag to the top of the page:')}</p>
 
         <CodeSnippet dark language="html">
           {beautify.html(
@@ -206,6 +202,18 @@ function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
           </div>
         )}
         <hr />
+
+        <p>
+          {t(
+            'Then create an intentional error, so you can test that everything is working:'
+          )}
+        </p>
+
+        <CodeSnippet dark language="js">
+          myUndefinedFunction();
+        </CodeSnippet>
+        <hr />
+
         <h2>{t('Next Steps')}</h2>
         <ul>
           <li>

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -21,12 +21,6 @@ import useApi from 'sentry/utils/useApi';
 import SetupIntroduction from 'sentry/views/onboarding/components/setupIntroduction';
 import {DynamicSDKLoaderOption} from 'sentry/views/settings/project/projectKeys/details/keySettings';
 
-const newDynamicSdkLoaderOptions: Record<DynamicSDKLoaderOption, boolean> = {
-  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
-  [DynamicSDKLoaderOption.HAS_REPLAY]: false,
-  [DynamicSDKLoaderOption.HAS_DEBUG]: false,
-};
-
 export function SetupDocsLoader({
   organization,
   location,
@@ -78,6 +72,12 @@ export function SetupDocsLoader({
     if (!keyId) {
       return;
     }
+
+    const newDynamicSdkLoaderOptions: Record<DynamicSDKLoaderOption, boolean> = {
+      [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+      [DynamicSDKLoaderOption.HAS_REPLAY]: false,
+      [DynamicSDKLoaderOption.HAS_DEBUG]: false,
+    };
 
     products.forEach(product => {
       // eslint-disable-next-line default-case


### PR DESCRIPTION
Follow up/fork of https://github.com/getsentry/sentry/pull/46452

This shows a new UI in the new onboarding for the JS Loader. This is shown when the platform is plain browser JS.

![Screenshot 2023-03-30 at 12 21 31](https://user-images.githubusercontent.com/2411343/228818637-617ca55a-aba7-48e6-99ef-0f8a9384757f.png)

![Screenshot 2023-03-30 at 12 21 36](https://user-images.githubusercontent.com/2411343/228818648-4d6568b8-ecf5-4191-8f16-eeb38f301956.png)

Notes on the implementation:

* We update the loader settings automatically whenever the user toggles a checkbox
* We _do not_ consider the settings that have been present on the DSN - as we always want to overwrite this with the defaults.
* We assume that a project has a single DSN setup and use this

Closes https://github.com/getsentry/sentry/issues/46718