### PR TITLE
ref(crons): Remove Integrate Using prefix on quick start guide

### DIFF
--- a/static/app/views/monitors/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/monitors/components/monitorQuickStartGuide.tsx
@@ -112,7 +112,6 @@ export default function MonitorQuickStartGuide({monitor, orgId}: Props) {
         options={exampleOptions}
         value={selectedGuide}
         onChange={({value}) => setSelectedGuide(value)}
-        triggerProps={{prefix: 'Integrate Using'}}
       />
       <Guide slug={monitor.slug} orgSlug={orgId} dsnKey={projectKeys?.[0].dsn.public} />
     </Container>


### PR DESCRIPTION
Request from @robinrendle 

Before:
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/9372512/229939339-11b73442-7700-4429-92ed-defb981ca3db.png">


After:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/9372512/229939219-89f1f26d-ea22-4079-9c9e-024f435e0bda.png">
