### PR TITLE
fix(ui): Fix mechansim type link placement

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -31,34 +31,32 @@ export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
     </StyledExternalLink>
   );
 
+  const typeName = type || 'unknown';
+
   const pills = [
-    <Pill
-      key="mechanism"
-      name={
-        description ? (
-          <Hovercard
-            showUnderline
-            header={
-              <Details>
-                {t('Details')}
-                {linkElement}
-              </Details>
-            }
-            body={description}
-          >
-            {'mechanism'}
-          </Hovercard>
-        ) : linkElement ? (
-          <Name>
-            {'mechanism '}
-            {linkElement}
-          </Name>
-        ) : (
-          'mechanism'
-        )
-      }
-      value={type || 'unknown'}
-    />,
+    <Pill key="mechanism" name="mechanism">
+      {description ? (
+        <Hovercard
+          showUnderline
+          header={
+            <Details>
+              {t('Details')}
+              {linkElement}
+            </Details>
+          }
+          body={description}
+        >
+          {typeName}
+        </Hovercard>
+      ) : linkElement ? (
+        <Name>
+          {typeName}
+          {linkElement}
+        </Name>
+      ) : (
+        typeName
+      )}
+    </Pill>,
   ];
 
   if (!isNil(handled)) {


### PR DESCRIPTION
Small nitpick.  Consider an event such as:

```json
{
  "type": "error",
  "exception": {
    "values": [
      {
        "type": "Exception",
        "mechanism": {
          "type": "some_mechanism_type",
          "help_link": "https://foo.bar",
          "description": "This is a human-readable description of some mechanism type."
        }
      }
    ]
  }
}
```

Within the mechanism, `type` is required, but `help_link` and `description` are optional.

When either are provided, currently the placement of the link or hover card is on the _name_ of the pill (the word `mechanism`).

- Example 1:
  <img width="276" alt="image" src="https://user-images.githubusercontent.com/1396388/231018373-a6390df5-6cc3-4ff7-897a-22fde3992ff6.png">

- Example 2:
  <img width="360" alt="image" src="https://user-images.githubusercontent.com/1396388/231018342-309b1cc6-8a37-4e05-bb85-94c9422095ea.png">

It should instead be on the _value_ of the pill (which corresponds to the `type`).

- Example 1:
  <img width="274" alt="image" src="https://user-images.githubusercontent.com/1396388/231018546-b135d47d-b9fe-4c41-9101-8d3ee8acc41d.png">

- Example 2:
  <img width="374" alt="image" src="https://user-images.githubusercontent.com/1396388/231018601-bf8c17df-44dd-4df8-babb-595e79c57b3f.png">
