### PR TITLE
fix(hc): Handle null User.name values

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -208,6 +208,11 @@ def serialize_rpc_user(user: User) -> RpcUser:
     # And process the _base_query special data additions
     args["permissions"] = frozenset(getattr(user, "permissions", None) or ())
 
+    if args["name"] is None:
+        # This field is non-nullable according to the Django schema, but may be null
+        # on some servers due to migration history
+        args["name"] = ""
+
     roles: FrozenSet[str] = frozenset()
     if hasattr(user, "roles") and user.roles is not None:
         roles = frozenset(flatten(user.roles))


### PR DESCRIPTION
The field is declared in our Django model as

```python
    name = models.CharField(_("name"), max_length=200, blank=True, db_column="first_name")
```

which is supposed to imply being non-nullable (`blank=True` being represented by `""`).

Consistently with that, when I do `\d+ auth_user` on my dev environment, I get

```
        Column        |           Type           | Collation | Nullable |                Default                | Storage  | Stats target | Description 
----------------------+--------------------------+-----------+----------+---------------------------------------+----------+--------------+-------------
 first_name           | character varying(200)   |           | not null |                                       | extended |              | 
 ```

but on our production database,

```
SELECT *
FROM INFORMATION_SCHEMA.COLUMNS
WHERE TABLE_NAME = 'auth_user'
  AND COLUMN_NAME = 'first_name';
```

yields

<img width="861" alt="Screenshot 2023-03-30 at 9 55 13 AM" src="https://user-images.githubusercontent.com/26411900/228909665-ab8c8d63-0a9e-4071-bd13-4a6186917dec.png">

And there are indeed plenty of rows with a null value there.