### PR TITLE
feat(replays): Remove user.displayName from the slim Replay List view

### DIFF
--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -40,9 +40,16 @@ async function fetchReplayList({
     // ask the server for compound fields like `os.name`.
     payload.field = payload.field.map(field => field.split('.')[0]);
 
-    const hasFullTable = !organization.features.includes('session-replay-slim-table');
-    if (!hasFullTable) {
-      const fieldsToRemove = ['browser', 'os', 'urls'];
+    const hasSlimTable = organization.features.includes('session-replay-slim-table');
+    if (hasSlimTable) {
+      // There is a 'slim table' view that renders less data. When that is
+      // enabled we should not fetch extra fields that won't be rendered.
+      // This helps the server save resources and return data faster.
+      const fieldsToRemove = ['browser', 'os', 'urls', 'user'];
+
+      // TODO(replay): https://github.com/getsentry/sentry/issues/46215
+      fieldsToRemove.push('started_at');
+
       payload.field = payload.field.filter(field => !fieldsToRemove.includes(field));
       payload.field.push('count_urls');
     } else {

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -74,7 +74,7 @@ export const getBreadcrumbsByCategory = (breadcrumbs: Crumb[], categories: strin
 export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
   // Marshal special fields into tags
   const user = Object.fromEntries(
-    Object.entries(apiResponse.user)
+    Object.entries(apiResponse.user || {})
       .filter(([key, value]) => key !== 'display_name' && value)
       .map(([key, value]) => [`user.${key}`, [value]])
   );

--- a/static/app/views/replays/replayTable/headerCell.tsx
+++ b/static/app/views/replays/replayTable/headerCell.tsx
@@ -37,6 +37,9 @@ function HeaderCell({column, sort}: Props) {
     case ReplayColumns.replay:
       return <SortableHeader sort={sort} fieldName="started_at" label={t('Replay')} />;
 
+    case ReplayColumns.replay_slim:
+      return <SortableHeader sort={sort} fieldName="started_at" label={t('Replay')} />;
+
     case ReplayColumns.slowestTransaction:
       return (
         <SortableHeader

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -45,30 +45,13 @@ export function ReplayCell({
     },
   };
 
-  const subText = replay.urls ? (
+  const subText = (
     <Cols>
-      <StringWalker urls={replay.urls} />
+      <StringWalker urls={replay.urls || []} />
       <Row gap={1}>
         <Row gap={0.5}>
           {project ? <Avatar size={12} project={project} /> : null}
           <Link to={replayDetails}>{getShortEventId(replay.id)}</Link>
-        </Row>
-        <Row gap={0.5}>
-          <IconCalendar color="gray300" size="xs" />
-          <TimeSince date={replay.started_at} />
-        </Row>
-      </Row>
-    </Cols>
-  ) : (
-    <Cols>
-      <Row gap={1}>
-        <Row gap={0.5} minWidth={80}>
-          {project ? <Avatar size={12} project={project} /> : null}
-          <Link to={replayDetails}>{getShortEventId(replay.id)}</Link>
-        </Row>
-        <Row gap={0.5} minWidth={80}>
-          <IconLocation color="green400" size="sm" />
-          {tn('%s Page', '%s Pages', replay.count_urls)}
         </Row>
         <Row gap={0.5}>
           <IconCalendar color="gray300" size="xs" />
@@ -84,19 +67,60 @@ export function ReplayCell({
         avatarSize={24}
         displayName={
           <MainLink to={replayDetails}>
-            {replay.user.display_name || t('Unknown User')}
+            {replay.user?.display_name || t('Unknown User')}
           </MainLink>
         }
         user={{
-          username: replay.user.display_name || '',
-          email: replay.user.email || '',
-          id: replay.user.id || '',
-          ip_address: replay.user.ip || '',
-          name: replay.user.username || '',
+          username: replay.user?.display_name || '',
+          email: replay.user?.email || '',
+          id: replay.user?.id || '',
+          ip_address: replay.user?.ip || '',
+          name: replay.user?.username || '',
         }}
         // this is the subheading for the avatar, so displayEmail in this case is a misnomer
         displayEmail={subText}
       />
+    </Item>
+  );
+}
+
+export function ReplaySlimCell({
+  eventView,
+  organization,
+  referrer,
+  replay,
+}: Props & {eventView: EventView; organization: Organization; referrer: string}) {
+  const {projects} = useProjects();
+  const project = projects.find(p => p.id === replay.project_id);
+
+  const replayDetails = {
+    pathname: `/organizations/${organization.slug}/replays/${project?.slug}:${replay.id}/`,
+    query: {
+      referrer,
+      ...eventView.generateQueryStringObject(),
+    },
+  };
+
+  return (
+    <Item>
+      <Row gap={1}>
+        {project ? <Avatar size={24} project={project} /> : null}
+        <Cols>
+          <MainLink to={replayDetails}>{getShortEventId(replay.id)}</MainLink>
+          <Row gap={1}>
+            <Row gap={0.5} minWidth={80}>
+              <IconLocation color="green400" size="sm" />
+              {tn('%s Page', '%s Pages', replay.count_urls)}
+            </Row>
+            {replay.started_at ? (
+              <Row gap={0.5}>
+                <IconCalendar color="gray300" size="xs" />
+                <TimeSince date={replay.started_at} />
+              </Row>
+            ) : null}
+          </Row>
+        </Cols>
+      </Row>
     </Item>
   );
 }

--- a/static/app/views/replays/replayTable/types.tsx
+++ b/static/app/views/replays/replayTable/types.tsx
@@ -5,5 +5,6 @@ export enum ReplayColumns {
   duration = 'duration',
   os = 'os',
   replay = 'replay',
+  replay_slim = 'replay_slim',
   slowestTransaction = 'slowestTransaction',
 }

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -111,9 +111,9 @@ export type ReplayListRecord = Pick<
   | 'id'
   | 'project_id'
   | 'started_at'
-  | 'user'
 > &
-  Partial<Pick<ReplayRecord, 'browser' | 'count_urls' | 'os' | 'urls'>>;
+  // These fields are optional becuase they might not exist when `session-replay-slim-table` is enabled
+  Partial<Pick<ReplayRecord, 'browser' | 'count_urls' | 'os' | 'urls' | 'user'>>;
 
 // Sync with ReplayListRecord above
 export const REPLAY_LIST_FIELDS: ReplayRecordNestedFieldName[] = [


### PR DESCRIPTION
Now the slim Replay List view is even smaller, not requesting `user.*` fields

Enable the slim list by putting an org into the `session-replay-slim-table` feature.





**Example Slim Replay List (missing started_at):**
I ran into https://github.com/getsentry/sentry/issues/46215 again with this, so `started_at` is also not requested, but it really should be. 

<img width="1043" alt="slim replay list" src="https://user-images.githubusercontent.com/187460/231696624-bd3f7975-b223-4044-913c-5b8ba6bc7c4d.png">

**Same, but with started_at fetched:**
<img width="1037" alt="slim replay list - with started_at" src="https://user-images.githubusercontent.com/187460/231696615-ad4f52fa-5c6c-40cc-9628-3eee536e8823.png">


Fixes https://github.com/getsentry/sentry/issues/47302
