### PR TITLE
ref(replays): useCrumbHandlers mouseEnter and mouseLeave optimization

### DIFF
--- a/static/app/utils/replays/hooks/useCrumbHandlers.tsx
+++ b/static/app/utils/replays/hooks/useCrumbHandlers.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useRef} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
@@ -16,24 +16,51 @@ function useCrumbHandlers(startTimestampMs: number = 0) {
   } = useReplayContext();
   const {setActiveTab} = useActiveReplayTab();
 
+  const mouseEnterCallback = useRef<{
+    id: string | number | null;
+    timeoutId: NodeJS.Timeout | null;
+  }>({
+    id: null,
+    timeoutId: null,
+  });
+
   const handleMouseEnter = useCallback(
     (item: Crumb | NetworkSpan) => {
-      if (startTimestampMs) {
-        setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestampMs));
-      }
+      // this debounces the mouseEnter callback in unison with mouseLeave
+      // we ensure the pointer remains over the target element before dispatching state events in order to minimize unnecessary renders
+      // this helps during scrolling or mouse move events which would otherwise fire in rapid succession slowing down our app
+      mouseEnterCallback.current.id = item.id;
+      mouseEnterCallback.current.timeoutId = setTimeout(() => {
+        if (startTimestampMs) {
+          setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestampMs));
+        }
 
-      if (item.data && typeof item.data === 'object' && 'nodeId' in item.data) {
-        // XXX: Kind of hacky, but mouseLeave does not fire if you move from a
-        // crumb to a tooltip
-        clearAllHighlights();
-        highlight({nodeId: item.data.nodeId, annotation: item.data.label});
-      }
+        if (item.data && typeof item.data === 'object' && 'nodeId' in item.data) {
+          // XXX: Kind of hacky, but mouseLeave does not fire if you move from a
+          // crumb to a tooltip
+          clearAllHighlights();
+          highlight({nodeId: item.data.nodeId, annotation: item.data.label});
+        }
+        mouseEnterCallback.current.id = null;
+        mouseEnterCallback.current.timeoutId = null;
+      }, 250);
     },
     [setCurrentHoverTime, startTimestampMs, highlight, clearAllHighlights]
   );
 
   const handleMouseLeave = useCallback(
     (item: Crumb | NetworkSpan) => {
+      // if there is a mouseEnter callback queued and we're leaving it we can just cancel the timeout
+      if (mouseEnterCallback.current.id === item.id) {
+        if (mouseEnterCallback.current.timeoutId) {
+          clearTimeout(mouseEnterCallback.current.timeoutId);
+        }
+        mouseEnterCallback.current.id = null;
+        mouseEnterCallback.current.timeoutId = null;
+        // since there is no more work to do we just return
+        return;
+      }
+
       setCurrentHoverTime(undefined);
 
       if (item.data && typeof item.data === 'object' && 'nodeId' in item.data) {


### PR DESCRIPTION
## Summary
Performance optimization mainly targeting the network tab mouseEnter mouseLeave state dispatching. 


See the re-renders indicated by the borders painted around individual components.

before:

https://user-images.githubusercontent.com/7349258/231864767-5b087824-68a6-45c8-be35-1f83d5908ce6.mov


after:

https://user-images.githubusercontent.com/7349258/231864892-af789d2d-9d32-4217-ae10-bc7dd621b94a.mov

