### PR TITLE
feat(rulesnooze): Add delete endpoint

### DIFF
--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -1,5 +1,4 @@
 import datetime
-from enum import Enum
 
 from rest_framework import serializers, status
 from rest_framework.exceptions import AuthenticationFailed
@@ -13,11 +12,6 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.incidents.models import AlertRule
 from sentry.models import Organization, Rule, RuleSnooze, Team
-
-
-class RuleType(Enum):
-    ISSUE_ALERT = 0
-    METRIC_ALERT = 1
 
 
 class RuleSnoozeValidator(CamelSnakeSerializer):
@@ -162,13 +156,11 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
 
 @region_silo_endpoint
 class RuleSnoozeEndpoint(BaseRuleSnoozeEndpoint):
-    rule_type = RuleType.ISSUE_ALERT.value
     rule_model = Rule
     rule_field = "rule"
 
 
 @region_silo_endpoint
 class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint):
-    rule_type = RuleType.METRIC_ALERT.value
     rule_model = AlertRule
     rule_field = "alert_rule"

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2066,7 +2066,7 @@ PROJECT_URLS = [
         name="sentry-api-0-project-rule-details",
     ),
     url(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/snooze/$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/(?P<rule_type>[^\/]+)/snooze/$",
         RuleSnoozeEndpoint.as_view(),
         name="sentry-api-0-rule-snooze",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -475,7 +475,7 @@ from .endpoints.relay import (
     RelayRegisterResponseEndpoint,
 )
 from .endpoints.release_deploys import ReleaseDeploysEndpoint
-from .endpoints.rule_snooze import RuleSnoozeEndpoint
+from .endpoints.rule_snooze import MetricRuleSnoozeEndpoint, RuleSnoozeEndpoint
 from .endpoints.setup_wizard import SetupWizard
 from .endpoints.shared_group_details import SharedGroupDetailsEndpoint
 from .endpoints.source_map_debug import SourceMapDebugEndpoint
@@ -2066,9 +2066,14 @@ PROJECT_URLS = [
         name="sentry-api-0-project-rule-details",
     ),
     url(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/(?P<rule_type>[^\/]+)/snooze/$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/snooze/$",
         RuleSnoozeEndpoint.as_view(),
         name="sentry-api-0-rule-snooze",
+    ),
+    url(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/alert-rules/(?P<rule_id>[^\/]+)/snooze/$",
+        MetricRuleSnoozeEndpoint.as_view(),
+        name="sentry-api-0-metric-rule-snooze",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/preview$",

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -7,6 +7,7 @@ from sentry.api.endpoints.rule_snooze import RuleType
 from sentry.models import AuditLogEntry, Rule, RuleSnooze
 from sentry.models.actor import ActorTuple
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import region_silo_test
 
 
@@ -29,17 +30,17 @@ class RuleSnoozeTest(APITestCase):
 class PostRuleSnoozeTest(RuleSnoozeTest):
     method = "post"
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_issue_alert_user_forever(self):
         """Test that a user can mute an issue alert rule for themselves forever"""
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -49,17 +50,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         assert response.data["alertRuleId"] is None
         assert response.data["until"] == "forever"
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_issue_alert_user_until(self):
         """Test that a user can mute an issue alert rule for themselves a period of time"""
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -69,17 +70,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         assert response.data["alertRuleId"] is None
         assert response.data["until"] == self.until
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_issue_alert_everyone_forever(self):
         """Test that an issue alert rule can be muted for everyone forever"""
         data = {"target": "everyone"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -95,17 +96,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             target_object=self.issue_alert_rule.id,
         )
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_issue_alert_everyone_until(self):
         """Test that an issue alert rule can be muted for everyone for a period of time"""
         data = {"target": "everyone", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -121,17 +122,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             target_object=self.issue_alert_rule.id,
         )
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_issue_alert_user_then_everyone(self):
         """Test that a user can mute an issue alert for themselves and then the same alert can be muted for everyone"""
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
@@ -139,77 +140,75 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_issue_alert_everyone_then_user(self):
         """Test that an issue alert can be muted for everyone and then a user can mute the same alert for themselves"""
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
         assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_edit_issue_alert_mute(self):
         """Test that we throw an error if an issue alert rule has already been muted by a user"""
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert len(RuleSnooze.objects.all()) == 1
         assert response.status_code == 410
         assert "RuleSnooze already exists for this rule and scope." in response.data["detail"]
 
+    @with_feature("organizations:mute-alerts")
     def test_user_cant_mute_issue_alert_for_everyone(self):
         """Test that if a user doesn't belong to the team that can edit an issue alert rule, we throw an error when they try to mute it for everyone."""
         other_team = self.create_team()
@@ -217,18 +216,18 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             label="test rule", project=self.project, owner=other_team.actor
         )
         data = {"target": "everyone"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                other_issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert not RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
         assert response.status_code == 401
         assert "Requesting user cannot mute this rule" in response.data["detail"]
 
+    @with_feature("organizations:mute-alerts")
     def test_user_can_mute_issue_alert_for_self(self):
         """Test that if a user doesn't belong to the team that can edit an issue alert rule, they can still mute it for just themselves."""
         other_team = self.create_team()
@@ -236,45 +235,44 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             label="test rule", project=self.project, owner=other_team.actor
         )
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                other_issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_user_can_mute_unassigned_issue_alert(self):
         """Test that if an issue alert rule's owner is unassigned, the user can mute it."""
         other_issue_alert_rule = Rule.objects.create(
             label="test rule", project=self.project, owner=None
         )
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                other_issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_metric_alert_user_forever(self):
         """Test that a user can mute a metric alert rule for themselves forever"""
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -284,17 +282,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         assert response.data["alertRuleId"] == self.metric_alert_rule.id
         assert response.data["until"] == "forever"
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_metric_alert_user_until(self):
         """Test that a user can mute a metric alert rule for themselves a period of time"""
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -304,17 +302,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         assert response.data["alertRuleId"] == self.metric_alert_rule.id
         assert response.data["until"] == self.until
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_metric_alert_everyone_forever(self):
         """Test that a metric alert rule can be muted for everyone forever"""
         data = {"target": "everyone"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -330,17 +328,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             target_object=self.metric_alert_rule.id,
         )
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_metric_alert_everyone_until(self):
         """Test that a metric alert rule can be muted for everyone for a period of time"""
         data = {"target": "everyone", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
         assert len(response.data) == 6
@@ -356,17 +354,17 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             target_object=self.metric_alert_rule.id,
         )
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_metric_alert_user_then_everyone(self):
         """Test that a user can mute a metric alert for themselves and then the same alert can be muted for everyone"""
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
@@ -374,77 +372,75 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_mute_metric_alert_everyone_then_user(self):
         """Test that a metric alert can be muted for everyone and then a user can mute the same alert for themselves"""
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
         assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_edit_metric_alert_mute(self):
         """Test that we throw an error if a metric alert rule has already been muted by a user"""
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert len(RuleSnooze.objects.all()) == 1
         assert response.status_code == 410
         assert "RuleSnooze already exists for this rule and scope." in response.data["detail"]
 
+    @with_feature("organizations:mute-alerts")
     def test_user_cant_snooze_metric_alert_for_everyone(self):
         """Test that if a user doesn't belong to the team that can edit a metric alert rule, we throw an error when they try to mute it for everyone"""
         other_team = self.create_team()
@@ -454,18 +450,18 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             owner=ActorTuple.from_actor_identifier(f"team:{other_team.id}"),
         )
         data = {"target": "everyone"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                other_metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert not RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule).exists()
         assert response.status_code == 401
         assert "Requesting user cannot mute this rule" in response.data["detail"]
 
