### PR TITLE
feat(escalating-issues): Handle 'until_escalating' substatus for GroupStatus.IGNORED

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -279,6 +279,8 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                                      the bookmark flag.
         :param boolean isSubscribed:
         :param boolean isPublic: sets the issue to public or private.
+        :param string substatus: the new substatus for the issues. Valid values
+                                 defined in GroupSubStatus.
         :auth: required
         """
         try:

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -423,6 +423,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :param boolean isBookmarked: in case this API call is invoked with a
                                      user context this allows changing of
                                      the bookmark flag.
+        :param string substatus: the new substatus for the issues. Valid values
+                                 defined in GroupSubStatus.
         :auth: required
         """
         projects = self.get_projects(request, organization)

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -231,6 +231,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         :param boolean isBookmarked: in case this API call is invoked with a
                                      user context this allows changing of
                                      the bookmark flag.
+        :param string substatus: the new substatus for the issues. Valid values
+                                 defined in GroupSubStatus.
         :auth: required
         """
 

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -549,7 +549,9 @@ def update_groups(
         ignore_until = None
 
         with transaction.atomic():
-            happened = queryset.exclude(status=new_status).update(status=new_status)
+            happened = queryset.exclude(status=new_status).update(
+                status=new_status, substatus=new_substatus
+            )
 
             GroupResolution.objects.filter(group__in=group_ids).delete()
             if new_status == GroupStatus.IGNORED:

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from datetime import timedelta
-from typing import Any, Dict, Mapping, MutableMapping, Sequence
+from typing import Any, Mapping, MutableMapping, Sequence
 from uuid import uuid4
 
 import rest_framework
@@ -18,6 +18,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.db.models.query import create_or_update
 from sentry.issues.grouptype import GroupCategory
+from sentry.issues.ignored import handle_archived_until_escalating
 from sentry.models import (
     TOMBSTONE_FIELDS_FROM_GROUP,
     Activity,
@@ -32,7 +33,6 @@ from sentry.models import (
     GroupResolution,
     GroupSeen,
     GroupShare,
-    GroupSnooze,
     GroupStatus,
     GroupSubscription,
     GroupTombstone,
@@ -48,6 +48,7 @@ from sentry.models.activity import ActivityIntegration
 from sentry.models.group import STATUS_UPDATE_CHOICES, SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.models.groupinbox import GroupInboxRemoveAction, add_group_to_inbox
+from sentry.models.groupsnooze import GroupSnooze
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
 from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.services.hybrid_cloud.user import RpcUser, user_service
@@ -557,9 +558,59 @@ def update_groups(
                 ):
                     handle_archived_until_escalating(group_ids, acting_user)
                 else:
-                    result["statusDetails"] = handle_ignored(
-                        group_ids, group_list, status_details, acting_user, user
-                    )
+                    metrics.incr("group.ignored", skip_internal=True)
+                    for group in group_ids:
+                        remove_group_from_inbox(
+                            group, action=GroupInboxRemoveAction.IGNORED, user=acting_user
+                        )
+
+                    ignore_duration = (
+                        status_details.pop("ignoreDuration", None)
+                        or status_details.pop("snoozeDuration", None)
+                    ) or None
+                    ignore_count = status_details.pop("ignoreCount", None) or None
+                    ignore_window = status_details.pop("ignoreWindow", None) or None
+                    ignore_user_count = status_details.pop("ignoreUserCount", None) or None
+                    ignore_user_window = status_details.pop("ignoreUserWindow", None) or None
+                    if ignore_duration or ignore_count or ignore_user_count:
+                        if ignore_duration:
+                            ignore_until = timezone.now() + timedelta(minutes=ignore_duration)
+                        else:
+                            ignore_until = None
+                        for group in group_list:
+                            state = {}
+                            if ignore_count and not ignore_window:
+                                state["times_seen"] = group.times_seen
+                            if ignore_user_count and not ignore_user_window:
+                                state["users_seen"] = group.count_users_seen()
+                            GroupSnooze.objects.create_or_update(
+                                group=group,
+                                values={
+                                    "until": ignore_until,
+                                    "count": ignore_count,
+                                    "window": ignore_window,
+                                    "user_count": ignore_user_count,
+                                    "user_window": ignore_user_window,
+                                    "state": state,
+                                    "actor_id": user.id if user.is_authenticated else None,
+                                },
+                            )
+                            serialized_user = user_service.serialize_many(
+                                filter=dict(user_ids=[user.id]), as_user=user
+                            )
+                            result["statusDetails"] = {
+                                "ignoreCount": ignore_count,
+                                "ignoreUntil": ignore_until,
+                                "ignoreUserCount": ignore_user_count,
+                                "ignoreUserWindow": ignore_user_window,
+                                "ignoreWindow": ignore_window,
+                            }
+                            if serialized_user:
+                                result["statusDetails"]["actor"] = serialized_user[0]
+                    else:
+                        GroupSnooze.objects.filter(group__in=group_ids).delete()
+                        ignore_until = None
+                        result["statusDetails"] = {}
                 result["inbox"] = None
             else:
                 result["statusDetails"] = {}
@@ -848,83 +899,3 @@ def update_groups(
         result["inbox"] = inbox
 
     return Response(result)
-
-
-def handle_ignored(
-    group_ids: Sequence[Group],
-    group_list: Sequence[Group],
-    status_details: Dict[str, Any],
-    acting_user: User | None,
-    user: User,
-) -> dict[str, str]:
-    result_status_details = {}
-    metrics.incr("group.ignored", skip_internal=True)
-    for group in group_ids:
-        remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED, user=acting_user)
-
-    ignore_duration = (
-        status_details.pop("ignoreDuration", None) or status_details.pop("snoozeDuration", None)
-    ) or None
-    ignore_count = status_details.pop("ignoreCount", None) or None
-    ignore_window = status_details.pop("ignoreWindow", None) or None
-    ignore_user_count = status_details.pop("ignoreUserCount", None) or None
-    ignore_user_window = status_details.pop("ignoreUserWindow", None) or None
-    if ignore_duration or ignore_count or ignore_user_count:
-        if ignore_duration:
-            ignore_until = timezone.now() + timedelta(minutes=ignore_duration)
-        else:
-            ignore_until = None
-        for group in group_list:
-            state = {}
-            if ignore_count and not ignore_window:
-                state["times_seen"] = group.times_seen
-            if ignore_user_count and not ignore_user_window:
-                state["users_seen"] = group.count_users_seen()
-            GroupSnooze.objects.create_or_update(
-                group=group,
-                values={
-                    "until": ignore_until,
-                    "count": ignore_count,
-                    "window": ignore_window,
-                    "user_count": ignore_user_count,
-                    "user_window": ignore_user_window,
-                    "state": state,
-                    "actor_id": user.id if user.is_authenticated else None,
-                },
-            )
-            serialized_user = user_service.serialize_many(
-                filter=dict(user_ids=[user.id]), as_user=user
-            )
-            result_status_details = {
-                "ignoreCount": ignore_count,
-                "ignoreUntil": ignore_until,
-                "ignoreUserCount": ignore_user_count,
-                "ignoreUserWindow": ignore_user_window,
-                "ignoreWindow": ignore_window,
-            }
-            if serialized_user:
-                result_status_details["actor"] = serialized_user[0]
-    else:
-        GroupSnooze.objects.filter(group__in=group_ids).delete()
-        ignore_until = None
-        result_status_details = {}
-
-    return result_status_details
-
-
-def handle_archived_until_escalating(
-    group_ids: Sequence[int],
-    acting_user: User | None,
-):
-    """
-    Handle issues that are archived until escalating and create a forecast for them.
-
-    Issues that are marked as ignored with `archiveDuration: until_escalating`
-    in the statusDetail are treated as `archived_until_escalating`.
-    """
-    metrics.incr("group.archived_until_escalating", skip_internal=True)
-    for group in group_ids:
-        remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED, user=acting_user)
-    # TODO(snigdha): create a forecast for this group
-
-    return

--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from sentry.api.fields import ActorField
 from sentry.models import Actor, Team, User
-from sentry.models.group import STATUS_UPDATE_CHOICES
+from sentry.models.group import STATUS_UPDATE_CHOICES, SUBSTATUS_UPDATE_CHOICES
 
 from . import InboxDetailsValidator, StatusDetailsValidator
 
@@ -16,6 +16,9 @@ class GroupValidator(serializers.Serializer):  # type: ignore
         choices=list(zip(STATUS_UPDATE_CHOICES.keys(), STATUS_UPDATE_CHOICES.keys()))
     )
     statusDetails = StatusDetailsValidator()
+    substatus = serializers.ChoiceField(
+        choices=list(zip(SUBSTATUS_UPDATE_CHOICES.keys(), SUBSTATUS_UPDATE_CHOICES.keys()))
+    )
     hasSeen = serializers.BooleanField()
     isBookmarked = serializers.BooleanField()
     isPublic = serializers.BooleanField()

--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -10,7 +10,7 @@ from sentry.utils import metrics
 def handle_archived_until_escalating(
     group_ids: Sequence[int],
     acting_user: User | None,
-):
+) -> None:
     """
     Handle issues that are archived until escalating and create a forecast for them.
 

