### PR TITLE
feat: add new badge and description for click search key

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -231,7 +231,6 @@ type Props = WithRouterProps &
      * trigger re-renders.
      */
     members?: User[];
-
     /**
      * Extend search group items with additional props
      * Useful for providing descriptions to field parents with many children
@@ -272,12 +271,10 @@ type Props = WithRouterProps &
      * Prepare query value before filtering dropdown items
      */
     prepareQuery?: (query: string) => string;
-
     /**
      * Indicates the usage of the search bar for analytics
      */
     searchSource?: string;
-
     /**
      * Type of supported tags
      */
@@ -1917,7 +1914,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
             customPerformanceMetrics={customPerformanceMetrics}
             supportedTags={supportedTags}
             customInvalidTagMessage={this.props.customInvalidTagMessage}
-            mergeSearchGroupWith={this.props.mergeSearchGroupWith}
+            mergeItemsWith={this.props.mergeSearchGroupWith}
           />
         )}
       </Container>

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -231,6 +231,12 @@ type Props = WithRouterProps &
      * trigger re-renders.
      */
     members?: User[];
+
+    /**
+     * Extend search group items with additional props
+     * Useful for providing descriptions to field parents with many children
+     */
+    mergeSearchGroupWith?: Record<string, SearchItem>;
     /**
      * Called when the search input is blurred.
      * Note that the input may be blurred when the user selects an autocomplete
@@ -266,6 +272,7 @@ type Props = WithRouterProps &
      * Prepare query value before filtering dropdown items
      */
     prepareQuery?: (query: string) => string;
+
     /**
      * Indicates the usage of the search bar for analytics
      */
@@ -1910,6 +1917,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
             customPerformanceMetrics={customPerformanceMetrics}
             supportedTags={supportedTags}
             customInvalidTagMessage={this.props.customInvalidTagMessage}
