### PR TITLE
feat(transactions): Add compact select to show memory data

### DIFF
--- a/static/app/components/events/interfaces/spans/profilingMeasurements.spec.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ProfilingMeasurements} from 'sentry/components/events/interfaces/spans/profilingMeasurements';
 
@@ -17,6 +17,19 @@ const mockProfileData = {
         },
       ],
     },
+    memory_footprint: {
+      unit: 'bytes',
+      values: [
+        {
+          elapsed_since_start_ns: 0,
+          value: 20000,
+        },
+        {
+          elapsed_since_start_ns: 1000000000,
+          value: 123456,
+        },
+      ],
+    },
   },
 } as Profiling.ProfileInput;
 
@@ -24,5 +37,15 @@ it('renders CPU Usage as a chart', function () {
   render(<ProfilingMeasurements profileData={mockProfileData} />);
 
   expect(screen.getByText('CPU Usage')).toBeInTheDocument();
-  expect(screen.getByTestId('profile-measurements-chart')).toBeInTheDocument();
+  expect(screen.getByTestId('profile-measurements-chart-cpu_usage')).toBeInTheDocument();
+});
+
+it('can toggle between CPU Usage and Memory charts', async function () {
+  render(<ProfilingMeasurements profileData={mockProfileData} />);
+
+  await userEvent.click(screen.getByText('CPU Usage'));
+  await userEvent.click(screen.getByText('Memory'));
+  expect(
+    screen.getByTestId('profile-measurements-chart-memory_footprint')
+  ).toBeInTheDocument();
 });

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -23,7 +23,7 @@ import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {SeriesDataUnit} from 'sentry/types/echarts';
-import {defined, formatBytesBase10} from 'sentry/utils';
+import {formatBytesBase10} from 'sentry/utils';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
 
@@ -77,7 +77,7 @@ function Chart({data, type}: ChartProps) {
 
   return (
     <LineChart
-      data-test-id="profile-measurements-chart"
+      data-test-id={`profile-measurements-chart-${type}`}
       height={PROFILE_MEASUREMENTS_CHART_HEIGHT}
       yAxis={{
         show: false,
@@ -155,12 +155,12 @@ function ProfilingMeasurements({
 
   if (
     !('measurements' in profileData) ||
-    !defined(profileData.measurements?.[measurementType])
+    profileData.measurements?.[measurementType] === undefined
   ) {
     return null;
   }
 
-  const data = profileData.measurements![measurementType];
+  const data = profileData.measurements[measurementType]!;
 
   return (
     <CursorGuideHandler.Consumer>

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -23,7 +23,7 @@ import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {SeriesDataUnit} from 'sentry/types/echarts';
-import {defined} from 'sentry/utils';
+import {defined, formatBytesBase10} from 'sentry/utils';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
 
@@ -108,7 +108,11 @@ function Chart({data, type}: ChartProps) {
       colors={[theme.green200] as string[]}
       tooltip={{
         valueFormatter: (value, _seriesName) => {
-          return `${value.toFixed(2)}%`;
+          if (type === CPU_USAGE) {
+            return `${value.toFixed(2)}%`;
+          }
+
+          return formatBytesBase10(value);
         },
       }}
     />

--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -17,6 +17,10 @@ declare namespace Profiling {
       unit: string;
       values: MeasurementValue[];
     }
+    memory_footprint?: {
+      unit: string;
+      values: MeasurementValue[];
+    };
     frozen_frame_renders?: {
       unit: string;
       values: MeasurementValue[];


### PR DESCRIPTION
Renders the label as a CompactSelect so users can switch between CPU Usage and Memory.

https://user-images.githubusercontent.com/22846452/231247182-17e23309-9b53-4feb-b8a3-98804931ca3b.mov

See the above example [here](https://localhost:7999/performance/sentry-android:56dbcab8a25b478883578daa80625e9f/?project=5428559&query=&referrer=performance-transaction-summary&statsPeriod=14d&transaction=MainActivity&unselectedSeries=p100%28%29)