--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from sentry.models import GroupInboxRemoveAction, User, remove_group_from_inbox
+from sentry.models import Group, GroupInboxRemoveAction, User, remove_group_from_inbox
 from sentry.utils import metrics
 
 
 def handle_archived_until_escalating(
-    group_ids: Sequence[int],
+    group_list: Sequence[Group],
     acting_user: User | None,
 ) -> None:
     """
@@ -17,7 +17,7 @@ def handle_archived_until_escalating(
     in the statusDetail are treated as `archived_until_escalating`.
     """
     metrics.incr("group.archived_until_escalating", skip_internal=True)
-    for group in group_ids:
+    for group in group_list:
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED, user=acting_user)
     # TODO(snigdha): create a forecast for this group
 

--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from sentry.models import User
+from sentry.models.groupinbox import GroupInboxRemoveAction, remove_group_from_inbox
+from sentry.utils import metrics
+
+
+def handle_archived_until_escalating(
+    group_ids: Sequence[int],
+    acting_user: User | None,
+):
+    """
+    Handle issues that are archived until escalating and create a forecast for them.
+
+    Issues that are marked as ignored with `archiveDuration: until_escalating`
+    in the statusDetail are treated as `archived_until_escalating`.
+    """
+    metrics.incr("group.archived_until_escalating", skip_internal=True)
+    for group in group_ids:
+        remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED, user=acting_user)
+    # TODO(snigdha): create a forecast for this group
+
+    return

