### PR TITLE
feat(compactSelect): Add `onInteractOutside` callback

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -157,6 +157,7 @@ export function Control({
   triggerProps,
   isOpen,
   onClose,
+  onInteractOutside,
   disabled,
   position = 'bottom-start',
   offset,
@@ -242,6 +243,7 @@ export function Control({
     position,
     offset,
     isOpen,
+    onInteractOutside,
     onOpenChange: async open => {
       // On open
       if (open) {

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -58,6 +58,7 @@ interface DropdownMenuProps
       | 'isDismissable'
       | 'shouldCloseOnBlur'
       | 'shouldCloseOnInteractOutside'
+      | 'onInteractOutside'
       | 'preventOverflowOptions'
     > {
   /**
@@ -143,6 +144,7 @@ function DropdownMenu({
   isDismissable = true,
   shouldCloseOnBlur = true,
   shouldCloseOnInteractOutside,
+  onInteractOutside,
   preventOverflowOptions,
   ...props
 }: DropdownMenuProps) {
@@ -163,6 +165,7 @@ function DropdownMenu({
     isDismissable,
     shouldCloseOnBlur,
     shouldCloseOnInteractOutside,
+    onInteractOutside,
     preventOverflowOptions,
   });
 


### PR DESCRIPTION
Add an optional `onInteractOutside` callback to `useOverlay`, which will be called when the overlay closes due to an outside interaction (click):

https://user-images.githubusercontent.com/44172267/229941787-4f3baf69-3cff-4c20-90c0-99590c8e82b4.mov

