### PR TITLE
ref(hc): Demonstrating how to use restricted user for org member

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,7 @@ def protect_hybrid_cloud_writes_and_deletes(request):
             restrict_role(role="postgres_unprivileged", model=fk_model, revocation_type="DELETE")
 
     restrict_role(role="postgres_unprivileged", model=OrganizationMember, revocation_type="CREATE")
+    restrict_role(role="postgres_unprivileged", model=OrganizationMember, revocation_type="UPDATE")
 
     with get_connection().cursor() as conn:
         conn.execute("SET ROLE 'postgres_unprivileged'")


### PR DESCRIPTION
A strategy for ensuring that all OrganizationMember write paths are covered, is to first make them all fail in tests, then mark individual code paths you have fixed (a handful, or maybe just one, "correct" way of doing it) with `in_test_psql_role_override`