### PR TITLE
test(ui): Remove act use from eventDetails, other cleanup

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -2,7 +2,7 @@ import {browserHistory, InjectedRouter} from 'react-router';
 import {Location} from 'history';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {EntryType, Event, Group, IssueCategory, IssueType} from 'sentry/types';
 import {Organization} from 'sentry/types/organization';
@@ -148,11 +148,6 @@ const mockGroupApis = (
   MockApiClient.addMockResponse({
     url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/committers/`,
     body: {committers: []},
-  });
-
-  MockApiClient.addMockResponse({
-    url: `/projects/${organization.slug}/${project.slug}/releases/completion/`,
-    body: [],
   });
 
   MockApiClient.addMockResponse({
@@ -344,16 +339,13 @@ describe('groupEventDetails', () => {
     );
 
     const routerContext = TestStubs.routerContext();
-    await act(async () => {
-      render(<TestComponent group={group} event={transaction} />, {
-        organization: props.organization,
-        context: routerContext,
-      });
-      await tick();
+    render(<TestComponent group={group} event={transaction} />, {
+      organization: props.organization,
+      context: routerContext,
     });
 
     expect(
-      screen.getByRole('heading', {
+      await screen.findByRole('heading', {
         name: /span evidence/i,
       })
     ).toBeInTheDocument();
@@ -395,16 +387,13 @@ describe('groupEventDetails', () => {
     );
 
     const routerContext = TestStubs.routerContext();
-    await act(async () => {
-      render(<TestComponent group={group} event={transaction} />, {
-        organization: props.organization,
-        context: routerContext,
-      });
-      await tick();
+    render(<TestComponent group={group} event={transaction} />, {
+      organization: props.organization,
+      context: routerContext,
     });
 
     expect(
-      screen.getByRole('heading', {
+      await screen.findByRole('heading', {
         name: /function evidence/i,
       })
     ).toBeInTheDocument();
@@ -448,16 +437,6 @@ describe('EventCause', () => {
     );
 
     MockApiClient.addMockResponse({
-      url: `/projects/${props.organization.slug}/${props.project.slug}/releases/completion/`,
-      body: [
-        {
-          step: 'commit',
-          complete: true,
-        },
-      ],
-    });
-
-    MockApiClient.addMockResponse({
       url: `/projects/${props.organization.slug}/${props.project.slug}/events/${props.event.id}/committers/`,
       body: {
         committers: [
@@ -472,42 +451,6 @@ describe('EventCause', () => {
     render(<TestComponent project={props.project} />, {organization: props.organization});
 
     expect(await screen.findByTestId(/event-cause/)).toBeInTheDocument();
-    expect(screen.queryByTestId(/loaded-event-cause-empty/)).not.toBeInTheDocument();
-  });
-
-  it('renders suspect commit if `releasesCompletion` empty', async function () {
-    const props = makeDefaultMockData(
-      undefined,
-      TestStubs.Project({firstEvent: TestStubs.Event()})
-    );
-
-    mockGroupApis(
-      props.organization,
-      props.project,
-      props.group,
-      TestStubs.Event({
-        size: 1,
-        dateCreated: '2019-03-20T00:00:00.000Z',
-        errors: [],
-        entries: [],
-        tags: [{key: 'environment', value: 'dev'}],
-        previousEventID: 'prev-event-id',
-        nextEventID: 'next-event-id',
-      })
-    );
-
-    MockApiClient.addMockResponse({
-      url: `/projects/${props.organization.slug}/${props.project.slug}/releases/completion/`,
-      body: [],
-    });
-
-    await act(async () => {
-      render(<TestComponent project={props.project} />, {
-        organization: props.organization,
-      });
-      await tick();
-    });
-
     expect(screen.queryByTestId(/loaded-event-cause-empty/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
cleanup unused `/releases/completion/` endpoint
use findBy instead of act w/ tick
