### PR TITLE
chore(profiling): Update text to view profile

### DIFF
--- a/static/app/components/events/contexts/profile/index.spec.tsx
+++ b/static/app/components/events/contexts/profile/index.spec.tsx
@@ -37,6 +37,6 @@ describe('profile event context', function () {
 
     expect(screen.getByText('Profile ID')).toBeInTheDocument();
     expect(screen.getByText(profileId)).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Go to Profile'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'View Profile'})).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -2,7 +2,6 @@ import Feature from 'sentry/components/acl/feature';
 import {Button} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {IconProfiling} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {Event, ProfileContext, ProfileContextKey} from 'sentry/types/event';
@@ -97,9 +96,8 @@ function getProfileKnownDataDetails({
                 source: 'events.profile_event_context',
               })
             }
-            icon={<IconProfiling size="xs" />}
           >
-            {t('Go to Profile')}
+            {t('View Profile')}
           </Button>
         ),
       };

--- a/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
@@ -239,8 +239,8 @@ function ProfilePreviewHeader({canvasView, event, organization}: ProfilePreviewP
           )}
         />
       </HeaderContainer>
-      <Button icon={<IconProfiling />} size="xs" onClick={handleGoToProfile} to={target}>
-        {t('Go to Profile')}
+      <Button size="xs" onClick={handleGoToProfile} to={target}>
+        {t('View Profile')}
       </Button>
     </HeaderContainer>
   );

--- a/static/app/components/profiling/transactionToProfileButton.tsx
+++ b/static/app/components/profiling/transactionToProfileButton.tsx
@@ -1,7 +1,6 @@
 import {Location} from 'history';
 
 import {Button, ButtonProps} from 'sentry/components/button';
-import {IconProfiling} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
@@ -19,7 +18,7 @@ interface Props {
 function TransactionToProfileButton({
   projectSlug,
   query,
-  children = t('Go to Profile'),
+  children = t('View Profile'),
   size = 'sm',
 }: Props) {
   const profileId = useTransactionProfileId();
@@ -44,12 +43,7 @@ function TransactionToProfileButton({
   });
 
   return (
-    <Button
-      size={size}
-      onClick={handleGoToProfile}
-      to={target}
-      icon={<IconProfiling size="xs" />}
-    >
+    <Button size={size} onClick={handleGoToProfile} to={target}>
       {children}
     </Button>
   );

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -19,7 +19,7 @@ import {
 } from 'sentry/components/performance/waterfall/rowDetails';
 import {generateIssueEventTarget} from 'sentry/components/quickTrace/utils';
 import {PAGE_URL_PARAM} from 'sentry/constants/pageFilters';
-import {IconLink, IconProfiling} from 'sentry/icons';
+import {IconLink} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -148,13 +148,8 @@ class TransactionDetail extends Component<Props> {
     }
 
     return (
-      <StyledButton
-        size="xs"
-        to={target}
-        onClick={handleOnClick}
-        icon={<IconProfiling size="xs" />}
-      >
-        {t('Go to Profile')}
+      <StyledButton size="xs" to={target} onClick={handleOnClick}>
+        {t('View Profile')}
       </StyledButton>
     );
   }


### PR DESCRIPTION
For consistency, we're changing the copy from "go to profile" to "view profile" and removing the icon.

Closes getsentry/team-profiling#232