### PR TITLE
fix(config) Accept more flavours of booleans

### DIFF
--- a/src/sentry/utils/types.py
+++ b/src/sentry/utils/types.py
@@ -69,9 +69,9 @@ class BoolType(Type):
         if isinstance(value, int):
             return bool(value)
         value = value.lower()
-        if value in ("y", "yes", "t", "true", "1", "on"):
+        if value in ("y", "yes", "t", "true", "True", "1", "on"):
             return True
-        if value in ("n", "no", "f", "false", "0", "off"):
+        if value in ("n", "no", "f", "false", "False", "0", "off"):
             return False
 
 

--- a/tests/sentry/utils/test_types.py
+++ b/tests/sentry/utils/test_types.py
@@ -22,6 +22,7 @@ class OptionsTypesTest(TestCase):
         assert Bool("YES") is True
         assert Bool("t") is True
         assert Bool("true") is True
+        assert Bool("True") is True
         assert Bool("1") is True
         assert Bool("on") is True
         assert Bool(False) is False
@@ -30,6 +31,7 @@ class OptionsTypesTest(TestCase):
         assert Bool("NO") is False
         assert Bool("f") is False
         assert Bool("false") is False
+        assert Bool("False") is False
         assert Bool("0") is False
         assert Bool("off") is False
         assert Bool() is False


### PR DESCRIPTION
Also accept the native string cast of python booleans. We sometimes use jinja's `|string` on boolean values when configuring the application. Currently this results in values being true (even when the config management value is false). Accepting string versions of python booleans lets us get what we want with less fuss.