### PR TITLE
feat(vercel-integration): Create environment variables for all Vercel deployment environments

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -256,7 +256,7 @@ class VercelIntegration(IntegrationInstallation):
         data = {
             "key": key,
             "value": value,
-            "target": ["production"],
+            "target": ["production", "preview", "development"],
             "type": type,
         }
         try:

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -232,19 +232,45 @@ class VercelIntegration(IntegrationInstallation):
             )
 
             env_var_map = {
-                "SENTRY_ORG": {"type": "encrypted", "value": sentry_project.organization.slug},
-                "SENTRY_PROJECT": {"type": "encrypted", "value": sentry_project.slug},
-                dsn_env_name: {"type": "encrypted", "value": sentry_project_dsn},
+                dsn_env_name: {
+                    "type": "encrypted",
+                    "value": sentry_project_dsn,
+                    "target": [
+                        "production",
+                        "preview",
+                        "development",  # The DSN is the only value that makes sense to have available locally via Vercel CLI's `vercel dev` command
+                    ],
+                },
+                "SENTRY_ORG": {
+                    "type": "encrypted",
+                    "value": sentry_project.organization.slug,
+                    "target": ["production", "preview"],
+                },
+                "SENTRY_PROJECT": {
+                    "type": "encrypted",
+                    "value": sentry_project.slug,
+                    "target": ["production", "preview"],
+                },
                 "SENTRY_AUTH_TOKEN": {
                     "type": "encrypted",
                     "value": sentry_auth_token,
+                    "target": ["production", "preview"],
                 },
-                "VERCEL_GIT_COMMIT_SHA": {"type": "system", "value": "VERCEL_GIT_COMMIT_SHA"},
+                "VERCEL_GIT_COMMIT_SHA": {
+                    "type": "system",
+                    "value": "VERCEL_GIT_COMMIT_SHA",
+                    "target": ["production", "preview"],
+                },
             }
 
             for env_var, details in env_var_map.items():
                 self.create_env_var(
-                    vercel_client, vercel_project_id, env_var, details["value"], details["type"]
+                    vercel_client,
+                    vercel_project_id,
+                    env_var,
+                    details["value"],
+                    details["type"],
+                    details["target"],
                 )
         config.update(data)
         self.org_integration = integration_service.update_organization_integration(
@@ -252,11 +278,11 @@ class VercelIntegration(IntegrationInstallation):
             config=config,
         )
 
