### PR TITLE
ref(compactSelect): Add optional `onSectionToggle` callback

### DIFF
--- a/static/app/components/compactSelect/gridList/index.tsx
+++ b/static/app/components/compactSelect/gridList/index.tsx
@@ -10,6 +10,7 @@ import {FormSize} from 'sentry/utils/theme';
 import {SelectContext} from '../control';
 import {SelectFilterContext} from '../list';
 import {ListLabel, ListSeparator, ListWrap, SizeLimitMessage} from '../styles';
+import {SelectSection} from '../types';
 
 import {GridListOption} from './option';
 import {GridListSection} from './section';
@@ -36,6 +37,15 @@ interface GridListProps
    * Text label to be rendered as heading on top of grid list.
    */
   label?: React.ReactNode;
+  /**
+   * To be called when the user toggle-selects a whole section (applicable when sections
+   * have `showToggleAllButton` set to true.) Note: this will be called in addition to
+   * and before `onChange`.
+   */
+  onSectionToggle?: (
+    section: SelectSection<React.Key>,
+    type: 'select' | 'unselect'
+  ) => void;
   size?: FormSize;
   /**
    * Message to be displayed when some options are hidden due to `sizeLimit`.
@@ -57,6 +67,7 @@ function GridList({
   listState,
   size = 'md',
   label,
+  onSectionToggle,
   sizeLimitMessage,
   keyDownHandler,
   ...props
@@ -107,6 +118,7 @@ function GridList({
                   key={item.key}
                   node={item}
                   listState={listState}
+                  onToggle={onSectionToggle}
                   size={size}
                 />
               );

--- a/static/app/components/compactSelect/gridList/section.tsx
+++ b/static/app/components/compactSelect/gridList/section.tsx
@@ -14,6 +14,7 @@ import {
   SectionTitle,
   SectionWrap,
 } from '../styles';
+import {SelectSection} from '../types';
 import {SectionToggle} from '../utils';
 
 import {GridListOption} from './option';
@@ -22,13 +23,14 @@ interface GridListSectionProps {
   listState: ListState<any>;
   node: Node<any>;
   size: FormSize;
+  onToggle?: (section: SelectSection<React.Key>, type: 'select' | 'unselect') => void;
 }
 
 /**
  * A <li /> element that functions as a grid list section (renders a nested <ul />
  * inside). https://react-spectrum.adobe.com/react-aria/useGridList.html
  */
-export function GridListSection({node, listState, size}: GridListSectionProps) {
+export function GridListSection({node, listState, onToggle, size}: GridListSectionProps) {
   const titleId = domId('grid-section-title-');
   const {separatorProps} = useSeparator({elementType: 'li'});
 
@@ -58,7 +60,9 @@ export function GridListSection({node, listState, size}: GridListSectionProps) {
                 {node.rendered}
               </SectionTitle>
             )}
-            {showToggleAllButton && <SectionToggle item={node} listState={listState} />}
+            {showToggleAllButton && (
+              <SectionToggle item={node} listState={listState} onToggle={onToggle} />
+            )}
           </SectionHeader>
         )}
         <SectionGroup role="presentation">

