### PR TITLE
feat(loader): Enable the new dynamic loader without feature flag

### DIFF
--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -444,8 +444,6 @@ describe('Onboarding Setup Docs', function () {
           features: [
             'onboarding-remove-multiselect-platform',
             'onboarding-docs-with-product-selection',
-            'onboarding-project-loader',
-            'js-sdk-dynamic-loader',
           ],
         },
         router: {

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -269,10 +269,6 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
     'onboarding-docs-with-product-selection'
   );
 
-  const loaderOnboarding = !!organization.features?.includes('onboarding-project-loader');
-
-  const jsDynamicLoader = !!organization.features?.includes('js-sdk-dynamic-loader');
-
   const selectedPlatforms = clientState?.selectedPlatforms || [];
   const platformToProjectIdMap = clientState?.platformToProjectIdMap || {};
   // id is really slug here
@@ -322,7 +318,7 @@ function SetupDocs({search, route, router, location, ...props}: Props) {
   const currentPlatform = loadedPlatform ?? project?.platform ?? 'other';
 
   const [showLoaderOnboarding, setShowLoaderOnboarding] = useState(
-    loaderOnboarding && jsDynamicLoader && currentPlatform === 'javascript'
+    currentPlatform === 'javascript'
   );
 
   const showIntegrationOnboarding = integrationSlug && !integrationUseManualSetup;

--- a/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
@@ -8,8 +8,6 @@ import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
 import {DynamicSDKLoaderOption, KeySettings, sdkLoaderOptions} from './keySettings';
 
-const ORG_FEATURES = ['js-sdk-dynamic-loader'];
-
 const dynamicSdkLoaderOptions = {
   [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
   [DynamicSDKLoaderOption.HAS_REPLAY]: true,
@@ -48,7 +46,6 @@ describe('Key Settings', function () {
         ...initializeOrg(),
         organization: {
           ...initializeOrg().organization,
-          features: ORG_FEATURES,
         },
         router: {
           params,
@@ -137,7 +134,6 @@ describe('Key Settings', function () {
         ...initializeOrg(),
         organization: {
           ...initializeOrg().organization,
-          features: ORG_FEATURES,
         },
         router: {
           params,
@@ -195,7 +191,6 @@ describe('Key Settings', function () {
         ...initializeOrg(),
         organization: {
           ...initializeOrg().organization,
-          features: ORG_FEATURES,
         },
         router: {
           params,
@@ -247,7 +242,6 @@ describe('Key Settings', function () {
         ...initializeOrg(),
         organization: {
           ...initializeOrg().organization,
-          features: ORG_FEATURES,
         },
         router: {
           params,

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -85,10 +85,6 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
     fixed: '__JS_SDK_LOADER_URL__',
   });
 
-  const hasJSSDKDynamicLoaderFeatureFlag = !!organization.features?.includes(
-    'js-sdk-dynamic-loader'
-  );
-
   const handleRemove = useCallback(async () => {
     addLoadingMessage(t('Revoking key\u2026'));
 
@@ -156,7 +152,6 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
       };
 
       const shouldRestrictDynamicSdkLoaderOptions =
-        hasJSSDKDynamicLoaderFeatureFlag &&
         !sdkVersionSupportsPerformanceAndReplay(newBrowserSDKVersion);
 
       if (shouldRestrictDynamicSdkLoaderOptions) {
@@ -194,7 +189,6 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
       apiEndpoint,
       setBrowserSdkVersion,
       setDynamicSDKLoaderOptions,
-      hasJSSDKDynamicLoaderFeatureFlag,
       dynamicSDKLoaderOptions,
     ]
   );
@@ -285,60 +279,59 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
                 )}
               />
             </PanelBody>
-            {hasJSSDKDynamicLoaderFeatureFlag && (
-              <PanelFooter>
-                {Object.entries(sdkLoaderOptions).map(([key, value]) => {
-                  const sdkLoaderOption = Object.keys(dynamicSDKLoaderOptions).find(
-                    dynamicSdkLoaderOption => dynamicSdkLoaderOption === key
-                  );
 
-                  if (!sdkLoaderOption) {
-                    return null;
-                  }
+            <PanelFooter>
+              {Object.entries(sdkLoaderOptions).map(([key, value]) => {
+                const sdkLoaderOption = Object.keys(dynamicSDKLoaderOptions).find(
+                  dynamicSdkLoaderOption => dynamicSdkLoaderOption === key
+                );
 
-                  return (
-                    <BooleanField
-                      label={value.label}
-                      key={key}
-                      name={key}
-                      value={
-                        value.requiresV7 &&
-                        !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
-                          ? false
-                          : dynamicSDKLoaderOptions[sdkLoaderOption]
-                      }
-                      onChange={() =>
-                        handleToggleDynamicSDKLoaderOption(
-                          sdkLoaderOption as DynamicSDKLoaderOption,
-                          !dynamicSDKLoaderOptions[sdkLoaderOption]
-                        )
-                      }
-                      disabled={
-                        !hasAccess ||
-                        (value.requiresV7 &&
-                          !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion))
-                      }
-                      help={
-                        value.requiresV7 &&
-                        !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
-                          ? t('Only available in SDK version 7.x and above')
-                          : key === DynamicSDKLoaderOption.HAS_REPLAY &&
-                            dynamicSDKLoaderOptions[sdkLoaderOption]
-                          ? t(
-                              'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
-                            )
-                          : undefined
-                      }
-                      disabledReason={
-                        !hasAccess
-                          ? t('You do not have permission to edit this setting')
-                          : undefined
-                      }
-                    />
-                  );
-                })}
-              </PanelFooter>
-            )}
+                if (!sdkLoaderOption) {
+                  return null;
+                }
+
+                return (
+                  <BooleanField
+                    label={value.label}
+                    key={key}
+                    name={key}
+                    value={
+                      value.requiresV7 &&
+                      !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
+                        ? false
+                        : dynamicSDKLoaderOptions[sdkLoaderOption]
+                    }
+                    onChange={() =>
+                      handleToggleDynamicSDKLoaderOption(
+                        sdkLoaderOption as DynamicSDKLoaderOption,
+                        !dynamicSDKLoaderOptions[sdkLoaderOption]
+                      )
+                    }
+                    disabled={
+                      !hasAccess ||
+                      (value.requiresV7 &&
+                        !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion))
+                    }
+                    help={
+                      value.requiresV7 &&
+                      !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
+                        ? t('Only available in SDK version 7.x and above')
+                        : key === DynamicSDKLoaderOption.HAS_REPLAY &&
+                          dynamicSDKLoaderOptions[sdkLoaderOption]
+                        ? t(
+                            'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+                          )
+                        : undefined
+                    }
+                    disabledReason={
+                      !hasAccess
+                        ? t('You do not have permission to edit this setting')
+                        : undefined
+                    }
+                  />
+                );
+              })}
+            </PanelFooter>
           </Panel>
 
           <Panel>


### PR DESCRIPTION
As discussed with @HazAT, this removes the feature checks for the new Loader setup.

I guess we remove them from the backend stuff in a separate follow up PR?