### PR TITLE
fix(starfish): Add Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -670,6 +670,12 @@ urlpatterns += [
         react_page_view,
         name="performance",
     ),
+    # Starfish
+    url(
+        r"^starfish/",
+        react_page_view,
+        name="starfish",
+    ),
     # Profiling
     url(
         r"^profiling/",


### PR DESCRIPTION
The `/starfish` route is correctly served by React, but subroutes like `/starfish/api` get a 302 to `/sentry/api` which doesn't exist. I think this is because there's no entry for starfish routes in `urls.py`, so it's falling through to incorrect behaviour. This PR adds the route, which should force all the Starfish subroutes to be handled by React.
