### PR TITLE
ref(sourcemaps): Use all events traffic as the base for sample rate

### DIFF
--- a/src/sentry/lang/javascript/utils.py
+++ b/src/sentry/lang/javascript/utils.py
@@ -1,3 +1,5 @@
+import random
+
 from sentry import options
 
 SYMBOLICATOR_SOURCEMAPS_PROJECTS_OPTION = "symbolicator.sourcemaps-processing-projects"
@@ -9,7 +11,7 @@ def should_use_symbolicator_for_sourcemaps(project_id: int) -> bool:
     # 11276 - sentry/javascript project for forced dogfooding
     # settings.SENTRY_PROJECT - default project for all installations
     # settings.SENTRY_FRONTEND_PROJECT - configurable default frontend project
-    if project_id in options.get(SYMBOLICATOR_SOURCEMAPS_PROJECTS_OPTION, []):
+    if project_id in options.get(SYMBOLICATOR_SOURCEMAPS_PROJECTS_OPTION):
         return True
 
-    return project_id % 1000 < options.get(SYMBOLICATOR_SOURCEMAPS_SAMPLE_RATE_OPTION, 0.0) * 1000
+    return options.get(SYMBOLICATOR_SOURCEMAPS_SAMPLE_RATE_OPTION) > random.random()


### PR DESCRIPTION
Make sample rate work across all processed traffic, not only specific projects IDs.