### PR TITLE
fix(profiling): Dedupe frames in sentry sampled format

### DIFF
--- a/static/app/utils/profiling/profile/utils.spec.tsx
+++ b/static/app/utils/profiling/profile/utils.spec.tsx
@@ -1,7 +1,51 @@
+import {Frame} from 'sentry/utils/profiling/frame';
 import {
+  createSentrySampleProfileFrameIndex,
   memoizeByReference,
   memoizeVariadicByReference,
 } from 'sentry/utils/profiling/profile/utils';
+
+describe('createSentrySampleProfileFrameIndex', () => {
+  it('dedupes frames', () => {
+    const frameIndex = createSentrySampleProfileFrameIndex([
+      {
+        in_app: true,
+        function: 'foo',
+        lineno: 100,
+      },
+      {
+        in_app: true,
+        function: 'bar',
+        lineno: 105,
+      },
+      {
+        in_app: true,
+        function: 'foo',
+        lineno: 100,
+      },
+    ]);
+
+    const fooFrame = new Frame({
+      key: 0,
+      is_application: true,
+      name: 'foo',
+      line: 100,
+    });
+
+    const barFrame = new Frame({
+      key: 1,
+      is_application: true,
+      name: 'bar',
+      line: 105,
+    });
+
+    expect(frameIndex).toEqual({
+      0: fooFrame,
+      1: barFrame,
+      2: fooFrame,
+    });
+  });
+});
 
 describe('memoizeByReference', () => {
   it('doesnt crash w/o args', () => {

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -18,12 +18,10 @@ export function createSentrySampleProfileFrameIndex(
   for (let i = 0; i < frames.length; i++) {
     const frame = frames[i];
     const frameKey = [
-      frame.function ?? 'unknown',
-      frame.abs_path ?? '',
       frame.filename ?? '',
-      frame.module ?? '',
-      frame.package ?? '',
+      frame.function ?? 'unknown',
       String(frame.lineno) ?? '',
+      frame.instruction_addr ?? '',
     ].join(':');
 
     let index = framesIndex[frameKey];

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -11,28 +11,50 @@ type FrameIndex = Record<string | number, Frame>;
 export function createSentrySampleProfileFrameIndex(
   frames: Profiling.SentrySampledProfile['profile']['frames']
 ): FrameIndex {
-  const frameIndex: FrameIndex = {};
+  const framesList: Frame[] = [];
+  const framesIndex: Record<string, number> = {};
+  const indices: number[] = [];
 
   for (let i = 0; i < frames.length; i++) {
     const frame = frames[i];
+    const frameKey = [
+      frame.function ?? 'unknown',
+      frame.abs_path ?? '',
+      frame.filename ?? '',
+      frame.module ?? '',
+      frame.package ?? '',
+      String(frame.lineno) ?? '',
+    ].join(':');
 
-    frameIndex[i] = new Frame({
-      key: i,
-      is_application: frame.in_app,
-      file: frame.filename,
-      path: frame.abs_path,
-      module: frame.module,
-      package: frame.package,
-      name: frame.function ?? 'unknown',
-      line: frame.lineno,
-      column: frame.colno,
-      instructionAddr: frame.instruction_addr,
-      symbol: frame.symbol,
-      symbolAddr: frame.sym_addr,
-      symbolicatorStatus: frame.status,
-    });
+    let index = framesIndex[frameKey];
+    if (!defined(index)) {
+      index = framesList.length;
+      framesIndex[frameKey] = index;
+      framesList.push(
+        new Frame({
+          key: i,
+          is_application: frame.in_app,
+          file: frame.filename,
+          path: frame.abs_path,
+          module: frame.module,
+          package: frame.package,
+          name: frame.function ?? 'unknown',
+          line: frame.lineno,
+          column: frame.colno,
+          instructionAddr: frame.instruction_addr,
+          symbol: frame.symbol,
+          symbolAddr: frame.sym_addr,
+          symbolicatorStatus: frame.status,
+        })
+      );
+    }
+    indices.push(index);
   }
 
+  const frameIndex: FrameIndex = {};
+  for (let i = 0; i < indices.length; i++) {
+    frameIndex[i] = framesList[indices[i]];
+  }
   return frameIndex;
 }
 

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -17,12 +17,9 @@ export function createSentrySampleProfileFrameIndex(
 
   for (let i = 0; i < frames.length; i++) {
     const frame = frames[i];
-    const frameKey = [
-      frame.filename ?? '',
-      frame.function ?? 'unknown',
-      String(frame.lineno) ?? '',
-      frame.instruction_addr ?? '',
-    ].join(':');
+    const frameKey = `${frame.filename ?? ''}:${frame.function ?? 'unknown'}:${
+      String(frame.lineno) ?? ''
+    }:${frame.instruction_addr ?? ''}`;
 
     let index = framesIndex[frameKey];
     if (!defined(index)) {


### PR DESCRIPTION
It is not a requirement that the sdks dedupe frames meaning it's possible that the same frame appears multiple times with different indices. This change ensures that we dedupe the frames prior to rendering so that identical frames can be properly merged.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/232838136-1a6abf8c-8e0f-47c5-afc3-138b6e3167ef.png)

## After

![image](https://user-images.githubusercontent.com/10239353/232838078-55f51622-a72a-46cc-b1d8-4103d68797ac.png)
