### PR TITLE
feat(worflow): Track unmerge issue usage

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -89,6 +89,14 @@ export type TeamInsightsEventParameters = {
   'issue_details.issue_tab.screenshot_modal_deleted': {};
   'issue_details.issue_tab.screenshot_modal_download': {};
   'issue_details.issue_tab.screenshot_modal_opened': {};
+  'issue_details.merged_tab.unmerge_clicked': {
+    /**
+     * comma separated list of event ids that were unmerged
+     */
+    event_ids_unmerged: string;
+    group_id: string;
+    total_unmerged: number;
+  };
   'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
     has_pull_request: boolean;
   };
@@ -156,6 +164,7 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'issue_details.suspect_commits.pull_request_clicked':
     'Issue Details: Suspect Pull Request Clicked',
   'issue_details.tab_changed': 'Issue Details: Tab Changed',
+  'issue_details.merged_tab.unmerge_clicked': 'Issue Details: Unmerge Clicked',
   'project_creation_page.created': 'Project Create: Project Created',
   'project_detail.open_issues': 'Project Detail: Open issues from project detail',
   'project_detail.open_discover': 'Project Detail: Open discover from project detail',

--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -9,6 +9,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import GroupingStore, {Fingerprint} from 'sentry/stores/groupingStore';
 import {Group, Organization, Project} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import MergedList from './mergedList';
@@ -102,6 +103,13 @@ class GroupMergedView extends Component<Props, State> {
       loadingMessage: t('Unmerging events\u2026'),
       successMessage: t('Events successfully queued for unmerging.'),
       errorMessage: t('Unable to queue events for unmerging.'),
+    });
+    const unmergeKeys = [...GroupingStore.getState().unmergeList.values()];
+    trackAdvancedAnalyticsEvent('issue_details.merged_tab.unmerge_clicked', {
+      organization: this.props.organization,
+      group_id: this.props.params.groupId,
+      event_ids_unmerged: unmergeKeys.join(','),
+      total_unmerged: unmergeKeys.length,
     });
   };
 


### PR DESCRIPTION
Tracking the number of events unmerged and the current group id

[WOR-2948](https://getsentry.atlassian.net/browse/WOR-2948)

[WOR-2948]: https://getsentry.atlassian.net/browse/WOR-2948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