### PR TITLE
fix(sourcemaps): Add error when fetching is disabled

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -1173,8 +1173,12 @@ class Fetcher:
         cache_key = f"source:cache:v4:{md5_text(url).hexdigest()}"
 
         if result is None:
-            if not self.allow_scraping or not url.startswith(("http:", "https:")):
+            if not url.startswith(("http:", "https:")):
                 error = {"type": EventError.JS_MISSING_SOURCE, "url": http.expose_url(url)}
+                raise http.CannotFetch(error)
+
+            if not self.allow_scraping:
+                error = {"type": EventError.JS_SCRAPING_DISABLED, "url": http.expose_url(url)}
                 raise http.CannotFetch(error)
 
             logger.debug("Checking cache for url %r", url)

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -35,6 +35,7 @@ class EventError:
     JS_TOO_LARGE = "js_too_large"  # deprecated in favor of FETCH_TOO_LARGE
     JS_FETCH_TIMEOUT = "js_fetch_timeout"  # deprecated in favor of FETCH_TIMEOUT
     JS_MISSING_SOURCES_CONTENT = "js_missing_sources_content"
+    JS_SCRAPING_DISABLED = "js_scraping_disabled"
 
     # Processing: Native
     NATIVE_NO_CRASHED_THREAD = "native_no_crashed_thread"

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -1631,6 +1631,42 @@ class TestJavascriptIntegration(RelayStoreHelper):
 
         assert "errors" not in event.data
 
+    def test_expansion_with_allow_scraping_false(self):
+        project = self.project
+        project.organization.update_option("sentry:scrape_javascript", False)
+
+        data = {
+            "timestamp": self.min_ago,
+            "message": "hello",
+            "platform": "javascript",
+            "release": "1.0",
+            "exception": {
+                "values": [
+                    {
+                        "type": "Error",
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "http://example.com/file.min.js",
+                                    "filename": "file.min.js",
+                                    "lineno": 1,
+                                    "colno": 39,
+                                },
+                            ]
+                        },
+                    }
+                ]
+            },
+        }
+
+        event = self.post_and_retrieve_event(data)
+
+        assert len(event.data["errors"]) == 1
+        assert event.data["errors"][0] == {
+            "type": "js_scraping_disabled",
+            "url": "http://example.com/file.min.js",
+        }
+
     def test_expansion_with_debug_id(self):
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")


### PR DESCRIPTION
This PR adds a new error type for the processing which communicates whether `allow_scraping` is set to false and you have an `http(s)` URL to fetch.