### PR TITLE
ref(integrations): Include URL when creating all `ApiError` instances

### DIFF
--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -33,7 +33,7 @@ class ApiHostError(ApiError):
     @classmethod
     def from_request(cls, request: Request) -> ApiHostError:
         host = urlparse(request.url).netloc
-        return cls(f"Unable to reach host: {host}")
+        return cls(f"Unable to reach host: {host}", url=request.url)
 
 
 class ApiTimeoutError(ApiError):
@@ -48,7 +48,7 @@ class ApiTimeoutError(ApiError):
     @classmethod
     def from_request(cls, request: Request) -> ApiTimeoutError:
         host = urlparse(request.url).netloc
-        return cls(f"Timed out attempting to reach host: {host}")
+        return cls(f"Timed out attempting to reach host: {host}", url=request.url)
 
 
 class ApiUnauthorized(ApiError):

--- a/src/sentry/shared_integrations/exceptions/base.py
+++ b/src/sentry/shared_integrations/exceptions/base.py
@@ -59,7 +59,7 @@ class ApiError(Exception):
         from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiUnauthorized
 
         if response.status_code == 401:
-            return ApiUnauthorized(response.text)
+            return ApiUnauthorized(response.text, url=url)
         elif response.status_code == 429:
-            return ApiRateLimitedError(response.text)
+            return ApiRateLimitedError(response.text, url=url)
         return cls(response.text, response.status_code, url=url)


### PR DESCRIPTION
This includes the URL of the outgoing request every time we instantiate an `ApiError` (or a subclass thereof), for future use in debugging.

Ref: WOR-2947