### PR TITLE
feat(replay): Give `<ObjectInspector> a default monospace font

### DIFF
--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -25,7 +25,7 @@ function ObjectInspector({data, theme, ...props}: Props) {
       // Reset some theme values
       BASE_COLOR: 'inherit',
       ERROR_COLOR: emotionTheme.red400,
-      TREENODE_FONT_FAMILY: 'inherit',
+      TREENODE_FONT_FAMILY: emotionTheme.text.familyMono,
       TREENODE_FONT_SIZE: 'inherit',
       TREENODE_LINE_HEIGHT: 'inherit',
       BASE_BACKGROUND_COLOR: 'none',
@@ -34,7 +34,7 @@ function ObjectInspector({data, theme, ...props}: Props) {
       OBJECT_PREVIEW_OBJECT_MAX_PROPERTIES: 1,
       ...theme,
     }),
-    [isDark, theme, emotionTheme.red400]
+    [isDark, theme, emotionTheme.red400, emotionTheme.text]
   );
 
   return (


### PR DESCRIPTION
This fixes the font for the network request tab

Before:
<img width="195" alt="image" src="https://user-images.githubusercontent.com/79684/228903107-6be99ed6-e197-4513-9e93-a55bbc666ac2.png">

After
<img width="351" alt="image" src="https://user-images.githubusercontent.com/79684/228902975-ed0806fe-2f03-475d-b100-3b78840a1b1b.png">
