### PR TITLE
fix(perf): Allow User Misery widget on Mobile landing

### DIFF
--- a/static/app/views/performance/landing/views/mobileView.tsx
+++ b/static/app/views/performance/landing/views/mobileView.tsx
@@ -17,6 +17,7 @@ export function MobileView(props: BasePerformanceViewProps) {
   const {organization} = props;
   const allowedCharts = [
     PerformanceWidgetSetting.TPM_AREA,
+    PerformanceWidgetSetting.USER_MISERY_AREA,
     PerformanceWidgetSetting.COLD_STARTUP_AREA,
     PerformanceWidgetSetting.WARM_STARTUP_AREA,
     PerformanceWidgetSetting.SLOW_FRAMES_AREA,


### PR DESCRIPTION
There's no major reason to disallow it, and some clients are interested in having it.
<img width="1191" alt="Screenshot 2023-04-05 at 10 45 18 AM" src="https://user-images.githubusercontent.com/989898/230117219-fc49c881-5d66-4db0-8b1d-cdb516370cca.png">
