### PR TITLE
feat(perf-issues): don't use span hash for fingerprinting consecutive http

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import hashlib
-import re
 from datetime import timedelta
-from urllib.parse import parse_qs, urlparse
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
@@ -12,33 +9,12 @@ from sentry.models import Organization, Project
 from ..base import (
     DetectorType,
     PerformanceDetector,
+    fingerprint_http_spans,
     get_duration_between_spans,
     get_span_duration,
-    get_url_from_span,
 )
 from ..performance_problem import PerformanceProblem
 from ..types import Span
-
-URL_PARAMETER_REGEX = re.compile(
-    r"""(?x)
-    (?P<uuid>
-        \b
-            [0-9a-fA-F]{8}-
-            [0-9a-fA-F]{4}-
-            [0-9a-fA-F]{4}-
-            [0-9a-fA-F]{4}-
-            [0-9a-fA-F]{12}
-        \b
-    ) |
-    (?P<hashlike>
-        \b[0-9a-fA-F]{10}([0-9a-fA-F]{14})?([0-9a-fA-F]{8})?([0-9a-fA-F]{8})?\b
-    ) |
-    (?P<int>
-        -\d+\b |
-        \b\d+\b
-    )
-"""
-)  # Adapted from message.py
 
 
 class ConsecutiveHTTPSpanDetector(PerformanceDetector):
@@ -155,16 +131,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         return True
 
     def _fingerprint(self) -> str:
-        url_paths = []
-        for http_span in self.consecutive_http_spans:
-            url = get_url_from_span(http_span)
-            parametrized_url = self.parameterize_url(url)
-            path = urlparse(parametrized_url).path
-            if path not in url_paths:
-                url_paths.append(path)
-        url_paths.sort()
-
-        hashed_url_paths = hashlib.sha1(("-".join(url_paths)).encode("utf8")).hexdigest()
+        hashed_url_paths = fingerprint_http_spans(self.consecutive_http_spans)
         return f"1-{PerformanceConsecutiveHTTPQueriesGroupType.type_id}-{hashed_url_paths}"
 
     def on_complete(self) -> None:
@@ -174,38 +141,6 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         return features.has(
             "organizations:performance-consecutive-http-detector", organization, actor=None
         )
-
-    @staticmethod
-    def parameterize_url(url: str) -> str:
-        parsed_url = urlparse(str(url))
-
-        protocol_fragments = []
-        if parsed_url.scheme:
-            protocol_fragments.append(parsed_url.scheme)
-            protocol_fragments.append("://")
-
-        host_fragments = []
-        for fragment in parsed_url.netloc.split("."):
-            host_fragments.append(str(fragment))
-
-        path_fragments = []
-        for fragment in parsed_url.path.split("/"):
-            if URL_PARAMETER_REGEX.search(fragment):
-                path_fragments.append("*")
-            else:
-                path_fragments.append(str(fragment))
-
-        query = parse_qs(parsed_url.query)
-
-        return "".join(
-            [
-                "".join(protocol_fragments),
-                ".".join(host_fragments),
-                "/".join(path_fragments),
-                "?",
-                "&".join(sorted([f"{key}=*" for key in query.keys()])),
-            ]
-        ).rstrip("?")
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:
         return True

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
@@ -60,7 +60,7 @@ class ConsecutiveDbDetectorTest(TestCase):
 
         assert problems == [
             PerformanceProblem(
-                fingerprint="1-1009-30ce2c8eaf7cae732346206dcd23c3f016e75f64",
+                fingerprint="1-1009-00b8644b56309c8391aa365783145162ab9c589a",
                 op="http",
                 desc="GET /api/0/organizations/endpoint1",
                 type=PerformanceConsecutiveHTTPQueriesGroupType,
@@ -104,7 +104,7 @@ class ConsecutiveDbDetectorTest(TestCase):
 
         assert problems == [
             PerformanceProblem(
-                fingerprint="1-1009-30ce2c8eaf7cae732346206dcd23c3f016e75f64",
+                fingerprint="1-1009-00b8644b56309c8391aa365783145162ab9c589a",
                 op="http",
                 desc="GET /api/0/organizations/endpoint1",
                 type=PerformanceConsecutiveHTTPQueriesGroupType,
@@ -182,5 +182,5 @@ class ConsecutiveDbDetectorTest(TestCase):
 
         problem_2 = self.find_problems(create_event(spans))[0]
 
-        assert problem_2.fingerprint == "1-1009-30ce2c8eaf7cae732346206dcd23c3f016e75f64"
+        assert problem_2.fingerprint == "1-1009-515a42c2614f98fa886b6d9ad1ddfe1929329f53"
         assert problem_1.fingerprint == problem_2.fingerprint

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -15,6 +15,7 @@ from sentry.testutils.performance_issues.event_generators import (
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.performance_issues.detectors import NPlusOneAPICallsDetector
 from sentry.utils.performance_issues.detectors.n_plus_one_api_calls_detector import (
+    parameterize_url,
     without_query_params,
 )
 from sentry.utils.performance_issues.performance_detection import (
@@ -311,7 +312,7 @@ class NPlusOneAPICallsDetectorTest(TestCase):
     ],
 )
 def test_parameterizes_url(url, parameterized_url):
-    r = NPlusOneAPICallsDetector.parameterize_url(url)
+    r = parameterize_url(url)
     assert r == parameterized_url
 
 

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -229,7 +229,7 @@ class PerformanceDetectionTest(TestCase):
             perf_problems = _detect_performance_problems(event, sdk_span_mock, self.project)
             assert perf_problems == [
                 PerformanceProblem(
-                    fingerprint="1-1009-c5e048717e2f5ca1a251cbbfbcfd82aee7e89cd9",
+                    fingerprint="1-1009-6654ad4d1d494222ce02c656386e6955575c17ed",
                     op="http",
                     desc="GET https://my-api.io/api/users?page=1",
                     type=PerformanceConsecutiveHTTPQueriesGroupType,


### PR DESCRIPTION
Relying on span hashes rn to fingerprint is brittle, especially with span url parametrization potentially changing them.
This PR uses the url path (mostly copied over from n plus one api calls), in order to fingerprint the urls.

I think a future task, it would be good to share this code (a fingerprint http span function).