### PR TITLE
feat(celery): new weekly_escalating_forecast queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -745,6 +745,7 @@ CELERY_QUEUES = [
         routing_key="dynamicsampling",
     ),
     Queue("auto_enable_codecov", routing_key="auto_enable_codecov"),
+    Queue("weekly_escalating_forecast", routing_key="weekly_escalating_forecast"),
 ]
 
 for queue in CELERY_QUEUES:


### PR DESCRIPTION
Round 2 of adding this queue (since last change broke some of our workers). Will look into removing the `process_owner_assignments` queue safely at a later date. 