### PR TITLE
feat: Check abs_path in JS A/B test

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -2070,8 +2070,8 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                     # - python resolves a `module`, whereas symbolicator does not
                     # - python adds `data.sourcemap` whereas symbolicator does not
                     # - symbolicator does not add trailing empty lines to `post_context`
-                    # a.get("abs_path") != b.get("abs_path") or
-                    a.get("lineno") != b.get("lineno")
+                    a.get("abs_path") != b.get("abs_path")
+                    or a.get("lineno") != b.get("lineno")
                     or a.get("colno") != b.get("colno")
                     or a.get("function") != b.get("function")
                     or a.get("filename") != b.get("filename")


### PR DESCRIPTION
Since https://github.com/getsentry/symbolicator/pull/1137, abs_paths should line up between Symbolicator and the monolith.