### PR TITLE
feat(crons): Record cron monitor created from upsert

### DIFF
--- a/src/sentry/analytics/events/first_cron_monitor_created.py
+++ b/src/sentry/analytics/events/first_cron_monitor_created.py
@@ -7,6 +7,7 @@ class FirstCronMonitorCreated(analytics.Event):
     attributes = (
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id"),
+        analytics.Attribute("from_upsert"),
         analytics.Attribute("user_id", required=False),
     )
 

--- a/src/sentry/monitors/consumers/check_in.py
+++ b/src/sentry/monitors/consumers/check_in.py
@@ -19,7 +19,7 @@ from sentry.monitors.models import (
     MonitorStatus,
     MonitorType,
 )
-from sentry.monitors.utils import signal_first_checkin
+from sentry.monitors.utils import signal_first_checkin, signal_first_monitor_created
 from sentry.monitors.validators import ConfigValidator
 from sentry.utils import json
 from sentry.utils.dates import to_datetime
@@ -66,6 +66,7 @@ def _ensure_monitor_with_config(
                 "config": validated_config,
             },
         )
+        signal_first_monitor_created(project, None, True)
 
     # Update existing monitor
     if monitor and not created and monitor.config != validated_config:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -134,7 +134,7 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
             # Create a new monitor during checkin. Uses update_or_create to
             # protect against races.
             if create_monitor:
-                monitor, _ = Monitor.objects.update_or_create(
+                monitor, created = Monitor.objects.update_or_create(
                     organization_id=project.organization_id,
                     slug=monitor_data["slug"],
                     defaults={
@@ -145,7 +145,9 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
                         "config": monitor_data["config"],
                     },
                 )
-                signal_first_monitor_created(project, request.user, True)
+
+                if created:
+                    signal_first_monitor_created(project, request.user, True)
 
             # Monitor does not exist and we have not created one
             if not monitor:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -26,10 +26,9 @@ from sentry.monitors.models import (
     MonitorStatus,
 )
 from sentry.monitors.serializers import MonitorCheckInSerializerResponse
-from sentry.monitors.utils import signal_first_checkin
+from sentry.monitors.utils import signal_first_checkin, signal_first_monitor_created
 from sentry.monitors.validators import MonitorCheckInValidator
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.signals import first_cron_monitor_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 
@@ -146,10 +145,7 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
                         "config": monitor_data["config"],
                     },
                 )
-                if not project.flags.has_cron_monitors:
-                    first_cron_monitor_created.send_robust(
-                        project=project, user=request.user, sender=Project
-                    )
+                signal_first_monitor_created(project, request.user, True)
 
             # Monitor does not exist and we have not created one
             if not monitor:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -29,6 +29,7 @@ from sentry.monitors.serializers import MonitorCheckInSerializerResponse
 from sentry.monitors.utils import signal_first_checkin
 from sentry.monitors.validators import MonitorCheckInValidator
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.signals import first_cron_monitor_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 
@@ -145,6 +146,10 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
                         "config": monitor_data["config"],
                     },
                 )
+                if not project.flags.has_cron_monitors:
+                    first_cron_monitor_created.send_robust(
+                        project=project, user=request.user, sender=Project
+                    )
 
             # Monitor does not exist and we have not created one
             if not monitor:

--- a/src/sentry/monitors/endpoints/organization_monitors.py
+++ b/src/sentry/monitors/endpoints/organization_monitors.py
@@ -7,12 +7,12 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.db.models.query import in_iexact
-from sentry.models import Environment, Organization, Project
+from sentry.models import Environment, Organization
 from sentry.monitors.models import Monitor, MonitorStatus, MonitorType
 from sentry.monitors.serializers import MonitorSerializer
+from sentry.monitors.utils import signal_first_monitor_created
 from sentry.monitors.validators import MonitorValidator
 from sentry.search.utils import tokenize_query
