### PR TITLE
feat(transaction): Allow window selection on CPU chart

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -418,6 +418,21 @@ class TraceViewHeader extends Component<PropType, State> {
 
   render() {
     const {organization} = this.props;
+    const handleStartWindowSelection = (event: React.MouseEvent<HTMLDivElement>) => {
+      const target = event.target;
+
+      if (
+        target instanceof Element &&
+        target.getAttribute &&
+        target.getAttribute('data-ignore')
+      ) {
+        // ignore this event if we need to
+        return;
+      }
+
+      this.props.dragProps.onWindowSelectionDragStart(event);
+    };
+
     return (
       <ProfileContext.Consumer>
         {profiles => {
@@ -491,20 +506,7 @@ class TraceViewHeader extends Component<PropType, State> {
                             onMouseMove={event => {
                               displayCursorGuide(event.pageX);
                             }}
-                            onMouseDown={event => {
-                              const target = event.target;
-
-                              if (
-                                target instanceof Element &&
-                                target.getAttribute &&
-                                target.getAttribute('data-ignore')
-                              ) {
-                                // ignore this event if we need to
-                                return;
-                              }
-
-                              this.props.dragProps.onWindowSelectionDragStart(event);
-                            }}
+                            onMouseDown={handleStartWindowSelection}
                           >
                             <MinimapContainer>
                               {this.renderFog(this.props.dragProps)}
@@ -531,6 +533,7 @@ class TraceViewHeader extends Component<PropType, State> {
                           renderWindowSelection={() =>
                             this.renderWindowSelection(this.props.dragProps)
                           }
+                          onChartMouseDown={handleStartWindowSelection}
                         />
                       )}
                       {this.renderSecondaryHeader(hasProfileMeasurementsChart)}

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -533,7 +533,7 @@ class TraceViewHeader extends Component<PropType, State> {
                           renderWindowSelection={() =>
                             this.renderWindowSelection(this.props.dragProps)
                           }
-                          onChartMouseDown={handleStartWindowSelection}
+                          onStartWindowSelection={handleStartWindowSelection}
                         />
                       )}
                       {this.renderSecondaryHeader(hasProfileMeasurementsChart)}

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -104,6 +104,7 @@ const MemoizedChart = React.memo(Chart);
 
 type ProfilingMeasurementsProps = {
   profileData: Profiling.ProfileInput;
+  onStartWindowSelection?: (event: React.MouseEvent<HTMLDivElement>) => void;
   renderCursorGuide?: ({
     cursorGuideHeight,
     mouseLeft,
@@ -119,6 +120,7 @@ type ProfilingMeasurementsProps = {
 
 function ProfilingMeasurements({
   profileData,
+  onStartWindowSelection,
   renderCursorGuide,
   renderFog,
   renderWindowSelection,
@@ -156,6 +158,7 @@ function ProfilingMeasurements({
                 onMouseMove={event => {
                   displayCursorGuide(event.pageX);
                 }}
+                onMouseDown={onStartWindowSelection}
               >
                 <MemoizedChart data={cpuUsageData} />
                 <Overlays>


### PR DESCRIPTION
If you're hovering over the CPU chart and find a spike you want to drill into, you shouldn't have to leave the CPU chart to do so.