### PR TITLE
feat(crons): Rate limit cron consumer check-ins

### DIFF
--- a/src/sentry/monitors/consumers/check_in.py
+++ b/src/sentry/monitors/consumers/check_in.py
@@ -10,6 +10,7 @@ from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, Message, Partition
 from django.db import transaction
 
+from sentry import ratelimits
 from sentry.models import Project
 from sentry.monitors.models import (
     CheckInStatus,
@@ -21,10 +22,13 @@ from sentry.monitors.models import (
 )
 from sentry.monitors.utils import signal_first_checkin, signal_first_monitor_created
 from sentry.monitors.validators import ConfigValidator
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.dates import to_datetime
 
 logger = logging.getLogger(__name__)
+
+CHECKIN_QUOTA_LIMIT = 5
+CHECKIN_QUOTA_WINDOW = 60
 
 
 def _ensure_monitor_with_config(
@@ -82,6 +86,20 @@ def _process_message(wrapper: Dict) -> None:
     project_id = int(wrapper["project_id"])
 
     project = Project.objects.get_from_cache(id=project_id)
+
+    ratelimit_key = params["monitor_slug"]
+
+    if ratelimits.is_limited(
+        f"monitor-checkins:{ratelimit_key}",
+        limit=CHECKIN_QUOTA_LIMIT,
+        window=CHECKIN_QUOTA_WINDOW,
+    ):
+        metrics.incr(
+            "monitors.checkin.dropped.ratelimited",
+            tags={"source": "consumer"},
+        )
+        logger.debug("monitor check in rate limited: %s", params["monitor_slug"])
+        return
 
     try:
         with transaction.atomic():


### PR DESCRIPTION
We had rate limiting on the legacy ingest APIs since https://github.com/getsentry/sentry/pull/44719 but not on the relay consumer.

Unfortuantely we're unable to let the customer know right now that they're being rate limited. We would need to have some kind of quote system for crons to help with that.