### PR TITLE
fix(dyn-sampling): update granularity for factor bias

### DIFF
--- a/src/sentry/dynamic_sampling/prioritise_projects.py
+++ b/src/sentry/dynamic_sampling/prioritise_projects.py
@@ -38,7 +38,9 @@ CHUNK_SIZE = 9998  # Snuba's limit is 10000, and we fetch CHUNK_SIZE+1
 
 
 def fetch_projects_with_total_volumes(
-    org_ids: List[int], query_interval: Optional[timedelta] = None
+    org_ids: List[int],
+    granularity: Optional[Granularity] = None,
+    query_interval: Optional[timedelta] = None,
 ) -> Mapping[OrganizationId, Sequence[Tuple[ProjectId, int, DecisionKeepCount, DecisionDropCount]]]:
     """
     This function fetch with pagination orgs and projects with count per root project
@@ -46,6 +48,7 @@ def fetch_projects_with_total_volumes(
     """
     if query_interval is None:
         query_interval = timedelta(hours=1)
+        granularity = Granularity(3600)
     aggregated_projects = defaultdict(list)
     start_time = time.time()
     offset = 0
@@ -97,7 +100,7 @@ def fetch_projects_with_total_volumes(
                 ],
                 groupby=[Column("org_id"), Column("project_id")],
                 where=where,
-                granularity=Granularity(3600),
+                granularity=granularity,
                 orderby=[
                     OrderBy(Column("org_id"), Direction.ASC),
                     OrderBy(Column("project_id"), Direction.ASC),

--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import Sequence, Tuple
 
 from django.core.exceptions import ObjectDoesNotExist
+from snuba_sdk import Granularity
 
 from sentry import options, quotas
 from sentry.dynamic_sampling.models.adjustment_models import AdjustedModel
@@ -66,7 +67,7 @@ def prioritise_projects() -> None:
                 process_projects_sample_rates.delay(org_id, projects_with_tx_count_and_rates)
             # TODO: @andrii potentially run it as separate celery job
             for org_id, projects_with_tx_count_and_rates in fetch_projects_with_total_volumes(
-                org_ids=orgs, query_interval=timedelta(minutes=5)
+                org_ids=orgs, granularity=Granularity(60), query_interval=timedelta(minutes=5)
             ).items():
                 process_projects_sample_factors.delay(org_id, projects_with_tx_count_and_rates)
 


### PR DESCRIPTION
DON'T merge until snuba PR https://github.com/getsentry/snuba/pull/4002

This PR change granularity to 60 for the query to calculate factor bias, because we use timedelta=5mins, not 1 hour.