### PR TITLE
fix(replays): Fix Replay Details header css alignment

### DIFF
--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -79,6 +79,7 @@ const KeyMetrics = styled('dl')`
   grid-auto-flow: column;
   gap: 0 ${space(3)};
   align-items: center;
+  align-self: end;
   color: ${p => p.theme.gray300};
   margin: 0;
 


### PR DESCRIPTION
Quick fix for alignment of header sections.

The OS/Browser/StartTime/Errors values were slightly higher up before. Now the bottom of those values align more closely with the bottom of the url walker that appears to the left.

**Before (prod):**
<img width="1106" alt="before" src="https://user-images.githubusercontent.com/187460/231345758-fe3e7661-6669-4a8d-b986-0b5e0efd2cac.png">

**After (dev):**
<img width="1105" alt="after" src="https://user-images.githubusercontent.com/187460/231345753-50a46b50-4e24-4aa5-8450-376406dd42b6.png">


Note: in the screen shots sentry.io shows "Contact Us" and in dev we see "Give Feedback". This difference is a SaaS thing, not related to this PR.