### PR TITLE
chore(urls): add spike protection web url

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -596,6 +596,11 @@ urlpatterns += [
                     name="sentry-customer-domain-subscription-settings",
                 ),
                 url(
+                    r"^spike-protection/",
+                    react_page_view,
+                    name="sentry-customer-domain-spike-protection-settings",
+                ),
+                url(
                     r"^legal/",
                     react_page_view,
                     name="sentry-customer-domain-legal-settings",


### PR DESCRIPTION
Adds` /settings/spike-protection/` as a web url. This will allow folks to directly hit the url and see the spike protection projects page.