### PR TITLE
fix(profiling): fix edge case for node profiling highlight

### DIFF
--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -521,9 +521,14 @@ export function computeConfigViewWithStrategy(
 }
 
 export function computeMinZoomConfigViewForFrames(view: Rect, frames: Rect[]): Rect {
+  if (!frames.length) {
+    return view;
+  }
+
   if (frames.length === 1) {
     return new Rect(frames[0].x, frames[0].y, frames[0].width, view.height);
   }
+
   const frame = frames.reduce(
     (min, f) => {
       return {


### PR DESCRIPTION
search returned 0 frames, which ended up setting X and Y to Number.MAX_SAFE_INTEGER