### PR TITLE
feat(loader): Add analytics for loader-based onboarding

### DIFF
--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -17,11 +17,16 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
-  'onboarding.js_loader_show_configuration': {
+  'onboarding.js_loader_npm_docs_shown': {
     platform: string;
     project_id: string;
   };
-  'onboarding.js_loader_show_npm': {
+  'onboarding.js_loader_optional_configuration_shown': {
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.setup_docs_rendered': {
+    mode: string;
     platform: string;
     project_id: string;
   };
@@ -41,9 +46,11 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.explore_sentry_button_clicked': 'Onboarding: Explore Sentry Button Clicked',
   'onboarding.first_error_received': 'Onboarding: First Error Received',
   'onboarding.first_error_processed': 'Onboarding: First Error Processed',
-  'onboarding.js_loader_show_configuration':
-    'Onboarding: JS Loader Configuration Expanded',
-  'onboarding.js_loader_show_npm': 'Onboarding: JS Loader Switch to npm Instructions',
+  'onboarding.js_loader_optional_configuration_shown':
+    'Onboarding: JS Loader Optional Configuration Expanded',
+  'onboarding.js_loader_npm_docs_shown':
+    'Onboarding: JS Loader Switch to npm Instructions',
+  'onboarding.setup_docs_rendered': 'Onboarding: Setup Docs Rendered',
   'onboarding.view_error_button_clicked': 'Onboarding: Go To Issues Button Clicked',
   'onboarding.view_sample_error_button_clicked':
     'Onboarding: View Sample Error Button Clicked',

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -25,8 +25,7 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
-  'onboarding.setup_docs_rendered': {
-    mode: string;
+  'onboarding.setup_loader_docs_rendered': {
     platform: string;
     project_id: string;
   };
@@ -50,7 +49,7 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
     'Onboarding: JS Loader Optional Configuration Expanded',
   'onboarding.js_loader_npm_docs_shown':
     'Onboarding: JS Loader Switch to npm Instructions',
-  'onboarding.setup_docs_rendered': 'Onboarding: Setup Docs Rendered',
+  'onboarding.setup_loader_docs_rendered': 'Onboarding: Setup Loader Docs Rendered',
   'onboarding.view_error_button_clicked': 'Onboarding: Go To Issues Button Clicked',
   'onboarding.view_sample_error_button_clicked':
     'Onboarding: View Sample Error Button Clicked',

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -17,6 +17,14 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
+  'onboarding.js_loader_show_configuration': {
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.js_loader_show_npm': {
+    platform: string;
+    project_id: string;
+  };
   'onboarding.view_error_button_clicked': {
     new_organization: boolean;
     platform: string;
@@ -33,6 +41,9 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.explore_sentry_button_clicked': 'Onboarding: Explore Sentry Button Clicked',
   'onboarding.first_error_received': 'Onboarding: First Error Received',
   'onboarding.first_error_processed': 'Onboarding: First Error Processed',
+  'onboarding.js_loader_show_configuration':
+    'Onboarding: JS Loader Configuration Expanded',
+  'onboarding.js_loader_show_npm': 'Onboarding: JS Loader Switch to npm Instructions',
   'onboarding.view_error_button_clicked': 'Onboarding: Go To Issues Button Clicked',
   'onboarding.view_sample_error_button_clicked':
     'Onboarding: View Sample Error Button Clicked',

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -325,6 +325,16 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
     loaderOnboarding && jsDynamicLoader && currentPlatform === 'javascript'
   );
 
+  const hideLoaderOnboarding = useCallback(() => {
+    setShowLoaderOnboarding(false);
+
+    trackAdvancedAnalyticsEvent('onboarding.js_loader_show_npm', {
+      organization,
+      platform: currentPlatform,
+      project_id: project.id,
+    });
+  }, [organization, currentPlatform, project.id]);
+
   const fetchData = useCallback(async () => {
     // TODO: add better error handling logic
     if (!project?.platform) {
@@ -455,7 +465,7 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
               project={project}
               location={location}
               platform={loadedPlatform}
-              close={() => setShowLoaderOnboarding(false)}
+              close={hideLoaderOnboarding}
             />
           ) : (
             <ProjectDocs

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -343,32 +343,6 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
     });
   }, [organization, currentPlatform, project?.id]);
 
-  const track = useCallback(() => {
-    if (!project?.id) {
-      return;
-    }
-
-    trackAdvancedAnalyticsEvent('onboarding.setup_docs_rendered', {
-      organization,
-      platform: currentPlatform,
-      project_id: project?.id,
-      mode: showIntegrationOnboarding
-        ? 'integration'
-        : showReactOnboarding
-        ? 'react'
-        : showLoaderOnboarding
-        ? 'loader'
-        : 'default',
-    });
-  }, [
-    organization,
-    currentPlatform,
-    project?.id,
-    showIntegrationOnboarding,
-    showReactOnboarding,
-    showLoaderOnboarding,
-  ]);
-
   const fetchData = useCallback(async () => {
     // TODO: add better error handling logic
     if (!project?.platform) {
@@ -426,10 +400,6 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
       newFooterLogExperiment();
     }
   }, [newFooterLogExperiment, heartbeatFooter]);
-
-  useEffect(() => {
-    track();
-  }, [track, showIntegrationOnboarding, showReactOnboarding, showLoaderOnboarding]);
 
   if (!project) {
     return null;

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -15,6 +15,7 @@ import platforms from 'sentry/data/platforms';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization, Project, ProjectKey} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import {decodeList} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
@@ -140,7 +141,14 @@ export function SetupDocsLoader({
       )}
 
       {!hasLoadingError ? (
-        projectKey !== null && <ProjectKeyInfo projectKey={projectKey} />
+        projectKey !== null && (
+          <ProjectKeyInfo
+            projectKey={projectKey}
+            platform={platform}
+            organization={organization}
+            project={project}
+          />
+        )
       ) : (
         <LoadingError
           message={t('Failed to load Client Keys for the project.')}
@@ -151,10 +159,21 @@ export function SetupDocsLoader({
   );
 }
 
-function ProjectKeyInfo({projectKey}: {projectKey: ProjectKey}) {
+function ProjectKeyInfo({
+  projectKey,
+  platform,
+  organization,
+  project,
+}: {
+  organization: Organization;
+  platform: PlatformKey | null;
+  project: Project;
+  projectKey: ProjectKey;
+}) {
   const [showOptionalConfig, setShowOptionalConfig] = useState(false);
 
   const loaderLink = projectKey.dsn.cdn;
+  const currentPlatform = platform ?? project?.platform ?? 'other';
 
   const configCodeSnippet = beautify.html(
     `<script>
@@ -176,6 +195,20 @@ Sentry.onLoad(function() {
     {indent_size: 2}
   );
 
+  const toggleOptionalConfiguration = useCallback(() => {
+    const show = !showOptionalConfig;
+
+    setShowOptionalConfig(show);
+
+    if (show) {
+      trackAdvancedAnalyticsEvent('onboarding.js_loader_show_configuration', {
+        organization,
+        platform: currentPlatform,
+        project_id: project.id,
+      });
+    }
+  }, [organization, project.id, currentPlatform, showOptionalConfig]);
+
   return (
     <DocsWrapper>
       <DocumentationWrapper>
@@ -196,11 +229,9 @@ Sentry.onLoad(function() {
             size="zero"
             icon={<IconChevron direction={showOptionalConfig ? 'down' : 'right'} />}
             aria-label={t('Toggle optional configuration')}
-            onClick={() => setShowOptionalConfig(!showOptionalConfig)}
+            onClick={toggleOptionalConfiguration}
           />
-          <h2 onClick={() => setShowOptionalConfig(!showOptionalConfig)}>
-            {t('Configuration (Optional)')}
-          </h2>
+          <h2 onClick={toggleOptionalConfiguration}>{t('Configuration (Optional)')}</h2>
         </OptionalConfigWrapper>
         {showOptionalConfig && (
           <div>

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -110,6 +110,18 @@ export function SetupDocsLoader({
     }
   }, [api, location.query.product, organization.slug, project.slug, projectKey?.id]);
 
+  const track = useCallback(() => {
+    if (!project?.id) {
+      return;
+    }
+
+    trackAdvancedAnalyticsEvent('onboarding.setup_loader_docs_rendered', {
+      organization,
+      platform: currentPlatform,
+      project_id: project?.id,
+    });
+  }, [organization, currentPlatform, project?.id]);
+
   useEffect(() => {
     fetchData();
   }, [fetchData, organization.slug, project.slug]);
@@ -117,6 +129,10 @@ export function SetupDocsLoader({
   useEffect(() => {
     handleUpdateSelectedProducts();
   }, [handleUpdateSelectedProducts, location.query.product]);
+
+  useEffect(() => {
+    track();
+  }, [track]);
 
   return (
     <Fragment>

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -201,7 +201,7 @@ Sentry.onLoad(function() {
     setShowOptionalConfig(show);
 
     if (show) {
-      trackAdvancedAnalyticsEvent('onboarding.js_loader_show_configuration', {
+      trackAdvancedAnalyticsEvent('onboarding.js_loader_optional_configuration_shown', {
         organization,
         platform: currentPlatform,
         project_id: project.id,


### PR DESCRIPTION
This adds analytics for the loader-based onboarding:

* Track how many people opt-out to the npm based installation
* Track how many people show the advanced config

I don't how to to verify this actually works, though 😅 