### PR TITLE
feat(sql-format): Apply SQL formatting to breadcrumbs on discover pages

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -5,6 +5,7 @@ from sentry import eventstore
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.event import SqlFormatEventSerializer
 from sentry.models.project import Project, ProjectStatus
 
 
@@ -39,7 +40,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if hasattr(event, "for_group") and event.group:
             event = event.for_group(event.group)
 
-        data = serialize(event)
+        data = serialize(event, request.user, SqlFormatEventSerializer())
         data["projectSlug"] = project_slug
 
         return Response(data)

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -8,14 +8,14 @@ from rest_framework.response import Response
 from sentry import eventstore
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.serializers import DetailedEventSerializer, serialize
+from sentry.api.serializers import IssueEventSerializer, serialize
 from sentry.eventstore.models import Event
 from sentry.issues.query import apply_performance_conditions
 from sentry.models.project import Project
 
 
 def wrap_event_response(request_user: Any, event: Event, project: Project, environments: List[str]):
-    event_data = serialize(event, request_user, DetailedEventSerializer())
+    event_data = serialize(event, request_user, IssueEventSerializer())
     # Used for paginating through events of a single issue in group details
     # Skip next/prev for issueless events
     next_event_id = None

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -1,7 +1,11 @@
 from unittest import mock
 
 from sentry.api.serializers import SimpleEventSerializer, serialize
-from sentry.api.serializers.models.event import DetailedEventSerializer, SharedEventSerializer
+from sentry.api.serializers.models.event import (
+    IssueEventSerializer,
+    SharedEventSerializer,
+    SqlFormatEventSerializer,
+)
 from sentry.api.serializers.rest_framework import convert_dict_key_case, snake_to_camel_case
 from sentry.event_manager import EventManager
 from sentry.models import EventError
@@ -316,7 +320,7 @@ class SimpleEventSerializerTest(TestCase):
 
 
 @region_silo_test
-class DetailedEventSerializerTest(TestCase):
+class IssueEventSerializerTest(TestCase):
     @mock.patch(
         "sentry.sdk_updates.SdkIndexState",
         return_value=SdkIndexState(sdk_versions={"example.sdk": "2.0.0"}),
@@ -335,7 +339,7 @@ class DetailedEventSerializerTest(TestCase):
             assert_no_errors=False,
         )
 
-        result = serialize(event, None, DetailedEventSerializer())
+        result = serialize(event, None, IssueEventSerializer())
         assert result["sdkUpdates"] == [
             {
                 "enables": [],
@@ -364,7 +368,7 @@ class DetailedEventSerializerTest(TestCase):
             assert_no_errors=False,
         )
 
-        result = serialize(event, None, DetailedEventSerializer())
+        result = serialize(event, None, IssueEventSerializer())
         assert result["sdkUpdates"] == [
             {
                 "enables": [],
@@ -393,7 +397,7 @@ class DetailedEventSerializerTest(TestCase):
             assert_no_errors=False,
         )
 
-        result = serialize(event, None, DetailedEventSerializer())
+        result = serialize(event, None, IssueEventSerializer())
         assert result["sdkUpdates"] == []
 
     @override_options({"performance.issues.all.problem-detection": 1.0})
@@ -406,7 +410,7 @@ class DetailedEventSerializerTest(TestCase):
             event = manager.save(self.project.id)
         group_event = event.for_group(event.groups[0])
 
-        result = json.loads(json.dumps(serialize(group_event, None, DetailedEventSerializer())))
+        result = json.loads(json.dumps(serialize(group_event, None, IssueEventSerializer())))
         assert result["perfProblem"] == {
             "causeSpanIds": ["9179e43ae844b174"],
             "desc": "SELECT `books_author`.`id`, `books_author`.`name` FROM "
@@ -460,9 +464,12 @@ class DetailedEventSerializerTest(TestCase):
             event = manager.save(self.project.id)
         group_event = event.for_group(event.groups[0])
 
-        result = json.loads(json.dumps(serialize(group_event, None, DetailedEventSerializer())))
+        result = json.loads(json.dumps(serialize(group_event, None, IssueEventSerializer())))
         assert result["perfProblem"] is None
 
+
+@region_silo_test
+class SqlFormatEventSerializerTest(TestCase):
     def test_event_breadcrumb_formatting(self):
         with self.feature("organizations:sql-format"):
             event = self.store_event(
@@ -477,7 +484,7 @@ class DetailedEventSerializerTest(TestCase):
                 },
                 project_id=self.project.id,
             )
-            result = serialize(event, None, DetailedEventSerializer())
+            result = serialize(event, None, SqlFormatEventSerializer())
 
             breadcrumb_entry = result["entries"][0]
             breadcrumbs = breadcrumb_entry["data"]["values"]
@@ -505,7 +512,7 @@ class DetailedEventSerializerTest(TestCase):
                 },
                 project_id=self.project.id,
             )
-            result = serialize(event, None, DetailedEventSerializer())
+            result = serialize(event, None, IssueEventSerializer())
 
             # Should remove quotes from all terms except the one that contains a space ("column name")
             assert (

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -512,7 +512,7 @@ class SqlFormatEventSerializerTest(TestCase):
                 },
                 project_id=self.project.id,
             )
-            result = serialize(event, None, IssueEventSerializer())
+            result = serialize(event, None, SqlFormatEventSerializer())
 
             # Should remove quotes from all terms except the one that contains a space ("column name")
             assert (


### PR DESCRIPTION
Currently the SQL formatting is only applied for events viewed on the issues page. Since discover uses a different endpoint, the formatting isn't applied. This changes ensures that it's applied for all places users will see breadcrumbs.

This required some shuffling around of the event serializers:

- Extract SQL formatting logic to `SqlFormatEventSerializer`
- Rename `DetailedEventSerializer` -> `IssueEventSerializer` to be more descriptive, since this is only used in the issue event endpoints
- Make the `/events/<project_id>:<event_id>` endpoint use `SqlFormatEventSerializer` instead of the default serializer