### PR TITLE
feat(replay): Always expand network details objects 1 level

### DIFF
--- a/static/app/views/replays/detail/network/networkDetails.tsx
+++ b/static/app/views/replays/detail/network/networkDetails.tsx
@@ -88,7 +88,7 @@ function NetworkRequestDetails({initialHeight = 100, items}: Props) {
           <Fragment key={label}>
             <SectionTitle>{label}</SectionTitle>
             <SectionData>
-              <ObjectInspector data={sectionData} />
+              <ObjectInspector data={sectionData} expandLevel={1} />
             </SectionData>
           </Fragment>
         ))}


### PR DESCRIPTION
This will always expand the objects in Network details a single level.

![image](https://user-images.githubusercontent.com/79684/232910888-c75195ef-39e2-45d3-be63-899456f0252c.png)
