### PR TITLE
fix(crons): Prevent pause/unpause from clearing monitor details page

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -39,7 +39,14 @@ function MonitorDetails({params, location}: Props) {
   const {data: monitor} = useApiQuery<Monitor>(queryKey, {staleTime: 0});
 
   function onUpdate(data: Monitor) {
-    setApiQueryData(queryClient, queryKey, data);
+    const updatedMonitor = {
+      ...data,
+      // TODO(davidenwang): This is a bit of a hack, due to the PUT request
+      // which pauses/unpauses a monitor not returning monitor environments
+      // we should reuse the environments retrieved from the initial request
+      environments: monitor?.environments,
+    };
+    setApiQueryData(queryClient, queryKey, updatedMonitor);
   }
 
   if (!monitor) {


### PR DESCRIPTION
When we pause/unpause a monitor we make a PUT request which modifies the monitor object in the backend and returns the modified monitor back, however this returned monitor doesn't have the corresponding monitor environment data causing this:

https://user-images.githubusercontent.com/9372512/231878582-28671c94-1235-4316-b1ed-a8a95f1deed0.mov

Fix: When using the returned monitor from the backend, patch in the environment that was fetched on the initial request

https://user-images.githubusercontent.com/9372512/231879359-769d53f3-3e80-47cb-b28c-e639ae141bbf.mov

This is definitely a bit of a hack and we should think about how we want to decouple the monitor object from its monitor environments better

Fixes https://github.com/getsentry/team-crons/issues/59
