### PR TITLE
ref(analytics): remove resource card analytics

### DIFF
--- a/static/app/components/resourceCard.tsx
+++ b/static/app/components/resourceCard.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import Card from 'sentry/components/card';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {space} from 'sentry/styles/space';
-import {analytics} from 'sentry/utils/analytics';
 
 type Props = {
   imgUrl: string;
@@ -14,10 +13,7 @@ type Props = {
 function ResourceCard({title, link, imgUrl}: Props) {
   return (
     <Card interactive>
-      <StyledLink
-        href={link}
-        onClick={() => analytics('orgdash.resource_clicked', {link, title})}
-      >
+      <StyledLink href={link}>
         <StyledImg src={imgUrl} alt={title} />
         <StyledTitle>{title}</StyledTitle>
       </StyledLink>


### PR DESCRIPTION
Removing some BQ-only analytics because we weren't actually looking at this at all