### PR TITLE
feat(escalating-issues): default Group.substatus with reasonable values based off status

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Mapping, Sequence
 
 from django.db import models
 from django.db.models import Q, QuerySet
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
@@ -705,3 +707,12 @@ class Group(Model):
     @property
     def issue_category(self):
         return GroupCategory(self.issue_type.category)
+
+
+@receiver(pre_save, sender=Group, dispatch_uid="pre_save_group_default_substatus", weak=False)
+def pre_save_group_default_substatus(instance, sender, *args, **kwargs):
+    if instance:
+        if instance.status == GroupStatus.UNRESOLVED and instance.substatus is None:
+            instance.substatus = GroupSubStatus.ONGOING
+        if instance.status == GroupStatus.IGNORED and instance.substatus is None:
+            instance.substatus = GroupSubStatus.UNTIL_ESCALATING

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -14,6 +14,7 @@ from sentry.models import (
     GroupRelease,
     GroupSnooze,
     GroupStatus,
+    GroupSubStatus,
     Release,
     get_group_with_redirect,
 )
@@ -300,6 +301,23 @@ class GroupTest(TestCase, SnubaTestCase):
         assert group.get_last_release() == "100"
 
         assert group2.get_last_release() is None
+
+    def test_group_substatus_defaults(self):
+        assert self.create_group(status=GroupStatus.UNRESOLVED).substatus == GroupSubStatus.ONGOING
+        assert (
+            self.create_group(status=GroupStatus.IGNORED).substatus
+            == GroupSubStatus.UNTIL_ESCALATING
+        )
+        assert (
+            self.create_group(status=GroupStatus.MUTED).substatus == GroupSubStatus.UNTIL_ESCALATING
+        )
+        for nullable_status in (
+            GroupStatus.RESOLVED,
+            GroupStatus.PENDING_DELETION,
+            GroupStatus.DELETION_IN_PROGRESS,
+            GroupStatus.REPROCESSING,
+        ):
+            assert self.create_group(status=nullable_status).substatus is None
 
 
 @region_silo_test


### PR DESCRIPTION
Group.substatus is nullable but we want to enforce some reasonable default values on the substatus based off the `status` value. 

A follow-up PR will be created to backfill existing Groups with the same defaults.