### PR TITLE
fix(ui): Check type is number when using `>` `<`

### DIFF
--- a/static/app/utils/profiling/gl/utils.spec.tsx
+++ b/static/app/utils/profiling/gl/utils.spec.tsx
@@ -182,7 +182,7 @@ describe('createShader', () => {
       shaderSource: jest.fn(),
       compileShader: jest.fn(),
       getShaderParameter: jest.fn().mockImplementation(() => 1),
-      COMPILE_STATUS: 1,
+      COMPILE_STATUS: 1 as any,
     };
 
     // @ts-ignore this is a partial mock
@@ -204,7 +204,7 @@ describe('createShader', () => {
       compileShader: jest.fn(),
       getShaderParameter: jest.fn().mockImplementation(() => 0),
       deleteShader: jest.fn(),
-      COMPILE_STATUS: 0,
+      COMPILE_STATUS: 0 as any,
     };
 
     // @ts-ignore this is a partial mock

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1499,11 +1499,14 @@ export const findIncompatibleRules = (
         regression = i;
       } else if (id.endsWith('ReappearedEventCondition')) {
         reappeared = i;
-      } else if (id.endsWith('EventFrequencyCondition') && conditions[i].value >= 1) {
+      } else if (
+        id.endsWith('EventFrequencyCondition') &&
+        (conditions[i].value as number) >= 1
+      ) {
         eventFrequency = i;
       } else if (
         id.endsWith('EventUniqueUserFrequencyCondition') &&
-        conditions[i].value >= 1
+        (conditions[i].value as number) >= 1
       ) {
         userFrequency = i;
       }
@@ -1530,14 +1533,14 @@ export const findIncompatibleRules = (
     for (let i = 0; i < filters.length; i++) {
       const filter = filters[i];
       const id = filter.id;
-      if (id.endsWith('IssueOccurrencesFilter')) {
+      if (id.endsWith('IssueOccurrencesFilter') && filter) {
         if (
-          (rule.filterMatch === 'all' && filter.value > 1) ||
-          (rule.filterMatch === 'none' && filter.value <= 1)
+          (rule.filterMatch === 'all' && (filter.value as number) > 1) ||
+          (rule.filterMatch === 'none' && (filter.value as number) <= 1)
         ) {
           return {conditionIndices: [firstSeen], filterIndices: [i]};
         }
-        if (rule.filterMatch === 'any' && filter.value > 1) {
+        if (rule.filterMatch === 'any' && (filter.value as number) > 1) {
           incompatibleFilters += 1;
         }
       } else if (id.endsWith('AgeComparisonFilter')) {
@@ -1548,7 +1551,7 @@ export const findIncompatibleRules = (
             }
             incompatibleFilters += 1;
           }
-        } else if (filter.comparison_type === 'newer' && filter.value > 0) {
+        } else if (filter.comparison_type === 'newer' && (filter.value as number) > 0) {
           return {conditionIndices: [firstSeen], filterIndices: [i]};
         }
       }

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -390,7 +390,12 @@ function TableView(props: TableViewProps) {
 
     const fieldName = columnKey;
     const value = dataRow[fieldName];
-    if (tableData.meta[fieldName] === 'integer' && defined(value) && value > 999) {
+    if (
+      tableData.meta[fieldName] === 'integer' &&
+      defined(value) &&
+      typeof value === 'number' &&
+      value > 999
+    ) {
       return (
         <Tooltip
           title={value.toLocaleString()}

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -17,7 +17,6 @@ import Truncate from 'sentry/components/truncate';
 import {IconStack} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
-import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -392,7 +391,6 @@ function TableView(props: TableViewProps) {
     const value = dataRow[fieldName];
     if (
       tableData.meta[fieldName] === 'integer' &&
-      defined(value) &&
       typeof value === 'number' &&
       value > 999
     ) {

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -211,7 +211,12 @@ class _Table extends Component<Props, State> {
 
     const fieldName = getAggregateAlias(field);
     const value = dataRow[fieldName];
-    if (tableMeta[fieldName] === 'integer' && defined(value) && value > 999) {
+    if (
+      tableMeta[fieldName] === 'integer' &&
+      defined(value) &&
+      typeof value === 'number' &&
+      value > 999
+    ) {
       return (
         <Tooltip
           title={value.toLocaleString()}

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -17,7 +17,6 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconStar} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
-import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery, {
   TableData,
@@ -211,12 +210,7 @@ class _Table extends Component<Props, State> {
 
     const fieldName = getAggregateAlias(field);
     const value = dataRow[fieldName];
-    if (
-      tableMeta[fieldName] === 'integer' &&
-      defined(value) &&
-      typeof value === 'number' &&
-      value > 999
-    ) {
+    if (tableMeta[fieldName] === 'integer' && typeof value === 'number' && value > 999) {
       return (
         <Tooltip
           title={value.toLocaleString()}

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -220,7 +220,12 @@ class EventsTable extends Component<Props, State> {
 
     const fieldName = getAggregateAlias(field);
     const value = dataRow[fieldName];
-    if (tableMeta[fieldName] === 'integer' && defined(value) && value > 999) {
+    if (
+      tableMeta[fieldName] === 'integer' &&
+      defined(value) &&
+      typeof value === 'number' &&
+      value > 999
+    ) {
       return (
         <Tooltip
           title={value.toLocaleString()}

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -17,7 +17,6 @@ import ReplayIdCountProvider from 'sentry/components/replays/replayIdCountProvid
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {IssueAttachment, Organization} from 'sentry/types';
-import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery, {
   TableData,
@@ -220,12 +219,7 @@ class EventsTable extends Component<Props, State> {
 
     const fieldName = getAggregateAlias(field);
     const value = dataRow[fieldName];
-    if (
-      tableMeta[fieldName] === 'integer' &&
-      defined(value) &&
-      typeof value === 'number' &&
-      value > 999
-    ) {
+    if (tableMeta[fieldName] === 'integer' && typeof value === 'number' && value > 999) {
       return (
         <Tooltip
           title={value.toLocaleString()}

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -152,8 +152,9 @@ function SidebarCharts({
                   epmSeries.markPoint = MarkPoint({
                     data: results.data.anomalies.map(a => ({
                       name: a.id,
-                      yAxis: epmSeries.data.find(({name}) => name > (a.end + a.start) / 2)
-                        ?.value,
+                      yAxis: epmSeries.data.find(
+                        ({name}) => (name as number) > (a.end + a.start) / 2
+                      )?.value,
                       // TODO: the above is O(n*m), remove after we change the api to include the midpoint of y.
                       xAxis: a.start,
                       itemStyle: {

--- a/static/app/views/starfish/components/table.tsx
+++ b/static/app/views/starfish/components/table.tsx
@@ -17,7 +17,6 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconStar} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
-import {defined} from 'sentry/utils';
 import DiscoverQuery, {
   TableData,
   TableDataRow,
@@ -206,12 +205,7 @@ class _Table extends Component<Props, State> {
 
     const fieldName = getAggregateAlias(field);
     const value = dataRow[fieldName];
-    if (
-      tableMeta[fieldName] === 'integer' &&
-      defined(value) &&
-      typeof value === 'number' &&
-      value > 999
-    ) {
+    if (tableMeta[fieldName] === 'integer' && typeof value === 'number' && value > 999) {
       return (
         <Tooltip
           title={value.toLocaleString()}

--- a/static/app/views/starfish/components/table.tsx
+++ b/static/app/views/starfish/components/table.tsx
@@ -206,7 +206,12 @@ class _Table extends Component<Props, State> {
 
     const fieldName = getAggregateAlias(field);
     const value = dataRow[fieldName];
-    if (tableMeta[fieldName] === 'integer' && defined(value) && value > 999) {
+    if (
+      tableMeta[fieldName] === 'integer' &&
+      defined(value) &&
+      typeof value === 'number' &&
+      value > 999
+    ) {
       return (
         <Tooltip
           title={value.toLocaleString()}


### PR DESCRIPTION
typescript v5 doesn't like `string | number` being compared using less/greater than. Check for number in a few places and cast others
