### PR TITLE
ref(analytics): create trackAnalytics function

### DIFF
--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -3,6 +3,7 @@ import {Transaction} from '@sentry/types';
 
 import HookStore from 'sentry/stores/hookStore';
 import {Hooks} from 'sentry/types/hooks';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 
 /**
  * Analytics and metric tracking functionality.
@@ -21,6 +22,16 @@ import {Hooks} from 'sentry/types/hooks';
  *
  *       https://github.com/getsentry/reload/blob/master/reload_app/metrics/__init__.py
  */
+
+/**
+ * This should be with all analytics events regardless of the analytics destination
+ * which includes Reload, Amplitude, and Google Analytics.
+ * All events go to Reload. If eventName is defined, events also go to Amplitude.
+ * For more details, refer to makeAnalyticsFunction.
+ *
+ * Should be used for all analytics that are defined in Sentry.
+ */
+export const trackAnalytics = trackAdvancedAnalyticsEvent;
 
 /**
  * This should be with all analytics events regardless of the analytics destination


### PR DESCRIPTION
This PR creates an alias for `trackAdvancedAnalyticsEvent` to `trackAnalytics`. Now that we've removed the old analytics functions, we can simplify the new stuff. We will replace `trackAdvancedAnalyticsEvent` with `trackAnalytics` in the next few days with this aliased function.

Before:
```
import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
```

After:
```
import {trackAnalytics} from 'sentry/utils/analytics';
```