### PR TITLE
feat(hc): Allow non-abstract methods in RPC interface

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/__init__.py
+++ b/src/sentry/services/hybrid_cloud/integration/__init__.py
@@ -184,6 +184,7 @@ class IntegrationService(RpcService):
         """
         pass
 
+    @rpc_method
     def get_organization_integration(
         self, *, integration_id: int, organization_id: int
     ) -> Optional[RpcOrganizationIntegration]:
@@ -295,6 +296,7 @@ class IntegrationService(RpcService):
 
     # The following methods replace instance methods of the ORM objects!
 
+    @rpc_method
     def get_installation(
         self,
         *,
@@ -315,6 +317,7 @@ class IntegrationService(RpcService):
         )
         return installation
 
+    @rpc_method
     def has_feature(self, *, provider: str, feature: "IntegrationFeatures") -> bool:
         """
         Returns True if the IntegrationProvider subclass contains a given feature

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -202,6 +202,7 @@ class UserService(RpcService):
         # Returns a serialized user
         pass
 
+    @rpc_method
     def get_user(self, user_id: int) -> Optional[RpcUser]:
         """
         This method returns a User object given an ID


### PR DESCRIPTION
This is a moot change for the typical case of one silo calling another silo. However, the RPC interface is also offered to arbitrary clients, and may include methods that neither silo needs to execute remotely.