### PR TITLE
feat(replays): track analytics for replay search events

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -47,7 +47,7 @@ export type ReplayEventParameters = {
     scale_bucket: 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100;
   };
   'replay.search': {
-    search_keys: string[];
+    search_keys: string;
   };
   'replay.toggle-fullscreen': {
     fullscreen: boolean;
@@ -65,10 +65,10 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.details-viewed': 'Viewed Replay Details',
   'replay.list-paginated': 'Paginated Replay List',
   'replay.list-sorted': 'Sorted Replay List',
-  'replay.search': 'Searched Replay',
   'replay.list-time-spent': 'Time Spent Viewing Replay List',
   'replay.list-view-setup-sidebar': 'Views Set Up Replays Sidebar',
   'replay.play-pause': 'Played/Paused Replay',
   'replay.render-player': 'Rendered ReplayPlayer',
+  'replay.search': 'Searched Replay',
   'replay.toggle-fullscreen': 'Toggled Replay Fullscreen',
 };

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -46,6 +46,9 @@ export type ReplayEventParameters = {
      */
     scale_bucket: 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100;
   };
+  'replay.search': {
+    search_keys: string[];
+  };
   'replay.toggle-fullscreen': {
     fullscreen: boolean;
     user_email: string;
@@ -62,6 +65,7 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.details-viewed': 'Viewed Replay Details',
   'replay.list-paginated': 'Paginated Replay List',
   'replay.list-sorted': 'Sorted Replay List',
+  'replay.search': 'Searched Replay',
   'replay.list-time-spent': 'Time Spent Viewing Replay List',
   'replay.list-view-setup-sidebar': 'Views Set Up Replays Sidebar',
   'replay.play-pause': 'Played/Paused Replay',

--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -12,6 +12,7 @@ import {
   TagCollection,
   TagValue,
 } from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {isAggregateField} from 'sentry/utils/discover/fields';
 import {
   FieldKind,
@@ -19,6 +20,7 @@ import {
   REPLAY_CLICK_FIELDS,
   REPLAY_FIELDS,
 } from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import useTags from 'sentry/utils/useTags';
 
@@ -121,6 +123,20 @@ function ReplaySearchBar(props: Props) {
       maxMenuHeight={500}
       hasRecentSearches
       fieldDefinitionGetter={getReplayFieldDefinition}
+      onSearch={(query: string) => {
+        props?.onSearch?.(query);
+        const conditions = new MutableSearch(query);
+        const searchKeys = conditions.tokens
+          .map(({key}) => key)
+          .filter(v => typeof v === 'string') as string[];
+
+        if (searchKeys.length > 0) {
+          trackAdvancedAnalyticsEvent('replay.search', {
+            search_keys: searchKeys,
+            organization,
+          });
+        }
+      }}
     />
   );
 }

--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -124,11 +124,9 @@ function ReplaySearchBar(props: Props) {
       hasRecentSearches
       fieldDefinitionGetter={getReplayFieldDefinition}
       onSearch={(query: string) => {
-        props?.onSearch?.(query);
+        props.onSearch?.(query);
         const conditions = new MutableSearch(query);
-        const searchKeys = conditions.tokens
-          .map(({key}) => key)
-          .filter(v => typeof v === 'string') as string[];
+        const searchKeys = conditions.tokens.map(({key}) => key).filter(Boolean);
 
         if (searchKeys.length > 0) {
           trackAdvancedAnalyticsEvent('replay.search', {

--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -132,7 +132,7 @@ function ReplaySearchBar(props: Props) {
 
         if (searchKeys.length > 0) {
           trackAdvancedAnalyticsEvent('replay.search', {
-            search_keys: searchKeys,
+            search_keys: searchKeys.join(','),
             organization,
           });
         }


### PR DESCRIPTION
## Summary
Fires a `replay.search` event `onSearch` and passes in the search field keys.

Relates to: https://github.com/getsentry/team-replay/issues/53