### PR TITLE
feat(crons): Include empty env checkins for prod environment

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
+from django.db.models import Q
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -61,8 +62,24 @@ class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint):
 
         environments = get_environments(request, organization)
 
+        # XXX(epurkhiser): This is a hack right now, since we were not dual
+        # writing missed check-ins, we have many past checkins that are not
+        # assocaiated to an environment.
+        #
+        # When the environment is 'production' (the default) or empty, we will
+        # explicitly include monitor environments that are missing
+        skip_environments_when_production = (
+            len(environments) == 1 and environments[0].name == "production"
+        )
+
         if environments:
-            queryset = queryset.filter(monitor_environment__environment__in=environments)
+            if skip_environments_when_production:
+                queryset = queryset.filter(
+                    Q(monitor_environment__environment__in=environments)
+                    | Q(monitor_environment=None)
+                )
+            else:
+                queryset = queryset.filter(monitor_environment__environment__in=environments)
 
         return self.paginate(
             request=request,

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
@@ -100,6 +100,45 @@ class ListMonitorCheckInsTest(MonitorTestCase):
         assert resp.data[0]["id"] == str(checkin1.guid)
         assert resp.data[0]["environment"] == str(checkin1.monitor_environment.environment.name)
 
+    def test_hack_environment_production_includes_all(self):
+        self.login_as(self.user)
+
+        monitor = self._create_monitor()
+        monitor_environment = self._create_monitor_environment(monitor, name="production")
+        checkin1 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            date_added=monitor.date_added - timedelta(minutes=2),
+            status=CheckInStatus.OK,
+        )
+        checkin2 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=self.project.id,
+            date_added=monitor.date_added - timedelta(minutes=1),
+            status=CheckInStatus.OK,
+        )
+
+        other_env = self._create_monitor_environment(monitor, name="jungle")
+        MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=other_env,
+            project_id=self.project.id,
+            date_added=monitor.date_added - timedelta(minutes=1),
+            status=CheckInStatus.OK,
+        )
+
+        # When querying for he production environment checkins all non
+        # environment checkins are included
+        resp = self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            **{"statsPeriod": "1d", "environment": "production"},
+        )
+        assert len(resp.data) == 2
+        assert resp.data[0]["id"] == str(checkin2.guid)
+        assert resp.data[1]["id"] == str(checkin1.guid)
+
     def test_bad_monitorenvironment(self):
         self.login_as(self.user)
 


### PR DESCRIPTION
This is a temporary hack while we backfill the old checkins which do not have monitor environments.

This allows us to get the frontend out for monitor environments (https://github.com/getsentry/sentry/issues/45024) without being blocked on this data integrity correction