### PR TITLE
feat(settings): Improve Project Settings > Client Keys overview

### DIFF
--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -18,7 +18,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import {decodeList} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
-import {DynamicSDKLoaderOption} from 'sentry/views/settings/project/projectKeys/details/keySettings';
+import {DynamicSDKLoaderOption} from 'sentry/views/settings/project/projectKeys/details/loaderSettings';
 
 export function SetupDocsLoader({
   organization,

--- a/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
@@ -1,290 +1,62 @@
-import selectEvent from 'react-select-event';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Organization, Project} from 'sentry/types';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
 import {KeySettings} from './keySettings';
 import {DynamicSDKLoaderOption, sdkLoaderOptions} from './loaderSettings';
 
-const dynamicSdkLoaderOptions = {
-  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
-  [DynamicSDKLoaderOption.HAS_REPLAY]: true,
-  [DynamicSDKLoaderOption.HAS_DEBUG]: false,
-};
-
-const fullDynamicSdkLoaderOptions = {
-  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: true,
-  [DynamicSDKLoaderOption.HAS_REPLAY]: true,
-  [DynamicSDKLoaderOption.HAS_DEBUG]: true,
-};
-
-function renderMockRequests(
-  organizationSlug: Organization['slug'],
-  projectSlug: Project['slug'],
-  keyId: ProjectKey['id']
-) {
-  const projectKeys = MockApiClient.addMockResponse({
-    url: `/projects/${organizationSlug}/${projectSlug}/keys/${keyId}/`,
-    method: 'PUT',
-    body: TestStubs.ProjectKeys()[0],
-  });
-
-  return {projectKeys};
-}
-
 describe('Key Settings', function () {
-  describe('Dynamic SDK Loader', function () {
-    it('renders default ui', async function () {
-      const params = {
-        projectId: '1',
-        keyId: '1',
-      };
+  it('renders Loader Script Settings', function () {
+    const dynamicSdkLoaderOptions = {
+      [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+      [DynamicSDKLoaderOption.HAS_REPLAY]: true,
+      [DynamicSDKLoaderOption.HAS_DEBUG]: false,
+    };
 
-      const {organization} = initializeOrg({
-        ...initializeOrg(),
-        organization: {
-          ...initializeOrg().organization,
-        },
-        router: {
-          params,
-        },
-      });
+    const params = {
+      projectId: '1',
+      keyId: '1',
+    };
 
-      const data = {
-        ...(TestStubs.ProjectKeys()[0] as ProjectKey),
-        dynamicSdkLoaderOptions,
-      } as ProjectKey;
+    const {organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {
+        ...initializeOrg().organization,
+      },
+      router: {
+        params,
+      },
+    });
 
-      const mockRequests = renderMockRequests(
-        organization.slug,
-        params.projectId,
-        params.keyId
-      );
+    const data = {
+      ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+      dynamicSdkLoaderOptions,
+    } as ProjectKey;
 
-      render(
-        <KeySettings
-          data={data}
-          onRemove={jest.fn()}
-          organization={organization}
-          params={params}
-        />
-      );
+    render(
+      <KeySettings
+        data={data}
+        onRemove={jest.fn()}
+        organization={organization}
+        params={params}
+      />
+    );
 
-      // Panel title
-      expect(screen.getByText('JavaScript Loader')).toBeInTheDocument();
+    // Panel title
+    expect(screen.getByText('JavaScript Loader')).toBeInTheDocument();
 
-      // SDK loader options
-      for (const key of Object.keys(sdkLoaderOptions)) {
-        expect(screen.getByText(sdkLoaderOptions[key].label)).toBeInTheDocument();
-        const toggle = screen.getByRole('checkbox', {name: sdkLoaderOptions[key].label});
-        expect(toggle).toBeEnabled();
+    // SDK loader options
+    for (const key of Object.keys(sdkLoaderOptions)) {
+      expect(screen.getByText(sdkLoaderOptions[key].label)).toBeInTheDocument();
+      const toggle = screen.getByRole('checkbox', {name: sdkLoaderOptions[key].label});
+      expect(toggle).toBeEnabled();
 
-        if (key === DynamicSDKLoaderOption.HAS_REPLAY) {
-          expect(toggle).toBeChecked();
-        } else {
-          expect(toggle).not.toBeChecked();
-        }
+      if (key === DynamicSDKLoaderOption.HAS_REPLAY) {
+        expect(toggle).toBeChecked();
+      } else {
+        expect(toggle).not.toBeChecked();
       }
-
-      // Toggle performance option
-      userEvent.click(
-        screen.getByRole('checkbox', {
-          name: sdkLoaderOptions[DynamicSDKLoaderOption.HAS_PERFORMANCE].label,
-        })
-      );
-
-      await waitFor(() => {
-        expect(mockRequests.projectKeys).toHaveBeenCalledWith(
-          `/projects/${organization.slug}/${params.projectId}/keys/${params.keyId}/`,
-          expect.objectContaining({
-            data: {
-              dynamicSdkLoaderOptions: {
-                ...dynamicSdkLoaderOptions,
-                [DynamicSDKLoaderOption.HAS_PERFORMANCE]: true,
-              },
-            },
-          })
-        );
-      });
-
-      // Update SDK version
-      await selectEvent.select(screen.getByText('latest'), '7.x');
-
-      await waitFor(() => {
-        expect(mockRequests.projectKeys).toHaveBeenCalledWith(
-          `/projects/${organization.slug}/${params.projectId}/keys/${params.keyId}/`,
-          expect.objectContaining({
-            data: {
-              browserSdkVersion: '7.x',
-            },
-          })
-        );
-      });
-    });
-
-    it('resets performance & replay when selecting SDK version <7', async function () {
-      const params = {
-        projectId: '1',
-        keyId: '1',
-      };
-
-      const {organization} = initializeOrg({
-        ...initializeOrg(),
-        organization: {
-          ...initializeOrg().organization,
-        },
-        router: {
-          params,
-        },
-      });
-
-      const data = {
-        ...(TestStubs.ProjectKeys()[0] as ProjectKey),
-        dynamicSdkLoaderOptions: fullDynamicSdkLoaderOptions,
-      } as ProjectKey;
-
-      const mockRequests = renderMockRequests(
-        organization.slug,
-        params.projectId,
-        params.keyId
-      );
-
-      render(
-        <KeySettings
-          data={data}
-          onRemove={jest.fn()}
-          organization={organization}
-          params={params}
-        />
-      );
-
-      // Update SDK version - should reset performance & replay
-      await selectEvent.select(screen.getByText('latest'), '6.x');
-
-      await waitFor(() => {
-        expect(mockRequests.projectKeys).toHaveBeenCalledWith(
-          `/projects/${organization.slug}/${params.projectId}/keys/${params.keyId}/`,
-          expect.objectContaining({
-            data: {
-              browserSdkVersion: '6.x',
-              dynamicSdkLoaderOptions: {
-                ...fullDynamicSdkLoaderOptions,
-                [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
-                [DynamicSDKLoaderOption.HAS_REPLAY]: false,
-                [DynamicSDKLoaderOption.HAS_DEBUG]: true,
-              },
-            },
-          })
-        );
-      });
-    });
-
-    it('disabled performance & replay when SDK version <7 is selected', function () {
-      const params = {
-        projectId: '1',
-        keyId: '1',
-      };
-
-      const {organization} = initializeOrg({
-        ...initializeOrg(),
-        organization: {
-          ...initializeOrg().organization,
-        },
-        router: {
-          params,
-        },
-      });
-
-      const data = {
-        ...(TestStubs.ProjectKeys()[0] as ProjectKey),
-        dynamicSdkLoaderOptions: {
-          [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
-          [DynamicSDKLoaderOption.HAS_REPLAY]: false,
-          [DynamicSDKLoaderOption.HAS_DEBUG]: true,
-        },
-        browserSdkVersion: '6.x',
-      } as ProjectKey;
-
-      render(
-        <KeySettings
-          data={data}
-          onRemove={jest.fn()}
-          organization={organization}
-          params={params}
-        />
-      );
-
-      for (const key of Object.keys(sdkLoaderOptions)) {
-        const toggle = screen.getByRole('checkbox', {name: sdkLoaderOptions[key].label});
-
-        if (key === DynamicSDKLoaderOption.HAS_DEBUG) {
-          expect(toggle).toBeEnabled();
-          expect(toggle).toBeChecked();
-        } else {
-          expect(toggle).toBeDisabled();
-          expect(toggle).not.toBeChecked();
-        }
-      }
-
-      const infos = screen.getAllByText('Only available in SDK version 7.x and above');
-      expect(infos.length).toBe(2);
-    });
-
-    it('shows replay message when it is enabled', function () {
-      const params = {
-        projectId: '1',
-        keyId: '1',
-      };
-
-      const {organization} = initializeOrg({
-        ...initializeOrg(),
-        organization: {
-          ...initializeOrg().organization,
-        },
-        router: {
-          params,
-        },
-      });
-
-      const data = {
-        ...(TestStubs.ProjectKeys()[0] as ProjectKey),
-        dynamicSdkLoaderOptions: fullDynamicSdkLoaderOptions,
-      } as ProjectKey;
-
-      const {rerender} = render(
-        <KeySettings
-          data={data}
-          onRemove={jest.fn()}
-          organization={organization}
-          params={params}
-        />
-      );
-
-      expect(
-        screen.queryByText(
-          'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
-        )
-      ).toBeInTheDocument();
-
-      data.dynamicSdkLoaderOptions.hasReplay = false;
-
-      rerender(
-        <KeySettings
-          data={data}
-          onRemove={jest.fn()}
-          organization={organization}
-          params={params}
-        />
-      );
-
-      expect(
-        screen.queryByText(
-          'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
-        )
-      ).not.toBeInTheDocument();
-    });
+    }
   });
 });

--- a/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
@@ -6,7 +6,8 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {Organization, Project} from 'sentry/types';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
-import {DynamicSDKLoaderOption, KeySettings, sdkLoaderOptions} from './keySettings';
+import {KeySettings} from './keySettings';
+import {DynamicSDKLoaderOption, sdkLoaderOptions} from './loaderSettings';
 
 const dynamicSdkLoaderOptions = {
   [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -104,6 +104,10 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
           <Panel>
             <PanelHeader>{t('JavaScript Loader')}</PanelHeader>
             <PanelBody>
+              <PanelAlert type="info" showIcon>
+                {t('Note that it can take a few minutes until changed options are live.')}
+              </PanelAlert>
+
               <LoaderSettings
                 orgSlug={organization.slug}
                 keyId={params.keyId}

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -105,7 +105,7 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
             <PanelHeader>{t('JavaScript Loader')}</PanelHeader>
             <PanelBody>
               <LoaderSettings
-                organizationId={organization.slug}
+                orgSlug={organization.slug}
                 keyId={params.keyId}
                 projectId={params.projectId}
                 projectKey={data}

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback} from 'react';
 
 import {
   addErrorMessage,
@@ -11,24 +11,14 @@ import Confirm from 'sentry/components/confirm';
 import DateTime from 'sentry/components/dateTime';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import BooleanField from 'sentry/components/forms/fields/booleanField';
-import SelectField from 'sentry/components/forms/fields/selectField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
-import ExternalLink from 'sentry/components/links/externalLink';
-import {
-  Panel,
-  PanelAlert,
-  PanelBody,
-  PanelFooter,
-  PanelHeader,
-} from 'sentry/components/panels';
-import TextCopyInput from 'sentry/components/textCopyInput';
-import {t, tct} from 'sentry/locale';
+import {Panel, PanelAlert, PanelBody, PanelHeader} from 'sentry/components/panels';
+import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
-import getDynamicText from 'sentry/utils/getDynamicText';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
 import KeyRateLimitsForm from 'sentry/views/settings/project/projectKeys/details/keyRateLimitsForm';
+import {LoaderSettings} from 'sentry/views/settings/project/projectKeys/details/loaderSettings';
 import ProjectKeyCredentials from 'sentry/views/settings/project/projectKeys/projectKeyCredentials';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
@@ -42,48 +32,11 @@ type Props = {
   };
 };
 
-export enum DynamicSDKLoaderOption {
-  HAS_DEBUG = 'hasDebug',
-  HAS_PERFORMANCE = 'hasPerformance',
-  HAS_REPLAY = 'hasReplay',
-}
-
-export const sdkLoaderOptions = {
-  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: {
-    label: t('Enable Performance Monitoring'),
-    requiresV7: true,
-  },
-  [DynamicSDKLoaderOption.HAS_REPLAY]: {
-    label: t('Enable Session Replay'),
-    requiresV7: true,
-  },
-  [DynamicSDKLoaderOption.HAS_DEBUG]: {
-    label: t('Enable Debug Bundles'),
-    requiresV7: false,
-  },
-};
-
 export function KeySettings({onRemove, organization, params, data}: Props) {
   const api = useApi();
-  const [browserSdkVersion, setBrowserSdkVersion] = useState(data.browserSdkVersion);
-  const [dynamicSDKLoaderOptions, setDynamicSDKLoaderOptions] = useState(
-    data.dynamicSdkLoaderOptions
-  );
-
-  useEffect(() => {
-    setBrowserSdkVersion(data.browserSdkVersion);
-  }, [data.browserSdkVersion]);
-
-  useEffect(() => {
-    setDynamicSDKLoaderOptions(data.dynamicSdkLoaderOptions);
-  }, [data.dynamicSdkLoaderOptions]);
 
   const {keyId, projectId} = params;
   const apiEndpoint = `/projects/${organization.slug}/${projectId}/keys/${keyId}/`;
-  const loaderLink = getDynamicText({
-    value: data.dsn.cdn,
-    fixed: '__JS_SDK_LOADER_URL__',
-  });
 
   const handleRemove = useCallback(async () => {
     addLoadingMessage(t('Revoking key\u2026'));
@@ -102,96 +55,6 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
       addErrorMessage(t('Unable to revoke key'));
     }
   }, [organization, api, onRemove, keyId, projectId]);
-
-  const handleToggleDynamicSDKLoaderOption = useCallback(
-    async <T extends typeof dynamicSDKLoaderOptions, K extends keyof T>(
-      dynamicSdkLoaderOption: K,
-      value: T[K]
-    ) => {
-      const newDynamicSdkLoaderOptions = Object.keys(dynamicSDKLoaderOptions).reduce(
-        (acc, key) => {
-          if (key === dynamicSdkLoaderOption) {
-            return {...acc, [key]: value};
-          }
-          return {...acc, [key]: dynamicSDKLoaderOptions[key]};
-        },
-        {}
-      );
-
-      addLoadingMessage();
-
-      try {
-        const response = await api.requestPromise(apiEndpoint, {
-          method: 'PUT',
-          data: {
-            dynamicSdkLoaderOptions: newDynamicSdkLoaderOptions,
-          },
-        });
-
-        setDynamicSDKLoaderOptions(response.dynamicSdkLoaderOptions);
-
-        addSuccessMessage(t('Successfully updated dynamic SDK loader configuration'));
-      } catch (error) {
-        const message = t('Unable to updated dynamic SDK loader configuration');
-        handleXhrErrorResponse(message)(error);
-        addErrorMessage(message);
-      }
-    },
-    [api, apiEndpoint, dynamicSDKLoaderOptions, setDynamicSDKLoaderOptions]
-  );
-
-  const handleUpdateBrowserSDKVersion = useCallback(
-    async (newBrowserSDKVersion: typeof browserSdkVersion) => {
-      addLoadingMessage();
-
-      const apiData: {
-        browserSdkVersion: typeof browserSdkVersion;
-        dynamicSdkLoaderOptions?: Partial<Record<DynamicSDKLoaderOption, boolean>>;
-      } = {
-        browserSdkVersion: newBrowserSDKVersion,
-      };
-
-      const shouldRestrictDynamicSdkLoaderOptions =
-        !sdkVersionSupportsPerformanceAndReplay(newBrowserSDKVersion);
-
-      if (shouldRestrictDynamicSdkLoaderOptions) {
-        // Performance & Replay are not supported before 7.x
-        const newDynamicSdkLoaderOptions = {
-          ...dynamicSDKLoaderOptions,
-          hasPerformance: false,
-          hasReplay: false,
-        };
-
-        apiData.dynamicSdkLoaderOptions = newDynamicSdkLoaderOptions;
-      }
-
-      try {
-        const response = await api.requestPromise(apiEndpoint, {
-          method: 'PUT',
-          data: apiData,
-        });
-
-        setBrowserSdkVersion(response.browserSdkVersion);
-
-        if (shouldRestrictDynamicSdkLoaderOptions) {
-          setDynamicSDKLoaderOptions(response.dynamicSdkLoaderOptions);
-        }
-
-        addSuccessMessage(t('Successfully updated SDK version'));
-      } catch (error) {
-        const message = t('Unable to updated SDK version');
-        handleXhrErrorResponse(message)(error);
-        addErrorMessage(message);
-      }
-    },
-    [
-      api,
-      apiEndpoint,
-      setBrowserSdkVersion,
-      setDynamicSDKLoaderOptions,
-      dynamicSDKLoaderOptions,
-    ]
-  );
 
   return (
     <Access access={['project:write']}>
@@ -241,97 +104,13 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
           <Panel>
             <PanelHeader>{t('JavaScript Loader')}</PanelHeader>
             <PanelBody>
-              <FieldGroup
-                help={tct(
-                  'Copy this script into your website to setup your JavaScript SDK without any additional configuration. [link]',
-                  {
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/lazy-load-sentry/">
-                        What does the script provide?
-                      </ExternalLink>
-                    ),
-                  }
-                )}
-                inline={false}
-                flexibleControlStateSize
-              >
-                <TextCopyInput>
-                  {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
-                </TextCopyInput>
-              </FieldGroup>
-              <SelectField
-                name="browserSdkVersion"
-                options={
-                  data.browserSdk
-                    ? data.browserSdk.choices.map(([value, label]) => ({
-                        value,
-                        label,
-                      }))
-                    : []
-                }
-                value={browserSdkVersion}
-                onChange={value => handleUpdateBrowserSDKVersion(value)}
-                placeholder={t('4.x')}
-                allowClear={false}
-                disabled={!hasAccess}
-                help={t(
-                  'Select the version of the SDK that should be loaded. Note that it can take a few minutes until this change is live.'
-                )}
+              <LoaderSettings
+                organizationId={organization.slug}
+                keyId={params.keyId}
+                projectId={params.projectId}
+                projectKey={data}
               />
             </PanelBody>
-
-            <PanelFooter>
-              {Object.entries(sdkLoaderOptions).map(([key, value]) => {
-                const sdkLoaderOption = Object.keys(dynamicSDKLoaderOptions).find(
-                  dynamicSdkLoaderOption => dynamicSdkLoaderOption === key
-                );
-
-                if (!sdkLoaderOption) {
-                  return null;
-                }
-
-                return (
-                  <BooleanField
-                    label={value.label}
-                    key={key}
-                    name={key}
-                    value={
-                      value.requiresV7 &&
-                      !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
-                        ? false
-                        : dynamicSDKLoaderOptions[sdkLoaderOption]
-                    }
-                    onChange={() =>
-                      handleToggleDynamicSDKLoaderOption(
-                        sdkLoaderOption as DynamicSDKLoaderOption,
-                        !dynamicSDKLoaderOptions[sdkLoaderOption]
-                      )
-                    }
-                    disabled={
-                      !hasAccess ||
-                      (value.requiresV7 &&
-                        !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion))
-                    }
-                    help={
-                      value.requiresV7 &&
-                      !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
-                        ? t('Only available in SDK version 7.x and above')
-                        : key === DynamicSDKLoaderOption.HAS_REPLAY &&
-                          dynamicSDKLoaderOptions[sdkLoaderOption]
-                        ? t(
-                            'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
-                          )
-                        : undefined
-                    }
-                    disabledReason={
-                      !hasAccess
-                        ? t('You do not have permission to edit this setting')
-                        : undefined
-                    }
-                  />
-                );
-              })}
-            </PanelFooter>
           </Panel>
 
           <Panel>
@@ -383,8 +162,4 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
       )}
     </Access>
   );
-}
-
-function sdkVersionSupportsPerformanceAndReplay(sdkVersion: string): boolean {
-  return sdkVersion === 'latest' || sdkVersion === '7.x';
 }

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -1,0 +1,284 @@
+import selectEvent from 'react-select-event';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {Organization, Project} from 'sentry/types';
+import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
+
+import {DynamicSDKLoaderOption, LoaderSettings, sdkLoaderOptions} from './loaderSettings';
+
+const dynamicSdkLoaderOptions = {
+  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+  [DynamicSDKLoaderOption.HAS_REPLAY]: true,
+  [DynamicSDKLoaderOption.HAS_DEBUG]: false,
+};
+
+const fullDynamicSdkLoaderOptions = {
+  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: true,
+  [DynamicSDKLoaderOption.HAS_REPLAY]: true,
+  [DynamicSDKLoaderOption.HAS_DEBUG]: true,
+};
+
+function renderMockRequests(
+  organizationSlug: Organization['slug'],
+  projectSlug: Project['slug'],
+  keyId: ProjectKey['id']
+) {
+  const projectKeys = MockApiClient.addMockResponse({
+    url: `/projects/${organizationSlug}/${projectSlug}/keys/${keyId}/`,
+    method: 'PUT',
+    body: TestStubs.ProjectKeys()[0],
+  });
+
+  return {projectKeys};
+}
+
+describe('Loader Script Settings', function () {
+  it('allows to toggle options', async function () {
+    const params = {
+      projectId: '1',
+      keyId: '1',
+    };
+
+    const {organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {
+        ...initializeOrg().organization,
+      },
+      router: {
+        params,
+      },
+    });
+
+    const data = {
+      ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+      dynamicSdkLoaderOptions,
+    } as ProjectKey;
+
+    const mockRequests = renderMockRequests(
+      organization.slug,
+      params.projectId,
+      params.keyId
+    );
+
+    render(
+      <LoaderSettings
+        orgSlug={organization.slug}
+        keyId={params.keyId}
+        projectId={params.projectId}
+        projectKey={data}
+      />
+    );
+
+    // SDK loader options
+    for (const key of Object.keys(sdkLoaderOptions)) {
+      expect(screen.getByText(sdkLoaderOptions[key].label)).toBeInTheDocument();
+      const toggle = screen.getByRole('checkbox', {name: sdkLoaderOptions[key].label});
+      expect(toggle).toBeEnabled();
+
+      if (key === DynamicSDKLoaderOption.HAS_REPLAY) {
+        expect(toggle).toBeChecked();
+      } else {
+        expect(toggle).not.toBeChecked();
+      }
+    }
+
+    // Toggle performance option
+    userEvent.click(
+      screen.getByRole('checkbox', {
+        name: sdkLoaderOptions[DynamicSDKLoaderOption.HAS_PERFORMANCE].label,
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockRequests.projectKeys).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${params.projectId}/keys/${params.keyId}/`,
+        expect.objectContaining({
+          data: {
+            dynamicSdkLoaderOptions: {
+              ...dynamicSdkLoaderOptions,
+              [DynamicSDKLoaderOption.HAS_PERFORMANCE]: true,
+            },
+          },
+        })
+      );
+    });
+
+    // Update SDK version
+    await selectEvent.select(screen.getByText('latest'), '7.x');
+
+    await waitFor(() => {
+      expect(mockRequests.projectKeys).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${params.projectId}/keys/${params.keyId}/`,
+        expect.objectContaining({
+          data: {
+            browserSdkVersion: '7.x',
+          },
+        })
+      );
+    });
+  });
+
+  it('resets performance & replay when selecting SDK version <7', async function () {
+    const params = {
+      projectId: '1',
+      keyId: '1',
+    };
+
+    const {organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {
+        ...initializeOrg().organization,
+      },
+      router: {
+        params,
+      },
+    });
+
+    const data = {
+      ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+      dynamicSdkLoaderOptions: fullDynamicSdkLoaderOptions,
+    } as ProjectKey;
+
+    const mockRequests = renderMockRequests(
+      organization.slug,
+      params.projectId,
+      params.keyId
+    );
+
+    render(
+      <LoaderSettings
+        orgSlug={organization.slug}
+        keyId={params.keyId}
+        projectId={params.projectId}
+        projectKey={data}
+      />
+    );
+
+    // Update SDK version - should reset performance & replay
+    await selectEvent.select(screen.getByText('latest'), '6.x');
+
+    await waitFor(() => {
+      expect(mockRequests.projectKeys).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${params.projectId}/keys/${params.keyId}/`,
+        expect.objectContaining({
+          data: {
+            browserSdkVersion: '6.x',
+            dynamicSdkLoaderOptions: {
+              ...fullDynamicSdkLoaderOptions,
+              [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+              [DynamicSDKLoaderOption.HAS_REPLAY]: false,
+              [DynamicSDKLoaderOption.HAS_DEBUG]: true,
+            },
+          },
+        })
+      );
+    });
+  });
+
+  it('disabled performance & replay when SDK version <7 is selected', function () {
+    const params = {
+      projectId: '1',
+      keyId: '1',
+    };
+
+    const {organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {
+        ...initializeOrg().organization,
+      },
+      router: {
+        params,
+      },
+    });
+
+    const data = {
+      ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+      dynamicSdkLoaderOptions: {
+        [DynamicSDKLoaderOption.HAS_PERFORMANCE]: false,
+        [DynamicSDKLoaderOption.HAS_REPLAY]: false,
+        [DynamicSDKLoaderOption.HAS_DEBUG]: true,
+      },
+      browserSdkVersion: '6.x',
+    } as ProjectKey;
+
+    render(
+      <LoaderSettings
+        orgSlug={organization.slug}
+        keyId={params.keyId}
+        projectId={params.projectId}
+        projectKey={data}
+      />
+    );
+
+    for (const key of Object.keys(sdkLoaderOptions)) {
+      const toggle = screen.getByRole('checkbox', {name: sdkLoaderOptions[key].label});
+
+      if (key === DynamicSDKLoaderOption.HAS_DEBUG) {
+        expect(toggle).toBeEnabled();
+        expect(toggle).toBeChecked();
+      } else {
+        expect(toggle).toBeDisabled();
+        expect(toggle).not.toBeChecked();
+      }
+    }
+
+    const infos = screen.getAllByText('Only available in SDK version 7.x and above');
+    expect(infos.length).toBe(2);
+  });
+
+  it('shows replay message when it is enabled', function () {
+    const params = {
+      projectId: '1',
+      keyId: '1',
+    };
+
+    const {organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {
+        ...initializeOrg().organization,
+      },
+      router: {
+        params,
+      },
+    });
+
+    const data = {
+      ...(TestStubs.ProjectKeys()[0] as ProjectKey),
+      dynamicSdkLoaderOptions: fullDynamicSdkLoaderOptions,
+    } as ProjectKey;
+
+    const {rerender} = render(
+      <LoaderSettings
+        orgSlug={organization.slug}
+        keyId={params.keyId}
+        projectId={params.projectId}
+        projectKey={data}
+      />
+    );
+
+    expect(
+      screen.queryByText(
+        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+      )
+    ).toBeInTheDocument();
+
+    data.dynamicSdkLoaderOptions.hasReplay = false;
+
+    rerender(
+      <LoaderSettings
+        orgSlug={organization.slug}
+        keyId={params.keyId}
+        projectId={params.projectId}
+        projectKey={data}
+      />
+    );
+
+    expect(
+      screen.queryByText(
+        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+      )
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -21,7 +21,7 @@ import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
 type Props = {
   keyId: string;
-  organizationId: string;
+  orgSlug: string;
   projectId: string;
   projectKey: ProjectKey;
 };
@@ -47,7 +47,7 @@ export const sdkLoaderOptions = {
   },
 };
 
-export function LoaderSettings({keyId, organizationId, projectId, projectKey}: Props) {
+export function LoaderSettings({keyId, orgSlug, projectId, projectKey}: Props) {
   const api = useApi();
   const [browserSdkVersion, setBrowserSdkVersion] = useState(
     projectKey.browserSdkVersion
@@ -64,7 +64,7 @@ export function LoaderSettings({keyId, organizationId, projectId, projectKey}: P
     setDynamicSDKLoaderOptions(projectKey.dynamicSdkLoaderOptions);
   }, [projectKey.dynamicSdkLoaderOptions]);
 
-  const apiEndpoint = `/projects/${organizationId}/${projectId}/keys/${keyId}/`;
+  const apiEndpoint = `/projects/${orgSlug}/${projectId}/keys/${keyId}/`;
   const loaderLink = getDynamicText({
     value: projectKey.dsn.cdn,
     fixed: '__JS_SDK_LOADER_URL__',
@@ -170,7 +170,7 @@ export function LoaderSettings({keyId, organizationId, projectId, projectKey}: P
               {
                 link: (
                   <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/lazy-load-sentry/">
-                   {t(' What does the script provide?')}
+                    {t(' What does the script provide?')}
                   </ExternalLink>
                 ),
               }
@@ -200,7 +200,7 @@ export function LoaderSettings({keyId, organizationId, projectId, projectKey}: P
             }
             value={browserSdkVersion}
             onChange={handleUpdateBrowserSDKVersion}
-            placeholder={t('4.x')}
+            placeholder="7.x"
             allowClear={false}
             disabled={!hasAccess}
           />

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -7,13 +7,11 @@ import {
 } from 'sentry/actionCreators/indicator';
 import Access from 'sentry/components/acl/access';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
-import FieldHelp from 'sentry/components/forms/fieldGroup/fieldHelp';
 import BooleanField from 'sentry/components/forms/fields/booleanField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import ExternalLink from 'sentry/components/links/externalLink';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
@@ -181,10 +179,6 @@ export function LoaderSettings({keyId, orgSlug, projectId, projectKey}: Props) {
             <TextCopyInput>
               {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
             </TextCopyInput>
-
-            <FieldHelp style={{paddingTop: space(1)}}>
-              {t('Note that it can take a few minutes until changed options are live.')}
-            </FieldHelp>
           </FieldGroup>
 
           <SelectField

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -170,7 +170,7 @@ export function LoaderSettings({keyId, organizationId, projectId, projectKey}: P
               {
                 link: (
                   <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/lazy-load-sentry/">
-                    What does the script provide?
+                   {t(' What does the script provide?')}
                   </ExternalLink>
                 ),
               }
@@ -199,7 +199,7 @@ export function LoaderSettings({keyId, organizationId, projectId, projectKey}: P
                 : []
             }
             value={browserSdkVersion}
-            onChange={value => handleUpdateBrowserSDKVersion(value)}
+            onChange={handleUpdateBrowserSDKVersion}
             placeholder={t('4.x')}
             allowClear={false}
             disabled={!hasAccess}

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -1,0 +1,259 @@
+import {Fragment, useCallback, useEffect, useState} from 'react';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import Access from 'sentry/components/acl/access';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import BooleanField from 'sentry/components/forms/fields/booleanField';
+import SelectField from 'sentry/components/forms/fields/selectField';
+import ExternalLink from 'sentry/components/links/externalLink';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t, tct} from 'sentry/locale';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import useApi from 'sentry/utils/useApi';
+import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
+
+type Props = {
+  keyId: string;
+  organizationId: string;
+  projectId: string;
+  projectKey: ProjectKey;
+};
+
+export enum DynamicSDKLoaderOption {
+  HAS_DEBUG = 'hasDebug',
+  HAS_PERFORMANCE = 'hasPerformance',
+  HAS_REPLAY = 'hasReplay',
+}
+
+export const sdkLoaderOptions = {
+  [DynamicSDKLoaderOption.HAS_PERFORMANCE]: {
+    label: t('Enable Performance Monitoring'),
+    requiresV7: true,
+  },
+  [DynamicSDKLoaderOption.HAS_REPLAY]: {
+    label: t('Enable Session Replay'),
+    requiresV7: true,
+  },
+  [DynamicSDKLoaderOption.HAS_DEBUG]: {
+    label: t('Enable Debug Bundles & Logging'),
+    requiresV7: false,
+  },
+};
+
+export function LoaderSettings({keyId, organizationId, projectId, projectKey}: Props) {
+  const api = useApi();
+  const [browserSdkVersion, setBrowserSdkVersion] = useState(
+    projectKey.browserSdkVersion
+  );
+  const [dynamicSDKLoaderOptions, setDynamicSDKLoaderOptions] = useState(
+    projectKey.dynamicSdkLoaderOptions
+  );
+
+  useEffect(() => {
+    setBrowserSdkVersion(projectKey.browserSdkVersion);
+  }, [projectKey.browserSdkVersion]);
+
+  useEffect(() => {
+    setDynamicSDKLoaderOptions(projectKey.dynamicSdkLoaderOptions);
+  }, [projectKey.dynamicSdkLoaderOptions]);
+
+  const apiEndpoint = `/projects/${organizationId}/${projectId}/keys/${keyId}/`;
+  const loaderLink = getDynamicText({
+    value: projectKey.dsn.cdn,
+    fixed: '__JS_SDK_LOADER_URL__',
+  });
+
+  const handleToggleDynamicSDKLoaderOption = useCallback(
+    async <T extends typeof dynamicSDKLoaderOptions, K extends keyof T>(
+      dynamicSdkLoaderOption: K,
+      value: T[K]
+    ) => {
+      const newDynamicSdkLoaderOptions = Object.keys(dynamicSDKLoaderOptions).reduce(
+        (acc, key) => {
+          if (key === dynamicSdkLoaderOption) {
+            return {...acc, [key]: value};
+          }
+          return {...acc, [key]: dynamicSDKLoaderOptions[key]};
+        },
+        {}
+      );
+
+      addLoadingMessage();
+
+      try {
+        const response = await api.requestPromise(apiEndpoint, {
+          method: 'PUT',
+          data: {
+            dynamicSdkLoaderOptions: newDynamicSdkLoaderOptions,
+          },
+        });
+
+        setDynamicSDKLoaderOptions(response.dynamicSdkLoaderOptions);
+
+        addSuccessMessage(t('Successfully updated dynamic SDK loader configuration'));
+      } catch (error) {
+        const message = t('Unable to updated dynamic SDK loader configuration');
+        handleXhrErrorResponse(message)(error);
+        addErrorMessage(message);
+      }
+    },
+    [api, apiEndpoint, dynamicSDKLoaderOptions, setDynamicSDKLoaderOptions]
+  );
+
+  const handleUpdateBrowserSDKVersion = useCallback(
+    async (newBrowserSDKVersion: typeof browserSdkVersion) => {
+      addLoadingMessage();
+
+      const apiData: {
+        browserSdkVersion: typeof browserSdkVersion;
+        dynamicSdkLoaderOptions?: Partial<Record<DynamicSDKLoaderOption, boolean>>;
+      } = {
+        browserSdkVersion: newBrowserSDKVersion,
+      };
+
+      const shouldRestrictDynamicSdkLoaderOptions =
+        !sdkVersionSupportsPerformanceAndReplay(newBrowserSDKVersion);
+
+      if (shouldRestrictDynamicSdkLoaderOptions) {
+        // Performance & Replay are not supported before 7.x
+        const newDynamicSdkLoaderOptions = {
+          ...dynamicSDKLoaderOptions,
+          hasPerformance: false,
+          hasReplay: false,
+        };
+
+        apiData.dynamicSdkLoaderOptions = newDynamicSdkLoaderOptions;
+      }
+
+      try {
+        const response = await api.requestPromise(apiEndpoint, {
+          method: 'PUT',
+          data: apiData,
+        });
+
+        setBrowserSdkVersion(response.browserSdkVersion);
+
+        if (shouldRestrictDynamicSdkLoaderOptions) {
+          setDynamicSDKLoaderOptions(response.dynamicSdkLoaderOptions);
+        }
+
+        addSuccessMessage(t('Successfully updated SDK version'));
+      } catch (error) {
+        const message = t('Unable to updated SDK version');
+        handleXhrErrorResponse(message)(error);
+        addErrorMessage(message);
+      }
+    },
+    [
+      api,
+      apiEndpoint,
+      setBrowserSdkVersion,
+      setDynamicSDKLoaderOptions,
+      dynamicSDKLoaderOptions,
+    ]
+  );
+
+  return (
+    <Access access={['project:write']}>
+      {({hasAccess}) => (
+        <Fragment>
+          <FieldGroup
+            help={tct(
+              'Copy this script into your website to setup your JavaScript SDK without any additional configuration. [link]',
+              {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/lazy-load-sentry/">
+                    What does the script provide?
+                  </ExternalLink>
+                ),
+              }
+            )}
+            inline={false}
+            flexibleControlStateSize
+          >
+            <TextCopyInput>
+              {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
+            </TextCopyInput>
+          </FieldGroup>
+          <SelectField
+            name="browserSdkVersion"
+            label={t('SDK Version')}
+            options={
+              projectKey.browserSdk
+                ? projectKey.browserSdk.choices.map(([value, label]) => ({
+                    value,
+                    label,
+                  }))
+                : []
+            }
+            value={browserSdkVersion}
+            onChange={value => handleUpdateBrowserSDKVersion(value)}
+            placeholder={t('4.x')}
+            allowClear={false}
+            disabled={!hasAccess}
+          />
+
+          {Object.entries(sdkLoaderOptions).map(([key, value]) => {
+            const sdkLoaderOption = Object.keys(dynamicSDKLoaderOptions).find(
+              dynamicSdkLoaderOption => dynamicSdkLoaderOption === key
+            );
+
+            if (!sdkLoaderOption) {
+              return null;
+            }
+
+            return (
+              <BooleanField
+                label={value.label}
+                key={key}
+                name={key}
+                value={
+                  value.requiresV7 &&
+                  !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
+                    ? false
+                    : dynamicSDKLoaderOptions[sdkLoaderOption]
+                }
+                onChange={() =>
+                  handleToggleDynamicSDKLoaderOption(
+                    sdkLoaderOption as DynamicSDKLoaderOption,
+                    !dynamicSDKLoaderOptions[sdkLoaderOption]
+                  )
+                }
+                disabled={
+                  !hasAccess ||
+                  (value.requiresV7 &&
+                    !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion))
+                }
+                help={
+                  value.requiresV7 &&
+                  !sdkVersionSupportsPerformanceAndReplay(browserSdkVersion)
+                    ? t('Only available in SDK version 7.x and above')
+                    : key === DynamicSDKLoaderOption.HAS_REPLAY &&
+                      dynamicSDKLoaderOptions[sdkLoaderOption]
+                    ? t(
+                        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+                      )
+                    : undefined
+                }
+                disabledReason={
+                  !hasAccess
+                    ? t('You do not have permission to edit this setting')
+                    : undefined
+                }
+              />
+            );
+          })}
+        </Fragment>
+      )}
+    </Access>
+  );
+}
+
+function sdkVersionSupportsPerformanceAndReplay(sdkVersion: string): boolean {
+  return sdkVersion === 'latest' || sdkVersion === '7.x';
+}

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -7,11 +7,13 @@ import {
 } from 'sentry/actionCreators/indicator';
 import Access from 'sentry/components/acl/access';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
+import FieldHelp from 'sentry/components/forms/fieldGroup/fieldHelp';
 import BooleanField from 'sentry/components/forms/fields/booleanField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import ExternalLink from 'sentry/components/links/externalLink';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
@@ -179,7 +181,12 @@ export function LoaderSettings({keyId, organizationId, projectId, projectKey}: P
             <TextCopyInput>
               {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
             </TextCopyInput>
+
+            <FieldHelp style={{paddingTop: space(1)}}>
+              {t('Note that it can take a few minutes until changed options are live.')}
+            </FieldHelp>
           </FieldGroup>
+
           <SelectField
             name="browserSdkVersion"
             label={t('SDK Version')}

--- a/static/app/views/settings/project/projectKeys/list/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.jsx
@@ -73,11 +73,11 @@ describe('ProjectKeys', function () {
       />
     );
 
-    const allDsn = screen.queryAllByRole('textbox', {name: 'DSN URL'});
+    const allDsn = screen.getAllByRole('textbox', {name: 'DSN URL'});
     expect(allDsn.length).toBe(1);
 
-    const expandButton = screen.queryByRole('button', {name: 'Expand'});
-    const dsn = screen.queryByRole('textbox', {name: 'DSN URL'});
+    const expandButton = screen.getByRole('button', {name: 'Expand'});
+    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
@@ -107,7 +107,7 @@ describe('ProjectKeys', function () {
     );
 
     const expandButton = screen.queryByRole('button', {name: 'Expand'});
-    const dsn = screen.queryByRole('textbox', {name: 'DSN URL'});
+    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
@@ -136,7 +136,7 @@ describe('ProjectKeys', function () {
     );
 
     const expandButton = screen.queryByRole('button', {name: 'Expand'});
-    const dsn = screen.queryByRole('textbox', {name: 'DSN URL'});
+    const dsn = screen.getByRole('textbox', {name: 'DSN URL'});
     const minidumpEndpoint = screen.queryByRole('textbox', {
       name: 'Minidump Endpoint URL',
     });
@@ -209,7 +209,7 @@ describe('ProjectKeys', function () {
       />
     );
 
-    const allDsn = screen.queryAllByRole('textbox', {name: 'DSN URL'});
+    const allDsn = screen.getAllByRole('textbox', {name: 'DSN URL'});
     expect(allDsn.length).toBe(2);
   });
 

--- a/static/app/views/settings/project/projectKeys/list/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.jsx
@@ -155,7 +155,7 @@ describe('ProjectKeys', function () {
   });
 
   it('renders multiple keys', function () {
-    projectKeys = TestStubs.ProjectKeys([
+    const multipleProjectKeys = TestStubs.ProjectKeys([
       {
         dsn: {
           secret:
@@ -197,7 +197,7 @@ describe('ProjectKeys', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/keys/`,
       method: 'GET',
-      body: projectKeys,
+      body: multipleProjectKeys,
     });
 
     render(

--- a/static/app/views/settings/project/projectKeys/list/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.jsx
@@ -63,6 +63,156 @@ describe('ProjectKeys', function () {
     expect(expandButton).not.toBeInTheDocument();
   });
 
+  it('renders for default project', function () {
+    render(
+      <ProjectKeys
+        routes={[]}
+        organization={org}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'other'})}
+      />
+    );
+
+    const allDsn = screen.queryAllByRole('textbox', {name: 'DSN URL'});
+    expect(allDsn.length).toBe(1);
+
+    const expandButton = screen.queryByRole('button', {name: 'Expand'});
+    const dsn = screen.queryByRole('textbox', {name: 'DSN URL'});
+    const minidumpEndpoint = screen.queryByRole('textbox', {
+      name: 'Minidump Endpoint URL',
+    });
+    const unrealEndpoint = screen.queryByRole('textbox', {
+      name: 'Unreal Engine 4 Endpoint URL',
+    });
+    const securityHeaderEndpoint = screen.queryByRole('textbox', {
+      name: 'Security Header Endpoint URL',
+    });
+
+    expect(expandButton).toBeInTheDocument();
+    expect(dsn).toHaveValue(projectKeys[0].dsn.public);
+    expect(minidumpEndpoint).toHaveValue(projectKeys[0].dsn.minidump);
+    // this is empty in the default ProjectKey
+    expect(unrealEndpoint).toHaveValue('');
+    expect(securityHeaderEndpoint).toHaveValue(projectKeys[0].dsn.security);
+  });
+
+  it('renders for javascript project', function () {
+    render(
+      <ProjectKeys
+        routes={[]}
+        organization={org}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'javascript'})}
+      />
+    );
+
+    const expandButton = screen.queryByRole('button', {name: 'Expand'});
+    const dsn = screen.queryByRole('textbox', {name: 'DSN URL'});
+    const minidumpEndpoint = screen.queryByRole('textbox', {
+      name: 'Minidump Endpoint URL',
+    });
+    const unrealEndpoint = screen.queryByRole('textbox', {
+      name: 'Unreal Engine 4 Endpoint URL',
+    });
+    const securityHeaderEndpoint = screen.queryByRole('textbox', {
+      name: 'Security Header Endpoint URL',
+    });
+
+    expect(expandButton).not.toBeInTheDocument();
+    expect(dsn).toHaveValue(projectKeys[0].dsn.public);
+    expect(minidumpEndpoint).not.toBeInTheDocument();
+    expect(unrealEndpoint).not.toBeInTheDocument();
+    expect(securityHeaderEndpoint).not.toBeInTheDocument();
+  });
+
+  it('renders for javascript-react project', function () {
+    render(
+      <ProjectKeys
+        routes={[]}
+        organization={org}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'javascript-react'})}
+      />
+    );
+
+    const expandButton = screen.queryByRole('button', {name: 'Expand'});
+    const dsn = screen.queryByRole('textbox', {name: 'DSN URL'});
+    const minidumpEndpoint = screen.queryByRole('textbox', {
+      name: 'Minidump Endpoint URL',
+    });
+    const unrealEndpoint = screen.queryByRole('textbox', {
+      name: 'Unreal Engine 4 Endpoint URL',
+    });
+    const securityHeaderEndpoint = screen.queryByRole('textbox', {
+      name: 'Security Header Endpoint URL',
+    });
+
+    expect(expandButton).not.toBeInTheDocument();
+    expect(dsn).toHaveValue(projectKeys[0].dsn.public);
+    expect(minidumpEndpoint).not.toBeInTheDocument();
+    expect(unrealEndpoint).not.toBeInTheDocument();
+    expect(securityHeaderEndpoint).not.toBeInTheDocument();
+  });
+
+  it('renders multiple keys', function () {
+    projectKeys = TestStubs.ProjectKeys([
+      {
+        dsn: {
+          secret:
+            'http://188ee45a58094d939428d8585aa6f662:a33bf9aba64c4bbdaf873bb9023b6d2c@dev.getsentry.net:8000/1',
+          minidump:
+            'http://dev.getsentry.net:8000/api/1/minidump?sentry_key=188ee45a58094d939428d8585aa6f662',
+          public: 'http://188ee45a58094d939428d8585aa6f662@dev.getsentry.net:8000/1',
+          csp: 'http://dev.getsentry.net:8000/api/1/csp-report/?sentry_key=188ee45a58094d939428d8585aa6f662',
+          security:
+            'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f662',
+        },
+        public: '188ee45a58094d939428d8585aa6f662',
+        secret: 'a33bf9aba64c4bbdaf873bb9023b6d2c',
+        name: 'Key 2',
+        rateLimit: null,
+        projectId: 1,
+        dateCreated: '2018-02-28T07:13:51.087Z',
+        id: '188ee45a58094d939428d8585aa6f662',
+        isActive: true,
+        label: 'Key 2',
+        browserSdkVersion: 'latest',
+        browserSdk: {
+          choices: [
+            ['latest', 'latest'],
+            ['7.x', '7.x'],
+            ['6.x', '6.x'],
+            ['5.x', '5.x'],
+            ['4.x', '4.x'],
+          ],
+        },
+        dynamicSdkLoaderOptions: {
+          hasPerformance: false,
+          hasReplay: false,
+          hasDebug: false,
+        },
+      },
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/keys/`,
+      method: 'GET',
+      body: projectKeys,
+    });
+
+    render(
+      <ProjectKeys
+        routes={[]}
+        organization={org}
+        params={{projectId: project.slug}}
+        project={TestStubs.Project({platform: 'other'})}
+      />
+    );
+
+    const allDsn = screen.queryAllByRole('textbox', {name: 'DSN URL'});
+    expect(allDsn.length).toBe(2);
+  });
+
   it('deletes key', async function () {
     render(
       <ProjectKeys

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -157,6 +157,7 @@ class ProjectKeys extends AsyncView<Props, State> {
             key={key.id}
             orgId={organization.slug}
             projectId={`${projectId}`}
+            project={this.props.project}
             data={key}
             onToggle={this.handleToggleKey}
             onRemove={this.handleRemoveKey}

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -9,7 +9,7 @@ import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Scope} from 'sentry/types';
+import {Project, Scope} from 'sentry/types';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import ProjectKeyCredentials from 'sentry/views/settings/project/projectKeys/projectKeyCredentials';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
@@ -20,15 +20,28 @@ type Props = {
   onRemove: (data: ProjectKey) => void;
   onToggle: (isActive: boolean, data: ProjectKey) => void;
   orgId: string;
+  project: Project;
   projectId: string;
 } & Pick<RouteComponentProps<{}, {}>, 'routes' | 'location' | 'params'>;
 
-function KeyRow({data, onRemove, onToggle, access, routes, location, params}: Props) {
+function KeyRow({
+  data,
+  onRemove,
+  onToggle,
+  access,
+  routes,
+  location,
+  params,
+  project,
+}: Props) {
   const handleEnable = () => onToggle(true, data);
   const handleDisable = () => onToggle(false, data);
 
   const editUrl = recreateRoute(`${data.id}/`, {routes, params, location});
   const controlActive = access.has('project:write');
+
+  const platform = project.platform || 'other';
+  const isJsPlatform = platform === 'javascript' || platform.startsWith('javascript-');
 
   return (
     <Panel>
@@ -77,9 +90,19 @@ function KeyRow({data, onRemove, onToggle, access, routes, location, params}: Pr
         </Controls>
       </PanelHeader>
 
-      <StyledClippedBox clipHeight={300} defaultClipped btnText={t('Expand')}>
+      <StyledClippedBox
+        clipHeight={300}
+        defaultClipped={!isJsPlatform}
+        btnText={t('Expand')}
+      >
         <StyledPanelBody disabled={!data.isActive}>
-          <ProjectKeyCredentials projectId={`${data.projectId}`} data={data} />
+          <ProjectKeyCredentials
+            projectId={`${data.projectId}`}
+            data={data}
+            showMinidump={!isJsPlatform}
+            showUnreal={!isJsPlatform}
+            showSecurityEndpoint={!isJsPlatform}
+          />
         </StyledPanelBody>
       </StyledClippedBox>
     </Panel>

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -103,7 +103,7 @@ function ProjectKeyCredentials({
           help={tct('Use your security header endpoint for features like [link].', {
             link: (
               <ExternalLink href="https://docs.sentry.io/product/security-policy-reporting/">
-                CSP and Expect-CT reports
+             {t('CSP and Expect-CT reports')}
               </ExternalLink>
             ),
           })}

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -100,9 +100,13 @@ function ProjectKeyCredentials({
       {showSecurityEndpoint && (
         <FieldGroup
           label={t('Security Header Endpoint')}
-          help={t(
-            'Use your security header endpoint for features like CSP and Expect-CT reports.'
-          )}
+          help={tct('Use your security header endpoint for features like [link].', {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/product/security-policy-reporting/">
+                CSP and Expect-CT reports
+              </ExternalLink>
+            ),
+          })}
           inline={false}
           flexibleControlStateSize
         >

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -52,7 +52,7 @@ function ProjectKeyCredentials({
             ) : null,
           })}
         >
-          <TextCopyInput>
+          <TextCopyInput aria-label={t('DSN URL')}>
             {getDynamicText({
               value: data.dsn.public,
               fixed: '__DSN__',
@@ -110,7 +110,7 @@ function ProjectKeyCredentials({
           inline={false}
           flexibleControlStateSize
         >
-          <TextCopyInput>
+          <TextCopyInput aria-label={t('Security Header Endpoint URL')}>
             {getDynamicText({
               value: data.dsn.security,
               fixed: '__SECURITY_HEADER_ENDPOINT__',
@@ -135,7 +135,7 @@ function ProjectKeyCredentials({
           inline={false}
           flexibleControlStateSize
         >
-          <TextCopyInput>
+          <TextCopyInput aria-label={t('Minidump Endpoint URL')}>
             {getDynamicText({
               value: data.dsn.minidump,
               fixed: '__MINIDUMP_ENDPOINT__',
@@ -151,7 +151,7 @@ function ProjectKeyCredentials({
           inline={false}
           flexibleControlStateSize
         >
-          <TextCopyInput>
+          <TextCopyInput aria-label={t('Unreal Engine 4 Endpoint URL')}>
             {getDynamicText({
               value: data.dsn.unreal || '',
               fixed: '__UNREAL_ENDPOINT__',

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -103,7 +103,7 @@ function ProjectKeyCredentials({
           help={tct('Use your security header endpoint for features like [link].', {
             link: (
               <ExternalLink href="https://docs.sentry.io/product/security-policy-reporting/">
-             {t('CSP and Expect-CT reports')}
+                {t('CSP and Expect-CT reports')}
               </ExternalLink>
             ),
           })}


### PR DESCRIPTION
This implements a few small improvements for the Project Settings > Client Keys (DSN) overview page:

* Add a link to the "CSP Reporting Endpoint" with more information
![image](https://user-images.githubusercontent.com/2411343/232740767-cc32484f-235d-4dc4-bd00-4cb8ae68acc7.png)
* Do not show Unreal, Minidump & CSP Reporting Endpoint URLs on overview page for javascript projects - they are not needed there
![image](https://user-images.githubusercontent.com/2411343/232737951-701f165f-8013-404f-9d82-0a6b49830dbc.png)
* Extract the loader settings component into a separate file for better composition - we may want to change this in the future, and having this split out makes future adjustments easier here.
* Streamline label of Loader settings "SDK Version" option:
![image](https://user-images.githubusercontent.com/2411343/232742342-cbaec47e-08a4-42b2-ae8e-6f43be44d611.png)
Instead of a label, we used to show "Select the version of the SDK that should be loaded. Note that it can take a few minutes until this change is live." there. IMHO this info does not relate to the SDK option anymore (but to all options, technically), and it makes more sense to have these all be labels there. Instead, I added this note below the script, where it is more obvious that this applies to all settings. For reference, this is how this looked before:
![image](https://user-images.githubusercontent.com/2411343/232742939-2ae6c27a-8150-4613-9592-4c0d3a3bfc48.png)

I also added some tests covering these different scenarios.

Related to https://github.com/getsentry/sentry/issues/47460