### PR TITLE
feat(migrations) Restore Run migrations on all primaries

### DIFF
--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -43,10 +43,9 @@ def _upgrade(interactive, traceback, verbosity, repair, with_nodestore):
     _check_history()
 
     for db_conn in settings.DATABASES.keys():
-        # Always run migrations for the default connection.
-        # Also run migrations on connections that have migrations explicitly enabled.
+        # Run migrations on all non-read replica connections.
         # This is used for sentry.io as our production database runs on multiple hosts.
-        if db_conn == "default" or settings.DATABASES[db_conn].get("RUN_MIGRATIONS", False):
+        if not settings.DATABASES[db_conn].get("REPLICA_OF", False):
             click.echo(f"Running migrations for {db_conn}")
             dj_call_command(
                 "migrate",


### PR DESCRIPTION
Third time is a charm. Previous attempts were thwarted by the `default_analytics` connection that has been removed but still lives on somewhere.

Revert "Revert "feat(migrations) Restore Run migrations on all primaries (#47402)""

This reverts commit 7d51f114887dc3d00f20019d696afab5a86b5f67.

Requires https://github.com/getsentry/getsentry/pull/10249
