### PR TITLE
feat(replay): Use `<ObjectInspector>` for DOM Mutations

### DIFF
--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {
   chromeDark,
   chromeLight,
-  ObjectInspector as OrigObjectInspector,
+  Inspector as OrigObjectInspector,
 } from '@sentry-internal/react-inspector';
 
 import {Button} from 'sentry/components/button';
@@ -42,7 +42,7 @@ function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props)
       OBJECT_PREVIEW_OBJECT_MAX_PROPERTIES: 1,
       ...theme,
     }),
-    [isDark, theme, emotionTheme.red400, emotionTheme.text]
+    [isDark, theme, emotionTheme.red400, emotionTheme.text.familyMono]
   );
 
   const [tooltipState, setTooltipState] = useState<'copy' | 'copied' | 'error'>('copy');

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, MouseEvent, useCallback, useMemo} from 'react';
+import {CSSProperties, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import beautify from 'js-beautify';
@@ -13,18 +13,15 @@ import type {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml'
 import IconWrapper from 'sentry/views/replays/detail/iconWrapper';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
+import {OnDimensionChange} from '../useVirtualizedInspector';
+
 type Props = {
   currentHoverTime: number | undefined;
   currentTime: number;
   expandPaths: string[];
   index: number;
   mutation: Extraction;
-  onDimensionChange: (
-    index: number,
-    path: string,
-    expandedState: Record<string, boolean>,
-    event: MouseEvent<HTMLDivElement>
-  ) => void;
+  onDimensionChange: OnDimensionChange;
   startTimestampMs: number;
   style: CSSProperties;
 };
@@ -63,7 +60,7 @@ function DomMutationRow({
   );
   const hasOccurred = currentTime >= crumbTime;
   const isBeforeHover = currentHoverTime === undefined || currentHoverTime >= crumbTime;
-  const handleDimensionChange = useCallback(
+  const handleExpand = useCallback(
     (path, expandedState, e) =>
       onDimensionChange && onDimensionChange(index, path, expandedState, e),
     [index, onDimensionChange]
@@ -100,7 +97,7 @@ function DomMutationRow({
           <ObjectInspector
             data={html}
             expandPaths={expandPaths}
-            onExpand={handleDimensionChange}
+            onExpand={handleExpand}
           />
         </CodeContainer>
       </List>

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -1,7 +1,6 @@
 import {CSSProperties, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import beautify from 'js-beautify';
 
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
 import ObjectInspector from 'sentry/components/objectInspector';
@@ -96,6 +95,7 @@ function DomMutationRow({
         <CodeContainer>
           <ObjectInspector
             data={html}
+            expandLevel={1}
             expandPaths={expandPaths}
             onExpand={handleExpand}
           />

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -19,6 +19,8 @@ import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import TabItemContainer from 'sentry/views/replays/detail/tabItemContainer';
 import useVirtualizedList from 'sentry/views/replays/detail/useVirtualizedList';
 
+import useVirtualizedInspector from '../useVirtualizedInspector';
+
 type Props = {
   replay: null | ReplayReader;
   startTimestampMs: number;
@@ -36,7 +38,7 @@ function DomMutations({replay, startTimestampMs}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
 
   const filterProps = useDomFilters({actions: actions || []});
-  const {items, setSearchTerm} = filterProps;
+  const {items, setSearchTerm, expandPathsRef} = filterProps;
   const clearSearchTerm = () => setSearchTerm('');
 
   const listRef = useRef<ReactVirtualizedList>(null);
@@ -46,6 +48,12 @@ function DomMutations({replay, startTimestampMs}: Props) {
     cellMeasurer,
     ref: listRef,
     deps,
+  });
+
+  const {handleDimensionChange} = useVirtualizedInspector({
+    cache,
+    listRef,
+    expandPathsRef,
   });
 
   const renderRow = ({index, key, style, parent}: ListRowProps) => {
@@ -60,11 +68,14 @@ function DomMutations({replay, startTimestampMs}: Props) {
         rowIndex={index}
       >
         <DomMutationRow
+          index={index}
           currentTime={currentTime}
           currentHoverTime={currentHoverTime}
           mutation={mutation}
           startTimestampMs={startTimestampMs}
           style={style}
+          expandPaths={Array.from(expandPathsRef.current?.get(index) || [])}
+          onDimensionChange={handleDimensionChange}
         />
       </CellMeasurer>
     );

--- a/static/app/views/replays/detail/domMutations/useDomFilters.spec.tsx
+++ b/static/app/views/replays/detail/domMutations/useDomFilters.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {INode} from '@sentry-internal/rrweb-snapshot';
 import type {Location} from 'history';
 
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
@@ -17,6 +18,15 @@ const mockBrowserHistoryPush = browserHistory.push as jest.MockedFunction<
   typeof browserHistory.push
 >;
 
+// Attempt to parse an html string to a DOM node
+//
+// Note this is not an `INode`, because there's no serialization information,
+// but it should not affect this current suite of tests for now
+function parseHtml(html: string) {
+  return new DOMParser().parseFromString(html, 'text/html').body
+    .childNodes[0] as unknown as INode;
+}
+
 const ACTION_1_DEBUG = {
   crumb: {
     type: BreadcrumbType.DEBUG,
@@ -34,7 +44,9 @@ const ACTION_1_DEBUG = {
     color: 'purple300',
     description: 'Debug',
   },
-  html: '<div class="css-vruter e1weinmj3">HTTP 400 (invalid_grant): The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.</div>',
+  html: parseHtml(
+    '<div class="css-vruter e1weinmj3">HTTP 400 (invalid_grant): The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.</div>'
+  ),
   timestamp: 1663691559961,
 } as Extraction;
 
@@ -52,7 +64,9 @@ const ACTION_2_UI = {
     description: 'User Action',
     level: BreadcrumbLevelType.UNDEFINED,
   },
-  html: '<span aria-describedby="tooltip-nxf8deymg3" class="css-507rzt e1lk5gpt0">Ignored <span type="default" class="css-2uol17 e1gotaso0"><span><!-- 1 descendents --></span></span></span>',
+  html: parseHtml(
+    '<span aria-describedby="tooltip-nxf8deymg3" class="css-507rzt e1lk5gpt0">Ignored <span type="default" class="css-2uol17 e1gotaso0"><span><!-- 1 descendents --></span></span></span>'
+  ),
   timestamp: 1663691570812,
 } as Extraction;
 
@@ -70,7 +84,7 @@ const ACTION_3_UI = {
     description: 'User Action',
     level: BreadcrumbLevelType.UNDEFINED,
   },
-  html: '<div class="loadmore" style="display: block;">Load more..</div>',
+  html: parseHtml('<div class="loadmore" style="display: block;">Load more..</div>'),
   timestamp: 1663691634529,
 } as Extraction;
 


### PR DESCRIPTION
Also refactor to use a hook `useVirtualizedInspector` (I can split this out into a new PR).


<img width="696" alt="image" src="https://user-images.githubusercontent.com/79684/231290101-63e93930-fa53-4613-ae27-7df8be46b9db.png">


Requires https://github.com/getsentry/sentry/pull/47432
Requires https://github.com/getsentry/react-inspector/pull/4