### PR TITLE
Fix Double-Random selection of JS Processing

### DIFF
--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -1,4 +1,3 @@
-from sentry.lang.javascript.utils import should_use_symbolicator_for_sourcemaps
 from sentry.plugins.base.v2 import Plugin2
 from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.utils.safe import get_path
@@ -45,7 +44,9 @@ class JavascriptPlugin(Plugin2):
         return []
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
-        if should_use_symbolicator_for_sourcemaps(data.get("project")):
+        if data.pop("processed_by_symbolicator", False):
+            # TODO: maybe we want to still return the `JavaScriptStacktraceProcessor` for A/B testing,
+            # so that both processors are running after one another?
             return []
 
         if "javascript" in platforms or "node" in platforms:

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -2054,6 +2054,14 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 "sourcemaps.processed", amount=len(self.sourcemaps_touched), skip_internal=True
             )
 
+        # TODO: If we do some A/B testing for symbolicator, we would want to compare
+        # the stack traces processed by both the existing processor (this one), and the
+        # symbolicator result, and log any differences.
+        # Q: what do we want to diff? raw/_stacktraces? With the full source context?
+        # Processing Errors? Do we want to sample those reports?
+        # We also need to account for known differences? Like symbolicator not
+        # outputting a trailing empty line, whereas the python processor does.
+
     def suspected_console_errors(self, frames):
         def is_suspicious_frame(frame) -> bool:
             function = frame.get("function", None)


### PR DESCRIPTION
The random sampling of events was done in two places, when deciding to process via symbolicator, and afterwards when deciding to skip processing via python. This means that at random, an event could be double-processed, or worse, not processed at all.

So far this was not a problem, as we do not yet sample *any* events :-)
I also added a bunch of comments to help with implementing https://github.com/getsentry/sentry/issues/47223 eventually.