### PR TITLE
fix(replays): correct archive query

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from typing import Any, Dict, Generator, List, Optional, Union
 
 from snuba_sdk import (
+    BooleanCondition,
+    BooleanOp,
     Column,
     Condition,
     Entity,
@@ -153,7 +155,13 @@ def query_replays_dataset(
                 # Make sure we're not too old.
                 Condition(Column("finished_at"), Op.LT, end),
                 # Require non-archived replays.
-                Condition(Column("isArchived"), Op.EQ, 0),
+                BooleanCondition(
+                    BooleanOp.OR,
+                    [
+                        Condition(Column("isArchived"), Op.EQ, 0),
+                        Condition(Column("isArchived"), Op.IS_NULL),
+                    ],
+                ),
                 # User conditions.
                 *generate_valid_conditions(search_filters, query_config=ReplayQueryConfig()),
                 # Other conditions.

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -153,7 +153,7 @@ def query_replays_dataset(
                 # Make sure we're not too old.
                 Condition(Column("finished_at"), Op.LT, end),
                 # Require non-archived replays.
-                Condition(Column("isArchived"), Op.IS_NULL),
+                Condition(Column("isArchived"), Op.EQ, 0),
                 # User conditions.
                 *generate_valid_conditions(search_filters, query_config=ReplayQueryConfig()),
                 # Other conditions.
@@ -673,8 +673,14 @@ QUERY_ALIAS_COLUMN_MAP = {
         alias="count_urls",
     ),
     "is_archived": Function(
-        "any",
-        parameters=[Column("is_archived")],
+        "greater",
+        parameters=[
+            Function(
+                "max",
+                parameters=[Column("is_archived")],
+            ),
+            0,
+        ],
         alias="isArchived",
     ),
     "activity": _activity_score(),

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -153,7 +153,7 @@ def query_replays_dataset(
                 # Make sure we're not too old.
                 Condition(Column("finished_at"), Op.LT, end),
                 # Require non-archived replays.
-                Condition(Column("isArchived"), Op.EQ, 0),
+                Condition(Column("isArchived"), Op.IS_NULL),
                 # User conditions.
                 *generate_valid_conditions(search_filters, query_config=ReplayQueryConfig()),
                 # Other conditions.
@@ -674,7 +674,7 @@ QUERY_ALIAS_COLUMN_MAP = {
     ),
     "is_archived": Function(
         "any",
-        parameters=[Function("isNotNull", parameters=[Column("is_archived")])],
+        parameters=[Column("is_archived")],
         alias="isArchived",
     ),
     "activity": _activity_score(),

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -676,14 +676,8 @@ QUERY_ALIAS_COLUMN_MAP = {
         "ifNull",
         parameters=[
             Function(
-                "greater",
-                parameters=[
-                    Function(
-                        "max",
-                        parameters=[Column("is_archived")],
-                    ),
-                    0,
-                ],
+                "max",
+                parameters=[Column("is_archived")],
             ),
             0,
         ],

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -185,8 +185,14 @@ def query_replays_count(
             select=[
                 _strip_uuid_dashes("replay_id", Column("replay_id")),
                 Function(
-                    "any",
-                    parameters=[Function("isNotNull", parameters=[Column("is_archived")])],
+                    "ifNull",
+                    parameters=[
+                        Function(
+                            "max",
+                            parameters=[Column("is_archived")],
+                        ),
+                        0,
+                    ],
                     alias="is_archived",
                 ),
             ],

--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -138,7 +138,7 @@ def mock_replay(
                         "segment_id": kwargs.pop("segment_id", 0),
                         "tags": tags,
                         "urls": kwargs.pop("urls", []),
-                        "is_archived": kwargs.pop("is_archived", False),
+                        "is_archived": kwargs.pop("is_archived", None),
                         "error_ids": kwargs.pop(
                             "error_ids", ["a3a62ef6-ac86-415b-83c2-416fc2f76db1"]
                         ),


### PR DESCRIPTION
- when i did #46269, i believe I broke the archive behavior in our query. The test still passed because the behavior was non-deterministic.

Explanation:
isNotNull returns 0 or 1. when we call `any` on this, it will randomly pick a value to be returned. in most cases it will return 0. in the test it always just happened to return 1.

Fix:
Simply change the IsArchived value to `any`, and expect it to be null. if it is not null, then the replay is archived and filtered.