### PR TITLE
feat(notification-actions): add disabled functionality to the UI

### DIFF
--- a/static/app/components/notificationActions/notificationActionItem.tsx
+++ b/static/app/components/notificationActions/notificationActionItem.tsx
@@ -14,6 +14,7 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import PagerdutyForm from 'sentry/components/notificationActions/forms/pagerdutyForm';
 import SlackForm from 'sentry/components/notificationActions/forms/slackForm';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis, IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
@@ -59,6 +60,7 @@ type NotificationActionItemProps = {
    * Set to "true" when adding a new notification action
    */
   defaultEdit?: boolean;
+  disabled?: boolean;
   /**
    * Optional list of roles to display as recipients of Sentry notifications
    */
@@ -75,7 +77,8 @@ function NotificationActionItem({
   recipientRoles,
   onDelete,
   onUpdate,
-}: NotificationActionItemProps) {
+  disabled = false,
+}: NotificationActionItemProps) => {
   const [isEditing, setIsEditing] = useState(defaultEdit);
   const [editedAction, setEditedAction] = useState(action);
   const serviceType = action.serviceType;
@@ -213,18 +216,24 @@ function NotificationActionItem({
     }
 
     return (
-      <DropdownMenu
-        items={menuItems}
-        trigger={triggerProps => (
-          <Button
-            {...triggerProps}
-            aria-label={t('Actions')}
-            size="xs"
-            icon={<IconEllipsis direction="down" size="sm" />}
-            data-test-id="edit-dropdown"
-          />
-        )}
-      />
+      <Tooltip
+        disabled={!disabled}
+        title={t('You do not have permission to edit notification actions.')}
+      >
+        <DropdownMenu
+          items={menuItems}
+          trigger={triggerProps => (
+            <Button
+              {...triggerProps}
+              aria-label={t('Actions')}
+              size="xs"
+              icon={<IconEllipsis direction="down" size="sm" />}
+              data-test-id="edit-dropdown"
+            />
+          )}
+          isDisabled={disabled}
+        />
+      </Tooltip>
     );
   };
 

--- a/static/app/components/notificationActions/notificationActionItem.tsx
+++ b/static/app/components/notificationActions/notificationActionItem.tsx
@@ -78,7 +78,7 @@ function NotificationActionItem({
   onDelete,
   onUpdate,
   disabled = false,
-}: NotificationActionItemProps) => {
+}: NotificationActionItemProps) {
   const [isEditing, setIsEditing] = useState(defaultEdit);
   const [editedAction, setEditedAction] = useState(action);
   const serviceType = action.serviceType;

--- a/static/app/components/notificationActions/notificationActionManager.spec.jsx
+++ b/static/app/components/notificationActions/notificationActionManager.spec.jsx
@@ -73,6 +73,25 @@ describe('Adds, deletes, and updates notification actions', function () {
     expect(projectNotificationActions.length).toBe(3);
   });
 
+  it('disables buttons and dropdowns when disabled is True', function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/notifications/actions/`,
+      body: notificationActions,
+    });
+    render(
+      <NotificationActionManager
+        actions={[notificationActions[0]]}
+        availableActions={availableActions}
+        recipientRoles={['owner', 'manager']}
+        project={project}
+        disabled
+      />
+    );
+
+    expect(screen.getByLabelText('Add Action')).toBeDisabled();
+    expect(screen.getByTestId('edit-dropdown')).toBeDisabled();
+  });
+
   it('Adds a Sentry notification action', async function () {
     const mockPOST = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/notifications/actions/`,

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -46,7 +46,7 @@ function NotificationActionManager({
   project,
   updateAlertCount = () => {},
   disabled = false,
-}: NotificationActionManagerProps) => {
+}: NotificationActionManagerProps) {
   const [notificationActions, setNotificationActions] =
     useState<Partial<NotificationAction>[]>(actions);
 

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -4,6 +4,7 @@ import capitalize from 'lodash/capitalize';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu, MenuItemProps} from 'sentry/components/dropdownMenu';
 import NotificationActionItem from 'sentry/components/notificationActions/notificationActionItem';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
@@ -31,6 +32,7 @@ type NotificationActionManagerProps = {
    * Updates the notification alert count for this project
    */
   updateAlertCount: (projectId: number, alertCount: number) => void;
+  disabled?: boolean;
   /**
    * Optional list of roles to display as recipients of Sentry notifications
    */
@@ -43,7 +45,8 @@ function NotificationActionManager({
   recipientRoles,
   project,
   updateAlertCount = () => {},
-}: NotificationActionManagerProps) {
+  disabled = false,
+}: NotificationActionManagerProps) => {
   const [notificationActions, setNotificationActions] =
     useState<Partial<NotificationAction>[]>(actions);
 
@@ -146,6 +149,7 @@ function NotificationActionManager({
           project={project}
           onDelete={removeNotificationAction}
           onUpdate={updateNotificationAction}
+          disabled={disabled}
         />
       ));
     });
@@ -185,19 +189,27 @@ function NotificationActionManager({
   };
 
   const addAlertButton = (
-    <DropdownMenu
-      items={getMenuItems()}
-      trigger={triggerProps => (
-        <DropdownButton
-          {...triggerProps}
-          aria-label={t('Add Action')}
-          size="xs"
-          icon={<IconAdd isCircled color="gray300" />}
-        >
-          {t('Add Action')}
-        </DropdownButton>
-      )}
-    />
+    <Tooltip
+      disabled={!disabled}
+      title={t('You do not have permission to add notification actions')}
+    >
+      <DropdownMenu
+        items={getMenuItems()}
+        trigger={triggerProps => (
+          <DropdownButton
+            {...triggerProps}
+            aria-label={t('Add Action')}
+            size="xs"
+            icon={<IconAdd isCircled color="gray300" />}
+            disabled={disabled}
+          >
+            {t('Add Action')}
+          </DropdownButton>
+        )}
+        isDisabled={disabled}
+        data-test-id="add-action-button"
+      />
+    </Tooltip>
   );
 
   return (


### PR DESCRIPTION
Organization members must have `org:admin` or `org:write` permissions to modify notification actions. Allows disabling buttons and dropdowns in the UI for notification actions and adds tooltips.

<img width="807" alt="Screenshot 2023-04-07 at 15 20 54" src="https://user-images.githubusercontent.com/70817427/230685927-63636681-3249-46f2-92e7-15d3a8d2024c.png">
<img width="882" alt="Screenshot 2023-04-07 at 15 21 08" src="https://user-images.githubusercontent.com/70817427/230685917-141d29d3-b9f1-434f-bdc3-ab921c039845.png">