### PR TITLE
feat(breadcrumbs): Format SQL queries in breadcrumbs

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import datetime
-from typing import Sequence
+from typing import Any, Sequence
 
+import sqlparse
 from django.utils import timezone
 from sentry_relay import meta_with_chunks
 
+from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.issues.grouptype import (
@@ -23,6 +25,7 @@ from sentry.utils.safe import get_path
 
 CRASH_FILE_TYPES = {"event.minidump"}
 RESERVED_KEYS = frozenset(["user", "sdk", "device", "contexts"])
+FORMATTED_BREADCRUMB_CATEGORIES = frozenset(["query", "sql.query"])
 
 
 def get_crash_files(events):
@@ -366,12 +369,36 @@ class DetailedEventSerializer(EventSerializer):
         converted_problem["issueType"] = get_group_type_by_type_id(issue_type).slug
         return converted_problem
 
+    def _format_breadcrumb_messages(
+        self, event_data: dict[str, Any], event: Event | GroupEvent, user: User
+    ):
+        breadcrumbs = next(
+            filter(lambda entry: entry["type"] == "breadcrumbs", event_data["entries"]), None
+        )
+
+        if not breadcrumbs or not features.has(
+            "organizations:issue-breadcrumbs-sql-format", event.project.organization, actor=user
+        ):
+            return event_data
+
+        try:
+            for breadcrumb_item in breadcrumbs["data"]["values"]:
+                if breadcrumb_item["category"] in FORMATTED_BREADCRUMB_CATEGORIES:
+                    breadcrumb_item["messageRaw"] = breadcrumb_item["message"]
+                    breadcrumb_item["message"] = sqlparse.format(
+                        breadcrumb_item["message"], reindent_aligned=True
+                    )
+            return event_data
+        except Exception:
+            return event_data
+
     def serialize(self, obj, attrs, user):
         result = super().serialize(obj, attrs, user)
         result["release"] = self._get_release_info(user, obj)
         result["userReport"] = self._get_user_report(user, obj)
         result["sdkUpdates"] = self._get_sdk_updates(obj)
         result["perfProblem"] = self._get_perf_problem(attrs)
+        result = self._format_breadcrumb_messages(result, obj, user)
         return result
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1211,6 +1211,8 @@ SENTRY_FEATURES = {
     "organizations:issue-alert-fallback-experiment": False,
     # Enable new issue alert "issue owners" fallback
     "organizations:issue-alert-fallback-targeting": False,
+    # Enable SQL formatting for breadcrumb items
+    "organizations:issue-breadcrumbs-sql-format": False,
     # Enable removing issue from issue list if action taken.
     "organizations:issue-list-removal-action": False,
     # Adds the ttid & ttfd vitals to the frontend

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -88,6 +88,7 @@ default_manager.add("organizations:issue-alert-fallback-targeting", Organization
 default_manager.add("organizations:issue-alert-incompatible-rules", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-alert-preview", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-alert-test-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:issue-breadcrumbs-sql-format", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-removal-action", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -489,8 +489,13 @@ class DetailedEventSerializerTest(TestCase):
             assert result["entries"][0]["type"] == "breadcrumbs"
             # First breadcrumb should not have a message_formatted property
             assert result["entries"][0]["data"]["values"][0]["message"] == "should not format this"
+            assert "messageRaw" not in result["entries"][0]["data"]["values"][0]
             # Second breadcrumb should have whitespace added in message_formatted
             assert (
                 result["entries"][0]["data"]["values"][1]["message"]
                 == "select *\n  from table\n where something = $1"
+            )
+            assert (
+                result["entries"][0]["data"]["values"][1]["messageRaw"]
+                == "select * from table where something = $1"
             )


### PR DESCRIPTION
This is a POC! Still requires testing to ensure that the formatting doesn't misfire too often on non-sql content.

This is the second attempt since the first caused too many calls to flagr. I've moved the logic to `DetailedEventSerializer` which should only be used in the event details endpoint.

Before:

![CleanShot 2023-04-04 at 15 49 46](https://user-images.githubusercontent.com/10888943/229939202-69c8c6b5-2076-4d1a-b11d-19d1b504a155.png)


After:

![CleanShot 2023-04-04 at 15 49 09](https://user-images.githubusercontent.com/10888943/229939146-786a39bb-634b-4e9d-ae5e-23b790cf291c.png)
