### PR TITLE
feat(starfish): Use span exclusive time in chart

### DIFF
--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -1,0 +1,9 @@
+export const MODULE_DURATION_QUERY = `SELECT
+ toStartOfInterval(start_timestamp, INTERVAL 5 MINUTE) as interval,
+ module,
+ quantile(0.75)(exclusive_time) as p75
+ FROM spans_experimental_starfish
+ WHERE module in ['http', 'db', 'cache']
+ GROUP BY interval, module
+ ORDER BY interval asc
+ `;

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -46,7 +46,8 @@ export function StarfishView(props: BasePerformanceViewProps) {
   });
 
   // Attempt at zerofilling data so that the charts stack properly and
-  // don't look like abstract art.
+  // don't look like abstract art. Only works if the primary orderby
+  // is timestamp.
   let lastInterval = undefined;
   modules.forEach(module => {
     moduleDurationData.forEach(value => {

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -45,9 +45,9 @@ export function StarfishView(props: BasePerformanceViewProps) {
     };
   });
 
-  // Attempt at zerofilling data so that the charts stack properly and
-  // don't look like abstract art. Only works if the primary orderby
-  // is timestamp.
+  // cross-reference the series, and makes sure
+  // they have the same number of points by backfilling
+  // missing timestamps for each other series with a 0
   let lastInterval = undefined;
   modules.forEach(module => {
     moduleDurationData.forEach(value => {

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -5,17 +6,14 @@ import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {PerformanceLayoutBodyRow} from 'sentry/components/performance/layouts';
 import {space} from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
 import EventView from 'sentry/utils/discover/eventView';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
-import withApi from 'sentry/utils/withApi';
+import {useQuery} from 'sentry/utils/queryClient';
 import Chart from 'sentry/views/starfish/components/chart';
+import {MODULE_DURATION_QUERY} from 'sentry/views/starfish/views/webServiceView/queries';
 
 import EndpointList from './endpointList';
-
-const EventsRequest = withApi(_EventsRequest);
-import {Fragment} from 'react';
-
-import {Series} from 'sentry/types/echarts';
 
 type BasePerformanceViewProps = {
   eventView: EventView;
@@ -24,71 +22,78 @@ type BasePerformanceViewProps = {
   projects: Project[];
 };
 
+const HOST = 'http://localhost:8080';
+
 export function StarfishView(props: BasePerformanceViewProps) {
-  const {organization, eventView} = props;
+  // const {organization, eventView} = props;
+
+  const {isLoading: isDurationDataLoading, data: moduleDurationData} = useQuery({
+    queryKey: ['graph'],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${MODULE_DURATION_QUERY}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+
+  const modules = ['db', 'cache', 'http'];
+
+  const seriesByModule: {[module: string]: Series} = {};
+  modules.forEach(module => {
+    seriesByModule[module] = {
+      seriesName: `p75(${module})`,
+      data: [],
+    };
+  });
+
+  let lastInterval = undefined;
+  modules.forEach(module => {
+    moduleDurationData.forEach(value => {
+      if (module === value.module) {
+        if (lastInterval === value.interval) {
+          seriesByModule[module].data.pop();
+        }
+        seriesByModule[module].data.push({
+          value: value.p75,
+          name: value.interval,
+        });
+      } else {
+        if (lastInterval !== value.interval) {
+          seriesByModule[module].data.push({
+            value: 0,
+            name: value.interval,
+          });
+        }
+      }
+      lastInterval = value.interval;
+    });
+  });
+
+  const data = Object.values(seriesByModule);
 
   return (
     <div data-test-id="starfish-view">
       <StyledRow minSize={200}>
-        <EventsRequest
-          query={eventView.query}
-          includePrevious={false}
-          partial
-          interval="1h"
-          includeTransformedData
-          limit={1}
-          environment={eventView.environment}
-          project={eventView.project}
-          period={eventView.statsPeriod}
-          referrer="starfish-homepage-span-breakdown"
-          start={eventView.start}
-          end={eventView.end}
-          organization={organization}
-          yAxis={[
-            'p95(spans.db)',
-            'p95(spans.http)',
-            'p95(spans.browser)',
-            'p95(spans.resource)',
-            'p95(spans.ui)',
-          ]}
-          queryExtras={{
-            dataset: 'metrics',
-          }}
-        >
-          {data => {
-            return (
-              <Fragment>
-                <Chart
-                  statsPeriod={eventView.statsPeriod}
-                  height={180}
-                  data={data.results as Series[]}
-                  start={eventView.start as string}
-                  end={eventView.end as string}
-                  loading={data.loading}
-                  utc={false}
-                  grid={{
-                    left: '0',
-                    right: '0',
-                    top: '16px',
-                    bottom: '8px',
-                  }}
-                  disableMultiAxis
-                  definedAxisTicks={4}
-                  stacked
-                  log
-                  chartColors={[
-                    '#444674',
-                    '#7a5088',
-                    '#b85586',
-                    '#e9626e',
-                    '#f58c46',
-                    '#f2b712',
-                  ]}
-                />
-              </Fragment>
-            );
-          }}
-        </EventsRequest>
+        <Fragment>
+          <Chart
+            statsPeriod="24h"
+            height={180}
+            data={data}
+            start=""
+            end=""
+            loading={isDurationDataLoading}
+            utc={false}
+            grid={{
+              left: '0',
+              right: '0',
+              top: '16px',
+              bottom: '8px',
+            }}
+            disableMultiAxis
+            definedAxisTicks={4}
+            stacked
+            chartColors={['#444674', '#7a5088', '#b85586']}
+          />
+        </Fragment>
       </StyledRow>
 
       <EndpointList

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -45,6 +45,8 @@ export function StarfishView(props: BasePerformanceViewProps) {
     };
   });
 
+  // Attempt at zerofilling data so that the charts stack properly and
+  // don't look like abstract art.
   let lastInterval = undefined;
   modules.forEach(module => {
     moduleDurationData.forEach(value => {


### PR DESCRIPTION
Use the span exclusive time to visualize module durations.
Had to add in a hack to ensure all series have the same number
of data points so the charts don't look strange and stack properly.


![Screenshot 2023-04-17 at 6 28 11 PM](https://user-images.githubusercontent.com/63818634/232624623-d7241f3d-2513-4d3c-a9c6-4163ca281572.png)
