### PR TITLE
chore(js): Prefer React.ComponentType over React.FC in types

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -150,7 +150,7 @@ export type ComponentHooks = {
   'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
   'component:set-up-sdk-doc': () => React.ComponentType<SetUpSdkDocProps>;
-  'component:superuser-access-category': React.FC<any>;
+  'component:superuser-access-category': React.ComponentType<any>;
 };
 
 /**

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -26,7 +26,7 @@ export enum GenericPerformanceWidgetDataType {
 }
 
 export type PerformanceWidgetProps = {
-  ContainerActions: React.FC<{isLoading: boolean}> | null;
+  ContainerActions: React.ComponentType<{isLoading: boolean}> | null;
   chartDefinition: ChartDefinition;
   chartHeight: number;
 
@@ -38,7 +38,7 @@ export type PerformanceWidgetProps = {
   title: string;
   titleTooltip: string;
 
-  InteractiveTitle?: React.FC<{isLoading: boolean}> | null;
+  InteractiveTitle?: React.ComponentType<{isLoading: boolean}> | null;
 
   chartColor?: string;
 
@@ -57,7 +57,7 @@ export interface WidgetDataConstraint {
 export type QueryChildren = {
   children: (props: any) => React.ReactNode; // TODO(k-fish): Fix any type.
 };
-export type QueryFC<T extends WidgetDataConstraint> = React.FC<
+export type QueryFC<T extends WidgetDataConstraint> = React.ComponentType<
   QueryChildren & {
     eventView: EventView;
     orgSlug: string;
@@ -95,7 +95,7 @@ export type Queries<T extends WidgetDataConstraint> = Record<
 >;
 
 type Visualization<T> = {
-  component: React.FC<{
+  component: React.ComponentType<{
     widgetData: T;
     grid?: React.ComponentProps<typeof BaseChart>['grid'];
     height?: number;
@@ -111,13 +111,13 @@ type Visualization<T> = {
 
 type Visualizations<T extends WidgetDataConstraint> = Readonly<Visualization<T>[]>; // Readonly because of index being used for React key.
 
-type HeaderActions<T> = React.FC<{
+type HeaderActions<T> = React.ComponentType<{
   widgetData: T;
 }>;
 
-type InteractiveTitle<T> = React.FC<{widgetData: T}>;
+type InteractiveTitle<T> = React.ComponentType<{widgetData: T}>;
 
-type Subtitle<T> = React.FC<{
+type Subtitle<T> = React.ComponentType<{
   widgetData: T;
 }>;
 
@@ -139,7 +139,7 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
   // Header;
   title: string;
   titleTooltip: string;
-  EmptyComponent?: React.FC<{height?: number}>;
+  EmptyComponent?: React.ComponentType<{height?: number}>;
 
   HeaderActions?: HeaderActions<T>;
   InteractiveTitle?: InteractiveTitle<T> | null;

--- a/static/app/views/starfish/landing/widgets/types.tsx
+++ b/static/app/views/starfish/landing/widgets/types.tsx
@@ -27,7 +27,7 @@ export enum GenericPerformanceWidgetDataType {
 }
 
 export type PerformanceWidgetProps = {
-  ContainerActions: React.FC<{isLoading: boolean}> | null;
+  ContainerActions: React.ComponentType<{isLoading: boolean}> | null;
   chartDefinition: ChartDefinition;
   chartHeight: number;
 
@@ -39,7 +39,7 @@ export type PerformanceWidgetProps = {
   title: string;
   titleTooltip: string;
 
-  InteractiveTitle?: React.FC<{isLoading: boolean}> | null;
+  InteractiveTitle?: React.ComponentType<{isLoading: boolean}> | null;
 
   chartColor?: string;
 
@@ -58,7 +58,7 @@ export interface WidgetDataConstraint {
 export type QueryChildren = {
   children: (props: any) => React.ReactNode; // TODO(k-fish): Fix any type.
 };
-export type QueryFC<T extends WidgetDataConstraint> = React.FC<
+export type QueryFC<T extends WidgetDataConstraint> = React.ComponentType<
   QueryChildren & {
     eventView: EventView;
     orgSlug: string;
@@ -96,7 +96,7 @@ export type Queries<T extends WidgetDataConstraint> = Record<
 >;
 
 type Visualization<T> = {
-  component: React.FC<{
+  component: React.ComponentType<{
     widgetData: T;
     grid?: React.ComponentProps<typeof BaseChart>['grid'];
     height?: number;
@@ -112,13 +112,13 @@ type Visualization<T> = {
 
 type Visualizations<T extends WidgetDataConstraint> = Readonly<Visualization<T>[]>; // Readonly because of index being used for React key.
 
-type HeaderActions<T> = React.FC<{
+type HeaderActions<T> = React.ComponentType<{
   widgetData: T;
 }>;
 
-type InteractiveTitle<T> = React.FC<{widgetData: T}>;
+type InteractiveTitle<T> = React.ComponentType<{widgetData: T}>;
 
-type Subtitle<T> = React.FC<{
+type Subtitle<T> = React.ComponentType<{
   widgetData: T;
 }>;
 
@@ -140,7 +140,7 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
   // Header;
   title: string;
   titleTooltip: string;
-  EmptyComponent?: React.FC<{height?: number}>;
+  EmptyComponent?: React.ComponentType<{height?: number}>;
 
   HeaderActions?: HeaderActions<T>;
   InteractiveTitle?: InteractiveTitle<T> | null;


### PR DESCRIPTION
React.FC has a slightly different meaning in react 18. Prefer
`React.ComponentType` instead, which is unchangedt