--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from sentry.models import User
-from sentry.models.groupinbox import GroupInboxRemoveAction, remove_group_from_inbox
+from sentry.models import GroupInboxRemoveAction, User, remove_group_from_inbox
 from sentry.utils import metrics
 
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -184,6 +184,12 @@ STATUS_UPDATE_CHOICES = {
     "muted": GroupStatus.IGNORED,
 }
 
+SUBSTATUS_UPDATE_CHOICES = {
+    "until_escalating": GroupSubStatus.UNTIL_ESCALATING,
+    "escalating": GroupSubStatus.ESCALATING,
+    "ongoing": GroupSubStatus.ONGOING,
+}
+
 
 class EventOrdering(Enum):
     LATEST = ["-timestamp", "-event_id"]

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -9,7 +9,13 @@ from sentry.api.helpers.group_index import (
     validate_search_filter_permissions,
 )
 from sentry.api.issue_search import parse_search_query
-from sentry.models import GroupInbox, GroupInboxReason, GroupStatus, add_group_to_inbox
+from sentry.models import (
+    GroupInbox,
+    GroupInboxReason,
+    GroupStatus,
+    GroupSubStatus,
+    add_group_to_inbox,
+)
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import with_feature
 
@@ -191,5 +197,6 @@ class UpdateGroupsTest(TestCase):
         group.refresh_from_db()
 
         assert group.status == GroupStatus.IGNORED
