### PR TITLE
feat(workflow): Ignore Release.DoesNotExist exceptions

### DIFF
--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -352,7 +352,7 @@ def determine_eligible_recipients(
                 ]
                 suggested_assignees.extend(suspect_commit_users)
             except Release.DoesNotExist:
-                logger.debug("Skipping suspect committers because release does not exist.")
+                logger.info("Skipping suspect committers because release does not exist.")
             except Exception:
                 logger.exception("Could not get suspect committers. Continuing execution.")
 

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -15,6 +15,7 @@ from sentry.models import (
     OrganizationMemberTeam,
     Project,
     ProjectOwnership,
+    Release,
     Team,
     User,
 )
@@ -350,6 +351,8 @@ def determine_eligible_recipients(
                     for user in get_suspect_commit_users(project, event)
                 ]
                 suggested_assignees.extend(suspect_commit_users)
+            except Release.DoesNotExist:
+                logger.debug("Skipping suspect committers because release does not exist.")
             except Exception:
                 logger.exception("Could not get suspect committers. Continuing execution.")
 


### PR DESCRIPTION
Streamline targeting added suspect commits to the assignee and its throwing a lot of this error, it isn't interesting.
