### PR TITLE
ref(crons): Change related issue view to query on monitor.slug

### DIFF
--- a/static/app/views/monitors/components/monitorIssues.tsx
+++ b/static/app/views/monitors/components/monitorIssues.tsx
@@ -54,9 +54,9 @@ function MonitorIssues({orgId, monitor}: Props) {
     <Fragment>
       <StyledAlert type="warning" showIcon>
         {tct(
-          'Some older issues may be missing from this list, visit the [link] for older related issues.',
+          'Some older issues may be missing from this list, visit the [link:issue stream] for older related issues.',
           {
-            link: <Link to={issueStreamLink}>{t('issue stream')}</Link>,
+            link: <Link to={issueStreamLink} />,
           }
         )}
       </StyledAlert>

--- a/static/app/views/monitors/components/monitorIssues.tsx
+++ b/static/app/views/monitors/components/monitorIssues.tsx
@@ -1,7 +1,13 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import GroupList from 'sentry/components/issues/groupList';
+import Link from 'sentry/components/links/link';
 import {Panel, PanelBody} from 'sentry/components/panels';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {getUtcDateString} from 'sentry/utils/dates';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -40,25 +46,43 @@ function MonitorIssues({orgId, monitor}: Props) {
 
   // TODO(epurkhiser): We probably want to filter on envrionemnt
 
+  const issueStreamLink = {
+    pathname: '/issues',
+    query: {query: `monitor.id:"${monitor.id}"`},
+  };
   return (
-    <GroupList
-      orgId={orgId}
-      endpointPath={`/organizations/${orgId}/issues/`}
-      queryParams={{
-        query: `monitor.id:"${monitor.id}"`,
-        project: monitor.project.id,
-        limit: 5,
-        ...timeProps,
-      }}
-      query=""
-      renderEmptyMessage={MonitorIssuesEmptyMessage}
-      canSelectGroups={false}
-      withPagination={false}
-      withChart={false}
-      useTintRow={false}
-      source="monitors"
-    />
+    <Fragment>
+      <StyledAlert type="warning" showIcon>
+        {tct(
+          'Some older issues may be missing from this list, visit the [link] for older related issues.',
+          {
+            link: <Link to={issueStreamLink}>{t('issue stream')}</Link>,
+          }
+        )}
+      </StyledAlert>
+      <GroupList
+        orgId={orgId}
+        endpointPath={`/organizations/${orgId}/issues/`}
+        queryParams={{
+          query: `monitor.slug:"${monitor.slug}"`,
+          project: monitor.project.id,
+          limit: 5,
+          ...timeProps,
+        }}
+        query=""
+        renderEmptyMessage={MonitorIssuesEmptyMessage}
+        canSelectGroups={false}
+        withPagination={false}
+        withChart={false}
+        useTintRow={false}
+        source="monitors"
+      />
+    </Fragment>
   );
 }
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(0.5)};
+`;
 
 export default MonitorIssues;


### PR DESCRIPTION
Link goes to issue stream with prefilled query

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/9372512/231304041-29fc5767-63cb-44df-8023-66edbfa8668e.png">

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/9372512/231304079-2114a694-c7e4-4e09-94f0-ac872562d995.png">
