### PR TITLE
feat(issue-details): Add 'View Full Trace' to right of trace navigator

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -1,4 +1,3 @@
-import {useContext} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
@@ -8,7 +7,6 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Clipboard from 'sentry/components/clipboard';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
 import {
@@ -24,7 +22,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Group} from 'sentry/types';
 import {defined, formatBytesBase2} from 'sentry/utils';
-import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {eventDetailsRoute, generateEventSlug} from 'sentry/utils/discover/urls';
 import {
@@ -33,7 +30,6 @@ import {
   getShortEventId,
 } from 'sentry/utils/events';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -91,8 +87,6 @@ export const GroupEventCarousel = ({
       group_id: parseInt(`${event.groupID}`, 10),
     });
   };
-
-  const quickTrace = useContext(QuickTraceContext);
 
   return (
     <CarouselAndButtonsWrapper>
@@ -224,24 +218,6 @@ export const GroupEventCarousel = ({
                 organization,
                 ...getAnalyticsDataForGroup(group),
                 ...getAnalyticsDataForEvent(event),
-              });
-            },
-          },
-          {
-            key: 'full-trace',
-            label: t('View Full Trace'),
-            hidden:
-              !defined(quickTrace) ||
-              defined(quickTrace.error) ||
-              quickTrace.isLoading ||
-              quickTrace.type === 'empty',
-            to: generateTraceTarget(event, organization),
-            onAction: () => {
-              trackAnalyticsEvent({
-                eventKey: 'quick_trace.trace_id.clicked',
-                eventName: 'Quick Trace: Trace ID clicked',
-                organization_id: parseInt(organization.id, 10),
-                source: 'issues',
               });
             },
           },

--- a/static/app/views/issueDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/issueDetails/quickTrace/issueQuickTrace.tsx
@@ -33,8 +33,10 @@ type Props = {
 
 function TransactionMissingPlaceholder({
   type,
+  event,
   group,
 }: {
+  event: Event;
   group: Group;
   type?: QuickTraceQueryChildrenProps['type'];
 }) {
@@ -49,32 +51,33 @@ function TransactionMissingPlaceholder({
 
   return (
     <QuickTraceWrapper>
-      <Tooltip
-        isHoverable
-        position="bottom"
-        title={tct(
-          'The [type] for this event cannot be found. [link:Read the  docs] to understand why.',
-          {
-            type: type === 'missing' ? t('transaction') : t('trace'),
-            link: (
-              <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#troubleshooting" />
-            ),
-          }
-        )}
-      >
-        <QuickTraceContainer data-test-id="missing-trace-placeholder">
+      <QuickTraceContainer data-test-id="missing-trace-placeholder">
+        <Tooltip
+          isHoverable
+          position="bottom"
+          title={tct(
+            'The [type] for this event cannot be found. [link:Read the  docs] to understand why.',
+            {
+              type: type === 'missing' ? t('transaction') : t('trace'),
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#troubleshooting" />
+              ),
+            }
+          )}
+        >
           <EventNode type="white" icon={null}>
             ???
           </EventNode>
-          <TraceConnector />
-          <EventNode type="error" data-test-id="event-node">
-            <ErrorNodeContent>
-              <IconFire size="xs" />
-              {t('This Event')}
-            </ErrorNodeContent>
-          </EventNode>
-        </QuickTraceContainer>
-      </Tooltip>
+        </Tooltip>
+        <TraceConnector />
+        <EventNode type="error" data-test-id="event-node">
+          <ErrorNodeContent>
+            <IconFire size="xs" />
+            {t('This Event')}
+          </ErrorNodeContent>
+        </EventNode>
+        <TraceLink event={event} />
+      </QuickTraceContainer>
     </QuickTraceWrapper>
   );
 }
@@ -86,7 +89,13 @@ function IssueQuickTrace({group, event, location, organization, quickTrace}: Pro
     !defined(quickTrace.trace) ||
     quickTrace.trace.length === 0
   ) {
-    return <TransactionMissingPlaceholder group={group} type={quickTrace?.type} />;
+    return (
+      <TransactionMissingPlaceholder
+        event={event}
+        group={group}
+        type={quickTrace?.type}
+      />
+    );
   }
 
   trackAdvancedAnalyticsEvent('issue.quick_trace_status', {

--- a/static/app/views/issueDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/issueDetails/quickTrace/issueQuickTrace.tsx
@@ -13,6 +13,7 @@ import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {QuickTraceQueryChildrenProps} from 'sentry/utils/performance/quickTrace/types';
+import {TraceLink} from 'sentry/views/issueDetails/quickTrace/traceLink';
 import usePromptCheck from 'sentry/views/issueDetails/quickTrace/usePromptCheck';
 
 type Props = {
@@ -98,12 +99,16 @@ function IssueQuickTrace({
           errorDest="issue"
           transactionDest="performance"
         />
+        <TraceLink event={event} />
       </QuickTraceWrapper>
     </ErrorBoundary>
   );
 }
 
 const QuickTraceWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   margin-top: ${space(0.5)};
 `;
 

--- a/static/app/views/issueDetails/quickTrace/traceLink.tsx
+++ b/static/app/views/issueDetails/quickTrace/traceLink.tsx
@@ -35,26 +35,12 @@ export function TraceLink({event}: TraceLinkProps) {
     return null;
   }
   return (
-    <LinkContainer>
-      <Link to={generateTraceTarget(event, organization)} onClick={handleTraceLink}>
-        {t('View Full Trace')}
-      </Link>
-    </LinkContainer>
+    <StyledLink to={generateTraceTarget(event, organization)} onClick={handleTraceLink}>
+      {t('View Full Trace')}
+    </StyledLink>
   );
 }
 
-const LinkContainer = styled('span')`
+const StyledLink = styled(Link)`
   margin-left: ${space(1)};
-  padding-left: ${space(1)};
-  position: relative;
-
-  &:before {
-    display: block;
-    position: absolute;
-    content: '';
-    left: 0;
-    top: 2px;
-    height: 14px;
-    border-left: 1px solid ${p => p.theme.border};
-  }
 `;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/46560

Removes "View Full Trace" from the overflow menu and adds it as a link to the right of the trace navigator.

![CleanShot 2023-03-30 at 13 21 01](https://user-images.githubusercontent.com/10888943/228955144-a485bcf7-d332-4338-a00d-d40a3cbe0fc3.png)