### PR TITLE
feat(escalating-issues): Undo adding `ESCALATING` group status (#45965)

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -143,8 +143,6 @@ class GroupStatus:
     # be deleted. In this state no new events shall be added to the group.
     REPROCESSING = 6
 
-    ESCALATING = 7
-
     # TODO(dcramer): remove in 9.0
     MUTED = IGNORED
 
@@ -415,7 +413,6 @@ class Group(Model):
             (GroupStatus.UNRESOLVED, _("Unresolved")),
             (GroupStatus.RESOLVED, _("Resolved")),
             (GroupStatus.IGNORED, _("Ignored")),
-            (GroupStatus.ESCALATING, _("Escalating")),
         ),
         db_index=True,
     )


### PR DESCRIPTION
This reverts commit 22873216ea9dc6444328f42e29afdc240241db9c from #45965. We will be adding `ESCALATING` as a substatus per WOR-2935.

FIXES WOR-2940