### PR TITLE
fix(gitlab): Use blame even for non-UTC timezones

### DIFF
--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -421,6 +421,8 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         assert commit_context == commit_context_expected
 
+        # We are now going to test the case where the Gitlab instance will return a non-UTC committed_data
+        # This 2015-12-18T11:12:22.000+03:00 vs 2015-10-03T09:34:32.000Z
         event_frame["lineno"] = 31
         responses.add(
             responses.GET,
@@ -443,6 +445,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             ],
         )
         commit_context = installation.get_commit_context(repo, filepath, ref, event_frame)
+        # The returned commit context has converted the timezone to UTC (000Z)
         assert commit_context == commit_context_expected
 
 

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -359,10 +359,11 @@ class GitlabIntegrationTest(IntegrationTestCase):
             "lineno": 30,
             "filename": "sentry/tasks.py",
         }
+        url = "https://gitlab.example.com/api/v4/projects/{id}/repository/files/{path}/blame?ref={ref}&range%5Bstart%5D={line}&range%5Bend%5D={line}"
 
         responses.add(
             responses.GET,
-            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{encoded_filepath}/blame?ref={ref}&range%5Bstart%5D=30&range%5Bend%5D=30",
+            url.format(id=external_id, path=encoded_filepath, ref=ref, line=event_frame["lineno"]),
             json=[
                 {
                     "commit": {
@@ -410,13 +411,39 @@ class GitlabIntegrationTest(IntegrationTestCase):
         )
         commit_context = installation.get_commit_context(repo, filepath, ref, event_frame)
 
-        assert commit_context == {
+        commit_context_expected = {
             "commitId": "d42409d56517157c48bf3bd97d3f75974dde19fb",
             "committedDate": "2015-12-18T08:12:22.000Z",
             "commitMessage": "Add installation instructions",
             "commitAuthorName": "Nisanthan Nanthakumar",
             "commitAuthorEmail": "nisanthan.nanthakumar@sentry.io",
         }
+
+        assert commit_context == commit_context_expected
+
+        event_frame["lineno"] = 31
+        responses.add(
+            responses.GET,
+            url.format(id=external_id, path=encoded_filepath, ref=ref, line=event_frame["lineno"]),
+            json=[
+                {
+                    "commit": {
+                        "id": "d42409d56517157c48bf3bd97d3f75974dde19fb",
+                        "message": "Add installation instructions",
+                        "parent_ids": ["cc6e14f9328fa6d7b5a0d3c30dc2002a3f2a3822"],
+                        "authored_date": "2015-12-18T11:12:22.000+03:00",
+                        "author_name": "Nisanthan Nanthakumar",
+                        "author_email": "nisanthan.nanthakumar@sentry.io",
+                        "committed_date": "2015-12-18T11:12:22.000+03:00",
+                        "committer_name": "Nisanthan Nanthakumar",
+                        "committer_email": "nisanthan.nanthakumar@sentry.io",
+                    },
+                    "lines": ["## Docs"],
+                },
+            ],
+        )
+        commit_context = installation.get_commit_context(repo, filepath, ref, event_frame)
+        assert commit_context == commit_context_expected
 
 
 class GitlabIntegrationInstanceTest(IntegrationTestCase):


### PR DESCRIPTION
This commit aims to allow usages of file blame information from Gitlab instances that return dates with non-UTC timezones.

Previously, the "2015-10-03T09:34:32.000Z" date was allowed, but not the "2015-12-18T11:12:22.000+03:00".

The output timezone and format are preserved – still UTC.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
