### PR TITLE
feat(starfish): Show raw and percent cumulative time

### DIFF
--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -119,7 +119,7 @@ class EndpointList extends Component<Props, State> {
       return (
         <Tooltip
           title={t(
-            'This endpoint accounts for %s of the cumulative load on your web service',
+            'This endpoint accounts for %s of the cumulative time on your web service',
             formatPercentage(cumulativeTimePercentage)
           )}
           containerDisplayMode="block"

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -27,6 +27,10 @@ import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transac
 
 const COLUMN_TITLES = ['endpoint', 'tpm', 'p50(duration)', 'p95(duration)'];
 
+import Duration from 'sentry/components/duration';
+import {t, tct} from 'sentry/locale';
+import {NumberContainer} from 'sentry/utils/discover/styles';
+import {formatPercentage} from 'sentry/utils/formatters';
 import {getProjectID} from 'sentry/views/performance/utils';
 import {TIME_SPENT_IN_SERVICE} from 'sentry/views/starfish/utils/generatePerformanceEventView';
 
@@ -106,6 +110,30 @@ class EndpointList extends Component<Props, State> {
           {prefix}
           {dataRow.transaction}
         </Link>
+      );
+    }
+
+    if (field === TIME_SPENT_IN_SERVICE) {
+      const cumulativeTime = Number(dataRow['sum(transaction.duration)']);
+      const cumulativeTimePercentage = Number(dataRow[TIME_SPENT_IN_SERVICE]);
+      return (
+        <Tooltip
+          title={t(
+            'This endpoint accounts for %s of the cumulative load on your web service',
+            formatPercentage(cumulativeTimePercentage)
+          )}
+          containerDisplayMode="block"
+          position="top"
+        >
+          <NumberContainer>
+            {tct('[cumulativeTime] ([cumulativeTimePercentage])', {
+              cumulativeTime: (
+                <Duration seconds={cumulativeTime / 1000} fixedDigits={2} abbreviation />
+              ),
+              cumulativeTimePercentage: formatPercentage(cumulativeTimePercentage),
+            })}
+          </NumberContainer>
+        </Tooltip>
       );
     }
 

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -100,7 +100,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
           'tpm',
           'p50(duration)',
           'p95(duration)',
-          '% time spent',
+          'cumulative time',
         ]}
       />
     </div>


### PR DESCRIPTION
Got some pretty strong signals from talking to folks that
this "time spent" is a good default sort but
% time spent is a bit vague and could be interpreted as
other things, maybe adding raw cumulative time makes
it more clear?

![Screenshot 2023-04-18 at 12 15 07 PM](https://user-images.githubusercontent.com/63818634/232839656-d4bf71b9-4be6-48f3-87dc-aaf454130e9d.png)
