### PR TITLE
feat(issue-platform): Convert issue occurrence consumer to be multiprocess

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -3,21 +3,7 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 from uuid import UUID
 
 import jsonschema
-import rapidjson
 import sentry_sdk
-from arroyo import Topic
-from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
-from arroyo.backends.kafka.consumer import KafkaConsumer, KafkaPayload
-from arroyo.commit import ONCE_PER_SECOND
-from arroyo.processing.processor import StreamProcessor
-from arroyo.processing.strategies import (
-    CommitOffsets,
-    ProcessingStrategy,
-    ProcessingStrategyFactory,
-    RunTaskWithMultiprocessing,
-)
-from arroyo.types import Commit, Message, Partition
-from django.conf import settings
 from django.utils import timezone
 
 from sentry import nodestore
@@ -28,9 +14,7 @@ from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
 from sentry.models import Organization, Project
-from sentry.utils import json, metrics
-from sentry.utils.batching_kafka_consumer import create_topics
-from sentry.utils.kafka_config import get_kafka_consumer_cluster_options
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -41,69 +25,6 @@ class InvalidEventPayloadError(Exception):
 
 class EventLookupError(Exception):
     pass
-
-
-def get_occurrences_ingest_consumer(
-    consumer_type: str,
-    auto_offset_reset: str,
-    group_id: str,
-    strict_offset_reset: bool,
-    max_batch_size: int,
-    max_batch_time: int,
-    processes: int,
-    input_block_size: int,
-    output_block_size: int,
-) -> StreamProcessor[KafkaPayload]:
-    return create_ingest_occurences_consumer(
-        consumer_type,
-        auto_offset_reset,
-        group_id,
-        strict_offset_reset,
-        max_batch_size,
-        max_batch_time,
-        processes,
-        input_block_size,
-        output_block_size,
-    )
-
-
-def create_ingest_occurences_consumer(
-    topic_name: str,
-    auto_offset_reset: str,
-    group_id: str,
-    strict_offset_reset: bool,
-    max_batch_size: int,
-    max_batch_time: int,
-    processes: int,
-    input_block_size: int,
-    output_block_size: int,
-) -> StreamProcessor[KafkaPayload]:
-    kafka_cluster = settings.KAFKA_TOPICS[topic_name]["cluster"]
-    create_topics(kafka_cluster, [topic_name])
-
-    consumer = KafkaConsumer(
-        build_kafka_consumer_configuration(
-            get_kafka_consumer_cluster_options(kafka_cluster),
-            auto_offset_reset=auto_offset_reset,
-            group_id=group_id,
-            strict_offset_reset=strict_offset_reset,
-        )
-    )
-
-    strategy_factory = OccurrenceStrategyFactory(
-        max_batch_size,
-        max_batch_time,
-        processes,
-        input_block_size,
-        output_block_size,
-    )
-
-    return StreamProcessor(
-        consumer,
-        Topic(topic_name),
-        strategy_factory,
-        ONCE_PER_SECOND,
-    )
 
 
 def save_event_from_occurrence(
@@ -325,60 +246,3 @@ def _process_message(
         except (ValueError, KeyError) as e:
             txn.set_tag("result", "error")
             raise InvalidEventPayloadError(e)
-
-
-class OccurrenceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
-    def __init__(
-        self,
-        max_batch_size: int,
-        max_batch_time: int,
-        processes: int,
-        input_block_size: int,
-        output_block_size: int,
-    ):
-        super().__init__()
-        self.max_batch_size = max_batch_size
-        self.max_batch_time = max_batch_time
-        self.num_processes = processes
-        self.input_block_size = input_block_size
-        self.output_block_size = output_block_size
-
-    def create_with_partitions(
-        self,
-        commit: Commit,
-        partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[KafkaPayload]:
-        def process_message(message: Message[KafkaPayload]) -> None:
-            try:
-                with metrics.timer("occurrence_consumer.process_message"):
-                    payload = json.loads(message.payload.value, use_rapid_json=True)
-                    _process_message(payload)
-            except (
-                rapidjson.JSONDecodeError,
-                InvalidEventPayloadError,
-                EventLookupError,
-                Exception,
-            ):
-                logger.exception("failed to process message payload")
-
-        return RunTaskWithMultiprocessing(
-            process_message,
-            CommitOffsets(commit),
-            self.num_processes,
-            self.max_batch_size,
-            self.max_batch_time,
-            self.input_block_size,
-            self.output_block_size,
-            initializer=initialize_consumer_state,
-        )
-
-
-def initialize_consumer_state() -> None:
-    """
-    Initialization function for subprocesses spawned by the occurrence ingestion consumer.
-
-    It initializes the Sentry Django app from scratch to avoid multiprocessing issues.
-    """
-    from sentry.runner import configure
-
-    configure()

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -369,4 +369,16 @@ class OccurrenceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             self.max_batch_time,
             self.input_block_size,
             self.output_block_size,
+            initializer=initialize_consumer_state,
         )
+
+
+def initialize_consumer_state() -> None:
+    """
+    Initialization function for subprocesses spawned by the occurrence ingestion consumer.
+
+    It initializes the Sentry Django app from scratch to avoid multiprocessing issues.
+    """
+    from sentry.runner import configure
+
+    configure()

--- a/src/sentry/issues/run.py
+++ b/src/sentry/issues/run.py
@@ -124,11 +124,12 @@ def process_message(message: Message[KafkaPayload]) -> None:
         InvalidEventPayloadError,
         _process_message,
     )
-    from sentry.utils import json
+    from sentry.utils import json, metrics
 
     try:
-        payload = json.loads(message.payload.value, use_rapid_json=True)
-        _process_message(payload)
+        with metrics.timer("occurrence_consumer.process_message"):
+            payload = json.loads(message.payload.value, use_rapid_json=True)
+            _process_message(payload)
     except (
         rapidjson.JSONDecodeError,
         InvalidEventPayloadError,

--- a/src/sentry/issues/run.py
+++ b/src/sentry/issues/run.py
@@ -1,0 +1,149 @@
+import logging
+from typing import Mapping
+
+import rapidjson
+from arroyo import Topic
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, build_kafka_consumer_configuration
+from arroyo.commit import ONCE_PER_SECOND
+from arroyo.processing import StreamProcessor
+from arroyo.processing.strategies import (
+    CommitOffsets,
+    ProcessingStrategy,
+    ProcessingStrategyFactory,
+    RunTaskWithMultiprocessing,
+)
+from arroyo.types import Commit, Message, Partition
+
+logger = logging.getLogger(__name__)
+
+
+def get_occurrences_ingest_consumer(
+    consumer_type: str,
+    auto_offset_reset: str,
+    group_id: str,
+    strict_offset_reset: bool,
+    max_batch_size: int,
+    max_batch_time: int,
+    processes: int,
+    input_block_size: int,
+    output_block_size: int,
+) -> StreamProcessor[KafkaPayload]:
+    return create_ingest_occurences_consumer(
+        consumer_type,
+        auto_offset_reset,
+        group_id,
+        strict_offset_reset,
+        max_batch_size,
+        max_batch_time,
+        processes,
+        input_block_size,
+        output_block_size,
+    )
+
+
+def create_ingest_occurences_consumer(
+    topic_name: str,
+    auto_offset_reset: str,
+    group_id: str,
+    strict_offset_reset: bool,
+    max_batch_size: int,
+    max_batch_time: int,
+    processes: int,
+    input_block_size: int,
+    output_block_size: int,
+) -> StreamProcessor[KafkaPayload]:
+    from django.conf import settings
+
+    from sentry.utils.batching_kafka_consumer import create_topics
+    from sentry.utils.kafka_config import get_kafka_consumer_cluster_options
+
+    kafka_cluster = settings.KAFKA_TOPICS[topic_name]["cluster"]
+    create_topics(kafka_cluster, [topic_name])
+
+    consumer = KafkaConsumer(
+        build_kafka_consumer_configuration(
+            get_kafka_consumer_cluster_options(kafka_cluster),
+            auto_offset_reset=auto_offset_reset,
+            group_id=group_id,
+            strict_offset_reset=strict_offset_reset,
+        )
+    )
+
+    strategy_factory = OccurrenceStrategyFactory(
+        max_batch_size,
+        max_batch_time,
+        processes,
+        input_block_size,
+        output_block_size,
+    )
+
+    return StreamProcessor(
+        consumer,
+        Topic(topic_name),
+        strategy_factory,
+        ONCE_PER_SECOND,
+    )
+
+
+class OccurrenceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
+    def __init__(
+        self,
+        max_batch_size: int,
+        max_batch_time: int,
+        processes: int,
+        input_block_size: int,
+        output_block_size: int,
+    ):
+        super().__init__()
+        self.max_batch_size = max_batch_size
+        self.max_batch_time = max_batch_time
+        self.num_processes = processes
+        self.input_block_size = input_block_size
+        self.output_block_size = output_block_size
+
+    def create_with_partitions(
+        self,
+        commit: Commit,
+        partitions: Mapping[Partition, int],
+    ) -> ProcessingStrategy[KafkaPayload]:
+        return RunTaskWithMultiprocessing(
+            process_message,
+            CommitOffsets(commit),
+            self.num_processes,
+            self.max_batch_size,
+            self.max_batch_time,
+            self.input_block_size,
+            self.output_block_size,
+            initializer=initialize_consumer_state,
+        )
+
+
+def process_message(message: Message[KafkaPayload]) -> None:
+    from sentry.issues.occurrence_consumer import (
+        EventLookupError,
+        InvalidEventPayloadError,
+        _process_message,
+    )
+    from sentry.utils import json
+
+    try:
+        payload = json.loads(message.payload.value, use_rapid_json=True)
+        _process_message(payload)
+    except (
+        rapidjson.JSONDecodeError,
+        InvalidEventPayloadError,
+        EventLookupError,
+        Exception,
+    ):
+        logger.exception("failed to process message payload")
+
+
+def initialize_consumer_state() -> None:
+    """
+    Initialization function for subprocesses spawned by the occurrence ingestion consumer.
+
+    It initializes the Sentry Django app from scratch to avoid multiprocessing issues.
+    """
+    from sentry.runner import configure
+
+    configure()

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -534,9 +534,16 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 
 
 @run.command("occurrences-ingest-consumer")
-@kafka_options("occurrence-consumer", allow_force_cluster=False)
+@kafka_options("occurrence-consumer", include_batching_options=True, allow_force_cluster=False)
 @strict_offset_reset_option()
 @configuration
+@click.option(
+    "--processes",
+    default=1,
+    type=int,
+)
+@click.option("--input-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
+@click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 def occurrences_ingest_consumer(**options):
     from django.conf import settings
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -9,6 +9,7 @@ import click
 
 from sentry.bgtasks.api import managed_bgtasks
 from sentry.ingest.types import ConsumerType
+from sentry.issues.run import get_occurrences_ingest_consumer
 from sentry.runner.decorators import configuration, log_options
 from sentry.sentry_metrics.consumers.indexer.slicing_router import get_slicing_router
 from sentry.utils.kafka import run_processor_with_signals
@@ -534,7 +535,12 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 
 
 @run.command("occurrences-ingest-consumer")
-@kafka_options("occurrence-consumer", include_batching_options=True, allow_force_cluster=False)
+@kafka_options(
+    "occurrence-consumer",
+    include_batching_options=True,
+    allow_force_cluster=False,
+    default_max_batch_size=100,
+)
 @strict_offset_reset_option()
 @configuration
 @click.option(
@@ -547,7 +553,6 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 def occurrences_ingest_consumer(**options):
     from django.conf import settings
 
-    from sentry.issues.occurrence_consumer import get_occurrences_ingest_consumer
     from sentry.utils import metrics
 
     consumer_type = settings.KAFKA_INGEST_OCCURRENCES


### PR DESCRIPTION
We're having scaling issues on this consumer. Not really hitting cpu limits, so it's likely io that we're waiting on. Converting this consumer to use multiprocessing to improve things here - and also to help with CPU scaling if we hit that in the future.

