### PR TITLE
chore: Remove unused silo mode decorator

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -20,7 +20,6 @@ __all__ = (
     "DefaultFieldsModel",
     "sane_repr",
     "get_model_if_available",
-    "control_silo_with_replication_model",
     "control_silo_only_model",
     "region_silo_only_model",
 )
@@ -233,4 +232,3 @@ class ModelSiloLimit(SiloLimit):
 
 control_silo_only_model = ModelSiloLimit(SiloMode.CONTROL)
 region_silo_only_model = ModelSiloLimit(SiloMode.REGION)
-control_silo_with_replication_model = control_silo_only_model


### PR DESCRIPTION
We don't have a replication mode model anymore.