### PR TITLE
chore(hybrid-cloud): Update drain_shard() to raise if it's called within an atomic transaction

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -203,6 +203,8 @@ class OutboxBase(Model):
         pass
 
     def drain_shard(self, max_updates_to_drain: int | None = None):
+        if not transaction.get_autocommit():
+            raise RuntimeError("drain_shard() should not be called within an atomic transaction.")
         runs = 0
         next_row: OutboxBase | None = self.selected_messages_in_shard().first()
         while next_row is not None and (


### PR DESCRIPTION
`Outbox.drain_shard()` should not be called within an atomic transaction. The rationale is that any exception that occurs from within `drain_shard()` should not trigger a rollback.

This should help us better organize our `drain_shard()` calls. 