### PR TITLE
chore(profiling): Remove all profiling previews flags from UI

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -32,9 +32,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
 
   const profileId = event.contexts?.profile?.profile_id ?? null;
 
-  const hasProfilingPreviewsFeature =
-    organization.features.includes('profiling') &&
-    organization.features.includes('profiling-previews');
+  const hasProfilingFeature = organization.features.includes('profiling');
 
   return (
     <EventDataSection
@@ -45,7 +43,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
       )}
     >
       <SpanEvidenceKeyValueList event={event} projectSlug={projectSlug} />
-      {hasProfilingPreviewsFeature ? (
+      {hasProfilingFeature ? (
         <ProfilesProvider
           orgSlug={organization.slug}
           projectSlug={projectSlug}

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -918,7 +918,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
   renderMissingInstrumentationProfileBadge(): React.ReactNode {
     const {organization, span} = this.props;
 
-    if (!organization.features.includes('profiling-previews')) {
+    if (!organization.features.includes('profiling')) {
       return null;
     }
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -340,7 +340,7 @@ function SpanDetail(props: Props) {
   function renderProfileMessage() {
     const {organization, span, event} = props;
 
-    if (!organization.features.includes('profiling-span-previews') || isGapSpan(span)) {
+    if (!organization.features.includes('profiling') || isGapSpan(span)) {
       return null;
     }
 
@@ -353,7 +353,7 @@ function SpanDetail(props: Props) {
     if (isGapSpan(span)) {
       return (
         <SpanDetails>
-          {organization.features.includes('profiling-previews') ? (
+          {organization.features.includes('profiling') ? (
             <GapSpanDetails
               event={event}
               span={span}

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -149,8 +149,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     const eventJsonUrl = `/api/0/projects/${organization.slug}/${this.projectId}/events/${event.eventID}/json/`;
 
     const hasProfilingFeature = organization.features.includes('profiling');
-    const hasProfilingPreviewsFeature =
-      hasProfilingFeature && organization.features.includes('profiling-previews');
 
     const profileId = isTransaction(event) ? event.contexts?.profile?.profile_id : null;
 
@@ -248,7 +246,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                     }}
                   >
                     <QuickTraceContext.Provider value={results}>
-                      {hasProfilingPreviewsFeature ? (
+                      {hasProfilingFeature ? (
                         <ProfilesProvider
                           orgSlug={organization.slug}
                           projectSlug={this.projectId}

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -154,8 +154,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     const {start, end} = getTraceTimeRangeFromEvent(event);
 
     const hasProfilingFeature = organization.features.includes('profiling');
-    const hasProfilingPreviewsFeature =
-      hasProfilingFeature && organization.features.includes('profiling-previews');
 
     const profileId = (event as EventTransaction).contexts?.profile?.profile_id ?? null;
 
@@ -240,7 +238,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                           }}
                         >
                           <QuickTraceContext.Provider value={results}>
-                            {hasProfilingPreviewsFeature ? (
+                            {hasProfilingFeature ? (
                               <ProfilesProvider
                                 orgSlug={organization.slug}
                                 projectSlug={this.projectId}


### PR DESCRIPTION
These features are all GAed, no need to keep these additional feature flags.