### PR TITLE
feat(profiling): Add profile column to supported perf issue all event…

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -215,7 +215,7 @@ export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
   'minidump',
 ]);
 
-export const profiling = [
+export const profiling: PlatformKey[] = [
   // mobile
   'android',
   'apple-ios',
@@ -225,7 +225,7 @@ export const profiling = [
   'node-koa',
   'node-connect',
   'javascript-nextjs',
-  // python, WSGI only
+  // python
   'python',
   'python-django',
   'python-flask',
@@ -244,7 +244,7 @@ export const profiling = [
   'php',
   'php-laravel',
   'php-symfony2',
-] as const;
+];
 
 export const releaseHealth: PlatformKey[] = [
   // frontend


### PR DESCRIPTION
…s tab

If a platform supports profiling, we should show the `profile` column in the all events tab of the issue.

Closes getsentry/team-profiling#230