### PR TITLE
ref(emails): Use normal font weight

### DIFF
--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -24,7 +24,7 @@
     border-spacing: 0;
   }
   * {
-    font-weight: 300;
+    font-weight: 400;
   }
 
   a {


### PR DESCRIPTION
The design team has decided to use a base font weight of 400 (instead of the current 300) in emails for better readability.

Fixes https://github.com/getsentry/sentry/issues/46570

**Before ——**
![image](https://user-images.githubusercontent.com/44172267/229597355-0e9fcea7-8c72-40ff-ad80-8576a8a69a70.png)

**After ——**
![image](https://user-images.githubusercontent.com/44172267/229597240-6c9b945c-6113-4202-8e25-53a5818a6c5d.png)