### PR TITLE
ref(sql-format): Rename feature flag to accommodate things other than breadcrumbs

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -385,7 +385,7 @@ class DetailedEventSerializer(EventSerializer):
             )
 
             if not breadcrumbs or not features.has(
-                "organizations:issue-breadcrumbs-sql-format", event.project.organization, actor=user
+                "organizations:sql-format", event.project.organization, actor=user
             ):
                 return event_data
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1229,8 +1229,8 @@ SENTRY_FEATURES = {
     "organizations:invite-members-rate-limits": True,
     # Enable new issue alert "issue owners" fallback
     "organizations:issue-alert-fallback-targeting": False,
-    # Enable SQL formatting for breadcrumb items
-    "organizations:issue-breadcrumbs-sql-format": False,
+    # Enable SQL formatting for breadcrumb items and performance spans
+    "organizations:sql-format": False,
     # Enable removing issue from issue list if action taken.
     "organizations:issue-list-removal-action": False,
     # Adds the ttid & ttfd vitals to the frontend

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -88,7 +88,7 @@ default_manager.add("organizations:issue-alert-fallback-targeting", Organization
 default_manager.add("organizations:issue-alert-incompatible-rules", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-alert-preview", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-alert-test-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:issue-breadcrumbs-sql-format", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:sql-format", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-removal-action", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -464,7 +464,7 @@ class DetailedEventSerializerTest(TestCase):
         assert result["perfProblem"] is None
 
     def test_event_breadcrumb_formatting(self):
-        with self.feature("organizations:issue-breadcrumbs-sql-format"):
+        with self.feature("organizations:sql-format"):
             event = self.store_event(
                 data={
                     "breadcrumbs": [
@@ -493,7 +493,7 @@ class DetailedEventSerializerTest(TestCase):
             assert breadcrumbs[1]["messageFormat"] == "sql"
 
     def test_event_breadcrumb_formatting_remove_quotes(self):
-        with self.feature("organizations:issue-breadcrumbs-sql-format"):
+        with self.feature("organizations:sql-format"):
             event = self.store_event(
                 data={
                     "breadcrumbs": [


### PR DESCRIPTION
Since we want to expand this to performance spans as well the old name doesn't make sense anymore.