### PR TITLE
feat(transactions): CPU/Memory chart redesign

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -179,13 +179,25 @@ class TraceViewHeader extends Component<PropType, State> {
     );
   }
 
-  renderFog(dragProps: DragManagerChildrenProps) {
+  renderFog(
+    dragProps: DragManagerChildrenProps,
+    hasProfileMeasurementsChart: boolean = false
+  ) {
     return (
       <Fragment>
-        <Fog style={{height: '100%', width: toPercent(dragProps.viewWindowStart)}} />
         <Fog
           style={{
-            height: '100%',
+            height: hasProfileMeasurementsChart
+              ? `calc(100% - ${TIME_AXIS_HEIGHT}px)`
+              : '100%',
+            width: toPercent(dragProps.viewWindowStart),
+          }}
+        />
+        <Fog
+          style={{
+            height: hasProfileMeasurementsChart
+              ? `calc(100% - ${TIME_AXIS_HEIGHT}px)`
+              : '100%',
             width: toPercent(1 - dragProps.viewWindowEnd),
             left: toPercent(dragProps.viewWindowEnd),
           }}
@@ -542,7 +554,7 @@ class TraceViewHeader extends Component<PropType, State> {
                         <ProfilingMeasurements
                           profileData={profiles.data}
                           renderCursorGuide={this.renderCursorGuide}
-                          renderFog={() => this.renderFog(this.props.dragProps)}
+                          renderFog={() => this.renderFog(this.props.dragProps, true)}
                           renderWindowSelection={() =>
                             this.renderWindowSelection(this.props.dragProps)
                           }

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -117,15 +117,18 @@ class TraceViewHeader extends Component<PropType, State> {
     );
   }
 
-  renderViewHandles({
-    isDragging,
-    onLeftHandleDragStart,
-    leftHandlePosition,
-    onRightHandleDragStart,
-    rightHandlePosition,
-    viewWindowStart,
-    viewWindowEnd,
-  }: DragManagerChildrenProps) {
+  renderViewHandles(
+    {
+      isDragging,
+      onLeftHandleDragStart,
+      leftHandlePosition,
+      onRightHandleDragStart,
+      rightHandlePosition,
+      viewWindowStart,
+      viewWindowEnd,
+    }: DragManagerChildrenProps,
+    hasProfileMeasurementsChart: boolean
+  ) {
     const leftHandleGhost = isDragging ? (
       <Handle
         left={viewWindowStart}
@@ -133,6 +136,7 @@ class TraceViewHeader extends Component<PropType, State> {
           // do nothing
         }}
         isDragging={false}
+        hasProfileMeasurementsChart={hasProfileMeasurementsChart}
       />
     ) : null;
 
@@ -141,6 +145,7 @@ class TraceViewHeader extends Component<PropType, State> {
         left={leftHandlePosition}
         onMouseDown={onLeftHandleDragStart}
         isDragging={isDragging}
+        hasProfileMeasurementsChart={hasProfileMeasurementsChart}
       />
     );
 
@@ -149,6 +154,7 @@ class TraceViewHeader extends Component<PropType, State> {
         left={rightHandlePosition}
         onMouseDown={onRightHandleDragStart}
         isDragging={isDragging}
+        hasProfileMeasurementsChart={hasProfileMeasurementsChart}
       />
     );
 
@@ -159,6 +165,7 @@ class TraceViewHeader extends Component<PropType, State> {
           // do nothing
         }}
         isDragging={false}
+        hasProfileMeasurementsChart={hasProfileMeasurementsChart}
       />
     ) : null;
 
@@ -517,7 +524,10 @@ class TraceViewHeader extends Component<PropType, State> {
                                 mouseLeft,
                                 cursorGuideHeight: MINIMAP_HEIGHT,
                               })}
