### PR TITLE
fix(perf-issue): Revert "Revert "feat(perf-issues): set a default project option (#469…

### DIFF
--- a/src/sentry/issues/utils.py
+++ b/src/sentry/issues/utils.py
@@ -35,5 +35,5 @@ def write_occurrence_to_platform(performance_problem: PerformanceProblem, projec
         # system-wide option
         and options.get("performance.issues.send_to_issues_platform", False)
         # more-granular per-project option
-        and project.get_option("sentry:performance_issue_send_to_issues_platform", False)
+        and project.get_option("sentry:performance_issue_send_to_issues_platform", True)
     )

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -103,7 +103,7 @@ register(key="sentry:performance_issue_creation_rate", default=1.0)
 
 # Rate at which performance problems are sent to issues platform. Defaults to False, system flags and options will determine if an organization sends perf problems to platform.
 # Can be used to turn off writing occurrences for users if there is a project-specific issue.
-register(key="sentry:performance_issue_send_to_issues_platform", default=False)
+register(key="sentry:performance_issue_send_to_issues_platform", default=True)
 
 # Rate at which performance issues are created through issues platform per project. Defaults to False, system flags and options will determine if an organization creates issues through platform.
 # Can be used to turn off issue creation for users if there is a project-specific issue.


### PR DESCRIPTION
Set this project option to default to `True` to turn on sending perf occurrences to issue platform.