--- a/static/app/components/compactSelect/index.spec.tsx
+++ b/static/app/components/compactSelect/index.spec.tsx
@@ -175,11 +175,14 @@ describe('CompactSelect', function () {
     });
 
     it('can toggle sections', async function () {
+      const mock = jest.fn();
       render(
         <CompactSelect
           multiple
+          onSectionToggle={mock}
           options={[
             {
+              key: 'section-1',
               label: 'Section 1',
               showToggleAllButton: true,
               options: [
@@ -188,6 +191,7 @@ describe('CompactSelect', function () {
               ],
             },
             {
+              key: 'section-2',
               label: 'Section 2',
               showToggleAllButton: true,
               options: [
@@ -217,6 +221,18 @@ describe('CompactSelect', function () {
         'aria-selected',
         'true'
       );
+      expect(mock).toHaveBeenCalledWith(
+        {
+          key: 'section-1',
+          label: 'Section 1',
+          showToggleAllButton: true,
+          options: [
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ],
+        },
+        'select'
+      );
 
       // press Section 1's toggle button again to unselect all
       await userEvent.keyboard('{Enter}');
@@ -227,6 +243,18 @@ describe('CompactSelect', function () {
       expect(screen.getByRole('option', {name: 'Option Two'})).toHaveAttribute(
         'aria-selected',
         'false'
+      );
+      expect(mock).toHaveBeenCalledWith(
+        {
+          key: 'section-1',
+          label: 'Section 1',
+          showToggleAllButton: true,
+          options: [
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ],
+        },
+        'unselect'
       );
 
       // move to Section 2's toggle button and select all
@@ -240,6 +268,18 @@ describe('CompactSelect', function () {
       expect(screen.getByRole('option', {name: 'Option Four'})).toHaveAttribute(
         'aria-selected',
         'true'
+      );
+      expect(mock).toHaveBeenCalledWith(
+        {
+          key: 'section-2',
+          label: 'Section 2',
+          showToggleAllButton: true,
+          options: [
+            {value: 'opt_three', label: 'Option Three'},
+            {value: 'opt_four', label: 'Option Four'},
+          ],
+        },
+        'select'
       );
     });
 
@@ -398,12 +438,15 @@ describe('CompactSelect', function () {
     });
 
     it('can toggle sections', async function () {
+      const mock = jest.fn();
       render(
         <CompactSelect
           grid
           multiple
+          onSectionToggle={mock}
           options={[
             {
+              key: 'section-1',
               label: 'Section 1',
               showToggleAllButton: true,
               options: [
@@ -412,6 +455,7 @@ describe('CompactSelect', function () {
               ],
             },
             {
+              key: 'section-2',
               label: 'Section 2',
               showToggleAllButton: true,
               options: [
@@ -441,6 +485,18 @@ describe('CompactSelect', function () {
         'aria-selected',
         'true'
       );
+      expect(mock).toHaveBeenCalledWith(
+        {
+          key: 'section-1',
+          label: 'Section 1',
+          showToggleAllButton: true,
+          options: [
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ],
+        },
+        'select'
+      );
 
       // press Section 1's toggle button again to unselect all
       await userEvent.keyboard('{Enter}');
@@ -451,6 +507,18 @@ describe('CompactSelect', function () {
       expect(screen.getByRole('row', {name: 'Option Two'})).toHaveAttribute(
         'aria-selected',
         'false'
+      );
+      expect(mock).toHaveBeenCalledWith(
+        {
+          key: 'section-1',
+          label: 'Section 1',
+          showToggleAllButton: true,
+          options: [
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ],
+        },
+        'unselect'
       );
 
       // move to Section 2's toggle button and select all
@@ -464,6 +532,18 @@ describe('CompactSelect', function () {
       expect(screen.getByRole('row', {name: 'Option Four'})).toHaveAttribute(
         'aria-selected',
         'true'
+      );
+      expect(mock).toHaveBeenCalledWith(
+        {
+          key: 'section-2',
+          label: 'Section 2',
+          showToggleAllButton: true,
+          options: [
+            {value: 'opt_three', label: 'Option Three'},
+            {value: 'opt_four', label: 'Option Four'},
+          ],
+        },
+        'select'
       );
     });
 

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -53,6 +53,7 @@ function CompactSelect<Value extends React.Key>({
   value,
   defaultValue,
   onChange,
+  onSectionToggle,
   multiple,
   disallowEmptySelection,
   isOptionDisabled,
@@ -107,6 +108,7 @@ function CompactSelect<Value extends React.Key>({
       <List
         {...listProps}
         items={optionsWithKey}
+        onSectionToggle={onSectionToggle}
         disallowEmptySelection={disallowEmptySelection}
         isOptionDisabled={isOptionDisabled}
         size={size}

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -11,7 +11,7 @@ import {FormSize} from 'sentry/utils/theme';
 import {SelectContext} from './control';
 import {GridList} from './gridList';
 import {ListBox} from './listBox';
-import {SelectOption, SelectOptionOrSectionWithKey} from './types';
+import {SelectOption, SelectOptionOrSectionWithKey, SelectSection} from './types';
 import {
   getDisabledOptions,
   getHiddenOptions,
@@ -60,6 +60,12 @@ interface BaseListProps<Value extends React.Key>
    * Text label to be rendered as heading on top of grid list.
    */
   label?: React.ReactNode;
+  /**
+   * To be called when the user toggle-selects a whole section (applicable when sections
+   * have `showToggleAllButton` set to true.) Note: this will be called in addition to
+   * and before `onChange`.
+   */
+  onSectionToggle?: (section: SelectSection<React.Key>) => void;
   size?: FormSize;
   /**
    * Upper limit for the number of options to display in the menu at a time. Users can
@@ -330,14 +336,18 @@ function List<Value extends React.Key>({
       )}
 
       {multiple &&
-        sections.map(section => (
-          <HiddenSectionToggle
-            key={section.key}
-            item={section}
-            listState={listState}
-            listId={listId}
-          />
-        ))}
+        sections.map(
+          section =>
+            section.value.showToggleAllButton && (
+              <HiddenSectionToggle
+                key={section.key}
+                item={section}
+                listState={listState}
+                listId={listId}
+                onToggle={props.onSectionToggle}
+              />
+            )
+        )}
     </SelectFilterContext.Provider>
   );
 }

--- a/static/app/components/compactSelect/listBox/index.tsx
+++ b/static/app/components/compactSelect/listBox/index.tsx
@@ -9,6 +9,7 @@ import {FormSize} from 'sentry/utils/theme';
 import {SelectContext} from '../control';
 import {SelectFilterContext} from '../list';
 import {ListLabel, ListSeparator, ListWrap, SizeLimitMessage} from '../styles';
+import {SelectSection} from '../types';
 
 import {ListBoxOption} from './option';
 import {ListBoxSection} from './section';
@@ -40,6 +41,15 @@ interface ListBoxProps
    * Text label to be rendered as heading on top of grid list.
    */
   label?: React.ReactNode;
+  /**
+   * To be called when the user toggle-selects a whole section (applicable when sections
+   * have `showToggleAllButton` set to true.) Note: this will be called in addition to
+   * and before `onChange`.
+   */
+  onSectionToggle?: (
+    section: SelectSection<React.Key>,
+    type: 'select' | 'unselect'
+  ) => void;
   size?: FormSize;
   /**
    * Message to be displayed when some options are hidden due to `sizeLimit`.
@@ -62,6 +72,7 @@ function ListBox({
   size = 'md',
   shouldFocusWrap = true,
   shouldFocusOnHover = true,
+  onSectionToggle,
   sizeLimitMessage,
   keyDownHandler,
   label,
@@ -118,6 +129,7 @@ function ListBox({
                   key={item.key}
                   item={item}
                   listState={listState}
+                  onToggle={onSectionToggle}
                   size={size}
                 />
               );

--- a/static/app/components/compactSelect/listBox/section.tsx
+++ b/static/app/components/compactSelect/listBox/section.tsx
@@ -14,6 +14,7 @@ import {
   SectionTitle,
   SectionWrap,
 } from '../styles';
+import {SelectSection} from '../types';
 import {SectionToggle} from '../utils';
 
 import {ListBoxOption} from './option';
@@ -22,13 +23,14 @@ interface ListBoxSectionProps extends AriaListBoxSectionProps {
   item: Node<any>;
   listState: ListState<any>;
   size: FormSize;
+  onToggle?: (section: SelectSection<React.Key>, type: 'select' | 'unselect') => void;
 }
 
 /**
  * A <li /> element that functions as a list box section (renders a nested <ul />
  * inside). https://react-spectrum.adobe.com/react-aria/useListBox.html
  */
-export function ListBoxSection({item, listState, size}: ListBoxSectionProps) {
+export function ListBoxSection({item, listState, onToggle, size}: ListBoxSectionProps) {
   const {itemProps, headingProps, groupProps} = useListBoxSection({
     heading: item.rendered,
     'aria-label': item['aria-label'],
@@ -55,7 +57,9 @@ export function ListBoxSection({item, listState, size}: ListBoxSectionProps) {
             {item.rendered && (
               <SectionTitle {...headingProps}>{item.rendered}</SectionTitle>
             )}
-            {showToggleAllButton && <SectionToggle item={item} listState={listState} />}
+            {showToggleAllButton && (
+              <SectionToggle item={item} listState={listState} onToggle={onToggle} />
+            )}
           </SectionHeader>
         )}
         <SectionGroup {...groupProps}>

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -9,7 +9,12 @@ import {Node, Selection} from '@react-types/shared';
 import {t} from 'sentry/locale';
 
 import {SectionToggleButton} from './styles';
-import {SelectOption, SelectOptionOrSection, SelectOptionOrSectionWithKey} from './types';
+import {
+  SelectOption,
+  SelectOptionOrSection,
+  SelectOptionOrSectionWithKey,
+  SelectSection,
+} from './types';
 
 /**
  * Recursively finds the selected option(s) from an options array. Useful for
@@ -168,13 +173,14 @@ interface SectionToggleProps {
   item: Node<any>;
   listState: ListState<any>;
   listId?: string;
+  onToggle?: (section: SelectSection<React.Key>, type: 'select' | 'unselect') => void;
 }
 
 /**
  * A visible toggle button to select/unselect all options within a given section. See
  * also: `HiddenSectionToggle`.
  */
-export function SectionToggle({item, listState}: SectionToggleProps) {
+export function SectionToggle({item, listState, onToggle}: SectionToggleProps) {
   const allOptionsSelected = useMemo(
     () => [...item.childNodes].every(n => listState.selectionManager.isSelected(n.key)),
     [item, listState.selectionManager]
@@ -188,14 +194,13 @@ export function SectionToggle({item, listState}: SectionToggleProps) {
     return listHasFocus && sectionHasFocus;
   }, [item, listState.selectionManager.focusedKey, listState.selectionManager.isFocused]);
 
-  const toggleAllOptions = useCallback(
-    () =>
-      toggleOptions(
-        [...item.childNodes].map(n => n.key),
-        listState.selectionManager
-      ),
-    [item, listState.selectionManager]
-  );
+  const toggleAllOptions = useCallback(() => {
+    onToggle?.(item.props, allOptionsSelected ? 'unselect' : 'select');
+    toggleOptions(
+      [...item.childNodes].map(n => n.key),
+      listState.selectionManager
+    );
+  }, [onToggle, allOptionsSelected, item, listState.selectionManager]);
 
   return (
     <SectionToggleButton
@@ -226,6 +231,7 @@ export function SectionToggle({item, listState}: SectionToggleProps) {
 export function HiddenSectionToggle({
   item,
   listState,
+  onToggle,
   listId = '',
   ...props
 }: SectionToggleProps) {
@@ -262,11 +268,13 @@ export function HiddenSectionToggle({
   );
 
   const {pressProps} = usePress({
-    onPress: () =>
+    onPress: () => {
+      onToggle?.(item.props, allOptionsSelected ? 'unselect' : 'select');
       toggleOptions(
         [...item.childNodes].map(n => n.key),
         listState.selectionManager
-      ),
+      );
+    },
   });
 
   return (

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -195,7 +195,7 @@ export function SectionToggle({item, listState, onToggle}: SectionToggleProps) {
   }, [item, listState.selectionManager.focusedKey, listState.selectionManager.isFocused]);
 
   const toggleAllOptions = useCallback(() => {
-    onToggle?.(item.props, allOptionsSelected ? 'unselect' : 'select');
+    onToggle?.(item.value, allOptionsSelected ? 'unselect' : 'select');
     toggleOptions(
       [...item.childNodes].map(n => n.key),
       listState.selectionManager
@@ -269,7 +269,7 @@ export function HiddenSectionToggle({
 
   const {pressProps} = usePress({
     onPress: () => {
-      onToggle?.(item.props, allOptionsSelected ? 'unselect' : 'select');
+      onToggle?.(item.value, allOptionsSelected ? 'unselect' : 'select');
       toggleOptions(
         [...item.childNodes].map(n => n.key),
         listState.selectionManager


### PR DESCRIPTION
Add an optional `onSectionToggle()` callback to `CompactSelect`, which can be useful for analytics and custom behaviors.

https://user-images.githubusercontent.com/44172267/230470018-b69f77ce-01b4-4b3a-873f-0375131fd9a5.mov

