### PR TITLE
fix(crons): Allow page filter bar to widen

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -208,7 +208,7 @@ class Monitors extends AsyncView<Props, State> {
 
 const Filters = styled('div')`
   display: grid;
-  grid-template-columns: minmax(auto, 300px) 1fr;
+  grid-template-columns: max-content 1fr;
   gap: ${space(1.5)};
   margin-bottom: ${space(2)};
 `;


### PR DESCRIPTION
Before:

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/9372512/230229903-b6c86126-f184-418b-8d05-5de1bd9952e5.png">

After:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/9372512/230230322-ec7e9071-3e67-4cf9-b141-5f3e0d66f3d7.png">