-from sentry.signals import first_cron_monitor_created
 
 from .base import OrganizationMonitorPermission
 
@@ -156,9 +156,6 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
         )
 
         project = result["project"]
-        if not project.flags.has_cron_monitors:
-            first_cron_monitor_created.send_robust(
-                project=project, user=request.user, sender=Project
-            )
+        signal_first_monitor_created(project, request.user, False)
 
         return self.respond(serialize(monitor, request.user), status=201)

--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -7,8 +7,14 @@ from .models import Monitor
 def signal_first_checkin(project: Project, monitor: Monitor):
     if not project.flags.has_cron_checkins:
         # Backfill users that already have cron monitors
-        if not project.flags.has_cron_monitors:
-            first_cron_monitor_created.send_robust(project=project, user=None, sender=Project)
+        signal_first_monitor_created(project, None, False)
         first_cron_checkin_received.send_robust(
             project=project, monitor_id=str(monitor.guid), sender=Project
+        )
+
+
+def signal_first_monitor_created(project: Project, user, from_upsert: bool):
+    if not project.flags.has_cron_monitors:
+        first_cron_monitor_created.send_robust(
+            project=project, user=user, from_upsert=from_upsert, sender=Project
         )

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -248,15 +248,16 @@ def record_first_replay(project, **kwargs):
 
 @first_cron_monitor_created.connect(weak=False)
 def record_first_cron_monitor(project, user, from_upsert, **kwargs):
-    project.update(flags=F("flags").bitor(Project.flags.has_cron_monitors))
+    updated = project.update(flags=F("flags").bitor(Project.flags.has_cron_monitors))
 
-    analytics.record(
-        "first_cron_monitor.created",
-        user_id=user.id if user else project.organization.default_owner_id,
-        organization_id=project.organization_id,
-        project_id=project.id,
-        from_upsert=from_upsert,
-    )
+    if updated:
+        analytics.record(
+            "first_cron_monitor.created",
+            user_id=user.id if user else project.organization.default_owner_id,
+            organization_id=project.organization_id,
+            project_id=project.id,
+            from_upsert=from_upsert,
+        )
 
 
 @first_cron_checkin_received.connect(weak=False)

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -247,7 +247,7 @@ def record_first_replay(project, **kwargs):
 
 
 @first_cron_monitor_created.connect(weak=False)
-def record_first_cron_monitor(project, user, **kwargs):
+def record_first_cron_monitor(project, user, from_upsert, **kwargs):
     project.update(flags=F("flags").bitor(Project.flags.has_cron_monitors))
 
     analytics.record(
@@ -255,6 +255,7 @@ def record_first_cron_monitor(project, user, **kwargs):
         user_id=user.id if user else project.organization.default_owner_id,
         organization_id=project.organization_id,
         project_id=project.id,
+        from_upsert=from_upsert,
     )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -122,7 +122,7 @@ first_event_with_minified_stack_trace_received = BetterSignal(providing_args=["p
 first_transaction_received = BetterSignal(providing_args=["project", "event"])
 first_profile_received = BetterSignal(providing_args=["project"])
 first_replay_received = BetterSignal(providing_args=["project"])
-first_cron_monitor_created = BetterSignal(providing_args=["project", "user"])
+first_cron_monitor_created = BetterSignal(providing_args=["project", "user", "from_upsert"])
 first_cron_checkin_received = BetterSignal(providing_args=["project", "monitor_id"])
 member_invited = BetterSignal(providing_args=["member", "user"])
 member_joined = BetterSignal(providing_args=["member", "organization"])

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -148,6 +148,7 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
             user_id=self.user.id,
             organization_id=self.organization.id,
             project_id=self.project.id,
+            from_upsert=False,
         )
 
     def test_slug(self):


### PR DESCRIPTION
Previously we had analytics that would fire everytime an org's user created the first cron monitor in their project, extending this and adding it to the revelant places where we create a cron monitor for the user automatically.