### PR TITLE
fix(escalating-issues): Change schedule from timedelta to crontab

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -914,7 +914,7 @@ CELERYBEAT_SCHEDULE = {
     "weekly-escalating-forecast": {
         "task": "sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",
         # TODO: Change this to run weekly once we verify the results
-        "schedule": timedelta(hours=6),
+        "schedule": crontab(minute=0, hour="*/6"),
         # TODO: Increase expiry time to x4 once we change this to run weekly
         "options": {"expires": 60 * 60 * 3},
     },


### PR DESCRIPTION
The task, `sentry.tasks.weekly_escalating_forecast.run_escalating_forecast`, is not running every 6 hours.

This may be caused by the restarts of the process that runs the celery beat schedule, as using `timedelta` schedules the first task 6 hours after the celery beat starts. Using `crontab` does not schedule relative to the celery beat start/restarts.

See [here](https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#periodic-tasks) for more details.