### PR TITLE
fix(issue-detectors): Filter out None values from tags

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -101,7 +101,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         return self.settings["detection_enabled"]
 
     def is_event_eligible(cls, event):
-        tags = event.get("tags", [])
+        tags = [tag for tag in event.get("tags", []) if tag is not None]
         browser_name = next(
             (tag[1] for tag in tags if tag[0] == "browser.name" and len(tag) == 2), ""
         )

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -101,9 +101,14 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         return self.settings["detection_enabled"]
 
     def is_event_eligible(cls, event):
-        tags = [tag for tag in event.get("tags", []) if tag is not None]
+        tags = event.get("tags", [])
         browser_name = next(
-            (tag[1] for tag in tags if tag[0] == "browser.name" and len(tag) == 2), ""
+            (
+                tag[1]
+                for tag in tags
+                if tag is not None and tag[0] == "browser.name" and len(tag) == 2
+            ),
+            "",
         )
         if browser_name.lower() in [
             "chrome",

--- a/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
@@ -54,7 +54,7 @@ class UncompressedAssetsDetectorTest(TestCase):
         event = {
             "event_id": "a" * 16,
             "project": PROJECT_ID,
-            "tags": [["browser.name", "chrome"]],
+            "tags": [["browser.name", "chrome"], None],
             "spans": [
                 create_asset_span(
                     duration=1000.0,

--- a/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
@@ -50,11 +50,48 @@ class UncompressedAssetsDetectorTest(TestCase):
         run_detector_on_data(detector, event)
         return list(detector.stored_problems.values())
 
+    def test_detects_uncompressed_asset_with_none_tag(self):
+        event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "tags": [None, ["browser.name", "chrome"]],
+            "spans": [
+                create_asset_span(
+                    duration=1000.0,
+                    data={
+                        "Transfer Size": 1_000_000,
+                        "Encoded Body Size": 1_000_000,
+                        "Decoded Body Size": 1_000_000,
+                    },
+                ),
+                create_compressed_asset_span(),
+            ],
+        }
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1012-6893fb5a8a875d692da96590f40dc6bddd6fcabc",
+                op="resource.script",
+                desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+                type=PerformanceUncompressedAssetsGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "op": "resource.script",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                },
+                evidence_display=[],
+            )
+        ]
+
     def test_detects_uncompressed_asset(self):
         event = {
             "event_id": "a" * 16,
             "project": PROJECT_ID,
-            "tags": [["browser.name", "chrome"], None],
+            "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
                     duration=1000.0,


### PR DESCRIPTION
Filters out None values from the tags array so we don't attempt to index None.

Fixes SENTRY-FOR-SENTRY-RZM