### PR TITLE
fix(onboarding): prevent error from usePersistedOnboardingState 

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -72,6 +72,7 @@ function hidePanel() {
 }
 
 function useOpenOnboardingSidebar(organization?: Organization) {
+  // usePersistedOnboardingState calls useOrganization (which might fail) so to prevent that, we do nothing if there is no organization
   function noOrgFunction() {
     return [null];
   }

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -72,12 +72,7 @@ function hidePanel() {
 }
 
 function useOpenOnboardingSidebar(organization?: Organization) {
-  // usePersistedOnboardingState calls useOrganization (which might fail) so to prevent that, we do nothing if there is no organization
-  function noOrgFunction() {
-    return [null];
-  }
-  const onboardingFunction = organization ? usePersistedOnboardingState : noOrgFunction;
-  const [onboardingState] = onboardingFunction();
+  const [onboardingState] = usePersistedOnboardingState();
   const {projects: project} = useProjects();
   const location = useLocation();
 

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -72,7 +72,14 @@ function hidePanel() {
 }
 
 function useOpenOnboardingSidebar(organization?: Organization) {
-  const [onboardingState] = usePersistedOnboardingState();
+  function onboardingStateFunction() {
+    return [null];
+  }
+
+  const onboardingFunction = organization
+    ? usePersistedOnboardingState
+    : onboardingStateFunction;
+  const [onboardingState] = onboardingFunction();
   const {projects: project} = useProjects();
   const location = useLocation();
 

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -72,13 +72,10 @@ function hidePanel() {
 }
 
 function useOpenOnboardingSidebar(organization?: Organization) {
-  function onboardingStateFunction() {
+  function noOrgFunction() {
     return [null];
   }
-
-  const onboardingFunction = organization
-    ? usePersistedOnboardingState
-    : onboardingStateFunction;
+  const onboardingFunction = organization ? usePersistedOnboardingState : noOrgFunction;
   const [onboardingState] = onboardingFunction();
   const {projects: project} = useProjects();
   const location = useLocation();


### PR DESCRIPTION
this pr prevents the error that comes from calling usePersistedOnboardingState from the sidebar since the organization might not be set. 