### PR TITLE
fix(dynamic-sampling) Prioritise transaction implicit factor rule

### DIFF
--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_rare_transactions_rule.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_rare_transactions_rule.py
@@ -17,15 +17,15 @@ def _create_mocks():
 
     proj.organization = org
 
+    explicit_rates = {"t1": 0.1, "t2": 0.2}
+    implicit_rate = 0.01
+
     def get_transactions_resampling_rates(org_id, proj_id, default_rate):
         if org_id == org.id and proj_id == proj.id:
-            return {
-                "t1": 0.1,
-                "t2": 0.2,
-            }, 0.01
+            return explicit_rates, implicit_rate
         return {}, default_rate
 
-    return proj, get_transactions_resampling_rates
+    return proj, get_transactions_resampling_rates, explicit_rates, implicit_rate
 
 
 @patch(
@@ -36,14 +36,23 @@ def test_transaction_boost_known_projects(get_transactions_resampling_rates):
     Test that when there is information available about project transactions it
     generates rules for boosting rare transactions
     """
-    project, fake_get_trans_res_rates = _create_mocks()
+    project, fake_get_trans_res_rates, explicit_rates, implicit_rate = _create_mocks()
     rate = 0.2
     get_transactions_resampling_rates.side_effect = fake_get_trans_res_rates
+
+    # the raw rates
+    t1_rate = explicit_rates["t1"]
+    t2_rate = explicit_rates["t2"]
+
+    # adjusted factors
+    implicit_factor = implicit_rate / rate
+    t1_factor = t1_rate / rate / implicit_factor
+    t2_factor = t2_rate / rate / implicit_factor
 
     rules = RareTransactionsRulesBias().generate_rules(project=project, base_sample_rate=rate)
     expected = [
         {
-            "samplingValue": {"type": "factor", "value": 0.1 / rate},
+            "samplingValue": {"type": "factor", "value": t1_factor},
             "type": "transaction",
             "condition": {
                 "op": "or",
@@ -59,7 +68,7 @@ def test_transaction_boost_known_projects(get_transactions_resampling_rates):
             "id": RESERVED_IDS[RuleType.BOOST_LOW_VOLUME_TRANSACTIONS],
         },
         {
-            "samplingValue": {"type": "factor", "value": 0.2 / rate},
+            "samplingValue": {"type": "factor", "value": t2_factor},
             "type": "transaction",
             "condition": {
                 "op": "or",
@@ -75,7 +84,7 @@ def test_transaction_boost_known_projects(get_transactions_resampling_rates):
             "id": RESERVED_IDS[RuleType.BOOST_LOW_VOLUME_TRANSACTIONS] + 1,
         },
         {
-            "samplingValue": {"type": "factor", "value": 0.01 / rate},
+            "samplingValue": {"type": "factor", "value": implicit_factor},
             "type": "transaction",
             "condition": {
                 "op": "and",
@@ -92,7 +101,7 @@ def test_transaction_boost_unknown_projects():
     Tests that when there is no information available for the project transactions
     it returns an empty set of rules.
     """
-    project, fake_get_trans_res_rates = _create_mocks()
+    project, fake_get_trans_res_rates, _explicit_rates, _implicit_rate = _create_mocks()
     rate = 0.2
 
     rules = RareTransactionsRulesBias().generate_rules(project=project, base_sample_rate=rate)

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -683,6 +683,9 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
         project_team=ProjectTeam.objects.get(project=default_project, team=default_team),
     )
     rules = generate_rules(default_project)
+    implicit_rate /= project_sample_rate
+    t1_rate /= project_sample_rate
+    t1_rate /= implicit_rate
     assert rules == [
         # transaction boosting rule
         {
@@ -698,13 +701,13 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
                 "op": "or",
             },
             "id": boost_low_transactions_id,
-            "samplingValue": {"type": "factor", "value": t1_rate / project_sample_rate},
+            "samplingValue": {"type": "factor", "value": t1_rate},
             "type": "transaction",
         },
         {
             "condition": {"inner": [], "op": "and"},
             "id": 1401,
-            "samplingValue": {"type": "factor", "value": implicit_rate / project_sample_rate},
+            "samplingValue": {"type": "factor", "value": implicit_rate},
             "type": "transaction",
         },
         {


### PR DESCRIPTION
 This PR fixes a mistake in the calculation of factors for prioritise by transaction.

Previously the rules generated were something like this:

	For transaction=T1 apply factor=F1
	For transaction=T2 apply factor=F2
	For everything apply factor=F3

F3 should be applied for everything that is not F1 and F2 and it applies for everything.
To compensate the new rules are like this:

	For transaction=T1 apply factor=F1/F3
	For transaction=T2 apply factor=F2/F3
	For everything apply factor=F3
