### PR TITLE
feat(chunk-upload): Decouple feature flag from chunk upload options

### DIFF
--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -55,11 +55,12 @@ class ChunkUploadTest(APITestCase):
             )
             assert "artifact_bundles" not in response.data["accept"]
 
+        # This currently should not flip the flag!
         with self.feature({"organizations:artifact-bundles": True}):
             response = self.client.get(
                 self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
             )
-            assert "artifact_bundles" in response.data["accept"]
+            assert "artifact_bundles" not in response.data["accept"]
 
     def test_relative_url_support(self):
         # Starting `sentry-cli@1.70.1` we added a support for relative chunk-uploads urls


### PR DESCRIPTION
Previously the `organizations:artifact-bundles` feature flag also controlled the chunk upload. We want to now only use this feature flag for the UI experience, and control the upload behavior explicitly via a flag in sentry-cli.