### PR TITLE
fix(crons): Properly allows updates where the slug doesn't change

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -80,6 +80,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
             partial=True,
             instance={
                 "name": monitor.name,
+                "slug": monitor.slug,
                 "status": monitor.status,
                 "type": monitor.type,
                 "config": monitor.config,

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -184,7 +184,8 @@ class MonitorValidator(serializers.Serializer):
         return value
 
     def validate_slug(self, value):
-        if not value:
+        # Ignore if slug is equal to current value
+        if not value or (self.instance and value == self.instance.get("slug")):
             return value
 
         if Monitor.objects.filter(

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -82,6 +82,13 @@ class UpdateMonitorTest(MonitorTestCase):
 
         assert resp.data["slug"][0] == 'The slug "my-test-monitor" is already in use.', resp.content
 
+    def test_slug_same(self):
+        monitor = self._create_monitor(slug="my-test-monitor")
+
+        self.get_success_response(
+            self.organization.slug, monitor.slug, method="PUT", **{"slug": "my-test-monitor"}
+        )
+
     def test_can_disable(self):
         monitor = self._create_monitor()
         resp = self.get_success_response(


### PR DESCRIPTION
Fixes behavior of blocking updates to monitor if slug is the same due to overly restrictive validator

Fixes FEEDBACK-BD
Fixes FEEDBACK-BC