### PR TITLE
fix(dynamic-sampling) Prioritise transaction implicit factor rule

### DIFF
--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_rare_transactions_rule.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_rare_transactions_rule.py
@@ -79,7 +79,26 @@ def test_transaction_boost_known_projects(get_transactions_resampling_rates):
             "type": "transaction",
             "condition": {
                 "op": "and",
-                "inner": [],
+                "inner": [
+                    {
+                        "op": "not",
+                        "inner": {
+                            "name": "event.transaction",
+                            "op": "eq",
+                            "options": {"ignoreCase": True},
+                            "value": ["t1"],
+                        },
+                    },
+                    {
+                        "op": "not",
+                        "inner": {
+                            "name": "event.transaction",
+                            "op": "eq",
+                            "options": {"ignoreCase": True},
+                            "value": ["t2"],
+                        },
+                    },
+                ],
             },
             "id": RESERVED_IDS[RuleType.BOOST_LOW_VOLUME_TRANSACTIONS] + 2,
         },

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -702,7 +702,20 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
             "type": "transaction",
         },
         {
-            "condition": {"inner": [], "op": "and"},
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {
+                        "op": "not",
+                        "inner": {
+                            "name": "event.transaction",
+                            "op": "eq",
+                            "options": {"ignoreCase": True},
+                            "value": ["t1"],
+                        },
+                    }
+                ],
+            },
             "id": 1401,
             "samplingValue": {"type": "factor", "value": implicit_rate / project_sample_rate},
             "type": "transaction",


### PR DESCRIPTION
This PR fixes the generation of the implicit rule in prioritise transactions.
It was previously applying to all transactions not only the implicit transactions