### PR TITLE
feat(issue-platform): add transaction_duration as optional to IssueOccurrence

### DIFF
--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -86,7 +86,7 @@ class IssueOccurrence:
     detection_time: datetime
     level: str
     culprit: str
-    transaction_duration: int = 0
+    transaction_duration: int | None = None
 
     def __post_init__(self) -> None:
         if not is_aware(self.detection_time):

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -34,6 +34,7 @@ class IssueOccurrenceData(TypedDict):
     detection_time: float
     level: Optional[str]
     culprit: Optional[str]
+    transaction_duration: Optional[int]
 
 
 @dataclass(frozen=True)
@@ -85,6 +86,7 @@ class IssueOccurrence:
     detection_time: datetime
     level: str
     culprit: str
+    transaction_duration: int = 0
 
     def __post_init__(self) -> None:
         if not is_aware(self.detection_time):
@@ -107,6 +109,7 @@ class IssueOccurrence:
             "detection_time": self.detection_time.timestamp(),
             "level": self.level,
             "culprit": self.culprit,
+            "transaction_duration": self.transaction_duration,
         }
 
     @classmethod
@@ -118,6 +121,9 @@ class IssueOccurrence:
         culprit = data.get("culprit")
         if not culprit:
             culprit = ""
+        transaction_duration = data.get("transaction_duration")
+        if not transaction_duration:
+            transaction_duration = 0
         return cls(
             data["id"],
             data["project_id"],
@@ -136,6 +142,7 @@ class IssueOccurrence:
             cast(datetime, parse_timestamp(data["detection_time"])),
             level,
             culprit,
+            transaction_duration,
         )
 
     @property

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -109,7 +109,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 "type": payload["type"],
                 "detection_time": payload["detection_time"],
                 "level": payload.get("level", DEFAULT_LEVEL),
-                "transaction_duration": payload.get("transaction_duration", 0),
+                "transaction_duration": payload.get("transaction_duration"),
             }
 
             if payload.get("event_id"):

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -109,6 +109,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 "type": payload["type"],
                 "detection_time": payload["detection_time"],
                 "level": payload.get("level", DEFAULT_LEVEL),
+                "transaction_duration": payload.get("transaction_duration", 0),
             }
 
             if payload.get("event_id"):

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -18,6 +18,12 @@ class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):  # type: ignor
         occurrence = IssueOccurrence.from_dict(occurrence_data)
         assert occurrence.level == DEFAULT_LEVEL
 
+    def test_transaction_duration_default(self) -> None:
+        occurrence_data = self.build_occurrence_data()
+        occurrence_data["transaction_duration"] = None
+        occurrence = IssueOccurrence.from_dict(occurrence_data)
+        assert occurrence.transaction_duration == 0
+
 
 @region_silo_test
 class IssueOccurenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):  # type: ignore

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -303,6 +303,16 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         kwargs = _get_kwargs(message)
         assert kwargs["occurrence_data"]["level"] == kwargs["event_data"]["level"]
 
+    def test_occurrence_transaction_duration(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["transaction_duration"] is None
+
+        message.update({"transaction_duration": 10000})
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["transaction_duration"] == 10000
+
     def test_debug_meta(self) -> None:
         debug_meta_cases = [
             {"debug_meta": {}},

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -47,6 +47,7 @@ class OccurrenceTestMixin:
             "type": ProfileFileIOGroupType.type_id,
             "detection_time": datetime.now().timestamp(),
             "level": "warning",
+            "transaction_duration": None,
         }
         kwargs.update(overrides)  # type: ignore
         return kwargs


### PR DESCRIPTION
To support the `All events` tab when we cut over to occurrences-backed performance issues, we need all the columns currently displayed when querying for transactions-backed performance issues:
![Screenshot 2023-04-12 at 6 00 28 PM](https://user-images.githubusercontent.com/101606877/231618790-bc3cffd6-d263-4461-b669-bc78d57f38bb.png)

We should have most of the columns already passed into the occurrence, except `total_duration`. This is the time between the start and end of the transaction. 

We'll make the `transaction_duration` optional to be backwards compatible and default it to `0` for any occurrences that don't make use of this field.