### PR TITLE
feat(compactSelect): Add ability to limit the number of displayed options

### DIFF
--- a/static/app/components/compactSelect/composite.tsx
+++ b/static/app/components/compactSelect/composite.tsx
@@ -27,7 +27,7 @@ export interface SingleCompositeSelectRegion<Value extends React.Key>
   extends BaseCompositeSelectRegion<Value>,
     Omit<
       SingleListProps<Value>,
-      'children' | 'items' | 'grid' | 'compositeIndex' | 'size'
+      'children' | 'items' | 'grid' | 'compositeIndex' | 'size' | 'limitOptions'
     > {}
 
 /**
@@ -40,7 +40,7 @@ export interface MultipleCompositeSelectRegion<Value extends React.Key>
   extends BaseCompositeSelectRegion<Value>,
     Omit<
       MultipleListProps<Value>,
-      'children' | 'items' | 'grid' | 'compositeIndex' | 'size'
+      'children' | 'items' | 'grid' | 'compositeIndex' | 'size' | 'limitOptions'
     > {}
 
 /**

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -22,12 +22,6 @@ import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
 import {SelectOption} from './types';
 
 export interface SelectContextValue {
-  /**
-   * Filter function to determine whether an option should be rendered in the select
-   * list. A true return value means the option should be rendered. This function is
-   * automatically updated based on the current search string.
-   */
-  filterOption: (opt: SelectOption<React.Key>) => boolean;
   overlayIsOpen: boolean;
   /**
    * Function to be called once when a list is initialized, to register its state in
@@ -46,6 +40,10 @@ export interface SelectContextValue {
     newSelectedOptions: SelectOption<React.Key> | SelectOption<React.Key>[]
   ) => void;
   /**
+   * Search string to determine whether an option should be rendered in the select list.
+   */
+  search: string;
+  /**
    * The control's overlay state. Useful for opening/closing the menu from inside the
    * selector.
    */
