### PR TITLE
fix(clusterer): Remove transaction rules if minimum threshold not met

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -64,7 +64,8 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 span.set_data("project_id", project.id)
                 tx_names = list(redis.get_transaction_names(project))
                 if len(tx_names) < redis.MAX_SET_SIZE:
-                    return
+                    redis.clear_transaction_names(project)
+                    continue
                 clusterer = TreeClusterer(merge_threshold=MERGE_THRESHOLD)
                 clusterer.add_input(tx_names)
                 new_rules = clusterer.get_rules()

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -253,7 +253,8 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
 @mock.patch("sentry.ingest.transaction_clusterer.rules.update_rules")
 @pytest.mark.django_db
 def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default_organization):
-    project = Project(id=123, name="test_project", organization_id=default_organization.id)
+    project = Project(id=456, name="test_project", organization_id=default_organization.id)
+    assert _get_rules(project) == {}
 
     _store_transaction_name(project, "/transaction/number/1")
     with Feature({"organizations:transaction-name-clusterer": True}):

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -259,7 +259,9 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
     with Feature({"organizations:transaction-name-clusterer": True}):
         cluster_projects([project])
     assert mock_update_rules.call_count == 0
+    assert _get_rules(project) == {}  # Transaction names are deleted if there aren't enough
 
+    _store_transaction_name(project, "/transaction/number/1")
     _store_transaction_name(project, "/transaction/number/2")
     with Feature({"organizations:transaction-name-clusterer": True}):
         cluster_projects([project])


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/46503 attempts to skip projects without enough transactions from running the clusterer. However, that PR introduces two regressions:

1. When there aren't enough transactions collected from a project, these aren't deleted. The purpose of the clusterer is to run the algorithm only on the transactions collected in the last time frame, so this doesn't meet the criteria.
2. The way to stop running the clusterer was with a `return`. This is problematic because it will also stop running the clusterer at all for the following projects in the task. Replacing it with a `continue` fixes the issue.