### PR TITLE
fix(transaction): Use uniqBy when calculating datapoints

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -478,7 +478,7 @@ class TraceViewHeader extends Component<PropType, State> {
             getDataPoints(
               profiles.data.measurements!.cpu_usage,
               transactionDuration * MS_PER_S
-            ).length > MIN_DATA_POINTS;
+            ).length >= MIN_DATA_POINTS;
 
           return (
             <HeaderContainer

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -48,14 +48,15 @@ export function getDataPoints(
   data: {unit: string; values: Profiling.MeasurementValue[]},
   maxDurationInMs: number
 ) {
-  return data.values
-    .map(value => {
+  return uniqBy(
+    data.values.map(value => {
       return {
         name: parseFloat(toMilliseconds(value.elapsed_since_start_ns).toFixed(2)),
         value: value.value,
       };
-    })
-    .filter(({name}) => name <= maxDurationInMs + 1); // Add 1ms to account for rounding
+    }),
+    'name'
+  ).filter(({name}) => name <= maxDurationInMs + 1); // Add 1ms to account for rounding
 }
 
 type ChartProps = {


### PR DESCRIPTION
Because this helper does a conversion from ns -> ms, we can get conflicts and the check for conditionally rendering this when there are at least 3 data points incorrectly passes