### PR TITLE
ref(analytics): alias track advanced analytics event

### DIFF
--- a/static/app/components/demoSandboxButton.tsx
+++ b/static/app/components/demoSandboxButton.tsx
@@ -1,6 +1,6 @@
 import {Button, ButtonProps} from 'sentry/components/button';
 import {Organization, SandboxData} from 'sentry/types';
-import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type DemoSandboxButtonProps = ButtonProps & {
@@ -78,7 +78,7 @@ function DemoSandboxButton({
       external
       href={url.toString()}
       onClick={() =>
-        trackAnalyticsEvent('growth.clicked_enter_sandbox', {
+        trackAnalytics('growth.clicked_enter_sandbox', {
           scenario,
           organization,
           source,

--- a/static/app/components/demoSandboxButton.tsx
+++ b/static/app/components/demoSandboxButton.tsx
@@ -1,6 +1,6 @@
 import {Button, ButtonProps} from 'sentry/components/button';
 import {Organization, SandboxData} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type DemoSandboxButtonProps = ButtonProps & {
@@ -78,7 +78,7 @@ function DemoSandboxButton({
       external
       href={url.toString()}
       onClick={() =>
-        trackAdvancedAnalyticsEvent('growth.clicked_enter_sandbox', {
+        trackAnalyticsEvent('growth.clicked_enter_sandbox', {
           scenario,
           organization,
           source,

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -3,6 +3,7 @@ import {Transaction} from '@sentry/types';
 
 import HookStore from 'sentry/stores/hookStore';
 import {Hooks} from 'sentry/types/hooks';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 
 /**
  * Analytics and metric tracking functionality.
@@ -21,6 +22,16 @@ import {Hooks} from 'sentry/types/hooks';
  *
  *       https://github.com/getsentry/reload/blob/master/reload_app/metrics/__init__.py
  */
+
+/**
+ * This should be with all analytics events regardless of the analytics destination
+ * which includes Reload, Amplitude, and Google Analytics.
+ * All events go to Reload. If eventName is defined, events also go to Amplitude.
+ * For more details, refer to makeAnalyticsFunction.
+ *
+ * Should be used for all analytics that are defined in Sentry.
+ */
+export const trackAnalytics = trackAdvancedAnalyticsEvent;
 
 /**
  * This should be with all analytics events regardless of the analytics destination

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -31,7 +31,15 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
  *
  * Should be used for all analytics that are defined in Sentry.
  */
-export const trackAnalytics = trackAdvancedAnalyticsEvent;
+
+export function trackAnalyticsEvent(
+  eventKey: Parameters<typeof trackAdvancedAnalyticsEvent>[0],
+  analyticsParams: Parameters<typeof trackAdvancedAnalyticsEvent>[1],
+  options?: Parameters<typeof trackAdvancedAnalyticsEvent>[2]
+) {
+  // TODO: Stop using trackAdvancedAnalyticsEvent
+  return trackAdvancedAnalyticsEvent(eventKey, analyticsParams, options);
+}
 
 /**
  * This should be with all analytics events regardless of the analytics destination

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -32,7 +32,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
  * Should be used for all analytics that are defined in Sentry.
  */
 
-export function trackAnalyticsEvent(
+export function trackAnalytics(
   eventKey: Parameters<typeof trackAdvancedAnalyticsEvent>[0],
   analyticsParams: Parameters<typeof trackAdvancedAnalyticsEvent>[1],
   options?: Parameters<typeof trackAdvancedAnalyticsEvent>[2]


### PR DESCRIPTION
This PR creates an alias for `trackAdvancedAnalyticsEvent` to `trackAnalytics`. Now that we've removed the old analytics functions, we can simplify the new stuff. We will replace `trackAdvancedAnalyticsEvent` with `trackAnalytics` in the next few days with this aliased function.

Before:
```
import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
```

After:
```
import {trackAnalytics} from 'sentry/utils/analytics';
```

Also did one conversion to show how this works