### PR TITLE
feat(profiling): Show total self time for suspect functions

### DIFF
--- a/static/app/components/profiling/functionsMiniGrid.tsx
+++ b/static/app/components/profiling/functionsMiniGrid.tsx
@@ -37,7 +37,9 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
   return (
     <FunctionsMiniGridContainer>
       <FunctionsMiniGridHeader>{t('Slowest app functions')}</FunctionsMiniGridHeader>
-      <FunctionsMiniGridHeader align="right">{t('P95')}</FunctionsMiniGridHeader>
+      <FunctionsMiniGridHeader align="right">
+        {t('Total Self Time')}
+      </FunctionsMiniGridHeader>
       <FunctionsMiniGridHeader align="right">{t('Count')}</FunctionsMiniGridHeader>
 
       {functions &&
@@ -57,7 +59,7 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
                 </FunctionNameTextTruncate>
               </FunctionsMiniGridCell>
               <FunctionsMiniGridCell align="right">
-                <PerformanceDuration nanoseconds={f.p95} abbreviation />
+                <PerformanceDuration nanoseconds={f.sum} abbreviation />
               </FunctionsMiniGridCell>
               <FunctionsMiniGridCell align="right">
                 <NumberContainer>{f.count}</NumberContainer>

--- a/static/app/components/profiling/suspectFunctions/functionsTable.spec.tsx
+++ b/static/app/components/profiling/suspectFunctions/functionsTable.spec.tsx
@@ -59,6 +59,7 @@ describe('FunctionsTable', function () {
       p75: 10000000,
       p95: 12000000,
       p99: 12500000,
+      sum: 25000000,
       package: 'bar',
       path: 'baz',
       worst: 'cccccccccccccccccccccccccccccccc',
@@ -86,8 +87,11 @@ describe('FunctionsTable', function () {
     expect(screen.getByText('Occurrences')).toBeInTheDocument();
     expect(screen.getByText('10')).toBeInTheDocument();
 
-    expect(screen.getByText('P75 Duration')).toBeInTheDocument();
+    expect(screen.getByText('P75 Self Time')).toBeInTheDocument();
     expect(screen.getByText('10.00ms')).toBeInTheDocument();
+
+    expect(screen.getByText('Total Self Time')).toBeInTheDocument();
+    expect(screen.getByText('25.00ms')).toBeInTheDocument();
   });
 
   it('renders empty name', function () {
@@ -99,6 +103,7 @@ describe('FunctionsTable', function () {
       p75: 10000000,
       p95: 12000000,
       p99: 12500000,
+      sum: 25000000,
       package: 'bar',
       path: 'baz',
       worst: 'cccccccccccccccccccccccccccccccc',
@@ -133,6 +138,7 @@ describe('FunctionsTable', function () {
       p75: 10000000,
       p95: 12000000,
       p99: 12500000,
+      sum: 25000000,
       package: '',
       path: 'baz',
       worst: 'cccccccccccccccccccccccccccccccc',

--- a/static/app/components/profiling/suspectFunctions/functionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/functionsTable.tsx
@@ -42,7 +42,7 @@ function FunctionsTable(props: FunctionsTableProps) {
     }
 
     if (!SORTABLE_COLUMNS.has(column as any)) {
-      column = 'p75';
+      column = 'sum';
     }
 
     return {
@@ -131,7 +131,13 @@ function FunctionsTable(props: FunctionsTableProps) {
   );
 }
 
-const RIGHT_ALIGNED_COLUMNS = new Set<TableColumnKey>(['p75', 'p95', 'p99', 'count']);
+const RIGHT_ALIGNED_COLUMNS = new Set<TableColumnKey>([
+  'p75',
+  'p95',
+  'p99',
+  'sum',
+  'count',
+]);
 const SORTABLE_COLUMNS = RIGHT_ALIGNED_COLUMNS;
 
 function renderFunctionsTableCell(
@@ -177,6 +183,7 @@ function ProfilingFunctionsTableCell({
     case 'p75':
     case 'p95':
     case 'p99':
+    case 'sum':
       return (
         <NumberContainer>
           <PerformanceDuration nanoseconds={value} abbreviation />
@@ -199,7 +206,14 @@ type TableDataRow = Record<TableColumnKey, any>;
 
 type TableColumn = GridColumnOrder<TableColumnKey>;
 
-const COLUMN_ORDER: TableColumnKey[] = ['name', 'package', 'count', 'p75', 'examples'];
+const COLUMN_ORDER: TableColumnKey[] = [
+  'name',
+  'package',
+  'count',
+  'p75',
+  'sum',
+  'examples',
+];
 
 const COLUMNS: Record<TableColumnKey, TableColumn> = {
   name: {
@@ -214,17 +228,22 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   },
   p75: {
     key: 'p75',
-    name: t('P75 Duration'),
+    name: t('P75 Self Time'),
     width: COL_WIDTH_UNDEFINED,
   },
   p95: {
     key: 'p95',
-    name: t('P95 Duration'),
+    name: t('P95 Self Time'),
     width: COL_WIDTH_UNDEFINED,
   },
   p99: {
     key: 'p99',
-    name: t('P99 Duration'),
+    name: t('P99 Self Time'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  sum: {
+    key: 'sum',
+    name: t('Total Self Time'),
     width: COL_WIDTH_UNDEFINED,
   },
   count: {

--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -36,7 +36,7 @@ export function SuspectFunctionsTable({
     [location.query.functionsCursor]
   );
   const functionsSort = useMemo(
-    () => decodeScalar(location.query.functionsSort, '-p75'),
+    () => decodeScalar(location.query.functionsSort, '-sum'),
     [location.query.functionsSort]
   );
 

--- a/static/app/types/profiling/core.tsx
+++ b/static/app/types/profiling/core.tsx
@@ -51,6 +51,7 @@ export type SuspectFunction = {
   p95: number;
   p99: number;
   package: string;
+  sum: number;
   worst: string;
 };
 

--- a/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
+++ b/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
@@ -63,7 +63,7 @@ export function useProfilingTransactionQuickSummary(
     query: '',
     selection,
     transaction,
-    sort: '-p95',
+    sort: '-sum',
     functionType: 'application',
     enabled: !skipFunctions,
   });


### PR DESCRIPTION
We want to surface total self time as a better metric of impact for each function over the p75.