### PR TITLE
fix(ui): Remove readonly type from span for ts 5

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -131,7 +131,7 @@ export type SpanBarProps = {
   resetCellMeasureCache: () => void;
   showEmbeddedChildren: boolean;
   showSpanTree: boolean;
-  span: Readonly<ProcessedSpanType>;
+  span: ProcessedSpanType;
   spanNumber: number;
   storeSpanBar: (spanBar: SpanBar) => void;
   toggleEmbeddedChildren:

--- a/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanDescendantGroupBar.tsx
@@ -42,7 +42,7 @@ export type SpanDescendantGroupBarProps = {
   getCurrentLeftPos: () => number;
   onWheel: (deltaX: number) => void;
   removeContentSpanBarRef: (instance: HTMLDivElement | null) => void;
-  span: Readonly<ProcessedSpanType>;
+  span: ProcessedSpanType;
   spanGrouping: EnhancedSpan[];
   spanNumber: number;
   toggleSpanGroup: () => void;

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -77,7 +77,7 @@ type Props = {
   relatedErrors: TraceError[] | null;
   resetCellMeasureCache: () => void;
   scrollToHash: (hash: string) => void;
-  span: Readonly<ProcessedSpanType>;
+  span: ProcessedSpanType;
   trace: Readonly<ParsedTraceType>;
 };
 

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -36,7 +36,7 @@ export type SpanSiblingGroupBarProps = {
   occurrence: number;
   onWheel: (deltaX: number) => void;
   removeContentSpanBarRef: (instance: HTMLDivElement | null) => void;
-  span: Readonly<ProcessedSpanType>;
+  span: ProcessedSpanType;
   spanGrouping: EnhancedSpan[];
   spanNumber: number;
   toggleSiblingSpanGroup: (span: SpanType, occurrence: number) => void;


### PR DESCRIPTION
Typescript v5 for some reason doesn't won't narrow these readonly types.

There is a `assert(!isGapSpan(span));` that should narrow the type but for some reason no longer is in typescript v5. I don't think the readonly was giving us a whole lot.

There might be another way to fix this? Open to ideas
