### PR TITLE
ref: Add integration tag to stacktrace linking

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -128,6 +128,7 @@ def set_tags(scope: Scope, result: JSONData) -> None:
         scope.set_tag(
             "stacktrace_link.auto_derived", result["config"]["automaticallyGenerated"] is True
         )
+    scope.set_tag("stacktrace_link.has_integration", len(result["integrations"]) > 0)
 
 
 @region_silo_endpoint


### PR DESCRIPTION
Set the tag stacktrace_link.has_integration to True or False based on if any integrations are found with stacktrace linking support

WOR-2961