### PR TITLE
Filter hierarchical GroupHash updates that already have a Group

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1582,7 +1582,7 @@ def _save_aggregate(
     # all group hashes
     if migrate_off_hierarchical:
         new_hashes = [h for h in flat_grouphashes if h.group_id is None]
-        if root_hierarchical_grouphash:
+        if root_hierarchical_grouphash and root_hierarchical_grouphash.group_id is None:
             new_hashes.append(root_hierarchical_grouphash)
     elif root_hierarchical_grouphash is None:
         # No hierarchical grouping was run, only consider flat hashes


### PR DESCRIPTION
When in `migrate_off_hierarchical` mode, every `root_hierarchical_grouphash` was triggering a SQL `UPDATE`, even if it already had a `goup_id` set, and it was setting that `group_id` to the exact same value with every `UPDATE`.

This was the conclusion of the investigation in NATIVE-585, and one probable cause of INC-337.