### PR TITLE
ref(analytics): remove view join analytics

### DIFF
--- a/static/app/views/organizationJoinRequest/index.spec.jsx
+++ b/static/app/views/organizationJoinRequest/index.spec.jsx
@@ -1,7 +1,6 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {trackAdhocEvent} from 'sentry/utils/analytics';
 import OrganizationJoinRequest from 'sentry/views/organizationJoinRequest';
 
 jest.mock('sentry/utils/analytics', () => ({
@@ -14,7 +13,6 @@ describe('OrganizationJoinRequest', function () {
   const endpoint = `/organizations/${org.slug}/join-request/`;
 
   beforeEach(function () {
-    trackAdhocEvent.mockClear();
     MockApiClient.clearMockResponses();
   });
 
@@ -24,11 +22,6 @@ describe('OrganizationJoinRequest', function () {
     expect(screen.getByRole('heading', {name: 'Request to Join'})).toBeInTheDocument();
     expect(screen.getByRole('textbox', {name: 'Email Address'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Request to Join'})).toBeInTheDocument();
-
-    expect(trackAdhocEvent).toHaveBeenCalledWith({
-      eventKey: 'join_request.viewed',
-      org_slug: org.slug,
-    });
   });
 
   it('submits', async function () {

--- a/static/app/views/organizationJoinRequest/index.tsx
+++ b/static/app/views/organizationJoinRequest/index.tsx
@@ -9,7 +9,6 @@ import NarrowLayout from 'sentry/components/narrowLayout';
 import {IconMegaphone} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {trackAdhocEvent} from 'sentry/utils/analytics';
 
 type Props = RouteComponentProps<{orgId: string}, {}>;
 
@@ -21,15 +20,6 @@ class OrganizationJoinRequest extends Component<Props, State> {
   state: State = {
     submitSuccess: null,
   };
-
-  componentDidMount() {
-    const {params} = this.props;
-
-    trackAdhocEvent({
-      eventKey: 'join_request.viewed',
-      org_slug: params.orgId,
-    });
-  }
 
   handleSubmitSuccess = () => {
     this.setState({submitSuccess: true});


### PR DESCRIPTION
I'm removing this event that wasn't going to Amplitude. We don't even have the orgid, just the slug, so this event is hard to use anyways.