### PR TITLE
feat(loader): Ensure new projects cannot select old SDK versions in loader

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -33,7 +33,7 @@ class ProjectKeySerializer(Serializer):
                 "cdn": obj.js_sdk_loader_cdn_url,
             },
             "browserSdkVersion": get_selected_browser_sdk_version(obj),
-            "browserSdk": {"choices": get_browser_sdk_version_choices()},
+            "browserSdk": {"choices": get_browser_sdk_version_choices(obj.project)},
             "dateCreated": obj.date_added,
             "dynamicSdkLoaderOptions": {
                 "hasReplay": get_dynamic_sdk_loader_option(obj, DynamicSdkLoaderOption.HAS_REPLAY),

--- a/src/sentry/api/serializers/rest_framework/project_key.py
+++ b/src/sentry/api/serializers/rest_framework/project_key.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from sentry.api.fields.empty_integer import EmptyIntegerField
-from sentry.loader.browsersdkversion import get_browser_sdk_version_choices
+from sentry.loader.browsersdkversion import get_all_browser_sdk_version_choices
 from sentry.loader.dynamic_sdk_options import DynamicSdkLoaderOption
 
 
@@ -34,7 +34,7 @@ class ProjectKeySerializer(serializers.Serializer):
     rateLimit = RateLimitSerializer(required=False, allow_null=True)
     isActive = serializers.BooleanField(required=False)
     browserSdkVersion = serializers.ChoiceField(
-        choices=get_browser_sdk_version_choices(), required=False
+        choices=get_all_browser_sdk_version_choices(), required=False
     )
     dynamicSdkLoaderOptions = DynamicSdkLoaderOptionSerializer(
         required=False, allow_null=True, partial=True

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -36,13 +36,24 @@ def get_highest_browser_sdk_version(versions):
     )
 
 
-def get_browser_sdk_version_versions():
+def get_all_browser_sdk_version_versions():
     return ["latest", "7.x", "6.x", "5.x", "4.x"]
 
 
-def get_browser_sdk_version_choices():
+def get_all_browser_sdk_version_choices():
+    versions = get_all_browser_sdk_version_versions()
+
     rv = []
-    for version in get_browser_sdk_version_versions():
+    for version in versions:
+        rv.append((version, version))
+    return tuple(rv)
+
+
+def get_browser_sdk_version_choices(project):
+    versions = get_available_sdk_versions_for_project(project)
+
+    rv = []
+    for version in versions:
         rv.append((version, version))
     return tuple(rv)
 
@@ -82,3 +93,7 @@ def get_selected_browser_sdk_version(project_key):
 
 def get_default_sdk_version_for_project(project):
     return project.get_option("sentry:default_loader_version")
+
+
+def get_available_sdk_versions_for_project(project):
+    return project.get_option("sentry:loader_available_sdk_versions")

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -1,7 +1,7 @@
 from sentry.projectoptions import register
 
 # latest epoch
-LATEST_EPOCH = 10
+LATEST_EPOCH = 11
 
 # grouping related configs
 #
@@ -135,4 +135,10 @@ register(
             "hasReplay": True,
         }
     },
+)
+
+# The available loader SDK versions
+register(
+    key="sentry:loader_available_sdk_versions",
+    epoch_defaults={1: ["latest", "7.x", "6.x", "5.x", "4.x"], 11: ["latest", "7.x"]},
 )

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.conf import settings
 
 from sentry.loader.browsersdkversion import (
-    get_browser_sdk_version_versions,
+    get_all_browser_sdk_version_versions,
     get_highest_browser_sdk_version,
     match_selected_version_to_browser_sdk_version,
 )
@@ -22,9 +22,9 @@ MOCK_VERSIONS = [
 
 
 class BrowserSdkVersionTestCase(TestCase):
-    def test_get_browser_sdk_version_versions(self):
-        assert "latest" in get_browser_sdk_version_versions()
-        assert "4.x" in get_browser_sdk_version_versions()
+    def test_get_all_browser_sdk_version_versions(self):
+        assert "latest" in get_all_browser_sdk_version_versions()
+        assert "4.x" in get_all_browser_sdk_version_versions()
 
     @mock.patch(
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS


### PR DESCRIPTION
We should not allow users to select SDK versions below 7 for new sentry projects in the loader.

This adds a new epoch, so any newly created projects will only be able to select 7 & latest as SDK versions.