### PR TITLE
feat(mobile): Enable GA for device classification

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1334,9 +1334,9 @@ SENTRY_FEATURES = {
     # Enable anr frame analysis
     "organizations:anr-analyze-frames": False,
     # Enable device.class as a selectable column
-    "organizations:device-classification": False,
+    "organizations:device-classification": True,
     # Enables synthesis of device.class in ingest
-    "organizations:device-class-synthesis": False,
+    "organizations:device-class-synthesis": True,
     # Enable the onboarding heartbeat footer on the sdk setup page
     "organizations:onboarding-heartbeat-footer": False,
     # Enable product selection in the setup-docs page. The docs reflects the selected products.

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -60,6 +60,8 @@ class OrganizationSerializerTest(TestCase):
             "dashboards-edit",
             "discover-basic",
             "discover-query",
+            "device-class-synthesis",
+            "device-classification",
             "derive-code-mappings",
             "event-attachments",
             "integrations-alert-rule",


### PR DESCRIPTION
Sets Device Classification feature flags to True by default, ie GA for saas and self hosted

Deleting all areas where flags are checked will come in a later pr