### PR TITLE
fix(group): default ignored issues to substatus=null

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -153,6 +153,7 @@ class GroupSubStatus:
     UNTIL_ESCALATING = 1
     ESCALATING = 2
     ONGOING = 3
+    FOREVER = 4
 
 
 # Statuses that can be queried/searched for
@@ -715,4 +716,4 @@ def pre_save_group_default_substatus(instance, sender, *args, **kwargs):
         if instance.status == GroupStatus.UNRESOLVED and instance.substatus is None:
             instance.substatus = GroupSubStatus.ONGOING
         if instance.status == GroupStatus.IGNORED and instance.substatus is None:
-            instance.substatus = GroupSubStatus.UNTIL_ESCALATING
+            instance.substatus = GroupSubStatus.FOREVER

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -153,7 +153,6 @@ class GroupSubStatus:
     UNTIL_ESCALATING = 1
     ESCALATING = 2
     ONGOING = 3
-    FOREVER = 4
 
 
 # Statuses that can be queried/searched for
@@ -715,5 +714,3 @@ def pre_save_group_default_substatus(instance, sender, *args, **kwargs):
     if instance:
         if instance.status == GroupStatus.UNRESOLVED and instance.substatus is None:
             instance.substatus = GroupSubStatus.ONGOING
-        if instance.status == GroupStatus.IGNORED and instance.substatus is None:
-            instance.substatus = GroupSubStatus.FOREVER

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -304,8 +304,8 @@ class GroupTest(TestCase, SnubaTestCase):
 
     def test_group_substatus_defaults(self):
         assert self.create_group(status=GroupStatus.UNRESOLVED).substatus == GroupSubStatus.ONGOING
-        assert self.create_group(status=GroupStatus.IGNORED).substatus == GroupSubStatus.FOREVER
-        assert self.create_group(status=GroupStatus.MUTED).substatus == GroupSubStatus.FOREVER
+        assert self.create_group(status=GroupStatus.IGNORED).substatus is None
+        assert self.create_group(status=GroupStatus.MUTED).substatus is None
         for nullable_status in (
             GroupStatus.RESOLVED,
             GroupStatus.PENDING_DELETION,

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -304,13 +304,8 @@ class GroupTest(TestCase, SnubaTestCase):
 
     def test_group_substatus_defaults(self):
         assert self.create_group(status=GroupStatus.UNRESOLVED).substatus == GroupSubStatus.ONGOING
-        assert (
-            self.create_group(status=GroupStatus.IGNORED).substatus
-            == GroupSubStatus.UNTIL_ESCALATING
-        )
-        assert (
-            self.create_group(status=GroupStatus.MUTED).substatus == GroupSubStatus.UNTIL_ESCALATING
-        )
+        assert self.create_group(status=GroupStatus.IGNORED).substatus == GroupSubStatus.FOREVER
+        assert self.create_group(status=GroupStatus.MUTED).substatus == GroupSubStatus.FOREVER
         for nullable_status in (
             GroupStatus.RESOLVED,
             GroupStatus.PENDING_DELETION,


### PR DESCRIPTION
This was erroneously defaulted to `UNTIL_ESCALATING` when it should have null.

A follow-up backfill migration PR will be created to set the correct substatus values.