### PR TITLE
feat(analytics): adds issue type and category to issue resolve analytics

### DIFF
--- a/src/sentry/analytics/events/issue_resolved.py
+++ b/src/sentry/analytics/events/issue_resolved.py
@@ -11,6 +11,9 @@ class IssueResolvedEvent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("group_id"),
         analytics.Attribute("resolution_type"),
+        # TODO: make required once we validate that all events have this
+        analytics.Attribute("issue_category", required=False),
+        analytics.Attribute("issue_type", required=False),
     )
 
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -435,6 +435,8 @@ class GroupSerializerBase(Serializer, ABC):
                 organization_id=obj.project.organization_id,
                 group_id=obj.id,
                 resolution_type="automatic",
+                issue_type=obj.issue_type.slug,
+                issue_category=obj.issue_category.name.lower(),
             )
         if status == GroupStatus.RESOLVED:
             status_label = "resolved"

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -211,6 +211,8 @@ def record_issue_resolved(organization_id, project, group, user, resolution_type
         organization_id=organization_id,
         group_id=group.id,
         resolution_type=resolution_type,
+        issue_type=group.issue_type.slug,
+        issue_category=group.issue_category.name.lower(),
     )
 
 

--- a/src/sentry/tasks/integrations/sync_status_inbound.py
+++ b/src/sentry/tasks/integrations/sync_status_inbound.py
@@ -48,6 +48,8 @@ def sync_status_inbound(
                 organization_id=organization_id,
                 group_id=group.id,
                 resolution_type="with_third_party_app",
+                issue_type=group.issue_type.slug,
+                issue_category=group.issue_category.name.lower(),
             )
     elif action == ResolveSyncAction.UNRESOLVE:
         Group.objects.update_group_status(

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -160,6 +160,8 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             organization_id=self.project.organization_id,
             group_id=group.id,
             resolution_type="automatic",
+            issue_type="error",
+            issue_category="error",
         )
 
     def test_subscribed(self):


### PR DESCRIPTION
This PR adds `issue_type` and `issue_category` to the `issue.resolved` analytics event. This will make it easier to do analysis on specific issue types with regards to resolutions.