### PR TITLE
feat(rulesnooze): Adds mute email link to issue alert email

### DIFF
--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -149,12 +149,9 @@ class AlertRuleNotification(ProjectNotification):
 
         if features.has("organizations:mute-alerts", self.organization) and len(self.rules) > 0:
             context["snooze_alert"] = True
-            context["snooze_alert_url"] = (
-                f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/"
-                + urlencode({"mute": "1"})
-                + "?"
-                + self.get_sentry_query_params(ExternalProviders.EMAIL)
-            )
+            context[
+                "snooze_alert_url"
+            ] = f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/?{urlencode({'mute': '1'})}&{self.get_sentry_query_params(ExternalProviders.EMAIL)}"
 
         if getattr(self.event, "occurrence", None):
             context["issue_title"] = self.event.occurrence.issue_title

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -155,9 +155,9 @@ class AlertRuleNotification(ProjectNotification):
             )
 
         if features.has("organizations:mute-alerts", self.organization) and len(self.rules) > 0:
-            context["mute_alert"] = True
+            context["snooze_alert"] = True
             context[
-                "mute_alert_url"
+                "snooze_alert_url"
             ] = f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/?mute=1"
 
         if getattr(self.event, "occurrence", None):

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -151,7 +151,7 @@ class AlertRuleNotification(ProjectNotification):
             context["snooze_alert"] = True
             context["snooze_alert_url"] = (
                 f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/"
-                + urlencode({"mute": True})
+                + urlencode({"mute": "1"})
             )
 
         if getattr(self.event, "occurrence", None):

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable, Mapping, MutableMapping
 
 import pytz
 
+from sentry import features
 from sentry.db.models import Model
 from sentry.issues.grouptype import GROUP_CATEGORIES_CUSTOM_EMAIL, GroupCategory
 from sentry.models import UserOption
@@ -152,6 +153,12 @@ class AlertRuleNotification(ProjectNotification):
                     "subtitle": get_performance_issue_alert_subtitle(self.event),
                 },
             )
+
+        if features.has("organizations:mute-alerts", self.organization) and len(self.rules) > 0:
+            context["mute_alert"] = True
+            context[
+                "mute_alert_url"
+            ] = f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/?mute=1"
 
         if getattr(self.event, "occurrence", None):
             context["issue_title"] = self.event.occurrence.issue_title

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -152,6 +152,8 @@ class AlertRuleNotification(ProjectNotification):
             context["snooze_alert_url"] = (
                 f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/"
                 + urlencode({"mute": "1"})
+                + "?"
+                + self.get_sentry_query_params(ExternalProviders.EMAIL)
             )
 
         if getattr(self.event, "occurrence", None):

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import urllib
 from typing import Any, Iterable, Mapping, MutableMapping
 
 import pytz
@@ -156,9 +157,10 @@ class AlertRuleNotification(ProjectNotification):
 
         if features.has("organizations:mute-alerts", self.organization) and len(self.rules) > 0:
             context["snooze_alert"] = True
-            context[
-                "snooze_alert_url"
-            ] = f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/?mute=1"
+            context["snooze_alert_url"] = (
+                f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/"
+                + urllib.urlencode({"mute": True})
+            )
 
         if getattr(self.event, "occurrence", None):
             context["issue_title"] = self.event.occurrence.issue_title

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-import urllib
 from typing import Any, Iterable, Mapping, MutableMapping
+from urllib.parse import urlencode
 
 import pytz
 
@@ -159,7 +159,7 @@ class AlertRuleNotification(ProjectNotification):
             context["snooze_alert"] = True
             context["snooze_alert_url"] = (
                 f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/"
-                + urllib.urlencode({"mute": True})
+                + urlencode({"mute": True})
             )
 
         if getattr(self.event, "occurrence", None):

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -104,6 +104,11 @@ class AlertRuleNotification(ProjectNotification):
         environment = self.event.get_tag("environment")
         enhanced_privacy = self.organization.flags.enhanced_privacy
         rule_details = get_rules(self.rules, self.organization, self.project)
+        sentry_query_params = self.get_sentry_query_params(ExternalProviders.EMAIL)
+        for rule in rule_details:
+            rule.url = rule.url + sentry_query_params
+            rule.status_url = rule.url + sentry_query_params
+
         notification_reason = get_owner_reason(
             project=self.project,
             target_type=self.target_type,
@@ -127,7 +132,7 @@ class AlertRuleNotification(ProjectNotification):
             "slack_link": get_integration_link(self.organization, "slack"),
             "notification_reason": notification_reason,
             "notification_settings_link": absolute_uri(
-                "/settings/account/notifications/alerts/?referrer=alert_email"
+                f"/settings/account/notifications/alerts/{sentry_query_params}"
             ),
             "has_alert_integration": has_alert_integration(self.project),
             "issue_type": self.group.issue_type.description,
@@ -151,7 +156,7 @@ class AlertRuleNotification(ProjectNotification):
             context["snooze_alert"] = True
             context[
                 "snooze_alert_url"
-            ] = f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/?{urlencode({'mute': '1'})}&{self.get_sentry_query_params(ExternalProviders.EMAIL)}"
+            ] = f"/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{self.rules[0].id}/details/{sentry_query_params}&{urlencode({'mute': '1'})}"
 
         if getattr(self.event, "occurrence", None):
             context["issue_title"] = self.event.occurrence.issue_title

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -218,7 +218,7 @@
   .info-box a.mute {
     float: right;
     color: #4674ca;
-    font-weight: 500;
+    font-weight: 700;
     text-decoration: none;
   }
 

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -205,9 +205,21 @@
     border: 1px solid #cce3f3;
     border-radius: 3px;
     padding: 15px;
