### PR TITLE
fix(issue-stream): Use issue short ID for discover link

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -225,7 +225,7 @@ function BaseGroupRow({
         name: group.title || group.type,
         fields: ['title', 'release', 'environment', 'user', 'timestamp'],
         orderby: '-timestamp',
-        query: `issue.id:${group.id}${filteredQuery}`,
+        query: `issue:${group.shortId}${filteredQuery}`,
         version: 2,
       };
 


### PR DESCRIPTION
Change the link to add `issue` instead of `issue.id` to the discover query. `issue.id` works, but we prefer that users use `issue`. This is consistent with other parts of Sentry because `issue.id` isn't documented as a searchable property.