### PR TITLE
feat(sourcemaps): Add feature flag for the chunk upload endpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -55,12 +55,11 @@ class ChunkUploadTest(APITestCase):
             )
             assert "artifact_bundles" not in response.data["accept"]
 
-        # This currently should not flip the flag!
         with self.feature({"organizations:artifact-bundles": True}):
             response = self.client.get(
                 self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
             )
-            assert "artifact_bundles" not in response.data["accept"]
+            assert "artifact_bundles" in response.data["accept"]
 
     def test_relative_url_support(self):
         # Starting `sentry-cli@1.70.1` we added a support for relative chunk-uploads urls


### PR DESCRIPTION
This PR feature flags the artifact bundles endpoint.

Closes: https://github.com/getsentry/sentry/issues/47148