### PR TITLE
feat(ci/codecov): Adjust number of builds for FE & BE

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -50,22 +50,22 @@ flags:
     paths:
     - "static/app/"
     carryforward: true
-    # FE uploads 5 coverage reports. This property ensures codecov waits
+    # FE uploads 4 coverage reports. This property ensures codecov waits
     #  for all reports to be uploaded before creating a GitHub status check.
-    after_n_builds: 5
+    after_n_builds: 4
   backend:
     paths:
     - "src/sentry/**/*.py"
     carryforward: true
     # Do not send any status checks until N coverage reports are uploaded
-    after_n_builds: 11
+    after_n_builds: 16
 
 # Read more here: https://docs.codecov.com/docs/pull-request-comments
 comment:
   # after_n_builds declared in flags cannot control when to make comments
-  # A value of 11 will mean that only BE PRs will get a comment (only if the score changes)
+  # A value of 16 will mean that only BE PRs will get a comment (only if the score changes)
   # XXX: Once commenting pays attention to the value in flags we can add comments to FE PRs
-  after_n_builds: 11
+  after_n_builds: 16
   layout: "diff, files"
   # Update, if comment exists. Otherwise post new.
   behavior: default


### PR DESCRIPTION
It seems the old number of jobs that were in my head have changed.

I discovered the right number by looking at [this](https://app.codecov.io/gh/getsentry/sentry/commit/8bdffb947962472575735891659a7c855a9c739d).
<img width="297" alt="image" src="https://user-images.githubusercontent.com/44410/231478330-54f3a7a0-677d-4dcf-8351-c157ec977232.png">