+        assert group.substatus == GroupSubStatus.UNTIL_ESCALATING
         assert send_robust.called
         assert not GroupInbox.objects.filter(group=group).exists()

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -11,6 +11,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.issue_search import parse_search_query
 from sentry.models import GroupInbox, GroupInboxReason, GroupStatus, add_group_to_inbox
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.features import with_feature
 
 
 class ValidateSearchFilterPermissionsTest(TestCase):
@@ -170,3 +171,25 @@ class UpdateGroupsTest(TestCase):
 
         assert not GroupInbox.objects.filter(group=group).exists()
         assert send_robust.called
+
+    @with_feature("organizations:escalating-issues")
+    @patch("sentry.signals.issue_ignored.send_robust")
+    def test_ignore_with_substatus_until_escalating(self, send_robust):
+        group = self.create_group()
+        add_group_to_inbox(group, GroupInboxReason.NEW)
+
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.data = {"status": "ignored", "substatus": "until_escalating"}
+        request.GET = QueryDict(query_string=f"id={group.id}")
+
+        search_fn = Mock()
+        update_groups(
+            request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
+        )
+
+        group.refresh_from_db()
+
+        assert group.status == GroupStatus.IGNORED
+        assert send_robust.called
+        assert not GroupInbox.objects.filter(group=group).exists()

--- a/tests/sentry/issues/test_ignored.py
+++ b/tests/sentry/issues/test_ignored.py
@@ -1,0 +1,15 @@
+from sentry.issues.ignored import handle_archived_until_escalating
+from sentry.models import GroupInbox, GroupInboxReason, GroupSnooze, add_group_to_inbox
+from sentry.testutils import TestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+
+
+@apply_feature_flag_on_cls("organizations:escalating-issues")
+class HandleArchiveUntilEscalating(TestCase):  # type: ignore
+    def test_archive_until_escalating(self):
+        group = self.create_group()
+        add_group_to_inbox(group, GroupInboxReason.NEW)
+
+        handle_archived_until_escalating([group], self.user)
+        assert not GroupInbox.objects.filter(group=group).exists()
+        assert not GroupSnooze.objects.filter(group=group).exists()

--- a/tests/sentry/issues/test_ignored.py
+++ b/tests/sentry/issues/test_ignored.py
@@ -6,7 +6,7 @@ from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 
 @apply_feature_flag_on_cls("organizations:escalating-issues")
 class HandleArchiveUntilEscalating(TestCase):  # type: ignore
-    def test_archive_until_escalating(self):
+    def test_archive_until_escalating(self) -> None:
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.NEW)
 

--- a/tests/sentry/issues/test_ignored.py
+++ b/tests/sentry/issues/test_ignored.py
@@ -10,6 +10,6 @@ class HandleArchiveUntilEscalating(TestCase):  # type: ignore
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        handle_archived_until_escalating([group], self.user)
+        handle_archived_until_escalating([group.id], self.user)
         assert not GroupInbox.objects.filter(group=group).exists()
         assert not GroupSnooze.objects.filter(group=group).exists()


### PR DESCRIPTION
* Adds a new field to the organization/project group update endpoints to provide the substatus. 
* Adds logic to handle `until_escalating` substatus (TODO: create a forecast, can be done in a followup PR)
* Breaks out the new logic in preparation for more refactors for  GroupStatus.IGNORED.

WOR-2835

