### PR TITLE
ref(jira): Clean up and differentiate errors raised by Jira webhooks

### DIFF
--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping
 
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
+from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Scope
@@ -42,6 +43,21 @@ class JiraWebhookBase(Endpoint, abc.ABC):
     ) -> Response:
         if isinstance(exc, (AtlassianConnectValidationError, JiraTokenError)):
             return self.respond(status=status.HTTP_400_BAD_REQUEST)
+
+        # Atlassian has an automated tool which tests to make sure integrations with Jira
+        # (like ours) pass certain security requirements, which leads them to probe certain
+        # of our endpoints to make sure we're not accepting insecure GET requests. Not
+        # actionable on our part and therefore not worth sending to Sentry.
+        if isinstance(
+            exc, MethodNotAllowed
+        ) and "github.com/atlassian-labs/connect-security-req-tester" in request.headers.get(
+            "User-Agent", ""
+        ):
+            logger.info(
+                "Atlassian Connect Security Request Tester tried disallowed method",
+                extra={"path": request.path, "method": request.method},
+            )
+            return self.respond(status=status.HTTP_405_METHOD_NOT_ALLOWED)
         # Perhaps it makes sense to do this in the base class, however, I'm concerned
         # it would create too many errors at once and may be grouped together
         logger.exception("Unclear JIRA exception.")

--- a/src/sentry/shared_integrations/exceptions/base.py
+++ b/src/sentry/shared_integrations/exceptions/base.py
@@ -54,6 +54,9 @@ class ApiError(Exception):
 
         super().__init__(text[:1024])
 
+    def __str__(self) -> str:
+        return self.text
+
     @classmethod
     def from_response(cls, response: Response, url: str | None = None) -> ApiError:
         from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiUnauthorized

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -11,7 +11,7 @@ from sentry.testutils import APITestCase
 TOKEN = "JWT anexampletoken"
 
 
-class JiraWebhooksTest(APITestCase):
+class JiraIssueUpdatedWebhookTest(APITestCase):
     endpoint = "sentry-extensions-jira-issue-updated"
     method = "post"
 


### PR DESCRIPTION
This updates the way we deal with errors which arise while handling incoming webhook requests. Key changes:
- Stop logging "unclear jira exception" exceptions for errors we've seen before. This both prevents duplicates in sentry (one copy of the error with the log statement, one without) and lets us identify new ones.
- Stop capturing Atlassian automated pen-testing `MethodNotAllowed` errors as sentry events and instead just log them.
- In cases where we have HTML or XML as our error message, move that to a context  and replace the message with a more human-friendly one. This requires adding a `__str__` method to `ApiError`, so that the message change will be picked up by the Sentry SDK. (`Exception` doesn't have a `text` attribute, and so its `__str__` method of course ignores the `text` attribute on `ApiError`.)

Ref: WOR-2926