### PR TITLE
feat(breadcrumbs): Add messageFormat property to breadcrumbs after formatting

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -386,6 +386,7 @@ class DetailedEventSerializer(EventSerializer):
 
             for breadcrumb_item in breadcrumbs["data"]["values"]:
                 if breadcrumb_item["category"] in FORMATTED_BREADCRUMB_CATEGORIES:
+                    breadcrumb_item["messageFormat"] = "sql"
                     breadcrumb_item["messageRaw"] = breadcrumb_item["message"]
                     breadcrumb_item["message"] = sqlparse.format(
                         breadcrumb_item["message"], reindent_aligned=True

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -479,16 +479,15 @@ class DetailedEventSerializerTest(TestCase):
             )
             result = serialize(event, None, DetailedEventSerializer())
 
-            assert result["entries"][0]["type"] == "breadcrumbs"
+            breadcrumb_entry = result["entries"][0]
+            breadcrumbs = breadcrumb_entry["data"]["values"]
+
+            assert breadcrumb_entry["type"] == "breadcrumbs"
             # First breadcrumb should not have a message_formatted property
-            assert result["entries"][0]["data"]["values"][0]["message"] == "should not format this"
-            assert "messageRaw" not in result["entries"][0]["data"]["values"][0]
-            # Second breadcrumb should have whitespace added in message_formatted
-            assert (
-                result["entries"][0]["data"]["values"][1]["message"]
-                == "select *\n  from table\n where something = $1"
-            )
-            assert (
-                result["entries"][0]["data"]["values"][1]["messageRaw"]
-                == "select * from table where something = $1"
-            )
+            assert breadcrumbs[0]["message"] == "should not format this"
+            assert "messageRaw" not in breadcrumbs[0]
+            assert "messageFormat" not in breadcrumbs[0]
+            # Second breadcrumb should have whitespace added
+            assert breadcrumbs[1]["message"] == "select *\n  from table\n where something = $1"
+            assert breadcrumbs[1]["messageRaw"] == "select * from table where something = $1"
+            assert breadcrumbs[1]["messageFormat"] == "sql"


### PR DESCRIPTION
This identifier will help the frontend decide how to display the information.

So far the only valid value is `messageFormat: "sql"`, but it could be extended in the future.