-    def create_env_var(self, client, vercel_project_id, key, value, type):
+    def create_env_var(self, client, vercel_project_id, key, value, type, target):
         data = {
             "key": key,
             "value": value,
-            "target": ["production", "preview", "development"],
+            "target": target,
             "type": type,
         }
         try:

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -232,15 +232,6 @@ class VercelIntegration(IntegrationInstallation):
             )
 
             env_var_map = {
-                dsn_env_name: {
-                    "type": "encrypted",
-                    "value": sentry_project_dsn,
-                    "target": [
-                        "production",
-                        "preview",
-                        "development",  # The DSN is the only value that makes sense to have available locally via Vercel CLI's `vercel dev` command
-                    ],
-                },
                 "SENTRY_ORG": {
                     "type": "encrypted",
                     "value": sentry_project.organization.slug,
@@ -250,6 +241,15 @@ class VercelIntegration(IntegrationInstallation):
                     "type": "encrypted",
                     "value": sentry_project.slug,
                     "target": ["production", "preview"],
+                },
+                dsn_env_name: {
+                    "type": "encrypted",
+                    "value": sentry_project_dsn,
+                    "target": [
+                        "production",
+                        "preview",
+                        "development",  # The DSN is the only value that makes sense to have available locally via Vercel CLI's `vercel dev` command
+                    ],
                 },
                 "SENTRY_AUTH_TOKEN": {
                     "type": "encrypted",

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -147,15 +147,6 @@ class VercelIntegrationTest(IntegrationTestCase):
         sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
 
         env_var_map = {
-            "SENTRY_DSN": {
-                "type": "encrypted",
-                "value": enabled_dsn,
-                "target": [
-                    "production",
-                    "preview",
-                    "development",
-                ],
-            },
             "SENTRY_ORG": {
                 "type": "encrypted",
                 "value": org.slug,
@@ -165,6 +156,15 @@ class VercelIntegrationTest(IntegrationTestCase):
                 "type": "encrypted",
                 "value": self.project.slug,
                 "target": ["production", "preview"],
+            },
+            "SENTRY_DSN": {
+                "type": "encrypted",
+                "value": enabled_dsn,
+                "target": [
+                    "production",
+                    "preview",
+                    "development",
+                ],
             },
             "SENTRY_AUTH_TOKEN": {
                 "type": "encrypted",
@@ -257,11 +257,35 @@ class VercelIntegrationTest(IntegrationTestCase):
         sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
 
         env_var_map = {
-            "SENTRY_ORG": {"type": "encrypted", "value": org.slug},
-            "SENTRY_PROJECT": {"type": "encrypted", "value": self.project.slug},
-            "SENTRY_DSN": {"type": "encrypted", "value": enabled_dsn},
-            "SENTRY_AUTH_TOKEN": {"type": "secret", "value": sentry_auth_token},
-            "VERCEL_GIT_COMMIT_SHA": {"type": "system", "value": "VERCEL_GIT_COMMIT_SHA"},
+            "SENTRY_ORG": {
+                "type": "encrypted",
+                "value": org.slug,
+                "target": ["production", "preview"],
+            },
+            "SENTRY_PROJECT": {
+                "type": "encrypted",
+                "value": self.project.slug,
+                "target": ["production", "preview"],
+            },
+            "SENTRY_DSN": {
+                "type": "encrypted",
+                "value": enabled_dsn,
+                "target": [
+                    "production",
+                    "preview",
+                    "development",
+                ],
+            },
+            "SENTRY_AUTH_TOKEN": {
+                "type": "encrypted",
+                "value": sentry_auth_token,
+                "target": ["production", "preview"],
+            },
+            "VERCEL_GIT_COMMIT_SHA": {
+                "type": "system",
+                "value": "VERCEL_GIT_COMMIT_SHA",
+                "target": ["production", "preview"],
+            },
         }
 
         # mock get_project API call
@@ -294,7 +318,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 json={
                     "key": env_var,
                     "value": details["value"],
-                    "target": ["production", "preview", "development"],
+                    "target": details["target"],
                     "type": details["type"],
                 },
             )

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -147,11 +147,35 @@ class VercelIntegrationTest(IntegrationTestCase):
         sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
 
         env_var_map = {
-            "SENTRY_ORG": {"type": "encrypted", "value": org.slug},
-            "SENTRY_PROJECT": {"type": "encrypted", "value": self.project.slug},
-            "SENTRY_DSN": {"type": "encrypted", "value": enabled_dsn},
-            "SENTRY_AUTH_TOKEN": {"type": "encrypted", "value": sentry_auth_token},
-            "VERCEL_GIT_COMMIT_SHA": {"type": "system", "value": "VERCEL_GIT_COMMIT_SHA"},
+            "SENTRY_DSN": {
+                "type": "encrypted",
+                "value": enabled_dsn,
+                "target": [
+                    "production",
+                    "preview",
+                    "development",
+                ],
+            },
+            "SENTRY_ORG": {
+                "type": "encrypted",
+                "value": org.slug,
+                "target": ["production", "preview"],
+            },
+            "SENTRY_PROJECT": {
+                "type": "encrypted",
+                "value": self.project.slug,
+                "target": ["production", "preview"],
+            },
+            "SENTRY_AUTH_TOKEN": {
+                "type": "encrypted",
+                "value": sentry_auth_token,
+                "target": ["production", "preview"],
+            },
+            "VERCEL_GIT_COMMIT_SHA": {
+                "type": "system",
+                "value": "VERCEL_GIT_COMMIT_SHA",
+                "target": ["production", "preview"],
+            },
         }
 
         # mock get_project API call
@@ -169,7 +193,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 json={
                     "key": env_var,
                     "value": details["value"],
-                    "target": ["production", "preview", "development"],
+                    "target": details["target"],
                     "type": details["type"],
                 },
             )
@@ -192,13 +216,13 @@ class VercelIntegrationTest(IntegrationTestCase):
         req_params = json.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[6].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[7].request.body)
@@ -209,13 +233,13 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[9].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "system"
 
     @responses.activate
@@ -292,13 +316,13 @@ class VercelIntegrationTest(IntegrationTestCase):
         req_params = json.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[11].request.body)
@@ -309,13 +333,13 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         req_params = json.loads(responses.calls[14].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[17].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["target"] == ["production", "preview"]
         assert req_params["type"] == "system"
 
     @responses.activate

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -169,7 +169,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 json={
                     "key": env_var,
                     "value": details["value"],
-                    "target": ["production"],
+                    "target": ["production", "preview", "development"],
                     "type": details["type"],
                 },
             )
@@ -192,30 +192,30 @@ class VercelIntegrationTest(IntegrationTestCase):
         req_params = json.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[6].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[7].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[9].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "system"
 
     @responses.activate
@@ -270,7 +270,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 json={
                     "key": env_var,
                     "value": details["value"],
-                    "target": ["production"],
+                    "target": ["production", "preview", "development"],
                     "type": details["type"],
                 },
             )
@@ -292,30 +292,30 @@ class VercelIntegrationTest(IntegrationTestCase):
         req_params = json.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[11].request.body)
         assert req_params["key"] == "SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[14].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[17].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "system"
 
     @responses.activate


### PR DESCRIPTION
We changed the Next.js SDK to upload source maps for every deployment target in https://github.com/getsentry/sentry-javascript/pull/7436. This requires the Vercel integration to follow suite.

Fixes https://github.com/getsentry/sentry-docs/issues/5690
Fixes https://github.com/getsentry/sentry-javascript/issues/5619