### PR TITLE
fix(dynamic-sampling) Remove unused prioritise by transaction/project features

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1319,8 +1319,6 @@ SENTRY_FEATURES = {
     "organizations:source-maps-debug-ids": False,
     # Enable the new opinionated dynamic sampling
     "organizations:dynamic-sampling": False,
-    # Enable new DS bias: prioritise by transaction
-    "organizations:ds-prioritise-by-transaction-bias": False,
     # Enable view hierarchies options
     "organizations:view-hierarchies-options-dev": False,
     # Enable anr improvements ui

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -74,8 +74,6 @@ default_manager.add("organizations:dashboards-rh-widget", OrganizationFeature, F
 default_manager.add("organizations:dashboards-template", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:discover-events-rate-limit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:ds-prioritise-by-project-bias", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:ds-prioritise-by-transaction-bias", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/dynamic_sampling/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/test_tasks.py
@@ -138,9 +138,8 @@ class TestPrioritiseTransactionsTask(BaseMetricsLayerTestCase, TestCase, SnubaTe
         get_blended_sample_rate.return_value = 0.25
 
         with self.options({"dynamic-sampling.prioritise_transactions.load_rate": 1.0}):
-            with self.feature({"organizations:ds-prioritise-by-transaction-bias": True}):
-                with self.tasks():
-                    prioritise_transactions()
+            with self.tasks():
+                prioritise_transactions()
 
         # now redis should contain rebalancing data for our projects
         for org in self.orgs_info:
@@ -173,9 +172,8 @@ class TestPrioritiseTransactionsTask(BaseMetricsLayerTestCase, TestCase, SnubaTe
                 "dynamic-sampling.prioritise_transactions.num_explicit_small_transactions": 1,
             }
         ):
-            with self.feature({"organizations:ds-prioritise-by-transaction-bias": True}):
-                with self.tasks():
-                    prioritise_transactions()
+            with self.tasks():
+                prioritise_transactions()
 
         # now redis should contain rebalancing data for our projects
         for org in self.orgs_info:


### PR DESCRIPTION
This PR cleans up two options that remained from the testing phase of  PrioritiseByTransaction and PrioritiseByProject dynamic sampling rules.

Removed:
* `organizations:ds-prioritise-by-project-bias`
* `organizations:ds-prioritise-by-transaction-bias`