-                              {this.renderViewHandles(this.props.dragProps)}
+                              {this.renderViewHandles(
+                                this.props.dragProps,
+                                hasProfileMeasurementsChart
+                              )}
                               {this.renderWindowSelection(this.props.dragProps)}
                             </MinimapContainer>
                             {this.renderTimeAxis({
@@ -811,6 +821,7 @@ const ViewHandleContainer = styled('div')`
   position: absolute;
   top: 0;
   height: 100%;
+  z-index: 1;
 `;
 
 const ViewHandleLine = styled('div')`
@@ -872,7 +883,9 @@ function Handle({
   left,
   onMouseDown,
   isDragging,
+  hasProfileMeasurementsChart,
 }: {
+  hasProfileMeasurementsChart: boolean;
   isDragging: boolean;
   left: number;
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -881,6 +894,11 @@ function Handle({
     <ViewHandleContainer
       style={{
         left: toPercent(left),
+        height: `${
+          hasProfileMeasurementsChart
+            ? MINIMAP_HEIGHT + PROFILE_MEASUREMENTS_CHART_HEIGHT
+            : MINIMAP_HEIGHT
+        }px`,
       }}
     >
       <ViewHandleLine />

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -309,12 +309,14 @@ class TraceViewHeader extends Component<PropType, State> {
   renderTimeAxis({
     showCursorGuide,
     mouseLeft,
+    hasProfileMeasurementsChart,
   }: {
+    hasProfileMeasurementsChart: boolean;
     mouseLeft: number | undefined;
     showCursorGuide: boolean;
   }) {
     return (
-      <TimeAxis>
+      <TimeAxis hasProfileMeasurementsChart={hasProfileMeasurementsChart}>
         {this.renderTicks()}
         {this.renderCursorGuide({
           showCursorGuide,
@@ -521,6 +523,7 @@ class TraceViewHeader extends Component<PropType, State> {
                             {this.renderTimeAxis({
                               showCursorGuide,
                               mouseLeft,
+                              hasProfileMeasurementsChart,
                             })}
                           </RightSidePane>
                         )}
@@ -674,12 +677,17 @@ class ActualMinimap extends PureComponent<{
   }
 }
 
-const TimeAxis = styled('div')`
+const TimeAxis = styled('div')<{hasProfileMeasurementsChart: boolean}>`
   width: 100%;
   position: absolute;
+  margin-left: -1px;
   left: 0;
-  top: ${MINIMAP_HEIGHT}px;
+  top: ${p =>
+    p.hasProfileMeasurementsChart
+      ? MINIMAP_HEIGHT + PROFILE_MEASUREMENTS_CHART_HEIGHT
+      : MINIMAP_HEIGHT}px;
   border-top: 1px solid ${p => p.theme.border};
+  border-left: 1px solid ${p => p.theme.border};
   height: ${TIME_AXIS_HEIGHT}px;
   background-color: ${p => p.theme.background};
   color: ${p => p.theme.gray300};

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -690,14 +690,12 @@ class ActualMinimap extends PureComponent<{
 const TimeAxis = styled('div')<{hasProfileMeasurementsChart: boolean}>`
   width: 100%;
   position: absolute;
-  margin-left: -1px;
   left: 0;
   top: ${p =>
     p.hasProfileMeasurementsChart
       ? MINIMAP_HEIGHT + PROFILE_MEASUREMENTS_CHART_HEIGHT
       : MINIMAP_HEIGHT}px;
   border-top: 1px solid ${p => p.theme.border};
-  border-left: 1px solid ${p => p.theme.border};
   height: ${TIME_AXIS_HEIGHT}px;
   background-color: ${p => p.theme.background};
   color: ${p => p.theme.gray300};

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -170,7 +170,7 @@ function ProfilingMeasurements({
                       [MEMORY, getChartName(MEMORY)],
                     ]}
                     value={measurementType}
-                    label={t('potato')}
+                    label={t('Profile Measurements Chart Type')}
                     onChange={type => {
                       setMeasurementType(type);
                     }}

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -4,19 +4,14 @@ import styled from '@emotion/styled';
 import uniqBy from 'lodash/uniqBy';
 
 import {LineChart, LineChartSeries} from 'sentry/components/charts/lineChart';
-import DropdownButton from 'sentry/components/dropdownButton';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {
   MINIMAP_HEIGHT,
   PROFILE_MEASUREMENTS_CHART_HEIGHT,
+  TIME_AXIS_HEIGHT,
 } from 'sentry/components/events/interfaces/spans/constants';
 import * as DividerHandlerManager from 'sentry/components/events/interfaces/spans/dividerHandlerManager';
-import {
-  OpsDot,
-  OpsLine,
-  OpsName,
-  OpsNameContainer,
-} from 'sentry/components/events/opsBreakdown';
+import {OpsLine} from 'sentry/components/events/opsBreakdown';
+import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import {DividerSpacer} from 'sentry/components/performance/waterfall/miniHeader';
 import {toPercent} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
@@ -104,7 +99,7 @@ function Chart({data, type}: ChartProps) {
       seriesOptions={{
         showSymbol: false,
       }}
-      colors={[theme.green200] as string[]}
+      colors={[theme.red300] as string[]}
       tooltip={{
         valueFormatter: (value, _seriesName) => {
           if (type === CPU_USAGE) {
@@ -147,7 +142,6 @@ function ProfilingMeasurements({
   renderFog,
   renderWindowSelection,
 }: ProfilingMeasurementsProps) {
-  const theme = useTheme();
   const [measurementType, setMeasurementType] = useState<
     typeof CPU_USAGE | typeof MEMORY
   >(CPU_USAGE);
@@ -169,32 +163,18 @@ function ProfilingMeasurements({
             <MeasurementContainer>
               <ChartOpsLabel dividerPosition={dividerPosition}>
                 <OpsLine>
-                  <OpsNameContainer>
-                    <OpsDot style={{backgroundColor: theme.green200}} />
-                    <StyledDropdownMenu
-                      trigger={triggerProps => (
-                        <StyledDropdownButton {...triggerProps} borderless>
-                          <OpsName>{getChartName(measurementType)}</OpsName>
-                        </StyledDropdownButton>
-                      )}
-                      items={[
-                        {
-                          key: CPU_USAGE,
-                          label: getChartName(CPU_USAGE),
-                          onAction: () => {
-                            setMeasurementType(CPU_USAGE);
-                          },
-                        },
-                        {
-                          key: MEMORY,
-                          label: getChartName(MEMORY),
-                          onAction: () => {
-                            setMeasurementType(MEMORY);
-                          },
-                        },
-                      ]}
-                    />
-                  </OpsNameContainer>
+                  <RadioGroup
+                    style={{overflowX: 'visible'}}
+                    choices={[
+                      [CPU_USAGE, getChartName(CPU_USAGE)],
+                      [MEMORY, getChartName(MEMORY)],
+                    ]}
+                    value={measurementType}
+                    label={t('potato')}
+                    onChange={type => {
+                      setMeasurementType(type);
+                    }}
+                  />
                 </OpsLine>
               </ChartOpsLabel>
               <DividerSpacer />
@@ -245,8 +225,10 @@ const ChartContainer = styled('div')`
 `;
 
 const ChartOpsLabel = styled('div')<{dividerPosition: number}>`
+  display: flex;
+  align-items: center;
   width: calc(${p => toPercent(p.dividerPosition)} - 0.5px);
-  height: 100%;
+  height: ${PROFILE_MEASUREMENTS_CHART_HEIGHT + TIME_AXIS_HEIGHT}px;
   padding-left: ${space(3)};
 `;
 
@@ -256,15 +238,4 @@ const MeasurementContainer = styled('div')`
   width: 100%;
   top: ${MINIMAP_HEIGHT}px;
   border-top: 1px solid ${p => p.theme.border};
-`;
-
-const StyledDropdownButton = styled(DropdownButton)`
-  padding: 0;
-  padding-right: ${space(0.5)};
-  margin-left: 0;
-  font-weight: normal;
-`;
-
-const StyledDropdownMenu = styled(DropdownMenu)`
-  margin-left: 0;
 `;

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -9,7 +9,6 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {
   MINIMAP_HEIGHT,
   PROFILE_MEASUREMENTS_CHART_HEIGHT,
-  TIME_AXIS_HEIGHT,
 } from 'sentry/components/events/interfaces/spans/constants';
 import * as DividerHandlerManager from 'sentry/components/events/interfaces/spans/dividerHandlerManager';
 import {
@@ -256,7 +255,7 @@ const MeasurementContainer = styled('div')`
   display: flex;
   position: absolute;
   width: 100%;
-  top: ${MINIMAP_HEIGHT + TIME_AXIS_HEIGHT}px;
+  top: ${MINIMAP_HEIGHT}px;
 `;
 
 const StyledDropdownButton = styled(DropdownButton)`

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -242,7 +242,6 @@ const Overlays = styled('div')`
 const ChartContainer = styled('div')`
   position: relative;
   flex: 1;
-  border-top: 1px solid ${p => p.theme.border};
 `;
 
 const ChartOpsLabel = styled('div')<{dividerPosition: number}>`
@@ -256,6 +255,7 @@ const MeasurementContainer = styled('div')`
   position: absolute;
   width: 100%;
   top: ${MINIMAP_HEIGHT}px;
+  border-top: 1px solid ${p => p.theme.border};
 `;
 
 const StyledDropdownButton = styled(DropdownButton)`

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -320,7 +320,7 @@ export const OpsLine = styled('div')`
   }
 `;
 
-export const OpsDot = styled('div')`
+const OpsDot = styled('div')`
   content: '';
   display: block;
   width: 8px;
@@ -335,11 +335,11 @@ const OpsContent = styled('div')`
   align-items: center;
 `;
 
-export const OpsNameContainer = styled(OpsContent)`
+const OpsNameContainer = styled(OpsContent)`
   overflow: hidden;
 `;
 
-export const OpsName = styled('div')`
+const OpsName = styled('div')`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Implements a new design by changing the select to radio buttons, updating the chart color, moving the time axis below the chart, and extending the view handles below the chart as well.

Before:

<img width="1116" alt="Screenshot 2023-04-12 at 1 18 17 PM" src="https://user-images.githubusercontent.com/22846452/231536835-83ee6de7-0a05-4ae7-b467-07b9bb26f8c9.png">


After:

<img width="1125" alt="Screenshot 2023-04-12 at 1 34 09 PM" src="https://user-images.githubusercontent.com/22846452/231538325-a055d5f3-1681-414e-be5d-d862f320c71b.png">