+            mergeSearchGroupWith={this.props.mergeSearchGroupWith}
           />
         )}
       </Container>

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -34,7 +34,7 @@ type Props = {
   customInvalidTagMessage?: (item: SearchItem) => React.ReactNode;
   customPerformanceMetrics?: CustomMeasurementCollection;
   maxMenuHeight?: number;
-  mergeSearchGroupWith?: Record<string, SearchItem>;
+  mergeItemsWith?: Record<string, SearchItem>;
   onIconClick?: (value: string) => void;
   runShortcut?: (shortcut: Shortcut) => void;
   supportedTags?: TagCollection;
@@ -54,7 +54,7 @@ function SearchDropdown({
   customPerformanceMetrics,
   supportedTags,
   customInvalidTagMessage,
-  mergeSearchGroupWith,
+  mergeItemsWith,
 }: Props) {
   return (
     <SearchDropdownOverlay className={className} data-test-id="smart-search-dropdown">
@@ -72,31 +72,25 @@ function SearchDropdown({
               <Fragment key={item.title}>
                 {item.type === 'header' && <HeaderItem group={item} />}
                 {item.children &&
-                  item.children.map(child => {
-                    if (
-                      mergeSearchGroupWith &&
-                      child.title &&
-                      mergeSearchGroupWith[child.title]
-                    ) {
-                      Object.assign(child, mergeSearchGroupWith[child.title]);
-                    }
-                    return (
-                      <DropdownItem
-                        key={getDropdownItemKey(child)}
-                        item={child}
-                        searchSubstring={searchSubstring}
-                        onClick={onClick}
-                        onIconClick={onIconClick}
-                        additionalSearchConfig={{
-                          ...getSearchConfigFromCustomPerformanceMetrics(
-                            customPerformanceMetrics
-                          ),
-                          supportedTags,
-                        }}
-                        customInvalidTagMessage={customInvalidTagMessage}
-                      />
-                    );
-                  })}
+                  item.children.map(child => (
+                    <DropdownItem
+                      key={getDropdownItemKey(child)}
+                      item={{
+                        ...child,
+                        ...mergeItemsWith?.[child.title!],
+                      }}
+                      searchSubstring={searchSubstring}
+                      onClick={onClick}
+                      onIconClick={onIconClick}
+                      additionalSearchConfig={{
+                        ...getSearchConfigFromCustomPerformanceMetrics(
+                          customPerformanceMetrics
+                        ),
+                        supportedTags,
+                      }}
+                      customInvalidTagMessage={customInvalidTagMessage}
+                    />
+                  ))}
                 {isEmpty && <Info>{t('No items found')}</Info>}
               </Fragment>
             );

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -34,6 +34,7 @@ type Props = {
   customInvalidTagMessage?: (item: SearchItem) => React.ReactNode;
   customPerformanceMetrics?: CustomMeasurementCollection;
   maxMenuHeight?: number;
+  mergeSearchGroupWith?: Record<string, SearchItem>;
   onIconClick?: (value: string) => void;
   runShortcut?: (shortcut: Shortcut) => void;
   supportedTags?: TagCollection;
@@ -53,6 +54,7 @@ function SearchDropdown({
   customPerformanceMetrics,
   supportedTags,
   customInvalidTagMessage,
+  mergeSearchGroupWith,
 }: Props) {
   return (
     <SearchDropdownOverlay className={className} data-test-id="smart-search-dropdown">
@@ -70,22 +72,31 @@ function SearchDropdown({
               <Fragment key={item.title}>
                 {item.type === 'header' && <HeaderItem group={item} />}
                 {item.children &&
-                  item.children.map(child => (
-                    <DropdownItem
-                      key={getDropdownItemKey(child)}
-                      item={child}
-                      searchSubstring={searchSubstring}
-                      onClick={onClick}
-                      onIconClick={onIconClick}
-                      additionalSearchConfig={{
-                        ...getSearchConfigFromCustomPerformanceMetrics(
-                          customPerformanceMetrics
-                        ),
-                        supportedTags,
-                      }}
-                      customInvalidTagMessage={customInvalidTagMessage}
-                    />
-                  ))}
+                  item.children.map(child => {
+                    if (
+                      mergeSearchGroupWith &&
+                      child.title &&
+                      mergeSearchGroupWith[child.title]
+                    ) {
+                      Object.assign(child, mergeSearchGroupWith[child.title]);
+                    }
+                    return (
+                      <DropdownItem
+                        key={getDropdownItemKey(child)}
+                        item={child}
+                        searchSubstring={searchSubstring}
+                        onClick={onClick}
+                        onIconClick={onIconClick}
+                        additionalSearchConfig={{
+                          ...getSearchConfigFromCustomPerformanceMetrics(
+                            customPerformanceMetrics
+                          ),
+                          supportedTags,
+                        }}
+                        customInvalidTagMessage={customInvalidTagMessage}
+                      />
+                    );
+                  })}
                 {isEmpty && <Info>{t('No items found')}</Info>}
               </Fragment>
             );
@@ -230,6 +241,7 @@ function ItemTitle({item, searchSubstring, isChild}: ItemTitleProps) {
               hasSplit={words.length > 1}
             />
           )}
+          {item.titleBadge}
         </SearchItemTitleWrapper>
       );
     }

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -44,6 +44,7 @@ export type SearchItem = {
   ignoreMaxSearchItems?: boolean;
   kind?: FieldKind;
   title?: string;
+  titleBadge?: React.ReactNode;
   type?: ItemType;
   /**
    * A value of null means that this item is not selectable in the search dropdown

--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -126,7 +126,7 @@ function ReplaySearchBar(props: Props) {
       fieldDefinitionGetter={getReplayFieldDefinition}
       mergeSearchGroupWith={{
         click: {
-          documentation: t('Requires min sdk >= 7.44.0'),
+          documentation: t('Requires SDK version >= 7.44.0'),
           titleBadge: <FeatureBadge type="new">{t('New')}</FeatureBadge>,
         },
       }}

--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect} from 'react';
 
 import {fetchTagValues, loadOrganizationTags} from 'sentry/actionCreators/tags';
+import FeatureBadge from 'sentry/components/featureBadge';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH, NEGATION_OPERATOR, SEARCH_WILDCARD} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -123,6 +124,12 @@ function ReplaySearchBar(props: Props) {
       maxMenuHeight={500}
       hasRecentSearches
       fieldDefinitionGetter={getReplayFieldDefinition}
+      mergeSearchGroupWith={{
+        click: {
+          documentation: t('Requires min sdk >= 7.44.0'),
+          titleBadge: <FeatureBadge type="new">{t('New')}</FeatureBadge>,
+        },
+      }}
       onSearch={(query: string) => {
         props.onSearch?.(query);
         const conditions = new MutableSearch(query);


### PR DESCRIPTION
## Summary
Adds the ability to extend search dropdown items. In our case this allows us to drop in a new feature badge and add a description to a search group parent item which would otherwise default to '-'.

Note: Its not the prettiest solution, but its effective. I went through the exploration of mutating the search items but ultimately decided it was better to provide an additional object to supply additional props. The codepath for modifying the search groups is non-trivial so i'd rather keep this simpler solution.