### PR TITLE
feat(roles): Info tooltip for org-roles

### DIFF
--- a/static/app/components/orgRole.tsx
+++ b/static/app/components/orgRole.tsx
@@ -109,12 +109,8 @@ export const OrgRoleInfo = ({
 };
 
 const Wrapper = styled('span')`
-  display: inline;
-
-  > :last-child {
-    vertical-align: middle;
-    margin: 0 ${space(0.5)};
-  }
+  display: inline-flex;
+  gap: ${space(0.5)};
 `;
 
 const TooltipWrapper = styled('div')`

--- a/static/app/components/orgRole.tsx
+++ b/static/app/components/orgRole.tsx
@@ -4,9 +4,8 @@ import * as Sentry from '@sentry/react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconInfo} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Member, Organization} from 'sentry/types';
 import {getEffectiveOrgRole} from 'sentry/utils/orgRole';
@@ -44,7 +43,7 @@ export const OrgRoleInfo = ({
     return <Fragment>{t('Error Role')}</Fragment>;
   }
 
-  if (!orgRolesFromTeams || orgRolesFromTeams.length === 0) {
+  if (orgRolesFromTeams.length === 0) {
     return <Fragment>{orgRoleFromMember.name}</Fragment>;
   }
 
@@ -69,16 +68,16 @@ export const OrgRoleInfo = ({
     <TooltipWrapper>
       <div>{t('This user recieved org-level roles from several sources.')}</div>
 
-      <ListWrapper>
+      <div>
         <TeamRow>
           <TeamLink to={`${urlPrefix}member/${member.id}/`}>
             {t('User-specific')}
           </TeamLink>
           <div>: {orgRoleFromMember.name}</div>
         </TeamRow>
+      </div>
 
-        <br />
-
+      <div>
         <div>{t('Teams')}:</div>
         {orgRolesFromTeams
           .sort((a, b) => a.teamSlug.localeCompare(b.teamSlug))
@@ -88,7 +87,7 @@ export const OrgRoleInfo = ({
               <div>: {r.role.name}</div>
             </TeamRow>
           ))}
-      </ListWrapper>
+      </div>
 
       <div>
         {tct(
@@ -106,9 +105,7 @@ export const OrgRoleInfo = ({
   return (
     <Wrapper>
       {effectiveOrgRole.name}
-      <Tooltip isHoverable title={tooltipBody}>
-        <IconInfo />
-      </Tooltip>
+      <QuestionTooltip isHoverable size="sm" title={tooltipBody} />
     </Wrapper>
   );
 };
@@ -124,9 +121,6 @@ const TooltipWrapper = styled('div')`
   row-gap: ${space(1.5)};
   text-align: left;
   overflow: hidden;
-`;
-const ListWrapper = styled('div')`
-  display: block;
 `;
 
 const TeamRow = styled('div')`

--- a/static/app/components/orgRole.tsx
+++ b/static/app/components/orgRole.tsx
@@ -92,7 +92,12 @@ export const OrgRoleInfo = ({
 
       <div>
         {tct(
-          'Sentry will grant them permissions equivalent to the union-set of all their role. [docsLink:See docs here].', {docsLink:  <ExternalLink href="https://docs.sentry.io/product/accounts/membership/#roles" />}
+          'Sentry will grant them permissions equivalent to the union-set of all their role. [docsLink:See docs here].',
+          {
+            docsLink: (
+              <ExternalLink href="https://docs.sentry.io/product/accounts/membership/#roles" />
+            ),
+          }
         )}
       </div>
     </TooltipWrapper>

--- a/static/app/components/orgRole.tsx
+++ b/static/app/components/orgRole.tsx
@@ -1,0 +1,123 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconInfo} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Member, Organization} from 'sentry/types';
+import {sortOrgRoles} from 'sentry/utils/orgRole';
+
+export const OrgRoleInfo = ({
+  organization,
+  member,
+}: {
+  member: Member;
+  organization: Organization;
+}) => {
+  const {orgRoleList} = organization;
+  const {orgRole, orgRolesFromTeams} = member;
+
+  const orgRoleFromMember = orgRoleList.find(r => r.id === orgRole);
+  if (!orgRoleFromMember) {
+    throw new Error();
+  }
+
+  if (!orgRolesFromTeams || orgRolesFromTeams.length === 0) {
+    return <Fragment>{orgRoleFromMember.name}</Fragment>;
+  }
+
+  const topOrgRoleId = sortOrgRoles(
+    orgRolesFromTeams.map(r => r.role.id).concat([orgRoleFromMember.id]),
+    orgRoleList
+  )[0];
+  const topOrgRole = orgRoleList.find(r => r.id === topOrgRoleId);
+  if (!topOrgRole) {
+    throw new Error();
+  }
+
+  const urlPrefix = `/settings/${organization.slug}/`;
+
+  const node = (
+    <RoleTooltip>
+      <div>{t('This user recieved org-level roles from several sources.')}</div>
+
+      <ListWrapper>
+        <TeamRow>
+          <TeamLink to={`${urlPrefix}member/${member.id}/`}>
+            {t('User-specific')}
+          </TeamLink>
+          <div>: {orgRoleFromMember.name}</div>
+        </TeamRow>
+
+        <br />
+
+        <div>{t('Teams:')}</div>
+        {orgRolesFromTeams
+          .sort((a, b) => a.teamSlug.localeCompare(b.teamSlug))
+          .map(r => (
+            <TeamRow key={r.teamSlug}>
+              <TeamLink to={`${urlPrefix}teams/${r.teamSlug}/`}>#{r.teamSlug}</TeamLink>
+              <div>: {r.role.name}</div>
+            </TeamRow>
+          ))}
+      </ListWrapper>
+
+      <div>
+        {t(
+          'Sentry will grant them permissions equivalent to their highest org-level role.'
+        )}{' '}
+        <ExternalLink href="https://docs.sentry.io/product/accounts/membership/#roles">
+          See docs here
+        </ExternalLink>
+        .
+      </div>
+    </RoleTooltip>
+  );
+
+  return (
+    <Wrapper>
+      {topOrgRole.name}
+      <Tooltip isHoverable title={node}>
+        <IconInfo />
+      </Tooltip>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled('span')`
+  display: inline;
+
+  > :last-child {
+    vertical-align: middle;
+    margin: 0 ${space(0.5)};
+  }
+`;
+
+const RoleTooltip = styled('div')`
+  width: 200px;
+  display: grid;
+  row-gap: ${space(1.5)};
+  text-align: left;
+  overflow: hidden;
+`;
+const ListWrapper = styled('div')`
+  display: block;
+`;
+
+const TeamRow = styled('div')`
+  display: grid;
+  grid-template-columns: auto 1fr;
+
+  > * {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
+const TeamLink = styled(Link)`
+  max-width: 130px;
+  font-weight: 700;
+`;

--- a/static/app/components/orgRole.tsx
+++ b/static/app/components/orgRole.tsx
@@ -91,13 +91,9 @@ export const OrgRoleInfo = ({
       </ListWrapper>
 
       <div>
-        {t(
-          'Sentry will grant them permissions equivalent to the union-set of all their role.'
-        )}{' '}
-        <ExternalLink href="https://docs.sentry.io/product/accounts/membership/#roles">
-          {t('See docs here')}
-        </ExternalLink>
-        .
+        {tct(
+          'Sentry will grant them permissions equivalent to the union-set of all their role. [docsLink:See docs here].', {docsLink:  <ExternalLink href="https://docs.sentry.io/product/accounts/membership/#roles" />}
+        )}
       </div>
     </TooltipWrapper>
   );

--- a/static/app/components/orgRole.tsx
+++ b/static/app/components/orgRole.tsx
@@ -8,7 +8,7 @@ import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Member, Organization} from 'sentry/types';
-import {sortOrgRoles} from 'sentry/utils/orgRole';
+import {getEffectiveOrgRole} from 'sentry/utils/orgRole';
 
 export const OrgRoleInfo = ({
   organization,
@@ -29,19 +29,19 @@ export const OrgRoleInfo = ({
     return <Fragment>{orgRoleFromMember.name}</Fragment>;
   }
 
-  const topOrgRoleId = sortOrgRoles(
+  const effectiveOrgRoleId = getEffectiveOrgRole(
     orgRolesFromTeams.map(r => r.role.id).concat([orgRoleFromMember.id]),
     orgRoleList
-  )[0];
-  const topOrgRole = orgRoleList.find(r => r.id === topOrgRoleId);
-  if (!topOrgRole) {
+  );
+  const effectiveOrgRole = orgRoleList.find(r => r.id === effectiveOrgRoleId);
+  if (!effectiveOrgRole) {
     throw new Error();
   }
 
   const urlPrefix = `/settings/${organization.slug}/`;
 
   const node = (
-    <RoleTooltip>
+    <TooltipWrapper>
       <div>{t('This user recieved org-level roles from several sources.')}</div>
 
       <ListWrapper>
@@ -67,19 +67,19 @@ export const OrgRoleInfo = ({
 
       <div>
         {t(
-          'Sentry will grant them permissions equivalent to their highest org-level role.'
+          'Sentry will grant them permissions equivalent to the union-set of all their role.'
         )}{' '}
         <ExternalLink href="https://docs.sentry.io/product/accounts/membership/#roles">
           See docs here
         </ExternalLink>
         .
       </div>
-    </RoleTooltip>
+    </TooltipWrapper>
   );
 
   return (
     <Wrapper>
-      {topOrgRole.name}
+      {effectiveOrgRole.name}
       <Tooltip isHoverable title={node}>
         <IconInfo />
       </Tooltip>
@@ -96,7 +96,7 @@ const Wrapper = styled('span')`
   }
 `;
 
-const RoleTooltip = styled('div')`
+const TooltipWrapper = styled('div')`
   width: 200px;
   display: grid;
   row-gap: ${space(1.5)};


### PR DESCRIPTION
You can get org-roles from several sources so we need a common component to bring people into docs for a thorough explanation.

<img width="413" alt="Screenshot 2023-03-30 at 6 10 36 PM" src="https://user-images.githubusercontent.com/1748388/228998375-116c9e5f-bf35-4c01-8287-08131c563de1.png">
