### PR TITLE
style(models): Indicate that project.name is deprecated

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -117,6 +117,7 @@ class Project(Model, PendingDeletionMixin, SnowflakeIdMixin):
     __include_in_export__ = True
 
     slug = models.SlugField(null=True)
+    # DEPRECATED do not use, prefer slug
     name = models.CharField(max_length=200)
     forced_color = models.CharField(max_length=6, null=True, blank=True)
     organization = FlexibleForeignKey("sentry.Organization")


### PR DESCRIPTION
This was never marked, but should have been. it should not be used