### PR TITLE
fix(hybrid-cloud): Add OutboxCategory.ORGANIZATION_MEMBER_CREATE

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -252,6 +252,15 @@ class OrganizationMember(Model):
         self.token = self.generate_token()
         self.refresh_expires_at()
 
+    def outbox_for_create(self) -> RegionOutbox:
+        return RegionOutbox(
+            shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+            shard_identifier=self.organization_id,
+            category=OutboxCategory.ORGANIZATION_MEMBER_CREATE,
+            object_identifier=self.id,
+            payload=dict(user_id=self.user_id),
+        )
+
     def outbox_for_update(self) -> RegionOutbox:
         return RegionOutbox(
             shard_scope=OutboxScope.ORGANIZATION_SCOPE,

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -61,6 +61,7 @@ class OutboxCategory(IntEnum):
     SENTRY_APP_INSTALLATION_UPDATE = 10
     TEAM_UPDATE = 11
     ORGANIZATION_INTEGRATION_UPDATE = 12
+    ORGANIZATION_MEMBER_CREATE = 13
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -54,6 +54,21 @@ def process_user_ip_event(payload: Any, **kwds: Any):
         DatabaseBackedLogService().record_user_ip(event=UserIpEvent(**payload))
 
 
+@receiver(process_region_outbox, sender=OutboxCategory.ORGANIZATION_MEMBER_CREATE)
+def process_organization_member_create(
+    object_identifier: int, payload: Any, shard_identifier: int, **kwds: Any
+):
+    if (org_member := maybe_process_tombstone(OrganizationMember, object_identifier)) is None:
+        # Delete all identities that may have been associated.  This is an implicit cascade.
+        if payload and "user_id" in payload:
+            identity_service.delete_identities(
+                user_id=payload["user_id"], organization_id=shard_identifier
+            )
+        return
+
+    organizationmember_mapping_service.create_with_organization_member(org_member=org_member)
+
+
 @receiver(process_region_outbox, sender=OutboxCategory.ORGANIZATION_MEMBER_UPDATE)
 def process_organization_member_updates(
     object_identifier: int, payload: Any, shard_identifier: int, **kwds: Any
@@ -69,7 +84,8 @@ def process_organization_member_updates(
         )
         return
 
-    organizationmember_mapping_service.create_with_organization_member(org_member=org_member)
+    # TODO: replace with organizationmember_mapping_service.update_with_organization_member(org_member=org_member)
+    org_member
 
 
 @receiver(process_region_outbox, sender=OutboxCategory.TEAM_UPDATE)

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -59,11 +59,6 @@ def process_organization_member_create(
     object_identifier: int, payload: Any, shard_identifier: int, **kwds: Any
 ):
     if (org_member := maybe_process_tombstone(OrganizationMember, object_identifier)) is None:
-        # Delete all identities that may have been associated.  This is an implicit cascade.
-        if payload and "user_id" in payload:
-            identity_service.delete_identities(
-                user_id=payload["user_id"], organization_id=shard_identifier
-            )
         return
 
     organizationmember_mapping_service.create_with_organization_member(org_member=org_member)

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -307,6 +307,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         assert (user_id is None and email) or (
             user_id and email is None
         ), "Must set either user_id or email"
+        region_outbox = None
         with transaction.atomic():
             org_member: OrganizationMember = OrganizationMember.objects.create(
                 organization_id=organization_id,
@@ -319,7 +320,8 @@ class DatabaseBackedOrganizationService(OrganizationService):
             )
             region_outbox = org_member.outbox_for_create()
             region_outbox.save()
-        region_outbox.drain_shard(max_updates_to_drain=10)
+        if region_outbox:
+            region_outbox.drain_shard(max_updates_to_drain=10)
         return self.serialize_member(org_member)
 
     def add_team_member(self, *, team_id: int, organization_member: RpcOrganizationMember) -> None:

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -317,7 +317,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 inviter_id=inviter_id,
                 invite_status=invite_status,
             )
-            region_outbox = org_member.outbox_for_update()
+            region_outbox = org_member.outbox_for_create()
             region_outbox.save()
         region_outbox.drain_shard(max_updates_to_drain=10)
         return self.serialize_member(org_member)

--- a/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
@@ -176,7 +176,7 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
             "invite_status": InviteStatus.REQUESTED_TO_JOIN.value,
         }
         org_member = OrganizationMember.objects.create(**fields)
-        region_outbox = org_member.outbox_for_update()
+        region_outbox = org_member.outbox_for_create()
         region_outbox.save()
         region_outbox.drain_shard()
 

--- a/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
@@ -153,7 +153,7 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
             "invite_status": InviteStatus.REQUESTED_TO_JOIN.value,
         }
         org_member = OrganizationMember.objects.create(**fields)
-        region_outbox = org_member.outbox_for_update()
+        region_outbox = org_member.outbox_for_create()
         region_outbox.save()
         region_outbox.drain_shard()
 


### PR DESCRIPTION
I had mistakenly used the `process_organization_member_updates()` receiver for processing `OrganizationMember` creates. 

Here, I created a separate receiver and methods for `OutboxCategory.ORGANIZATION_MEMBER_CREATE`.

Later on, I plan to add `organizationmember_mapping_service.update_with_organization_member()`.