### PR TITLE
ref(indexer): add sentry_received_timestamp

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -389,9 +389,7 @@ class IndexerBatch:
 
             # timestamp when the message was produced to ingest-* topic,
             # used for end-to-end latency metrics
-            sentry_received_timestamp = bytes(
-                message.value.timestamp.strftime(SENTRY_RECEIVED_FORMAT), "utf-8"
-            )
+            sentry_received_timestamp = bytes(f"{message.value.timestamp.timestamp()}", "utf-8")
 
             if self.__should_index_tag_values:
                 new_payload_v1: Metric = {

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -44,8 +44,6 @@ MRI_RE_PATTERN = re.compile("^([c|s|d|g|e]):([a-zA-Z0-9_]+)/.*$")
 
 OrgId = int
 
-SENTRY_RECEIVED_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-
 
 class PartitionIdxOffset(NamedTuple):
     partition_idx: int

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -385,6 +385,10 @@ class IndexerBatch:
 
             new_payload_value: Mapping[str, Any]
 
+            # timestamp when the message was produced to ingest-* topic,
+            # used for end-to-end latency metrics
+            origin_timestamp = message.value.timestamp
+
             if self.__should_index_tag_values:
                 new_payload_v1: Metric = {
                     "tags": new_tags,
@@ -398,6 +402,7 @@ class IndexerBatch:
                     "project_id": old_payload_value["project_id"],
                     "type": old_payload_value["type"],
                     "value": old_payload_value["value"],
+                    "origin_timestamp": origin_timestamp,
                 }
 
                 new_payload_value = new_payload_v1
@@ -417,6 +422,7 @@ class IndexerBatch:
                     "project_id": old_payload_value["project_id"],
                     "type": old_payload_value["type"],
                     "value": old_payload_value["value"],
+                    "origin_timestamp": origin_timestamp,
                 }
                 new_payload_value = new_payload_v2
 

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -387,7 +387,7 @@ class IndexerBatch:
 
             # timestamp when the message was produced to ingest-* topic,
             # used for end-to-end latency metrics
-            sentry_received_timestamp = bytes(f"{message.value.timestamp.timestamp()}", "utf-8")
+            sentry_received_timestamp = message.value.timestamp.timestamp()
 
             if self.__should_index_tag_values:
                 new_payload_v1: Metric = {
@@ -402,6 +402,7 @@ class IndexerBatch:
                     "project_id": old_payload_value["project_id"],
                     "type": old_payload_value["type"],
                     "value": old_payload_value["value"],
+                    "sentry_received_timestamp": sentry_received_timestamp,
                 }
 
                 new_payload_value = new_payload_v1
@@ -421,6 +422,7 @@ class IndexerBatch:
                     "project_id": old_payload_value["project_id"],
                     "type": old_payload_value["type"],
                     "value": old_payload_value["value"],
+                    "sentry_received_timestamp": sentry_received_timestamp,
                 }
                 new_payload_value = new_payload_v2
 
@@ -432,7 +434,6 @@ class IndexerBatch:
                     ("mapping_sources", mapping_header_content),
                     # XXX: type mismatch, but seems to work fine in prod
                     ("metric_type", new_payload_value["type"]),  # type: ignore
-                    ("sentry_received_timestamp", sentry_received_timestamp),
                 ],
             )
             if self.is_output_sliced:


### PR DESCRIPTION
**context**:
We want to be able to track the time it takes a message to be picked up by the indexer consumer up until it's written into ClickHouse. In order to do that we want to use the timestamp for when the message is produce to the `ingest-metrics` topic  and `ingest-performance-metrics` topic. 

The `BrokerValue` on the arroyo message has that produced timestamp - `message.value.timestamp`.

~Because we are changing the message payload, we need to update the snuba schemas in https://github.com/getsentry/sentry-kafka-schemas.~ [updated]: now we are putting it in the headers

Once this PR is merged, we can use the `sentry_received_timestamp` in [snuba](https://github.com/getsentry/snuba/blob/master/snuba/consumers/consumer.py#L142).