### PR TITLE
ref(analytics): remove analytics for resources

### DIFF
--- a/static/app/views/projectsDashboard/resources.tsx
+++ b/static/app/views/projectsDashboard/resources.tsx
@@ -8,8 +8,13 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ResourceCard from 'sentry/components/resourceCard';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
 
-function Resources() {
+type Props = {
+  organization: Organization;
+};
+
+function Resources(_props: Props) {
   return (
     <ResourcesWrapper data-test-id="resources">
       <Layout.Title withMargins>{t('Resources')}</Layout.Title>

--- a/static/app/views/projectsDashboard/resources.tsx
+++ b/static/app/views/projectsDashboard/resources.tsx
@@ -1,4 +1,3 @@
-import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import breadcrumbsImg from 'sentry-images/spot/breadcrumbs-generic.svg';
@@ -9,22 +8,8 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ResourceCard from 'sentry/components/resourceCard';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Organization} from 'sentry/types';
-import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 
-type Props = {
-  organization: Organization;
-};
-
-function Resources({organization}: Props) {
-  useEffect(() => {
-    trackAnalyticsEvent({
-      eventKey: 'orgdash.resources_shown',
-      eventName: 'Projects Dashboard: Resources Shown',
-      organization_id: organization.id,
-    });
-  });
-
+function Resources() {
   return (
     <ResourcesWrapper data-test-id="resources">
       <Layout.Title withMargins>{t('Resources')}</Layout.Title>


### PR DESCRIPTION
We've been blocking this event in Amplitude for a while and I don't think anyone cares about this event in our data warehouse 