### PR TITLE
fix(hybridcloud) Fix most of the pydantic warnings for RPC data classes

### DIFF
--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -323,7 +323,7 @@ def silo_mode_delegation(
 
 @dataclasses.dataclass
 class RpcPaginationArgs:
-    encoded_cursor: str | None = None
+    encoded_cursor: Optional[str] = None
     per_page: int = -1
 
     @classmethod

--- a/src/sentry/services/hybrid_cloud/app/__init__.py
+++ b/src/sentry/services/hybrid_cloud/app/__init__.py
@@ -6,9 +6,10 @@
 import abc
 import datetime
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Protocol, TypedDict, cast
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Protocol, cast
 
 from pydantic.fields import Field
+from typing_extensions import TypedDict
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.models import SentryApp, SentryAppInstallation

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -151,14 +151,14 @@ def authentication_request_from(request: Request) -> AuthenticationRequest:
 
 @dataclass(eq=True)
 class AuthenticatedToken:
+    allowed_origins: List[str] = field(default_factory=list)
+    audit_log_data: Dict[str, Any] = field(default_factory=dict)
+    scopes: List[str] = field(default_factory=list)
     entity_id: Optional[int] = None
     kind: str = "system"
     user_id: Optional[int] = None  # only relevant for ApiToken
     organization_id: Optional[int] = None
     application_id: Optional[int] = None  # only relevant for ApiToken
-    allowed_origins: List[str] = field(default_factory=list)
-    audit_log_data: Dict[str, Any] = field(default_factory=dict)
-    scopes: List[str] = field(default_factory=list)
 
     @classmethod
     def from_token(cls, token: Any) -> Optional["AuthenticatedToken"]:
@@ -175,14 +175,14 @@ class AuthenticatedToken:
             raise KeyError(f"Token {token} is a not a registered AuthenticatedToken type!")
 
         return cls(
+            allowed_origins=token.get_allowed_origins(),
+            scopes=token.get_scopes(),
+            audit_log_data=token.get_audit_log_data(),
             entity_id=getattr(token, "id", None),
             kind=kind,
             user_id=getattr(token, "user_id", None),
             organization_id=getattr(token, "organization_id", None),
             application_id=getattr(token, "application_id", None),
-            allowed_origins=token.get_allowed_origins(),
-            audit_log_data=token.get_audit_log_data(),
-            scopes=token.get_scopes(),
         )
 
     @classmethod

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -5,10 +5,11 @@
 
 from abc import abstractmethod
 from datetime import datetime
-from typing import Optional, TypedDict, cast
+from typing import Optional, cast
 
 from django.utils import timezone
 from pydantic.fields import Field
+from typing_extensions import TypedDict
 
 from sentry.models import Organization
 from sentry.models.user import User

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -6,9 +6,10 @@
 import datetime
 from abc import abstractmethod
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, FrozenSet, List, Optional, TypedDict, cast
+from typing import TYPE_CHECKING, Any, FrozenSet, List, Optional, cast
 
 from pydantic.fields import Field
+from typing_extensions import TypedDict
 
 from sentry.services.hybrid_cloud import DEFAULT_DATE, RpcModel
 from sentry.services.hybrid_cloud.filter_query import OpaqueSerializedResponse

--- a/src/sentry/services/hybrid_cloud/user_option/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user_option/__init__.py
@@ -4,7 +4,9 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from typing import Any, Iterable, List, Optional, TypedDict, cast
+from typing import Any, Iterable, List, Optional, cast
+
+from typing_extensions import TypedDict
 
 from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.auth import AuthenticationContext


### PR DESCRIPTION
Fix most (but not all) warnings from pydantic during startup. The remaining two warnings are related to User and Request not having validators. I'll add those separately.