-    text-align: center;
+    text-align: left;
     margin-bottom: 10px;
     font-size: 15px;
+  }
+
+  .info-box a {
+    color: #493e54;
+    text-decoration: underline;
+  }
+
+  .info-box a.mute {
+    float: right;
+    color: #4674ca;
+    font-weight: 500;
+    text-decoration: none;
   }
 
   .footer {

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -215,10 +215,13 @@
     {% endif %}
 
     <p class="info-box">
-        You are receiving this email due to matching rules:
+        This email was triggered by
         {% for rule in rules %}
             <a href="{% absolute_uri rule.status_url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
         {% endfor %}
+        {% if mute_alert %}
+         <a class='mute' href="{% absolute_uri mute_alert_url %}">Mute for me</a>
+        {% endif %}
     </p>
 
     {% if not has_integrations %}

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -219,8 +219,8 @@
         {% for rule in rules %}
             <a href="{% absolute_uri rule.status_url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
         {% endfor %}
-        {% if mute_alert %}
-         <a class='mute' href="{% absolute_uri mute_alert_url %}">Mute for me</a>
+        {% if snooze_alert %}
+         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute for me</a>
         {% endif %}
     </p>
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -241,16 +241,21 @@ def make_generic_event(project):
 
 
 def get_shared_context(rule, org, project, group, event):
+    rules = get_rules([rule], org, project)
+    mute_alert = len(rules) > 0
+    mute_alert_url = rules[0].status_url + "?mute=1" if mute_alert else ""
     return {
         "rule": rule,
-        "rules": get_rules([rule], org, project),
+        "rules": rules,
         "group": group,
         "event": event,
         "timezone": pytz.timezone("Europe/Vienna"),
         # http://testserver/organizations/example/issues/<issue-id>/?referrer=alert_email
         #       &alert_type=email&alert_timestamp=<ts>&alert_rule_id=1
-        "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
+        "link": get_group_settings_link(group, None, rules, 1337),
         "tags": event.tags,
+        "mute_alert": mute_alert,
+        "mute_alert_url": absolute_uri(mute_alert_url),
     }
 
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -5,11 +5,11 @@ import itertools
 import logging
 import time
 import traceback
-import urllib
 import uuid
 from datetime import datetime, timedelta
 from random import Random
 from typing import Any, MutableMapping
+from urllib.parse import urlencode
 
 import pytz
 from django.shortcuts import redirect
@@ -244,9 +244,7 @@ def make_generic_event(project):
 def get_shared_context(rule, org, project, group, event):
     rules = get_rules([rule], org, project)
     snooze_alert = len(rules) > 0
-    snooze_alert_url = (
-        rules[0].status_url + urllib.urlencode({"mute": True}) if snooze_alert else ""
-    )
+    snooze_alert_url = rules[0].status_url + urlencode({"mute": True}) if snooze_alert else ""
     return {
         "rule": rule,
         "rules": rules,

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -244,7 +244,7 @@ def make_generic_event(project):
 def get_shared_context(rule, org, project, group, event):
     rules = get_rules([rule], org, project)
     snooze_alert = len(rules) > 0
-    snooze_alert_url = rules[0].status_url + urlencode({"mute": True}) if snooze_alert else ""
+    snooze_alert_url = rules[0].status_url + urlencode({"mute": "1"}) if snooze_alert else ""
     return {
         "rule": rule,
         "rules": rules,

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import time
 import traceback
+import urllib
 import uuid
 from datetime import datetime, timedelta
 from random import Random
@@ -242,8 +243,10 @@ def make_generic_event(project):
 
 def get_shared_context(rule, org, project, group, event):
     rules = get_rules([rule], org, project)
-    mute_alert = len(rules) > 0
-    mute_alert_url = rules[0].status_url + "?mute=1" if mute_alert else ""
+    snooze_alert = len(rules) > 0
+    snooze_alert_url = (
+        rules[0].status_url + urllib.urlencode({"mute": True}) if snooze_alert else ""
+    )
     return {
         "rule": rule,
         "rules": rules,
@@ -254,8 +257,8 @@ def get_shared_context(rule, org, project, group, event):
         #       &alert_type=email&alert_timestamp=<ts>&alert_rule_id=1
         "link": get_group_settings_link(group, None, rules, 1337),
         "tags": event.tags,
-        "mute_alert": mute_alert,
-        "mute_alert_url": absolute_uri(mute_alert_url),
+        "snooze_alert": snooze_alert,
+        "snooze_alert_url": absolute_uri(snooze_alert_url),
     }
 
 


### PR DESCRIPTION
this pr adds in the link to mute alerts to the issue alert email and slightly updates the banner of the issue alert email.

Banner Update: 
<img width="710" alt="Screenshot 2023-04-17 at 2 51 45 PM" src="https://user-images.githubusercontent.com/46740234/232619078-82e7ff92-3c69-4f79-bae5-00fc76873d2a.png">


With Mute Alert Link: 
<img width="707" alt="Screenshot 2023-04-17 at 2 54 19 PM" src="https://user-images.githubusercontent.com/46740234/232619306-5a6fb201-fb35-4f46-8bed-7376ac7a63d9.png">

Closes https://github.com/getsentry/sentry/issues/46833
