### PR TITLE
feat(crons): Warn users they are deleting additional monitor environments

### DIFF
--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -28,6 +28,7 @@ import {MonitorBadge} from './monitorBadge';
 
 interface MonitorRowProps {
   monitor: Monitor;
+  monitorEnv: MonitorEnvironment;
   onDelete: () => void;
   organization: Organization;
   monitorEnv?: MonitorEnvironment;

--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -86,7 +86,7 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
         <AdditionalEnvironmentWarning>
           <Text>
             {t(
-              `This monitor has checkin data associated with these environments which will also be affected:`
+              `This will delete check-in data for this monitor associated with these environments:`
             )}
           </Text>
           <List symbol="bullet">

--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -72,6 +72,13 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
     <TimeSince unitStyle="regular" date={monitorEnv.lastCheckIn} />
   ) : null;
 
+  const extraEnvironmentsWarning =
+    monitor.environments.length > 1
+      ? ` This monitor has checkin data associated with these environments which will be affected: ${monitor.environments
+          .map(e => `'${e.name}'`)
+          .join(', ')}`
+      : '';
+
   const actions: MenuItemProps[] = [
     {
       key: 'edit',
@@ -89,9 +96,13 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
             onDelete();
           },
           header: t('Delete Monitor?'),
-          message: tct('Are you sure you want to permanently delete [name]?', {
-            name: monitor.name,
-          }),
+          message: tct(
+            'Are you sure you want to permanently delete [name]?[extraEnvironmentsWarning]',
+            {
+              name: monitor.name,
+              extraEnvironmentsWarning,
+            }
+          ),
           confirmText: t('Delete Monitor'),
           priority: 'danger',
         });

--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -6,6 +6,9 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
+import Text from 'sentry/components/text';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
@@ -72,13 +75,29 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
     <TimeSince unitStyle="regular" date={monitorEnv.lastCheckIn} />
   ) : null;
 
-  const extraEnvironmentsWarning =
-    monitor.environments.length > 1
-      ? ` This monitor has checkin data associated with these environments which will be affected: ${monitor.environments
-          .map(e => `'${e.name}'`)
-          .join(', ')}`
-      : '';
-
+  const deletionModalMessage = (
+    <Fragment>
+      <Text>
+        {tct('Are you sure you want to permanently delete "[name]"?', {
+          name: monitor.name,
+        })}
+      </Text>
+      {monitor.environments.length > 1 && (
+        <AdditionalEnvironmentWarning>
+          <Text>
+            {t(
+              `This monitor has checkin data associated with these environments which will also be affected:`
+            )}
+          </Text>
+          <List symbol="bullet">
+            {monitor.environments.map(environment => (
+              <ListItem key={environment.name}>{environment.name}</ListItem>
+            ))}
+          </List>
+        </AdditionalEnvironmentWarning>
+      )}
+    </Fragment>
+  );
   const actions: MenuItemProps[] = [
     {
       key: 'edit',
@@ -96,13 +115,7 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
             onDelete();
           },
           header: t('Delete Monitor?'),
-          message: tct(
-            'Are you sure you want to permanently delete [name]?[extraEnvironmentsWarning]',
-            {
-              name: monitor.name,
-              extraEnvironmentsWarning,
-            }
-          ),
+          message: deletionModalMessage,
           confirmText: t('Delete Monitor'),
           priority: 'danger',
         });
@@ -204,4 +217,8 @@ const ActionsColumn = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+const AdditionalEnvironmentWarning = styled('div')`
+  margin: ${space(1)} 0;
 `;

--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -28,7 +28,6 @@ import {MonitorBadge} from './monitorBadge';
 
 interface MonitorRowProps {
   monitor: Monitor;
-  monitorEnv: MonitorEnvironment;
   onDelete: () => void;
   organization: Organization;
   monitorEnv?: MonitorEnvironment;


### PR DESCRIPTION
If multiple monitor environments
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/9372512/229894228-1d0698f0-01fc-4d05-b65c-ea0d1f3796c1.png">

If not multiple monitor environments
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/9372512/229895096-17482d46-5057-46ba-9b66-18b3bdeb949a.png">