@@ -55,8 +53,8 @@ export interface SelectContextValue {
 export const SelectContext = createContext<SelectContextValue>({
   registerListState: () => {},
   saveSelectedOptions: () => {},
-  filterOption: () => true,
   overlayIsOpen: false,
+  search: '',
 });
 
 export interface ControlProps extends UseOverlayProps {
@@ -194,13 +192,6 @@ export function Control({
       onSearch?.(newValue);
     },
     [onSearch]
-  );
-  const filterOption = useCallback<SelectContextValue['filterOption']>(
-    opt =>
-      String(opt.label ?? '')
-        .toLowerCase()
-        .includes(search.toLowerCase()),
-    [search]
   );
 
   const {keyboardProps: searchKeyboardProps} = useKeyboard({
@@ -347,9 +338,9 @@ export function Control({
       saveSelectedOptions,
       overlayState,
       overlayIsOpen,
-      filterOption,
+      search,
     }),
-    [registerListState, saveSelectedOptions, overlayState, overlayIsOpen, filterOption]
+    [registerListState, saveSelectedOptions, overlayState, overlayIsOpen, search]
   );
 
   const theme = useTheme();

--- a/static/app/components/compactSelect/gridList/section.tsx
+++ b/static/app/components/compactSelect/gridList/section.tsx
@@ -6,7 +6,7 @@ import {Node} from '@react-types/shared';
 import domId from 'sentry/utils/domId';
 import {FormSize} from 'sentry/utils/theme';
 
-import {SelectContext} from '../control';
+import {SelectFilterContext} from '../list';
 import {
   SectionGroup,
   SectionHeader,
@@ -32,16 +32,15 @@ export function GridListSection({node, listState, size}: GridListSectionProps) {
   const titleId = domId('grid-section-title-');
   const {separatorProps} = useSeparator({elementType: 'li'});
 
-  const {filterOption} = useContext(SelectContext);
-  const filteredOptions = useMemo(() => {
-    return [...node.childNodes].filter(child => {
-      return filterOption(child.props);
-    });
-  }, [node.childNodes, filterOption]);
-
   const showToggleAllButton =
     listState.selectionManager.selectionMode === 'multiple' &&
     node.value.showToggleAllButton;
+
+  const hiddenOptions = useContext(SelectFilterContext);
+  const childNodes = useMemo(
+    () => [...node.childNodes].filter(child => !hiddenOptions.has(child.props.value)),
+    [node.childNodes, hiddenOptions]
+  );
 
   return (
     <Fragment>
@@ -63,7 +62,7 @@ export function GridListSection({node, listState, size}: GridListSectionProps) {
           </SectionHeader>
         )}
         <SectionGroup role="presentation">
-          {filteredOptions.map(child => (
+          {childNodes.map(child => (
             <GridListOption
               key={child.key}
               node={child}

--- a/static/app/components/compactSelect/index.spec.tsx
+++ b/static/app/components/compactSelect/index.spec.tsx
@@ -133,6 +133,45 @@ describe('CompactSelect', function () {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
+    it('can limit the number of options', async function () {
+      render(
+        <CompactSelect
+          sizeLimit={2}
+          sizeLimitMessage="Use search for more options…"
+          searchable
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+            {value: 'opt_three', label: 'Option Three'},
+          ]}
+        />
+      );
+
+      // click on the trigger button
+      await userEvent.click(screen.getByRole('button'));
+
+      // only the first two options should be visible due to `sizeLimit`
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'Option Three'})
+      ).not.toBeInTheDocument();
+
+      // there's a message prompting the user to use search to find more options
+      expect(screen.getByText('Use search for more options…')).toBeInTheDocument();
+
+      // Option Three is not reachable via keyboard, focus wraps back to Option One
+      await userEvent.keyboard(`{ArrowDown>2}`);
+      expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
+
+      // Option Three is still available via search
+      await userEvent.type(screen.getByPlaceholderText('Search…'), 'three');
+      expect(screen.getByRole('option', {name: 'Option Three'})).toBeInTheDocument();
+
+      // the size limit message is gone during search
+      expect(screen.queryByText('Use search for more options…')).not.toBeInTheDocument();
+    });
+
     it('can toggle sections', async function () {
       render(
         <CompactSelect
@@ -314,6 +353,44 @@ describe('CompactSelect', function () {
       // only Option Two should be available, Option One should be filtered out
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+    });
+
+    it('can limit the number of options', async function () {
+      render(
+        <CompactSelect
+          grid
+          sizeLimit={2}
+          sizeLimitMessage="Use search for more options…"
+          searchable
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+            {value: 'opt_three', label: 'Option Three'},
+          ]}
+        />
+      );
+
+      // click on the trigger button
+      await userEvent.click(screen.getByRole('button'));
+
+      // only the first two options should be visible due to `sizeLimit`
+      expect(screen.getByRole('row', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('row', {name: 'Option Three'})).not.toBeInTheDocument();
+
+      // there's a message prompting the user to use search to find more options
+      expect(screen.getByText('Use search for more options…')).toBeInTheDocument();
+
+      // Option Three is not reachable via keyboard, focus wraps back to Option One
+      await userEvent.keyboard(`{ArrowDown>2}`);
+      expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus();
+
+      // Option Three is still available via search
+      await userEvent.type(screen.getByPlaceholderText('Search…'), 'three');
+      expect(screen.getByRole('row', {name: 'Option Three'})).toBeInTheDocument();
+
+      // the size limit message is gone during search
+      expect(screen.queryByText('Use search for more options…')).not.toBeInTheDocument();
     });
 
     it('can toggle sections', async function () {

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -56,6 +56,8 @@ function CompactSelect<Value extends React.Key>({
   multiple,
   disallowEmptySelection,
   isOptionDisabled,
+  sizeLimit,
+  sizeLimitMessage,
 
   // Control props
   grid,
@@ -108,6 +110,8 @@ function CompactSelect<Value extends React.Key>({
         disallowEmptySelection={disallowEmptySelection}
         isOptionDisabled={isOptionDisabled}
         size={size}
+        sizeLimit={sizeLimit}
+        sizeLimitMessage={sizeLimitMessage}
         aria-labelledby={triggerId}
       >
         {(item: SelectOptionOrSection<Value>) => {

--- a/static/app/components/compactSelect/listBox/section.tsx
+++ b/static/app/components/compactSelect/listBox/section.tsx
@@ -6,7 +6,7 @@ import {Node} from '@react-types/shared';
 
 import {FormSize} from 'sentry/utils/theme';
 
-import {SelectContext} from '../control';
+import {SelectFilterContext} from '../list';
 import {
   SectionGroup,
   SectionHeader,
@@ -36,16 +36,15 @@ export function ListBoxSection({item, listState, size}: ListBoxSectionProps) {
 
   const {separatorProps} = useSeparator({elementType: 'li'});
 
-  const {filterOption} = useContext(SelectContext);
-  const filteredOptions = useMemo(() => {
-    return [...item.childNodes].filter(child => {
-      return filterOption(child.props);
-    });
-  }, [item.childNodes, filterOption]);
-
   const showToggleAllButton =
     listState.selectionManager.selectionMode === 'multiple' &&
     item.value.showToggleAllButton;
+
+  const hiddenOptions = useContext(SelectFilterContext);
+  const childItems = useMemo(
+    () => [...item.childNodes].filter(child => !hiddenOptions.has(child.props.value)),
+    [item.childNodes, hiddenOptions]
+  );
 
   return (
     <Fragment>
@@ -60,7 +59,7 @@ export function ListBoxSection({item, listState, size}: ListBoxSectionProps) {
           </SectionHeader>
         )}
         <SectionGroup {...groupProps}>
-          {filteredOptions.map(child => (
+          {childItems.map(child => (
             <ListBoxOption
               key={child.key}
               item={child}

--- a/static/app/components/compactSelect/styles.tsx
+++ b/static/app/components/compactSelect/styles.tsx
@@ -156,3 +156,15 @@ export const EmptyMessage = styled('p')`
     display: none;
   }
 `;
+
+export const SizeLimitMessage = styled('li')`
+  border-top: solid 1px ${p => p.theme.innerBorder};
+  margin: ${space(0.5)} ${space(1.5)} ${space(0.5)};
+  padding: ${space(0.75)} ${space(1)} 0;
+
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  list-style-type: none;
+  white-space: nowrap;
+  text-align: center;
+`;

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -35,8 +35,9 @@ export function getSelectedOptions<Value extends React.Key>(
 }
 
 /**
- * Recursively finds the selected option(s) from an options array. Useful for
- * non-flat arrays that contain sections (groups of options).
+ * Recursively finds the selected option(s) from an options array. Useful for non-flat
+ * arrays that contain sections (groups of options). Returns the values of options that
+ * were removed.
  */
 export function getDisabledOptions<Value extends React.Key>(
   items: SelectOptionOrSection<Value>[],
@@ -58,6 +59,88 @@ export function getDisabledOptions<Value extends React.Key>(
     }
     return acc;
   }, []);
+}
+
+/**
+ * Recursively finds the option(s) that don't match the designated search string or are
+ * outside the list box's count limit.
+ */
+export function getHiddenOptions<Value extends React.Key>(
+  items: SelectOptionOrSection<Value>[],
+  search: string,
+  limit: number = Infinity
+): Set<Value> {
+  //
+  // First, filter options using `search` value
+  //
+  const filterOption = (opt: SelectOption<Value>) =>
+    String(opt.label ?? '')
+      .toLowerCase()
+      .includes(search.toLowerCase());
+
+  const itemsToHide: Value[] = [];
+  const remainingItems = items
+    .map<SelectOptionOrSection<Value> | null>(item => {
+      if ('options' in item) {
+        const filteredOptions = item.options
+          .map(opt => {
+            if (filterOption(opt)) {
+              return opt;
+            }
+
+            itemsToHide.push(opt.value);
+            return null;
+          })
+          .filter((opt): opt is SelectOption<Value> => !!opt);
+
+        return filteredOptions.length > 0 ? {...item, options: filteredOptions} : null;
+      }
+
+      if (filterOption(item)) {
+        return item;
+      }
+
+      itemsToHide.push(item.value);
+      return null;
+    })
+    .flat()
+    .filter((item): item is SelectOptionOrSection<Value> => !!item);
+
+  //
+  // Then, limit the number of remaining options to `limit`
+  //
+  let threshold = [Infinity, Infinity];
+  let accumulator = 0;
+  let currentIndex = 0;
+
+  while (currentIndex < remainingItems.length) {
+    const item = remainingItems[currentIndex];
+    const delta = 'options' in item ? item.options.length : 1;
+
+    if (accumulator + delta > limit) {
+      threshold = [currentIndex, limit - accumulator];
+      break;
+    }
+
+    accumulator += delta;
+    currentIndex += 1;
+  }
+
+  // Return the values of options that were removed.
+  return new Set([
+    ...itemsToHide,
+    ...remainingItems.slice(threshold[0]).reduce((acc: Value[], cur, index) => {
+      if ('options' in cur) {
+        return acc.concat(
+          index === 0
+            ? cur.options.slice(threshold[1]).map(o => o.value)
+            : cur.options.map(o => o.value)
+        );
+      }
+
+      return acc.concat(cur.value);
+    }, []),
+  ]);
 }
 
 /**


### PR DESCRIPTION
Add a `sizeLimit` prop that when used will limit the number of options in the select menu to the specified number:
![image](https://user-images.githubusercontent.com/44172267/228912477-6d333a40-65d7-4381-af4d-1e7ad0187ef7.png)

The hidden options will still be available via search:
![image](https://user-images.githubusercontent.com/44172267/228912402-c1ceb5f6-add0-4839-92a6-8964cd910aa5.png)

This works well as a way to improve rendering performance and I don't expect it to impact the user experience, since when a list reaches a certain length, scrolling becomes an rather inefficient and effortful way to find options — users should (and do) use the search bar instead.