### PR TITLE
fix(profiling): event.projectSlug does not always exist profile context

### DIFF
--- a/static/app/components/events/contexts/profile/index.spec.tsx
+++ b/static/app/components/events/contexts/profile/index.spec.tsx
@@ -1,6 +1,7 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ProfileEventContext} from 'sentry/components/events/contexts/profile';
+import ProjectsStore from 'sentry/stores/projectsStore';
 
 const organization = TestStubs.Organization({
   features: ['profiling'],
@@ -13,8 +14,13 @@ const profileContext = {
 };
 
 const event = TestStubs.Event();
+const project = TestStubs.Project();
 
 describe('profile event context', function () {
+  beforeEach(function () {
+    act(() => ProjectsStore.loadInitialData([project]));
+  });
+
   it('renders empty context', function () {
     render(<ProfileEventContext data={{}} event={event} />, {organization});
   });
@@ -30,7 +36,7 @@ describe('profile event context', function () {
     render(
       <ProfileEventContext
         data={profileContext}
-        event={{...event, projectSlug: 'test-project'}}
+        event={{...event, projectID: project.id}}
       />,
       {organization}
     );


### PR DESCRIPTION
The profile context needs the project slug to generate a link but `event.projectSlug` does not always exist. So we should use `event.projectID` and map it to the slug.

Closes getsentry/team-profiling#231