### PR TITLE
fix(issue-platform): Fix issue with duplicate performance issues

### DIFF
--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2486,7 +2486,10 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         self.error_group_2 = error_event_2.group
 
     def test_no_feature(self):
-        results = self.make_query(search_filter_query="issue.category:profile my_tag:1")
+        with self.feature(
+            ["organizations:issue-platform", ProfileFileIOGroupType.build_visible_feature_name()]
+        ):
+            results = self.make_query(search_filter_query="issue.category:profile my_tag:1")
         assert list(results) == []
 
     def test_generic_query(self):
@@ -2611,7 +2614,9 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         Any queries with `error.handled` or `error.unhandled` filters querying the search_issues dataset
         should be rejected and return empty results.
         """
-        with self.feature("organizations:issue-platform"):
+        with self.feature(
+            ["organizations:issue-platform", ProfileFileIOGroupType.build_visible_feature_name()]
+        ):
             results = self.make_query(
                 projects=[self.project],
                 search_filter_query="issue.category:profile error.unhandled:0",

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2486,10 +2486,7 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         self.error_group_2 = error_event_2.group
 
     def test_no_feature(self):
-        with self.feature(
-            ["organizations:issue-platform", ProfileFileIOGroupType.build_visible_feature_name()]
-        ):
-            results = self.make_query(search_filter_query="issue.category:profile my_tag:1")
+        results = self.make_query(search_filter_query="issue.category:profile my_tag:1")
         assert list(results) == []
 
     def test_generic_query(self):


### PR DESCRIPTION
We were unintentionally not filtering results from the generic dataset by issue type. This caused us to return profile issues + perf issues that we are dual writing. Since perf issues are already being returned by `_query_params_for_perf`, this caused us to double up.


