### PR TITLE
fix(replay): Fix breadcrumb item not display React elements

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, memo, MouseEvent, useCallback} from 'react';
+import {CSSProperties, isValidElement, memo, MouseEvent, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
@@ -104,7 +104,7 @@ function BreadcrumbItem({
           ) : null}
         </TitleContainer>
 
-        {typeof description === 'string' ? (
+        {typeof description === 'string' || isValidElement(description) ? (
           <Description title={description} showOnlyOnOverflow>
             {description}
           </Description>


### PR DESCRIPTION
Regression due to https://github.com/getsentry/sentry/pull/46423 -- React elements are incorrectly being passed to `<ObjectInspector>` (e.g. in outdated SDKs with LCP)
