### PR TITLE
feat(perf-issues): Span evidence UI with issue occurences

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -88,6 +88,78 @@ describe('SpanEvidenceKeyValueList', () => {
     });
   });
 
+  describe('N+1 Database Queries with occurences', () => {
+    const builder = new TransactionEventBuilder('a1', '/', undefined, undefined, true);
+    builder.getEvent().projectID = '123';
+
+    const parentSpan = new MockSpan({
+      startTimestamp: 0,
+      endTimestamp: 0.2,
+      op: 'http.server',
+      problemSpan: ProblemSpan.PARENT,
+    });
+
+    parentSpan.addChild({
+      startTimestamp: 0.01,
+      endTimestamp: 2.1,
+      op: 'db',
+      description: 'SELECT * FROM books',
+      hash: 'aaa',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+
+    parentSpan.addChild({
+      startTimestamp: 2.1,
+      endTimestamp: 4.0,
+      op: 'db',
+      description: 'SELECT * FROM books',
+      hash: 'aaa',
+      problemSpan: ProblemSpan.OFFENDER,
+    });
+
+    builder.addSpan(parentSpan);
+
+    it('Renders relevant fields', () => {
+      render(
+        <SpanEvidenceKeyValueList event={builder.getEvent()} projectSlug={projectSlug} />
+      );
+
+      expect(screen.getByRole('cell', {name: 'Transaction'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction')
+      ).toHaveTextContent('/');
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.transaction').querySelector('a')
+      ).toHaveAttribute(
+        'href',
+        `/organizations/org-slug/performance/summary/?project=123&referrer=performance-transaction-summary&transaction=%2F&unselectedSeries=p100%28%29`
+      );
+      expect(
+        screen.getByRole('button', {
+          name: /view full event/i,
+        })
+      ).toHaveAttribute('href', '/organizations/org-slug/performance/project:a1/?');
+
+      expect(screen.getByRole('cell', {name: 'Parent Span'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.parent-span')
+      ).toHaveTextContent('http.server');
+
+      expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId(/span-evidence-key-value-list.repeating-spans/)
+      ).toHaveTextContent('db - SELECT * FROM books');
+      expect(
+        screen.queryByTestId('span-evidence-key-value-list.')
+      ).not.toBeInTheDocument();
+
+      expect(screen.queryByRole('cell', {name: 'Parameter'})).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('span-evidence-key-value-list.problem-parameters')
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe('MN+1 Database Queries', () => {
     const builder = new TransactionEventBuilder('a1', '/');
     builder.getEvent().projectID = '123';

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -16,6 +16,7 @@ import {
   EntryType,
   Event,
   EventTransaction,
+  getIssueTypeFromOccurenceType,
   IssueType,
   KeyValueListData,
   KeyValueListDataItem,
@@ -58,9 +59,11 @@ export function SpanEvidenceKeyValueList({
 }) {
   const {slug: orgSlug} = useOrganization();
   const spanInfo = getSpanInfoFromTransactionEvent(event);
-  const performanceProblem = event?.perfProblem;
 
-  if (!performanceProblem?.issueType || !spanInfo) {
+  const issueType =
+    event.perfProblem?.issueType ?? getIssueTypeFromOccurenceType(event.occurrence?.type);
+
+  if (!issueType || !spanInfo) {
     return (
       <DefaultSpanEvidence
         event={event}
@@ -82,7 +85,7 @@ export function SpanEvidenceKeyValueList({
       [IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET]: RenderBlockingAssetSpanEvidence,
       [IssueType.PERFORMANCE_UNCOMPRESSED_ASSET]: UncompressedAssetSpanEvidence,
       [IssueType.PERFORMANCE_CONSECUTIVE_HTTP]: ConsecutiveHTTPSpanEvidence,
-    }[performanceProblem.issueType] ?? DefaultSpanEvidence;
+    }[issueType] ?? DefaultSpanEvidence;
 
   return (
     <ClippedBox clipHeight={300}>

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -75,6 +75,25 @@ export enum IssueType {
   PROFILE_JSON_DECODE_MAIN_THREAD = 'profile_json_decode_main_thread',
 }
 
+export const getIssueTypeFromOccurenceType = (
+  typeId: number | undefined
+): IssueType | null => {
+  const occurrenceTypeToIssueIdMap = {
+    1001: IssueType.PERFORMANCE_SLOW_DB_QUERY,
+    1004: IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET,
+    1006: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+    1007: IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES,
+    1008: IssueType.PERFORMANCE_FILE_IO_MAIN_THREAD,
+    1009: IssueType.PERFORMANCE_CONSECUTIVE_HTTP,
+    1010: IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
+    1012: IssueType.PERFORMANCE_UNCOMPRESSED_ASSET,
+  };
+  if (!typeId) {
+    return null;
+  }
+  return occurrenceTypeToIssueIdMap[typeId] ?? null;
+};
+
 // endpoint: /api/0/issues/:issueId/attachments/?limit=50
 export type IssueAttachment = {
   dateCreated: string;

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -34,8 +34,14 @@ export class TransactionEventBuilder {
     id?: string,
     title?: string,
     problemType?: IssueType,
-    transactionSettings?: TransactionSettings
+    transactionSettings?: TransactionSettings,
+    occurenceBasedEvent?: boolean
   ) {
+    const perfEvidenceData = {
+      causeSpanIds: [],
+      offenderSpanIds: [],
+      parentSpanIds: [],
+    };
     this.#event = {
       id: id ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       eventID: id ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -58,12 +64,7 @@ export class TransactionEventBuilder {
           type: EntryType.SPANS,
         },
       ],
-      perfProblem: {
-        causeSpanIds: [],
-        offenderSpanIds: [],
-        parentSpanIds: [],
-        issueType: problemType ?? IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-      },
+
       // For the purpose of mock data, we don't care as much about the properties below.
       // They're here to satisfy the type constraints, but in the future if we need actual values here
       // for testing purposes, we can add methods on the builder to set them.
@@ -81,6 +82,7 @@ export class TransactionEventBuilder {
           unit: 'millisecond',
         },
       },
+      perfProblem: undefined,
       metadata: {
         current_level: undefined,
         current_tree_label: undefined,
@@ -103,6 +105,24 @@ export class TransactionEventBuilder {
       tags: [],
       user: null,
     };
+    if (occurenceBasedEvent) {
+      this.#event.occurrence = {
+        evidenceData: perfEvidenceData,
+        eventId: id ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        detectionTime: '100',
+        evidenceDisplay: [],
+        fingerprint: ['fingerprint123'],
+        id: 'id123',
+        issueTitle: 'N + 1 Query',
+        resourceId: '',
+        subtitle: 'SELECT * FROM TABLE',
+        type: 1006,
+      };
+    } else {
+      this.#event.perfProblem = perfEvidenceData;
+      this.#event.perfProblem.issueType =
+        problemType ?? IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES;
+    }
   }
 
   generateSpanId() {
@@ -130,16 +150,19 @@ export class TransactionEventBuilder {
         ? mockSpan.problemSpan
         : [mockSpan.problemSpan];
 
+      const perfEvidenceData =
+        this.#event.perfProblem ?? this.#event.occurrence?.evidenceData;
+
       problemSpans.forEach(problemSpan => {
         switch (problemSpan) {
           case ProblemSpan.PARENT:
-            this.#event.perfProblem?.parentSpanIds.push(spanId);
+            perfEvidenceData?.parentSpanIds.push(spanId);
             break;
           case ProblemSpan.OFFENDER:
-            this.#event.perfProblem?.offenderSpanIds.push(spanId);
+            perfEvidenceData?.offenderSpanIds.push(spanId);
             break;
           case ProblemSpan.CAUSE:
-            this.#event.perfProblem?.causeSpanIds.push(spanId);
+            perfEvidenceData?.causeSpanIds.push(spanId);
             break;
           default:
             break;


### PR DESCRIPTION
First PR to get span evidences working with issue occurrences. This PR focuses on the span evidence section for performance issues.
Before
![Pasted Graphic](https://user-images.githubusercontent.com/44422760/231278359-d3f79ca2-e2f8-437b-b54f-f94d1051a7ea.png)

After with N+1
![Pasted Graphic 1](https://user-images.githubusercontent.com/44422760/231278369-13133c10-44e4-47b9-835e-537e38832b17.png)

After with Render Blocking Assets
![Pasted Graphic 2](https://user-images.githubusercontent.com/44422760/231278386-72789859-96dc-4eab-a1d0-969149ca3841.png)
