### PR TITLE
ref(tx-clusterer): Always run the clusterer

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1743,9 +1743,6 @@ SENTRY_RELEASE_MONITOR = (
 )
 SENTRY_RELEASE_MONITOR_OPTIONS = {}
 
-# Whether or not to run transaction clusterer
-SENTRY_TRANSACTION_CLUSTERER_RUN = False
-
 # Render charts on the backend. This uses the Chartcuterie external service.
 SENTRY_CHART_RENDERER = "sentry.charts.chartcuterie.Chartcuterie"
 SENTRY_CHART_RENDERER_OPTIONS = {}

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -2,7 +2,6 @@ from itertools import islice
 from typing import Any, Sequence
 
 import sentry_sdk
-from django.conf import settings
 
 from sentry import features
 from sentry.models import Project
@@ -34,8 +33,6 @@ PROJECTS_PER_TASK = 100
 )  # type: ignore
 def spawn_clusterers(**kwargs: Any) -> None:
     """Look for existing transaction name sets in redis and spawn clusterers for each"""
-    if not settings.SENTRY_TRANSACTION_CLUSTERER_RUN:
-        return
     with sentry_sdk.start_span(op="txcluster_spawn"):
         project_count = 0
         project_iter = redis.get_active_projects()

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -188,7 +188,6 @@ def test_save_rules(default_project):
     assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
 
 
-@mock.patch("django.conf.settings.SENTRY_TRANSACTION_CLUSTERER_RUN", True)
 # From the test -- number of transactions: 30 == 10 * 2 + 5 * 2
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 30)
 @mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 5)
@@ -249,7 +248,6 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
         }
 
 
-@mock.patch("django.conf.settings.SENTRY_TRANSACTION_CLUSTERER_RUN", True)
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
 @mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 2)
 @mock.patch("sentry.ingest.transaction_clusterer.rules.update_rules")
@@ -317,7 +315,6 @@ def test_transaction_clusterer_generates_rules(default_project):
         ]
 
 
-@mock.patch("django.conf.settings.SENTRY_TRANSACTION_CLUSTERER_RUN", True)
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 10)
 @mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 5)
 @mock.patch(
@@ -374,7 +371,6 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
         assert _get_rules(project1) == {"/user/*/**": 2}
 
 
-@mock.patch("django.conf.settings.SENTRY_TRANSACTION_CLUSTERER_RUN", True)
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 3)
 @mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 2)
 @mock.patch(


### PR DESCRIPTION
The clusterer seems to produce solid results, so we're keeping it. Thus, the flag to control whether to run it is no longer required.