### PR TITLE
fix(releases): Ignore release health for invalid versions

### DIFF
--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -75,6 +75,10 @@ def adopt_releases(org_id: int, totals: Totals) -> Sequence[int]:
             for environment, environment_totals in project_totals.items():
                 total_releases = len(environment_totals["releases"])
                 for release_version in environment_totals["releases"]:
+                    # Ignore versions that were saved with an empty string
+                    if not Release.is_valid_version(release_version):
+                        continue
+
                     threshold = 0.1 / total_releases
                     if (
                         environment

--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -533,6 +533,25 @@ class BaseTestReleaseMonitor:
         no_env_project.refresh_from_db()
         assert not no_env_project.flags.has_releases
 
+    def test_invalid_version(self):
+        invalid_release_version = self.create_release(project=self.project, version="")
+
+        # If environment is None, we shouldn't make any changes
+        self.bulk_store_sessions(
+            [
+                self.build_session(
+                    project_id=self.project,
+                    release=invalid_release_version,
+                    environment="somenvname",
+                )
+            ]
+        )
+        process_projects_with_sessions(
+            invalid_release_version.organization_id, [invalid_release_version.id]
+        )
+        invalid_release_version.refresh_from_db()
+        assert not invalid_release_version.flags.has_releases
+
 
 class TestSessionReleaseMonitor(BaseTestReleaseMonitor, TestCase, SnubaTestCase):
     backend_class = SessionReleaseMonitorBackend

--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -533,25 +533,6 @@ class BaseTestReleaseMonitor:
         no_env_project.refresh_from_db()
         assert not no_env_project.flags.has_releases
 
-    def test_invalid_version(self):
-        invalid_release_version = self.create_release(project=self.project, version="")
-
-        # If environment is None, we shouldn't make any changes
-        self.bulk_store_sessions(
-            [
-                self.build_session(
-                    project_id=self.project,
-                    release=invalid_release_version,
-                    environment="somenvname",
-                )
-            ]
-        )
-        process_projects_with_sessions(
-            invalid_release_version.organization_id, [invalid_release_version.id]
-        )
-        invalid_release_version.refresh_from_db()
-        assert not invalid_release_version.flags.has_releases
-
 
 class TestSessionReleaseMonitor(BaseTestReleaseMonitor, TestCase, SnubaTestCase):
     backend_class = SessionReleaseMonitorBackend


### PR DESCRIPTION
Skip over releases that cannot be created because they were created with invalid versions

fixes [SENTRY-XXM](https://sentry.sentry.io/issues/3899251044/?project=11276&referrer=issue-list&statsPeriod=14d)