### PR TITLE
feat(issue-details): Add max-width to event selector

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -271,6 +271,7 @@ const CarouselAndButtonsWrapper = styled('div')`
   display: flex;
   gap: ${space(1)};
   margin-bottom: ${space(0.5)};
+  max-width: 900px;
 `;
 
 const StyledButtonBar = styled(ButtonBar)`


### PR DESCRIPTION
This will made the event selector easier to use on wide screens.

Before:

![CleanShot 2023-03-30 at 11 57 53](https://user-images.githubusercontent.com/10888943/228937094-1d33f437-fe5c-4638-8370-959464c10335.png)


After:

![CleanShot 2023-03-30 at 11 57 37](https://user-images.githubusercontent.com/10888943/228937096-8cc68918-816c-48d7-aad9-e108c63a3f4f.png)
