### PR TITLE
Document 'download' query parameter

### DIFF
--- a/api-docs/paths/releases/project-release-file.json
+++ b/api-docs/paths/releases/project-release-file.json
@@ -116,6 +116,14 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "download",
+        "in": "query",
+        "description": "If this is set to true, then the response payload will be the raw file contents. Otherwise, the response will be the file metadata as JSON.",
+        "schema": {
+          "type": "boolean"
+        }
       }
     ],
     "requestBody": {

--- a/api-docs/paths/releases/project-release-file.json
+++ b/api-docs/paths/releases/project-release-file.json
@@ -39,6 +39,14 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "download",
+        "in": "query",
+        "description": "If this is set to true, then the response payload will be the raw file contents. Otherwise, the response will be the file metadata as JSON.",
+        "schema": {
+          "type": "boolean"
+        }
       }
     ],
     "responses": {
@@ -115,14 +123,6 @@
         "required": true,
         "schema": {
           "type": "string"
-        }
-      },
-      {
-        "name": "download",
-        "in": "query",
-        "description": "If this is set to true, then the response payload will be the raw file contents. Otherwise, the response will be the file metadata as JSON.",
-        "schema": {
-          "type": "boolean"
         }
       }
     ],

--- a/api-docs/paths/releases/release-file.json
+++ b/api-docs/paths/releases/release-file.json
@@ -30,6 +30,14 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "download",
+        "in": "query",
+        "description": "If this is set to true, then the response payload will be the raw file contents. Otherwise, the response will be the file metadata as JSON.",
+        "schema": {
+          "type": "boolean"
+        }
       }
     ],
     "responses": {


### PR DESCRIPTION

<!-- Describe your PR here. -->

Documents the `download` query parameter for downloading files from a given release. I've updated two places:

 - Project release file [here](https://docs.sentry.io/api/releases/retrieve-a-project-releases-file/). 
 - Organization release file [here](https://docs.sentry.io/api/releases/retrieve-an-organization-releases-file/)

I've assumed it works for both, but have only personally verified the first one in testing so worth checking I'm not lying about the organization one :grin: 

This was mentioned in [this issue comment](https://github.com/getsentry/sentry/issues/32107#issuecomment-1060521498) but never actually done. Also mentioned in https://github.com/getsentry/sentry/issues/42759.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
