### PR TITLE
fix(migration-runner): Use migration models instead of real models when manually running migrations

### DIFF
--- a/src/sentry/runner/commands/migrations.py
+++ b/src/sentry/runner/commands/migrations.py
@@ -21,8 +21,8 @@ def run(ctx, app_name, migration_name):
     from django.db.migrations.executor import MigrationExecutor
 
     executor = MigrationExecutor(connections["default"])
-    apps = executor.loader.project_state(migration_name).apps
     migration = executor.loader.get_migration_by_prefix(app_name, migration_name)
+    apps = executor.loader.project_state(migration.migration_name).apps
 
     for op in migration.operations:
         if not isinstance(op, RunPython):

--- a/src/sentry/runner/commands/migrations.py
+++ b/src/sentry/runner/commands/migrations.py
@@ -16,14 +16,14 @@ def migrations():
 def run(ctx, app_name, migration_name):
     "Manually run a single data migration. Will error if migration is not data only."
 
-    from django.apps import apps
     from django.db import connections
     from django.db.migrations import RunPython
     from django.db.migrations.executor import MigrationExecutor
 
-    migration = MigrationExecutor(connections["default"]).loader.get_migration_by_prefix(
-        app_name, migration_name
-    )
+    executor = MigrationExecutor(connections["default"])
+    apps = executor.loader.project_state(migration_name).apps
+    migration = executor.loader.get_migration_by_prefix(app_name, migration_name)
+
     for op in migration.operations:
         if not isinstance(op, RunPython):
             raise click.ClickException(

--- a/src/sentry/runner/commands/migrations.py
+++ b/src/sentry/runner/commands/migrations.py
@@ -22,7 +22,7 @@ def run(ctx, app_name, migration_name):
 
     executor = MigrationExecutor(connections["default"])
     migration = executor.loader.get_migration_by_prefix(app_name, migration_name)
-    apps = executor.loader.project_state(migration.migration_name).apps
+    apps = executor.loader.project_state(nodes=[(app_name, migration.name)]).apps
 
     for op in migration.operations:
         if not isinstance(op, RunPython):


### PR DESCRIPTION
Currently when a backfill migration runs as part of the deploy it uses migration models, but when ops run them manually it uses real models. This causes weirdness like signals firing.

