### PR TITLE
ref(escalating-issues): Move functions to centralize helper functions

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List, Tuple, TypedDict
+from typing import Dict, List, Tuple, TypedDict
 
 from snuba_sdk import (
     Column,
@@ -15,6 +15,7 @@ from snuba_sdk import (
     Request,
 )
 
+from sentry.issues.escalating_issues_alg import GroupCount
 from sentry.models import Group
 from sentry.utils.snuba import raw_snql_query
 
@@ -26,6 +27,8 @@ GroupsCountResponse = TypedDict(
     "GroupsCountResponse",
     {"group_id": int, "hourBucket": str, "count()": int},
 )
+
+ParsedGroupsCount = Dict[int, GroupCount]
 
 
 def query_groups_past_counts(groups: List[Group]) -> List[GroupsCountResponse]:
@@ -46,6 +49,28 @@ def query_groups_past_counts(groups: List[Group]) -> List[GroupsCountResponse]:
             offset += QUERY_LIMIT
 
     return all_results
+
+
+def parse_groups_past_counts(response: List[GroupsCountResponse]) -> ParsedGroupsCount:
+    """
+    Return the parsed snuba response for groups past counts to be used in generate_issue_forecast.
+    ParsedGroupCount is of the form {<group_id>: {"intervals": [str], "data": [int]}}.
+
+    `response`: Snuba response for group event counts
+    """
+    group_counts: ParsedGroupsCount = {}
+    group_ids_list = group_counts.keys()
+    for data in response:
+        group_id = data["group_id"]
+        if group_id not in group_ids_list:
+            group_counts[group_id] = {
+                "intervals": [data["hourBucket"]],
+                "data": [data["count()"]],
+            }
+        else:
+            group_counts[group_id]["intervals"].append(data["hourBucket"])
+            group_counts[group_id]["data"].append(data["count()"])
+    return group_counts
 
 
 def _generate_query(

--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional, TypedDict, cast
+
+from sentry import nodestore
+from sentry.utils.dates import parse_timestamp
+
+TWO_WEEKS_IN_SECONDS = 1209600
+
+
+class EscalatingGroupForecastData(TypedDict):
+    project_id: int
+    group_id: int
+    forecast: List[int]
+    date_added: float
+
+
+@dataclass(frozen=True)
+class EscalatingGroupForecast:
+    """
+    A class representing a group's escalating forecast.
+    """
+
+    project_id: int
+    group_id: int
+    forecast: List[int]
+    date_added: datetime
+
+    def to_dict(
+        self,
+    ) -> EscalatingGroupForecastData:
+        return {
+            "project_id": self.project_id,
+            "group_id": self.group_id,
+            "forecast": self.forecast,
+            "date_added": self.date_added.timestamp(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: EscalatingGroupForecastData) -> EscalatingGroupForecast:
+        return cls(
+            data["project_id"],
+            data["group_id"],
+            data["forecast"],
+            cast(datetime, parse_timestamp(data["date_added"])),
+        )
+
+    @classmethod
+    def build_storage_identifier(cls, project_id: int, group_id: int) -> str:
+        identifier = hashlib.md5(f"{project_id}::{group_id}".encode()).hexdigest()
+        return f"e-g-f:{identifier}"
+
+    def save(self) -> None:
+        nodestore.set(
+            self.build_storage_identifier(self.project_id, self.group_id),
+            self.to_dict(),
+            ttl=TWO_WEEKS_IN_SECONDS,
+        )
+
+    @classmethod
+    def fetch(cls, project_id: int, group_id: int) -> Optional[EscalatingGroupForecast]:
+        results = nodestore.get(cls.build_storage_identifier(project_id, group_id))
+        if results:
+            return EscalatingGroupForecast.from_dict(results)
+        return None

--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional, TypedDict, cast
 
 from sentry import nodestore
 from sentry.utils.dates import parse_timestamp
 
-TWO_WEEKS_IN_SECONDS = 1209600
+TWO_WEEKS_IN_DAYS = 14
 
 
 class EscalatingGroupForecastData(TypedDict):
@@ -57,7 +57,7 @@ class EscalatingGroupForecast:
         nodestore.set(
             self.build_storage_identifier(self.project_id, self.group_id),
             self.to_dict(),
-            ttl=TWO_WEEKS_IN_SECONDS,
+            ttl=timedelta(TWO_WEEKS_IN_DAYS),
         )
 
     @classmethod

--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -1,3 +1,8 @@
+"""
+This module represents a group's escalating forecast and has the logic to retrieve/store it in
+Sentry's NodeStore. The forecasts are stored for 2 weeks.
+"""
+
 from __future__ import annotations
 
 import hashlib
@@ -8,7 +13,7 @@ from typing import List, Optional, TypedDict, cast
 from sentry import nodestore
 from sentry.utils.dates import parse_timestamp
 
-TWO_WEEKS_IN_DAYS = 14
+TWO_WEEKS_IN_DAYS_TTL = 14
 
 
 class EscalatingGroupForecastData(TypedDict):
@@ -21,13 +26,33 @@ class EscalatingGroupForecastData(TypedDict):
 @dataclass(frozen=True)
 class EscalatingGroupForecast:
     """
-    A class representing a group's escalating forecast.
+    This class represents a group's escalating forecast and has the logic to retrieve/store it in
+    Sentry's NodeStore.
     """
 
     project_id: int
     group_id: int
     forecast: List[int]
     date_added: datetime
+
+    def save(self) -> None:
+        nodestore.set(
+            self.build_storage_identifier(self.project_id, self.group_id),
+            self.to_dict(),
+            ttl=timedelta(TWO_WEEKS_IN_DAYS_TTL),
+        )
+
+    @classmethod
+    def fetch(cls, project_id: int, group_id: int) -> Optional[EscalatingGroupForecast]:
+        results = nodestore.get(cls.build_storage_identifier(project_id, group_id))
+        if results:
+            return EscalatingGroupForecast.from_dict(results)
+        return None
+
+    @classmethod
+    def build_storage_identifier(cls, project_id: int, group_id: int) -> str:
+        identifier = hashlib.md5(f"{project_id}::{group_id}".encode()).hexdigest()
+        return f"e-g-f:{identifier}"
 
     def to_dict(
         self,
@@ -47,22 +72,3 @@ class EscalatingGroupForecast:
             data["forecast"],
             cast(datetime, parse_timestamp(data["date_added"])),
         )
-
-    @classmethod
-    def build_storage_identifier(cls, project_id: int, group_id: int) -> str:
-        identifier = hashlib.md5(f"{project_id}::{group_id}".encode()).hexdigest()
-        return f"e-g-f:{identifier}"
-
-    def save(self) -> None:
-        nodestore.set(
-            self.build_storage_identifier(self.project_id, self.group_id),
-            self.to_dict(),
-            ttl=timedelta(TWO_WEEKS_IN_DAYS),
-        )
-
-    @classmethod
-    def fetch(cls, project_id: int, group_id: int) -> Optional[EscalatingGroupForecast]:
-        results = nodestore.get(cls.build_storage_identifier(project_id, group_id))
-        if results:
-            return EscalatingGroupForecast.from_dict(results)
-        return None

--- a/src/sentry/issues/forecasts.py
+++ b/src/sentry/issues/forecasts.py
@@ -1,0 +1,45 @@
+"""
+This module is for helper functions for escalating issues forecasts.
+"""
+
+from datetime import datetime
+from typing import List
+
+from sentry.issues.escalating import (
+    ParsedGroupsCount,
+    parse_groups_past_counts,
+    query_groups_past_counts,
+)
+from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
+from sentry.issues.escalating_issues_alg import generate_issue_forecast
+from sentry.models import Group
+
+
+def save_forecast_per_group(
+    until_escalating_groups: List[Group], group_counts: ParsedGroupsCount
+) -> None:
+    """
+    Saves the list of forecasted values for each group in nodestore.
+
+    `until_escalating_groups`: List of archived until escalating groups to be forecasted
+    `group_counts`: Parsed snuba response of group counts
+    """
+    time = datetime.now()
+    group_dict = {group.id: group for group in until_escalating_groups}
+    for group_id in group_counts.keys():
+        forecasts = generate_issue_forecast(group_counts[group_id], time)
+        forecasts_list = [forecast["forecasted_value"] for forecast in forecasts]
+        escalating_group_forecast = EscalatingGroupForecast(
+            group_dict[group_id].project.id, group_id, forecasts_list, datetime.now()
+        )
+        escalating_group_forecast.save()
+
+
+def get_forecasts(groups: List[Group]) -> None:
+    """
+    Returns a list of forecasted values for each group.
+    `groups`: List of groups to be forecasted
+    """
+    past_counts = query_groups_past_counts(groups)
+    group_counts = parse_groups_past_counts(past_counts)
+    save_forecast_per_group(groups, group_counts)

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -1,12 +1,9 @@
 import logging
-from datetime import datetime
 from typing import Dict, List, TypedDict
 
 from sentry_sdk.crons.decorator import monitor
 
-from sentry.issues.escalating import GroupsCountResponse, query_groups_past_counts
-from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
-from sentry.issues.escalating_issues_alg import generate_issue_forecast
+from sentry.issues.forecasts import get_forecasts
 from sentry.models import Group, GroupStatus
 from sentry.models.group import GroupSubStatus
 from sentry.tasks.base import instrumented_task
@@ -50,55 +47,3 @@ def run_escalating_forecast() -> None:
         return
 
     get_forecasts(until_escalating_groups)
-
-
-def parse_groups_past_counts(response: List[GroupsCountResponse]) -> ParsedGroupsCount:
-    """
-    Return the parsed snuba response for groups past counts to be used in generate_issue_forecast.
-    ParsedGroupCount is of the form {<group_id>: {"intervals": [str], "data": [int]}}.
-
-    `response`: Snuba response for group event counts
-    """
-    group_counts: ParsedGroupsCount = {}
-    group_ids_list = group_counts.keys()
-    for data in response:
-        group_id = data["group_id"]
-        if group_id not in group_ids_list:
-            group_counts[group_id] = {
-                "intervals": [data["hourBucket"]],
-                "data": [data["count()"]],
-            }
-        else:
-            group_counts[group_id]["intervals"].append(data["hourBucket"])
-            group_counts[group_id]["data"].append(data["count()"])
-    return group_counts
-
-
-def save_forecast_per_group(
-    until_escalating_groups: List[Group], group_counts: ParsedGroupsCount
-) -> None:
-    """
-    Saves the list of forecasted values for each group in nodestore.
-
-    `until_escalating_groups`: List of archived until escalating groups to be forecasted
-    `group_counts`: Parsed snuba response of group counts
-    """
-    time = datetime.now()
-    group_dict = {group.id: group for group in until_escalating_groups}
-    for group_id in group_counts.keys():
-        forecasts = generate_issue_forecast(group_counts[group_id], time)
-        forecasts_list = [forecast["forecasted_value"] for forecast in forecasts]
-        escalating_group_forecast = EscalatingGroupForecast(
-            group_dict[group_id].project.id, group_id, forecasts_list, datetime.now()
-        )
-        escalating_group_forecast.save()
-
-
-def get_forecasts(groups: List[Group]) -> None:
-    """
-    Returns a list of forecasted values for each group.
-    `groups`: List of groups to be forecasted
-    """
-    past_counts = query_groups_past_counts(groups)
-    group_counts = parse_groups_past_counts(past_counts)
-    save_forecast_per_group(groups, group_counts)

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -56,7 +56,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
             group_list.append(group)
         return group_list
 
-    @patch("sentry.tasks.weekly_escalating_forecast.query_groups_past_counts")
+    @patch("sentry.issues.escalating.query_groups_past_counts")
     def test_empty_escalating_forecast(self, mock_query_groups_past_counts):
         group_list = self.create_archived_until_escalating_groups(num_groups=1)
 
@@ -66,7 +66,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
         fetched_forecast = EscalatingGroupForecast.fetch(group_list[0].project.id, group_list[0].id)
         assert fetched_forecast is None
 
-    @patch("sentry.tasks.weekly_escalating_forecast.query_groups_past_counts")
+    @patch("sentry.issues.forecasts.query_groups_past_counts")
     def test_single_group_escalating_forecast(self, mock_query_groups_past_counts):
         group_list = self.create_archived_until_escalating_groups(num_groups=1)
 
@@ -85,7 +85,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
         ) == approximate_date_added.replace(second=0, microsecond=0)
         assert fetched_forecast.date_added < approximate_date_added
 
-    @patch("sentry.tasks.weekly_escalating_forecast.query_groups_past_counts")
+    @patch("sentry.issues.forecasts.query_groups_past_counts")
     def test_multiple_groups_escalating_forecast(self, mock_query_groups_past_counts):
         group_list = self.create_archived_until_escalating_groups(num_groups=3)
 
@@ -107,7 +107,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
             ) == approximate_date_added.replace(second=0, microsecond=0)
             assert fetched_forecast.date_added < approximate_date_added
 
-    @patch("sentry.tasks.weekly_escalating_forecast.query_groups_past_counts")
+    @patch("sentry.issues.forecasts.query_groups_past_counts")
     def test_update_group_escalating_forecast(self, mock_query_groups_past_counts):
         group_list = self.create_archived_until_escalating_groups(num_groups=1)
 

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -12,7 +12,7 @@ from sentry.models.project import Project
 from sentry.tasks.weekly_escalating_forecast import run_escalating_forecast
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 
-FORECAST_LIST_MOCK = [200] * 14
+DEFAULT_MINIMUM_CEILING_FORECAST = [200] * 14
 
 
 class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -79,7 +79,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
         fetched_forecast = EscalatingGroupForecast.fetch(group_list[0].project.id, group_list[0].id)
         assert fetched_forecast.project_id == group_list[0].project.id
         assert fetched_forecast.group_id == group_list[0].id
-        assert fetched_forecast.forecast == FORECAST_LIST_MOCK
+        assert fetched_forecast.forecast == DEFAULT_MINIMUM_CEILING_FORECAST
         assert fetched_forecast.date_added.replace(
             second=0, microsecond=0
         ) == approximate_date_added.replace(second=0, microsecond=0)
@@ -101,7 +101,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):
             )
             assert fetched_forecast.project_id == group_list[i].project.id
             assert fetched_forecast.group_id == group_list[i].id
-            assert fetched_forecast.forecast == FORECAST_LIST_MOCK
+            assert fetched_forecast.forecast == DEFAULT_MINIMUM_CEILING_FORECAST
             assert fetched_forecast.date_added.replace(
                 second=0, microsecond=0
             ) == approximate_date_added.replace(second=0, microsecond=0)


### PR DESCRIPTION
Move escalating issue forecast helper functions into centralized location

- Move `save_forecast_per_group` and `get_forecasts` to `src/sentry/issues/forecasts.py`
- Move `parse_groups_past_counts` to `src/sentry/issues/escalating.py` since it is related to the snuba query