### PR TITLE
feat(crons): Include `hasMonitors` in project serializer

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -73,8 +73,9 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                         "hasSessions": True,
                         "hasProfiles": True,
                         "hasReplays": True,
-                        "latestRelease": None,
+                        "hasMonitors": True,
                         "hasUserReports": False,
+                        "latestRelease": None,
                     }
                 ],
             )

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -212,6 +212,7 @@ class ProjectSerializerBaseResponse(_ProjectSerializerOptionalBaseResponse):
     hasSessions: bool
     hasProfiles: bool
     hasReplays: bool
+    hasMonitors: bool
     platform: Optional[str]
     firstEvent: Optional[datetime]
 
@@ -470,6 +471,7 @@ class ProjectSerializer(Serializer):  # type: ignore
             "hasSessions": bool(obj.flags.has_sessions),
             "hasProfiles": bool(obj.flags.has_profiles),
             "hasReplays": bool(obj.flags.has_replays),
+            "hasMonitors": bool(obj.flags.has_cron_monitors),
             "hasMinifiedStackTrace": bool(obj.flags.has_minified_stack_trace),
             "features": attrs["features"],
             "status": status_label,
@@ -702,6 +704,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             hasSessions=bool(obj.flags.has_sessions),
             hasProfiles=bool(obj.flags.has_profiles),
             hasReplays=bool(obj.flags.has_replays),
+            hasMonitors=bool(obj.flags.has_cron_monitors),
             hasMinifiedStackTrace=bool(obj.flags.has_minified_stack_trace),
             platform=obj.platform,
             platforms=attrs["platforms"],

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -367,6 +367,16 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasReplays"] is True
 
+    def test_has_monitors_flag(self):
+        result = serialize(self.project, self.user, ProjectSummarySerializer())
+        assert result["hasMonitors"] is False
+
+        self.project.first_event = timezone.now()
+        self.project.update(flags=F("flags").bitor(Project.flags.has_cron_monitors))
+
+        result = serialize(self.project, self.user, ProjectSummarySerializer())
+        assert result["hasMonitors"] is True
+
     def test_has_minified_stracktrace_flag(self):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasMinifiedStackTrace"] is False


### PR DESCRIPTION
Need this to show a better empty state.