### PR TITLE
fix: handle openai rate limit [47063]

### DIFF
--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -5,6 +5,7 @@ import openai
 from django.conf import settings
 from django.dispatch import Signal
 from django.http import HttpResponse
+from openai.error import RateLimitError
 
 from sentry import eventstore, features
 from sentry.api.base import region_silo_endpoint
@@ -317,7 +318,15 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
         cache_key = "ai:" + event.get_primary_hash()
         suggestion = cache.get(cache_key)
         if suggestion is None:
-            suggestion = suggest_fix(event.data)
+            try:
+                suggestion = suggest_fix(event.data)
+            except RateLimitError as err:
+                return HttpResponse(
+                    json.dumps({"error": err.json_body}),
+                    content_type="application/json",
+                    status=429,
+                )
+
             cache.set(cache_key, suggestion, 300)
 
         return HttpResponse(

--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -321,7 +321,7 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
                 suggestion = suggest_fix(event.data)
             except openai.error.RateLimitError as err:
                 return HttpResponse(
-                    json.dumps({"error": err.json_body}),
+                    json.dumps({"error": err.json_body["error"]}),
                     content_type="application/json",
                     status=429,
                 )

--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -5,7 +5,6 @@ import openai
 from django.conf import settings
 from django.dispatch import Signal
 from django.http import HttpResponse
-from openai.error import RateLimitError
 
 from sentry import eventstore, features
 from sentry.api.base import region_silo_endpoint
@@ -320,7 +319,7 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
         if suggestion is None:
             try:
                 suggestion = suggest_fix(event.data)
-            except RateLimitError as err:
+            except openai.error.RateLimitError as err:
                 return HttpResponse(
                     json.dumps({"error": err.json_body}),
                     content_type="application/json",


### PR DESCRIPTION
This PR catch 429 rate limit error and wrap it into sentry error.

Example:
```
GET http://localhost:8000/api/0/projects/sentry/earth/events/<event_id>/ai-fix-suggest/
```

response:
```
{"error":{"message":"That model is currently overloaded with other requests. You can retry your request, or contact us through our help center at help.openai.com if the error persists. (Please include the request ID f654eb218381045603239dda3d97eaf0 in your message.)","type":"server_error","param":null,"code":null}}
```

resolves https://github.com/getsentry/sentry/issues/47063