### PR TITLE
ref(generic-metrics): Add timestamp checking to indexer

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -2,6 +2,8 @@ import logging
 import random
 import re
 from collections import defaultdict
+from datetime import timedelta
+from time import time
 from typing import (
     Any,
     Dict,
@@ -146,6 +148,11 @@ class IndexerBatch:
                     extra={"payload_value": str(msg.payload.value)},
                     exc_info=True,
                 )
+                continue
+
+            if time() - parsed_payload["timestamp"] > timedelta(days=5).total_seconds():
+                self.skipped_offsets.add(partition_offset)
+                metrics.incr("sentry_metrics.indexer.process_messages.dropped_message")
                 continue
 
             # Ensure that the parsed_payload can be cast back to to


### PR DESCRIPTION
### Overview
Add timestamp check to indexer to drop metrics that are older than 5 days.

Closes [SNS-1787](https://getsentry.atlassian.net/browse/SNS-1787)


[SNS-1787]: https://getsentry.atlassian.net/browse/SNS-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