### PR TITLE
chore(hybrid-cloud): Update organization_service.add_organization_member to accept user_id

### DIFF
--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -302,7 +302,7 @@ class DatabaseBackedAuthService(AuthService):
             organization_id=organization.id,
             default_org_role=organization.default_role,
             role=organization.default_role,
-            user=serial_user,
+            user_id=user.id,
             flags=flags,
         )
 

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -20,7 +20,6 @@ from sentry.services.hybrid_cloud.region import (
     UnimplementedRegionResolution,
 )
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
-from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
 
 
@@ -272,7 +271,7 @@ class OrganizationService(RpcService):
         *,
         organization_id: int,
         default_org_role: str,
-        user: Optional[RpcUser] = None,
+        user_id: Optional[int] = None,
         email: Optional[str] = None,
         flags: Optional[RpcOrganizationMemberFlags] = None,
         role: Optional[str] = None,

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Iterable, List, MutableMapping, Optional, Set, cast
+from typing import Iterable, List, MutableMapping, Optional, Set, cast
 
 from django.db import transaction
 
@@ -34,9 +34,6 @@ from sentry.services.hybrid_cloud.organization import (
     RpcUserOrganizationContext,
 )
 from sentry.services.hybrid_cloud.util import flags_to_bits
-
-if TYPE_CHECKING:
-    from sentry.services.hybrid_cloud.user import RpcUser
 
 
 def escape_flag_name(flag_name: str) -> str:
@@ -282,18 +279,20 @@ class DatabaseBackedOrganizationService(OrganizationService):
         *,
         organization_id: int,
         default_org_role: str,
-        user: RpcUser | None = None,
+        user_id: int | None = None,
         email: str | None = None,
         flags: RpcOrganizationMemberFlags | None = None,
         role: str | None = None,
         inviter_id: int | None = None,
         invite_status: int | None = InviteStatus.APPROVED.value,
     ) -> RpcOrganizationMember:
-        assert (user is None and email) or (user and email is None), "Must set either user or email"
+        assert (user_id is None and email) or (
+            user_id and email is None
+        ), "Must set either user_id or email"
         with transaction.atomic():
             org_member: OrganizationMember = OrganizationMember.objects.create(
                 organization_id=organization_id,
-                user_id=user.id if user else None,
+                user_id=user_id,
                 email=email,
                 flags=self._deserialize_member_flags(flags) if flags else 0,
                 role=role or default_org_role,

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -61,7 +61,7 @@ class RpcServiceTest(TestCase):
         assert serial_arguments.keys() == {
             "organization_id",
             "default_org_role",
-            "user",
+            "user_id",
             "email",
             "flags",
             "role",
@@ -90,12 +90,11 @@ class RpcServiceTest(TestCase):
         user = self.create_user()
         organization = self.create_organization()
 
-        serial_user = RpcUser(id=user.id)
         serial_org = DatabaseBackedOrganizationService.serialize_organization(organization)
         serial_arguments = dict(
             organization_id=serial_org.id,
             default_org_role=serial_org.default_role,
-            user=serial_user.dict(),
+            user_id=user.id,
             flags=RpcOrganizationMemberFlags().dict(),
             role=None,
         )


### PR DESCRIPTION
By having `add_organization_member()` to just only require the user id, we remove the dilemma of having to construct `RpcUser`.