### PR TITLE
feat(replays): updated dropdown with projects partitioned and sorted

### DIFF
--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -1,10 +1,10 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import HighlightTopRightPattern from 'sentry-images/pattern/highlight-top-right.svg';
 
 import {Button} from 'sentry/components/button';
-import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
+import {CompactSelect} from 'sentry/components/compactSelect';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useOnboardingDocs from 'sentry/components/onboardingWizard/useOnboardingDocs';
@@ -21,7 +21,7 @@ import platforms from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import {space} from 'sentry/styles/space';
-import {Project} from 'sentry/types';
+import {Project, SelectValue} from 'sentry/types';
 import EventWaiter from 'sentry/utils/eventWaiter';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -34,27 +34,65 @@ function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
   const isActive = currentPanel === SidebarPanelKey.ReplaysOnboarding;
   const hasProjectAccess = organization.access.includes('project:read');
 
-  const {projects, allProjects, currentProject, setCurrentProject} =
-    useCurrentProjectState({
-      currentPanel,
-    });
+  const {
+    projects,
+    allProjects,
+    currentProject,
+    setCurrentProject,
+    supportedProjects,
+    unsupportedProjects,
+  } = useCurrentProjectState({
+    currentPanel,
+  });
+
+  const projectSelectOptions = useMemo(() => {
+    const supportedProjectItems: SelectValue<string>[] = supportedProjects
+      .sort((aProject, bProject) => {
+        // if we're comparing two projects w/ or w/o replays alphabetical sort
+        if (aProject.hasReplays === bProject.hasReplays) {
+          return aProject.slug.localeCompare(bProject.slug);
+        }
+        // otherwise sort by whether or not they have replays
+        return aProject.hasReplays ? 1 : -1;
+      })
+      .map(project => {
+        return {
+          value: project.id,
+          textValue: project.id,
+          label: (
+            <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />
+          ),
+        };
+      });
+
+    const unsupportedProjectItems: SelectValue<string>[] = unsupportedProjects.map(
+      project => {
+        return {
+          value: project.id,
+          textValue: project.id,
+          label: (
+            <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />
+          ),
+          disabled: true,
+        };
+      }
+    );
+    return [
+      {
+        label: t('Supported'),
+        options: supportedProjectItems,
+      },
+      {
+        label: t('Unsupported'),
+        options: unsupportedProjectItems,
+      },
+    ];
+  }, [supportedProjects, unsupportedProjects]);
 
   const selectedProject = currentProject ?? projects[0] ?? allProjects[0];
   if (!isActive || !hasProjectAccess || !selectedProject) {
     return null;
   }
-
-  const items: MenuItemProps[] = allProjects.reduce((acc: MenuItemProps[], project) => {
-    const itemProps: MenuItemProps = {
-      key: project.id,
-      label: <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />,
-      onAction: () => setCurrentProject(project),
-    };
-
-    acc.push(itemProps);
-
-    return acc;
-  }, []);
 
   return (
     <TaskSidebarPanel
@@ -65,19 +103,35 @@ function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
       <TopRightBackgroundImage src={HighlightTopRightPattern} />
       <TaskList>
         <Heading>{t('Getting Started with Session Replay')}</Heading>
-        <DropdownMenu
-          items={items}
-          triggerLabel={
-            <StyledIdBadge
-              project={selectedProject}
-              avatarSize={16}
-              hideOverflow
-              disableLink
-            />
-          }
-          triggerProps={{'aria-label': selectedProject.slug}}
-          position="bottom-end"
-        />
+        <div
+          onClick={e => {
+            // we need to stop bubbling the CompactSelect click event
+            // failing to do so will cause the sidebar panel to close
+            // the event.target will be unmounted by the time the panel listener
+            // receives the event and assume the click was outside the panel
+            e.stopPropagation();
+          }}
+        >
+          <CompactSelect
+            triggerLabel={
+              currentProject ? (
+                <StyledIdBadge
+                  project={currentProject}
+                  avatarSize={16}
+                  hideOverflow
+                  disableLink
+                />
+              ) : (
+                t('Select a project')
+              )
+            }
+            value={currentProject?.id}
+            onChange={opt => setCurrentProject(allProjects.find(p => p.id === opt.value))}
+            triggerProps={{'aria-label': currentProject?.slug}}
+            options={projectSelectOptions}
+            position="bottom-end"
+          />
+        </div>
         <OnboardingContent currentProject={selectedProject} />
       </TaskList>
     </TaskSidebarPanel>

--- a/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useMemo, useState} from 'react';
 import first from 'lodash/first';
 
+import {splitProjectsByReplaySupport} from 'sentry/components/replaysOnboarding/utils';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {replayOnboardingPlatforms, replayPlatforms} from 'sentry/data/platformCategories';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
@@ -82,9 +83,15 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
     projectWithReplaySupport,
   ]);
 
+  const {supported, unsupported} = useMemo(() => {
+    return splitProjectsByReplaySupport(projects);
+  }, [projects]);
+
   return {
     projects: projectWithReplaySupport,
     allProjects: projects,
+    supportedProjects: supported,
+    unsupportedProjects: unsupported,
     currentProject,
     setCurrentProject,
   };

--- a/static/app/components/replaysOnboarding/utils.tsx
+++ b/static/app/components/replaysOnboarding/utils.tsx
@@ -1,5 +1,7 @@
+import partition from 'lodash/partition';
+
 import {PlatformKey, replayPlatforms} from 'sentry/data/platformCategories';
-import {PlatformIntegration} from 'sentry/types';
+import {PlatformIntegration, Project} from 'sentry/types';
 
 export function generateDocKeys(platform: PlatformKey): string[] {
   return ['1-install', '2-configure'].map(key => `${platform}-replay-onboarding-${key}`);
@@ -7,4 +9,14 @@ export function generateDocKeys(platform: PlatformKey): string[] {
 
 export function isPlatformSupported(platform: undefined | PlatformIntegration) {
   return platform?.id ? replayPlatforms.includes(platform?.id) : false;
+}
+
+export function splitProjectsByReplaySupport(projects: Project[]) {
+  const [supported, unsupported] = partition(projects, project =>
+    replayPlatforms.includes(project.platform!)
+  );
+  return {
+    supported,
+    unsupported,
+  };
 }


### PR DESCRIPTION
## Summary

This change aligns the onboarding project selector to how we display it in Profiling. In addition to this we sort the projects based on whether they have the `hasReplays` event.

Relates to: https://github.com/getsentry/sentry/issues/45474