### PR TITLE
feat(profiling): Link from profile summary to transaction summary

### DIFF
--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import {Button} from 'sentry/components/button';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
@@ -32,6 +33,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import Tags from 'sentry/views/discover/tags';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {DEFAULT_PROFILING_DATETIME_SELECTION} from 'sentry/views/profiling/utils';
 
 import {ProfileSummaryContent} from './content';
@@ -121,6 +123,16 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
     selection: props.selection,
     disabled: profilingUsingTransactions,
   });
+
+  const transactionSummaryTarget =
+    project &&
+    transaction &&
+    transactionSummaryRouteWithQuery({
+      orgSlug: organization.slug,
+      transaction,
+      projectID: project.id,
+      query: {query},
+    });
 
   const handleSearch: SmartSearchBarProps['onSearch'] = useCallback(
     (searchQuery: string) => {
@@ -214,6 +226,13 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
                     {transaction}
                   </Layout.Title>
                 </Layout.HeaderContent>
+                {transactionSummaryTarget && (
+                  <Layout.HeaderActions>
+                    <Button to={transactionSummaryTarget} size="sm">
+                      {t('View Transaction Summary')}
+                    </Button>
+                  </Layout.HeaderActions>
+                )}
               </Layout.Header>
               <Layout.Body>
                 <Layout.Main fullWidth={!profilingUsingTransactions}>


### PR DESCRIPTION
For convenience, we want to be able to navigate from a transaction summary page to the profile summary page easily.