### PR TITLE
fix(threads): Hide thread tags if none exist

### DIFF
--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -485,7 +485,7 @@ describe('Threads', function () {
                   id: 0,
                   current: false,
                   crashed: true,
-                  name: null,
+                  name: 'main',
                   stacktrace: {
                     frames: [
                       {
@@ -901,7 +901,7 @@ describe('Threads', function () {
         expect(screen.getByText('Threads')).toBeInTheDocument();
         expect(screen.getByText('Thread State')).toBeInTheDocument();
         expect(screen.getByText('Blocked')).toBeInTheDocument();
-        expect(screen.getByText('waiting on tid=1')).toBeInTheDocument();
+        expect(screen.getAllByText('waiting on tid=1')).toHaveLength(2);
         expect(screen.getByText('Thread Tags')).toBeInTheDocument();
 
         // Actions
@@ -919,6 +919,62 @@ describe('Threads', function () {
 
         expect(screen.getByTestId('stack-trace')).toBeInTheDocument();
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);
+
+        expect(container).toSnapshot();
+      });
+
+      it('hides thread tag event entry if none', function () {
+        const newOrg = {
+          ...organization,
+          features: ['anr-improvements'],
+        };
+        const newProps = {
+          ...props,
+          data: {
+            values: [
+              {
+                id: 0,
+                current: false,
+                crashed: true,
+                name: null,
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: null,
+                      absPath: null,
+                      module: null,
+                      package: '/System/Library/Frameworks/UIKit.framework/UIKit',
+                      platform: null,
+                      instructionAddr: '0x197885c54',
+                      symbolAddr: '0x197885bf4',
+                      function: '<redacted>',
+                      rawFunction: null,
+                      symbol: null,
+                      context: [],
+                      lineNo: null,
+                      colNo: null,
+                      inApp: false,
+                      trust: null,
+                      errors: null,
+                      vars: null,
+                    },
+                  ],
+                  framesOmitted: null,
+                  registers: {
+                    cpsr: '0x60000000',
+                    fp: '0x16fd79870',
+                    lr: '0x10008c5ac',
+                  },
+                  hasSystemFrames: true,
+                },
+                rawStacktrace: null,
+              },
+            ],
+          },
+          organization: newOrg,
+        };
+        const {container} = render(<Threads {...newProps} />, {organization: newOrg});
+        expect(screen.queryByText('Thread Tags')).not.toBeInTheDocument();
 
         expect(container).toSnapshot();
       });

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -242,7 +242,7 @@ export function Threads({
   const threadStateDisplay = getMappedThreadState(activeThread?.state);
 
   const {id: activeThreadId, name: activeThreadName} = activeThread ?? {};
-  const showThreadTags = isNil(activeThreadId) || !activeThreadName;
+  const hideThreadTags = isNil(activeThreadId) || !activeThreadName;
 
   return (
     <Fragment>
@@ -285,7 +285,7 @@ export function Threads({
               </EventDataSection>
             )}
           </Grid>
-          {showThreadTags && (
+          {!hideThreadTags && (
             <EventDataSection type={EntryType.THREAD_TAGS} title={t('Thread Tags')}>
               {renderPills()}
             </EventDataSection>

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -241,6 +241,10 @@ export function Threads({
   const platform = getPlatform();
   const threadStateDisplay = getMappedThreadState(activeThread?.state);
 
+  const {id: activeThreadId, name: activeThreadName} = activeThread ?? {};
+
+  const showThreadTags = isNil(activeThreadId) || !activeThreadName;
+
   return (
     <Fragment>
       {hasMoreThanOneThread && organization.features.includes('anr-improvements') && (
@@ -282,9 +286,11 @@ export function Threads({
               </EventDataSection>
             )}
           </Grid>
-          <EventDataSection type={EntryType.THREAD_TAGS} title={t('Thread Tags')}>
-            {renderPills()}
-          </EventDataSection>
+          {showThreadTags && (
+            <EventDataSection type={EntryType.THREAD_TAGS} title={t('Thread Tags')}>
+              {renderPills()}
+            </EventDataSection>
+          )}
         </Fragment>
       )}
       <TraceEventDataSection

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -242,7 +242,6 @@ export function Threads({
   const threadStateDisplay = getMappedThreadState(activeThread?.state);
 
   const {id: activeThreadId, name: activeThreadName} = activeThread ?? {};
-
   const showThreadTags = isNil(activeThreadId) || !activeThreadName;
 
   return (


### PR DESCRIPTION
Hides the data section if no thread tags exist.

Before
![image (3)](https://user-images.githubusercontent.com/63818634/230069640-f4728407-aed9-469f-97f4-22aebbb58a85.png)

After
![Screenshot 2023-04-05 at 7 37 58 AM](https://user-images.githubusercontent.com/63818634/230069620-8115538d-54b7-4895-9529-79ff97419297.png)
