### PR TITLE
fix(gcs): retry on 503s and GatewayTimeouts

### DIFF
--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -9,6 +9,7 @@ from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text, smart_str
+from google.api_core.exceptions import ServiceUnavailable
 from google.auth.exceptions import RefreshError, TransportError
 from google.cloud.exceptions import NotFound
 from google.cloud.storage.blob import Blob
@@ -56,7 +57,13 @@ def try_repeated(func):
             metrics_tags.update({"success": "1"})
             metrics.timing(metrics_key, idx, tags=metrics_tags)
             return result
-        except (DataCorruption, TransportError, RefreshError, RequestException) as e:
+        except (
+            DataCorruption,
+            TransportError,
+            RefreshError,
+            RequestException,
+            ServiceUnavailable,
+        ) as e:
             if idx >= GCS_RETRIES:
                 metrics_tags.update({"success": "0", "exception_class": e.__class__.__name__})
                 metrics.timing(metrics_key, idx, tags=metrics_tags)

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -9,7 +9,7 @@ from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text, smart_str
-from google.api_core.exceptions import ServiceUnavailable
+from google.api_core.exceptions import GatewayTimeout, ServiceUnavailable
 from google.auth.exceptions import RefreshError, TransportError
 from google.cloud.exceptions import NotFound
 from google.cloud.storage.blob import Blob
@@ -63,6 +63,7 @@ def try_repeated(func):
             RefreshError,
             RequestException,
             ServiceUnavailable,
+            GatewayTimeout,
         ) as e:
             if idx >= GCS_RETRIES:
                 metrics_tags.update({"success": "0", "exception_class": e.__class__.__name__})


### PR DESCRIPTION
adds the error thrown by a GCS 503 to our list of errors available for retry. Within gcs's internal retry logic, this error is eligible for retries, so should be fine. If we continue to see errors we may have to implement an exponential backoff

Should help with https://sentry.sentry.io/issues/4031481406/?project=-1&query=is%3Aunresolved+assigned_or_suggested%3A%5Bme%5D&referrer=issue-stream&stream_index=2


edit: also adding GatewayTimeout. should help with https://sentry.sentry.io/issues/4036100292/?project=-1&query=is%3Aunresolved+assigned_or_suggested%3A%5Bme%5D&referrer=issue-stream&stream_index=10
