### PR TITLE
Introduce a `TaskKind` for `symbolicate_event` tasks 

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -1,9 +1,10 @@
 import logging
+from typing import Any, Callable
 
 from sentry.lang.javascript.utils import should_use_symbolicator_for_sourcemaps
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
-from sentry.models import EventError, Project
+from sentry.models import EventError
 from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.utils.safe import get_path
 
@@ -118,14 +119,11 @@ def map_symbolicator_process_js_errors(errors):
     return mapped_errors
 
 
-def process_payload(data):
-    project = Project.objects.get_from_cache(id=data.get("project"))
-
+def process_payload(symbolicator: Symbolicator, data: Any) -> Any:
+    project = symbolicator.project
     allow_scraping_org_level = project.organization.get_option("sentry:scrape_javascript", True)
     allow_scraping_project_level = project.get_option("sentry:scrape_javascript", True)
     allow_scraping = allow_scraping_org_level and allow_scraping_project_level
-
-    symbolicator = Symbolicator(project=project, event_id=data["event_id"])
 
     modules = sourcemap_images_from_data(data)
 
@@ -185,6 +183,6 @@ def process_payload(data):
     return data
 
 
-def get_symbolication_function(data):
+def get_symbolication_function(data: Any) -> Callable[[Symbolicator, Any], Any]:
     if should_use_symbolicator_for_sourcemaps(data.get("project")):
         return process_payload

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import uuid
+from typing import Optional
 from urllib.parse import urljoin
 
 import sentry_sdk
@@ -14,7 +15,6 @@ from sentry.lang.native.sources import (
 )
 from sentry.models import Project
 from sentry.net.http import Session
-from sentry.tasks.symbolication import RetrySymbolication
 from sentry.utils import json, metrics
 
 MAX_ATTEMPTS = 3
@@ -150,6 +150,11 @@ class TaskIdNotFound(Exception):
 
 class ServiceUnavailable(Exception):
     pass
+
+
+class RetrySymbolication(Exception):
+    def __init__(self, retry_after: Optional[int] = None) -> None:
+        self.retry_after = retry_after
 
 
 class SymbolicatorSession:

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -10,7 +10,7 @@ from sentry import options
 from sentry.eventstore import processing
 from sentry.eventstore.processing.base import Event
 from sentry.killswitches import killswitch_matches_context
-from sentry.lang.native.symbolicator import Symbolicator
+from sentry.lang.native.symbolicator import RetrySymbolication, Symbolicator
 from sentry.models import Organization, Project
 from sentry.processing import realtime_metrics
 from sentry.tasks import store
@@ -39,11 +39,6 @@ SYMBOLICATOR_MAX_QUEUE_SWITCHES = 3
 #
 # New tasks and metrics are welcome to use the correct naming scheme as they are not
 # burdened by aforementioned legacy concerns.
-
-
-class RetrySymbolication(Exception):
-    def __init__(self, retry_after: Optional[int] = None) -> None:
-        self.retry_after = retry_after
 
 
 def should_demote_symbolication(project_id: int) -> bool:

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -152,7 +152,7 @@ def test_cocoa_function_name(mock_symbolicator, default_project):
         "modules": [],
     }
 
-    process_payload(data)
+    process_payload(mock_symbolicator, data)
 
     function_name = get_path(data, "exception", "values", 0, "stacktrace", "frames", 0, "function")
     assert function_name == "thunk for closure"
@@ -352,7 +352,7 @@ def test_il2cpp_symbolication(mock_symbolicator, default_project):
         ],
     }
 
-    process_payload(data)
+    process_payload(mock_symbolicator, data)
 
     frame = get_path(data, "exception", "values", 0, "stacktrace", "frames", 3)
 

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -160,7 +160,7 @@ def test_symbolicate_event_call_process_inline(
 
     symbolicated_data = {"type": "error"}
 
-    mock_get_symbolication_function.return_value = lambda _: symbolicated_data
+    mock_get_symbolication_function.return_value = lambda _symbolicator, _event: symbolicated_data
 
     with mock.patch("sentry.tasks.store.do_process_event") as mock_do_process_event:
         symbolicate_event(cache_key="e:1", start_time=1)


### PR DESCRIPTION
This tries to contain the combinatorial explosion of different symbolication tasks behind a new tuple, and introduces new tasks/queues for js symbolication.

This is on top of https://github.com/getsentry/sentry/pull/46858