### PR TITLE
fix(ui): Switch keyof to [number] on array of types

### DIFF
--- a/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
@@ -25,7 +25,7 @@ type Output = {
 type Props = {
   data: DeviceContext;
   event: Event;
-  type: keyof typeof deviceKnownDataValues;
+  type: (typeof deviceKnownDataValues)[number];
 };
 
 export function getDeviceKnownDataDetails({

--- a/static/app/components/events/contexts/device/index.tsx
+++ b/static/app/components/events/contexts/device/index.tsx
@@ -25,7 +25,7 @@ export function DeviceEventContext({data, event}: Props) {
   return (
     <Fragment>
       <ContextBlock
-        data={getKnownData<DeviceContext, keyof typeof deviceKnownDataValues>({
+        data={getKnownData<DeviceContext, (typeof deviceKnownDataValues)[number]>({
           data: inferredData,
           meta,
           knownDataTypes: deviceKnownDataValues,

--- a/static/app/components/events/contexts/memoryInfo/getMemoryInfoKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/memoryInfo/getMemoryInfoKnownDataDetails.tsx
@@ -11,7 +11,7 @@ type Output = {
 type Props = {
   data: MemoryInfoContext;
   event: Event;
-  type: keyof typeof memoryInfoKnownDataValues;
+  type: (typeof memoryInfoKnownDataValues)[number];
 };
 
 export function getMemoryInfoKnownDataDetails({data, type}: Props): Output | undefined {

--- a/static/app/components/events/contexts/memoryInfo/index.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.tsx
@@ -26,12 +26,14 @@ export function MemoryInfoEventContext({data, event}: Props) {
   return (
     <Fragment>
       <ContextBlock
-        data={getKnownData<MemoryInfoContext, keyof typeof memoryInfoKnownDataValues>({
-          data,
-          meta,
-          knownDataTypes: memoryInfoKnownDataValues,
-          onGetKnownDataDetails: v => getMemoryInfoKnownDataDetails({...v, event}),
-        })}
+        data={getKnownData<MemoryInfoContext, (typeof memoryInfoKnownDataValues)[number]>(
+          {
+            data,
+            meta,
+            knownDataTypes: memoryInfoKnownDataValues,
+            onGetKnownDataDetails: v => getMemoryInfoKnownDataDetails({...v, event}),
+          }
+        )}
       />
       <ContextBlock
         data={getUnknownData({

--- a/static/app/components/events/contexts/threadPoolInfo/getThreadPoolInfoKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/getThreadPoolInfoKnownDataDetails.tsx
@@ -11,7 +11,7 @@ type Output = {
 type Props = {
   data: ThreadPoolInfoContext;
   event: Event;
-  type: keyof typeof threadPoolInfoKnownDataValues;
+  type: (typeof threadPoolInfoKnownDataValues)[number];
 };
 
 export function getThreadPoolInfoKnownDataDetails({

--- a/static/app/components/events/contexts/threadPoolInfo/index.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.tsx
@@ -30,7 +30,7 @@ export function ThreadPoolInfoEventContext({data, event}: Props) {
       <ContextBlock
         data={getKnownData<
           ThreadPoolInfoContext,
-          keyof typeof threadPoolInfoKnownDataValues
+          (typeof threadPoolInfoKnownDataValues)[number]
         >({
           data,
           meta,

--- a/static/app/components/events/contexts/unity/getUnityKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/unity/getUnityKnownDataDetails.tsx
@@ -10,7 +10,7 @@ type Output = {
 
 type Props = {
   data: UnityContext;
-  type: keyof typeof unityKnownDataValues;
+  type: (typeof unityKnownDataValues)[number];
 };
 
 export function getUnityKnownDataDetails({data, type}: Props): Output | undefined {

--- a/static/app/components/events/contexts/unity/index.tsx
+++ b/static/app/components/events/contexts/unity/index.tsx
@@ -22,7 +22,7 @@ export function UnityEventContext({data, event}: Props) {
   return (
     <Fragment>
       <ContextBlock
-        data={getKnownData<UnityContext, keyof typeof unityKnownDataValues>({
+        data={getKnownData<UnityContext, (typeof unityKnownDataValues)[number]>({
           data,
           meta,
           knownDataTypes: unityKnownDataValues,


### PR DESCRIPTION
Required for typescript v5, doesn't like the keyof anymore

`keyof Something[]` should be `Something[number]`