### PR TITLE
ref(metrics): allow reporting only one payload metric

### DIFF
--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import zlib
 from datetime import datetime, timezone
-from typing import TypedDict, Union
+from typing import Optional, TypedDict, Union
 
 from django.conf import settings
 from sentry_sdk import Hub
@@ -258,7 +258,9 @@ def decompress(data: bytes) -> bytes:
         return zlib.decompress(data, zlib.MAX_WBITS | 32)
 
 
-def _report_size_metrics(size_compressed: int = None, size_uncompressed: int = None) -> None:
+def _report_size_metrics(
+    size_compressed: Optional[int] = None, size_uncompressed: Optional[int] = None
+) -> None:
     if size_compressed:
         metrics.timing("replays.usecases.ingest.size_compressed", size_compressed)
     if size_uncompressed:

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -258,9 +258,11 @@ def decompress(data: bytes) -> bytes:
         return zlib.decompress(data, zlib.MAX_WBITS | 32)
 
 
-def _report_size_metrics(size_compressed: int, size_uncompressed: int) -> None:
-    metrics.timing("replays.usecases.ingest.size_compressed", size_compressed)
-    metrics.timing("replays.usecases.ingest.size_uncompressed", size_uncompressed)
+def _report_size_metrics(size_compressed: int = None, size_uncompressed: int = None) -> None:
+    if size_compressed:
+        metrics.timing("replays.usecases.ingest.size_compressed", size_compressed)
+    if size_uncompressed:
+        metrics.timing("replays.usecases.ingest.size_uncompressed", size_uncompressed)
 
 
 def replay_click_post_processor(
@@ -274,6 +276,7 @@ def replay_click_post_processor(
         options.get("replay.ingest.dom-click-search"),
         settings.SENTRY_REPLAYS_DOM_CLICK_SEARCH_ALLOWLIST,
     ):
+        _report_size_metrics(size_compressed=len(segment_bytes))
         return None
 
     try:


### PR DESCRIPTION
Our datadog payload size metrics were looking wonky because we (temporarily) started returning before we reported most size metrics. This allows sending only either compressed or uncompressed size metrics instead of requiring both. 

The immediate issue will resolve once we roll out DOM search to everyone, so if this seems like a bad idea feel free to close. 