### PR TITLE
chore(hybrid-cloud): Add test for UnimplementedRegionResolution

### DIFF
--- a/tests/sentry/hybrid_cloud/test_region.py
+++ b/tests/sentry/hybrid_cloud/test_region.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.region import (
@@ -5,7 +7,9 @@ from sentry.services.hybrid_cloud.region import (
     ByOrganizationIdAttribute,
     ByOrganizationObject,
     ByOrganizationSlug,
+    UnimplementedRegionResolution,
 )
+from sentry.services.hybrid_cloud.rpc import RpcServiceUnimplementedException
 from sentry.testutils import TestCase
 from sentry.testutils.region import override_regions
 from sentry.types.region import Region, RegionCategory
@@ -57,3 +61,10 @@ class RegionResolutionTest(TestCase):
             arguments = {"organization_member": org_member}
             actual_region = region_resolution.resolve(arguments)
             assert actual_region == self.target_region
+
+    def test_unimplemented_region_resolution(self):
+        with override_regions(self.regions):
+            region_resolution = UnimplementedRegionResolution()
+            with pytest.raises(RpcServiceUnimplementedException):
+                arguments = {"team_id": 1234}
+                region_resolution.resolve(arguments)


### PR DESCRIPTION
I forgot to add the test for `UnimplementedRegionResolution` in https://github.com/getsentry/sentry/pull/46972.