### PR TITLE
fix(dynamic-sampling) Run prioritise transactions task every 5 minutes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -896,7 +896,7 @@ CELERYBEAT_SCHEDULE = {
     "dynamic-sampling-prioritize-transactions": {
         "task": "sentry.dynamic_sampling.tasks.prioritise_transactions",
         # Run every 5 minutes
-        "schedule": timedelta(minutes=5),
+        "schedule": timedelta(minutes=6),
     },
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -895,8 +895,8 @@ CELERYBEAT_SCHEDULE = {
     },
     "dynamic-sampling-prioritize-transactions": {
         "task": "sentry.dynamic_sampling.tasks.prioritise_transactions",
-        # Run job every hour at min 10
-        "schedule": crontab(minute=10),
+        # Run every 5 minutes
+        "schedule": timedelta(minutes=5),
     },
 }
 


### PR DESCRIPTION
This PR sets the prioritise transactions task to run every 6 minutes.