### PR TITLE
feat(transactions): Add time window selection to CPU chart

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -535,26 +535,9 @@ class TraceViewHeader extends Component<PropType, State> {
                           profileData={profiles.data}
                           renderCursorGuide={this.renderCursorGuide}
                           renderFog={() => this.renderFog(this.props.dragProps)}
-                          renderViewHandles={() =>
-                            this.renderViewHandles(this.props.dragProps, true)
-                          }
                           renderWindowSelection={() =>
                             this.renderWindowSelection(this.props.dragProps)
                           }
-                          onChartMouseDown={event => {
-                            const target = event.target;
-
-                            if (
-                              target instanceof Element &&
-                              target.getAttribute &&
-                              target.getAttribute('data-ignore')
-                            ) {
-                              // ignore this event if we need to
-                              return;
-                            }
-
-                            this.props.dragProps.onWindowSelectionDragStart(event);
-                          }}
                         />
                       )}
                       {this.renderSecondaryHeader(hasProfileMeasurementsChart)}

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -117,18 +117,15 @@ class TraceViewHeader extends Component<PropType, State> {
     );
   }
 
-  renderViewHandles(
-    {
-      isDragging,
-      onLeftHandleDragStart,
-      leftHandlePosition,
-      onRightHandleDragStart,
-      rightHandlePosition,
-      viewWindowStart,
-      viewWindowEnd,
-    }: DragManagerChildrenProps,
-    isChart: boolean = false
-  ) {
+  renderViewHandles({
+    isDragging,
+    onLeftHandleDragStart,
+    leftHandlePosition,
+    onRightHandleDragStart,
+    rightHandlePosition,
+    viewWindowStart,
+    viewWindowEnd,
+  }: DragManagerChildrenProps) {
     const leftHandleGhost = isDragging ? (
       <Handle
         left={viewWindowStart}
@@ -136,7 +133,6 @@ class TraceViewHeader extends Component<PropType, State> {
           // do nothing
         }}
         isDragging={false}
-        isChart={isChart}
       />
     ) : null;
 
@@ -145,7 +141,6 @@ class TraceViewHeader extends Component<PropType, State> {
         left={leftHandlePosition}
         onMouseDown={onLeftHandleDragStart}
         isDragging={isDragging}
-        isChart={isChart}
       />
     );
 
@@ -154,7 +149,6 @@ class TraceViewHeader extends Component<PropType, State> {
         left={rightHandlePosition}
         onMouseDown={onRightHandleDragStart}
         isDragging={isDragging}
-        isChart={isChart}
       />
     );
 
@@ -165,7 +159,6 @@ class TraceViewHeader extends Component<PropType, State> {
           // do nothing
         }}
         isDragging={false}
-        isChart={isChart}
       />
     ) : null;
 
@@ -803,16 +796,14 @@ const MinimapContainer = styled('div')`
   left: 0;
 `;
 
-const ViewHandleContainer = styled('div')<{isChart: boolean}>`
+const ViewHandleContainer = styled('div')`
   position: absolute;
   top: 0;
-  height: ${p => (p.isChart ? PROFILE_MEASUREMENTS_CHART_HEIGHT : MINIMAP_HEIGHT)}px;
+  height: 100%;
 `;
 
-const ViewHandleLine = styled('div')<{isChart: boolean}>`
-  height: ${p =>
-    (p.isChart ? PROFILE_MEASUREMENTS_CHART_HEIGHT : MINIMAP_HEIGHT) -
-    VIEW_HANDLE_HEIGHT}px;
+const ViewHandleLine = styled('div')`
+  height: calc(100% - ${VIEW_HANDLE_HEIGHT}px);
   width: 2px;
   background-color: ${p => p.theme.textColor};
 `;
