### PR TITLE
ref(crons): Adjust default timeout to 30 minutes (from 12hr)

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -20,7 +20,7 @@ from .models import (
 logger = logging.getLogger("sentry")
 
 # default maximum runtime for a monitor, in minutes
-TIMEOUT = 12 * 60
+TIMEOUT = 30
 
 # This is the MAXIMUM number of MONITOR this job will check.
 #
@@ -83,6 +83,8 @@ def check_monitors(current_datetime=None):
     # check for any monitors which are still running and have exceeded their maximum runtime
     for checkin in RangeQuerySetWrapper(qs):
         timeout = timedelta(minutes=(checkin.monitor.config or {}).get("max_runtime") or TIMEOUT)
+        # Check against date_updated to allow monitors to run for longer as
+        # long as they continute to send heart beats updating the checkin
         if checkin.date_updated > current_datetime - timeout:
             continue
 


### PR DESCRIPTION
This will help us to avoid users having a large number of in_progress check-ins that only are marked as failed after 12 hours. We've seen a number of users continually sending check-ins pegged at the rate limit and they end up having a LOT of in progress check-ins

Some quick numbers:

```sql
SELECT count(*)
FROM
  (SELECT mon.id,
          ceil(avg(c.duration / 1000 / 60)) AS duration_in_min
   FROM sentry_monitor mon
   JOIN sentry_monitorcheckin c ON c.monitor_id = mon.id
   WHERE cast(mon.config AS json)->>'max_runtime' IS NULL
   GROUP BY mon.id) AS v
WHERE v.duration_in_min > 30
```

This query will tell us how many users have monitors *without a configured max_timeout* who's runtimes are on avergae longer than 30 minutes

> Count: 43

The alternative, users who do not have a max runtime configured whos monitor usually takes less than 30 minutes

> Count: 948

So 30 minutes seems like a pretty reasonable default timeout.