### PR TITLE
feat(js): Support getResponseHeader in useApiQuery

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -19,6 +19,8 @@ import {PERFORMANCE_URL_PARAM} from 'sentry/utils/performance/constants';
 import {QueryBatching} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import {
   ApiQueryKey,
+  getApiQueryData,
+  setApiQueryData,
   useApiQuery,
   UseApiQueryOptions,
   useMutation,
@@ -293,11 +295,13 @@ export const useDeleteEventAttachmentOptimistic = (
     onMutate: async variables => {
       await queryClient.cancelQueries(makeFetchEventAttachmentsQueryKey(variables));
 
-      const previous = queryClient.getQueryData<FetchEventAttachmentResponse>(
+      const previous = getApiQueryData<FetchEventAttachmentResponse>(
+        queryClient,
         makeFetchEventAttachmentsQueryKey(variables)
       );
 
-      queryClient.setQueryData<FetchEventAttachmentResponse>(
+      setApiQueryData<FetchEventAttachmentResponse>(
+        queryClient,
         makeFetchEventAttachmentsQueryKey(variables),
         oldData => {
           if (!Array.isArray(oldData)) {
@@ -316,7 +320,8 @@ export const useDeleteEventAttachmentOptimistic = (
       addErrorMessage(t('An error occurred while deleting the attachment'));
 
       if (context) {
-        queryClient.setQueryData(
+        setApiQueryData(
+          queryClient,
           makeFetchEventAttachmentsQueryKey(variables),
           context.previous
         );

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -43,6 +43,12 @@ export class Request {
   }
 }
 
+export type ApiResult<Data = any> = [
+  data: Data,
+  statusText: string | undefined,
+  resp: ResponseMeta | undefined
+];
+
 export type ResponseMeta<R = any> = {
   /**
    * Get a header value from the response
@@ -530,11 +536,7 @@ export class Client {
       includeAllArgs,
       ...options
     }: {includeAllArgs?: IncludeAllArgsType} & Readonly<RequestOptions> = {}
-  ): Promise<
-    IncludeAllArgsType extends true
-      ? [data: any, textStatus: string | undefined, response: ResponseMeta | undefined]
-      : any
-  > {
+  ): Promise<IncludeAllArgsType extends true ? ApiResult : any> {
     // Create an error object here before we make any async calls so that we
     // have a helpful stack trace if it errors
     //

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -31,7 +31,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForEvent} from 'sentry/utils/events';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
-import {useQueryClient} from 'sentry/utils/queryClient';
+import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -74,7 +74,8 @@ function StacktraceLinkSetup({organization, project, event}: StacktraceLinkSetup
 
     // Update cached query data
     // Will set prompt to dismissed
-    queryClient.setQueryData<PromptResponse>(
+    setApiQueryData<PromptResponse>(
+      queryClient,
       makePromptsCheckQueryKey({
         feature: 'stacktrace_link',
         organizationId: organization.id,

--- a/static/app/utils/queryClient.spec.tsx
+++ b/static/app/utils/queryClient.spec.tsx
@@ -23,7 +23,7 @@ describe('queryClient', function () {
         headers: {'Custom-Header': 'header value'},
       });
 
-      const TestComponent = () => {
+      function TestComponent() {
         const {data, getResponseHeader} = useApiQuery<ResponseData>(
           ['/some/test/path/'],
           {staleTime: 0}
@@ -39,7 +39,7 @@ describe('queryClient', function () {
             <div>{getResponseHeader?.('Custom-Header')}</div>
           </Fragment>
         );
-      };
+      }
 
       render(<TestComponent />);
 

--- a/static/app/utils/queryClient.spec.tsx
+++ b/static/app/utils/queryClient.spec.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -18,21 +20,31 @@ describe('queryClient', function () {
       const mock = MockApiClient.addMockResponse({
         url: '/some/test/path/',
         body: {value: 5},
+        headers: {'Custom-Header': 'header value'},
       });
 
-      function TestComponent() {
-        const {data} = useApiQuery<ResponseData>(['/some/test/path/'], {staleTime: 0});
+      const TestComponent = () => {
+        const {data, getResponseHeader} = useApiQuery<ResponseData>(
+          ['/some/test/path/'],
+          {staleTime: 0}
+        );
 
         if (!data) {
           return null;
         }
 
-        return <div>{data.value}</div>;
-      }
+        return (
+          <Fragment>
+            <div>{data.value}</div>
+            <div>{getResponseHeader?.('Custom-Header')}</div>
+          </Fragment>
+        );
+      };
 
       render(<TestComponent />);
 
       expect(await screen.findByText('5')).toBeInTheDocument();
+      expect(screen.getByText('header value')).toBeInTheDocument();
 
       expect(mock).toHaveBeenCalledWith('/some/test/path/', expect.anything());
     });
@@ -64,22 +76,6 @@ describe('queryClient', function () {
         '/some/test/path/',
         expect.objectContaining({query: {filter: 'red'}})
       );
-    });
-
-    it('can fetch with custom query function', async function () {
-      function TestComponent() {
-        const {data} = useApiQuery<ResponseData>(['some-key'], () => ({value: 5}));
-
-        if (!data) {
-          return null;
-        }
-
-        return <div>{data.value}</div>;
-      }
-
-      render(<TestComponent />);
-
-      expect(await screen.findByText('5')).toBeInTheDocument();
     });
 
     it('can return error state', async function () {

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -1,24 +1,43 @@
 import * as reactQuery from '@tanstack/react-query';
 import {QueryClientConfig} from '@tanstack/react-query';
 
+import {ApiResult, ResponseMeta} from 'sentry/api';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
+
+// Overrides to the default react-query options.
+// See https://tanstack.com/query/v4/docs/guides/important-defaults
+const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+};
 
 type QueryKeyEndpointOptions = {
   query?: Record<string, any>;
 };
 
-export type ApiQueryKey =
+type ApiQueryKey =
   | readonly [url: string]
   | readonly [url: string, options: QueryKeyEndpointOptions];
 
-export interface UseApiQueryOptions<
-  TQueryFnData,
-  TError = RequestError,
-  TData = TQueryFnData
-> extends Omit<
-    reactQuery.UseQueryOptions<TQueryFnData, TError, TData, ApiQueryKey>,
-    'queryKey' | 'queryFn'
+interface UseApiQueryOptions<TApiResponse, TError = RequestError>
+  extends Omit<
+    reactQuery.UseQueryOptions<
+      ApiResult<TApiResponse>,
+      TError,
+      TApiResponse,
+      ApiQueryKey
+    >,
+    // This is an explicit option in our function
+    | 'queryKey'
+    // This will always be a useApi api Query
+    | 'queryFn'
+    // We do not include the select option as this is difficult to make interop
+    // with the way we extract data out of the ApiResult tuple
+    | 'select'
   > {
   /**
    * staleTime is the amount of time (in ms) before cached data gets marked as stale.
@@ -38,23 +57,12 @@ export interface UseApiQueryOptions<
   staleTime: number;
 }
 
-// Overrides to the default react-query options.
-// See https://tanstack.com/query/v4/docs/guides/important-defaults
-const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-    },
-  },
+type UseApiQueryResult<TData, TError> = reactQuery.UseQueryResult<TData, TError> & {
+  /**
+   * Get a header value from the response
+   */
+  getResponseHeader?: ResponseMeta['getResponseHeader'];
 };
-
-function isQueryFn<TQueryFnData, TError, TData>(
-  queryFnOrQueryOptions?:
-    | reactQuery.QueryFunction<TQueryFnData, ApiQueryKey>
-    | UseApiQueryOptions<TQueryFnData, TError, TData>
-): queryFnOrQueryOptions is reactQuery.QueryFunction<TQueryFnData, ApiQueryKey> {
-  return typeof queryFnOrQueryOptions === 'function';
-}
 
 /**
  * Wraps React Query's useQuery for consistent usage in the Sentry app.
@@ -71,67 +79,86 @@ function isQueryFn<TQueryFnData, TError, TData>(
  *   {staleTime: 0}
  * );
  */
-function useApiQuery<TQueryFnData, TError = RequestError, TData = TQueryFnData>(
+function useApiQuery<TResponseData, TError = RequestError>(
   queryKey: ApiQueryKey,
-  queryOptions: UseApiQueryOptions<TQueryFnData, TError, TData>
-): reactQuery.UseQueryResult<TData, TError>;
-/**
- * Example usage with custom query function:
- *
- * const { data, isLoading, isError } = useQuery<EventsResponse>(
- *   ['events', {limit: 50}],
- *   () => api.requestPromise({limit: 50}),
- *   {staleTime: 0}
- * )
- */
-function useApiQuery<TQueryFnData, TError = RequestError, TData = TQueryFnData>(
-  queryKey: ApiQueryKey,
-  queryFn: reactQuery.QueryFunction<TQueryFnData, ApiQueryKey>,
-  queryOptions?: UseApiQueryOptions<TQueryFnData, TError, TData>
-): reactQuery.UseQueryResult<TData, TError>;
-function useApiQuery<TQueryFnData, TError = RequestError, TData = TQueryFnData>(
-  queryKey: ApiQueryKey,
-  queryFnOrQueryOptions:
-    | reactQuery.QueryFunction<TQueryFnData, ApiQueryKey>
-    | UseApiQueryOptions<TQueryFnData, TError, TData>,
-  queryOptions?: UseApiQueryOptions<TQueryFnData, TError, TData>
-): reactQuery.UseQueryResult<TData, TError> {
-  // XXX: We need to set persistInFlight to disable query cancellation on unmount.
-  // The current implementation of our API client does not reject on query
-  // cancellation, which causes React Query to never update from the isLoading state.
-  // This matches the library default as well: https://tanstack.com/query/v4/docs/guides/query-cancellation#default-behavior
-  const api = useApi({persistInFlight: true});
+  options: UseApiQueryOptions<TResponseData, TError>
+): UseApiQueryResult<TResponseData, TError> {
+  const api = useApi({
+    // XXX: We need to set persistInFlight to disable query cancellation on
+    //      unmount. The current implementation of our API client does not
+    //      reject on query cancellation, which causes React Query to never
+    //      update from the isLoading state. This matches the library default
+    //      as well [0].
+    //
+    //      This is slightly different from our typical usage of our api client
+    //      in components, where we do not want it to resolve, since we would
+    //      then have to guard our setState's against being unmounted.
+    //
+    //      This has the advantage of storing the result in the cache as well.
+    //
+    //      [0]: https://tanstack.com/query/v4/docs/guides/query-cancellation#default-behavior
+    persistInFlight: true,
+  });
 
   const [path, endpointOptions] = queryKey;
 
-  const defaultQueryFn: reactQuery.QueryFunction<TQueryFnData, ApiQueryKey> = () =>
+  const queryFn: reactQuery.QueryFunction<ApiResult<TResponseData>, ApiQueryKey> = () =>
     api.requestPromise(path, {
       method: 'GET',
       query: endpointOptions?.query,
+      includeAllArgs: true,
     });
 
-  const queryFn = isQueryFn(queryFnOrQueryOptions)
-    ? queryFnOrQueryOptions
-    : defaultQueryFn;
+  const {data, ...rest} = reactQuery.useQuery(queryKey, queryFn, options);
 
-  const options =
-    queryOptions ??
-    (isQueryFn(queryFnOrQueryOptions) ? undefined : queryFnOrQueryOptions);
+  return {
+    data: data?.[0],
+    getResponseHeader: data?.[2]?.getResponseHeader,
+    ...rest,
+  };
+}
 
-  return reactQuery.useQuery(queryKey, queryFn, options);
+export function getApiQueryData<TResponseData>(
+  queryClient: reactQuery.QueryClient,
+  queryKey: ApiQueryKey
+): TResponseData | undefined {
+  return queryClient.getQueryData<ApiResult<TResponseData>>(queryKey)?.[0];
 }
 
 function setApiQueryData<TResponseData>(
   queryClient: reactQuery.QueryClient,
   queryKey: ApiQueryKey,
-  updater: reactQuery.Updater<TResponseData | undefined, TResponseData | undefined>,
+  updater: reactQuery.Updater<TResponseData, TResponseData>,
   options?: reactQuery.SetDataOptions
 ): TResponseData | undefined {
-  return queryClient.setQueryData(queryKey, updater, options);
+  const previous = queryClient.getQueryData<ApiResult<TResponseData>>(queryKey);
+
+  const newData =
+    typeof updater === 'function'
+      ? (updater as (input?: TResponseData) => TResponseData)(previous?.[0])
+      : updater;
+
+  const [_prevdata, prevStatusText, prevResponse] = previous ?? [
+    undefined,
+    undefined,
+    undefined,
+  ];
+
+  const newResponse: ApiResult<TResponseData> = [newData, prevStatusText, prevResponse];
+
+  queryClient.setQueryData(queryKey, newResponse, options);
+
+  return newResponse[0];
 }
 
 // eslint-disable-next-line import/export
 export * from '@tanstack/react-query';
 
 // eslint-disable-next-line import/export
-export {DEFAULT_QUERY_CLIENT_CONFIG, useApiQuery, setApiQueryData};
+export {
+  DEFAULT_QUERY_CLIENT_CONFIG,
+  useApiQuery,
+  setApiQueryData,
+  UseApiQueryOptions,
+  ApiQueryKey,
+};

--- a/static/app/views/issueList/mutations/useDeleteSavedSearch.tsx
+++ b/static/app/views/issueList/mutations/useDeleteSavedSearch.tsx
@@ -2,6 +2,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import {SavedSearch} from 'sentry/types';
 import {
+  getApiQueryData,
   setApiQueryData,
   useMutation,
   UseMutationOptions,
@@ -47,7 +48,8 @@ export const useDeleteSavedSearchOptimistic = (
         makeFetchSavedSearchesForOrgQueryKey({orgSlug: variables.orgSlug})
       );
 
-      const previousSavedSearches = queryClient.getQueryData<SavedSearch[]>(
+      const previousSavedSearches = getApiQueryData<SavedSearch[]>(
+        queryClient,
         makeFetchSavedSearchesForOrgQueryKey({orgSlug: variables.orgSlug})
       );
 

--- a/static/app/views/issueList/mutations/useModifySavedSearch.tsx
+++ b/static/app/views/issueList/mutations/useModifySavedSearch.tsx
@@ -1,5 +1,10 @@
 import {SavedSearch, SavedSearchType, SavedSearchVisibility} from 'sentry/types';
-import {useMutation, UseMutationOptions, useQueryClient} from 'sentry/utils/queryClient';
+import {
+  setApiQueryData,
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchSavedSearchesForOrgQueryKey} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
@@ -38,7 +43,8 @@ export const useModifySavedSearch = (
           data,
         }),
       onSuccess: (savedSearch, parameters, context) => {
-        queryClient.setQueryData<SavedSearch[]>(
+        setApiQueryData<SavedSearch[]>(
+          queryClient,
           makeFetchSavedSearchesForOrgQueryKey({orgSlug: parameters.orgSlug}),
           oldData => {
             if (!Array.isArray(oldData)) {

--- a/static/app/views/issueList/mutations/usePinSearch.tsx
+++ b/static/app/views/issueList/mutations/usePinSearch.tsx
@@ -1,7 +1,12 @@
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import {SavedSearch, SavedSearchType} from 'sentry/types';
-import {useMutation, UseMutationOptions, useQueryClient} from 'sentry/utils/queryClient';
+import {
+  setApiQueryData,
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchSavedSearchesForOrgQueryKey} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
@@ -32,7 +37,8 @@ export const usePinSearch = (
         data: {query, type, sort},
       }),
     onSuccess: (savedSearch, variables, context) => {
-      queryClient.setQueryData<SavedSearch[]>(
+      setApiQueryData<SavedSearch[]>(
+        queryClient,
         makeFetchSavedSearchesForOrgQueryKey({orgSlug: variables.orgSlug}),
         oldData => {
           if (!Array.isArray(oldData)) {

--- a/static/app/views/issueList/mutations/useUnpinSearch.tsx
+++ b/static/app/views/issueList/mutations/useUnpinSearch.tsx
@@ -1,7 +1,12 @@
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import {SavedSearch, SavedSearchType} from 'sentry/types';
-import {useMutation, UseMutationOptions, useQueryClient} from 'sentry/utils/queryClient';
+import {
+  setApiQueryData,
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {makeFetchSavedSearchesForOrgQueryKey} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
@@ -32,7 +37,8 @@ export const useUnpinSearch = (
         },
       }),
     onSuccess: (savedSearch, variables, context) => {
-      queryClient.setQueryData<SavedSearch[]>(
+      setApiQueryData<SavedSearch[]>(
+        queryClient,
         makeFetchSavedSearchesForOrgQueryKey({orgSlug: variables.orgSlug}),
         oldData => {
           if (!Array.isArray(oldData)) {

--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -152,21 +152,16 @@ export function ProjectSourceMaps({location, router, project}: Props) {
 
   const {
     data: archivesData,
+    getResponseHeader: archivesHeaders,
     isLoading: archivesLoading,
     refetch: archivesRefetch,
-  } = useApiQuery<[SourceMapsArchive[], any, any]>(
+  } = useApiQuery<SourceMapsArchive[]>(
     [
       sourceMapsEndpoint,
       {
         query: {query, cursor, sortBy},
       },
     ],
-    () => {
-      return api.requestPromise(sourceMapsEndpoint, {
-        query: {query, cursor, sortBy},
-        includeAllArgs: true,
-      });
-    },
     {
       staleTime: 0,
       keepPreviousData: true,
@@ -176,21 +171,16 @@ export function ProjectSourceMaps({location, router, project}: Props) {
 
   const {
     data: debugIdBundlesData,
+    getResponseHeader: debugIdBundlesHeaders,
     isLoading: debugIdBundlesLoading,
     refetch: debugIdBundlesRefetch,
-  } = useApiQuery<[DebugIdBundle[], any, any]>(
+  } = useApiQuery<DebugIdBundle[]>(
     [
       debugIdBundlesEndpoint,
       {
         query: {query, cursor, sortBy},
       },
     ],
-    () => {
-      return api.requestPromise(debugIdBundlesEndpoint, {
-        query: {query, cursor, sortBy},
-        includeAllArgs: true,
-      });
-    },
     {
       staleTime: 0,
       keepPreviousData: true,
@@ -312,15 +302,13 @@ export function ProjectSourceMaps({location, router, project}: Props) {
               })
         }
         isEmpty={
-          (tabDebugIdBundlesActive
-            ? debugIdBundlesData?.[0] ?? []
-            : archivesData?.[0] ?? []
-          ).length === 0
+          (tabDebugIdBundlesActive ? debugIdBundlesData ?? [] : archivesData ?? [])
+            .length === 0
         }
         isLoading={tabDebugIdBundlesActive ? debugIdBundlesLoading : archivesLoading}
       >
         {tabDebugIdBundlesActive
-          ? debugIdBundlesData?.[0].map(data => (
+          ? debugIdBundlesData?.map(data => (
               <SourceMapsTableRow
                 key={data.bundleId}
                 bundleType={SourceMapsBundleType.DebugId}
@@ -336,7 +324,7 @@ export function ProjectSourceMaps({location, router, project}: Props) {
                 }
               />
             ))
-          : archivesData?.[0].map(data => (
+          : archivesData?.map(data => (
               <SourceMapsTableRow
                 key={data.name}
                 bundleType={SourceMapsBundleType.Release}
@@ -353,8 +341,8 @@ export function ProjectSourceMaps({location, router, project}: Props) {
       <Pagination
         pageLinks={
           tabDebugIdBundlesActive
-            ? debugIdBundlesData?.[2]?.getResponseHeader('Link') ?? ''
-            : archivesData?.[2]?.getResponseHeader('Link') ?? ''
+            ? debugIdBundlesHeaders?.('Link') ?? ''
+            : archivesHeaders?.('Link') ?? ''
         }
       />
     </Fragment>

--- a/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.tsx
@@ -127,21 +127,17 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
 
   const tabDebugIdBundlesActive = location.pathname === debugIdsUrl;
 
-  const {data: artifactsData, isLoading: artifactsLoading} = useApiQuery<
-    [Artifact[], any, any]
-  >(
+  const {
+    data: artifactsData,
+    getResponseHeader: artifactsHeaders,
+    isLoading: artifactsLoading,
+  } = useApiQuery<Artifact[]>(
     [
       artifactsEndpoint,
       {
         query: {query, cursor},
       },
     ],
-    () => {
-      return api.requestPromise(artifactsEndpoint, {
-        query: cursor ? {query, cursor} : {query},
-        includeAllArgs: true,
-      });
-    },
     {
       staleTime: 0,
       keepPreviousData: true,
@@ -149,26 +145,23 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
     }
   );
 
-  const {data: debugIdBundlesArtifactsData, isLoading: debugIdBundlesArtifactsLoading} =
-    useApiQuery<[DebugIdBundleArtifact, any, any]>(
-      [
-        debugIdBundlesArtifactsEndpoint,
-        {
-          query: {query, cursor},
-        },
-      ],
-      () => {
-        return api.requestPromise(debugIdBundlesArtifactsEndpoint, {
-          query: cursor ? {query, cursor} : {query},
-          includeAllArgs: true,
-        });
-      },
+  const {
+    data: debugIdBundlesArtifactsData,
+    getResponseHeader: debugIdBundlesArtifactsHeaders,
+    isLoading: debugIdBundlesArtifactsLoading,
+  } = useApiQuery<DebugIdBundleArtifact>(
+    [
+      debugIdBundlesArtifactsEndpoint,
       {
-        staleTime: 0,
-        keepPreviousData: true,
-        enabled: tabDebugIdBundlesActive,
-      }
-    );
+        query: {query, cursor},
+      },
+    ],
+    {
+      staleTime: 0,
+      keepPreviousData: true,
+      enabled: tabDebugIdBundlesActive,
+    }
+  );
 
   const handleSearch = useCallback(
     (newQuery: string) => {
@@ -189,8 +182,8 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
             {params.bundleId}
             {tabDebugIdBundlesActive && (
               <DebugIdBundlesTags
-                dist={debugIdBundlesArtifactsData?.[0]?.dist}
-                release={debugIdBundlesArtifactsData?.[0]?.release}
+                dist={debugIdBundlesArtifactsData?.dist}
+                release={debugIdBundlesArtifactsData?.release}
                 loading={debugIdBundlesArtifactsLoading}
               />
             )}
@@ -219,8 +212,8 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
         }
         isEmpty={
           (tabDebugIdBundlesActive
-            ? debugIdBundlesArtifactsData?.[0].files ?? []
-            : artifactsData?.[0] ?? []
+            ? debugIdBundlesArtifactsData?.files ?? []
+            : artifactsData ?? []
           ).length === 0
         }
         isLoading={
@@ -228,7 +221,7 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
         }
       >
         {tabDebugIdBundlesActive
-          ? (debugIdBundlesArtifactsData?.[0].files ?? []).map(data => {
+          ? (debugIdBundlesArtifactsData?.files ?? []).map(data => {
               const downloadUrl = `${api.baseUrl}/projects/${organization.slug}/${
                 project.slug
               }/artifact-bundles/${encodeURIComponent(params.bundleId)}/files/${
@@ -252,7 +245,7 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
                 />
               );
             })
-          : artifactsData?.[0].map(data => {
+          : artifactsData?.map(data => {
               const downloadUrl = `${api.baseUrl}/projects/${organization.slug}/${
                 project.slug
               }/releases/${encodeURIComponent(params.bundleId)}/files/${
@@ -288,8 +281,8 @@ export function ProjectSourceMapsArtifacts({params, location, router, project}: 
       <Pagination
         pageLinks={
           tabDebugIdBundlesActive
-            ? debugIdBundlesArtifactsData?.[2]?.getResponseHeader('Link') ?? ''
-            : artifactsData?.[2]?.getResponseHeader('Link') ?? ''
+            ? debugIdBundlesArtifactsHeaders?.('Link') ?? ''
+            : artifactsHeaders?.('Link') ?? ''
         }
       />
     </Fragment>


### PR DESCRIPTION
This allows us to extract headers from the API result when using useApiQuery

Important since we have a number of places where we pull out page links