### PR TITLE
fix(performance): Add tooltip to transaction name if overflown

### DIFF
--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {Button} from 'sentry/components/button';
@@ -20,6 +21,7 @@ import {TransactionProfileIdProvider} from 'sentry/components/profiling/transact
 import {TransactionToProfileButton} from 'sentry/components/profiling/transactionToProfileButton';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {TagsTable} from 'sentry/components/tagsTable';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
@@ -184,7 +186,11 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                       }}
                       eventSlug={eventSlug}
                     />
-                    <Layout.Title data-test-id="event-header">{event.title}</Layout.Title>
+                    <Layout.Title data-test-id="event-header">
+                      <Tooltip showOnlyOnOverflow skipWrapper title={transactionName}>
+                        <EventTitle>{event.title}</EventTitle>
+                      </Tooltip>
+                    </Layout.Title>
                   </Layout.HeaderContent>
                   <Layout.HeaderActions>
                     <ButtonBar gap={1}>
@@ -351,5 +357,9 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     );
   }
 }
+
+const EventTitle = styled('div')`
+  ${p => p.theme.overflowEllipsis}
+`;
 
 export default withRouteAnalytics(EventDetailsContent);

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo} from 'react';
+import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
@@ -12,6 +13,7 @@ import ReplayCountBadge from 'sentry/components/replays/replayCountBadge';
 import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import useReplaysCount from 'sentry/components/replays/useReplaysCount';
 import {TabList} from 'sentry/components/tabs';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -137,7 +139,9 @@ function TransactionHeader({
               avatarProps={{hasTooltip: true, tooltip: project.slug}}
             />
           )}
-          {transactionName}
+          <Tooltip showOnlyOnOverflow skipWrapper title={transactionName}>
+            <TransactionName>{transactionName}</TransactionName>
+          </Tooltip>
         </Layout.Title>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
@@ -236,5 +240,11 @@ function TransactionHeader({
     </Layout.Header>
   );
 }
+
+const TransactionName = styled('div')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+`;
 
 export default TransactionHeader;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -242,9 +242,7 @@ function TransactionHeader({
 }
 
 const TransactionName = styled('div')`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  flex: 1;
+  ${p => p.theme.overflowEllipsis}
 `;
 
 export default TransactionHeader;


### PR DESCRIPTION
If the transaction name is long and overflows, then the name should have an ellipse and tooltip on hover for readability. Adds it to the transaction summary and transaction details pages.

https://user-images.githubusercontent.com/22846452/232826308-b12323d0-d9e6-4500-a452-e5c112418058.mov

Closes #47378 