### PR TITLE
feat(migrations) Restore Run migrations on all primaries

### DIFF
--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -43,10 +43,9 @@ def _upgrade(interactive, traceback, verbosity, repair, with_nodestore):
     _check_history()
 
     for db_conn in settings.DATABASES.keys():
-        # Always run migrations for the default connection.
-        # Also run migrations on connections that have migrations explicitly enabled.
+        # Run migrations on all non-read replica connections.
         # This is used for sentry.io as our production database runs on multiple hosts.
-        if db_conn == "default" or settings.DATABASES[db_conn].get("RUN_MIGRATIONS", False):
+        if not settings.DATABASES[db_conn].get("REPLICA_OF", False):
             click.echo(f"Running migrations for {db_conn}")
             dj_call_command(
                 "migrate",


### PR DESCRIPTION
Redo #45853 as the deploy containing this change failed due to bad db configuration in getsentry which I'm going to remove.

This reverts commit bfeb96090719f5e136c63a63a13b27f2748255ad.

Refs getsentry/getsentry#10232