### PR TITLE
ref(prism): Auto-download language dependencies

### DIFF
--- a/static/app/utils/loadPrismLanguage.ts
+++ b/static/app/utils/loadPrismLanguage.ts
@@ -40,7 +40,7 @@ export async function loadPrismLanguage(
   }
 ) {
   try {
-    const language = prismLanguageMap[lang.toLowerCase()];
+    const language: string | undefined = prismLanguageMap[lang.toLowerCase()];
 
     // If Prism doesn't have any grammar file available for the language
     if (!language) {
@@ -54,7 +54,16 @@ export async function loadPrismLanguage(
       return;
     }
 
+    // Check for dependencies (e.g. `php` requires `markup-templating`) & download them
+    const deps: string[] | string | undefined =
+      prismComponents.languages[language].require;
+    (Array.isArray(deps) ? deps : [deps]).forEach(
+      async dep => dep && (await import(`prismjs/components/prism-${dep}.min`))
+    );
+
+    // Download language grammar file
     await import(`prismjs/components/prism-${language}.min`);
+
     onLoad?.();
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Automatically detect and download Prism language dependencies (some languages will not load correctly without them, e.g. [`php` requires `markup-templating`](https://github.com/PrismJS/prism/issues/1400)).

**Before ——**
![image](https://user-images.githubusercontent.com/44172267/229880541-9436a9fd-520b-43f8-b284-08db9971ea1d.png)
![image](https://user-images.githubusercontent.com/44172267/229880582-6ab702ea-80c6-4ebc-ac4f-6637e7be5153.png)


**After ——**
![image](https://user-images.githubusercontent.com/44172267/229880475-aa604e16-1bef-4c78-9742-6c3fdf48536f.png)
