### PR TITLE
fix(quick-trace): Set height to 20px to match the placeholder

### DIFF
--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -45,6 +45,7 @@ const nodeColors = (theme: Theme) => ({
 });
 
 export const EventNode = styled(Tag)`
+  height: 20px;
   span {
     display: flex;
     color: ${p => nodeColors(p.theme)[p.type || 'white'].color};

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -79,7 +79,7 @@ export default function QuickTraceMeta({
     footer = <ExternalLink href={docsLink}>{t('Read the docs')}</ExternalLink>;
   } else {
     if (quickTrace.isLoading) {
-      body = <Placeholder height="24px" />;
+      body = <Placeholder height="20px" />;
     } else if (quickTrace.error) {
       body = '\u2014';
     } else {


### PR DESCRIPTION
Very subtle change, but the height of the "This Event" node was slightly more than 20px which caused everything to shift when loaded because it did not match the placeholder height.

![CleanShot 2023-03-30 at 13 31 43](https://user-images.githubusercontent.com/10888943/228957692-258c4fbe-7ef2-452e-966e-695fbeb4567a.png)
