### PR TITLE
fix(vercel-integration): Remove requirement for Vercel project to have a git repo connected

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -212,16 +212,6 @@ class VercelIntegration(IntegrationInstallation):
             sentry_project_dsn = enabled_dsn.get_dsn(public=True)
 
             vercel_project = vercel_client.get_project(vercel_project_id)
-            source_code_provider = vercel_project.get("link", {}).get("type")
-
-            if not source_code_provider:
-                raise ValidationError(
-                    {
-                        "project_mappings": [
-                            "You must connect your Vercel project to a Git repository to continue!"
-                        ]
-                    }
-                )
 
             is_next_js = vercel_project.get("framework") == "nextjs"
             dsn_env_name = "NEXT_PUBLIC_SENTRY_DSN" if is_next_js else "SENTRY_DSN"

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -337,27 +337,6 @@ class VercelIntegrationTest(IntegrationTestCase):
             installation.update_organization_config(data)
 
     @responses.activate
-    def test_upgrade_org_config_no_source_code_provider(self):
-        """Test that the function doesn't progress if the Vercel project hasn't been connected to a Git repository"""
-
-        with self.tasks():
-            self.assert_setup_flow()
-
-        project_id = self.project.id
-        org = self.organization
-        data = {"project_mappings": [[project_id, self.project_id]]}
-        integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(org.id)
-
-        responses.add(
-            responses.GET,
-            f"{VercelClient.base_url}{VercelClient.GET_PROJECT_URL % self.project_id}",
-            json={},
-        )
-        with pytest.raises(ValidationError):
-            installation.update_organization_config(data)
-
-    @responses.activate
     def test_get_dynamic_display_information(self):
         with self.tasks():
             self.assert_setup_flow()


### PR DESCRIPTION
While testing the integration on one of my personal projects, I noticed that setting up the integration didn't work because my project on Vercel didn't have a git repo connected.

To me this limitation seems unnecessary, or rather we shouldn't prevent users from continuing if they don't have a repository connected, as there is no downstream dependency on that (I believe). I'd be happy if anybody from the ecosystem team can double-check that for me though.