### PR TITLE
ref(interactionStateLayer): Fix CSS selector specificity

### DIFF
--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -11,18 +11,6 @@ interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
   isPressed?: boolean;
 }
 
-function getControlledOpacityValue(p: StateLayerProps) {
-  if (p.isPressed) {
-    return p.higherOpacity ? 0.12 : 0.09;
-  }
-
-  if (p.isHovered) {
-    return p.higherOpacity ? 0.085 : 0.06;
-  }
-
-  return null;
-}
-
 const InteractionStateLayer = styled(
   (props: StateLayerProps) => <span role="presentation" {...props} />,
   {shouldForwardProp: p => typeof p === 'string' && isPropValid(p)}
@@ -45,31 +33,35 @@ const InteractionStateLayer = styled(
   opacity: 0;
 
   ${p =>
-    !defined(p.isHovered)
-      ? css`
+    defined(p.isHovered)
+      ? p.isHovered &&
+        css`
+          opacity: ${p.higherOpacity ? 0.085 : 0.06};
+        `
+      : // If isHovered is undefined, then fallback to a default hover selector
+        css`
           *:hover:not(.focus-visible) > & {
             opacity: ${p.higherOpacity ? 0.085 : 0.06};
           }
-        `
-      : ''}
+        `}
 
   ${p =>
-    !defined(p.isPressed)
-      ? css`
+    defined(p.isPressed)
+      ? p.isPressed &&
+        css`
+          &&& {
+            opacity: ${p.higherOpacity ? 0.12 : 0.09};
+          }
+        `
+      : // If isPressed is undefined, then fallback to default press selectors
+        css`
           *:active > &&,
           *[aria-expanded='true'] > &&,
           *[aria-selected='true'] > && {
             opacity: ${p.higherOpacity ? 0.12 : 0.09};
           }
-        `
-      : ''}
+        `}
 
-  ${p =>
-    getControlledOpacityValue(p)
-      ? css`
-          opacity: ${getControlledOpacityValue(p)};
-        `
-      : ''}
 
   *:disabled &&,
   *[aria-disabled="true"] && {


### PR DESCRIPTION
Update opacity rules in `InteractionStateLayer` to better reflect normal expectations of how the `isPressed` and `isHovered` props work — as overrides to the default behavior. 

**The order of priority is as follows:** 
 - value of `isPressed` if defined
 -  CSS press selectors (e.g. `:active`)
 - value of `isHovered` if defined
 - CSS hover selector (`:hover`)

For example, if `isPressed` is defined and true, then the press state should apply regardless of the value of `isHovered` or whether the element is actually being pressed/hovered. Currently this is not the case: hover effects can override press effects triggered by `isPressed` — see the _before_ recording.

**Before ——** `isPressed` is `true`, `isHovered` is `undefined` —> hover effects take priority over press state

https://user-images.githubusercontent.com/44172267/232865950-3b641c78-6ca9-4aad-800e-64c8df040bf8.mov

**After ——** same config —> press state is maintained upon hover

https://user-images.githubusercontent.com/44172267/232865946-507938b6-8fd0-401b-bab5-f26c1b240548.mov