### PR TITLE
chore(perf): Remove old feature flag

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -158,15 +158,9 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
             },
           });
 
-          const target = organization.features.includes(
-            'performance-metrics-backed-transaction-summary'
-          )
-            ? transactionTarget
-            : trendsTarget;
-
           return (
             <Fragment>
-              <GrowLink to={target}>
+              <GrowLink to={transactionTarget}>
                 <Truncate value={listItem.transaction} maxLength={40} />
               </GrowLink>
               <RightAlignedCell>

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -255,22 +255,13 @@ export function VitalWidget(props: PerformanceWidgetProps) {
           _eventView.query = initialConditions.formatString();
 
           const isUnparameterizedRow = transaction === UNPARAMETERIZED_TRANSACTION;
-          const transactionTarget = organization.features.includes(
-            'performance-metrics-backed-transaction-summary'
-          )
-            ? transactionSummaryRouteWithQuery({
-                orgSlug: props.organization.slug,
-                projectID: listItem['project.id'],
-                transaction: listItem.transaction,
-                query: _eventView.generateQueryStringObject(),
-                display: DisplayModes.VITALS,
-              })
-            : vitalDetailRouteWithQuery({
-                orgSlug: organization.slug,
-                query: _eventView.generateQueryStringObject(),
-                vitalName: vital,
-                projectID: decodeList(location.query.project),
-              });
+          const transactionTarget = transactionSummaryRouteWithQuery({
+            orgSlug: props.organization.slug,
+            projectID: listItem['project.id'],
+            transaction: listItem.transaction,
+            query: _eventView.generateQueryStringObject(),
+            display: DisplayModes.VITALS,
+          });
 
           const target = isUnparameterizedRow
             ? createUnnamedTransactionsDiscoverTarget({

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -182,10 +182,7 @@ function SummaryContent({
 
   function generateActionBarItems(_org: Organization, _location: Location) {
     let items: ActionBarItem[] | undefined = undefined;
-    if (
-      _org.features.includes('performance-metrics-backed-transaction-summary') &&
-      !canUseTransactionMetricsData(_org, _location)
-    ) {
+    if (!canUseTransactionMetricsData(_org, _location)) {
       items = [
         {
           key: 'alert',
@@ -419,7 +416,6 @@ function SummaryContent({
       </Layout.Main>
       <Layout.Side>
         <TransactionPercentage
-          organization={organization}
           isLoading={isLoading}
           error={error}
           totals={totalValues}

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -578,8 +578,12 @@ describe('Performance > TransactionSummary', function () {
       expect(screen.getByTestId('failure-rate-summary-value')).toHaveTextContent('100%');
 
       // Renders TPM widget
-      expect(screen.getByRole('heading', {name: 'TPM'})).toBeInTheDocument();
-      expect(screen.getByTestId('tpm-summary-value')).toHaveTextContent('100%');
+      expect(
+        screen.getByRole('heading', {name: 'Percentage of Total Transactions'})
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('count-percentage-summary-value')).toHaveTextContent(
+        '100%'
+      );
     });
 
     it('fetches transaction threshold', function () {
@@ -993,8 +997,12 @@ describe('Performance > TransactionSummary', function () {
       expect(screen.getByTestId('failure-rate-summary-value')).toHaveTextContent('100%');
 
       // Renders TPM widget
-      expect(screen.getByRole('heading', {name: 'TPM'})).toBeInTheDocument();
-      expect(screen.getByTestId('tpm-summary-value')).toHaveTextContent('100%');
+      expect(
+        screen.getByRole('heading', {name: 'Percentage of Total Transactions'})
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('count-percentage-summary-value')).toHaveTextContent(
+        '100%'
+      );
     });
 
     it('fetches transaction threshold', function () {

--- a/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
@@ -9,7 +9,7 @@ import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
-import {formatAbbreviatedNumber, formatPercentage} from 'sentry/utils/formatters';
+import {formatPercentage} from 'sentry/utils/formatters';
 import Histogram from 'sentry/utils/performance/histogram';
 import HistogramQuery from 'sentry/utils/performance/histogram/histogramQuery';
 import {HistogramData} from 'sentry/utils/performance/histogram/types';
@@ -57,9 +57,6 @@ function Content({
   totalCount,
 }: Props) {
   const [zoomError, setZoomError] = useState(false);
-  const displayCountAsPercentage = organization.features.includes(
-    'performance-metrics-backed-transaction-summary'
-  );
 
   function handleMouseOver() {
     // Hide the zoom error tooltip on the next hover.
@@ -70,7 +67,7 @@ function Content({
 
   function parseHistogramData(data: HistogramData): HistogramData {
     // display each bin's count as a % of total count
-    if (displayCountAsPercentage && totalCount) {
+    if (totalCount) {
       return data.map(({bin, count}) => ({bin, count: count / totalCount}));
     }
     return data;
@@ -100,10 +97,8 @@ function Content({
         if (!zoomError) {
           // Replicate the necessary logic from sentry/components/charts/components/tooltip.jsx
           contents = seriesData.map(item => {
-            const label = displayCountAsPercentage ? t('Transactions') : item.seriesName;
-            const value = displayCountAsPercentage
-              ? formatPercentage(item.value[1])
-              : item.value[1].toLocaleString();
+            const label = t('Transactions');
+            const value = formatPercentage(item.value[1]);
 
             return [
               '<div class="tooltip-series">',
@@ -149,10 +144,7 @@ function Content({
             yAxis={{
               type: 'value',
               axisLabel: {
-                formatter: value =>
-                  displayCountAsPercentage
-                    ? formatPercentage(value, 0)
-                    : formatAbbreviatedNumber(value),
+                formatter: value => formatPercentage(value, 0),
               },
             }}
             series={[series]}

--- a/static/app/views/performance/transactionSummary/transactionOverview/transactionPercentage.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/transactionPercentage.tsx
@@ -48,7 +48,7 @@ export function TransactionPercentage({
     <Fragment>
       <SectionHeading>{t('Percentage of Total Transactions')}</SectionHeading>
       <SectionSummaryValue
-        data-test-id="tpm-summary-value"
+        data-test-id="count-percentage-summary-value"
         isLoading={isLoading}
         error={error}
         value={getValueFromTotals('count()', totals, unfilteredTotals)}

--- a/static/app/views/performance/transactionSummary/transactionOverview/transactionPercentage.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/transactionPercentage.tsx
@@ -5,52 +5,40 @@ import clamp from 'lodash/clamp';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
-import {Organization} from 'sentry/types';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
-import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
+import {formatPercentage} from 'sentry/utils/formatters';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 
 interface TransactionPercentageProps {
   error: QueryError | null;
   isLoading: boolean;
-  organization: Organization;
   totals: Record<string, number> | null;
   unfilteredTotals?: Record<string, number> | null;
 }
 
 export function TransactionPercentage({
-  organization,
   isLoading,
   error,
   totals,
   unfilteredTotals,
 }: TransactionPercentageProps) {
-  const showTPMAsPercentage = organization.features.includes(
-    'performance-metrics-backed-transaction-summary'
-  );
-
   function getValueFromTotals(field, totalValues, unfilteredTotalValues) {
-    if (totalValues) {
-      if (unfilteredTotalValues) {
-        // clamp handles rare cases when % > 1
-        const volumeRatio = clamp(
-          // handles 0 case to avoid diving by 0
-          unfilteredTotalValues[field] > 0
-            ? totalValues[field] / unfilteredTotalValues[field]
-            : 0,
-          0,
-          1
-        );
-        const formattedPercentage =
-          volumeRatio > 0 && volumeRatio < 0.0001
-            ? '<0.01%'
-            : formatPercentage(volumeRatio);
-        return tct('[tpm]', {
-          tpm: formattedPercentage,
-        });
-      }
-      return tct('[tpm] tpm', {
-        tpm: formatFloat(totalValues[field], 4),
+    if (totalValues && unfilteredTotalValues) {
+      // clamp handles rare cases when % > 1
+      const volumeRatio = clamp(
+        // handles 0 case to avoid diving by 0
+        unfilteredTotalValues[field] > 0
+          ? totalValues[field] / unfilteredTotalValues[field]
+          : 0,
+        0,
+        1
+      );
+      const formattedPercentage =
+        volumeRatio > 0 && volumeRatio < 0.0001
+          ? '<0.01%'
+          : formatPercentage(volumeRatio);
+      return tct('[value]', {
+        value: formattedPercentage,
       });
     }
     return null;
@@ -58,9 +46,7 @@ export function TransactionPercentage({
 
   return (
     <Fragment>
-      <SectionHeading>
-        {showTPMAsPercentage ? t('Percentage of Total Transactions') : t('TPM')}
-      </SectionHeading>
+      <SectionHeading>{t('Percentage of Total Transactions')}</SectionHeading>
       <SectionSummaryValue
         data-test-id="tpm-summary-value"
         isLoading={isLoading}

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -38,10 +38,6 @@ export function getTransactionMEPParamsIfApplicable(
   organization: Organization,
   location: Location
 ) {
-  if (!organization.features.includes('performance-metrics-backed-transaction-summary')) {
-    return undefined;
-  }
-
   if (!canUseTransactionMetricsData(organization, location)) {
     return undefined;
   }
@@ -53,10 +49,6 @@ export function getTransactionTotalsMEPParamsIfApplicable(
   mepContext: MetricsEnhancedSettingContext,
   organization: Organization
 ) {
-  if (!organization.features.includes('performance-metrics-backed-transaction-summary')) {
-    return undefined;
-  }
-
   if (!canUseMetricsData(organization)) {
     return undefined;
   }


### PR DESCRIPTION
Metrics-backed transaction summary has GA-ed, so I'm removing all references to the feature flag and `tpm`s