### PR TITLE
ref(jira): Rename Jira webhook base class

### DIFF
--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -19,7 +19,7 @@ class JiraTokenError(Exception):
     pass
 
 
-class JiraEndpointBase(Endpoint, abc.ABC):
+class JiraWebhookBase(Endpoint, abc.ABC):
     authentication_classes = ()
     permission_classes = ()
     provider = "jira"

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -20,6 +20,10 @@ class JiraTokenError(Exception):
 
 
 class JiraWebhookBase(Endpoint, abc.ABC):
+    """
+    Base class for webhooks used in the Jira integration
+    """
+
     authentication_classes = ()
     permission_classes = ()
     provider = "jira"

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -9,11 +9,11 @@ from sentry.tasks.integrations import sync_metadata
 from sentry.utils import jwt
 
 from ..integration import JiraIntegrationProvider
-from .base import JiraEndpointBase
+from .base import JiraWebhookBase
 
 
 @pending_silo_endpoint
-class JiraSentryInstalledWebhook(JiraEndpointBase):
+class JiraSentryInstalledWebhook(JiraWebhookBase):
     """
     Webhook hit by Jira whenever someone installs the Sentry integration in their Jira instance.
     """

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -12,13 +12,13 @@ from sentry.integrations.utils import get_integration_from_jwt
 from sentry.shared_integrations.exceptions import ApiError
 
 from ..utils import handle_assignee_change, handle_jira_api_error, handle_status_change
-from .base import JiraEndpointBase
+from .base import JiraWebhookBase
 
 logger = logging.getLogger(__name__)
 
 
 @pending_silo_endpoint
-class JiraIssueUpdatedWebhook(JiraEndpointBase):
+class JiraIssueUpdatedWebhook(JiraWebhookBase):
     """
     Webhook hit by Jira whenever an issue is updated in Jira's database.
     """

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -5,11 +5,11 @@ from sentry.api.base import pending_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.utils import get_integration_from_jwt
 
-from .base import JiraEndpointBase
+from .base import JiraWebhookBase
 
 
 @pending_silo_endpoint
-class JiraSentryUninstalledWebhook(JiraEndpointBase):
+class JiraSentryUninstalledWebhook(JiraWebhookBase):
     """
     Webhook hit by Jira whenever someone uninstalls the Sentry integration from their Jira instance.
     """


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/47526, renaming the base class for Jira webhooks from `JiraEndpointBase` to `JiraWebhookBase` and adding a docstring to it. (It should have been part of that PR but accidentally got left out somehow.)