### PR TITLE
feat(spurl-param): Callable class wildcard replacement span strategy

### DIFF
--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -1,3 +1,4 @@
+import functools
 import re
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Sequence, TypedDict, Union
@@ -88,7 +89,11 @@ def span_op(op_name: Union[str, Sequence[str]]) -> Callable[[CallableStrategy], 
     permitted_ops = [op_name] if isinstance(op_name, str) else op_name
 
     def wrapped(fn: CallableStrategy) -> CallableStrategy:
-        return lambda span: fn(span) if span.get("op") in permitted_ops else None
+        @functools.wraps(fn)
+        def inner(span):
+            return fn(span) if span.get("op") in permitted_ops else None
+
+        return inner
 
     return wrapped
 

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -259,11 +259,6 @@ def remove_http_client_query_string_strategy(span: Span) -> Optional[Sequence[st
     return [method, url.scheme, url.netloc, url.path]
 
 
-@span_op("http.client")
-def wildcard_replacement_strategy(span: Span) -> Optional[Sequence[str]]:
-    return None
-
-
 @span_op(["redis", "db.redis"])
 def remove_redis_command_arguments_strategy(span: Span) -> Optional[Sequence[str]]:
     """For a `redis` span, the fingerprint to use is simply the redis command name.

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -93,7 +93,7 @@ def span_op(op_name: Union[str, Sequence[str]]) -> Callable[[CallableStrategy], 
 
     def wrapped(fn: CallableStrategy) -> CallableStrategy:
         @functools.wraps(fn)
-        def inner(span):
+        def inner(span: Span) -> Optional[Sequence[str]]:
             return fn(span) if span.get("op") in permitted_ops else None
 
         return inner
@@ -279,8 +279,8 @@ class BaseSpanStrategy:
     that can accept event data.
     """
 
-    def __init__(self, event_data=None):
+    def __init__(self, event_data: Any = None) -> None:
         self.event_data = event_data
 
-    def __call__(self):
+    def __call__(self, span: Span) -> Optional[Sequence[str]]:
         raise NotImplementedError

--- a/src/sentry/spans/grouping/strategy/config.py
+++ b/src/sentry/spans/grouping/strategy/config.py
@@ -10,8 +10,8 @@ from sentry.spans.grouping.strategy.base import (
     parametrize_db_span_strategy,
     remove_http_client_query_string_strategy,
     remove_redis_command_arguments_strategy,
-    wildcard_replacement_strategy,
 )
+from sentry.spans.grouping.strategy.wildcard_replacement_strategy import WildcardReplacementStrategy
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ register_configuration(
     "clustering:2023-04-03",
     strategies=[
         parametrize_db_span_strategy,
-        wildcard_replacement_strategy,
+        WildcardReplacementStrategy,
         remove_http_client_query_string_strategy,
         remove_redis_command_arguments_strategy,
     ],

--- a/src/sentry/spans/grouping/strategy/wildcard_replacement_strategy.py
+++ b/src/sentry/spans/grouping/strategy/wildcard_replacement_strategy.py
@@ -29,11 +29,11 @@ class WildcardReplacementStrategy(BaseSpanStrategy):
             return None
 
         method, url = parts
-        url = urlparse(url)
+        parsed_url = urlparse(url)
 
         for rule in rules:
-            parameterized_path = glob_replace(url.path, rule)
-            if parameterized_path != url.path:
-                return [method, url.scheme, url.netloc, parameterized_path]
+            parameterized_path = glob_replace(parsed_url.path, rule)
+            if parameterized_path != parsed_url.path:
+                return [method, parsed_url.scheme, parsed_url.netloc, parameterized_path]
 
         return None

--- a/src/sentry/spans/grouping/strategy/wildcard_replacement_strategy.py
+++ b/src/sentry/spans/grouping/strategy/wildcard_replacement_strategy.py
@@ -1,0 +1,39 @@
+from typing import Optional, Sequence
+from urllib.parse import urlparse
+
+from .base import BaseSpanStrategy, Span
+from .glob_replace import glob_replace
+
+RULES = ["**/organizations/*/**"]
+
+
+class WildcardReplacementStrategy(BaseSpanStrategy):
+    def __call__(self, span: Span) -> Optional[Sequence[str]]:
+        # TODO: Adapt the `span_op` decorator to work on callable methods
+        # instead of manually comparing against `"http.client"` here
+        if span.get("op") != "http.client":
+            return None
+
+        rules = RULES
+        if len(rules) == 0:
+            return None
+
+        # TODO: Check span['data'] first, it'll have up-to-date parsed
+        # information
+        description = span.get("description") or ""
+
+        # Check the description is of the form `<HTTP METHOD> <URL>`
+        description = span.get("description") or ""
+        parts = description.split(" ", 1)
+        if len(parts) != 2:
+            return None
+
+        method, url = parts
+        url = urlparse(url)
+
+        for rule in rules:
+            parameterized_path = glob_replace(url.path, rule)
+            if parameterized_path != url.path:
+                return [method, url.scheme, url.netloc, parameterized_path]
+
+        return None

--- a/tests/sentry/spans/grouping/test_base.py
+++ b/tests/sentry/spans/grouping/test_base.py
@@ -1,0 +1,24 @@
+import unittest
+
+import pytest
+
+from sentry.spans.grouping.strategy.base import span_op
+from sentry.testutils.performance_issues.span_builder import SpanBuilder
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+@pytest.mark.django_db
+class SpanOpDecoratorTestCase(unittest.TestCase):
+    def test_returns_none_if_op_is_not_eligible(self):
+        span = SpanBuilder().with_op("http.server").with_description("run").build()
+
+        wrapped = span_op("http.client")(description_strategy)
+        assert wrapped(span) is None
+
+        wrapped = span_op("http.server")(description_strategy)
+        assert wrapped(span) == "run"
+
+
+def description_strategy(span):
+    return span["description"]

--- a/tests/sentry/spans/grouping/test_wildcard_replacement_strategy.py
+++ b/tests/sentry/spans/grouping/test_wildcard_replacement_strategy.py
@@ -1,0 +1,25 @@
+import unittest
+
+from sentry.spans.grouping.strategy.wildcard_replacement_strategy import WildcardReplacementStrategy
+from sentry.testutils.performance_issues.span_builder import SpanBuilder
+
+
+class WildcardReplacementStrategyTest(unittest.TestCase):
+    def test_replaces_wildcards(self):
+        event_data = {
+            "transaction": "transaction name",
+            "contexts": {
+                "trace": {
+                    "span_id": "a" * 16,
+                },
+            },
+            "spans": [
+                SpanBuilder()
+                .with_op("http.client")
+                .with_description("GET /api/0/organizations/sentry/details")
+                .build(),
+            ],
+        }
+
+        strategy = WildcardReplacementStrategy(event_data)
+        assert strategy(event_data["spans"][0]) == ["GET", "", "", "/api/0/organizations/*/details"]


### PR DESCRIPTION
Right now, all span grouping strategies are plain functions that accept a `span`. For span URL parameterization, that's not enough! In order to parameterize a span, we need to fetch some project information! The strategy must have access to some more data.

The solution space was pretty wide:

- I can pass the necessary parameters through the entire chain (i.e., initialize the strategy with some extra data, pass it through to every function). I didn't like this because most strategies would ignore the extra parameters
- I can have a new fully custom grouping strategy that doesn't use the strategy functions, or combines them with an internal strategy of some kind. I don't like this because I'd be throwing away a lot of useful functionality and re-inventing it. I also really like supplying an ordered list of strategy functions!
- I can do Python binding shenanigans to provide `self` to every function. I don't like this, because I think it's confusing and surprising

The solution I went with:

- now, the `strategies` list for a configuration can contain callables, or `type`
- if the code sees a `type`, it instantiates it with the event data. Then it calls the callable that it got back
- the callable can do whatever it wants in terms of looking things up, etc.

Then I changed the wildcard strategy from a function to a callable class, and gave it some dummy logic with generic replacement rules. This should be a good foundation for more complex logic later.
