### PR TITLE
fix(transaction): Add echart props to more accurately align datapoints

### DIFF
--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -108,6 +108,9 @@ function Chart({data, type, transactionDuration}: ChartProps) {
           triggerOn: 'mousemove',
         },
         boundaryGap: false,
+        type: 'value',
+        alignTicks: false,
+        max: parseFloat(transactionDuration.toFixed(2)),
       }}
       series={series}
       renderer="svg"


### PR DESCRIPTION
The default behaviour is to plot the datapoints evenly spaced apart. This is slightly inaccurate in some cases and these changes allow the datapoints to be more accurate in where they're positioned.

An example can be seen here: https://sentry-sdks.localhost:7999/performance/sentry-android:40830809c3434dc99db6d3ab032d5406/

Notice that the 296ms datapoint isn't directly over the 286ms tick:

<img width="731" alt="Screenshot 2023-04-18 at 4 35 04 PM" src="https://user-images.githubusercontent.com/22846452/232898809-60681a53-83b3-4969-b1e2-a09378d7f5f2.png">
