### PR TITLE
ref(update-groups): Move is_public to new method

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Dict, List, Mapping, MutableMapping, Sequence
+from typing import Any, Mapping, MutableMapping, Sequence
 
 import rest_framework
 from django.db import IntegrityError, transaction
@@ -719,8 +719,8 @@ def update_groups(
 
 def handle_is_public(
     is_public: Any,
-    group_list: List[Group],
-    project_lookup: Dict[int, Project],
+    group_list: list[Group],
+    project_lookup: dict[int, Project],
     acting_user: User | None,
 ) -> str | None:
     """
@@ -728,7 +728,7 @@ def handle_is_public(
 
     This deletes the existing share ID and creates a new share ID if isPublic is True.
     We always want to delete an existing share, because triggering an isPublic=True
-    even when it's already public, should trigger regenerating.
+    when it's already public should trigger regenerating.
     """
     user_id = acting_user.id if acting_user else None
     share_id = None

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -723,9 +723,13 @@ def handle_is_public(
     project_lookup: Dict[int, Project],
     acting_user: User | None,
 ) -> str | None:
-    # We always want to delete an existing share, because triggering
-    # an isPublic=True even when it's already public, should trigger
-    # regenerating.
+    """
+    Handle the isPublic flag on a group update.
+
+    This deletes the existing share ID and creates a new share ID if isPublic is True.
+    We always want to delete an existing share, because triggering an isPublic=True
+    even when it's already public, should trigger regenerating.
+    """
     user_id = acting_user.id if acting_user else None
     share_id = None
     for group in group_list:

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -681,7 +681,7 @@ def update_groups(
 
     if "isPublic" in result:
         result["shareId"] = handle_is_public(
-            result.get("isPublic"), group_list, project_lookup, acting_user
+            result["isPublic"], group_list, project_lookup, acting_user
         )
 
     # XXX(dcramer): this feels a bit shady like it should be its own endpoint.
@@ -718,7 +718,7 @@ def update_groups(
 
 
 def handle_is_public(
-    is_public: Any,
+    is_public: bool,
     group_list: list[Group],
     project_lookup: dict[int, Project],
     acting_user: User | None,

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -8,16 +8,20 @@ from sentry.api.helpers.group_index import (
     update_groups,
     validate_search_filter_permissions,
 )
+from sentry.api.helpers.group_index.update import handle_is_public
 from sentry.api.issue_search import parse_search_query
 from sentry.models import (
+    Activity,
     GroupInbox,
     GroupInboxReason,
+    GroupShare,
     GroupStatus,
     GroupSubStatus,
     add_group_to_inbox,
 )
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.activity import ActivityType
 
 
 class ValidateSearchFilterPermissionsTest(TestCase):
@@ -200,3 +204,47 @@ class UpdateGroupsTest(TestCase):
         assert group.substatus == GroupSubStatus.UNTIL_ESCALATING
         assert send_robust.called
         assert not GroupInbox.objects.filter(group=group).exists()
+
+
+class TestHandleIsPublic(TestCase):
+    def setUp(self):
+        self.group = self.create_group()
+        self.group_list = [self.group]
+        self.project_lookup = {self.group.project_id: self.group.project}
+
+    def test_is_public(self):
+        share_id = handle_is_public(True, self.group_list, self.project_lookup, self.user)
+
+        new_share = GroupShare.objects.get(group=self.group)
+        assert Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PUBLIC.value
+        ).exists()
+        assert share_id == new_share.uuid
+
+    def test_is_public_existing_shares(self):
+        share = GroupShare.objects.create(group=self.group, project=self.group.project)
+
+        share_id = handle_is_public(True, self.group_list, self.project_lookup, self.user)
+
+        new_share = GroupShare.objects.get(group=self.group)
+        assert Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PRIVATE.value
+        ).exists()
+        assert new_share != share
+        assert Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PUBLIC.value
+        ).exists()
+        assert share_id == new_share.uuid
+
+    def test_not_is_public(self):
+        GroupShare.objects.create(group=self.group, project=self.group.project)
+
+        share_id = handle_is_public(False, self.group_list, self.project_lookup, self.user)
+        assert Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PRIVATE.value
+        ).exists()
+        assert not GroupShare.objects.filter(group=self.group).exists()
+        assert not Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PUBLIC.value
+        ).exists()
+        assert share_id is None


### PR DESCRIPTION
[Part of a larger effort to [refactor](https://getsentry.atlassian.net/browse/WOR-2944) update_groups]

This PR breaks up the logic to share an issue and generate the share link.

WOR-2977