### PR TITLE
fix(replays): warn instead of exception on replays storage get 404

### DIFF
--- a/src/sentry/replays/lib/storage.py
+++ b/src/sentry/replays/lib/storage.py
@@ -126,7 +126,7 @@ class StorageBlob(Blob):
             result = blob.read()
             blob.close()
         except Exception:
-            logger.exception("Storage GET error.")
+            logger.warning("Storage GET error.")
             return None
         else:
             return result


### PR DESCRIPTION
- this happens a lot and isn't critical. replays team should double check there isn't a bug / error here in the future but for now we can simply log instead of reporting an exception.