### PR TITLE
fix(issue-platform): Change default batch size to be lower

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -539,7 +539,7 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
     "occurrence-consumer",
     include_batching_options=True,
     allow_force_cluster=False,
-    default_max_batch_size=100,
+    default_max_batch_size=20,
 )
 @strict_offset_reset_option()
 @configuration


### PR DESCRIPTION
This default is too high and causing spikness in consumer lag. We can tinker with this + processes more with ops, but for now making this something more reasonable