### PR TITLE
fix(crons): Do not default to production

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -29,7 +29,7 @@ function MonitorDetails({params, location}: Props) {
 
   // TODO(epurkhiser): For now we just use the fist environment OR production
   // if we have all environments selected
-  const environment = selection.environments[0] ?? 'production';
+  const environment = selection.environments[0];
 
   const queryKey = [
     `/organizations/${organization.slug}/monitors/${params.monitorSlug}/`,


### PR DESCRIPTION
Remove this for the case where there's no environments at all, in that case we will not 404 because the production env is missing.