### PR TITLE
feat(perf-issues): init large http payload detector ui

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -85,6 +85,7 @@ export function SpanEvidenceKeyValueList({
       [IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET]: RenderBlockingAssetSpanEvidence,
       [IssueType.PERFORMANCE_UNCOMPRESSED_ASSET]: UncompressedAssetSpanEvidence,
       [IssueType.PERFORMANCE_CONSECUTIVE_HTTP]: ConsecutiveHTTPSpanEvidence,
+      [IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD]: LargeHTTPPayloadSpanEvidence,
     }[issueType] ?? DefaultSpanEvidence;
 
   return (
@@ -142,6 +143,28 @@ function ConsecutiveHTTPSpanEvidence({
           makeRow(
             'Offending Spans',
             offendingSpans.map(span => span.description)
+          ),
+        ].filter(Boolean) as KeyValueListData
+      }
+    />
+  );
+}
+
+function LargeHTTPPayloadSpanEvidence({
+  event,
+  offendingSpans,
+  orgSlug,
+  projectSlug,
+}: SpanEvidenceKeyValueListProps) {
+  return (
+    <PresortedKeyValueList
+      data={
+        [
+          makeTransactionNameRow(event, orgSlug, projectSlug),
+          makeRow(t('Large HTTP Payload Span'), getSpanEvidenceValue(offendingSpans[0])),
+          makeRow(
+            t('Payload Size'),
+            getSpanFieldBytes(offendingSpans[0], 'Encoded Body Size')
           ),
         ].filter(Boolean) as KeyValueListData
       }

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -68,6 +68,7 @@ export enum IssueType {
   PERFORMANCE_SLOW_DB_QUERY = 'performance_slow_db_query',
   PERFORMANCE_RENDER_BLOCKING_ASSET = 'performance_render_blocking_asset_span',
   PERFORMANCE_UNCOMPRESSED_ASSET = 'performance_uncompressed_assets',
+  PERFORMANCE_LARGE_HTTP_PAYLOAD = 'performance_large_http_payload',
 
   // Profile
   PROFILE_FILE_IO_MAIN_THREAD = 'profile_file_io_main_thread',
@@ -87,6 +88,7 @@ export const getIssueTypeFromOccurenceType = (
     1009: IssueType.PERFORMANCE_CONSECUTIVE_HTTP,
     1010: IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
     1012: IssueType.PERFORMANCE_UNCOMPRESSED_ASSET,
+    1015: IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD,
   };
   if (!typeId) {
     return null;

--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -139,7 +139,20 @@ const performanceConfig: IssueCategoryConfigMapping = {
       linksByPlatform: {},
     },
   },
-
+  [IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD]: {
+    resources: {
+      description: t(
+        'A Large HTTP Payload issue occurs when an http payload size consistently exceeds a threshold'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: Large HTTP Payload'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/large-http-payload/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
   [IssueType.PERFORMANCE_UNCOMPRESSED_ASSET]: {
     resources: {
       description: t(


### PR DESCRIPTION
Creates the span evidence section for the large http payload detector