### PR TITLE
fix(hybrid-cloud): Fix integration.organizations references

### DIFF
--- a/src/sentry/integrations/bitbucket/uninstalled.py
+++ b/src/sentry/integrations/bitbucket/uninstalled.py
@@ -5,7 +5,8 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint, pending_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils import AtlassianConnectValidationError, get_integration_from_jwt
-from sentry.models import Repository
+from sentry.models import Organization, Repository
+from sentry.services.hybrid_cloud.integration import integration_service
 
 
 @pending_silo_endpoint
@@ -31,7 +32,12 @@ class BitbucketUninstalledEndpoint(Endpoint):
             return self.respond(status=400)
 
         integration.update(status=ObjectStatus.DISABLED)
-        organizations = integration.organizations.all()
+        org_integrations = integration_service.get_organization_integrations(
+            integration_id=integration.id
+        )
+        organizations = Organization.objects.filter(
+            id__in=[oi.organization_id for oi in org_integrations]
+        )
 
         Repository.objects.filter(
             organization_id__in=organizations.values_list("id", flat=True),

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -148,7 +148,12 @@ class InstallationEventWebhook(Webhook):
                 logger.exception("Installation is missing.")
 
     def _handle_delete(self, event: Mapping[str, Any], integration: Integration) -> None:
-        organizations = integration.organizations.all()
+        org_integrations = integration_service.get_organization_integrations(
+            integration_id=integration.id
+        )
+        organizations = Organization.objects.filter(
+            id__in=[oi.organization_id for oi in org_integrations]
+        )
 
         logger.info(
             "InstallationEventWebhook._handle_delete",


### PR DESCRIPTION
`integration.organizations` got nuked in https://github.com/getsentry/sentry/pull/45528; so patch these up.

Fixes SENTRY-1095