### PR TITLE
chore(hybrid-cloud): Update OrganizationMemberMapping to consume RpcService subclass

### DIFF
--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
@@ -9,16 +9,17 @@ from datetime import datetime
 from typing import Optional, TypedDict
 
 from django.utils import timezone
+from pydantic.fields import Field
 
 from sentry.models import OrganizationMember
-from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
+from sentry.services.hybrid_cloud import RpcModel, silo_mode_delegation, stubbed
+from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.silo import SiloMode
 
 
-@dataclass(frozen=True, eq=True)
-class RpcOrganizationMemberMapping:
+class RpcOrganizationMemberMapping(RpcModel):
     organization_id: int = -1
-    date_added: datetime = field(default_factory=timezone.now)
+    date_added: datetime = Field(default_factory=timezone.now)
 
     role: str = ""
     user_id: Optional[int] = None

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
@@ -4,15 +4,14 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, cast
 
 from django.utils import timezone
 from pydantic.fields import Field
 
 from sentry.models import OrganizationMember
-from sentry.services.hybrid_cloud import RpcModel, silo_mode_delegation, stubbed
+from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.silo import SiloMode
 
@@ -54,7 +53,19 @@ def update_organizationmember_mapping_from_instance(
     return RpcOrganizationMemberMappingUpdate(**attributes)  # type: ignore
 
 
-class OrganizationMemberMappingService(InterfaceWithLifecycle):
+class OrganizationMemberMappingService(RpcService):
+    key = "organizationmember_mapping"
+    local_mode = SiloMode.CONTROL
+
+    @classmethod
+    def get_local_implementation(cls) -> RpcService:
+        from sentry.services.hybrid_cloud.organizationmember_mapping.impl import (
+            DatabaseBackedOrganizationMemberMappingService,
+        )
+
+        return DatabaseBackedOrganizationMemberMappingService()
+
+    @rpc_method
     @abstractmethod
     def create_mapping(
         self,
@@ -68,9 +79,10 @@ class OrganizationMemberMappingService(InterfaceWithLifecycle):
     ) -> RpcOrganizationMemberMapping:
         pass
 
+    @rpc_method
     @abstractmethod
     def create_with_organization_member(
-        self, org_member: OrganizationMember
+        self, *, org_member: OrganizationMember
     ) -> RpcOrganizationMemberMapping:
         pass
 
@@ -83,10 +95,6 @@ def impl_with_db() -> OrganizationMemberMappingService:
     return DatabaseBackedOrganizationMemberMappingService()
 
 
-organizationmember_mapping_service: OrganizationMemberMappingService = silo_mode_delegation(
-    {
-        SiloMode.MONOLITH: impl_with_db,
-        SiloMode.REGION: stubbed(impl_with_db, SiloMode.CONTROL),
-        SiloMode.CONTROL: impl_with_db,
-    }
+organizationmember_mapping_service: OrganizationMemberMappingService = cast(
+    OrganizationMemberMappingService, OrganizationMemberMappingService.create_delegation()
 )

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
@@ -3,8 +3,7 @@
 # in modules such as this one where hybrid cloud service classes and data models are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from dataclasses import fields
-from typing import Optional
+from typing import Optional, cast
 
 from django.db import transaction
 
@@ -44,7 +43,7 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
         return self._serialize_rpc(org_member_mapping)
 
     def create_with_organization_member(
-        self, org_member: OrganizationMember
+        self, *, org_member: OrganizationMember
     ) -> RpcOrganizationMemberMapping:
         return self.create_mapping(
             organization_id=org_member.organization_id,
@@ -61,9 +60,7 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
     def _serialize_rpc(
         self, org_member_mapping: OrganizationMemberMapping
     ) -> RpcOrganizationMemberMapping:
-        args = {
-            field.name: getattr(org_member_mapping, field.name)
-            for field in fields(RpcOrganizationMemberMapping)
-            if hasattr(org_member_mapping, field.name)
-        }
-        return RpcOrganizationMemberMapping(**args)
+        return cast(
+            RpcOrganizationMemberMapping,
+            RpcOrganizationMemberMapping.serialize_by_field_name(org_member_mapping),
+        )

--- a/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
@@ -53,7 +53,7 @@ class OrganizationMappingTest(TransactionTestCase):
         with exempt_from_silo_limits():
             org_member = OrganizationMember.objects.create(**fields)
         rpc_orgmember_mapping = organizationmember_mapping_service.create_with_organization_member(
-            org_member
+            org_member=org_member
         )
         orgmember_mapping = OrganizationMemberMapping.objects.get(
             organization_id=self.organization.id


### PR DESCRIPTION
Making use of the `RpcService` subclass and `rpc_method` decorator introduced by @RyanSkonnord  in https://github.com/getsentry/sentry/pull/46488.