### PR TITLE
feat(replays): hide onboarding alert for AM1

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -83,7 +83,8 @@ type DashboardHeadersProps = {organization: Organization};
 
 type ReplayGracePeriodAlertProps = {organization: Organization};
 
-type ReplayOnboardinCTAProps = {children: React.ReactNode; organization: Organization};
+type ReplayOnboardingAlertProps = {children: React.ReactNode};
+type ReplayOnboardingCTAProps = {children: React.ReactNode; organization: Organization};
 
 type ProfilingBetaAlertBannerProps = {
   organization: Organization;
@@ -146,7 +147,8 @@ export type ComponentHooks = {
   'component:profiling-billing-banner': () => React.ComponentType<ProfilingBetaAlertBannerProps>;
   'component:replay-beta-grace-period-alert': () => React.ComponentType<ReplayGracePeriodAlertProps>;
   'component:replay-feedback-button': () => React.ComponentType<{}>;
-  'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardinCTAProps>;
+  'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;
+  'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
   'component:set-up-sdk-doc': () => React.ComponentType<SetUpSdkDocProps>;
   'component:superuser-access-category': React.FC<any>;
 };

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -33,6 +33,11 @@ const OnboardingCTAHook = HookOrDefault({
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
 
+const OnboardingAlertHook = HookOrDefault({
+  hookName: 'component:replay-onboarding-alert',
+  defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
+});
+
 export default function ReplayOnboardingPanel() {
   const preferences = useLegacyStore(PreferencesStore);
   const pageFilters = usePageFilters();
@@ -80,29 +85,31 @@ export default function ReplayOnboardingPanel() {
 
   return (
     <Fragment>
-      {hasSelectedProjects && allSelectedProjectsUnsupported && (
-        <Alert icon={<IconInfo />}>
-          {tct(
-            `[projectMsg] [action] a project using our [link], or equivalent framework SDK.`,
-            {
-              action: primaryAction === 'create' ? t('Create') : t('Select'),
-              projectMsg: (
-                <strong>
-                  {t(
-                    `Session Replay isn't available for project %s.`,
-                    selectedProjects[0].slug
-                  )}
-                </strong>
-              ),
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/">
-                  {t('Sentry browser SDK package')}
-                </ExternalLink>
-              ),
-            }
-          )}
-        </Alert>
-      )}
+      <OnboardingAlertHook>
+        {hasSelectedProjects && allSelectedProjectsUnsupported && (
+          <Alert icon={<IconInfo />}>
+            {tct(
+              `[projectMsg] [action] a project using our [link], or equivalent framework SDK.`,
+              {
+                action: primaryAction === 'create' ? t('Create') : t('Select'),
+                projectMsg: (
+                  <strong>
+                    {t(
+                      `Session Replay isn't available for project %s.`,
+                      selectedProjects[0].slug
+                    )}
+                  </strong>
+                ),
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/">
+                    {t('Sentry browser SDK package')}
+                  </ExternalLink>
+                ),
+              }
+            )}
+          </Alert>
+        )}
+      </OnboardingAlertHook>
       <OnboardingPanel
         image={<HeroImage src={emptyStateImg} breakpoints={breakpoints} />}
       >


### PR DESCRIPTION
## Summary

This change hides the replay onboarding alert for AM1 plans.

See also: https://github.com/getsentry/getsentry/pull/10100
Relates to: https://github.com/getsentry/sentry/issues/45474