### PR TITLE
fix(features): Make `batch_has` fall back to defaults if no entity handler is registered

### DIFF
--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -263,8 +263,7 @@ class FeatureManager(RegisteredFeatureManager):
                 feature_names, actor, projects=projects, organization=organization
             )
         else:
-            # Fall back to default handler if no entity handler available. We can add batching here
-            # if w
+            # Fall back to default handler if no entity handler available.
             project_features = filter(lambda name: name.startswith("projects:"), feature_names)
             if projects and project_features:
                 results: MutableMapping[str, Mapping[str, bool]] = {}

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -263,6 +263,34 @@ class FeatureManager(RegisteredFeatureManager):
                 feature_names, actor, projects=projects, organization=organization
             )
         else:
+            # Fall back to default handler if no entity handler available. We can add batching here
+            # if w
+            project_features = filter(lambda name: name.startswith("projects:"), feature_names)
+            if projects and project_features:
+                results: MutableMapping[str, Mapping[str, bool]] = {}
+                for project in projects:
+                    proj_results = results[f"project:{project.id}"] = {}
+                    for feature_name in project_features:
+                        proj_results[feature_name] = self.has(feature_name, project, actor=actor)
+                return results
+
+            org_features = filter(lambda name: name.startswith("organizations:"), feature_names)
+            if organization and org_features:
+                org_results = {}
+                for feature_name in org_features:
+                    org_results[feature_name] = self.has(feature_name, organization, actor=actor)
+                return {f"organization:{organization.id}": org_results}
+
+            unscoped_features = filter(
+                lambda name: not name.startswith("organizations:")
+                and not name.startswith("projects:"),
+                feature_names,
+            )
+            if unscoped_features:
+                unscoped_results = {}
+                for feature_name in unscoped_features:
+                    unscoped_results[feature_name] = self.has(feature_name, actor=actor)
+                return {"unscoped": unscoped_results}
             return None
 
     @staticmethod


### PR DESCRIPTION
Currently, any features going through `batch_has` will be False in ST and self hosted. This adds a fallback to use `.has` in those cases. This doesn't perform any batching, but that should be ok in this case, since it'll just be reading from the local defaults.
