### PR TITLE
feat(code mapping): Derive code mappings for more distinct issues

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -760,11 +760,14 @@ def process_code_mappings(job: PostProcessJob) -> None:
             if event.data["platform"] not in SUPPORTED_LANGUAGES:
                 return
 
-            # Limit the overall number of tasks by only processing one issue per project
-            # per hour
-            project_cache_key = f"code-mappings:project:{project.id}:"
-            if cache.get(project_cache_key) is None:
-                cache.set(project_cache_key, True, 3600)
+            # To limit the overall number of tasks, only process one issue per project per hour. In
+            # order to give the most issues a chance to to be processed, don't reprocess any given
+            # issue for at least 24 hours.
+            project_cache_key = f"code-mappings:project:{project.id}"
+            issue_cache_key = f"code-mappings:group:{group_id}"
+            if cache.get(project_cache_key) is None and cache.get(issue_cache_key) is None:
+                cache.set(project_cache_key, True, 3600)  # 1 hour
+                cache.set(issue_cache_key, True, 86400)  # 24 hours
             else:
                 return
 


### PR DESCRIPTION
In order not to run into rate-limit problems with GitHub (and in order not to overwhelm our own processing resources), we only derive code mappings for one issue per project per hour. If an issue happens disproportionately frequently compared to other issues in the same project, it's likely that it will get repeatedly mapped at the expense of all of the others. Since in many (most?) cases repeated mapping doesn't gain us new information, it would be better to map as many distinct issues as possible.

This implements that change, by caching the id of any issue we've mapped within the last 24 hours and refusing to map it again until the cache entry expires.

Ref: WOR-2671