### PR TITLE
feat(starfish): Add nested routing

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1689,6 +1689,18 @@ function buildRoutes() {
           {performanceChildRoutes}
         </Route>
       )}
+      <Route
+        path="/organizations/:orgId/performance/"
+        component={withDomainRedirect(make(() => import('sentry/views/performance')))}
+        key="org-performance"
+      >
+        {performanceChildRoutes}
+      </Route>
+    </Fragment>
+  );
+
+  const starfishRoutes = (
+    <Fragment>
       {usingCustomerDomain && (
         <Route
           path="/starfish/"
@@ -1701,13 +1713,6 @@ function buildRoutes() {
         path="organizations/:orgId/starfish/"
         component={make(() => import('sentry/views/starfish/content'))}
       />
-      <Route
-        path="/organizations/:orgId/performance/"
-        component={withDomainRedirect(make(() => import('sentry/views/performance')))}
-        key="org-performance"
-      >
-        {performanceChildRoutes}
-      </Route>
     </Fragment>
   );
 
@@ -2137,6 +2142,7 @@ function buildRoutes() {
       {statsRoutes}
       {discoverRoutes}
       {performanceRoutes}
+      {starfishRoutes}
       {profilingRoutes}
       {adminManageRoutes}
       {gettingStartedRoutes}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1699,20 +1699,43 @@ function buildRoutes() {
     </Fragment>
   );
 
+  const starfishChildRoutes = (
+    <Fragment>
+      <IndexRoute component={make(() => import('sentry/views/starfish/content'))} />
+      <Route
+        path="database/"
+        component={make(() => import('sentry/views/starfish/modules/databaseModule'))}
+      />
+      <Route
+        path="api/"
+        component={make(() => import('sentry/views/starfish/modules/APIModule'))}
+      />
+      <Route
+        path="cache/"
+        component={make(() => import('sentry/views/starfish/modules/cacheModule'))}
+      />
+    </Fragment>
+  );
+
   const starfishRoutes = (
     <Fragment>
       {usingCustomerDomain && (
         <Route
           path="/starfish/"
-          component={withDomainRequired(
-            make(() => import('sentry/views/starfish/content'))
-          )}
-        />
+          component={withDomainRequired(make(() => import('sentry/views/starfish')))}
+          key="orgless-starfish-route"
+        >
+          {starfishChildRoutes}
+        </Route>
       )}
+
       <Route
         path="organizations/:orgId/starfish/"
         component={make(() => import('sentry/views/starfish/content'))}
-      />
+        key="org-starfish"
+      >
+        {starfishChildRoutes}
+      </Route>
     </Fragment>
   );
 

--- a/static/app/views/starfish/index.tsx
+++ b/static/app/views/starfish/index.tsx
@@ -1,0 +1,49 @@
+import {Location} from 'history';
+
+import Feature from 'sentry/components/acl/feature';
+import {Alert} from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import {t} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
+import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+import withOrganization from 'sentry/utils/withOrganization';
+
+type Props = {
+  children: React.ReactChildren;
+  location: Location;
+  organization: Organization;
+};
+
+const queryClient = new QueryClient();
+
+function StarfishContainer({organization, location, children}: Props) {
+  return (
+    <Feature
+      hookName="feature-disabled:starfish-view"
+      features={['starfish-view']}
+      organization={organization}
+      renderDisabled={NoAccess}
+    >
+      <NoProjectMessage organization={organization}>
+        <QueryClientProvider client={queryClient}>
+          <MetricsCardinalityProvider location={location} organization={organization}>
+            <MEPSettingProvider>{children}</MEPSettingProvider>
+          </MetricsCardinalityProvider>
+        </QueryClientProvider>
+      </NoProjectMessage>
+    </Feature>
+  );
+}
+
+function NoAccess() {
+  return (
+    <Layout.Page withPadding>
+      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+    </Layout.Page>
+  );
+}
+
+export default withOrganization(StarfishContainer);

--- a/static/app/views/starfish/landing/index.tsx
+++ b/static/app/views/starfish/landing/index.tsx
@@ -14,15 +14,11 @@ import {space} from 'sentry/styles/space';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {GenericQueryBatcher} from 'sentry/utils/performance/contexts/genericQueryBatcher';
-import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
-import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
 import useTeams from 'sentry/utils/useTeams';
-import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
-import {MetricsDataSwitcherAlert} from 'sentry/views/performance/landing/metricsDataSwitcherAlert';
 
 import {StarfishView} from './views/starfishView';
 
@@ -39,7 +35,7 @@ type Props = {
 };
 
 export function StarfishLanding(props: Props) {
-  const {organization, location, eventView, projects, onboardingProject} = props;
+  const {organization, location, eventView, onboardingProject} = props;
 
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
 
@@ -92,55 +88,27 @@ export function StarfishLanding(props: Props) {
 
         <Layout.Body data-test-id="performance-landing-body">
           <Layout.Main fullWidth>
-            <MetricsCardinalityProvider
-              sendOutcomeAnalytics
-              organization={organization}
-              location={location}
-            >
-              <MetricsDataSwitcher
-                organization={organization}
-                eventView={eventView}
-                location={location}
-              >
-                {metricsDataSide => {
-                  return (
-                    <MEPSettingProvider
-                      location={location}
-                      forceTransactions={metricsDataSide.forceTransactionsOnly}
-                    >
-                      <MetricsDataSwitcherAlert
-                        organization={organization}
-                        eventView={eventView}
-                        projects={projects}
-                        location={location}
-                        router={props.router}
-                        {...metricsDataSide}
-                      />
-                      <PageErrorAlert />
-                      <Fragment>
-                        <SearchContainerWithFilterAndMetrics>
-                          {pageFilters}
-                        </SearchContainerWithFilterAndMetrics>
-                        {initiallyLoaded ? (
-                          <TeamKeyTransactionManager.Provider
-                            organization={organization}
-                            teams={teams}
-                            selectedTeams={['myteams']}
-                            selectedProjects={eventView.project.map(String)}
-                          >
-                            <GenericQueryBatcher>
-                              <StarfishView {...props} />
-                            </GenericQueryBatcher>
-                          </TeamKeyTransactionManager.Provider>
-                        ) : (
-                          <LoadingIndicator />
-                        )}
-                      </Fragment>
-                    </MEPSettingProvider>
-                  );
-                }}
-              </MetricsDataSwitcher>
-            </MetricsCardinalityProvider>
+            <PageErrorAlert />
+            <Fragment>
+              <SearchContainerWithFilterAndMetrics>
+                {pageFilters}
+              </SearchContainerWithFilterAndMetrics>
+
+              {initiallyLoaded ? (
+                <TeamKeyTransactionManager.Provider
+                  organization={organization}
+                  teams={teams}
+                  selectedTeams={['myteams']}
+                  selectedProjects={eventView.project.map(String)}
+                >
+                  <GenericQueryBatcher>
+                    <StarfishView {...props} />
+                  </GenericQueryBatcher>
+                </TeamKeyTransactionManager.Provider>
+              ) : (
+                <LoadingIndicator />
+              )}
+            </Fragment>
           </Layout.Main>
         </Layout.Body>
       </PageErrorProvider>

--- a/static/app/views/starfish/modules/APIModule/index.tsx
+++ b/static/app/views/starfish/modules/APIModule/index.tsx
@@ -1,0 +1,29 @@
+import {Fragment} from 'react';
+
+import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
+
+export default function APIModule() {
+  return (
+    <Layout.Page>
+      <PageErrorProvider>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Layout.Title>{t('API')}</Layout.Title>
+          </Layout.HeaderContent>
+        </Layout.Header>
+
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <PageErrorAlert />
+            <Fragment />
+          </Layout.Main>
+        </Layout.Body>
+      </PageErrorProvider>
+    </Layout.Page>
+  );
+}

--- a/static/app/views/starfish/modules/cacheModule/index.tsx
+++ b/static/app/views/starfish/modules/cacheModule/index.tsx
@@ -1,0 +1,29 @@
+import {Fragment} from 'react';
+
+import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
+
+export default function CacheModule() {
+  return (
+    <Layout.Page>
+      <PageErrorProvider>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Layout.Title>{t('Cache')}</Layout.Title>
+          </Layout.HeaderContent>
+        </Layout.Header>
+
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <PageErrorAlert />
+            <Fragment />
+          </Layout.Main>
+        </Layout.Body>
+      </PageErrorProvider>
+    </Layout.Page>
+  );
+}

--- a/static/app/views/starfish/modules/databaseModule/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/index.tsx
@@ -1,0 +1,29 @@
+import {Fragment} from 'react';
+
+import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
+
+export default function DatabaseModule() {
+  return (
+    <Layout.Page>
+      <PageErrorProvider>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Layout.Title>{t('Database')}</Layout.Title>
+          </Layout.HeaderContent>
+        </Layout.Header>
+
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <PageErrorAlert />
+            <Fragment />
+          </Layout.Main>
+        </Layout.Body>
+      </PageErrorProvider>
+    </Layout.Page>
+  );
+}


### PR DESCRIPTION
Barebones nested routes. Adds dummy pages for `/starfish/api`, `/starfish/database` and `/starfish/cache`. Puts in some dummy content, just to keep things distinguishable.
