### PR TITLE
feat(mute-alerts): simplify the rule unsnooze endpoint

### DIFF
--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -128,7 +128,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
         made_delete = False
         kwargs = {self.rule_field: rule, "user_id": None}
         try:
-            shared_snooze = RuleSnooze.objects.filter(**kwargs)
+            shared_snooze = RuleSnooze.objects.get(**kwargs)
         except RuleSnooze.DoesNotExist:
             pass
 

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -578,12 +578,8 @@ class DeleteMetricRuleSnoozeTest(BaseRuleSnoozeTest):
         RuleSnooze.objects.create(
             user_id=self.user.id, alert_rule=self.metric_alert_rule, owner_id=self.user.id
         )
-        data = {"target": "me"}
         response = self.get_response(
-            self.organization.slug,
-            self.project.slug,
-            self.metric_alert_rule.id,
-            **data,
+            self.organization.slug, self.project.slug, self.metric_alert_rule.id
         )
         assert not RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id
@@ -594,12 +590,10 @@ class DeleteMetricRuleSnoozeTest(BaseRuleSnoozeTest):
     def test_delete_metric_alert_rule_mute_everyone(self):
         """Test that a user can unsnooze a metric rule they've snoozed for everyone"""
         RuleSnooze.objects.create(alert_rule=self.metric_alert_rule, owner_id=self.user.id)
-        data = {"target": "everyone"}
         response = self.get_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
-            **data,
         )
         assert not RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id
@@ -616,12 +610,8 @@ class DeleteMetricRuleSnoozeTest(BaseRuleSnoozeTest):
             owner=ActorTuple.from_actor_identifier(f"team:{other_team.id}"),
         )
         RuleSnooze.objects.create(alert_rule=other_metric_alert_rule)
-        data = {"target": "everyone"}
         response = self.get_response(
-            self.organization.slug,
-            self.project.slug,
-            other_metric_alert_rule.id,
-            **data,
+            self.organization.slug, self.project.slug, other_metric_alert_rule.id
         )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule.id).exists()
         assert response.status_code == 401


### PR DESCRIPTION
This PR simplifies the rule unsnooze endpoint so it doesn't require query params. Note that there is an edge case where two snoozes could be deleted if there is snooze for everyone and for that user and they have permission.