### PR TITLE
fix: Use FailoverRedis by default [INC-311]

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -235,7 +235,7 @@ class _RedisCluster:
                 return (
                     import_string(config["client_class"])
                     if "client_class" in config
-                    else StrictRedis
+                    else FailoverRedis
                 )(**host)
 
         return SimpleLazyObject(cluster_factory)

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -28,10 +28,6 @@ make_manager = functools.partial(
             "foo": {"hosts": {0: {"db": 0}}},
             "bar": {"hosts": {0: {"db": 0}, 1: {"db": 1}}},
             "baz": {"is_redis_cluster": True, "hosts": {0: {}}},
-            "failover": {
-                "client_class": "sentry.utils.redis.FailoverRedis",
-                "hosts": {0: {"db": 0}},
-            },
         }
     },
 )
@@ -59,9 +55,7 @@ class ClusterManagerTestCase(TestCase):
         # object to verify it's correct.
 
         # cluster foo is fine since it's a single node, without specific client_class
-        assert manager.get("foo")._setupfunc() is StrictRedis.return_value
-        # failover cluster is single host and specifies client_class to FailoverRedis
-        assert manager.get("failover")._setupfunc() is FailoverRedis.return_value
+        assert manager.get("foo")._setupfunc() is FailoverRedis.return_value
         # baz works becasue it's explicitly is_redis_cluster
         assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value
 


### PR DESCRIPTION
FailoverRedis works fine with other kinds of single-node setups. Let's
just use it by default, people typically forget about it and then we get
incidents like INC-311.

See also https://github.com/getsentry/snuba/pull/4035 -- we can't use
sentry-redis-tools yet though, I first want to try and upgrade the redis
package in Sentry to v4, so we can drop redis-py-cluster.
