### PR TITLE
feat: Bump sentry-kafka-schemas daily

### DIFF
--- a/.github/workflows/bump-version-sentry-kafka-schemas.yml
+++ b/.github/workflows/bump-version-sentry-kafka-schemas.yml
@@ -1,0 +1,15 @@
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/bump-version.yml
+        with:
+          package: sentry-kafka-schemas
+          version: latest
+          # TODO: we'd like to auto-assign SNS to the PR, but the BUMP_TOKEN
+          # does not have permissions


### PR DESCRIPTION
Background: The sentry-kafka-schemas repository contains schema definitions that are supposed to ensure we do not deploy changes to production that would break downstream consumers. For more context see this RFC: https://github.com/getsentry/rfcs/pull/72

TLDR: The idea is that, for each Kafka topic, we have a source of truth as to what constitutes a valid message inside of that topic.

Since sentry-kafka-schemas is just an ordinary PyPI package, its versions can go out of sync between services. So, let's have an action that ensures it doesn't go out of sync. I view this similarly to the integration tests we have running in sentry, relay and snuba, which also just pull from master branch of each other (or pull the latest, unpinned docker image)

This directly goes against how we treat other Python dependencies in Sentry, which we don't usually bump automatically. So maybe this repo shouldn't be a (pinned) Python dependency, but that's the mechanism we have today.

We cannot reuse dependabot for this, because it only supports one update schedule per ecosystem. Meaning that:

* if we wanted to bump sentry-kafka-schemas daily, and other PyPI dependencies weekly (as is the case in snuba), we cannot do that

* if we wanted to bump sentry-kafka-schemas to latest daily, and other PyPI packages only if they are security updates, we cannot do that

I _think_ we can also not define custom ownership rules for each kind of dependency bump we want to have. Meaning that, if we wanted to use dependabot for different "kinds" of updates concerning the same ecosystem (PyPI), those updates will only be assigned to owners-build-python.

IMO what we want to do instead is to bump sentry-kafka-schemas specifically, and then assign that PR to S&S. Further down the road we might want to refine that process and not only assign to S&S, but actually to the team that released a new version of sentry-kafka-schemas? Who knows. But there needs to be a clear definition of "who owns this upgrade" and IMO that can't be a single GitHub team for the entire company if we want those upgrades to happen at all. And dependabot doesn't seem powerful enough to define rules that would support sophisticated workflows like that.

To clarify: The automatically created PRs still have to be approved and merged by a human. But in order for that to actually work, we need to be clear about which human is responsible for each dependency bump PR.

**Technical implementation**

This runs .github/workflows/bump-version.yml daily. That workflow crashes if the branch for a particular version bump already exists, meaning we won't get duplicate PRs.

I tried manually running that workflow with `-r @getsentry/owners-snuba`, but got an error that the access token does not have permissions:

```
GraphQL: Your token has not been granted the required scopes to execute this query. The 'id' field requires one of the following scopes: ['read:org', 'read:discussion'], but your token has only been granted the: ['repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens., Your token has not been granted the required scopes to execute this query. The 'slug' field requires one of the following scopes: ['read:org', 'read:discussion'], but your token has only been granted the: ['repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.
```

https://github.com/getsentry/sentry/actions/runs/4595647439/jobs/8116169073

I would like to fix that.

