### PR TITLE
fix(crons): Show correct status when monitor is paused

### DIFF
--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -128,12 +128,13 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
   }`;
 
   // TODO(davidenwang): Change accordingly when we have ObjectStatus on monitor
-  const monitorStatus = monitorEnv ? monitorEnv.status : monitor.status;
+  const monitorStatus =
+    monitor.status !== 'disabled' && monitorEnv ? monitorEnv.status : monitor.status;
 
   return (
     <Fragment>
       <MonitorName>
-        <MonitorBadge status={monitorEnv?.status ?? monitor.status} />
+        <MonitorBadge status={monitorStatus} />
         <NameAndSlug>
           <Link to={monitorDetailUrl}>{monitor.name}</Link>
           <MonitorSlug>{monitor.slug}</MonitorSlug>


### PR DESCRIPTION
Because monitor environment status reflects the last check-in we were not showing the paused state correctly for monitors.

Before: [This monitor is paused]
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/9372512/231851500-3d3fc160-1fe0-411b-9ade-70d124c40764.png">

After:
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/9372512/231851551-63927bae-f267-4821-9d0f-714cfa1ffc2f.png">

Resolves https://github.com/getsentry/team-crons/issues/58

