### PR TITLE
ref(alerts): Display better performance error messages if invalid query

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -182,7 +182,10 @@ type Props = WithRouterProps &
      */
     actionBarItems?: ActionBarItem[];
     className?: string;
-
+    /**
+     * A function that provides the current search item and can return a custom invalid tag error message for the drop-down.
+     */
+    customInvalidTagMessage?: (item: SearchItem) => React.ReactNode;
     /**
      * Custom Performance Metrics for query string unit parsing
      */
@@ -267,6 +270,7 @@ type Props = WithRouterProps &
      * Indicates the usage of the search bar for analytics
      */
     searchSource?: string;
+
     /**
      * Type of supported tags
      */
@@ -1905,6 +1909,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
             maxMenuHeight={maxMenuHeight}
             customPerformanceMetrics={customPerformanceMetrics}
             supportedTags={supportedTags}
+            customInvalidTagMessage={this.props.customInvalidTagMessage}
           />
         )}
       </Container>

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -301,7 +301,7 @@ function DropdownItem({
   } else if (item.type === ItemType.INVALID_TAG) {
     children = customInvalidTagMessage?.(item) ?? (
       <SearchInvalidTag
-        message={tct("The field [field] isn't supported here. ", {
+        message={tct("The field [field] isn't supported here.", {
           field: <code>{item.desc}</code>,
         })}
       />

--- a/static/app/components/smartSearchBar/searchInvalidTag.tsx
+++ b/static/app/components/smartSearchBar/searchInvalidTag.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+type Props = {
+  message: React.ReactNode;
+  docLink?: string;
+};
+
+export function SearchInvalidTag({message, docLink}: Props) {
+  return (
+    <Invalid
+      onClick={event => {
+        if (!docLink) {
+          return;
+        }
+        event.stopPropagation();
+        window.open(docLink);
+      }}
+    >
+      <span>{message}</span>
+      <Highlight>{t('See all searchable properties in the docs.')}</Highlight>
+    </Invalid>
+  );
+}
+
+const Invalid = styled(`span`)`
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-family: ${p => p.theme.text.family};
+  color: ${p => p.theme.gray400};
+
+  code {
+    font-weight: bold;
+    padding: 0;
+  }
+  display: flex;
+  gap: ${space(0.25)};
+  width: 100%;
+`;
+
+const Highlight = styled(`strong`)`
+  color: ${p => p.theme.linkColor};
+`;

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -7,13 +7,11 @@ import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
-import {Alert} from 'sentry/components/alert';
 import SearchBar from 'sentry/components/events/searchBar';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import FormField from 'sentry/components/forms/formField';
 import IdBadge from 'sentry/components/idBadge';
-import ExternalLink from 'sentry/components/links/externalLink';
 import ListItem from 'sentry/components/list/listItem';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import {SearchInvalidTag} from 'sentry/components/smartSearchBar/searchInvalidTag';
@@ -64,7 +62,6 @@ type Props = {
   project: Project;
   projects: Project[];
   router: InjectedRouter;
-  showMEPAlertBanner: boolean;
   thresholdChart: React.ReactNode;
   timeWindow: number;
   allowChangeEventTypes?: boolean;
@@ -402,14 +399,8 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   render() {
-    const {
-      organization,
-      disabled,
-      onFilterSearch,
-      allowChangeEventTypes,
-      dataset,
-      showMEPAlertBanner,
-    } = this.props;
+    const {organization, disabled, onFilterSearch, allowChangeEventTypes, dataset} =
+      this.props;
     const {environments} = this.state;
 
     const environmentOptions: SelectValue<string | null>[] = [
@@ -421,27 +412,11 @@ class RuleConditionsForm extends PureComponent<Props, State> {
         []),
     ];
 
-    const hasMetricDataset = organization.features.includes('mep-rollout-flag');
-
     return (
       <Fragment>
         <ChartPanel>
           <StyledPanelBody>{this.props.thresholdChart}</StyledPanelBody>
         </ChartPanel>
-        {showMEPAlertBanner && hasMetricDataset && (
-          <AlertContainer>
-            <Alert type="info" showIcon>
-              {tct(
-                'Based on your search criteria and sample rate, the events available may be limited. [link:Learn more].',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/alerts/create-alerts/metric-alert-config/#filters" />
-                  ),
-                }
-              )}
-            </Alert>
-          </AlertContainer>
-        )}
         {this.renderInterval()}
         <StyledListItem>{t('Filter events')}</StyledListItem>
         <FormRow noMargin columns={1 + (allowChangeEventTypes ? 1 : 0) + 1}>
@@ -564,10 +539,6 @@ const StyledListTitle = styled('div')`
 
 const ChartPanel = styled(Panel)`
   margin-bottom: ${space(1)};
-`;
-
-const AlertContainer = styled('div')`
-  margin-bottom: ${space(2)};
 `;
 
 const StyledPanelBody = styled(PanelBody)`

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -107,7 +107,6 @@ type State = {
   project: Project;
   query: string;
   resolveThreshold: UnsavedMetricRule['resolveThreshold'];
-  showMEPAlertBanner: boolean;
   thresholdPeriod: UnsavedMetricRule['thresholdPeriod'];
   thresholdType: UnsavedMetricRule['thresholdType'];
   timeWindow: number;
@@ -153,7 +152,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       eventTypes: _eventTypes,
       dataset: _dataset,
       name,
-      showMEPAlertBanner,
     } = location?.query ?? {};
     const eventTypes = typeof _eventTypes === 'string' ? [_eventTypes] : _eventTypes;
 
@@ -188,7 +186,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         : AlertRuleComparisonType.COUNT,
       project: this.props.project,
       owner: rule.owner,
-      showMEPAlertBanner: showMEPAlertBanner ?? false,
       alertType: getAlertTypeFromAggregateDataset({aggregate, dataset}),
     };
   }
@@ -742,14 +739,14 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       return;
     }
 
-    const {dataset, showMEPAlertBanner} = this.state;
+    const {dataset} = this.state;
 
     if (isMetricsData && dataset === Dataset.TRANSACTIONS) {
-      this.setState({dataset: Dataset.GENERIC_METRICS, showMEPAlertBanner: false});
+      this.setState({dataset: Dataset.GENERIC_METRICS});
     }
 
-    if (!isMetricsData && dataset === Dataset.GENERIC_METRICS && !showMEPAlertBanner) {
-      this.setState({dataset: Dataset.TRANSACTIONS, showMEPAlertBanner: true});
+    if (!isMetricsData && dataset === Dataset.GENERIC_METRICS) {
+      this.setState({dataset: Dataset.TRANSACTIONS});
     }
   };
 
@@ -784,7 +781,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       loading,
       eventTypes,
       dataset,
-      showMEPAlertBanner,
       alertType,
       isQueryValid,
     } = this.state;
@@ -944,7 +940,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                         this.handleFieldChange('timeWindow', value)
                       }
                       disableProjectSelector={disableProjectSelector}
-                      showMEPAlertBanner={showMEPAlertBanner}
                     />
                     <AlertListItem>{t('Set thresholds')}</AlertListItem>
                     {thresholdTypeForm(formDisabled)}

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -786,6 +786,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       dataset,
       showMEPAlertBanner,
       alertType,
+      isQueryValid,
     } = this.state;
 
     const chartProps = {
@@ -804,6 +805,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       thresholdType,
       comparisonDelta,
       comparisonType,
+      isQueryValid,
     };
 
     const wizardBuilderChart = (

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -42,6 +42,7 @@ describe('Incident Rules Create', () => {
         thresholdType={AlertRuleThresholdType.BELOW}
         newAlertOrQuery
         handleMEPAlertDataset={() => {}}
+        isQueryValid
       />
     );
 

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -233,10 +233,12 @@ class TriggersChart extends PureComponent<Props, State> {
     minutesThresholdToDisplaySeconds,
     isQueryValid,
     errored,
+    orgFeatures,
   }: {
     isLoading: boolean;
     isQueryValid: boolean;
     isReloading: boolean;
+    orgFeatures: string[];
     timeseriesData: Series[];
     comparisonData?: Series[];
     comparisonMarkLines?: LineChartSeries[];
@@ -256,7 +258,9 @@ class TriggersChart extends PureComponent<Props, State> {
     const {statsPeriod, totalCount} = this.state;
     const statsPeriodOptions = this.availableTimePeriods[timeWindow];
     const period = this.getStatsPeriod();
-    const error = errored || !isQueryValid || errorMessage;
+    const error = orgFeatures.includes('alert-allow-indexed')
+      ? false
+      : errored || !isQueryValid || errorMessage;
 
     return (
       <Fragment>
@@ -392,6 +396,7 @@ class TriggersChart extends PureComponent<Props, State> {
             minutesThresholdToDisplaySeconds: MINUTES_THRESHOLD_TO_DISPLAY_SECONDS,
             isQueryValid,
             errored,
+            orgFeatures: organization.features,
           });
         }}
       </SessionsRequest>
@@ -440,6 +445,7 @@ class TriggersChart extends PureComponent<Props, State> {
             errorMessage,
             isQueryValid,
             errored,
+            orgFeatures: organization.features,
           });
         }}
       </EventsRequest>

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -258,20 +258,21 @@ class TriggersChart extends PureComponent<Props, State> {
     const {statsPeriod, totalCount} = this.state;
     const statsPeriodOptions = this.availableTimePeriods[timeWindow];
     const period = this.getStatsPeriod();
+
     const error = orgFeatures.includes('alert-allow-indexed')
-      ? false
-      : errored || !isQueryValid || errorMessage;
+      ? errored || errorMessage
+      : errored || errorMessage || !isQueryValid;
 
     return (
       <Fragment>
         {header}
         <TransparentLoadingMask visible={isReloading} />
-        {isLoading ? (
+        {isLoading && !error ? (
           <ChartPlaceholder />
         ) : error ? (
           <ChartErrorWrapper>
             <PanelAlert type="error">
-              {!isQueryValid
+              {!orgFeatures.includes('alert-allow-indexed') && !isQueryValid
                 ? t(
                     'Your filter conditions contain an unsupported field - please review.'
                   )

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -8,6 +8,7 @@ import minBy from 'lodash/minBy';
 
 import {fetchTotalCount} from 'sentry/actionCreators/events';
 import {Client} from 'sentry/api';
+import ErrorPanel from 'sentry/components/charts/errorPanel';
 import EventsRequest from 'sentry/components/charts/eventsRequest';
 import {LineChartSeries} from 'sentry/components/charts/lineChart';
 import OptionSelector from 'sentry/components/charts/optionSelector';
@@ -19,7 +20,9 @@ import {
   SectionValue,
 } from 'sentry/components/charts/styles';
 import LoadingMask from 'sentry/components/loadingMask';
+import {PanelAlert} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
+import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {
@@ -60,6 +63,7 @@ type Props = {
   dataset: MetricRule['dataset'];
   environment: string | null;
   handleMEPAlertDataset: (data: EventsStats | MultiSeriesEventsStats | null) => void;
+  isQueryValid: boolean;
   location: Location;
   newAlertOrQuery: boolean;
   organization: Organization;
@@ -219,14 +223,27 @@ class TriggersChart extends PureComponent<Props, State> {
     }
   }
 
-  renderChart(
-    timeseriesData: Series[] = [],
-    isLoading: boolean,
-    isReloading: boolean,
-    comparisonData?: Series[],
-    comparisonMarkLines?: LineChartSeries[],
-    minutesThresholdToDisplaySeconds?: number
-  ) {
+  renderChart({
+    isLoading,
+    isReloading,
+    timeseriesData = [],
+    comparisonData,
+    comparisonMarkLines,
+    errorMessage,
+    minutesThresholdToDisplaySeconds,
+    isQueryValid,
+    errored,
+  }: {
+    isLoading: boolean;
+    isQueryValid: boolean;
+    isReloading: boolean;
+    timeseriesData: Series[];
+    comparisonData?: Series[];
+    comparisonMarkLines?: LineChartSeries[];
+    errorMessage?: string;
+    errored?: boolean;
+    minutesThresholdToDisplaySeconds?: number;
+  }) {
     const {
       triggers,
       resolveThreshold,
@@ -239,12 +256,29 @@ class TriggersChart extends PureComponent<Props, State> {
     const {statsPeriod, totalCount} = this.state;
     const statsPeriodOptions = this.availableTimePeriods[timeWindow];
     const period = this.getStatsPeriod();
+    const error = errored || !isQueryValid || errorMessage;
+
     return (
       <Fragment>
         {header}
         <TransparentLoadingMask visible={isReloading} />
         {isLoading ? (
           <ChartPlaceholder />
+        ) : error ? (
+          <ChartErrorWrapper>
+            <PanelAlert type="error">
+              {!isQueryValid
+                ? t(
+                    'Your filter conditions contain an unsupported field - please review.'
+                  )
+                : typeof errorMessage === 'string'
+                ? errorMessage
+                : t('An error occurred while fetching data')}
+            </PanelAlert>
+            <StyledErrorPanel>
+              <IconWarning color="gray500" size="lg" />
+            </StyledErrorPanel>
+          </ChartErrorWrapper>
         ) : (
           <ThresholdsChart
             period={statsPeriod}
@@ -306,6 +340,7 @@ class TriggersChart extends PureComponent<Props, State> {
       comparisonDelta,
       triggers,
       thresholdType,
+      isQueryValid,
     } = this.props;
 
     const period = this.getStatsPeriod();
@@ -332,7 +367,7 @@ class TriggersChart extends PureComponent<Props, State> {
         field={SESSION_AGGREGATE_TO_FIELD[aggregate]}
         groupBy={['session.status']}
       >
-        {({loading, reloading, response}) => {
+        {({loading, errored, reloading, response}) => {
           const {groups, intervals} = response || {};
           const sessionTimeSeries = [
             {
@@ -348,14 +383,16 @@ class TriggersChart extends PureComponent<Props, State> {
             },
           ];
 
-          return this.renderChart(
-            sessionTimeSeries,
-            loading,
-            reloading,
-            undefined,
-            undefined,
-            MINUTES_THRESHOLD_TO_DISPLAY_SECONDS
-          );
+          return this.renderChart({
+            timeseriesData: sessionTimeSeries,
+            isLoading: loading,
+            isReloading: reloading,
+            comparisonData: undefined,
+            comparisonMarkLines: undefined,
+            minutesThresholdToDisplaySeconds: MINUTES_THRESHOLD_TO_DISPLAY_SECONDS,
+            isQueryValid,
+            errored,
+          });
         }}
       </SessionsRequest>
     ) : (
@@ -375,7 +412,14 @@ class TriggersChart extends PureComponent<Props, State> {
         queryExtras={queryExtras}
         dataLoadedCallback={handleMEPAlertDataset}
       >
-        {({loading, reloading, timeseriesData, comparisonTimeseriesData}) => {
+        {({
+          loading,
+          errored,
+          errorMessage,
+          reloading,
+          timeseriesData,
+          comparisonTimeseriesData,
+        }) => {
           let comparisonMarkLines: LineChartSeries[] = [];
           if (renderComparisonStats && comparisonTimeseriesData) {
             comparisonMarkLines = getComparisonMarkLines(
@@ -387,13 +431,16 @@ class TriggersChart extends PureComponent<Props, State> {
             );
           }
 
-          return this.renderChart(
-            timeseriesData,
-            loading,
-            reloading,
-            comparisonTimeseriesData,
-            comparisonMarkLines
-          );
+          return this.renderChart({
+            timeseriesData: timeseriesData as Series[],
+            isLoading: loading,
+            isReloading: reloading,
+            comparisonData: comparisonTimeseriesData,
+            comparisonMarkLines,
+            errorMessage,
+            isQueryValid,
+            errored,
+          });
         }}
       </EventsRequest>
     );
@@ -412,4 +459,12 @@ const ChartPlaceholder = styled(Placeholder)`
   /* Height and margin should add up to graph size (200px) */
   margin: 0 0 ${space(2)};
   height: 184px;
+`;
+
+const StyledErrorPanel = styled(ErrorPanel)`
+  padding: ${space(2)};
+`;
+
+const ChartErrorWrapper = styled('div')`
+  margin-top: ${space(2)};
 `;


### PR DESCRIPTION
Adds an alert to the chart informing the user that an error occurred.

![image](https://user-images.githubusercontent.com/29228205/231757031-d6de0b45-4bb0-45f7-b54c-0c6141abc4a6.png)

Updates the message displayed in the smart search drop-down informing the user that a certain query is not valid for performance alerts and adds a more specific doc.

![image](https://user-images.githubusercontent.com/29228205/231757105-47f6b8ec-1b34-4ec4-b57b-ce77dcf5ccba.png)

Removes the blu banner alert, since we are now displaying the error in the chart
![image](https://user-images.githubusercontent.com/29228205/231985840-ddba2620-c37a-4a06-82ae-3bd84668a6b4.png)


resolves https://github.com/getsentry/sentry/issues/47004