### PR TITLE
fix(hc): Catch error if no org_integration is set

### DIFF
--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -373,7 +373,7 @@ class IssueSyncMixin(IssueBasicMixin):
 
     def should_sync(self, attribute: str) -> bool:
         key = getattr(self, f"{attribute}_key", None)
-        if key is None:
+        if key is None or self.org_integration is None:
             return False
         value: bool = self.org_integration.config.get(key, False)
         return value


### PR DESCRIPTION
Fixes SENTRY-Z2C

cc @dashed: The `org_integration` property comes from [the IntegrationInstallation class](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/base.py#L269-L276) which is alongside this mixin when used for setting up specific integration installations like [Jira](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/jira/integration.py#L121). It's not a great pattern because it means the class isn't pure, and depends on always being mixed in along side  `IntegrationInstallation` but doesn't cause obvious errors if not.

The problem is that this isn't easily fixed since the pattern bites both ways, with serialization of the integration calling methods that may [only exist in the mixin](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/integration.py#L89-L92). And for context, the `Installation` classes only exist in memory, they just provide a bunch of helpful methods to interface with the 3rd party, but don't have a direct DB mapping (the closest thing is org_integration), but they may combine data from the org, the integration, the org_integration, or any mixins as well.