### PR TITLE
fix(sourcemaps): Return -1 for releases that have no bundle

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -439,8 +439,10 @@ class SourceMapsEndpoint(ProjectEndpoint):
 
         def serialize_results(results):
             file_count_map = get_artifact_counts([r["id"] for r in results])
+            # In case we didn't find a file count for a specific release, we will return -1, signaling to the
+            # frontend that this release doesn't have one or more ReleaseFile.
             return serialize(
-                [expose_release(r, file_count_map.get(r["id"], 0)) for r in results], request.user
+                [expose_release(r, file_count_map.get(r["id"], -1)) for r in results], request.user
             )
 
         sort_by = request.GET.get("sortBy", "-date_added")


### PR DESCRIPTION
This PR adds the logic for returning `-1` in case a release doesn't have one or more `ReleaseFile` connected.

Closes: https://github.com/getsentry/sentry/issues/46770