### PR TITLE
ref(crons): Remove deprecated monitor fields from frontend

### DIFF
--- a/static/app/views/monitors/components/monitorBadge.tsx
+++ b/static/app/views/monitors/components/monitorBadge.tsx
@@ -7,12 +7,13 @@ import {
   IconTimer,
 } from 'sentry/icons';
 import {SVGIconProps} from 'sentry/icons/svgIcon';
+import {ObjectStatus} from 'sentry/types';
 import {ColorOrAlias} from 'sentry/utils/theme';
 
 import {MonitorStatus} from '../types';
 
 interface MonitorBadgeProps {
-  status: MonitorStatus;
+  status: MonitorStatus | ObjectStatus;
 }
 
 interface StatusData {

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -15,7 +15,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import Text from 'sentry/components/text';
-import TimeSince from 'sentry/components/timeSince';
 import {timezoneOptions} from 'sentry/data/timezones';
 import {t, tct, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -231,17 +230,10 @@ function MonitorForm({
           {t('How often you expect your recurring jobs to run.')}
         </ListItemSubText>
         <InputGroup>
-          {monitor !== undefined && monitor.nextCheckIn && (
+          {monitor !== undefined && (
             <Alert type="info">
-              {tct(
-                'Any changes you make to the execution schedule will only be applied after the next expected check-in [nextCheckin].',
-                {
-                  nextCheckin: (
-                    <strong>
-                      <TimeSince date={monitor.nextCheckIn} />
-                    </strong>
-                  ),
-                }
+              {t(
+                'Any changes you make to the execution schedule will only be applied after the next expected check-in.'
               )}
             </Alert>
           )}

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -1,4 +1,4 @@
-import {Project} from 'sentry/types';
+import {ObjectStatus, Project} from 'sentry/types';
 
 export enum MonitorType {
   UNKNOWN = 'unknown',
@@ -79,21 +79,10 @@ export interface Monitor {
   dateCreated: string;
   environments: MonitorEnvironment[];
   id: string;
-  /**
-   * @deprecated Each monitor environment has this
-   */
-  lastCheckIn: string;
   name: string;
-  /**
-   * @deprecated Each monitor environment has this
-   */
-  nextCheckIn: string;
   project: Project;
   slug: string;
-  /**
-   * @deprecated This is going to be become a standard ObjectStatus type
-   */
-  status: MonitorStatus;
+  status: ObjectStatus;
   type: MonitorType;
 }
 


### PR DESCRIPTION
These fields are no longer in use on the frontend and will unblock us from beginning to remove these from the backend, now that monitor environments are the source of status truth.