### PR TITLE
Give JS/Native symbolication fns different names

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -119,7 +119,7 @@ ALL_KILLSWITCH_OPTIONS = {
             "project_id": "A project ID to filter events by.",
             "event_id": "An event ID as given in the event payload.",
             "platform": "The event platform as defined in the event payload's platform field.",
-            "symbolication_function": "process_minidump, process_applecrashreport, or process_payload",
+            "symbolication_function": "process_minidump, process_applecrashreport, process_native_stacktraces, or process_js_stacktraces",
         },
     ),
     "store.load-shed-save-event-projects": KillswitchInfo(

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -132,7 +132,7 @@ def map_symbolicator_process_js_errors(errors):
     return mapped_errors
 
 
-def process_payload(symbolicator: Symbolicator, data: Any) -> Any:
+def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     project = symbolicator.project
     allow_scraping_org_level = project.organization.get_option("sentry:scrape_javascript", True)
     allow_scraping_project_level = project.get_option("sentry:scrape_javascript", True)
@@ -208,7 +208,7 @@ def process_payload(symbolicator: Symbolicator, data: Any) -> Any:
     return data
 
 
-def get_symbolication_function(data: Any) -> Optional[Callable[[Symbolicator, Any], Any]]:
+def get_js_symbolication_function(data: Any) -> Optional[Callable[[Symbolicator, Any], Any]]:
     if should_use_symbolicator_for_sourcemaps(data.get("project")):
-        return process_payload
+        return process_js_stacktraces
     return None

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -366,7 +366,7 @@ def get_frames_for_symbolication(
     return rv
 
 
-def process_payload(symbolicator: Symbolicator, data: Any) -> Any:
+def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     stacktrace_infos = [
         stacktrace
         for stacktrace in find_stacktraces_in_data(data)
@@ -444,13 +444,13 @@ def process_payload(symbolicator: Symbolicator, data: Any) -> Any:
     return data
 
 
-def get_symbolication_function(data) -> Callable[[Symbolicator, Any], Any]:
+def get_native_symbolication_function(data) -> Callable[[Symbolicator, Any], Any]:
     if is_minidump_event(data):
         return process_minidump
     elif is_applecrashreport_event(data):
         return process_applecrashreport
     elif is_native_event(data):
-        return process_payload
+        return process_native_stacktraces
 
 
 def get_required_attachment_types(data) -> Set[str]:

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -139,11 +139,15 @@ def _do_preprocess_event(
 
     is_js = False
     if data["platform"] in ("javascript", "node"):
-        from sentry.lang.javascript.processing import get_symbolication_function
+        from sentry.lang.javascript.processing import (
+            get_js_symbolication_function as get_symbolication_function,
+        )
 
         is_js = True
     else:
-        from sentry.lang.native.processing import get_symbolication_function
+        from sentry.lang.native.processing import (
+            get_native_symbolication_function as get_symbolication_function,
+        )
 
     symbolication_function = get_symbolication_function(data)
     if symbolication_function:

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -145,9 +145,13 @@ def _do_symbolicate_event(
         )
 
     if data["platform"] in ("javascript", "node"):
-        from sentry.lang.javascript.processing import get_symbolication_function
+        from sentry.lang.javascript.processing import (
+            get_js_symbolication_function as get_symbolication_function,
+        )
     else:
-        from sentry.lang.native.processing import get_symbolication_function
+        from sentry.lang.native.processing import (
+            get_native_symbolication_function as get_symbolication_function,
+        )
 
     symbolication_function = get_symbolication_function(data)
     symbolication_function_name = getattr(symbolication_function, "__name__", "none")

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -11,7 +11,7 @@ import pytest
 from sentry.lang.native.processing import (
     _merge_image,
     get_frames_for_symbolication,
-    process_payload,
+    process_native_stacktraces,
 )
 from sentry.models.eventerror import EventError
 from sentry.utils.safe import get_path
@@ -152,7 +152,7 @@ def test_cocoa_function_name(mock_symbolicator, default_project):
         "modules": [],
     }
 
-    process_payload(mock_symbolicator, data)
+    process_native_stacktraces(mock_symbolicator, data)
 
     function_name = get_path(data, "exception", "values", 0, "stacktrace", "frames", 0, "function")
     assert function_name == "thunk for closure"
@@ -352,7 +352,7 @@ def test_il2cpp_symbolication(mock_symbolicator, default_project):
         ],
     }
 
-    process_payload(mock_symbolicator, data)
+    process_native_stacktraces(mock_symbolicator, data)
 
     frame = get_path(data, "exception", "values", 0, "stacktrace", "frames", 3)
 

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -68,7 +68,7 @@ def mock_symbolicate_event_low_priority():
 
 @pytest.fixture
 def mock_get_symbolication_function():
-    with mock.patch("sentry.lang.native.processing.get_symbolication_function") as m:
+    with mock.patch("sentry.lang.native.processing.get_native_symbolication_function") as m:
         yield m
 
 

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -68,7 +68,7 @@ def mock_symbolicate_event_low_priority():
 
 @pytest.fixture
 def mock_get_symbolication_function():
-    with mock.patch("sentry.lang.native.processing.get_symbolication_function") as m:
+    with mock.patch("sentry.lang.native.processing.get_native_symbolication_function") as m:
         yield m
 
 


### PR DESCRIPTION
The function names are being used as metrics tags, which we want to separate for Native and JS processing