### PR TITLE
fix(crons): Prefill project in monitor creation form

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -27,6 +27,7 @@ import withRouteAnalytics, {
   WithRouteAnalyticsProps,
 } from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import withOrganization from 'sentry/utils/withOrganization';
 // eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
@@ -48,9 +49,14 @@ type State = AsyncView['state'] & {
 
 function NewMonitorButton(props: ButtonProps) {
   const organization = useOrganization();
+  const {selection} = usePageFilters();
+
   return (
     <Button
-      to={`/organizations/${organization.slug}/crons/create/`}
+      to={{
+        pathname: `/organizations/${organization.slug}/crons/create/`,
+        query: {project: selection.projects},
+      }}
       priority="primary"
       {...props}
     >


### PR DESCRIPTION
Now when you move from the monitor details page to the monitor form, any selected projects (even when not locked) will prefill the project selector here:

<img width="707" alt="image" src="https://user-images.githubusercontent.com/9372512/231896693-7993e954-9aa3-48cf-aeff-45d0ad6464c9.png">
