### PR TITLE
security fix for setuptools

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -215,4 +215,4 @@ zstandard==0.18.0
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.1.2
-setuptools==56.0.0
+setuptools==65.5.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -146,4 +146,4 @@ yarl==1.8.2
 zstandard==0.18.0
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==56.0.0
+setuptools==65.5.1


### PR DESCRIPTION


<!-- Describe your PR here. -->
Security fix for setuptools
following docs :-
1:- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
2:- https://github.com/advisories/GHSA-r9hx-vwmv-q579
3:- https://github.com/advisories/GHSA-r9hx-vwmv-q579

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
