### PR TITLE
feat(starfish): 0-fill API duration chart

### DIFF
--- a/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
+++ b/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
@@ -2,11 +2,13 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 import {Location} from 'history';
+import moment from 'moment';
 
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import {Series} from 'sentry/types/echarts';
 import Chart from 'sentry/views/starfish/components/chart';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
 import {ENDPOINT_GRAPH_QUERY, ENDPOINT_LIST_QUERY} from './queries';
 
@@ -70,7 +72,9 @@ export default function APIModuleView({location, onSelect}: Props) {
     });
   });
 
-  const data = Object.values(seriesByQuantile);
+  const data = Object.values(seriesByQuantile).map(series =>
+    zeroFillSeries(series, moment.duration(12, 'hours'))
+  );
 
   return (
     <Fragment>

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -7,7 +7,7 @@ export const ENDPOINT_LIST_QUERY = `SELECT description, count() AS count, domain
 `;
 
 export const ENDPOINT_GRAPH_QUERY = `SELECT
- toStartOfInterval(start_timestamp, INTERVAL 5 MINUTE) as interval,
+ toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
  quantile(0.5)(exclusive_time) as p50,
  quantile(0.75)(exclusive_time) as p75,
  quantile(0.95)(exclusive_time) as p95,

--- a/static/app/views/starfish/utils/zeroFillSeries.spec.tsx
+++ b/static/app/views/starfish/utils/zeroFillSeries.spec.tsx
@@ -1,0 +1,50 @@
+import moment from 'moment';
+
+import {zeroFillSeries} from './zeroFillSeries';
+
+describe('zeroFillSeries', () => {
+  test('Fills all missing entries with a zero object', () => {
+    const series = {
+      seriesName: 'p50',
+      data: [
+        {
+          name: '2023-03-21T00:00:00',
+          value: 5,
+        },
+        {
+          name: '2023-03-24T00:00:00',
+          value: 4,
+        },
+        {
+          name: '2023-03-25T00:00:00',
+          value: 6,
+        },
+      ],
+    };
+
+    const newSeries = zeroFillSeries(series, moment.duration(1, 'day'));
+
+    expect(newSeries.data).toEqual([
+      {
+        name: '2023-03-21T00:00:00',
+        value: 5,
+      },
+      {
+        name: '2023-03-22T00:00:00',
+        value: 0,
+      },
+      {
+        name: '2023-03-23T00:00:00',
+        value: 0,
+      },
+      {
+        name: '2023-03-24T00:00:00',
+        value: 4,
+      },
+      {
+        name: '2023-03-25T00:00:00',
+        value: 6,
+      },
+    ]);
+  });
+});

--- a/static/app/views/starfish/utils/zeroFillSeries.tsx
+++ b/static/app/views/starfish/utils/zeroFillSeries.tsx
@@ -1,0 +1,53 @@
+import moment from 'moment';
+
+import {Series} from 'sentry/types/echarts';
+
+export function zeroFillSeries(series: Series, interval: moment.Duration): Series {
+  if (!series?.data?.length) {
+    return series;
+  }
+
+  const firstDatum = series.data[0];
+  const dateFormat = moment(firstDatum.name).creationData().format?.toString();
+
+  if (!dateFormat) {
+    return series;
+  }
+
+  const newData = [firstDatum];
+
+  let currentDatum, nextDatum, lastSeenDate, nextDate, diff;
+  for (let index = 1; index < series.data.length; index++) {
+    currentDatum = series.data[index - 1];
+    nextDatum = series.data[index];
+
+    lastSeenDate = moment(currentDatum.name);
+    nextDate = moment(nextDatum.name);
+
+    diff = moment.duration(nextDate.diff(lastSeenDate));
+
+    while (diff.asMilliseconds() > interval.asMilliseconds()) {
+      // The gap between the two datapoints is more than the intended interval!
+      // We need to fill 0s
+      lastSeenDate.add(interval);
+
+      newData.push({
+        value: 0,
+        name: moment(lastSeenDate).format(dateFormat),
+      });
+
+      diff = moment.duration(moment(nextDatum.name).diff(lastSeenDate));
+    }
+
+    // Push the next datapoint
+    newData.push({
+      ...nextDatum,
+      name: moment(nextDatum.name).format(dateFormat),
+    });
+  }
+
+  return {
+    ...series,
+    data: newData,
+  };
+}


### PR DESCRIPTION
eCharts _breaks horribly_ if you don't 0-fill data, and our data is pretty sparse. This adds a simple algo that 0-fills a `Series` object.
e.g.,

**Before:**
<img width="1135" alt="Screenshot 2023-04-18 at 4 34 58 PM" src="https://user-images.githubusercontent.com/989898/232899082-db4ed8c7-319d-477f-80c6-89a0e5cdf59e.png">

**After:**
<img width="1137" alt="Screenshot 2023-04-18 at 4 35 19 PM" src="https://user-images.githubusercontent.com/989898/232899101-282093b7-7cf2-4c08-b468-437580e0e76f.png">

