### PR TITLE
feat: render n collapsed frames

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -11,7 +11,10 @@ import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {
+  FlamegraphFrame,
+  getFlamegraphFrameDisplayName,
+} from 'sentry/utils/profiling/flamegraphFrame';
 import {formatColorForFrame} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {Rect} from 'sentry/utils/profiling/speedscope';
@@ -75,7 +78,7 @@ export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
           props.frame.node,
           props.flamegraphRenderer.flamegraph
         )}{' '}
-        {props.frame.frame.name}
+        {getFlamegraphFrameDisplayName(props.frame)}
       </FlamegraphTooltipFrameMainInfo>
       <FlamegraphTooltipTimelineInfo>
         {defined(props.frame.frame.file) && (

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -1,3 +1,5 @@
+import {t} from 'sentry/locale';
+
 import {CallTreeNode} from './callTreeNode';
 import {Frame} from './frame';
 
@@ -14,6 +16,14 @@ export interface FlamegraphFrame {
   processId?: number;
   profileIds?: string[];
   threadId?: number;
+}
+
+export function getFlamegraphFrameDisplayName(frame: FlamegraphFrame) {
+  if (frame.collapsed && frame.collapsed.length > 0) {
+    return t('%s collapsed frames', frame.collapsed.length);
+  }
+
+  return frame.frame.name;
 }
 
 export function getFlamegraphFrameSearchId(frame: FlamegraphFrame) {

--- a/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphTextRenderer.tsx
@@ -13,7 +13,11 @@ import {TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
 
 import {Flamegraph} from '../flamegraph';
 import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
-import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
+import {
+  FlamegraphFrame,
+  getFlamegraphFrameDisplayName,
+  getFlamegraphFrameSearchId,
+} from '../flamegraphFrame';
 import {findRangeBinarySearch, Rect, trimTextCenter} from '../speedscope';
 
 class FlamegraphTextRenderer extends TextRenderer {
@@ -129,11 +133,13 @@ class FlamegraphTextRenderer extends TextRenderer {
       const y = frameY + (frameHeight < 0 ? frameHeight : 0) + BASELINE_OFFSET;
       const x = frameX + (frameWidth < 0 ? frameWidth : 0) + HALF_SIDE_PADDING;
 
+      const frameName = getFlamegraphFrameDisplayName(frame);
+
       const trim = trimTextCenter(
-        frame.frame.name,
+        frameName,
         findRangeBinarySearch(
           {low: 0, high: paddedRectangleWidth},
-          n => this.measureAndCacheText(frame.frame.name.substring(0, n)).width,
+          n => this.measureAndCacheText(frameName.substring(0, n)).width,
           paddedRectangleWidth
         )[0]
       );


### PR DESCRIPTION
## Summary
I think theres alot of opportunity to make this better, but this is the keep it simple version. - Important to note that if there aren't any collapsed frames it will render the actual frame name, see below.


![image](https://user-images.githubusercontent.com/7349258/229205459-4965ff52-5797-4d23-a6d8-602424ceaf52.png)
![image](https://user-images.githubusercontent.com/7349258/229205504-0a257170-2a56-4d20-99e2-26df7a9c8780.png)
