### PR TITLE
feat(starfish): Introduce a floored_epm function

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -869,6 +869,35 @@ class DiscoverDatasetConfig(DatasetConfig):
                     ),
                 ),
                 SnQLFunction(
+                    "floored_epm",
+                    snql_aggregate=lambda args, alias: Function(
+                        "pow",
+                        [
+                            10,
+                            Function(
+                                "floor",
+                                [
+                                    Function(
+                                        "log10",
+                                        [
+                                            Function(
+                                                "divide",
+                                                [
+                                                    Function("count", []),
+                                                    Function("divide", [args["interval"], 60]),
+                                                ],
+                                            )
+                                        ],
+                                    )
+                                ],
+                            ),
+                        ],
+                        alias,
+                    ),
+                    optional_args=[IntervalDefault("interval", 1, None)],
+                    default_result_type="number",
+                ),
+                SnQLFunction(
                     "fn_span_exclusive_time",
                     required_args=[
                         SnQLStringArg("spans_op", True, True),

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -551,6 +551,49 @@ class MetricsDatasetConfig(DatasetConfig):
                     default_result_type="number",
                 ),
                 fields.MetricsFunction(
+                    "floored_epm",
+                    snql_distribution=lambda args, alias: Function(
+                        "pow",
+                        [
+                            10,
+                            Function(
+                                "floor",
+                                [
+                                    Function(
+                                        "log10",
+                                        [
+                                            Function(
+                                                "divide",
+                                                [
+                                                    Function(
+                                                        "countIf",
+                                                        [
+                                                            Column("value"),
+                                                            Function(
+                                                                "equals",
+                                                                [
+                                                                    Column("metric_id"),
+                                                                    self.resolve_metric(
+                                                                        "transaction.duration"
+                                                                    ),
+                                                                ],
+                                                            ),
+                                                        ],
+                                                    ),
+                                                    Function("divide", [args["interval"], 60]),
+                                                ],
+                                            ),
+                                        ],
+                                    )
+                                ],
+                            ),
+                        ],
+                        alias,
+                    ),
+                    optional_args=[fields.IntervalDefault("interval", 1, None)],
+                    default_result_type="number",
+                ),
+                fields.MetricsFunction(
                     "eps",
                     snql_distribution=lambda args, alias: Function(
                         "divide",

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6058,3 +6058,53 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
         response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["group_id"] == "this should just get returned"
+
+    def test_floored_epm(self):
+        for _ in range(5):
+            data = self.load_data(
+                timestamp=self.ten_mins_ago,
+                duration=timedelta(seconds=5),
+            )
+            data["transaction"] = "/aggregates/1"
+            event1 = self.store_event(data, project_id=self.project.id)
+
+        query = {
+            "field": ["transaction", "floored_epm()", "epm()"],
+            "query": "event.type:transaction",
+            "orderby": ["transaction"],
+            "start": self.eleven_mins_ago_iso,
+            "end": iso_format(self.nine_mins_ago),
+        }
+        response = self.do_request(query)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"]
+        assert data[0]["transaction"] == event1.transaction
+        assert data[0]["floored_epm()"] == 1
+        assert data[0]["epm()"] == 2.5
+
+    def test_floored_epm_more_events(self):
+        for _ in range(25):
+            data = self.load_data(
+                timestamp=self.ten_mins_ago,
+                duration=timedelta(seconds=5),
+            )
+            data["transaction"] = "/aggregates/1"
+            event1 = self.store_event(data, project_id=self.project.id)
+
+        query = {
+            "field": ["transaction", "floored_epm()", "epm()"],
+            "query": "event.type:transaction",
+            "orderby": ["transaction"],
+            "start": self.eleven_mins_ago_iso,
+            "end": iso_format(self.nine_mins_ago),
+        }
+        response = self.do_request(query)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"]
+        assert data[0]["transaction"] == event1.transaction
+        assert data[0]["epm()"] == 12.5
+        assert data[0]["floored_epm()"] == 10


### PR DESCRIPTION
- This introduces a function that will floor epm() to the closest power of ten. For example 12849 would become 10k
  - Hopefully this will work as a grouping function in starfish so we can secondary sort by duration or similar, while showing interesting transactions (ie. not something with epm=1 but duration=9001)