### PR TITLE
ref(replays): defer rendering of the whole network tab list

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useRef} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
@@ -95,6 +95,17 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
       deps,
     });
 
+  // this is a stop-gap fix for switching to the network tab
+  // we block the main thread to do all the cellMeasurer computation
+  // and since active tab rendering is bound the useLocation, we have no choice but to render this component
+  // to provide a snappier experience, we render the table headers first followed by rows
+  const [didMount, setDidMount] = useState(false);
+  useEffect(() => {
+    setTimeout(() => {
+      setDidMount(true);
+    });
+  }, []);
+
   const cellRenderer = ({columnIndex, rowIndex, key, style, parent}: GridCellProps) => {
     const network = items[rowIndex - 1];
 
@@ -172,7 +183,7 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
                     onScrollbarPresenceChange={onScrollbarPresenceChange}
                     overscanColumnCount={COLUMN_COUNT}
                     overscanRowCount={5}
-                    rowCount={items.length + 1}
+                    rowCount={didMount ? items.length + 1 : Math.min(items.length + 1, 5)}
                     rowHeight={({index}) => (index === 0 ? HEADER_HEIGHT : BODY_HEIGHT)}
                     width={width}
                   />


### PR DESCRIPTION
## Summary
Stop gap fix for lazyish loading of the network tab.

This fix allows us to do an initial render of a few rows followed by the rest of them on the 2nd pass. At the bare minimum, we can render the Network tab and the click event is snappy. 

We can figure out a clever way to render a placeholder row at the bottom to indicate loading state.

Fixes https://github.com/getsentry/sentry/issues/46428
