### PR TITLE
fix(workflow): Add features array to share issue org

### DIFF
--- a/static/app/views/sharedGroupDetails/index.tsx
+++ b/static/app/views/sharedGroupDetails/index.tsx
@@ -123,10 +123,13 @@ class SharedGroupDetails extends Component<Props, State> {
     const {location} = this.props;
     const {permalink, latestEvent, project} = group;
     const title = this.getTitle();
+    // project.organization is not a real organization, it's just the slug and name
+    // Add the features array to avoid errors when using OrganizationContext
+    const org = {...project.organization, features: []};
 
     return (
       <SentryDocumentTitle noSuffix title={title}>
-        <OrganizationContext.Provider value={project.organization}>
+        <OrganizationContext.Provider value={org}>
           <div className="app">
             <div className="pattern-bg" />
             <div className="container">
@@ -146,7 +149,7 @@ class SharedGroupDetails extends Component<Props, State> {
                   <Container className="group-overview event-details-container">
                     <BorderlessEventEntries
                       location={location}
-                      organization={project.organization}
+                      organization={org}
                       group={group}
                       event={latestEvent}
                       project={project}


### PR DESCRIPTION
Organization on the share page is only `{name: 'sentry', slug: 'sentry'}` this is a pretty unique page in that the user isn't logged in. The organization types are not helpful on these pages and we often access properties that don't work.

Adding features will silence the most common error. 

Examples: 
https://sentry.sentry.io/issues/4061689187/
https://sentry.sentry.io/issues/4062235924/
https://sentry.sentry.io/issues/4062119796/
