### PR TITLE
fix(issues): More adjustments for the page filter bar styling

### DIFF
--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -52,7 +52,7 @@ const PageFilterBar = styled('div')<{condensed?: boolean}>`
     }
 
     /* Prevent date filter from shrinking below 6.5rem */
-    &:nth-last-child(2) {
+    &:last-child {
       min-width: 6.5rem;
     }
   }

--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -52,7 +52,7 @@ const PageFilterBar = styled('div')<{condensed?: boolean}>`
     }
 
     /* Prevent date filter from shrinking below 6.5rem */
-    &:last-child {
+    &:nth-last-child(2) {
       min-width: 6.5rem;
     }
   }

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -42,6 +42,8 @@ const SearchContainer = styled('div')`
 `;
 
 const StyledPageFilterBar = styled(PageFilterBar)`
+  display: flex;
+  flex-basis: content;
   width: 100%;
   max-width: 43rem;
 `;

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -46,6 +46,18 @@ const StyledPageFilterBar = styled(PageFilterBar)`
   flex-basis: content;
   width: 100%;
   max-width: 43rem;
+  align-self: flex-start;
+
+  & > * {
+    /* Prevent date filter from shrinking below 6.5rem */
+    &:nth-last-child(2) {
+      min-width: 6.5rem;
+    }
+
+    &:last-child {
+      min-width: 0;
+    }
+  }
 `;
 
 export default IssueListFilters;

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -43,11 +43,7 @@ const SearchContainer = styled('div')`
 
 const StyledPageFilterBar = styled(PageFilterBar)`
   width: 100%;
-  max-width: 40rem;
-
-  > div > button {
-    width: 100%;
-  }
+  max-width: 43rem;
 `;
 
 export default IssueListFilters;

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -42,9 +42,8 @@ const SearchContainer = styled('div')`
 `;
 
 const StyledPageFilterBar = styled(PageFilterBar)`
-  flex: 0 1 0;
   width: 100%;
-  max-width: 45rem;
+  max-width: 40rem;
 
   > div > button {
     width: 100%;

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -48,6 +48,10 @@ const StyledPageFilterBar = styled(PageFilterBar)`
   max-width: 43rem;
   align-self: flex-start;
 
+  > div > button {
+    width: 100%;
+  }
+
   & > * {
     /* Prevent date filter from shrinking below 6.5rem */
     &:nth-last-child(2) {

--- a/static/app/views/issueList/issueCategoryFilter.tsx
+++ b/static/app/views/issueList/issueCategoryFilter.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
 import FeatureBadge from 'sentry/components/featureBadge';
@@ -29,16 +30,16 @@ function IssueCategoryFilter({
     (issueCategory?: IssueCategory, isTriggerLabel?: boolean) => {
       switch (issueCategory) {
         case IssueCategory.ERROR:
-          return t('Errors');
+          return <LabelWrapper>{t('Errors')}</LabelWrapper>;
         case IssueCategory.PERFORMANCE:
           return (
-            <React.Fragment>
+            <LabelWrapper>
               {t('Performance')}
               {!isTriggerLabel && !isPerformanceSeen && <FeatureBadge type="new" />}
-            </React.Fragment>
+            </LabelWrapper>
           );
         default:
-          return t('All Categories');
+          return <LabelWrapper>{t('All Categories')}</LabelWrapper>;
       }
     },
     [isPerformanceSeen]
@@ -117,5 +118,10 @@ function IssueCategoryFilter({
     />
   );
 }
+
+const LabelWrapper = styled('div')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 export default IssueCategoryFilter;


### PR DESCRIPTION
The page filter bar styling broke again, this PR adds some more CSS rules to further refine the styling. Slightly improves the mobile experience as well

### Before
![image](https://user-images.githubusercontent.com/16740047/229565147-d7378836-6d3f-485e-9b4b-f05813408f7b.png)

(Mobile)
![image](https://user-images.githubusercontent.com/16740047/229565329-97ec9a74-ac66-457f-b98c-d47e9ed275a9.png)


### After
![image](https://user-images.githubusercontent.com/16740047/229565189-cdb68318-7779-49a1-90c3-262701288f60.png)

(Mobile)
![image](https://user-images.githubusercontent.com/16740047/229565428-d58d5e30-64b7-480a-9a84-aadb52d2389d.png)