+    @with_feature("organizations:mute-alerts")
     def test_user_can_snooze_metric_alert_for_self(self):
         """Test that if a user doesn't belong to the team that can edit a metric alert rule, they are able to mute it for just themselves."""
         other_team = self.create_team()
@@ -475,67 +471,66 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             owner=ActorTuple.from_actor_identifier(f"team:{other_team.id}"),
         )
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                other_metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_user_can_mute_unassigned_metric_alert(self):
         """Test that if a metric alert rule's owner is unassigned, the user can mute it."""
         other_metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project], owner=None
         )
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                other_metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule.id).exists()
         assert response.status_code == 201
 
+    @with_feature("organizations:mute-alerts")
     def test_no_issue_alert(self):
         """Test that we throw an error when an issue alert rule doesn't exist"""
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug, self.project.slug, 777, RuleType.ISSUE_ALERT.value, **data
-            )
+        response = self.get_response(
+            self.organization.slug, self.project.slug, 777, RuleType.ISSUE_ALERT.value, **data
+        )
         assert not RuleSnooze.objects.filter(alert_rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 400
         assert "Rule does not exist" in response.data
 
+    @with_feature("organizations:mute-alerts")
     def test_no_metric_alert(self):
         """Test that we throw an error when a metric alert rule doesn't exist"""
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug, self.project.slug, 777, RuleType.METRIC_ALERT.value, **data
-            )
+        response = self.get_response(
+            self.organization.slug, self.project.slug, 777, RuleType.METRIC_ALERT.value, **data
+        )
         assert not RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 400
         assert "Rule does not exist" in response.data
 
