### PR TITLE
feat(escalating-issues): Switch ignored issues tab to archived

### DIFF
--- a/static/app/views/issueList/overview.spec.jsx
+++ b/static/app/views/issueList/overview.spec.jsx
@@ -304,6 +304,28 @@ describe('IssueList', function () {
       expect(screen.getByRole('button', {name: 'My Default Search'})).toBeInTheDocument();
     });
 
+    it('shows archived tab', async function () {
+      render(
+        <IssueListWithStores
+          {...routerProps}
+          {...defaultProps}
+          organization={{...organization, features: ['escalating-issues']}}
+        />,
+        {
+          context: routerContext,
+        }
+      );
+
+      await waitFor(() => {
+        expect(issuesRequest).toHaveBeenCalled();
+      });
+
+      expect(screen.getByRole('textbox')).toHaveValue('is:unresolved ');
+
+      // TODO(workflow): remove this test when we remove the feature flag
+      expect(screen.getByRole('tab', {name: 'Archived'})).toBeInTheDocument();
+    });
+
     it('loads with a saved query', async function () {
       savedSearchesRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/searches/',

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -7,6 +7,7 @@ export enum Query {
   FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
+  ARCHIVED = 'is:archived',
   REPROCESSING = 'is:reprocessing',
 }
 
@@ -61,17 +62,28 @@ export function getTabs(organization: Organization) {
           Issues are automatically marked reviewed in 7 days.`),
       },
     ],
-    [
-      Query.IGNORED,
-      {
-        name: t('Ignored'),
-        analyticsName: 'ignored',
-        count: true,
-        enabled: true,
-        tooltipTitle: t(`Ignored issues don’t trigger alerts. When their ignore
+    organization.features.includes('escalating-issues')
+      ? [
+          Query.ARCHIVED,
+          {
+            name: t('Archived'),
+            analyticsName: 'archived',
+            count: true,
+            enabled: true,
+            tooltipTitle: t(`Archived issues don’t trigger alerts.`),
+          },
+        ]
+      : [
+          Query.IGNORED,
+          {
+            name: t('Ignored'),
+            analyticsName: 'ignored',
+            count: true,
+            enabled: true,
+            tooltipTitle: t(`Ignored issues don’t trigger alerts. When their ignore
         conditions are met they become Unresolved and are flagged for review.`),
-      },
-    ],
+          },
+        ],
     [
       Query.REPROCESSING,
       {


### PR DESCRIPTION
Instead of showing an "Ignored" tab we'll show an "Archived" tab on the issues stream.

[WOR-2870](https://getsentry.atlassian.net/browse/WOR-2870)

[WOR-2870]: https://getsentry.atlassian.net/browse/WOR-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