### PR TITLE
feat(replays): mask archived replays instead of removing them from query

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -90,6 +90,7 @@ Retrieve a collection of replays.
 | error_ids         | array[string]                 | -                                                      |
 | finished_at       | string                        | The **latest** timestamp received.                     |
 | id                | string                        | The ID of the Replay instance.                         |
+| is_archived       | bool                          | Whether the replay was deleted or not.                 |
 | os.name           | optional[string]              | -                                                      |
 | os.version        | optional[string]              | -                                                      |
 | platform          | string                        | -                                                      |
@@ -133,6 +134,7 @@ Retrieve a collection of replays.
         "error_ids": ["7e07485f-12f9-416b-8b14-26260799b51f"],
         "finished_at": "2022-07-07T14:15:33.201019",
         "id": "7e07485f-12f9-416b-8b14-26260799b51f",
+        "is_archived": false,
         "os": {
           "name": "iOS",
           "version": "16.2"
@@ -391,7 +393,6 @@ Queryable fields:
 | click.testid      | string        | The data-testid of an HTML element. (omitted from public docs) |
 | click.textContent | string        | The text-content of an HTML element.                           |
 | click.title       | string        | The title attribute of an HTML element.                        |
-
 
 ### Fetch Replay Clicks [GET]
 

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -32,6 +32,10 @@ def generate_normalized_output(
 ) -> Generator[dict[str, Any], None, None]:
     """For each payload in the response strip "agg_" prefixes."""
     for item in response:
+        if item["isArchived"]:
+            yield _archived_row(item["replay_id"], item["project_id"])
+            continue
+
         item["id"] = _strip_dashes(item.pop("replay_id", None))
         item["project_id"] = str(item["project_id"])
         item["trace_ids"] = item.pop("traceIds", [])
@@ -111,3 +115,25 @@ def dict_unique_list(items: Iterable[tuple[str, str]]) -> dict[str, list[str]]:
         unique[key].add(value)
 
     return {key: list(value_set) for key, value_set in unique.items()}
+
+
+def _archived_row(replay_id, project_id):
+    return {
+        "id": _strip_dashes(replay_id),
+        "project_id": str(project_id),
+        "trace_ids": [],
+        "error_ids": [],
+        "environment": None,
+        "tags": [],
+        "user": {"id": "Archived Replay", "display_name": "Archived Replay"},
+        "sdk": {"name": None, "version": None},
+        "os": {"name": None, "version": None},
+        "browser": {"name": None, "version": None},
+        "device": {"name": None, "brand": None, "model": None, "family": None},
+        "urls": None,
+        "activity": None,
+        "count_errors": None,
+        "duration": None,
+        "finished_at": None,
+        "started_at": None,
+    }

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -117,7 +117,7 @@ def dict_unique_list(items: Iterable[tuple[str, str]]) -> dict[str, list[str]]:
     return {key: list(value_set) for key, value_set in unique.items()}
 
 
-def _archived_row(replay_id, project_id):
+def _archived_row(replay_id: str, project_id: int) -> dict[str, Any]:
     return {
         "id": _strip_dashes(replay_id),
         "project_id": str(project_id),

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -81,7 +81,7 @@ def generate_normalized_output(
         item.pop("agg_urls", None)
         item["urls"] = item.pop("urls_sorted", None)
 
-        item.pop("isArchived")
+        item["is_archived"] = bool(item.pop("isArchived", 0))
 
         item.pop("click_alt", None)
         item.pop("click_aria_label", None)

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -136,4 +136,5 @@ def _archived_row(replay_id: str, project_id: int) -> dict[str, Any]:
         "duration": None,
         "finished_at": None,
         "started_at": None,
+        "is_archived": True,
     }

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -97,7 +97,7 @@ def query_replay_instance(
         where=[
             Condition(Column("replay_id"), Op.EQ, replay_id),
         ],
-        having=[],
+        having=[Condition(Column("isArchived"), Op.EQ, 0)],
         fields=[],
         sorting=[],
         pagination=None,
@@ -152,8 +152,6 @@ def query_replays_dataset(
                 Condition(Function("min", parameters=[Column("segment_id")]), Op.EQ, 0),
                 # Make sure we're not too old.
                 Condition(Column("finished_at"), Op.LT, end),
-                # Require non-archived replays.
-                Condition(Column("isArchived"), Op.EQ, 0),
                 # User conditions.
                 *generate_valid_conditions(search_filters, query_config=ReplayQueryConfig()),
                 # Other conditions.

--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -111,6 +111,7 @@ def mock_expected_response(
         },
         "tags": kwargs.pop("tags", {}),
         "activity": kwargs.pop("activity", 0),
+        "is_archived": kwargs.pop("is_archived", False),
     }
 
 

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -819,7 +819,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             response = self.client.get(self.url + "?field=activity")
             assert response.status_code == 200
 
-    def test_archived_records_are_not_returned(self):
+    def test_archived_records_are_null_fields(self):
         replay1_id = uuid.uuid4().hex
         seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=30)
         seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=15)
@@ -832,7 +832,27 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         with self.feature(REPLAYS_FEATURES):
             response = self.client.get(self.url)
             assert response.status_code == 200
-            assert len(response.json()["data"]) == 0
+            assert response.json()["data"] == [
+                {
+                    "id": replay1_id,
+                    "project_id": str(self.project.id),
+                    "trace_ids": [],
+                    "error_ids": [],
+                    "environment": None,
+                    "tags": [],
+                    "user": {"id": "Archived Replay", "display_name": "Archived Replay"},
+                    "sdk": {"name": None, "version": None},
+                    "os": {"name": None, "version": None},
+                    "browser": {"name": None, "version": None},
+                    "device": {"name": None, "brand": None, "model": None, "family": None},
+                    "urls": None,
+                    "started_at": None,
+                    "count_errors": None,
+                    "activity": None,
+                    "finished_at": None,
+                    "duration": None,
+                }
+            ]
 
     def test_archived_records_not_returned_with_environment_filtered(self):
         self.create_environment(name="prod", project=self.project)

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -851,6 +851,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                     "activity": None,
                     "finished_at": None,
                     "duration": None,
+                    "is_archived": True,
                 }
             ]
 

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -854,40 +854,6 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 }
             ]
 
