### PR TITLE
ref(notification-actions): allow managers to delete actions

### DIFF
--- a/src/sentry/api/endpoints/notifications/notification_actions_details.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_details.py
@@ -8,6 +8,9 @@ from rest_framework.response import Response
 from sentry import audit_log
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.endpoints.notifications.notification_actions_index import (
+    NotificationActionsPermission,
+)
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.notification_action import NotificationActionSerializer
@@ -25,6 +28,8 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     PUT: Update the entire NotificationAction, overwriting previous values
     DELETE: Delete the NotificationAction
     """
+
+    permission_classes = (NotificationActionsPermission,)
 
     def convert_args(self, request: Request, action_id: int, *args, **kwargs):
         parsed_args, parsed_kwargs = super().convert_args(request, *args, **kwargs)

--- a/src/sentry/api/endpoints/notifications/notification_actions_index.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_index.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 from sentry import audit_log
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.rest_framework.notification_action import NotificationActionSerializer
@@ -18,6 +18,15 @@ from sentry.models.organization import Organization
 logger = logging.getLogger(__name__)
 
 
+class NotificationActionsPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:write", "org:admin"],
+        "PUT": ["org:write", "org:admin"],
+        "DELETE": ["org:write", "org:admin"],
+    }
+
+
 @region_silo_endpoint
 class NotificationActionsIndexEndpoint(OrganizationEndpoint):
     """
@@ -25,6 +34,8 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
     GET: Returns paginated, serialized NotificationActions for an organization
     POST: Create a new NotificationAction
     """
+
+    permission_classes = (NotificationActionsPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:
         queryset = NotificationAction.objects.filter(organization_id=organization.id)

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
@@ -373,3 +373,16 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
             method="DELETE",
         )
         assert not NotificationAction.objects.filter(id=self.notif_action.id).exists()
+
+    def test_delete_success_as_manager(self):
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, role="manager")
+        self.login_as(user)
+        assert NotificationAction.objects.filter(id=self.notif_action.id).exists()
+        self.get_success_response(
+            self.organization.slug,
+            self.notif_action.id,
+            status_code=status.HTTP_204_NO_CONTENT,
+            method="DELETE",
+        )
+        assert not NotificationAction.objects.filter(id=self.notif_action.id).exists()


### PR DESCRIPTION
Extends the scope map to allow managers (who have `org:write`) to delete notification actions.