### PR TITLE
ref(jira): Rename and add docstrings to Jira endpoint classes

### DIFF
--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -7,9 +7,9 @@ from .views import (
 )
 from .webhooks import (
     JiraDescriptorEndpoint,
-    JiraInstalledEndpoint,
     JiraIssueUpdatedWebhook,
     JiraSearchEndpoint,
+    JiraSentryInstalledWebhook,
     JiraUninstalledEndpoint,
 )
 
@@ -24,7 +24,7 @@ urlpatterns = [
     ),
     url(
         r"^installed/$",
-        JiraInstalledEndpoint.as_view(),
+        JiraSentryInstalledWebhook.as_view(),
         name="sentry-extensions-jira-installed",
     ),
     url(

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,6 +1,10 @@
 from django.conf.urls import url
 
-from .views import JiraExtensionConfigurationView, JiraSentryIssueDetailsView, JiraUiHookView
+from .views import (
+    JiraExtensionConfigurationView,
+    JiraSentryInstallationView,
+    JiraSentryIssueDetailsView,
+)
 from .webhooks import (
     JiraDescriptorEndpoint,
     JiraInstalledEndpoint,
@@ -12,7 +16,7 @@ from .webhooks import (
 urlpatterns = [
     url(
         r"^ui-hook/$",
-        JiraUiHookView.as_view(),
+        JiraSentryInstallationView.as_view(),
     ),
     url(
         r"^descriptor/$",

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -10,7 +10,7 @@ from .webhooks import (
     JiraIssueUpdatedWebhook,
     JiraSearchEndpoint,
     JiraSentryInstalledWebhook,
-    JiraUninstalledEndpoint,
+    JiraSentryUninstalledWebhook,
 )
 
 urlpatterns = [
@@ -29,7 +29,7 @@ urlpatterns = [
     ),
     url(
         r"^uninstalled/$",
-        JiraUninstalledEndpoint.as_view(),
+        JiraSentryUninstalledWebhook.as_view(),
     ),
     url(
         r"^issue-updated/$",

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from .views import JiraExtensionConfigurationView, JiraIssueHookView, JiraUiHookView
+from .views import JiraExtensionConfigurationView, JiraSentryIssueDetailsView, JiraUiHookView
 from .webhooks import (
     JiraDescriptorEndpoint,
     JiraInstalledEndpoint,
@@ -43,7 +43,7 @@ urlpatterns = [
     ),
     url(
         r"^issue/(?P<issue_key>[^\/]+)/$",
-        JiraIssueHookView.as_view(),
+        JiraSentryIssueDetailsView.as_view(),
         name="sentry-extensions-jira-issue-hook",
     ),
 ]

--- a/src/sentry/integrations/jira/views/__init__.py
+++ b/src/sentry/integrations/jira/views/__init__.py
@@ -2,13 +2,13 @@ UNABLE_TO_VERIFY_INSTALLATION = "Unable to verify installation"
 
 from .base import JiraSentryUIBaseView
 from .extension_configuration import JiraExtensionConfigurationView
-from .issue_hook import JiraIssueHookView
+from .issue_hook import JiraSentryIssueDetailsView
 from .ui_hook import JiraUiHookView
 
 __all__ = (
     "JiraSentryUIBaseView",
     "JiraExtensionConfigurationView",
-    "JiraIssueHookView",
+    "JiraSentryIssueDetailsView",
     "JiraUiHookView",
     "UNABLE_TO_VERIFY_INSTALLATION",
 )

--- a/src/sentry/integrations/jira/views/__init__.py
+++ b/src/sentry/integrations/jira/views/__init__.py
@@ -3,12 +3,12 @@ UNABLE_TO_VERIFY_INSTALLATION = "Unable to verify installation"
 from .base import JiraSentryUIBaseView
 from .extension_configuration import JiraExtensionConfigurationView
 from .issue_hook import JiraSentryIssueDetailsView
-from .ui_hook import JiraUiHookView
+from .ui_hook import JiraSentryInstallationView
 
 __all__ = (
     "JiraSentryUIBaseView",
     "JiraExtensionConfigurationView",
     "JiraSentryIssueDetailsView",
-    "JiraUiHookView",
+    "JiraSentryInstallationView",
     "UNABLE_TO_VERIFY_INSTALLATION",
 )

--- a/src/sentry/integrations/jira/views/__init__.py
+++ b/src/sentry/integrations/jira/views/__init__.py
@@ -1,12 +1,12 @@
 UNABLE_TO_VERIFY_INSTALLATION = "Unable to verify installation"
 
-from .base import JiraBaseHook
+from .base import JiraSentryUIBaseView
 from .extension_configuration import JiraExtensionConfigurationView
 from .issue_hook import JiraIssueHookView
 from .ui_hook import JiraUiHookView
 
 __all__ = (
-    "JiraBaseHook",
+    "JiraSentryUIBaseView",
     "JiraExtensionConfigurationView",
     "JiraIssueHookView",
     "JiraUiHookView",

--- a/src/sentry/integrations/jira/views/base.py
+++ b/src/sentry/integrations/jira/views/base.py
@@ -5,7 +5,16 @@ from sentry.web.helpers import render_to_response
 
 
 class JiraSentryUIBaseView(View):
+    """
+    Base class for the UI of the Sentry integration in Jira.
+    """
+
     def get_response(self, context):
+        """
+        Wrap the HTML rendered using the template at `self.html_file` in a Response and
+        add the requisite CSP headers before returning it.
+        """
+
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         response = render_to_response(self.html_file, context, self.request)
         sources = [

--- a/src/sentry/integrations/jira/views/base.py
+++ b/src/sentry/integrations/jira/views/base.py
@@ -4,7 +4,7 @@ from sentry import options
 from sentry.web.helpers import render_to_response
 
 
-class JiraBaseHook(View):
+class JiraSentryUIBaseView(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         response = render_to_response(self.html_file, context, self.request)

--- a/src/sentry/integrations/jira/views/extension_configuration.py
+++ b/src/sentry/integrations/jira/views/extension_configuration.py
@@ -9,6 +9,10 @@ INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 
 class JiraExtensionConfigurationView(IntegrationExtensionConfigurationView):
+    """
+    Handle the UI for adding the Jira integration to a Sentry org.
+    """
+
     provider = "jira"
     external_provider_key = "jira"
 

--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -19,7 +19,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.sdk import configure_scope
 
 from ..utils import handle_jira_api_error, set_badge
-from . import UNABLE_TO_VERIFY_INSTALLATION, JiraBaseHook
+from . import UNABLE_TO_VERIFY_INSTALLATION, JiraSentryUIBaseView
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ def build_context(group: Group) -> Mapping[str, Any]:
     }
 
 
-class JiraIssueHookView(JiraBaseHook):
+class JiraIssueHookView(JiraSentryUIBaseView):
     html_file = "sentry/integrations/jira-issue.html"
 
     def handle_groups(self, groups: Sequence[Group]) -> Response:

--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -85,6 +85,11 @@ def build_context(group: Group) -> Mapping[str, Any]:
 
 
 class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
+    """
+    Handles requests (from the Sentry integration in Jira) for HTML to display when you
+    click on "Sentry -> Linked Issues" in the RH sidebar of an issue in the Jira UI.
+    """
+
     html_file = "sentry/integrations/jira-issue.html"
 
     def handle_groups(self, groups: Sequence[Group]) -> Response:

--- a/src/sentry/integrations/jira/views/issue_hook.py
+++ b/src/sentry/integrations/jira/views/issue_hook.py
@@ -84,7 +84,7 @@ def build_context(group: Group) -> Mapping[str, Any]:
     }
 
 
-class JiraIssueHookView(JiraSentryUIBaseView):
+class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
     html_file = "sentry/integrations/jira-issue.html"
 
     def handle_groups(self, groups: Sequence[Group]) -> Response:

--- a/src/sentry/integrations/jira/views/ui_hook.py
+++ b/src/sentry/integrations/jira/views/ui_hook.py
@@ -11,7 +11,7 @@ from sentry.utils.signing import sign
 from . import UNABLE_TO_VERIFY_INSTALLATION, JiraSentryUIBaseView
 
 
-class JiraUiHookView(JiraSentryUIBaseView):
+class JiraSentryInstallationView(JiraSentryUIBaseView):
     html_file = "sentry/integrations/jira-config.html"
 
     def get(self, request: Request, *args, **kwargs) -> Response:

--- a/src/sentry/integrations/jira/views/ui_hook.py
+++ b/src/sentry/integrations/jira/views/ui_hook.py
@@ -8,10 +8,10 @@ from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
 
-from . import UNABLE_TO_VERIFY_INSTALLATION, JiraBaseHook
+from . import UNABLE_TO_VERIFY_INSTALLATION, JiraSentryUIBaseView
 
 
-class JiraUiHookView(JiraBaseHook):
+class JiraUiHookView(JiraSentryUIBaseView):
     html_file = "sentry/integrations/jira-config.html"
 
     def get(self, request: Request, *args, **kwargs) -> Response:

--- a/src/sentry/integrations/jira/views/ui_hook.py
+++ b/src/sentry/integrations/jira/views/ui_hook.py
@@ -12,6 +12,11 @@ from . import UNABLE_TO_VERIFY_INSTALLATION, JiraSentryUIBaseView
 
 
 class JiraSentryInstallationView(JiraSentryUIBaseView):
+    """
+    Handles requests (from the Sentry integration in Jira) for HTML to display when
+    setting up the integration in the Jira UI.
+    """
+
     html_file = "sentry/integrations/jira-config.html"
 
     def get(self, request: Request, *args, **kwargs) -> Response:

--- a/src/sentry/integrations/jira/webhooks/__init__.py
+++ b/src/sentry/integrations/jira/webhooks/__init__.py
@@ -1,12 +1,12 @@
 from .descriptor import JiraDescriptorEndpoint
-from .installed import JiraInstalledEndpoint
+from .installed import JiraSentryInstalledWebhook
 from .issue_updated import JiraIssueUpdatedWebhook
 from .search import JiraSearchEndpoint
 from .uninstalled import JiraUninstalledEndpoint
 
 __all__ = (
     "JiraDescriptorEndpoint",
-    "JiraInstalledEndpoint",
+    "JiraSentryInstalledWebhook",
     "JiraIssueUpdatedWebhook",
     "JiraSearchEndpoint",
     "JiraUninstalledEndpoint",

--- a/src/sentry/integrations/jira/webhooks/__init__.py
+++ b/src/sentry/integrations/jira/webhooks/__init__.py
@@ -2,12 +2,12 @@ from .descriptor import JiraDescriptorEndpoint
 from .installed import JiraSentryInstalledWebhook
 from .issue_updated import JiraIssueUpdatedWebhook
 from .search import JiraSearchEndpoint
-from .uninstalled import JiraUninstalledEndpoint
+from .uninstalled import JiraSentryUninstalledWebhook
 
 __all__ = (
     "JiraDescriptorEndpoint",
     "JiraSentryInstalledWebhook",
     "JiraIssueUpdatedWebhook",
     "JiraSearchEndpoint",
-    "JiraUninstalledEndpoint",
+    "JiraSentryUninstalledWebhook",
 )

--- a/src/sentry/integrations/jira/webhooks/descriptor.py
+++ b/src/sentry/integrations/jira/webhooks/descriptor.py
@@ -19,6 +19,12 @@ if settings.JIRA_USE_EMAIL_SCOPE:
 
 @pending_silo_endpoint
 class JiraDescriptorEndpoint(Endpoint):
+    """
+    Provides the metadata needed by Jira to setup an instance of the Sentry integration within Jira.
+    Only used by on-prem orgs and devs setting up local instances of the integration. (Sentry SAAS
+    already has an established, official instance of the Sentry integration registered with Jira.)
+    """
+
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -13,7 +13,7 @@ from .base import JiraEndpointBase
 
 
 @pending_silo_endpoint
-class JiraInstalledEndpoint(JiraEndpointBase):
+class JiraSentryInstalledWebhook(JiraEndpointBase):
     def post(self, request: Request, *args, **kwargs) -> Response:
         token = self.get_token(request)
 

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -14,6 +14,10 @@ from .base import JiraEndpointBase
 
 @pending_silo_endpoint
 class JiraSentryInstalledWebhook(JiraEndpointBase):
+    """
+    Webhook hit by Jira whenever someone installs the Sentry integration in their Jira instance.
+    """
+
     def post(self, request: Request, *args, **kwargs) -> Response:
         token = self.get_token(request)
 

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 
 @pending_silo_endpoint
 class JiraIssueUpdatedWebhook(JiraEndpointBase):
+    """
+    Webhook hit by Jira whenever an issue is updated in Jira's database.
+    """
+
     def handle_exception(
         self, request: Request, exc: Exception, handler_context: Mapping[str, Any] | None = None
     ) -> Response:

--- a/src/sentry/integrations/jira/webhooks/search.py
+++ b/src/sentry/integrations/jira/webhooks/search.py
@@ -12,6 +12,10 @@ from ..utils import build_user_choice
 
 @pending_silo_endpoint
 class JiraSearchEndpoint(IntegrationEndpoint):
+    """
+    Called by our front end when it needs to make requests to Jira's API for data.
+    """
+
     provider = "jira"
 
     def _get_integration(self, organization, integration_id):

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -10,6 +10,10 @@ from .base import JiraEndpointBase
 
 @pending_silo_endpoint
 class JiraSentryUninstalledWebhook(JiraEndpointBase):
+    """
+    Webhook hit by Jira whenever someone uninstalls the Sentry integration from their Jira instance.
+    """
+
     def post(self, request: Request, *args, **kwargs) -> Response:
         token = self.get_token(request)
         integration = get_integration_from_jwt(

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -9,7 +9,7 @@ from .base import JiraEndpointBase
 
 
 @pending_silo_endpoint
-class JiraUninstalledEndpoint(JiraEndpointBase):
+class JiraSentryUninstalledWebhook(JiraEndpointBase):
     def post(self, request: Request, *args, **kwargs) -> Response:
         token = self.get_token(request)
         integration = get_integration_from_jwt(

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -31,6 +31,11 @@ class IntegrationManager(BaseManager):
 
 @control_silo_only_model
 class Integration(DefaultFieldsModel):
+    """
+    An integration tied to a particular instance of a third-party provider (a single Slack
+    workspace, a single GH org, etc.), which can be shared by multiple Sentry orgs.
+    """
+
     __include_in_export__ = False
 
     provider = models.CharField(max_length=64)

--- a/tests/sentry/integrations/jira/test_ui_hook.py
+++ b/tests/sentry/integrations/jira/test_ui_hook.py
@@ -12,7 +12,7 @@ REFRESH_REQUIRED = b"This page has expired, please refresh to configure your Sen
 CLICK_TO_FINISH = b"Finish Installation in Sentry"
 
 
-class JiraUiHookViewTestCase(APITestCase):
+class JiraSentryInstallationViewTestCase(APITestCase):
     def setUp(self):
         super().setUp()
         self.path = absolute_uri("extensions/jira/ui-hook/") + "?xdm_e=base_url"
@@ -23,7 +23,7 @@ class JiraUiHookViewTestCase(APITestCase):
         self.integration = Integration.objects.create(provider="jira", name="Example Jira")
 
 
-class JiraUiHookViewErrorsTest(JiraUiHookViewTestCase):
+class JiraSentryInstallationViewErrorsTest(JiraSentryInstallationViewTestCase):
     @patch(
         "sentry.integrations.jira.views.ui_hook.get_integration_from_request",
         side_effect=ExpiredSignatureError(),
@@ -43,7 +43,7 @@ class JiraUiHookViewErrorsTest(JiraUiHookViewTestCase):
         assert UNABLE_TO_VERIFY_INSTALLATION.encode() in response.content
 
 
-class JiraUiHookViewTest(JiraUiHookViewTestCase):
+class JiraSentryInstallationViewTest(JiraSentryInstallationViewTestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)


### PR DESCRIPTION
This renames many of the Jira integration endpoint classes, so that their names better reflect their purpose. It also adds docstrings to all jira endpoints, renamed or not.

When renaming, the following conventions were followed:
- All classes start with `Jira`. (This was already true.)
- Anything that's a webhook (that is, which accepts posted data from Jira without sending anything meaningful in return) is called `Webhook`.
- Anything which is an endpoint in our REST API is called `Endpoint`.
- All other routes are called `View`. (For the Jira integration, these primarily provide Jira with UI to show when installing and using the Sentry integration inside of Jira.)
- Anything which powers the Sentry integration inside of Jira is prefixed with `Sentry`, as in, `JiraSentryInstalledWebhook`.

(I know, these seem rather obvious. But by laying them all out so explicitly I'm hoping they can become a standard we can apply to other integrations as well, so that it's easier for folks unfamiliar with the code to figure out how everything fits together.)

Ref: WOR-2982