### PR TITLE
feat(reply): Add infinite scrolling to the trace view

### DIFF
--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -1,4 +1,4 @@
-import React, {createRef, useEffect} from 'react';
+import React, {createRef, ReactNode, useEffect} from 'react';
 import {RouteComponentProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 
@@ -51,6 +51,7 @@ type Props = Pick<RouteComponentProps<{}, {}>, 'location'> & {
   traceSlug: string;
   traces: TraceFullDetailed[] | null;
   filteredTransactionIds?: Set<string>;
+  footer?: ReactNode;
   traceInfo?: TraceInfo;
 };
 
@@ -104,6 +105,7 @@ export default function TraceView({
   traceSlug,
   traceEventView,
   filteredTransactionIds,
+  footer,
   ...props
 }: Props) {
   const sentryTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
@@ -360,6 +362,7 @@ export default function TraceView({
                     meta={meta}
                   />
                 </TraceViewContainer>
+                {footer}
               </TracePanel>
             </ScrollbarManager.Provider>
           )}

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -1,6 +1,10 @@
-import {useEffect, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
+import {Location} from 'history';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {Client, ResponseMeta} from 'sentry/api';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -10,6 +14,7 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
+import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 import {
   getTraceRequestPayload,
@@ -31,6 +36,14 @@ type State = {
    */
   isLoading: boolean;
   /**
+   * Loading state of next pages
+   */
+  isLoadingNext: boolean;
+  /**
+   * Are there more pages
+   */
+  nextPage: string | null;
+  /**
    * Pagelinks, if applicable. Can be provided to the Pagination component.
    */
   pageLinks: string | null;
@@ -38,6 +51,7 @@ type State = {
    * EventView that generates API payload
    */
   traceEventView: EventView | null;
+
   /**
    * Data / result.
    */
@@ -52,14 +66,85 @@ interface Props {
 const INITIAL_STATE = Object.freeze({
   error: null,
   isLoading: true,
+  isLoadingNext: false,
   pageLinks: null,
   traceEventView: null,
   traces: null,
+  nextPage: null,
 });
+
+function getNextPage(resp?: ResponseMeta) {
+  if (!resp) {
+    return null;
+  }
+
+  const pageLinks = resp.getResponseHeader('Link');
+  if (pageLinks) {
+    const {next} = parseLinkHeader(pageLinks);
+    if (!next.results) {
+      return null;
+    }
+
+    return next.href;
+  }
+
+  return null;
+}
+
+interface TraceDetailsParams {
+  api: Client;
+  end: string;
+  location: Location<ReplayListLocationQuery>;
+  orgSlug: string;
+  start: string;
+  traceIds: string[];
+}
+
+// TODO(replays): Performance concerns here if number of traceIds is large
+async function getTraceDetails({
+  api,
+  end,
+  location,
+  orgSlug,
+  start,
+  traceIds,
+}: TraceDetailsParams): Promise<TraceFullDetailed[]> {
+  const traceDetails = await Promise.allSettled(
+    traceIds.map(traceId =>
+      doDiscoverQuery(
+        api,
+        `/organizations/${orgSlug}/events-trace/${traceId}/`,
+        getTraceRequestPayload({
+          eventView: makeEventView({start, end}),
+          location,
+        })
+      )
+    )
+  );
+
+  const successfulTraceDetails = traceDetails
+    .map(settled => (settled.status === 'fulfilled' ? settled.value[0] : undefined))
+    .filter(Boolean);
+
+  if (successfulTraceDetails.length !== traceDetails.length) {
+    traceDetails.forEach(trace => {
+      if (trace.status === 'rejected') {
+        Sentry.captureMessage(trace.reason);
+      }
+    });
+  }
+
+  return successfulTraceDetails.flat() as TraceFullDetailed[];
+}
 
 export default function Trace({replayRecord, organization}: Props) {
   const [state, setState] = useState<State>(INITIAL_STATE);
   const api = useApi();
+  const previousTracesLoaded = useRef(new Set<string>());
+  const fetchedPages = useRef(new Set<string>());
+  // This is used in combination with IntersectionObserver to trigger an
+  // infinite scroll.
+  const endOfListPlaceholder = useRef(null);
   const location = useLocation<ReplayListLocationQuery>();
 
   const replayId = replayRecord.id;
@@ -69,13 +154,94 @@ export default function Trace({replayRecord, organization}: Props) {
   const start = getUtcDateString(replayRecord.started_at.getTime());
   const end = getUtcDateString(replayRecord.finished_at.getTime());
 
+  const fetchNext = useCallback(async () => {
+    // Do not fetch if already fetching (e.g. scrolling up and down so the
+    // placeholder element triggers fetch multiple times)
+    if (!state.nextPage || state.isLoadingNext) {
+      return;
+    }
+
+    // Probably not needed, but make sure we only fetch pages once. This gets
+    // reset when `loadTraces` is called
+    if (fetchedPages.current.has(state.nextPage)) {
+      return;
+    }
+
+    fetchedPages.current.add(state.nextPage);
+
+    setState(prevState => ({
+      ...prevState,
+      isLoadingNext: true,
+    }));
+
+    try {
+      // Get the trace ids that were loaded in the last page and make sure we
+      // don't include them in next page's query. The reason for this is
+      // because we can have many traces with the same timestamp, so the next
+      // page could include traces that we fetched in the previous page. Note
+      // this means we are assuming we will not have multiple pages worth of
+      // traces with identical timestamps.
+      const excludePreviousPageTraces = Array.from(previousTracesLoaded.current)
+        .map(trace => `!trace:${trace}`)
+        .join(' ');
+
+      // Filter out query, it should only be filtering by replay id. Note that
+      // we will have multiple entries with the same key (e.g. `field`), so we
+      // can't turn into an object.
+      const path = new URL(state.nextPage);
+      const queryParamList = new URLSearchParams(Array.from(path.searchParams.entries()));
+      queryParamList.delete('query');
+      queryParamList.append('query', `replayId:${replayId} ${excludePreviousPageTraces}`);
+
+      const [data, , resp] = await api.requestPromise(
+        `${path.pathname}?${queryParamList.toString()}`,
+        {
+          includeAllArgs: true,
+        }
+      );
+
+      const nextPage = getNextPage(resp);
+      const traceIds = data.data.map(({trace}) => trace).filter(Boolean);
+
+      // Update the loaded trace ids so the next page does not include this
+      // fetch's trace ids
+      previousTracesLoaded.current = new Set(traceIds);
+
+      const traces = await getTraceDetails({
+        api,
+        end,
+        location,
+        orgSlug,
+        start,
+        traceIds,
+      });
+
+      setState(prevState => ({
+        ...prevState,
+        nextPage,
+        isLoadingNext: false,
+        traces: [...(prevState.traces || []), ...traces],
+      }));
+    } catch {
+      fetchedPages.current.delete(state.nextPage);
+      setState(prevState => ({
+        ...prevState,
+        isLoadingNext: false,
+      }));
+      addErrorMessage(t('Error loading traces'));
+    }
+  }, [api, end, location, orgSlug, replayId, start, state]);
+
   useEffect(() => {
     async function loadTraces() {
+      fetchedPages.current = new Set();
+
       const eventView = EventView.fromSavedQuery({
         id: undefined,
         name: `Traces in replay ${replayId}`,
-        fields: ['trace', 'count(trace)', 'min(timestamp)'],
-        orderby: 'min_timestamp',
+        fields: ['trace', 'count(trace)', 'timestamp'],
+        orderby: 'timestamp',
+        // XXX: Update `fetchNext` if query is changed
         query: `replayId:${replayId}`,
         projects: [Number(projectId)],
         version: 2,
@@ -87,49 +253,39 @@ export default function Trace({replayRecord, organization}: Props) {
         const [data, , resp] = await doDiscoverQuery<TableData>(
           api,
           `/organizations/${orgSlug}/events/`,
-          eventView.getEventsAPIPayload(location)
+          {...eventView.getEventsAPIPayload(location), per_page: 25}
         );
 
-        const traceIds = data.data.map(({trace}) => trace).filter(trace => trace);
+        const traceIds = data.data
+          .map(({trace}) => trace)
+          .filter(Boolean)
+          .map(String);
 
-        // TODO(replays): Potential performance concerns here if number of traceIds is large
-        const traceDetails = await Promise.allSettled(
-          traceIds.map(traceId =>
-            doDiscoverQuery(
-              api,
-              `/organizations/${orgSlug}/events-trace/${traceId}/`,
-              getTraceRequestPayload({
-                eventView: makeEventView({start, end}),
-                location,
-              })
-            )
-          )
-        );
-
-        const successfulTraceDetails = traceDetails
-          .map(settled => (settled.status === 'fulfilled' ? settled.value[0] : undefined))
-          .filter(Boolean);
-
-        if (successfulTraceDetails.length !== traceDetails.length) {
-          traceDetails.forEach(trace => {
-            if (trace.status === 'rejected') {
-              Sentry.captureMessage(trace.reason);
-            }
-          });
-        }
+        previousTracesLoaded.current = new Set(traceIds);
+        const traces = await getTraceDetails({
+          api,
+          end,
+          location,
+          orgSlug,
+          start,
+          traceIds,
+        });
 
         setState(prevState => ({
           isLoading: false,
+          isLoadingNext: false,
           error: null,
           traceEventView: eventView,
+          nextPage: getNextPage(resp),
           pageLinks: resp?.getResponseHeader('Link') ?? prevState.pageLinks,
-          traces:
-            successfulTraceDetails.flatMap(trace => trace as TraceFullDetailed[]) || [],
+          traces,
         }));
       } catch (err) {
         setState({
           isLoading: false,
+          isLoadingNext: false,
           error: err,
+          nextPage: null,
           pageLinks: null,
           traceEventView: null,
           traces: null,
@@ -141,6 +297,35 @@ export default function Trace({replayRecord, organization}: Props) {
 
     return () => {};
   }, [api, replayId, projectId, orgSlug, location, start, end]);
+
+  /**
+   * Add a placeholder DOM element at the bottom of the list. Use the
+   * IntersectionObserver to detect when placeholder element is visible, if
+   * it's visible we call function to fetch more results.
+   */
+  useEffect(() => {
+    const observer = new IntersectionObserver(entities => {
+      const [el] = entities;
+      // The placeholder at bottom of list is visible, attempt to fetch next
+      // page.
+      if (el.isIntersecting) {
+        fetchNext();
+      }
+    });
+
+    const placeholderEl = endOfListPlaceholder.current;
+
+    if (!placeholderEl) {
+      return () => {};
+    }
+
+    observer.observe(placeholderEl);
+    return () => {
+      if (placeholderEl) {
+        observer.unobserve(placeholderEl);
+      }
+    };
+  }, [endOfListPlaceholder, fetchNext]);
 
   if (state.isLoading) {
     return <LoadingIndicator />;
@@ -162,7 +347,32 @@ export default function Trace({replayRecord, organization}: Props) {
       organization={organization}
       traceEventView={state.traceEventView}
       traceSlug="Replay"
+      footer={
+        <Fragment>
+          {state.isLoadingNext ? (
+            <LoadingContainer>
+              {' '}
+              <LoadingIndicator mini />{' '}
+            </LoadingContainer>
+          ) : null}
+          {!state.isLoading ? <InfinitePlaceholder ref={endOfListPlaceholder} /> : null}
+        </Fragment>
+      }
     />
   );
-  // TODO(replays): pagination
 }
+
+const LoadingContainer = styled('div')`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+`;
+
+/**
+ * This means next page fetch starts when user is 40px from the bottom of the
+ * list.
+ */
+const InfinitePlaceholder = styled('div')`
+  position: relative;
+  bottom: 60px;
+`;

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -25,6 +25,12 @@ import {useLocation} from 'sentry/utils/useLocation';
 import TraceView from 'sentry/views/performance/traceDetails/traceView';
 import type {ReplayListLocationQuery, ReplayRecord} from 'sentry/views/replays/types';
 
+// Max number of traces to list per page. Lower number means initial list will
+// load faster, but will require more queries afterwards to fill up the height
+// up the view. It also means higher chances of multi-page traces with
+// identical timestamps.
+const MAX_PAGE = 25;
+
 type State = {
   /**
    * Error, if not null.
@@ -253,7 +259,7 @@ export default function Trace({replayRecord, organization}: Props) {
         const [data, , resp] = await doDiscoverQuery<TableData>(
           api,
           `/organizations/${orgSlug}/events/`,
-          {...eventView.getEventsAPIPayload(location), per_page: 25}
+          {...eventView.getEventsAPIPayload(location), per_page: MAX_PAGE}
         );
 
         const traceIds = data.data

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -357,8 +357,7 @@ export default function Trace({replayRecord, organization}: Props) {
         <Fragment>
           {state.isLoadingNext ? (
             <LoadingContainer>
-              {' '}
-              <LoadingIndicator mini />{' '}
+              <LoadingIndicator mini />
             </LoadingContainer>
           ) : null}
           {!state.isLoading ? <InfinitePlaceholder ref={endOfListPlaceholder} /> : null}

--- a/static/app/views/replays/detail/trace/useIsVisible.tsx
+++ b/static/app/views/replays/detail/trace/useIsVisible.tsx
@@ -1,0 +1,48 @@
+import {RefObject, useEffect} from 'react';
+
+interface UseIsVisible {
+  /**
+   * Callback function that is run when the DOM element referenced in `ref` is visible.
+   */
+  onIsVisible: () => void;
+  /**
+   * A React RefObject to the element to detect if visible.
+   */
+  ref: RefObject<HTMLElement>;
+  /**
+   * Function that is run when dependencies to the useEffect hook are changed.
+   */
+  cleanup?: () => void;
+}
+
+/**
+ * Add an IntersectionObserver on `ref` to detect when element is visible.
+ * If it's visible call `onIsVisible` callback. Runs `cleanup` when
+ * dependencies change (ref, onIsVisible).
+ */
+export default function useIsVisible({ref, cleanup, onIsVisible}: UseIsVisible) {
+  useEffect(() => {
+    const observer = new IntersectionObserver(entities => {
+      const [el] = entities;
+      // The element (e.g. at bottom of a list) is visible, call callback
+      if (el.isIntersecting) {
+        onIsVisible();
+      }
+    });
+
+    const currentElement = ref.current;
+
+    if (currentElement) {
+      observer.observe(currentElement);
+    }
+
+    return () => {
+      if (currentElement) {
+        observer.unobserve(currentElement);
+      }
+      if (cleanup) {
+        cleanup();
+      }
+    };
+  }, [cleanup, onIsVisible, ref]);
+}


### PR DESCRIPTION
TraceView is currently limited to 50 traces due to pagination. It is also very slow to load because we make 50 concurrent requests for trace details (which is then limited by the browser). This PR reduces limits the number of rows returned by initial trace list query to 25 and introduces infinite scrolling to handle pagination.

Also of note, the initial query to get a list of traces in a replay is not deterministic. If there are many replays with the same timestamp, we could have traces near the pagination border show up on multiple pages. To get around this, we save the last page worth of traceIds and exclude them for the next page query. This assumes that we will not have more than 1 page worth of traces with identical timestamps.

Resolves: https://github.com/getsentry/team-replay/issues/60