@@ -870,9 +861,7 @@ const Handle = ({
   left,
   onMouseDown,
   isDragging,
-  isChart,
 }: {
-  isChart: boolean;
   isDragging: boolean;
   left: number;
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -881,9 +870,8 @@ const Handle = ({
     style={{
       left: toPercent(left),
     }}
-    isChart={isChart}
   >
-    <ViewHandleLine isChart={isChart} />
+    <ViewHandleLine />
     <ViewHandle
       data-ignore="true"
       onMouseDown={onMouseDown}

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -898,7 +898,7 @@ const Handle = ({
 const WindowSelection = styled('div')`
   position: absolute;
   top: 0;
-  height: ${MINIMAP_HEIGHT}px;
+  height: 100%;
   background-color: ${p => p.theme.textColor};
   opacity: 0.1;
 `;

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -104,7 +104,6 @@ const MemoizedChart = React.memo(Chart);
 
 type ProfilingMeasurementsProps = {
   profileData: Profiling.ProfileInput;
-  onChartMouseDown?: (event: React.MouseEvent<HTMLDivElement>) => void;
   renderCursorGuide?: ({
     cursorGuideHeight,
     mouseLeft,
@@ -115,7 +114,6 @@ type ProfilingMeasurementsProps = {
     showCursorGuide: boolean;
   }) => void;
   renderFog?: () => void;
-  renderViewHandles?: () => void;
   renderWindowSelection?: () => void;
 };
 
@@ -123,9 +121,7 @@ function ProfilingMeasurements({
   profileData,
   renderCursorGuide,
   renderFog,
-  renderViewHandles,
   renderWindowSelection,
-  onChartMouseDown,
 }: ProfilingMeasurementsProps) {
   const theme = useTheme();
 
@@ -160,7 +156,6 @@ function ProfilingMeasurements({
                 onMouseMove={event => {
                   displayCursorGuide(event.pageX);
                 }}
-                onMouseDown={onChartMouseDown}
               >
                 <MemoizedChart data={cpuUsageData} />
                 {renderFog?.()}
@@ -169,7 +164,6 @@ function ProfilingMeasurements({
                   mouseLeft,
                   cursorGuideHeight: PROFILE_MEASUREMENTS_CHART_HEIGHT,
                 })}
-                {/* {renderViewHandles?.()} */}
                 {renderWindowSelection?.()}
               </ChartContainer>
             </MeasurementContainer>

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -158,13 +158,15 @@ function ProfilingMeasurements({
                 }}
               >
                 <MemoizedChart data={cpuUsageData} />
-                {renderFog?.()}
-                {renderCursorGuide?.({
-                  showCursorGuide,
-                  mouseLeft,
-                  cursorGuideHeight: PROFILE_MEASUREMENTS_CHART_HEIGHT,
-                })}
-                {renderWindowSelection?.()}
+                <Overlays dividerPosition={dividerPosition}>
+                  {renderFog?.()}
+                  {renderCursorGuide?.({
+                    showCursorGuide,
+                    mouseLeft,
+                    cursorGuideHeight: PROFILE_MEASUREMENTS_CHART_HEIGHT,
+                  })}
+                  {renderWindowSelection?.()}
+                </Overlays>
               </ChartContainer>
             </MeasurementContainer>
           )}
@@ -175,6 +177,14 @@ function ProfilingMeasurements({
 }
 
 export {ProfilingMeasurements};
+
+const Overlays = styled('div')<{dividerPosition: number}>`
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 100%;
+`;
 
 const ChartContainer = styled('div')`
   position: relative;

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -158,7 +158,7 @@ function ProfilingMeasurements({
                 }}
               >
                 <MemoizedChart data={cpuUsageData} />
-                <Overlays dividerPosition={dividerPosition}>
+                <Overlays>
                   {renderFog?.()}
                   {renderCursorGuide?.({
                     showCursorGuide,
@@ -178,7 +178,7 @@ function ProfilingMeasurements({
 
 export {ProfilingMeasurements};
 
-const Overlays = styled('div')<{dividerPosition: number}>`
+const Overlays = styled('div')`
   pointer-events: none;
   position: absolute;
   top: 0;

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -104,6 +104,7 @@ const MemoizedChart = React.memo(Chart);
 
 type ProfilingMeasurementsProps = {
   profileData: Profiling.ProfileInput;
+  onChartMouseDown?: (event: React.MouseEvent<HTMLDivElement>) => void;
   renderCursorGuide?: ({
     cursorGuideHeight,
     mouseLeft,
@@ -113,11 +114,18 @@ type ProfilingMeasurementsProps = {
     mouseLeft: number | undefined;
     showCursorGuide: boolean;
   }) => void;
+  renderFog?: () => void;
+  renderViewHandles?: () => void;
+  renderWindowSelection?: () => void;
 };
 
 function ProfilingMeasurements({
   profileData,
   renderCursorGuide,
+  renderFog,
+  renderViewHandles,
+  renderWindowSelection,
+  onChartMouseDown,
 }: ProfilingMeasurementsProps) {
   const theme = useTheme();
 
@@ -152,13 +160,17 @@ function ProfilingMeasurements({
                 onMouseMove={event => {
                   displayCursorGuide(event.pageX);
                 }}
+                onMouseDown={onChartMouseDown}
               >
                 <MemoizedChart data={cpuUsageData} />
+                {renderFog?.()}
                 {renderCursorGuide?.({
                   showCursorGuide,
                   mouseLeft,
                   cursorGuideHeight: PROFILE_MEASUREMENTS_CHART_HEIGHT,
                 })}
+                {/* {renderViewHandles?.()} */}
+                {renderWindowSelection?.()}
               </ChartContainer>
             </MeasurementContainer>
           )}


### PR DESCRIPTION
Adds the greyed out areas when making a time range selection. The chart's datapoints should still be hoverable when there's a selection. There was an explicit decision to not include the click and drag selection on the CPU chart at this time.


https://user-images.githubusercontent.com/22846452/229894216-9d788b3e-1401-4908-9639-60fdaf10e1a6.mov

Depends on #46686 
Closes #46689
