### PR TITLE
ref(policies): Restrict superusers to accept policies

### DIFF
--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -49,6 +49,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {uniqueId} from 'sentry/utils/guid';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import withApi from 'sentry/utils/withApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -367,6 +368,7 @@ class Actions extends Component<Props> {
     } = getConfigForIssueType(group).actions;
 
     const hasDeleteAccess = organization.access.includes('event:admin');
+    const activeSuperUser = isActiveSuperuser();
 
     const {dropdownItems, onIgnore} = getIgnoreActions({onUpdate: this.onUpdate});
     return (
@@ -408,6 +410,10 @@ class Actions extends Component<Props> {
             {
               key: 'suggested-fix',
               className: 'hidden-sm hidden-md hidden-lg',
+              disabled: activeSuperUser,
+              tooltip: activeSuperUser
+                ? t("Superusers can't consent to policies")
+                : undefined,
               label: (
                 <Tooltip
                   title={experimentalFeatureTooltipDesc}
@@ -517,6 +523,7 @@ class Actions extends Component<Props> {
               disabled={disabled}
               groupId={group.id}
               onClick={() => this.trackIssueAction('open_ai_suggested_fix')}
+              activeSuperUser={activeSuperUser}
             />
           </GuideAnchor>
         </Feature>

--- a/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionButton.tsx
+++ b/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionButton.tsx
@@ -10,6 +10,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {experimentalFeatureTooltipDesc} from 'sentry/views/issueDetails/openAIFixSuggestion/utils';
 
 type Props = {
+  activeSuperUser: boolean;
   groupId: Group['id'];
   onClick: () => void;
   className?: string;
@@ -23,6 +24,7 @@ export function OpenAIFixSuggestionButton({
   size,
   onClick,
   groupId,
+  activeSuperUser,
 }: Props) {
   const organization = useOrganization();
   const router = useRouter();
@@ -45,10 +47,14 @@ export function OpenAIFixSuggestionButton({
   return (
     <ActionButton
       className={className}
-      disabled={disabled}
+      disabled={activeSuperUser || disabled}
+      title={
+        activeSuperUser
+          ? t("Superusers can't consent to policies")
+          : experimentalFeatureTooltipDesc
+      }
       size={size}
       onClick={handleShowAISuggestion}
-      title={experimentalFeatureTooltipDesc}
     >
       {t('Suggested Fix')}
       <FeatureBadge type="experimental" noTooltip />

--- a/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionPanel.tsx
+++ b/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionPanel.tsx
@@ -14,6 +14,7 @@ import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import marked from 'sentry/utils/marked';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -117,7 +118,10 @@ export function OpenAIFixSuggestionPanel({eventID, projectSlug}: Props) {
       />
     );
   }
+
   if (error?.responseJSON?.restriction === 'individual_consent') {
+    const activeSuperUser = isActiveSuperuser();
+
     PolicyErrorState = (
       <EmptyMessage
         icon={<IconFlag size="xl" />}
@@ -141,6 +145,10 @@ export function OpenAIFixSuggestionPanel({eventID, projectSlug}: Props) {
                 setIndividualConsent(true);
                 dataRefetch();
               }}
+              disabled={activeSuperUser}
+              title={
+                activeSuperUser ? t("Superusers can't consent to policies") : undefined
+              }
             >
               {t('Confirm')}
             </Button>


### PR DESCRIPTION
Superusers can't consent to policies. This PR restricts this in the sentry's frontend

**Previews:**

<img width="315" alt="image" src="https://user-images.githubusercontent.com/29228205/230055418-bdd41e80-0a02-437f-b3fa-50efd9bf6b37.png">

<img width="247" alt="image" src="https://user-images.githubusercontent.com/29228205/230056152-a4092c55-26db-4f3d-92df-714d3db1c4a5.png">


<img width="1127" alt="image" src="https://user-images.githubusercontent.com/29228205/230055864-9717167a-dbf6-48ad-b91a-8b99fdec8ee5.png">


closes https://github.com/orgs/getsentry/projects/79?pane=issue&itemId=24705957

related PRs:
https://github.com/getsentry/getsentry/pull/10131
https://github.com/getsentry/getsentry/pull/10132
