### PR TITLE
fix(relay_integration): Temp disable circular dependency test

### DIFF
--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -88,6 +88,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert contexts.get("os") == {"name": "Windows", "version": "8", "type": "os"}
         assert contexts.get("device") is None
 
+    @pytest.mark.skip(reason="temp disable test due to circular dependency before merging PR: https://github.com/getsentry/relay/pull/2004")
     def test_adds_contexts_with_device(self):
         data = {
             "timestamp": self.min_ago,

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -88,7 +88,9 @@ class TestJavascriptIntegration(RelayStoreHelper):
         assert contexts.get("os") == {"name": "Windows", "version": "8", "type": "os"}
         assert contexts.get("device") is None
 
-    @pytest.mark.skip(reason="temp disable test due to circular dependency before merging PR: https://github.com/getsentry/relay/pull/2004")
+    @pytest.mark.skip(
+        reason="temp disable test due to circular dependency before merging PR: https://github.com/getsentry/relay/pull/2004"
+    )
     def test_adds_contexts_with_device(self):
         data = {
             "timestamp": self.min_ago,


### PR DESCRIPTION


I have a relay PR that fails CI due to this test in sentry:

https://github.com/getsentry/relay/pull/2004


it fails because we are adding product-names to device contexts, so I want to disable this test, so that I can merge my relay-pr, then after it merges i will re-enable this test with the added product-name. I dont think i can simply edit the test here since tests must pass on both sides to merge

```
  Common items:
  {'brand': 'Samsung',
   'family': 'Samsung SCH-R530U',
   'model': 'SCH-R530U',
   'type': 'device'}
  Left contains 1 more item:
  {'name': 'Galaxy S3'}
  Full diff:
    {
     'brand': 'Samsung',
     'family': 'Samsung SCH-R530U',
     'model': 'SCH-R530U',
  +  'name': 'Galaxy S3',
     'type': 'device',
    }
```

^ this is assert equal that fails
