### PR TITLE
ref(suggested-fix): Move experimental badge to tooltip - button

### DIFF
--- a/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionButton.tsx
+++ b/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionButton.tsx
@@ -49,10 +49,14 @@ export function OpenAIFixSuggestionButton({
       className={className}
       disabled={activeSuperUser || disabled}
       title={
-        <div>
-          {experimentalFeatureTooltipDesc}
-          <FeatureBadge type="experimental" noTooltip />
-        </div>
+        activeSuperUser ? (
+          t("Superusers can't consent to policies")
+        ) : (
+          <div>
+            {experimentalFeatureTooltipDesc}
+            <FeatureBadge type="experimental" noTooltip />
+          </div>
+        )
       }
       size={size}
       onClick={handleShowAISuggestion}

--- a/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionButton.tsx
+++ b/static/app/views/issueDetails/openAIFixSuggestion/openAIFixSuggestionButton.tsx
@@ -49,15 +49,15 @@ export function OpenAIFixSuggestionButton({
       className={className}
       disabled={activeSuperUser || disabled}
       title={
-        activeSuperUser
-          ? t("Superusers can't consent to policies")
-          : experimentalFeatureTooltipDesc
+        <div>
+          {experimentalFeatureTooltipDesc}
+          <FeatureBadge type="experimental" noTooltip />
+        </div>
       }
       size={size}
       onClick={handleShowAISuggestion}
     >
       {t('Suggested Fix')}
-      <FeatureBadge type="experimental" noTooltip />
     </ActionButton>
   );
 }


### PR DESCRIPTION
**Before:**

<img width="274" alt="image" src="https://user-images.githubusercontent.com/29228205/230080871-79bc32e2-9c75-49c6-9774-dedb38275e58.png">

**After:**

<img width="302" alt="image" src="https://user-images.githubusercontent.com/29228205/230080764-00cee440-3bec-48a5-991e-a71c2db4df03.png">


closes https://github.com/orgs/getsentry/projects/79/views/3?pane=issue&itemId=24869592