### PR TITLE
ref(quota-metric): Fix name

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -155,10 +155,10 @@ def get_quotas(project: Project, keys: Optional[Sequence[ProjectKey]] = None) ->
     try:
         computed_quotas = [quota.to_json() for quota in quotas.get_quotas(project, keys=keys)]
     except BaseException:
-        metrics.incr("sentry.relay.config.get_quotas", tags={"success": False}, sample_rate=1.0)
+        metrics.incr("relay.config.get_quotas", tags={"success": False}, sample_rate=1.0)
         raise
     else:
-        metrics.incr("sentry.relay.config.get_quotas", tags={"success": True}, sample_rate=1.0)
+        metrics.incr("relay.config.get_quotas", tags={"success": True}, sample_rate=1.0)
         return computed_quotas
 
 


### PR DESCRIPTION
The prefix `sentry.` is added automatically, so the current metric name is `sentry.sentry.relay.config.get_quotas`, with an extra `sentry.`.