### PR TITLE
fix: Add devinfra as reserved slug

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -116,6 +116,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "customers",
         "debug",
         "demo",
+        "devinfra",
         "docs",
         "enterprise",
         "eu1",


### PR DESCRIPTION
pypi.devinfra.sentry.io is a real thing.
