### PR TITLE
fix(performance-issues): DB on Main Thread spans should highlight

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -568,7 +568,7 @@ class SpanTree extends Component<PropType> {
         }
 
         const isAffectedSpan =
-          !('type' in span) && waterfallModel.affectedSpanIds?.includes(span.span_id);
+          !isGapSpan(span) && waterfallModel.affectedSpanIds?.includes(span.span_id);
 
         let spanBarType: SpanBarType | undefined = undefined;
 


### PR DESCRIPTION
The offending spans for DB on Main Thread issues weren't being highlighted in red. This is because they had a type: trace property which is being excluded here. I've changed the condition to specifically check for gap spans because after some discussion it makes sense that gap spans can't be affected spans (it's missing instrumentation)