+    @with_feature("organizations:mute-alerts")
     def test_invalid_data_issue_alert(self):
         """Test that we throw an error when passed invalid data"""
         data = {"target": "me", "until": 123}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.metric_alert_rule.id,
-                RuleType.METRIC_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
         assert not RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 400
         assert "Datetime has wrong format." in response.data["until"][0]
@@ -545,42 +540,43 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 class DeleteRuleSnoozeTest(RuleSnoozeTest):
     method = "delete"
 
+    @with_feature("organizations:mute-alerts")
     def test_delete_issue_alert_rule_mute_myself(self):
         """Test that a user can unsnooze a rule they've snoozed for just themselves"""
         RuleSnooze.objects.create(
             user_id=self.user.id, rule=self.issue_alert_rule, owner_id=self.user.id
         )
         data = {"target": "me"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert not RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id
         ).exists()
         assert response.status_code == 204
 
+    @with_feature("organizations:mute-alerts")
     def test_delete_issue_alert_rule_mute_everyone(self):
         """Test that a user can unsnooze a rule they've snoozed for everyone"""
         RuleSnooze.objects.create(rule=self.issue_alert_rule, owner_id=self.user.id)
         data = {"target": "everyone"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                self.issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert not RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id
         ).exists()
         assert response.status_code == 204
 
+    @with_feature("organizations:mute-alerts")
     def test_cant_delete_issue_alert_rule_mute_everyone(self):
         """Test that a user can't unsnooze a rule that's snoozed for everyone if they do not belong to the team the owns the rule"""
         other_team = self.create_team()
@@ -589,13 +585,69 @@ class DeleteRuleSnoozeTest(RuleSnoozeTest):
         )
         RuleSnooze.objects.create(rule=other_issue_alert_rule)
         data = {"target": "everyone"}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                other_issue_alert_rule.id,
-                RuleType.ISSUE_ALERT.value,
-                **data,
-            )
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_issue_alert_rule.id,
+            RuleType.ISSUE_ALERT.value,
+            **data,
+        )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
+        assert response.status_code == 401
+
+    @with_feature("organizations:mute-alerts")
+    def test_delete_metric_alert_rule_mute_myself(self):
+        """Test that a user can unsnooze a metric alert rule they've snoozed for just themselves"""
+        RuleSnooze.objects.create(
+            user_id=self.user.id, alert_rule=self.metric_alert_rule, owner_id=self.user.id
+        )
+        data = {"target": "me"}
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
+        assert not RuleSnooze.objects.filter(
+            alert_rule=self.metric_alert_rule.id, user_id=self.user.id
+        ).exists()
+        assert response.status_code == 204
+
+    @with_feature("organizations:mute-alerts")
+    def test_delete_metric_alert_rule_mute_everyone(self):
+        """Test that a user can unsnooze a metric rule they've snoozed for everyone"""
+        RuleSnooze.objects.create(alert_rule=self.metric_alert_rule, owner_id=self.user.id)
+        data = {"target": "everyone"}
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            self.metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
+        assert not RuleSnooze.objects.filter(
+            alert_rule=self.metric_alert_rule.id, user_id=self.user.id
+        ).exists()
+        assert response.status_code == 204
+
+    @with_feature("organizations:mute-alerts")
+    def test_cant_delete_metric_alert_rule_mute_everyone(self):
+        """Test that a user can't unsnooze a metric rule that's snoozed for everyone if they do not belong to the team the owns the rule"""
+        other_team = self.create_team()
+        other_metric_alert_rule = self.create_alert_rule(
+            organization=self.project.organization,
+            projects=[self.project],
+            owner=ActorTuple.from_actor_identifier(f"team:{other_team.id}"),
+        )
+        RuleSnooze.objects.create(alert_rule=other_metric_alert_rule)
+        data = {"target": "everyone"}
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            other_metric_alert_rule.id,
+            RuleType.METRIC_ALERT.value,
+            **data,
+        )
+        assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule.id).exists()
         assert response.status_code == 401

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import pytz
 
 from sentry import audit_log
+from sentry.api.endpoints.rule_snooze import RuleType
 from sentry.models import AuditLogEntry, Rule, RuleSnooze
 from sentry.models.actor import ActorTuple
 from sentry.testutils import APITestCase
@@ -30,10 +31,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_issue_alert_user_forever(self):
         """Test that a user can mute an issue alert rule for themselves forever"""
