### PR TITLE
fix(rulesnooze) : update endpoint to return 403 instead of 401

### DIFF
--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -1,7 +1,7 @@
 import datetime
 
 from rest_framework import serializers, status
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -76,7 +76,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
 
         user_id = request.user.id if data.get("target") == "me" else None
         if not can_edit_alert_rule(rule, project.organization, user_id, request.user):
-            raise AuthenticationFailed(
+            raise PermissionDenied(
                 detail="Requesting user cannot mute this rule.", code=status.HTTP_403_FORBIDDEN
             )
 
@@ -175,8 +175,8 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
 
         # didn't find a match but there is a shared snooze
         if shared_snooze:
-            raise AuthenticationFailed(
-                detail="Requesting user cannot mute this rule.", code=status.HTTP_403_FORBIDDEN
+            raise PermissionDenied(
+                detail="Requesting user cannot unmute this rule.", code=status.HTTP_403_FORBIDDEN
             )
         # no snooze at all found
         return Response(

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -77,7 +77,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
         user_id = request.user.id if data.get("target") == "me" else None
         if not can_edit_alert_rule(rule, project.organization, user_id, request.user):
             raise AuthenticationFailed(
-                detail="Requesting user cannot mute this rule.", code=status.HTTP_401_UNAUTHORIZED
+                detail="Requesting user cannot mute this rule.", code=status.HTTP_403_FORBIDDEN
             )
 
         kwargs = {self.rule_field: rule}
@@ -176,7 +176,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
         # didn't find a match but there is a shared snooze
         if shared_snooze:
             raise AuthenticationFailed(
-                detail="Requesting user cannot mute this rule.", code=status.HTTP_401_UNAUTHORIZED
+                detail="Requesting user cannot mute this rule.", code=status.HTTP_403_FORBIDDEN
             )
         # no snooze at all found
         return Response(

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -211,7 +211,7 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
             **data,
         )
         assert not RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
-        assert response.status_code == 401
+        assert response.status_code == 403
         assert "Requesting user cannot mute this rule" in response.data["detail"]
 
     @with_feature("organizations:mute-alerts")
@@ -326,7 +326,7 @@ class DeleteRuleSnoozeTest(BaseRuleSnoozeTest):
             **data,
         )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
-        assert response.status_code == 401
+        assert response.status_code == 403
 
 
 @region_silo_test
@@ -519,7 +519,7 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
             **data,
         )
         assert not RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule).exists()
-        assert response.status_code == 401
+        assert response.status_code == 403
         assert "Requesting user cannot mute this rule" in response.data["detail"]
 
     @with_feature("organizations:mute-alerts")
@@ -614,4 +614,4 @@ class DeleteMetricRuleSnoozeTest(BaseRuleSnoozeTest):
             self.organization.slug, self.project.slug, other_metric_alert_rule.id
         )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule.id).exists()
-        assert response.status_code == 401
+        assert response.status_code == 403


### PR DESCRIPTION
this pr updates the rule snooze endpoint to return a 403 error instead of 401 if the user does not have edit access. This is to allow the frontend to show an error message instead of having the page force reloaded (which happens when the 401 is returned) 