### PR TITLE
ref(escalating-issues): Change cron schedule to every 6 hours

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -914,7 +914,7 @@ CELERYBEAT_SCHEDULE = {
     "weekly-escalating-forecast": {
         "task": "sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",
         # TODO: Change this to run weekly once we verify the results
-        "schedule": crontab(minute=0, hour="*/1"),
+        "schedule": crontab(minute=0, hour="*/6"),
         # TODO: Increase expiry time to x4 once we change this to run weekly
         "options": {"expires": 60 * 60 * 3},
     },


### PR DESCRIPTION
Change the escalating issue forecast cron job schedule to every 6 hours now that we have confirmed it is running as scheduled
