### PR TITLE
feat: Enable performance & replay by default for new ProjectKey

### DIFF
--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -8,6 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ProjectKeySerializer
+from sentry.loader.dynamic_sdk_options import get_default_loader_data
 from sentry.models import ProjectKey, ProjectKeyStatus
 
 
@@ -78,6 +79,7 @@ class ProjectKeysEndpoint(ProjectEndpoint):
                 secret_key=result.get("secret"),
                 rate_limit_count=rate_limit_count,
                 rate_limit_window=rate_limit_window,
+                data=get_default_loader_data(project),
             )
 
             self.create_audit_entry(

--- a/src/sentry/loader/dynamic_sdk_options.py
+++ b/src/sentry/loader/dynamic_sdk_options.py
@@ -13,7 +13,7 @@ def get_dynamic_sdk_loader_option(project_key, option: DynamicSdkLoaderOption, d
 
 
 def get_default_loader_data(project):
-    dynamic_sdk_loader_options = project.get_option("sentry:default_loader_options")
+    dynamic_sdk_loader_options = project.get_option("sentry:default_loader_options", None)
 
     if dynamic_sdk_loader_options is not None:
         return {"dynamicSdkLoaderOptions": dynamic_sdk_loader_options}

--- a/src/sentry/loader/dynamic_sdk_options.py
+++ b/src/sentry/loader/dynamic_sdk_options.py
@@ -10,3 +10,12 @@ class DynamicSdkLoaderOption(str, Enum):
 def get_dynamic_sdk_loader_option(project_key, option: DynamicSdkLoaderOption, default=False):
     dynamic_sdk_loader_options = project_key.data.get("dynamicSdkLoaderOptions", {})
     return dynamic_sdk_loader_options.get(option.value, default)
+
+
+def get_default_loader_data(project):
+    dynamic_sdk_loader_options = project.get_option("sentry:default_loader_options")
+
+    if dynamic_sdk_loader_options is not None:
+        return {"dynamicSdkLoaderOptions": dynamic_sdk_loader_options}
+
+    return {}

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -1,7 +1,7 @@
 from sentry.projectoptions import register
 
 # latest epoch
-LATEST_EPOCH = 9
+LATEST_EPOCH = 10
 
 # grouping related configs
 #
@@ -125,3 +125,14 @@ register(
 # Contains a mapping from rule to last seen timestamp,
 # for example `{"/organizations/*/**": 1334318402}`
 register(key="sentry:transaction_name_cluster_rules", default={})
+
+# The JavaScript loader dynamic SDK options that are the project defaults.
+register(
+    key="sentry:default_loader_options",
+    epoch_defaults={
+        10: {
+            "hasPerformance": True,
+            "hasReplay": True,
+        }
+    },
+)

--- a/tests/sentry/api/endpoints/test_project_key_details.py
+++ b/tests/sentry/api/endpoints/test_project_key_details.py
@@ -151,7 +151,7 @@ class UpdateProjectKeyTest(APITestCase):
         key = ProjectKey.objects.get(id=key.id)
         assert key.data["browserSdkVersion"] == "5.x"
 
-    def test_empty_dynamic_sdk_loader_options(self):
+    def test_default_dynamic_sdk_loader_options(self):
         project = self.create_project()
         key = ProjectKey.objects.get_or_create(project=project)[0]
         self.login_as(user=self.user)
@@ -166,7 +166,11 @@ class UpdateProjectKeyTest(APITestCase):
         response = self.client.put(url, {})
         assert response.status_code == 200
         key = ProjectKey.objects.get(id=key.id)
-        assert "dynamicSdkLoaderOptions" not in key.data
+        assert "dynamicSdkLoaderOptions" in key.data
+        assert key.data["dynamicSdkLoaderOptions"] == {
+            "hasPerformance": True,
+            "hasReplay": True,
+        }
 
     def test_dynamic_sdk_loader_options(self):
         project = self.create_project()
@@ -186,20 +190,22 @@ class UpdateProjectKeyTest(APITestCase):
         )
         assert response.status_code == 200
         key = ProjectKey.objects.get(id=key.id)
-        assert key.data.get("dynamicSdkLoaderOptions") is None
+        assert "dynamicSdkLoaderOptions" in key.data
+        assert key.data["dynamicSdkLoaderOptions"] == {
+            "hasPerformance": True,
+            "hasReplay": True,
+        }
 
         response = self.client.put(
             url,
-            {
-                "dynamicSdkLoaderOptions": {
-                    "hasReplay": True,
-                }
-            },
+            {"dynamicSdkLoaderOptions": {"hasReplay": False, "hasDebug": True}},
         )
         assert response.status_code == 200
         key = ProjectKey.objects.get(id=key.id)
         assert key.data.get("dynamicSdkLoaderOptions") == {
-            "hasReplay": True,
+            "hasReplay": False,
+            "hasPerformance": True,
+            "hasDebug": True,
         }
 
         response = self.client.put(
@@ -216,18 +222,19 @@ class UpdateProjectKeyTest(APITestCase):
         assert key.data.get("dynamicSdkLoaderOptions") == {
             "hasReplay": False,
             "hasPerformance": True,
+            "hasDebug": True,
         }
 
         response = self.client.put(
             url,
-            {"dynamicSdkLoaderOptions": {"hasDebug": True, "invalid-key": "blah"}},
+            {"dynamicSdkLoaderOptions": {"hasDebug": False, "invalid-key": "blah"}},
         )
         assert response.status_code == 200
         key = ProjectKey.objects.get(id=key.id)
         assert key.data.get("dynamicSdkLoaderOptions") == {
             "hasReplay": False,
             "hasPerformance": True,
-            "hasDebug": True,
+            "hasDebug": False,
         }
 
         response = self.client.put(
@@ -243,7 +250,7 @@ class UpdateProjectKeyTest(APITestCase):
         assert key.data.get("dynamicSdkLoaderOptions") == {
             "hasReplay": False,
             "hasPerformance": True,
-            "hasDebug": True,
+            "hasDebug": False,
         }
 
         response = self.client.put(
@@ -259,7 +266,7 @@ class UpdateProjectKeyTest(APITestCase):
         assert key.data.get("dynamicSdkLoaderOptions") == {
             "hasReplay": False,
             "hasPerformance": True,
-            "hasDebug": True,
+            "hasDebug": False,
         }
 
 

--- a/tests/sentry/api/endpoints/test_project_keys.py
+++ b/tests/sentry/api/endpoints/test_project_keys.py
@@ -38,6 +38,11 @@ class CreateProjectKeyTest(APITestCase):
         assert key.label == "hello world"
         assert key.rate_limit_count == 10
         assert key.rate_limit_window == 60
+        assert "dynamicSdkLoaderOptions" in key.data
+        assert key.data["dynamicSdkLoaderOptions"] == {
+            "hasPerformance": True,
+            "hasReplay": True,
+        }
 
     def test_minimal_args(self):
         project = self.create_project()
@@ -50,6 +55,11 @@ class CreateProjectKeyTest(APITestCase):
         assert resp.status_code == 201, resp.content
         key = ProjectKey.objects.get(public_key=resp.data["public"])
         assert key.label
+        assert "dynamicSdkLoaderOptions" in key.data
+        assert key.data["dynamicSdkLoaderOptions"] == {
+            "hasPerformance": True,
+            "hasReplay": True,
+        }
 
     def test_keys(self):
         project = self.create_project()

--- a/tests/sentry/receivers/test_core.py
+++ b/tests/sentry/receivers/test_core.py
@@ -29,6 +29,11 @@ class CreateDefaultProjectsTest(TestCase):
         pk = ProjectKey.objects.get(project=project)
         assert not pk.roles.api
         assert pk.roles.store
+        assert "dynamicSdkLoaderOptions" in pk.data
+        assert pk.data["dynamicSdkLoaderOptions"] == {
+            "hasPerformance": True,
+            "hasReplay": True,
+        }
 
         # ensure that we don't hit an error here
         create_default_projects(config)
@@ -53,6 +58,11 @@ class CreateDefaultProjectsTest(TestCase):
         pk = ProjectKey.objects.get(project=project)
         assert not pk.roles.api
         assert pk.roles.store
+        assert "dynamicSdkLoaderOptions" in pk.data
+        assert pk.data["dynamicSdkLoaderOptions"] == {
+            "hasPerformance": True,
+            "hasReplay": True,
+        }
 
         # ensure that we don't hit an error here
         create_default_projects(config)
@@ -77,6 +87,11 @@ class CreateDefaultProjectsTest(TestCase):
             pk = ProjectKey.objects.get(project=project)
             assert not pk.roles.api
             assert pk.roles.store
+            assert "dynamicSdkLoaderOptions" in pk.data
+            assert pk.data["dynamicSdkLoaderOptions"] == {
+                "hasPerformance": True,
+                "hasReplay": True,
+            }
 
             # ensure that we don't hit an error here
             create_default_projects(config)

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -88,6 +88,7 @@ class PerformanceDetectionTest(TestCase):
         super().setUp()
         patch_project_option_get = patch("sentry.models.ProjectOption.objects.get_value")
         self.project_option_mock = patch_project_option_get.start()
+        self.project_option_mock.return_value = {}
         self.addCleanup(patch_project_option_get.stop)
 
         patch_project = patch("sentry.models.Project.objects.get_from_cache")

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -73,6 +73,8 @@ class JavaScriptSdkLoaderTest(TestCase):
         self, load_version_from_file, get_selected_browser_sdk_version
     ):
         settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        self.projectkey.data = {}
+        self.projectkey.save()
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
@@ -88,6 +90,8 @@ class JavaScriptSdkLoaderTest(TestCase):
         self, load_version_from_file, get_selected_browser_sdk_version
     ):
         settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        self.projectkey.data = {}
+        self.projectkey.save()
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
@@ -101,10 +105,25 @@ class JavaScriptSdkLoaderTest(TestCase):
         self, load_version_from_file, get_selected_browser_sdk_version
     ):
         settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        self.projectkey.data = {}
+        self.projectkey.save()
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/8.3.15/bundle.es5.min.js" in resp.content
+
+    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])
+    @mock.patch(
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
+    )
+    def test_returns_es6_with_defaults(
+        self, load_version_from_file, get_selected_browser_sdk_version
+    ):
+        settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
+        assert b"/7.37.0/bundle.tracing.replay.min.js" in resp.content
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])
     @mock.patch(


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-javascript/issues/6944, we want to default performance & replay to true for new ProjectKeys that are generated.

I am not sure if this is enough to add there, or if there is another place where project keys may be created?

I tried:
* Creating a new project
* Creating a new key for an existing project

And got the correct settings for both scenarios.