### PR TITLE
ref(crons): Add defaults to monitor creation form

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -40,6 +40,7 @@ const SCHEDULE_OPTIONS: RadioOption<string>[] = [
 ];
 
 const DEFAULT_MONITOR_TYPE = 'cron_job';
+const DEFAULT_CRONTAB = '* * * * *';
 
 const getIntervals = (n: number): SelectValue<string>[] => [
   {value: 'minute', label: tn('minute', 'minutes', n)},
@@ -107,7 +108,7 @@ function MonitorForm({
   const [crontabInput, setCrontabInput] = useState(
     monitor?.config.schedule_type === ScheduleType.CRONTAB
       ? monitor?.config.schedule
-      : null
+      : DEFAULT_CRONTAB
   );
 
   function formDataFromConfig(type: MonitorType, config: MonitorConfig) {
@@ -245,7 +246,8 @@ function MonitorForm({
                   <ScheduleGroupInputs>
                     <StyledTextField
                       name="config.schedule"
-                      placeholder="*/5 * * * *"
+                      placeholder="* * * * *"
+                      defaultValue={DEFAULT_CRONTAB}
                       css={{input: {fontFamily: commonTheme.text.familyMono}}}
                       required
                       stacked
@@ -271,6 +273,7 @@ function MonitorForm({
                     <StyledNumberField
                       name="config.schedule.frequency"
                       placeholder="e.g. 1"
+                      defaultValue="1"
                       required
                       stacked
                       inline={false}
@@ -280,7 +283,7 @@ function MonitorForm({
                       options={getIntervals(
                         Number(form.current.getValue('config.schedule.frequency') ?? 1)
                       )}
-                      placeholder="minute"
+                      defaultValue="minute"
                       required
                       stacked
                       inline={false}

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -40,7 +40,7 @@ const SCHEDULE_OPTIONS: RadioOption<string>[] = [
 ];
 
 const DEFAULT_MONITOR_TYPE = 'cron_job';
-const DEFAULT_CRONTAB = '* * * * *';
+const DEFAULT_CRONTAB = '0 0 * * *';
 
 const getIntervals = (n: number): SelectValue<string>[] => [
   {value: 'minute', label: tn('minute', 'minutes', n)},
@@ -283,7 +283,7 @@ function MonitorForm({
                       options={getIntervals(
                         Number(form.current.getValue('config.schedule.frequency') ?? 1)
                       )}
-                      defaultValue="minute"
+                      defaultValue="day"
                       required
                       stacked
                       inline={false}


### PR DESCRIPTION
Defaults to the most commonly used schedules for interval and crontab

EDIT: most commonly used schedule as of 4/10/2023 is now 1 day for interval/crontab [screenshots below outdated]

Old Form:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/9372512/229942122-aa8961d2-9bcb-477c-bc74-6648299f52fe.png">

<img width="699" alt="image" src="https://user-images.githubusercontent.com/9372512/229942145-c8420ca1-3898-4466-bdb6-39ad8a0bd74e.png">


New Defaults:
<img width="651" alt="image" src="https://user-images.githubusercontent.com/9372512/229942061-74f9b75c-86d1-44fc-b23d-3640f3e4c4f9.png">

<img width="724" alt="image" src="https://user-images.githubusercontent.com/9372512/229942088-1ba030d3-4422-40b9-9714-151d3d5c32b5.png">

