### PR TITLE
feat(crons): Allow searching by slug on monitors list page

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitors.py
+++ b/src/sentry/monitors/endpoints/organization_monitors.py
@@ -88,7 +88,9 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
             for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
-                    queryset = queryset.filter(Q(name__icontains=value) | Q(id__iexact=value))
+                    queryset = queryset.filter(
+                        Q(name__icontains=value) | Q(id__iexact=value) | Q(slug__icontains=value)
+                    )
                 elif key == "id":
                     queryset = queryset.filter(in_iexact("id", value))
                 elif key == "name":

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -100,6 +100,13 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         )
         self.check_valid_response(response, [monitor, monitor_visible])
 
+    def test_search_by_slug(self):
+        monitor = self._create_monitor(status=MonitorStatus.OK, slug="test-slug")
+        self._create_monitor(status=MonitorStatus.OK, slug="other-monitor")
+
+        response = self.get_success_response(self.organization.slug, query="test-slug")
+        self.check_valid_response(response, [monitor])
+
 
 @region_silo_test(stable=True)
 class CreateOrganizationMonitorTest(MonitorTestCase):


### PR DESCRIPTION
Allows users to search by slug along with name/id in this search bar

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/9372512/230229632-a8e79d27-3c31-4904-9813-2180dcb7727a.png">
