### PR TITLE
feat(issue-details): Use absolute date for event selector

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -6,8 +6,8 @@ import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Clipboard from 'sentry/components/clipboard';
+import DateTime from 'sentry/components/dateTime';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
 import {
   IconChevron,
@@ -138,13 +138,11 @@ export const GroupEventCarousel = ({
             {(event.dateCreated ?? event.dateReceived) && (
               <EventTimeLabel>
                 {getDynamicText({
-                  fixed: '1d ago',
+                  fixed: 'Jan 1, 12:00 AM',
                   value: (
-                    <TimeSince
-                      date={event.dateCreated ?? event.dateReceived}
-                      tooltipBody={<EventCreatedTooltip event={event} />}
-                      unitStyle="short"
-                    />
+                    <Tooltip showUnderline title={<EventCreatedTooltip event={event} />}>
+                      <DateTime date={event.dateCreated ?? event.dateReceived} />
+                    </Tooltip>
                   ),
                 })}
                 {isOverLatencyThreshold && (


### PR DESCRIPTION
After receiving feedback we are switching back to an absolute date in the event selector (although still more condensed than it was to begin with)

Before:

![CleanShot 2023-03-31 at 11 13 24](https://user-images.githubusercontent.com/10888943/229198079-053d8665-b2ca-4ba2-857e-685eeb6a6c02.png)

After:

![CleanShot 2023-03-31 at 11 12 19](https://user-images.githubusercontent.com/10888943/229197926-2b8f4ac5-71ca-47ca-98de-7bb5c3dfbf3c.png)
