### PR TITLE
fix(suspect-commits): Add logging to debug suspect commits

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -162,6 +162,7 @@ def process_commit_context(
                     extra={
                         **basic_logging_details,
                         "reason": "could_not_fetch_commit_context",
+                        "code_mappings_count": len(code_mappings),
                     },
                 )
                 return


### PR DESCRIPTION
Add logging to debug missing suspect commits with `could_not_fetch_commit_context` errors.

WOR-2865