### PR TITLE
feat(crons): Add environment selector to crons list page

### DIFF
--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -16,12 +16,19 @@ import useApi from 'sentry/utils/useApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {crontabAsText} from 'sentry/views/monitors/utils';
 
-import {Monitor, MonitorConfig, MonitorStatus, ScheduleType} from '../types';
+import {
+  Monitor,
+  MonitorConfig,
+  MonitorEnvironment,
+  MonitorStatus,
+  ScheduleType,
+} from '../types';
 
 import {MonitorBadge} from './monitorBadge';
 
 interface MonitorRowProps {
   monitor: Monitor;
+  monitorEnv: MonitorEnvironment;
   onDelete: () => void;
   organization: Organization;
 }
@@ -59,9 +66,9 @@ function scheduleAsText(config: MonitorConfig) {
   return t('Unknown schedule');
 }
 
-function MonitorRow({monitor, organization, onDelete}: MonitorRowProps) {
+function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowProps) {
   const api = useApi();
-  const lastCheckin = <TimeSince unitStyle="regular" date={monitor.lastCheckIn} />;
+  const lastCheckin = <TimeSince unitStyle="regular" date={monitorEnv.lastCheckIn} />;
 
   const actions: MenuItemProps[] = [
     {
@@ -93,7 +100,7 @@ function MonitorRow({monitor, organization, onDelete}: MonitorRowProps) {
   return (
     <Fragment>
       <MonitorName>
-        <MonitorBadge status={monitor.status} />
+        <MonitorBadge status={monitorEnv.status} />
         <NameAndSlug>
           <Link to={`/organizations/${organization.slug}/crons/${monitor.slug}/`}>
             {monitor.name}
@@ -101,38 +108,39 @@ function MonitorRow({monitor, organization, onDelete}: MonitorRowProps) {
           <MonitorSlug>{monitor.slug}</MonitorSlug>
         </NameAndSlug>
       </MonitorName>
-      <StatusColumn>
+      <MonitorColumn>
         <TextOverflow>
-          {monitor.status === MonitorStatus.DISABLED
+          {monitorEnv.status === MonitorStatus.DISABLED
             ? t('Paused')
-            : monitor.status === MonitorStatus.ACTIVE
+            : monitorEnv.status === MonitorStatus.ACTIVE
             ? t('Waiting for first check-in')
-            : monitor.status === MonitorStatus.OK
+            : monitorEnv.status === MonitorStatus.OK
             ? tct('Check-in [lastCheckin]', {lastCheckin})
-            : monitor.status === MonitorStatus.MISSED_CHECKIN
+            : monitorEnv.status === MonitorStatus.MISSED_CHECKIN
             ? tct('Missed [lastCheckin]', {lastCheckin})
-            : monitor.status === MonitorStatus.ERROR
+            : monitorEnv.status === MonitorStatus.ERROR
             ? tct('Failed [lastCheckin]', {lastCheckin})
             : null}
         </TextOverflow>
-      </StatusColumn>
-      <ScheduleColumn>{scheduleAsText(monitor.config)}</ScheduleColumn>
-      <NextCheckin>
-        {monitor.nextCheckIn &&
-        monitor.status !== MonitorStatus.DISABLED &&
-        monitor.status !== MonitorStatus.ACTIVE ? (
-          <TimeSince unitStyle="regular" date={monitor.nextCheckIn} />
+      </MonitorColumn>
+      <MonitorColumn>{scheduleAsText(monitor.config)}</MonitorColumn>
+      <MonitorColumn>
+        {monitorEnv.nextCheckIn &&
+        monitorEnv.status !== MonitorStatus.DISABLED &&
+        monitorEnv.status !== MonitorStatus.ACTIVE ? (
+          <TimeSince unitStyle="regular" date={monitorEnv.nextCheckIn} />
         ) : (
           '\u2014'
         )}
-      </NextCheckin>
-      <ProjectColumn>
+      </MonitorColumn>
+      <MonitorColumn>
         <IdBadge
           project={monitor.project}
           avatarSize={18}
           avatarProps={{hasTooltip: true, tooltip: monitor.project.slug}}
         />
-      </ProjectColumn>
+      </MonitorColumn>
+      <MonitorColumn>{monitorEnv.name}</MonitorColumn>
       <ActionsColumn>
         <DropdownMenu
           items={actions}
@@ -169,22 +177,7 @@ const MonitorSlug = styled('div')`
   color: ${p => p.theme.subText};
 `;
 
-const StatusColumn = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-const ScheduleColumn = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-const NextCheckin = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-const ProjectColumn = styled('div')`
+const MonitorColumn = styled('div')`
   display: flex;
   align-items: center;
 `;

--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -102,7 +102,9 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
       <MonitorName>
         <MonitorBadge status={monitorEnv.status} />
         <NameAndSlug>
-          <Link to={`/organizations/${organization.slug}/crons/${monitor.slug}/`}>
+          <Link
+            to={`/organizations/${organization.slug}/crons/${monitor.slug}/?environment=${monitorEnv.name}`}
+          >
             {monitor.name}
           </Link>
           <MonitorSlug>{monitor.slug}</MonitorSlug>

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -7,9 +7,11 @@ import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
 
 import {Button, ButtonProps} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import FeatureBadge from 'sentry/components/featureBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import Pagination from 'sentry/components/pagination';
@@ -128,7 +130,10 @@ class Monitors extends AsyncView<Props, State> {
         <Layout.Body>
           <Layout.Main fullWidth>
             <Filters>
-              <ProjectPageFilter resetParamsOnChange={['cursor']} />
+              <PageFilterBar>
+                <ProjectPageFilter resetParamsOnChange={['cursor']} />
+                <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
+              </PageFilterBar>
               <SearchBar
                 query={decodeScalar(qs.parse(location.search)?.query, '')}
                 placeholder={t('Search by name')}
@@ -144,21 +149,29 @@ class Monitors extends AsyncView<Props, State> {
                     t('Schedule'),
                     t('Next Checkin'),
                     t('Project'),
+                    t('Environment'),
                     t('Actions'),
                   ]}
                 >
-                  {monitorList?.map(monitor => (
-                    <MonitorRow
-                      key={monitor.slug}
-                      monitor={monitor}
-                      onDelete={() => {
-                        this.setState({
-                          monitorList: monitorList.filter(m => m.slug !== monitor.slug),
-                        });
-                      }}
-                      organization={organization}
-                    />
-                  ))}
+                  {monitorList
+                    ?.map(monitor =>
+                      monitor.environments.map(monitorEnv => (
+                        <MonitorRow
+                          key={monitor.slug}
+                          monitor={monitor}
+                          monitorEnv={monitorEnv}
+                          onDelete={() => {
+                            this.setState({
+                              monitorList: monitorList.filter(
+                                m => m.slug !== monitor.slug
+                              ),
+                            });
+                          }}
+                          organization={organization}
+                        />
+                      ))
+                    )
+                    .flat()}
                 </StyledPanelTable>
                 {monitorListPageLinks && (
                   <Pagination pageLinks={monitorListPageLinks} {...this.props} />
@@ -195,7 +208,7 @@ const Filters = styled('div')`
 `;
 
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: 1fr max-content max-content max-content max-content max-content;
+  grid-template-columns: 1fr max-content 1fr max-content max-content max-content max-content;
 `;
 
 const ButtonList = styled(ButtonBar)`


### PR DESCRIPTION
Very similar to https://github.com/getsentry/sentry/pull/46716, except includes the `?includeNew` so that newly created monitors with no checkins/envs are visible in the monitor list page.

![image](https://user-images.githubusercontent.com/9372512/229866008-61dbf58e-9f40-4846-bc02-9ecb7617d010.png)
