### PR TITLE
perf(replays): up concurrency of download segments

### DIFF
--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -254,7 +254,7 @@ def download_segments(segments: List[RecordingSegmentStorageMeta]) -> Iterator[b
     )
 
     # Map all of the segments to a worker process for download.
-    with ThreadPoolExecutor(max_workers=4) as exe:
+    with ThreadPoolExecutor(max_workers=10) as exe:
         results = exe.map(download_segment_with_fixed_args, segments)
 
     yield b"["


### PR DESCRIPTION
looking at our [transaction](https://sentry.sentry.io/performance/summary/?project=1&query=&referrer=performance-transaction-summary&statsPeriod=24h&transaction=ProjectReplayRecordingSegmentIndexEndpoint.download_segments&unselectedSeries=p100%28%29 ) and some of its spans, it looks like we'll benefit a decent amount from more concurrency, as we're mainly IO bound.