### PR TITLE
perf(replays): always sample segment download

### DIFF
--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -246,6 +246,7 @@ def download_segments(segments: List[RecordingSegmentStorageMeta]) -> Iterator[b
     transaction = sentry_sdk.start_transaction(
         op="http.server",
         name="ProjectReplayRecordingSegmentIndexEndpoint.download_segments",
+        sampled=True,
     )
 
     download_segment_with_fixed_args = functools.partial(


### PR DESCRIPTION
via docs here: https://github.com/getsentry/sentry/pull/new/jferg/bump-up-sampling-rate

- this endpoint does not receive a notable amount of traffic, so bumping up so always sampled should not make a difference in terms of dynamic sampling balancing.