### PR TITLE
fix(monitors): Returns monitor envs when no env is selected

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitors.py
+++ b/src/sentry/monitors/endpoints/organization_monitors.py
@@ -7,7 +7,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.db.models.query import in_iexact
-from sentry.models import Organization, Project
+from sentry.models import Environment, Organization, Project
 from sentry.monitors.models import Monitor, MonitorStatus, MonitorType
 from sentry.monitors.serializers import MonitorSerializer
 from sentry.monitors.validators import MonitorValidator
@@ -80,6 +80,8 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
                 )
             else:
                 queryset = queryset.filter(monitorenvironment__environment__in=environments)
+        else:
+            environments = list(Environment.objects.filter(organization_id=organization.id))
 
         if query:
             tokens = tokenize_query(query)

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -59,12 +59,14 @@ class MonitorSerializer(Serializer):
                     )
                 )
 
-            environment_data = {str(item.id): monitor_environments[item.id] for item in item_list}
+            environment_data = {
+                str(item.id): monitor_environments.get(item.id, []) for item in item_list
+            }
 
         return {
             item: {
                 "project": projects[str(item.project_id)] if item.project_id else None,
-                "environments": environment_data[str(item.id)] if self.environments else None,
+                "environments": environment_data[str(item.id)] if self.environments else [],
             }
             for item in item_list
         }

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -67,13 +67,15 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         )
 
     def test_all_monitor_environments(self):
-        monitor = self._create_monitor()
+        monitor = self._create_monitor(status=MonitorStatus.OK)
         monitor_environment = self._create_monitor_environment(monitor, name="test")
 
+        monitor_empty = self._create_monitor(name="empty")
+
         response = self.get_success_response(self.organization.slug)
-        self.check_valid_response(response, [monitor])
-        for monitor in response.data:
-            self.check_valid_environments_response(response, monitor, [monitor_environment])
+        self.check_valid_response(response, [monitor, monitor_empty])
+        self.check_valid_environments_response(response, response.data[0], [monitor_environment])
+        self.check_valid_environments_response(response, response.data[1], [])
 
     def test_monitor_environment(self):
         monitor = self._create_monitor()

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -21,6 +21,14 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
             monitor_resp["slug"] for monitor_resp in response.data
         ]
 
+    def check_valid_environments_response(self, response, monitor, expected_environments):
+        assert {
+            monitor_environment.environment.name for monitor_environment in expected_environments
+        } == {
+            monitor_environment_resp["name"]
+            for monitor_environment_resp in monitor.get("environments", [])
+        }
+
     def test_simple(self):
         monitor = self._create_monitor()
         response = self.get_success_response(self.organization.slug)
@@ -57,6 +65,15 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
                 monitor_disabled,
             ],
         )
+
+    def test_all_monitor_environments(self):
+        monitor = self._create_monitor()
+        monitor_environment = self._create_monitor_environment(monitor, name="test")
+
+        response = self.get_success_response(self.organization.slug)
+        self.check_valid_response(response, [monitor])
+        for monitor in response.data:
+            self.check_valid_environments_response(response, monitor, [monitor_environment])
 
     def test_monitor_environment(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
Returns all `MonitorEnvironment` data when no environment is selected on the `Monitors` page
<img width="1497" alt="image" src="https://user-images.githubusercontent.com/7078270/229183266-3733e12d-7ad6-40d0-a759-fb1fc068dae1.png">