### PR TITLE
fix(features) Add feature implementation for organizations:create

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -57,7 +57,7 @@ default_manager = FeatureManager()  # NOQA
 # No formatting so that we can keep them as single lines
 # fmt: off
 
-# Unscoped features
+# Features that don't use resource scoping
 default_manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -4,6 +4,7 @@ from .base import (  # NOQA
     OrganizationFeature,
     ProjectFeature,
     ProjectPluginFeature,
+    SystemFeature,
     UserFeature,
 )
 from .handler import *  # NOQA
@@ -57,8 +58,8 @@ default_manager = FeatureManager()  # NOQA
 # fmt: off
 
 # Unscoped features
-default_manager.add("auth:register")
-default_manager.add("organizations:create")
+default_manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:javascript-console-error-tag", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/features/base.py
+++ b/src/sentry/features/base.py
@@ -30,8 +30,18 @@ class Feature:
         self.name = name
 
     @abc.abstractmethod
-    def get_subject(self) -> User | Organization:
+    def get_subject(self) -> User | Organization | None:
         raise NotImplementedError
+
+
+class SystemFeature(Feature):
+    """
+    System feature flags don't have user/project/organization and are
+    based on how the application is configured instead.
+    """
+
+    def get_subject(self) -> None:
+        return None
 
 
 class OrganizationFeature(Feature):


### PR DESCRIPTION
Previously the `organizations:create` feature flag was turned off via SENTRY_FEATURES. However, because of how getsentry, featureflags
+ singletenant interact we need to have a FeatureHandler for `organizations:create` which results in a `NotImplementedError` when the feature flag is checked as a subject does not exist. By having a `SystemFeature` implementation we can avoid that error.

Fixes SENTRY-FOR-SENTRY-1R4