### PR TITLE
feat(replays): align dom events ts btn to console

### DIFF
--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -47,13 +47,6 @@ const StyledButton = styled('button')`
   align-items: center;
   gap: ${space(0.25)};
   padding: 0;
-
-  & > svg {
-    visibility: hidden;
-  }
-  &:hover svg {
-    visibility: visible;
-  }
 `;
 
 export default TimestampButton;


### PR DESCRIPTION
## Summary
This change will always display the timestamp button in the DOM Events panel to better align to the console tab.

Closes: https://github.com/getsentry/sentry/issues/46798