### PR TITLE
feat(spurl-param): Register a new span grouping strategy

### DIFF
--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -251,6 +251,11 @@ def remove_http_client_query_string_strategy(span: Span) -> Optional[Sequence[st
     return [method, url.scheme, url.netloc, url.path]
 
 
+@span_op("http.client")
+def wildcard_replacement_strategy(span: Span) -> Optional[Sequence[str]]:
+    return None
+
+
 @span_op(["redis", "db.redis"])
 def remove_redis_command_arguments_strategy(span: Span) -> Optional[Sequence[str]]:
     """For a `redis` span, the fingerprint to use is simply the redis command name.

--- a/src/sentry/spans/grouping/strategy/config.py
+++ b/src/sentry/spans/grouping/strategy/config.py
@@ -10,6 +10,7 @@ from sentry.spans.grouping.strategy.base import (
     parametrize_db_span_strategy,
     remove_http_client_query_string_strategy,
     remove_redis_command_arguments_strategy,
+    wildcard_replacement_strategy,
 )
 
 
@@ -65,6 +66,16 @@ register_configuration(
     "default:2022-10-27",
     strategies=[
         parametrize_db_span_strategy,
+        remove_http_client_query_string_strategy,
+        remove_redis_command_arguments_strategy,
+    ],
+)
+
+register_configuration(
+    "clustering:2023-04-03",
+    strategies=[
+        parametrize_db_span_strategy,
+        wildcard_replacement_strategy,
         remove_http_client_query_string_strategy,
         remove_redis_command_arguments_strategy,
     ],


### PR DESCRIPTION
Adds a new dummy strategy, unused. This is where the clustering-backed code will eventually go. Note that the _configuration_ is called "clustering" because that's the underlying technology. The _strategy_ is called "wildcard replacement" (at least for now) because it works by replacing string segments with wildcards. Open to suggestions, though.
