### PR TITLE
feat(settings): Ensure JS Loader validates SDK version & products

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
@@ -16,6 +16,12 @@ const dynamicSdkLoaderOptions = {
   [DynamicSDKLoaderOption.HAS_DEBUG]: false,
 };
 
+const fullDynamicSdkLoaderOptions = {
+  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: true,
+  [DynamicSDKLoaderOption.HAS_REPLAY]: true,
+  [DynamicSDKLoaderOption.HAS_DEBUG]: true,
+};
+
 function renderMockRequests(
   organizationSlug: Organization['slug'],
   projectSlug: Project['slug'],
@@ -119,6 +125,171 @@ describe('Key Settings', function () {
           })
         );
       });
+    });
+
+    it('resets performance & replay when selecting SDK version <7', async function () {
+      const params = {
+        projectId: '1',
+        keyId: '1',
+      };
+
+      const {organization} = initializeOrg({
+        ...initializeOrg(),
+        organization: {
+          ...initializeOrg().organization,
+          features: ORG_FEATURES,
+        },
+        router: {
+          params,
+        },
+      });
+
+      const data = {
+        ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+        dynamicSdkLoaderOptions: fullDynamicSdkLoaderOptions,
+      } as ProjectKey;
+
+      const mockRequests = renderMockRequests(
+        organization.slug,
+        params.projectId,
+        params.keyId
+      );
+
+      render(
+        <KeySettings
+          data={data}
+          onRemove={jest.fn()}
+          organization={organization}
+          params={params}
+        />
+      );
+
+      // Update SDK version - should reset performance & replay
+      await selectEvent.select(screen.getByText('latest'), '6.x');
+
+      await waitFor(() => {
+        expect(mockRequests.projectKeys).toHaveBeenCalledWith(
+          `/projects/${organization.slug}/${params.projectId}/keys/${params.keyId}/`,
+          expect.objectContaining({
+            data: {
+              browserSdkVersion: '6.x',
+              dynamicSdkLoaderOptions: {
+                ...fullDynamicSdkLoaderOptions,
+                [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+                [DynamicSDKLoaderOption.HAS_REPLAY]: false,
+                [DynamicSDKLoaderOption.HAS_DEBUG]: true,
+              },
+            },
+          })
+        );
+      });
+    });
+
+    it('disabled performance & replay when SDK version <7 is selected', function () {
+      const params = {
+        projectId: '1',
+        keyId: '1',
+      };
+
+      const {organization} = initializeOrg({
+        ...initializeOrg(),
+        organization: {
+          ...initializeOrg().organization,
+          features: ORG_FEATURES,
+        },
+        router: {
+          params,
+        },
+      });
+
+      const data = {
+        ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+        dynamicSdkLoaderOptions: {
+          [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+          [DynamicSDKLoaderOption.HAS_REPLAY]: false,
+          [DynamicSDKLoaderOption.HAS_DEBUG]: true,
+        },
+        browserSdkVersion: '6.x',
+      } as ProjectKey;
+
+      render(
+        <KeySettings
+          data={data}
+          onRemove={jest.fn()}
+          organization={organization}
+          params={params}
+        />
+      );
+
+      for (const key of Object.keys(sdkLoaderOptions)) {
+        const toggle = screen.getByRole('checkbox', {name: sdkLoaderOptions[key].label});
+
+        if (key === DynamicSDKLoaderOption.HAS_DEBUG) {
+          expect(toggle).toBeEnabled();
+          expect(toggle).toBeChecked();
+        } else {
+          expect(toggle).toBeDisabled();
+          expect(toggle).not.toBeChecked();
+        }
+      }
+
+      const infos = screen.getAllByText('Only available in SDK version 7.x and above');
+      expect(infos.length).toBe(2);
+    });
+
+    it('shows replay message when it is enabled', function () {
+      const params = {
+        projectId: '1',
+        keyId: '1',
+      };
+
+      const {organization} = initializeOrg({
+        ...initializeOrg(),
+        organization: {
+          ...initializeOrg().organization,
+          features: ORG_FEATURES,
+        },
+        router: {
+          params,
+        },
+      });
+
+      const data = {
+        ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+        dynamicSdkLoaderOptions: fullDynamicSdkLoaderOptions,
+      } as ProjectKey;
+
+      const {rerender} = render(
+        <KeySettings
+          data={data}
+          onRemove={jest.fn()}
+          organization={organization}
+          params={params}
+        />
+      );
+
+      expect(
+        screen.queryByText(
+          'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+        )
+      ).toBeInTheDocument();
+
+      data.dynamicSdkLoaderOptions.hasReplay = false;
+
+      rerender(
+        <KeySettings
+          data={data}
+          onRemove={jest.fn()}
+          organization={organization}
+          params={params}
+        />
+      );
+
+      expect(
+        screen.queryByText(
+          'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+        )
+      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Pulled out the frontend changes from https://github.com/getsentry/sentry/pull/46447.

* Enforce that when performance or replay is enabled, we use SDK v7. This is also enforced UI-side now:

![image](https://user-images.githubusercontent.com/2411343/228859339-ea86c786-bceb-4cc0-acd3-dda685f279a9.png)

When you switch your SDK version to <7, it automatically removes performance & tracing. This should ensure we do not get into a weird state.

* When Replay is enabled, we show a message that this will result in the ES6 bundle:

![image](https://user-images.githubusercontent.com/2411343/228860629-1a08a126-13bf-403e-8853-507400a2927e.png)

ref https://github.com/getsentry/sentry/issues/46436
