### PR TITLE
ref(code mappings): Prework for deriving mappings for more distinct issues

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -760,10 +760,10 @@ def process_code_mappings(job: PostProcessJob) -> None:
             if event.data["platform"] not in SUPPORTED_LANGUAGES:
                 return
 
-            cache_key = f"code-mappings:{project.id}"
-            project_queued = cache.get(cache_key)
+            project_cache_key = f"code-mappings:project:{project.id}:"
+            project_queued = cache.get(project_cache_key)
             if project_queued is None:
-                cache.set(cache_key, True, 3600)
+                cache.set(project_cache_key, True, 3600)
 
             if project_queued:
                 return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -753,6 +753,7 @@ def process_code_mappings(job: PostProcessJob) -> None:
     try:
         event = job["event"]
         project = event.project
+        group_id = event.group_id
 
         with metrics.timer("post_process.process_code_mappings.duration"):
             # Supported platforms
@@ -773,7 +774,7 @@ def process_code_mappings(job: PostProcessJob) -> None:
 
             if features.has("organizations:derive-code-mappings", org):
                 logger.info(
-                    f"derive_code_mappings: Queuing code mapping derivation for {project.slug=} {event.group_id=}."
+                    f"derive_code_mappings: Queuing code mapping derivation for {project.slug=} {group_id=}."
                     + f" Future events in {org_slug=} will not have not have code mapping derivation until {next_time}"
                 )
                 derive_code_mappings.delay(project.id, event.data)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -760,12 +760,12 @@ def process_code_mappings(job: PostProcessJob) -> None:
             if event.data["platform"] not in SUPPORTED_LANGUAGES:
                 return
 
+            # Limit the overall number of tasks by only processing one issue per project
+            # per hour
             project_cache_key = f"code-mappings:project:{project.id}:"
-            project_queued = cache.get(project_cache_key)
-            if project_queued is None:
+            if cache.get(project_cache_key) is None:
                 cache.set(project_cache_key, True, 3600)
-
-            if project_queued:
+            else:
                 return
 
             org = event.project.organization

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -7,12 +7,10 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
 from sentry.testutils import APITestCase
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 
 
 @region_silo_test(stable=True)
-@apply_feature_flag_on_cls("organizations:derive-code-mappings")
 class OrganizationDeriveCodeMappingsTest(APITestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -13,7 +13,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.tasks.derive_code_mappings import derive_code_mappings, identify_stacktrace_paths
 from sentry.testutils import TestCase
-from sentry.testutils.helpers import apply_feature_flag_on_cls, with_feature
+from sentry.testutils.helpers import with_feature
 from sentry.utils.locking import UnableToAcquireLock
 
 
@@ -35,7 +35,6 @@ class BaseDeriveCodeMappings(TestCase):
         return self.store_event(data=test_data, project_id=self.project.id).data
 
 
-@apply_feature_flag_on_cls("organizations:derive-code-mappings")
 class TestTaskBehavior(BaseDeriveCodeMappings):
     """Test task behavior that is not language specific."""
 
@@ -138,7 +137,6 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
         assert stacktrace_paths == []
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_starts_with_period_slash(self):
         repo_name = "foo/bar"
         with patch(
@@ -158,7 +156,6 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_starts_with_period_slash_no_containing_directory(self):
         repo_name = "foo/bar"
         with patch(
@@ -178,7 +175,6 @@ class TestJavascriptDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_one_to_one_match(self):
         repo_name = "foo/bar"
         with patch(
@@ -217,7 +213,6 @@ class TestRubyDeriveCodeMappings(BaseDeriveCodeMappings):
         assert set(stacktrace_paths) == {"some/path/test.rb", "lib/tasks/crontask.rake"}
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_rb(self):
         repo_name = "foo/bar"
         with patch(
@@ -233,7 +228,6 @@ class TestRubyDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_rake(self):
         repo_name = "foo/bar"
         with patch(
@@ -279,7 +273,6 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
         }
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_starts_with_app(self):
         repo_name = "foo/bar"
         with patch(
@@ -295,7 +288,6 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_starts_with_multiple_dot_dot_slash(self):
         repo_name = "foo/bar"
         with patch(
@@ -311,7 +303,6 @@ class TestNodeDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_starts_with_app_dot_dot_slash(self):
         repo_name = "foo/bar"
         with patch(
@@ -390,7 +381,6 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             )
         ],
     )
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_single_project(
         self, mock_generate_code_mappings, mock_get_trees_for_org
     ):
@@ -428,7 +418,6 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
         ],
     )
     @patch("sentry.tasks.derive_code_mappings.logger")
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_duplicates(
         self, mock_logger, mock_generate_code_mappings, mock_get_trees_for_org
     ):
@@ -466,7 +455,6 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
         assert mock_logger.info.call_count == 1
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_stack_and_source_root_do_not_match(self):
         repo_name = "foo/bar"
         with patch(
@@ -482,7 +470,6 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.source_root == "src/sentry/"
 
     @responses.activate
-    @with_feature("organizations:derive-code-mappings")
     def test_derive_code_mappings_no_normalization(self):
         repo_name = "foo/bar"
         with patch(

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from copy import deepcopy
-from typing import Dict, List, Union
 from unittest.mock import patch
 
 import pytest
 import responses
 
+from sentry.db.models.fields.node import NodeData
 from sentry.integrations.utils.code_mapping import CodeMapping, Repo, RepoTree
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
@@ -30,7 +32,7 @@ class BaseDeriveCodeMappings(TestCase):
             metadata={"domain_name": "github.com/Test-Org"},
         )
 
-    def generate_data(self, frames: List[Dict[str, Union[str, bool]]], platform: str = ""):
+    def generate_data(self, frames: list[dict[str, str | bool]], platform: str = "") -> NodeData:
         test_data = {"platform": platform or self.platform, "stacktrace": {"frames": frames}}
         return self.store_event(data=test_data, project_id=self.project.id).data
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 from datetime import datetime, timedelta
-from typing import Dict
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -170,7 +169,7 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
 
 
 class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
-    def _call_post_process_group(self, data: Dict[str, str]) -> None:
+    def _call_post_process_group(self, data: dict[str, str]) -> None:
         event = self.create_event(data=data, project_id=self.project.id)
         self.call_post_process_group(
             is_new=True,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -53,7 +53,7 @@ from sentry.tasks.post_process import (
 )
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import BaseTestCase
-from sentry.testutils.helpers import apply_feature_flag_on_cls, with_feature
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
@@ -169,7 +169,6 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
         assert event_processing_store.get(cache_key) is None
 
 
-@apply_feature_flag_on_cls("organizations:derive-code-mappings")
 class DeriveCodeMappingsProcessGroupTestMixin(BasePostProgressGroupMixin):
     def _call_post_process_group(self, data: Dict[str, str]) -> None:
         event = self.create_event(data=data, project_id=self.project.id)


### PR DESCRIPTION
This is a collection of small refactorings pulled from an upcoming PR in order to make review easier. No changes in behavior.

Included changes:

- In `post_process.process_code_mappings`, specify the cache key is for keeping track of projects and simplify conditional logic.
- Remove test decorators turning on the `organizations:derive-code-mappings` feature, now that it's [on by default](https://github.com/getsentry/sentry/blob/d9e6cc0bb554c367b48708107d6e34458342340c/src/sentry/conf/server.py#L1066).
- Clean up a few types in tests based on updated best practices according to the [Python docs](https://typing.readthedocs.io/en/latest/source/best_practices.html#stylistic-practices).
- In `test_post_process.DeriveCodeMappingsProcessGroupTestMixin`, pull event creation out into a separate helper method.
