### PR TITLE
fix(migration): use RangeQuerySetWrapper instead of RangeQuerySetWrapperWithProgressB…

### DIFF
--- a/src/sentry/migrations/0417_backfill_groupedmessage_substatus.py
+++ b/src/sentry/migrations/0417_backfill_groupedmessage_substatus.py
@@ -5,7 +5,7 @@ from psycopg2.extras import execute_values
 
 from sentry.models import GroupStatus, GroupSubStatus
 from sentry.new_migrations.migrations import CheckedMigration
-from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+from sentry.utils.query import RangeQuerySetWrapper
 
 BATCH_SIZE = 100
 
@@ -20,7 +20,7 @@ UPDATE_QUERY = """
 def backfill_substatus(apps, schema_editor):
     Group = apps.get_model("sentry", "Group")
 
-    queryset = RangeQuerySetWrapperWithProgressBar(
+    queryset = RangeQuerySetWrapper(
         Group.objects.filter(status__in=(GroupStatus.UNRESOLVED, GroupStatus.IGNORED)).values_list(
             "id", "status", "substatus"
         ),

--- a/src/sentry/migrations/0420_backfill_groupedmessage_ignored_substatus.py
+++ b/src/sentry/migrations/0420_backfill_groupedmessage_ignored_substatus.py
@@ -5,7 +5,7 @@ from psycopg2.extras import execute_values
 
 from sentry.models import GroupStatus
 from sentry.new_migrations.migrations import CheckedMigration
-from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+from sentry.utils.query import RangeQuerySetWrapper
 
 BATCH_SIZE = 100
 
@@ -20,7 +20,7 @@ UPDATE_QUERY = """
 def backfill_substatus(apps, schema_editor):
     Group = apps.get_model("sentry", "Group")
 
-    queryset = RangeQuerySetWrapperWithProgressBar(
+    queryset = RangeQuerySetWrapper(
         Group.objects.filter(status=GroupStatus.IGNORED).values_list("id", "status", "substatus"),
         result_value_getter=lambda item: item[0],
     )


### PR DESCRIPTION
…ar to avoid initial count() for progress

Was running into timeouts since `RangeQuerySetWrapperWithProgressBar` was trying to do a `count()` agg on a lot of data to estimate ETA on this migration. Just use `RangeQuerySetWrapper` instead.