### PR TITLE
feat(issue-details): Update analytics for IssueQuickTrace

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -26,10 +26,6 @@ export type IssueEventParameters = {
   'inbox_tab.issue_clicked': {
     group_id: string;
   };
-  'issue.quick_trace_status': {
-    is_performance_issue: boolean;
-    status: string;
-  };
   'issue.search_sidebar_clicked': {};
   'issue.shared_publicly': {};
   'issue_details.copy_event_link_clicked': GroupEventParams;
@@ -208,7 +204,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
     'Issue Group Details: Setup Source Maps Alert Clicked',
   resolve_issue: 'Resolve Issue',
   'tag.clicked': 'Tag: Clicked',
-  'issue.quick_trace_status': 'Issue Quick Trace Status',
   'quick_trace.missing_service.dismiss': 'Quick Trace: Missing Service Dismissed',
   'quick_trace.missing_service.docs': 'Quick Trace: Missing Service Clicked',
   'quick_trace.dropdown.clicked': 'Quick Trace: Dropdown clicked',

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -172,6 +172,8 @@ class GroupDetails extends Component<Props, State> {
       ref_fallback,
       // Will be updated by StacktraceLink if there is a stacktrace link
       stacktrace_link_viewed: false,
+      // Will be updated by IssueQuickTrace if there is a trace
+      trace_status: 'none',
     });
   }
 


### PR DESCRIPTION
Replaced `issue.quick_trace_status` with an extra property in the `issue_details.viewed` event.

The existing event was blocked in amplitude so removing it won't affect anyone.