### PR TITLE
feat(codeowners): Enable 3mb max size to all users

### DIFF
--- a/src/sentry/api/endpoints/codeowners/__init__.py
+++ b/src/sentry/api/endpoints/codeowners/__init__.py
@@ -12,7 +12,7 @@ from sentry.api.validators.project_codeowners import validate_codeowners_associa
 from sentry.models import Project, ProjectCodeOwners, RepositoryProjectPathConfig
 from sentry.ownership.grammar import convert_codeowners_syntax, create_schema_from_issue_owners
 from sentry.utils import metrics
-from sentry.utils.codeowners import HIGHER_MAX_RAW_LENGTH, MAX_RAW_LENGTH
+from sentry.utils.codeowners import MAX_RAW_LENGTH
 
 from .analytics import *  # NOQA
 
@@ -27,11 +27,6 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
         fields = ["raw", "code_mapping_id", "organization_integration_id"]
 
     def get_max_length(self) -> int:
-        if features.has(
-            "organizations:scaleable-codeowners-search",
-            self.context["project"].organization,
-        ):
-            return int(HIGHER_MAX_RAW_LENGTH)
         # typecast needed for typing, though these will always be ints
         return int(MAX_RAW_LENGTH)
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1223,8 +1223,6 @@ SENTRY_FEATURES = {
     "organizations:enterprise-perf": False,
     # Enable the API to importing CODEOWNERS for a project
     "organizations:integrations-codeowners": False,
-    # Enable fast CODEOWNERS path matching
-    "organizations:scaleable-codeowners-search": False,
     # Enable inviting members to organizations.
     "organizations:invite-members": True,
     # Enable rate limits for inviting members.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -163,7 +163,6 @@ default_manager.add("organizations:reprocessing-v2", OrganizationFeature, Featur
 default_manager.add("organizations:required-email-verification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:rule-page", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:scaleable-codeowners-search", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sentry-functions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/utils/codeowners.py
+++ b/src/sentry/utils/codeowners.py
@@ -1,8 +1,7 @@
 import sentry_relay
 
 # Max accepted string length of the CODEOWNERS file
-MAX_RAW_LENGTH: int = 1_000_000
-HIGHER_MAX_RAW_LENGTH: int = 3_000_000
+MAX_RAW_LENGTH: int = 3_000_000
 
 
 def codeowners_match(value, pat):


### PR DESCRIPTION
## Objective:
Remove the `scaleable-codeowners-search` feature flag and enables the 3mb CODEOWNERS file size limit to all users.