-        data = {"target": "me", "rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
@@ -46,10 +51,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_issue_alert_user_until(self):
         """Test that a user can mute an issue alert rule for themselves a period of time"""
-        data = {"target": "me", "rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
@@ -62,10 +71,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_issue_alert_everyone_forever(self):
         """Test that an issue alert rule can be muted for everyone forever"""
-        data = {"target": "everyone", "rule": True}
+        data = {"target": "everyone"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
@@ -84,10 +97,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_issue_alert_everyone_until(self):
         """Test that an issue alert rule can be muted for everyone for a period of time"""
-        data = {"target": "everyone", "rule": True, "until": self.until}
+        data = {"target": "everyone", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
@@ -106,10 +123,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_issue_alert_user_then_everyone(self):
         """Test that a user can mute an issue alert for themselves and then the same alert can be muted for everyone"""
-        data = {"target": "me", "rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id, until=self.until
@@ -117,10 +138,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         assert response.status_code == 201
 
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
-        data = {"target": "everyone", "rule": True, "until": everyone_until}
+        data = {"target": "everyone", "until": everyone_until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=None, until=everyone_until
@@ -130,20 +155,28 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
     def test_mute_issue_alert_everyone_then_user(self):
         """Test that an issue alert can be muted for everyone and then a user can mute the same alert for themselves"""
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
-        data = {"target": "everyone", "rule": True, "until": everyone_until}
+        data = {"target": "everyone", "until": everyone_until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
         assert response.status_code == 201
 
-        data = {"target": "me", "rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id, until=self.until
@@ -152,18 +185,26 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_edit_issue_alert_mute(self):
         """Test that we throw an error if an issue alert rule has already been muted by a user"""
-        data = {"target": "me", "rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 201
 
-        data = {"target": "me", "rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert len(RuleSnooze.objects.all()) == 1
         assert response.status_code == 410
@@ -175,10 +216,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         other_issue_alert_rule = Rule.objects.create(
             label="test rule", project=self.project, owner=other_team.actor
         )
-        data = {"target": "everyone", "rule": True}
+        data = {"target": "everyone"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, other_issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                other_issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert not RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
         assert response.status_code == 401
@@ -190,10 +235,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         other_issue_alert_rule = Rule.objects.create(
             label="test rule", project=self.project, owner=other_team.actor
         )
-        data = {"target": "me", "rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, other_issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                other_issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
         assert response.status_code == 201
@@ -203,20 +252,28 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         other_issue_alert_rule = Rule.objects.create(
             label="test rule", project=self.project, owner=None
         )
-        data = {"target": "me", "rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, other_issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                other_issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
         assert response.status_code == 201
 
     def test_mute_metric_alert_user_forever(self):
         """Test that a user can mute a metric alert rule for themselves forever"""
-        data = {"target": "me", "alert_rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
@@ -229,10 +286,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_metric_alert_user_until(self):
         """Test that a user can mute a metric alert rule for themselves a period of time"""
-        data = {"target": "me", "alert_rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
@@ -245,10 +306,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_metric_alert_everyone_forever(self):
         """Test that a metric alert rule can be muted for everyone forever"""
-        data = {"target": "everyone", "alert_rule": True}
+        data = {"target": "everyone"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
@@ -267,10 +332,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_metric_alert_everyone_until(self):
         """Test that a metric alert rule can be muted for everyone for a period of time"""
-        data = {"target": "everyone", "alert_rule": True, "until": self.until}
+        data = {"target": "everyone", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
@@ -289,10 +358,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_mute_metric_alert_user_then_everyone(self):
         """Test that a user can mute a metric alert for themselves and then the same alert can be muted for everyone"""
-        data = {"target": "me", "alert_rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id, until=self.until
@@ -300,10 +373,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         assert response.status_code == 201
 
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
-        data = {"target": "everyone", "alert_rule": True, "until": everyone_until}
+        data = {"target": "everyone", "until": everyone_until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=None, until=everyone_until
@@ -313,20 +390,28 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
     def test_mute_metric_alert_everyone_then_user(self):
         """Test that a metric alert can be muted for everyone and then a user can mute the same alert for themselves"""
         everyone_until = datetime.now(pytz.UTC) + timedelta(days=1)
-        data = {"target": "everyone", "alert_rule": True, "until": everyone_until}
+        data = {"target": "everyone", "until": everyone_until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
         assert response.status_code == 201
 
-        data = {"target": "me", "alert_rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id, until=self.until
@@ -335,18 +420,26 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
 
     def test_edit_metric_alert_mute(self):
         """Test that we throw an error if a metric alert rule has already been muted by a user"""
-        data = {"target": "me", "alert_rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 201
 
-        data = {"target": "me", "alert_rule": True, "until": self.until}
+        data = {"target": "me", "until": self.until}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert len(RuleSnooze.objects.all()) == 1
         assert response.status_code == 410
@@ -360,10 +453,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             projects=[self.project],
             owner=ActorTuple.from_actor_identifier(f"team:{other_team.id}"),
         )
-        data = {"target": "everyone", "alertRule": True}
+        data = {"target": "everyone"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, other_metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                other_metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert not RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule).exists()
         assert response.status_code == 401
@@ -377,10 +474,14 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
             projects=[self.project],
             owner=ActorTuple.from_actor_identifier(f"team:{other_team.id}"),
         )
-        data = {"target": "me", "alertRule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, other_metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                other_metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule).exists()
         assert response.status_code == 201
@@ -390,53 +491,54 @@ class PostRuleSnoozeTest(RuleSnoozeTest):
         other_metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project], owner=None
         )
-        data = {"target": "me", "alertRule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, other_metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                other_metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule.id).exists()
         assert response.status_code == 201
 
     def test_no_issue_alert(self):
         """Test that we throw an error when an issue alert rule doesn't exist"""
-        data = {"target": "me", "rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(self.organization.slug, self.project.slug, 777, **data)
+            response = self.get_response(
+                self.organization.slug, self.project.slug, 777, RuleType.ISSUE_ALERT.value, **data
+            )
         assert not RuleSnooze.objects.filter(alert_rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 400
         assert "Rule does not exist" in response.data
 
     def test_no_metric_alert(self):
         """Test that we throw an error when a metric alert rule doesn't exist"""
-        data = {"target": "me", "alert_rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(self.organization.slug, self.project.slug, 777, **data)
+            response = self.get_response(
+                self.organization.slug, self.project.slug, 777, RuleType.METRIC_ALERT.value, **data
+            )
         assert not RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 400
         assert "Rule does not exist" in response.data
 
     def test_invalid_data_issue_alert(self):
         """Test that we throw an error when passed invalid data"""
-        data = {"target": "me", "rule": self.issue_alert_rule.id}
+        data = {"target": "me", "until": 123}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.metric_alert_rule.id,
+                RuleType.METRIC_ALERT.value,
+                **data,
             )
         assert not RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
         assert response.status_code == 400
-        assert "Must be a valid boolean" in response.data["rule"][0]
-
-    def test_rule_and_alert_rule(self):
-        """Test that we throw an error if both rule and alert rule are passed"""
-        data = {"target": "me", "rule": True, "alert_rule": True}
-        with self.feature({"organizations:mute-alerts": True}):
-            response = self.get_response(
-                self.organization.slug, self.project.slug, self.metric_alert_rule.id, **data
-            )
-        assert not RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 400
-        assert "Pass either rule or alert rule, not both." in response.data
+        assert "Datetime has wrong format." in response.data["until"][0]
 
 
 @region_silo_test
@@ -448,10 +550,14 @@ class DeleteRuleSnoozeTest(RuleSnoozeTest):
         RuleSnooze.objects.create(
             user_id=self.user.id, rule=self.issue_alert_rule, owner_id=self.user.id
         )
-        data = {"target": "me", "rule": True}
+        data = {"target": "me"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert not RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id
@@ -461,10 +567,14 @@ class DeleteRuleSnoozeTest(RuleSnoozeTest):
     def test_delete_issue_alert_rule_mute_everyone(self):
         """Test that a user can unsnooze a rule they've snoozed for everyone"""
         RuleSnooze.objects.create(rule=self.issue_alert_rule, owner_id=self.user.id)
-        data = {"target": "everyone", "rule": True}
+        data = {"target": "everyone"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, self.issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                self.issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert not RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id
@@ -478,10 +588,14 @@ class DeleteRuleSnoozeTest(RuleSnoozeTest):
             label="test rule", project=self.project, owner=other_team.actor
         )
         RuleSnooze.objects.create(rule=other_issue_alert_rule)
-        data = {"target": "everyone", "rule": True}
+        data = {"target": "everyone"}
         with self.feature({"organizations:mute-alerts": True}):
             response = self.get_response(
-                self.organization.slug, self.project.slug, other_issue_alert_rule.id, **data
+                self.organization.slug,
+                self.project.slug,
+                other_issue_alert_rule.id,
+                RuleType.ISSUE_ALERT.value,
+                **data,
             )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
         assert response.status_code == 401


### PR DESCRIPTION
A follow up to https://github.com/getsentry/sentry/pull/47050 and https://github.com/getsentry/sentry/pull/47123 - this adds a delete endpoint for `RuleSnooze` so that in the front end someone can click "unmute" and receive notifications for the muted rule again. 