### PR TITLE
fix(commit-context): Trigger suspect commit fallback in more places

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -134,7 +134,16 @@ def process_commit_context(
                     extra={
                         **basic_logging_details,
                         "reason": "could_not_find_in_app_stacktrace_frame",
+                        "fallback": True,
                     },
+                )
+                process_suspect_commits.delay(
+                    event_id=event_id,
+                    event_platform=event_platform,
+                    event_frames=event_frames,
+                    group_id=group_id,
+                    project_id=project_id,
+                    sdk_name=sdk_name,
                 )
                 return
 
@@ -163,7 +172,16 @@ def process_commit_context(
                         **basic_logging_details,
                         "reason": "could_not_fetch_commit_context",
                         "code_mappings_count": len(code_mappings),
+                        "fallback": True,
                     },
+                )
+                process_suspect_commits.delay(
+                    event_id=event_id,
+                    event_platform=event_platform,
+                    event_frames=event_frames,
+                    group_id=group_id,
+                    project_id=project_id,
+                    sdk_name=sdk_name,
                 )
                 return
 

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -194,7 +194,8 @@ class TestCommitContext(TestCase):
             assert GroupOwner.objects.filter(group=self.event.group).count() == 1
             assert GroupOwner.objects.filter(group=self.event.group, user_id=self.user.id).exists()
 
-    def test_no_inapp_frame_in_stacktrace(self):
+    @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
+    def test_no_inapp_frame_in_stacktrace(self, mock_process_suspect_commits):
         with self.tasks():
             assert not GroupOwner.objects.filter(group=self.event.group).exists()
             self.event_2 = self.store_event(
@@ -235,6 +236,7 @@ class TestCommitContext(TestCase):
                 group_id=self.event.group_id,
                 project_id=self.event.project_id,
             )
+        assert mock_process_suspect_commits.call_count == 1
         assert not GroupOwner.objects.filter(
             group=self.event.group,
             project=self.event.project,


### PR DESCRIPTION
Trigger the suspect commit fallback logic whenever we return without a suspect committer in the new commit context task.

WOR-2942