### PR TITLE
feat(transaction): Align profile measurements with transaction timeline

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {
   getDataPoints,
   MIN_DATA_POINTS,
+  MS_PER_S,
   ProfilingMeasurements,
 } from 'sentry/components/events/interfaces/spans/profilingMeasurements';
 import OpsBreakdown from 'sentry/components/events/opsBreakdown';
@@ -474,7 +475,7 @@ class TraceViewHeader extends Component<PropType, State> {
             // Check that this profile has enough data points
             getDataPoints(
               profiles.data.measurements!.cpu_usage,
-              transactionDuration * 1000
+              transactionDuration * MS_PER_S
             ).length > MIN_DATA_POINTS;
 
           return (

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -1,7 +1,11 @@
 import {Component, Fragment, PureComponent} from 'react';
 import styled from '@emotion/styled';
 
-import {ProfilingMeasurements} from 'sentry/components/events/interfaces/spans/profilingMeasurements';
+import {
+  getDataPoints,
+  MIN_DATA_POINTS,
+  ProfilingMeasurements,
+} from 'sentry/components/events/interfaces/spans/profilingMeasurements';
 import OpsBreakdown from 'sentry/components/events/opsBreakdown';
 import {
   DividerSpacer,
@@ -438,7 +442,7 @@ class TraceViewHeader extends Component<PropType, State> {
   }
 
   render() {
-    const {organization} = this.props;
+    const {organization, trace} = this.props;
     const handleStartWindowSelection = (event: React.MouseEvent<HTMLDivElement>) => {
       const target = event.target;
 
@@ -457,6 +461,7 @@ class TraceViewHeader extends Component<PropType, State> {
     return (
       <ProfileContext.Consumer>
         {profiles => {
+          const transactionDuration = trace.traceEndTimestamp - trace.traceStartTimestamp;
           const hasProfileMeasurementsChart =
             organization.features.includes('mobile-cpu-memory-in-transactions') &&
             profiles?.type === 'resolved' &&
@@ -465,7 +470,12 @@ class TraceViewHeader extends Component<PropType, State> {
             profiles.data.metadata.platform === 'android' &&
             // Check that this profile has measurements
             'measurements' in profiles?.data &&
-            defined(profiles.data.measurements?.cpu_usage);
+            defined(profiles.data.measurements?.cpu_usage) &&
+            // Check that this profile has enough data points
+            getDataPoints(
+              profiles.data.measurements!.cpu_usage,
+              transactionDuration * 1000
+            ).length > MIN_DATA_POINTS;
 
           return (
             <HeaderContainer
@@ -552,6 +562,7 @@ class TraceViewHeader extends Component<PropType, State> {
                       </CursorGuideHandler.Consumer>
                       {hasProfileMeasurementsChart && (
                         <ProfilingMeasurements
+                          transactionDuration={transactionDuration}
                           profileData={profiles.data}
                           renderCursorGuide={this.renderCursorGuide}
                           renderFog={() => this.renderFog(this.props.dragProps, true)}

--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -462,7 +462,9 @@ class TraceViewHeader extends Component<PropType, State> {
     return (
       <ProfileContext.Consumer>
         {profiles => {
-          const transactionDuration = trace.traceEndTimestamp - trace.traceStartTimestamp;
+          const transactionDuration = Math.abs(
+            trace.traceEndTimestamp - trace.traceStartTimestamp
+          );
           const hasProfileMeasurementsChart =
             organization.features.includes('mobile-cpu-memory-in-transactions') &&
             profiles?.type === 'resolved' &&

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.spec.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.spec.tsx
@@ -12,7 +12,7 @@ const mockProfileData = {
           value: 0,
         },
         {
-          elapsed_since_start_ns: 1000000000,
+          elapsed_since_start_ns: 1000,
           value: 12.0,
         },
       ],
@@ -25,7 +25,7 @@ const mockProfileData = {
           value: 20000,
         },
         {
-          elapsed_since_start_ns: 1000000000,
+          elapsed_since_start_ns: 1000,
           value: 123456,
         },
       ],
@@ -34,14 +34,18 @@ const mockProfileData = {
 } as Profiling.ProfileInput;
 
 it('renders CPU Usage as a chart', function () {
-  render(<ProfilingMeasurements profileData={mockProfileData} />);
+  render(
+    <ProfilingMeasurements profileData={mockProfileData} transactionDuration={2000} />
+  );
 
   expect(screen.getByText('CPU Usage')).toBeInTheDocument();
   expect(screen.getByTestId('profile-measurements-chart-cpu_usage')).toBeInTheDocument();
 });
 
 it('can toggle between CPU Usage and Memory charts', async function () {
-  render(<ProfilingMeasurements profileData={mockProfileData} />);
+  render(
+    <ProfilingMeasurements profileData={mockProfileData} transactionDuration={2000} />
+  );
 
   await userEvent.click(screen.getByText('CPU Usage'));
   await userEvent.click(screen.getByText('Memory'));


### PR DESCRIPTION
Profiles can have a different duration than transactions, this is because some transactions have a timeout and there's post processing to cut down the transaction duration to when it was actually active. During this time, profiles can be recording data which does not get trimmed yet.

This PR filters out datapoints that exceed the transaction duration and if there are less than 3 relevant datapoints we don't show the chart at all. It also zerofills a datapoint at the start and at the end, so when plotted, the datapoints should align with the transaction timeline.

An example transaction to see these changes can be seen [here](https://localhost:7999/performance/sentry-android:9107c602c69e434598596edccb75f4e9/)

Closes #46687 