### PR TITLE
ref(rect): dont throw if matrix is null

### DIFF
--- a/static/app/utils/profiling/speedscope.tsx
+++ b/static/app/utils/profiling/speedscope.tsx
@@ -195,7 +195,11 @@ export class Rect {
     return this.overlapsX(other) && this.overlapsY(other);
   }
 
-  transformRect(transform: mat3 | Readonly<mat3>): Rect {
+  transformRect(transform: mat3 | Readonly<mat3> | null): Rect {
+    if (!transform) {
+      return this.clone();
+    }
+
     const x = this.x * transform[0] + this.y * transform[3] + transform[6];
     const y = this.x * transform[1] + this.y * transform[4] + transform[7];
     const width = this.width * transform[0] + this.height * transform[3];


### PR DESCRIPTION
I set the canvas so 0 width and height which reproduced the crash, after this fix everything worked, except profile GL code did not render anything which is expected, but the rest of the UI did not break