### PR TITLE
ref(replays): hold weak references to cellMeasurer cache to avoid rer…

### DIFF
--- a/static/app/views/replays/detail/useVirtualizedGrid.tsx
+++ b/static/app/views/replays/detail/useVirtualizedGrid.tsx
@@ -30,6 +30,9 @@ type Opts = {
    */
   gridRef: RefObject<MultiGrid>;
 };
+
+const globalCellMeasurerCache = new WeakMap<CellMeasurerCacheParams, CellMeasurerCache>();
+
 function useVirtualizedGrid({
   cellMeasurer,
   columnCount,
@@ -37,7 +40,14 @@ function useVirtualizedGrid({
   dynamicColumnIndex,
   gridRef,
 }: Opts) {
-  const cache = useMemo(() => new CellMeasurerCache(cellMeasurer), [cellMeasurer]);
+  const cache = useMemo(() => {
+    if (globalCellMeasurerCache.has(cellMeasurer)) {
+      return globalCellMeasurerCache.get(cellMeasurer)!;
+    }
+    const newCellMeasurer = new CellMeasurerCache(cellMeasurer);
+    globalCellMeasurerCache.set(cellMeasurer, newCellMeasurer);
+    return newCellMeasurer;
+  }, [cellMeasurer]);
   const [scrollBarWidth, setScrollBarWidth] = useState(0);
 
   const onWrapperResize = useCallback(() => {


### PR DESCRIPTION
## Summary
This is a performance optimization that caches.. the cache. 
As a result, we only do expensive cell measure computations once and not every time we change to the network tab.