### PR TITLE
ref(replay): Move `<ObjectInspector>` logic to a hook

### DIFF
--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -1,4 +1,4 @@
-import {ComponentProps, useMemo} from 'react';
+import {ComponentProps, MouseEvent, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import {
   chromeDark,
@@ -46,5 +46,11 @@ function ObjectInspector({data, theme, ...props}: Props) {
     />
   );
 }
+
+export type OnExpand = (
+  path: string,
+  expandedState: Record<string, boolean>,
+  event: MouseEvent<HTMLDivElement>
+) => void;
 
 export default ObjectInspector;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import {memo, MouseEvent, useCallback, useMemo, useRef} from 'react';
+import {memo, useMemo, useRef} from 'react';
 import {
   AutoSizer,
   CellMeasurer,
@@ -18,6 +18,8 @@ import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import useVirtualizedList from 'sentry/views/replays/detail/useVirtualizedList';
 
+import useVirtualizedInspector from '../useVirtualizedInspector';
+
 type Props = {
   breadcrumbs: undefined | Crumb[];
   startTimestampMs: number;
@@ -32,14 +34,20 @@ const cellMeasurer = {
 
 function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
-  const expandPaths = useRef(new Map<number, Set<string>>());
   const items = useMemo(
     () =>
       (breadcrumbs || []).filter(crumb => !['console'].includes(crumb.category || '')),
     [breadcrumbs]
   );
-
   const listRef = useRef<ReactVirtualizedList>(null);
+  // Keep a reference of object paths that are expanded (via <ObjectInspector>)
+  // by log row, so they they can be restored as the Console pane is scrolling.
+  // Due to virtualization, components can be unmounted as the user scrolls, so
+  // state needs to be remembered.
+  //
+  // Note that this is intentionally not in state because we do not want to
+  // re-render when items are expanded/collapsed, though it may work in state as well.
+  const expandPathsRef = useRef(new Map<number, Set<string>>());
 
   const itemLookup = useMemo(
     () =>
@@ -80,29 +88,11 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
     ref: listRef,
     deps,
   });
-
-  const handleDimensionChange = useCallback(
-    (
-      index: number,
-      path: string,
-      expandedState: Record<string, boolean>,
-      event: MouseEvent<HTMLDivElement>
-    ) => {
-      const rowState = expandPaths.current.get(index) || new Set();
-      if (expandedState[path]) {
-        rowState.add(path);
-      } else {
-        // Collapsed, i.e. its default state, so no need to store state
-        rowState.delete(path);
-      }
-      expandPaths.current.set(index, rowState);
-      cache.clear(index, 0);
-      listRef.current?.recomputeGridSize({rowIndex: index});
-      listRef.current?.forceUpdateGrid();
-      event.stopPropagation();
-    },
-    [cache, expandPaths, listRef]
-  );
+  const {handleDimensionChange} = useVirtualizedInspector({
+    cache,
+    listRef,
+    expandPathsRef,
+  });
 
   useScrollToCurrentItem({
     breadcrumbs,
@@ -128,7 +118,7 @@ function Breadcrumbs({breadcrumbs, startTimestampMs}: Props) {
           breadcrumb={item}
           startTimestampMs={startTimestampMs}
           style={style}
-          expandPaths={Array.from(expandPaths.current.get(index) || [])}
+          expandPaths={Array.from(expandPathsRef.current?.get(index) || [])}
           onDimensionChange={handleDimensionChange}
         />
       </CellMeasurer>

--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -13,6 +13,8 @@ import {breadcrumbHasIssue} from 'sentry/views/replays/detail/console/utils';
 import ViewIssueLink from 'sentry/views/replays/detail/console/viewIssueLink';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
+import {OnDimensionChange} from '../useVirtualizedInspector';
+
 type Props = {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
   index: number;
@@ -21,11 +23,7 @@ type Props = {
   startTimestampMs: number;
   style: CSSProperties;
   expandPaths?: string[];
-  onDimensionChange?: (
-    index: number,
-    path: string,
-    expandedState: Record<string, boolean>
-  ) => void;
+  onDimensionChange?: OnDimensionChange;
 };
 
 function UnmemoizedConsoleLogRow({
@@ -56,8 +54,8 @@ function UnmemoizedConsoleLogRow({
     [handleMouseLeave, breadcrumb]
   );
   const handleDimensionChange = useCallback(
-    (path, expandedState) =>
-      onDimensionChange && onDimensionChange(index, path, expandedState),
+    (path, expandedState, e) =>
+      onDimensionChange && onDimensionChange(index, path, expandedState, e),
     [onDimensionChange, index]
   );
 
@@ -85,7 +83,7 @@ function UnmemoizedConsoleLogRow({
           <MessageFormatter
             expandPaths={expandPaths}
             breadcrumb={breadcrumb}
-            onDimensionChange={handleDimensionChange}
+            onExpand={handleDimensionChange}
           />
         </ErrorBoundary>
       </Message>

--- a/static/app/views/replays/detail/console/format.tsx
+++ b/static/app/views/replays/detail/console/format.tsx
@@ -22,7 +22,7 @@
 import {Fragment} from 'react';
 import isObject from 'lodash/isObject';
 
-import ObjectInspector from 'sentry/components/objectInspector';
+import ObjectInspector, {OnExpand} from 'sentry/components/objectInspector';
 
 const formatRegExp = /%[sdj%]/g;
 
@@ -32,7 +32,7 @@ function isNull(arg: unknown) {
 interface FormatProps {
   args: any[];
   expandPaths?: string[];
-  onExpand?: (path: string, expandedState: Record<string, boolean>) => void;
+  onExpand?: OnExpand;
 }
 
 /**

--- a/static/app/views/replays/detail/console/messageFormatter.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.tsx
@@ -3,6 +3,7 @@ import isObject from 'lodash/isObject';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {getMeta} from 'sentry/components/events/meta/metaProxy';
+import {OnExpand} from 'sentry/components/objectInspector';
 import {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
 import {objectIsEmpty} from 'sentry/utils';
 
@@ -11,13 +12,13 @@ import Format from './format';
 interface Props {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
   expandPaths?: string[];
-  onDimensionChange?: (path: string, expandedState: Record<string, boolean>) => void;
+  onExpand?: OnExpand;
 }
 
 /**
  * Attempt to emulate the browser console as much as possible
  */
-function UnmemoizedMessageFormatter({breadcrumb, expandPaths, onDimensionChange}: Props) {
+function UnmemoizedMessageFormatter({breadcrumb, expandPaths, onExpand}: Props) {
   let args = breadcrumb.data?.arguments;
 
   if (!args) {
@@ -74,7 +75,7 @@ function UnmemoizedMessageFormatter({breadcrumb, expandPaths, onDimensionChange}
     args = [fakeError];
   }
 
-  return <Format expandPaths={expandPaths} onExpand={onDimensionChange} args={args} />;
+  return <Format expandPaths={expandPaths} onExpand={onExpand} args={args} />;
 }
 
 const MessageFormatter = memo(UnmemoizedMessageFormatter);

--- a/static/app/views/replays/detail/console/useConsoleFilters.tsx
+++ b/static/app/views/replays/detail/console/useConsoleFilters.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef} from 'react';
+import {RefObject, useCallback, useMemo, useRef} from 'react';
 
 import type {
   BreadcrumbLevelType,
@@ -26,7 +26,7 @@ type Options = {
 };
 
 type Return = {
-  expandPaths: Map<number, Set<string>>;
+  expandPathsRef: RefObject<Map<number, Set<string>>>;
   getLogLevels: () => {label: string; value: string}[];
   items: Item[];
   logLevel: BreadcrumbType[];
@@ -87,7 +87,7 @@ function useConsoleFilters({breadcrumbs}: Options): Return {
   //
   // Note that this is intentionally not in state because we do not want to
   // re-render when items are expanded/collapsed, though it may work in state as well.
-  const expandPaths = useRef(new Map<number, Set<string>>());
+  const expandPathsRef = useRef(new Map<number, Set<string>>());
 
   const typeDefaultCrumbs = useMemo(
     () => breadcrumbs.filter(isBreadcrumbTypeDefault),
@@ -134,22 +134,22 @@ function useConsoleFilters({breadcrumbs}: Options): Return {
     (f_c_logLevel: string[]) => {
       setFilter({f_c_logLevel});
       // Need to reset `expandPaths` when filtering
-      expandPaths.current = new Map();
+      expandPathsRef.current = new Map();
     },
-    [setFilter, expandPaths]
+    [setFilter, expandPathsRef]
   );
 
   const setSearchTerm = useCallback(
     (f_c_search: string) => {
       setFilter({f_c_search: f_c_search || undefined});
       // Need to reset `expandPaths` when filtering
-      expandPaths.current = new Map();
+      expandPathsRef.current = new Map();
     },
-    [setFilter, expandPaths]
+    [setFilter, expandPathsRef]
   );
 
   return {
-    expandPaths: expandPaths.current,
+    expandPathsRef,
     getLogLevels,
     items,
     logLevel,

--- a/static/app/views/replays/detail/useVirtualizedInspector.tsx
+++ b/static/app/views/replays/detail/useVirtualizedInspector.tsx
@@ -1,0 +1,44 @@
+import {MouseEvent, RefObject, useCallback} from 'react';
+import {CellMeasurerCache, List} from 'react-virtualized';
+
+import {OnExpand} from 'sentry/components/objectInspector';
+
+type Opts = {
+  cache: CellMeasurerCache;
+  expandPathsRef: RefObject<Map<number, Set<string>>>;
+  listRef: RefObject<List>;
+};
+function useVirtualizedInspector({cache, listRef, expandPathsRef}: Opts) {
+  const handleDimensionChange = useCallback(
+    (
+      index: number,
+      path: string,
+      expandedState: Record<string, boolean>,
+      event: MouseEvent<HTMLDivElement>
+    ) => {
+      const rowState = expandPathsRef.current?.get(index) || new Set();
+      if (expandedState[path]) {
+        rowState.add(path);
+      } else {
+        // Collapsed, i.e. its default state, so no need to store state
+        rowState.delete(path);
+      }
+      expandPathsRef.current?.set(index, rowState);
+      cache.clear(index, 0);
+      listRef.current?.recomputeGridSize({rowIndex: index});
+      listRef.current?.forceUpdateGrid();
+      event.stopPropagation();
+    },
+    [cache, expandPathsRef, listRef]
+  );
+
+  return {
+    expandPaths: expandPathsRef.current,
+    handleDimensionChange,
+  };
+}
+
+export type OnDimensionChange = OnExpand extends (...a: infer U) => infer R
+  ? (index: number, ...a: U) => R
+  : never;
+export default useVirtualizedInspector;


### PR DESCRIPTION
Moves some logic for using `<ObjectInspector>` with virtualized rows into a hook `useVirtualizedInspector`
