### PR TITLE
feat(issue-platform): calculate and pass through transaction_duration for Perf issue occurrences

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2464,14 +2464,10 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
                 EventPerformanceProblem(event, performance_problems_by_hash[problem_hash]).save()
 
 
-def _calculate_transaction_duration(event) -> int:
+def _calculate_transaction_duration(event: Event) -> int:
     try:
-
-        def __extract_timestamp(int) -> datetime:
-            return datetime.utcfromtimestamp(int)
-
-        start_ts = __extract_timestamp(event["data"]["start_timestamp"])
-        finish_ts = __extract_timestamp(event["data"]["timestamp"])
+        start_ts = datetime.utcfromtimestamp(event.data["start_timestamp"])
+        finish_ts = datetime.utcfromtimestamp(event.data["timestamp"])
         duration_secs = (finish_ts - start_ts).total_seconds()
         return max(int(duration_secs * 1000), 0)
     except Exception:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -33,6 +33,7 @@ from sentry.event_manager import (
     EventManager,
     EventUser,
     HashDiscarded,
+    _calculate_transaction_duration,
     _get_event_instance,
     _save_grouphash_and_group,
     has_pending_commit_resolution,
@@ -3685,3 +3686,13 @@ class TestSaveGroupHashAndGroup(TransactionTestCase):
         assert created
         assert group_2.id != group_3.id
         assert Group.objects.filter(grouphash__hash=group_hash).count() == 1
+
+
+class TestCalculateTransactionDuration(TransactionTestCase):
+    def test(self):
+        perf_data = load_data("transaction-n-plus-one", timestamp=before_now(minutes=10))
+        event = _get_event_instance(perf_data, project_id=self.project.id)
+        assert event.data["start_timestamp"]
+        assert event.data["timestamp"]
+
+        assert _calculate_transaction_duration(event) != 0


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/pull/47293

Basically a copy-paste of what's being done in snuba when processing a transaction.
https://github.com/getsentry/snuba/blob/9fba7cfbd50f22e7ad0bb3607e0cb089e29d9fdb/snuba/datasets/processors/transactions_processor.py#L116-L135

We can't embed that in our dataset processor because we don't have the transaction times in the occurrence payload so we're doing it here.