### PR TITLE
feat(starfish): Add rudimentary span duration chart to API module view

### DIFF
--- a/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
+++ b/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
@@ -1,9 +1,12 @@
+import {Fragment} from 'react';
 import {useQuery} from '@tanstack/react-query';
 import {Location} from 'history';
 
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import {Series} from 'sentry/types/echarts';
+import Chart from 'sentry/views/starfish/components/chart';
 
-import {ENDPOINT_LIST_QUERY} from './queries';
+import {ENDPOINT_GRAPH_QUERY, ENDPOINT_LIST_QUERY} from './queries';
 
 const HOST = 'http://localhost:8080';
 
@@ -36,18 +39,68 @@ export default function APIModuleView({location}: Props) {
     initialData: [],
   });
 
+  const {isLoading: isGraphLoading, data: graphData} = useQuery({
+    queryKey: ['graph'],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${ENDPOINT_GRAPH_QUERY}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+
+  const quantiles = ['p50', 'p75', 'p95', 'p99'];
+
+  const seriesByQuantile: {[quantile: string]: Series} = {};
+  quantiles.forEach(quantile => {
+    seriesByQuantile[quantile] = {
+      seriesName: quantile,
+      data: [],
+    };
+  });
+
+  graphData.forEach(datum => {
+    quantiles.forEach(quantile => {
+      seriesByQuantile[quantile].data.push({
+        value: datum[quantile],
+        name: datum.interval,
+      });
+    });
+  });
+
+  const data = Object.values(seriesByQuantile);
+
   return (
-    <GridEditable
-      isLoading={areEndpointsLoading}
-      data={endpointsData}
-      columnOrder={COLUMN_ORDER}
-      columnSortBy={[]}
-      grid={{
-        renderHeadCell,
-        renderBodyCell,
-      }}
-      location={location}
-    />
+    <Fragment>
+      <Chart
+        statsPeriod="24h"
+        height={180}
+        data={data}
+        start=""
+        end=""
+        loading={isGraphLoading}
+        utc={false}
+        grid={{
+          left: '0',
+          right: '0',
+          top: '16px',
+          bottom: '8px',
+        }}
+        disableMultiAxis
+        definedAxisTicks={4}
+        stacked
+      />
+
+      <GridEditable
+        isLoading={areEndpointsLoading}
+        data={endpointsData}
+        columnOrder={COLUMN_ORDER}
+        columnSortBy={[]}
+        grid={{
+          renderHeadCell,
+          renderBodyCell,
+        }}
+        location={location}
+      />
+    </Fragment>
   );
 }
 

--- a/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
+++ b/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
@@ -3,15 +3,9 @@ import {Location} from 'history';
 
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 
-const HOST = 'http://localhost:8080';
+import {ENDPOINT_LIST_QUERY} from './queries';
 
-const ENDPOINT_QUERY = `SELECT description, count() AS count
- FROM spans_experimental_starfish
- WHERE module = 'http'
- GROuP BY description
- ORDER BY count DESC
- LIMIT 10
-`;
+const HOST = 'http://localhost:8080';
 
 type Props = {
   location: Location;
@@ -37,7 +31,7 @@ const COLUMN_ORDER = [
 export default function APIModuleView({location}: Props) {
   const {isLoading: areEndpointsLoading, data: endpointsData} = useQuery({
     queryKey: ['endpoints'],
-    queryFn: () => fetch(`${HOST}/?query=${ENDPOINT_QUERY}`).then(res => res.json()),
+    queryFn: () => fetch(`${HOST}/?query=${ENDPOINT_LIST_QUERY}`).then(res => res.json()),
     retry: false,
     initialData: [],
   });

--- a/static/app/views/starfish/modules/APIModule/index.tsx
+++ b/static/app/views/starfish/modules/APIModule/index.tsx
@@ -13,7 +13,7 @@ type Props = {
   location: Location;
 };
 
-export default function APIModule({location}: Props) {
+export default function APIModule(props: Props) {
   return (
     <Layout.Page>
       <PageErrorProvider>
@@ -26,7 +26,7 @@ export default function APIModule({location}: Props) {
         <Layout.Body>
           <Layout.Main fullWidth>
             <PageErrorAlert />
-            <APIModuleView location={location} />
+            <APIModuleView {...props} />
           </Layout.Main>
         </Layout.Body>
       </PageErrorProvider>

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -1,0 +1,7 @@
+export const ENDPOINT_LIST_QUERY = `SELECT description, count() AS count
+ FROM spans_experimental_starfish
+ WHERE module = 'http'
+ GROuP BY description
+ ORDER BY count DESC
+ LIMIT 10
+`;

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -5,3 +5,15 @@ export const ENDPOINT_LIST_QUERY = `SELECT description, count() AS count
  ORDER BY count DESC
  LIMIT 10
 `;
+
+export const ENDPOINT_GRAPH_QUERY = `SELECT
+ toStartOfInterval(start_timestamp, INTERVAL 5 MINUTE) as interval,
+ quantile(0.5)(exclusive_time) as p50,
+ quantile(0.75)(exclusive_time) as p75,
+ quantile(0.95)(exclusive_time) as p95,
+ quantile(0.99)(exclusive_time) as p99
+ FROM spans_experimental_starfish
+ WHERE module = 'http'
+ GROUP BY interval
+ ORDER BY interval asc
+ `;


### PR DESCRIPTION
_Very_ rudimentary, just getting some data on the page.
<img width="1180" alt="Screenshot 2023-04-17 at 3 06 43 PM" src="https://user-images.githubusercontent.com/989898/232587364-ed61fdb6-8a14-4712-93b5-3cbd56935799.png">
