### PR TITLE
feat(rulesnooze): Update endpoint to include info about if snooze is for all

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -101,6 +101,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 creator_name = user_service.get_user(snooze.owner_id).get_display_name()
                 created_by = creator_name
             serialized_rule["snoozeCreatedBy"] = created_by
+            serialized_rule["snnozeForEveryone"] = snooze.user_id is None
         else:
             serialized_rule["snooze"] = False
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -101,7 +101,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 creator_name = user_service.get_user(snooze.owner_id).get_display_name()
                 created_by = creator_name
             serialized_rule["snoozeCreatedBy"] = created_by
-            serialized_rule["snnozeForEveryone"] = snooze.user_id is None
+            serialized_rule["snoozeForEveryone"] = snooze.user_id is None
         else:
             serialized_rule["snooze"] = False
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -160,6 +160,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
 
         assert response.data["snooze"]
         assert response.data["snoozeCreatedBy"] == "You"
+        assert not response.data["snoozeForEveryone"]
 
     def test_with_snooze_rule_everyone(self):
         user2 = self.create_user("user2@example.com")
@@ -176,6 +177,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
 
         assert response.data["snooze"]
         assert response.data["snoozeCreatedBy"] == user2.get_display_name()
+        assert response.data["snoozeForEveryone"]
 
     @responses.activate
     def test_with_unresponsive_sentryapp(self):


### PR DESCRIPTION
this pr adds an additional field to the ProjectRuleDetailsEndpoint to show if the snoozed rule is snoozed for everyone or just one user. This will be used in a banner on the front end.