-    def test_archived_records_not_returned_with_environment_filtered(self):
-        self.create_environment(name="prod", project=self.project)
-
-        replay1_id = uuid.uuid4().hex
-        timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=30)
-        timestamp2 = datetime.datetime.now() - datetime.timedelta(seconds=20)
-
-        self.store_replays(mock_replay(timestamp1, self.project.id, replay1_id, environment="prod"))
-        self.store_replays(mock_replay(timestamp2, self.project.id, replay1_id, is_archived=True))
-
-        with self.feature(REPLAYS_FEATURES):
-            # We can't manipulate environment to hide the archival state.
-            response = self.client.get(self.url + "?field=id&environment=prod")
-            assert response.status_code == 200
-            assert len(response.json()["data"]) == 0
-
-    def test_archived_records_not_returned_with_selective_date_range(self):
-        """If the archive entry falls outside the date range ensure it can still be returned."""
-        replay1_id = uuid.uuid4().hex
-        timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=30)
-        timestamp2 = datetime.datetime.now() - datetime.timedelta(seconds=20)
-        timestamp3 = datetime.datetime.now() - datetime.timedelta(seconds=10)
-
-        self.store_replays(mock_replay(timestamp1, self.project.id, replay1_id))
-        self.store_replays(mock_replay(timestamp3, self.project.id, replay1_id, is_archived=True))
-
-        with self.feature(REPLAYS_FEATURES):
-            # We can't manipulate dates to hide the archival state.
-            response = self.client.get(
-                self.url + f"?start={timestamp1.isoformat()}&end={timestamp2.isoformat()}"
-            )
-            assert response.status_code == 200
-            assert len(response.json()["data"]) == 0
-
     def test_get_replays_filter_clicks(self):
         """Test replays conform to the interchange format."""
         project = self.create_project(teams=[self.team])


### PR DESCRIPTION
- instead of trying to filter out archived ("deleted") replays from querying, show a masked entry. this will make pagination logic far simpler on our index page, as aggregated rows will match the subquery rows in many cases.
- We can also take this as an opportunity to describe to the user what happened to their replay (the recording is deleted, and metadata is never returned to client)


Screenshot below.
<img width="1466" alt="Screenshot 2023-04-11 at 4 41 22 PM" src="https://user-images.githubusercontent.com/1976777/231313185-9ac87486-4eec-4bb9-9f40-ab47651175fb.png">
