### PR TITLE
chore(ci): remove github admin blurb for modified migrations

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Failure because of modified migration
         run: |
           echo "If you have a valid reason to modify a migration please get approval"
-          echo "from @getsentry/owners-migrations, then ask a Github admin to merge." && exit 1
+          echo "from @getsentry/owners-migrations." && exit 1
 
   sql:
     name: Generate SQL


### PR DESCRIPTION
Remove migrations modified error message requesting a dev to ask a github admin to merge the PR. This doesn't seem relevant anymore.