### PR TITLE
fix(metrics): Throw error when wildcard is used in search for metrics

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -41,6 +41,7 @@ from snuba_sdk import (
 )
 
 from sentry.api import event_search
+from sentry.api.event_search import SearchFilter
 from sentry.discover.arithmetic import (
     OperandType,
     Operation,
@@ -1553,6 +1554,25 @@ class UnresolvedQuery(QueryBuilder):
         orderby: Optional[List[str]] = None,
     ) -> None:
         pass
+
+
+class ReleaseHealthQueryBuilder(UnresolvedQuery):
+    def _contains_wildcard_in_query(self, query: Optional[str]):
+        parsed_terms = self.parse_query(query)
+        for parsed_term in parsed_terms:
+            # Since wildcards search uses the clickhouse `match` operator that works on strings, we can't
+            # use it for release health, since tags are stored as integers and converted through
+            # the indexer.
+            if isinstance(parsed_term, SearchFilter) and parsed_term.value.is_wildcard():
+                raise InvalidSearchQuery(f"Query {query} contains wildcards")
+
+    def resolve_conditions(
+        self,
+        query: Optional[str],
+        use_aggregate_conditions: bool,
+    ) -> Tuple[List[WhereType], List[WhereType]]:
+        self._contains_wildcard_in_query(query)
+        return super().resolve_conditions(query, use_aggregate_conditions)
 
 
 class TimeseriesQueryBuilder(UnresolvedQuery):

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -41,7 +41,6 @@ from snuba_sdk import (
 )
 
 from sentry.api import event_search
-from sentry.api.event_search import SearchFilter
 from sentry.discover.arithmetic import (
     OperandType,
     Operation,
@@ -1554,29 +1553,6 @@ class UnresolvedQuery(QueryBuilder):
         orderby: Optional[List[str]] = None,
     ) -> None:
         pass
-
-
-class ReleaseHealthQueryBuilder(UnresolvedQuery):
-    def _contains_wildcard_in_query(self, query: Optional[str]) -> bool:
-        parsed_terms = self.parse_query(query)
-        for parsed_term in parsed_terms:
-            # Since wildcards search uses the clickhouse `match` operator that works on strings, we can't
-            # use it for release health, since tags are stored as integers and converted through
-            # the indexer.
-            if isinstance(parsed_term, SearchFilter) and parsed_term.value.is_wildcard():
-                return True
-
-        return False
-
-    def resolve_conditions(
-        self,
-        query: Optional[str],
-        use_aggregate_conditions: bool,
-    ) -> Tuple[List[WhereType], List[WhereType]]:
-        if not self._contains_wildcard_in_query(query):
-            return super().resolve_conditions(query, use_aggregate_conditions)
-
-        raise InvalidSearchQuery(f"Query {query} contains wildcards")
 
 
 class TimeseriesQueryBuilder(UnresolvedQuery):

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -29,10 +29,12 @@ from snuba_sdk import (
 from snuba_sdk.conditions import BooleanCondition
 from snuba_sdk.orderby import Direction, OrderBy
 
+from sentry.api.event_search import SearchFilter
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Project
-from sentry.search.events.builder.discover import ReleaseHealthQueryBuilder
+from sentry.search.events.builder import UnresolvedQuery
+from sentry.search.events.types import WhereType
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import (
     STRING_NOT_FOUND,
@@ -354,6 +356,29 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
         raise InvalidParams(f"Failed to parse query: {e}")
 
     return where
+
+
+class ReleaseHealthQueryBuilder(UnresolvedQuery):
+    def _contains_wildcard_in_query(self, query: Optional[str]) -> bool:
+        parsed_terms = self.parse_query(query)
+        for parsed_term in parsed_terms:
+            # Since wildcards search uses the clickhouse `match` operator that works on strings, we can't
+            # use it for release health, since tags are stored as integers and converted through
+            # the indexer.
+            if isinstance(parsed_term, SearchFilter) and parsed_term.value.is_wildcard():
+                return True
+
+        return False
+
+    def resolve_conditions(
+        self,
+        query: Optional[str],
+        use_aggregate_conditions: bool,
+    ) -> Tuple[List[WhereType], List[WhereType]]:
+        if not self._contains_wildcard_in_query(query):
+            return super().resolve_conditions(query, use_aggregate_conditions)
+
+        raise InvalidSearchQuery("Release Health Queries don't support wildcards")
 
 
 class QueryDefinition:

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -32,7 +32,7 @@ from snuba_sdk.orderby import Direction, OrderBy
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Project
-from sentry.search.events.builder import UnresolvedQuery
+from sentry.search.events.builder.discover import ReleaseHealthQueryBuilder
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import (
     STRING_NOT_FOUND,
@@ -342,7 +342,7 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
     # HACK: Parse a sessions query, validate / transform afterwards.
     # We will want to write our own grammar + interpreter for this later.
     try:
-        query_builder = UnresolvedQuery(
+        query_builder = ReleaseHealthQueryBuilder(
             Dataset.Sessions,
             params={
                 "project_id": [project.id for project in projects],
@@ -350,9 +350,9 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
             },
         )
         where, _ = query_builder.resolve_conditions(query_string, use_aggregate_conditions=True)
-
     except InvalidSearchQuery as e:
         raise InvalidParams(f"Failed to parse query: {e}")
+
     return where
 
 

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -442,6 +442,25 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         )
         assert response.status_code == 200
 
+    def test_query_with_wildcard(self):
+        rh_indexer_record(self.organization.id, "session.crash_free_user_rate")
+        self.build_and_store_session(
+            project_id=self.project.id,
+        )
+        response = self.get_response(
+            self.organization.slug,
+            field="session.crash_free_user_rate",
+            groupBy="release",
+            environment="Release",
+            query='!release:"0.99.0 (*)"',
+            statsPeriod="14d",
+            interval="1h",
+            includeTotals="1",
+            includeSeries="0",
+        )
+
+        assert response.status_code == 400
+
     def test_pagination_offset_without_orderby(self):
         """
         Test that ensures a successful response is returned even when requesting an offset

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -462,7 +462,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"]
-            == 'Failed to parse query: Query !release:"0.99.0 (*)" contains wildcards'
+            == "Failed to parse query: Release Health Queries don't support wildcards"
         )
 
     def test_pagination_offset_without_orderby(self):

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -460,6 +460,10 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         )
 
         assert response.status_code == 400
+        assert (
+            response.data["detail"]
+            == 'Failed to parse query: Query !release:"0.99.0 (*)" contains wildcards'
+        )
 
     def test_pagination_offset_without_orderby(self):
         """


### PR DESCRIPTION
This PR adds guarding to the organization metric data endpoint which will disallow the use of wildcard searches (e.g., `!release:"0.99.0 (*)"`).

Closes: https://github.com/getsentry/sentry/issues/46747