### PR TITLE
chore(replays): Add fallback for misspelling of the data-testid attribute

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -146,7 +146,7 @@ def get_user_actions(
                         "text": node["textContent"][:1024],
                         "role": attributes.get("role", "")[:32],
                         "alt": attributes.get("alt", "")[:64],
-                        "testid": attributes.get("data-testid", "")[:64],
+                        "testid": _get_testid(attributes)[:64],
                         "aria_label": attributes.get("aria-label", "")[:64],
                         "title": attributes.get("title", "")[:64],
                         "timestamp": int(payload["timestamp"]),
@@ -186,6 +186,10 @@ def get_user_actions(
                     )
 
     return result
+
+
+def _get_testid(container: Dict[str, str]) -> str:
+    return container.get("data-testid") or container.get("data-test-id") or ""
 
 
 def _initialize_publisher() -> KafkaPublisher:

--- a/tests/sentry/replays/unit/test_ingest_dom_index.py
+++ b/tests/sentry/replays/unit/test_ingest_dom_index.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from sentry.utils import json
 from src.sentry.replays.usecases.ingest.dom_index import (
+    _get_testid,
     encode_as_uuid,
     get_user_actions,
     parse_replay_actions,
@@ -304,3 +305,17 @@ def test_parse_request_response_old_format_request_and_response():
             mock.call("replays.usecases.ingest.request_body_size", 1002),
             mock.call("replays.usecases.ingest.response_body_size", 8001),
         ]
+
+
+def test_get_testid():
+    # data-testid takes precedence.
+    assert _get_testid({"data-testid": "123", "data-test-id": "456"}) == "123"
+    assert _get_testid({"data-testid": "123", "data-test-id": ""}) == "123"
+    assert _get_testid({"data-testid": "123"}) == "123"
+
+    # data-test-id is the fallback case.
+    assert _get_testid({"data-testid": "", "data-test-id": "456"}) == "456"
+    assert _get_testid({"data-test-id": "456"}) == "456"
+
+    # Defaults to empty string.
+    assert _get_testid({}) == ""


### PR DESCRIPTION
Catches an additional permutation of data-testid: `data-test-id`.