### PR TITLE
ref(analytics): alias trackIntegrationAnalytics to trackAdvancedAnalyticsEvent

### DIFF
--- a/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/trackAdvancedAnalyticsEvent.tsx
@@ -10,6 +10,7 @@ import {
   DynamicSamplingEventParameters,
 } from './dynamicSamplingAnalyticsEvents';
 import {growthEventMap, GrowthEventParameters} from './growthAnalyticsEvents';
+import {integrationEventMap, IntegrationEventParameters} from './integrations';
 import {issueEventMap, IssueEventParameters} from './issueAnalyticsEvents';
 import makeAnalyticsFunction from './makeAnalyticsFunction';
 import {monitorsEventMap, MonitorsEventParameters} from './monitorsAnalyticsEvents';
@@ -42,7 +43,8 @@ type EventParameters = GrowthEventParameters &
   DynamicSamplingEventParameters &
   OnboardingEventParameters &
   StackTraceEventParameters &
-  AiSuggestedSolutionEventParameters;
+  AiSuggestedSolutionEventParameters &
+  IntegrationEventParameters;
 
 const allEventMap: Record<string, string | null> = {
   ...coreUIEventMap,
@@ -62,6 +64,7 @@ const allEventMap: Record<string, string | null> = {
   ...onboardingEventMap,
   ...stackTraceEventMap,
   ...aiSuggestedSolutionEventMap,
+  ...integrationEventMap,
 };
 
 /**

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -34,7 +34,10 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 
 import {IconSize} from './theme';
 
-// TODO: remove alias once all usages are updated
+/**
+ * TODO: remove alias once all usages are updated
+ * @deprecated Use trackAdvancedAnalyticsEvent instead
+ */
 export const trackIntegrationAnalytics = trackAdvancedAnalyticsEvent;
 
 /**

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -25,36 +25,17 @@ import type {
   IntegrationFeature,
   IntegrationInstallationStatus,
   IntegrationType,
-  Organization,
   PluginWithProjectList,
   SentryApp,
   SentryAppInstallation,
 } from 'sentry/types';
 import {Hooks} from 'sentry/types/hooks';
-import {
-  integrationEventMap,
-  IntegrationEventParameters,
-} from 'sentry/utils/analytics/integrations';
-import makeAnalyticsFunction from 'sentry/utils/analytics/makeAnalyticsFunction';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 
 import {IconSize} from './theme';
 
-const mapIntegrationParams = analyticsParams => {
-  // Reload expects integration_status even though it's not relevant for non-sentry apps
-  // Passing in a dummy value of published in those cases
-  const fullParams = {...analyticsParams};
-  if (analyticsParams.integration && analyticsParams.integration_type !== 'sentry_app') {
-    fullParams.integration_status = 'published';
-  }
-  return fullParams;
-};
-
-export const trackIntegrationAnalytics = makeAnalyticsFunction<
-  IntegrationEventParameters,
-  {organization: Organization} // org is required
->(integrationEventMap, {
-  mapValuesFn: mapIntegrationParams,
-});
+// TODO: remove alias once all usages are updated
+export const trackIntegrationAnalytics = trackAdvancedAnalyticsEvent;
 
 /**
  * In sentry.io the features list supports rendering plan details. If the hook


### PR DESCRIPTION
We want to finally combine `trackIntegrationAnalytics` with `trackAdvancedAnalyticsEvent`. We can do this because we are removing the schema checks (https://github.com/getsentry/reload/pull/312) that required us to have a custom `mapIntegrationParams` for integrations. The first step in removing `trackIntegrationAnalytics` is to just alias `trackAdvancedAnalyticsEvent` to it. I'm going to replace the calls with `trackAdvancedAnalyticsEvent` after.