### PR TITLE
fix(tabs): Fix IntersectionObserver sensitivity in Windows Edge

### DIFF
--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -38,7 +38,7 @@ function useOverflowTabs({
       root: tabListRef.current,
       // Nagative right margin to account for overflow menu's trigger button
       rootMargin: `0px -42px 1px ${space(1)}`,
-      threshold: 1,
+      threshold: 0.95,
     };
 
     const callback: IntersectionObserverCallback = entries => {

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -38,6 +38,8 @@ function useOverflowTabs({
       root: tabListRef.current,
       // Nagative right margin to account for overflow menu's trigger button
       rootMargin: `0px -42px 1px ${space(1)}`,
+      // Use 0.95 rather than 1 because of a bug in Edge (Windows) where the intersection
+      // ratio may unexpectedly drop to slightly below 1 (0.999…) on page scroll.
       threshold: 0.95,
     };
 


### PR DESCRIPTION
Fix an issue with `<Tabs />` in Windows Edge where all the tab items disappear on page scroll:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/44172267/231002715-53cc95fe-e015-4e78-915d-69658ac79a60.png">

This happens because Edge changes the intersection ratio by a very small amount on page scroll (I have no idea why. Other browsers don't do this.) Since the intersection threshold is 1, that small change is enough to trigger the callback function and hide the tab item.
<img width="428" alt="image" src="https://user-images.githubusercontent.com/44172267/231003148-eabe850a-fd36-4941-a9c1-0f43c68f9bb5.png">

**Changing the threshold from 1 to 0.95 fixes the issue:**
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/44172267/231002592-2b47e81b-f2e9-40f3-8253-570f4bda5770.png">

Overflow prevention still works fine:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/44172267/231004759-6f1afead-438d-4c96-9436-a8071afd95b0.png">

