### PR TITLE
ref(analytics): add new analytics hook

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -185,7 +185,9 @@ export type CustomizationHooks = {
 export type AnalyticsHooks = {
   'analytics:init-user': AnalyticsInitUser;
   'analytics:log-experiment': AnalyticsLogExperiment;
-  'analytics:track-event-v2': AnalyticsTrackEventV2;
+  'analytics:raw-trace-event': RawAnalyticsTrackEvent;
+  // TODO: remove this hook once we've migrated to the new one
+  'analytics:track-event-v2': RawAnalyticsTrackEvent;
   'metrics:event': MetricsEvent;
 };
 
@@ -362,7 +364,7 @@ type AnalyticsInitUser = (user: User) => void;
 /**
  * Trigger analytics tracking in the hook store.
  */
-type AnalyticsTrackEventV2 = (
+type RawAnalyticsTrackEvent = (
   data: {
     /**
      * Arbitrary data to track

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -185,9 +185,9 @@ export type CustomizationHooks = {
 export type AnalyticsHooks = {
   'analytics:init-user': AnalyticsInitUser;
   'analytics:log-experiment': AnalyticsLogExperiment;
-  'analytics:raw-trace-event': RawAnalyticsTrackEvent;
+  'analytics:raw-track-event': AnalyticsRawTrackEvent;
   // TODO: remove this hook once we've migrated to the new one
-  'analytics:track-event-v2': RawAnalyticsTrackEvent;
+  'analytics:track-event-v2': AnalyticsRawTrackEvent;
   'metrics:event': MetricsEvent;
 };
 
@@ -364,7 +364,7 @@ type AnalyticsInitUser = (user: User) => void;
 /**
  * Trigger analytics tracking in the hook store.
  */
-type RawAnalyticsTrackEvent = (
+type AnalyticsRawTrackEvent = (
   data: {
     /**
      * Arbitrary data to track


### PR DESCRIPTION
I'm renaming `trackAnalyticsEventV2` to `rawTackAnalytics` because this function should only be called in `makeAnalyticsFunction`. Here's the ordering of PRs:
1. Add the type
2. Set the hook in getentry
3. Swap the hooks in sentry
4. Remove the old hook in getsentry
5. Remove the old hook in sentry