### PR TITLE
feat(txnames): Always run transaction clusterer

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1168,8 +1168,6 @@ SENTRY_FEATURES = {
     # NOTE: This flag does not concern transactions rewritten by clusterer rules.
     # Those are always marked as "sanitized".
     "organizations:transaction-name-mark-scrubbed-as-sanitized": False,
-    # Try to derive normalization rules by clustering transaction names.
-    "organizations:transaction-name-clusterer": False,
     # Sanitize transaction names in the ingestion pipeline.
     "organizations:transaction-name-sanitization": False,  # DEPRECATED
     # Extraction metrics for transactions during ingestion.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -184,7 +184,6 @@ default_manager.add("organizations:symbol-sources", OrganizationFeature, Feature
 default_manager.add("organizations:team-roles", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:transaction-name-clusterer", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -5,7 +5,6 @@ from typing import Any, Iterator, Mapping
 import sentry_sdk
 from django.conf import settings
 
-from sentry import features
 from sentry.ingest.transaction_clusterer.datasource import (
     HTTP_404_TAG,
     TRANSACTION_SOURCE_SANITIZED,
@@ -85,11 +84,7 @@ def clear_transaction_names(project: Project) -> None:
 def record_transaction_name(project: Project, event_data: Mapping[str, Any], **kwargs: Any) -> None:
     transaction_name = event_data.get("transaction")
 
-    if (
-        transaction_name
-        and features.has("organizations:transaction-name-clusterer", project.organization)
-        and _should_store_transaction_name(event_data)
-    ):
+    if transaction_name and _should_store_transaction_name(event_data):
         safe_execute(_store_transaction_name, project, transaction_name, _with_transaction=False)
         safe_execute(_bump_rule_lifetime, project, event_data, _with_transaction=False)
 

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -106,31 +106,26 @@ def test_distribution():
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis._store_transaction_name")
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "source, txname, tags, feature_enabled, expected",
+    "source, txname, tags, expected",
     [
-        ("url", "/a/b/c", [["transaction", "/a/b/c"]], True, 1),
-        ("url", "/a/b/c", [["http.status_code", "200"]], True, 1),
-        ("route", "/", [["transaction", "/"]], True, 0),
-        ("url", None, [], True, 0),
-        ("url", "/a/b/c", [["http.status_code", "404"]], True, 0),
-        ("url", "/", [["transaction", "/"]], False, 0),
-        ("route", None, [], False, 0),
+        ("url", "/a/b/c", [["transaction", "/a/b/c"]], 1),
+        ("url", "/a/b/c", [["http.status_code", "200"]], 1),
+        ("route", "/", [["transaction", "/"]], 0),
+        ("url", None, [], 0),
+        ("url", "/a/b/c", [["http.status_code", "404"]], 0),
     ],
 )
-def test_record_transactions(
-    mocked_record, default_organization, source, txname, tags, feature_enabled, expected
-):
-    with Feature({"organizations:transaction-name-clusterer": feature_enabled}):
-        project = Project(id=111, name="project", organization_id=default_organization.id)
-        record_transaction_name(
-            project,
-            {
-                "tags": tags,
-                "transaction": txname,
-                "transaction_info": {"source": source},
-            },
-        )
-        assert len(mocked_record.mock_calls) == expected
+def test_record_transactions(mocked_record, default_organization, source, txname, tags, expected):
+    project = Project(id=111, name="project", organization_id=default_organization.id)
+    record_transaction_name(
+        project,
+        {
+            "tags": tags,
+            "transaction": txname,
+            "transaction_info": {"source": source},
+        },
+    )
+    assert len(mocked_record.mock_calls) == expected
 
 
 def test_sort_rules():
@@ -202,50 +197,49 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
             _store_transaction_name(proj, f"/user/tx-{proj.name}-{i}")
             _store_transaction_name(proj, f"/org/tx-{proj.name}-{i}")
 
-    with Feature({"organizations:transaction-name-clusterer": True}):
-        project1 = Project(id=123, name="project1", organization_id=default_organization.id)
-        project2 = Project(id=223, name="project2", organization_id=default_organization.id)
-        for project in (project1, project2):
-            project.save()
-            _add_mock_data(project, 10)
+    project1 = Project(id=123, name="project1", organization_id=default_organization.id)
+    project2 = Project(id=223, name="project2", organization_id=default_organization.id)
+    for project in (project1, project2):
+        project.save()
+        _add_mock_data(project, 10)
 
+    spawn_clusterers()
+
+    assert cluster_projects_delay.call_count == 1
+    cluster_projects_delay.reset_mock()
+
+    # Not stored enough transactions yet
+    assert _get_rules(project1) == {}
+    assert _get_rules(project2) == {}
+
+    # Clear transactions if batch minimum is not met
+    assert list(get_transaction_names(project1)) == []
+    assert list(get_transaction_names(project2)) == []
+
+    _add_mock_data(project1, 10)
+    _add_mock_data(project2, 10)
+
+    # add more transactions to the project 1
+    for i in range(5):
+        _store_transaction_name(project1, f"/users/trans/tx-{project1.id}-{i}")
+        _store_transaction_name(project1, f"/test/path/{i}")
+
+    # Add a transaction to project2 so it runs again
+    _store_transaction_name(project2, "foo")
+
+    with mock.patch("sentry.ingest.transaction_clusterer.tasks.PROJECTS_PER_TASK", 1):
         spawn_clusterers()
 
-        assert cluster_projects_delay.call_count == 1
-        cluster_projects_delay.reset_mock()
+    # One project per batch now:
+    assert cluster_projects_delay.call_count == 2, cluster_projects_delay.call_args
 
-        # Not stored enough transactions yet
-        assert _get_rules(project1) == {}
-        assert _get_rules(project2) == {}
-
-        # Clear transactions if batch minimum is not met
-        assert list(get_transaction_names(project1)) == []
-        assert list(get_transaction_names(project2)) == []
-
-        _add_mock_data(project1, 10)
-        _add_mock_data(project2, 10)
-
-        # add more transactions to the project 1
-        for i in range(5):
-            _store_transaction_name(project1, f"/users/trans/tx-{project1.id}-{i}")
-            _store_transaction_name(project1, f"/test/path/{i}")
-
-        # Add a transaction to project2 so it runs again
-        _store_transaction_name(project2, "foo")
-
-        with mock.patch("sentry.ingest.transaction_clusterer.tasks.PROJECTS_PER_TASK", 1):
-            spawn_clusterers()
-
-        # One project per batch now:
-        assert cluster_projects_delay.call_count == 2, cluster_projects_delay.call_args
-
-        pr_rules = _get_rules(project1)
-        assert pr_rules.keys() == {
-            "/org/*/**",
-            "/user/*/**",
-            "/test/path/*/**",
-            "/users/trans/*/**",
-        }
+    pr_rules = _get_rules(project1)
+    assert pr_rules.keys() == {
+        "/org/*/**",
+        "/user/*/**",
+        "/test/path/*/**",
+        "/users/trans/*/**",
+    }
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
@@ -257,8 +251,7 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
     assert _get_rules(project) == {}
 
     _store_transaction_name(project, "/transaction/number/1")
-    with Feature({"organizations:transaction-name-clusterer": True}):
-        cluster_projects([project])
+    cluster_projects([project])
     # Clusterer didn't create rules. Still, it updates the stores.
     assert mock_update_rules.call_count == 1
     assert mock_update_rules.call_args == mock.call(project, [])
@@ -266,8 +259,7 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
 
     _store_transaction_name(project, "/transaction/number/1")
     _store_transaction_name(project, "/transaction/number/2")
-    with Feature({"organizations:transaction-name-clusterer": True}):
-        cluster_projects([project])
+    cluster_projects([project])
     assert mock_update_rules.call_count == 2
     assert mock_update_rules.call_args == mock.call(project, ["/transaction/number/*/**"])
 
@@ -332,9 +324,7 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
         def write(self, project: Project, rules) -> None:
             tmp_redis_storage[project] = rules
 
-    with mock.patch(
-        "sentry.ingest.transaction_clusterer.rules.RedisRuleStore", MockRedisRuleStore
-    ), Feature({"organizations:transaction-name-clusterer": True}):
+    with mock.patch("sentry.ingest.transaction_clusterer.rules.RedisRuleStore", MockRedisRuleStore):
         project1 = Project(id=123, name="project1", organization_id=default_organization.id)
         project1.save()
         for i in range(10):
@@ -404,9 +394,7 @@ def test_dont_store_inexisting_rules(_, default_organization):
         },
     }
 
-    with mock.patch(
-        "sentry.ingest.transaction_clusterer.rules.RedisRuleStore", MockRedisRuleStore
-    ), Feature({"organizations:transaction-name-clusterer": True}):
+    with mock.patch("sentry.ingest.transaction_clusterer.rules.RedisRuleStore", MockRedisRuleStore):
         project1 = Project(id=234, name="project1", organization_id=default_organization.id)
         project1.save()
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1611,7 +1611,6 @@ class PostProcessGroupPerformanceTest(
 
 
 class TransactionClustererTestCase(TestCase, SnubaTestCase):
-    @with_feature("organizations:transaction-name-clusterer")
     @patch("sentry.ingest.transaction_clusterer.datasource.redis._store_transaction_name")
     def test_process_transaction_event_clusterer(
         self,


### PR DESCRIPTION
Transaction clustering is now enabled for all orgs in SaaS.

To introduce it to self-hosted and single-tenant, remove clustering feature flag.

See https://github.com/getsentry/team-ingest/issues/99 and https://github.com/getsentry/team-ingest/issues/100