### PR TITLE
ref(replays): initialize client on endpoint init

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -8,11 +8,15 @@ from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.replays.usecases.reader import download_segments, fetch_segments_metadata
+from sentry.replays.usecases.reader import download_segments, fetch_segments_metadata, storage
 
 
 @region_silo_endpoint
 class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
+    def __init__(self, **options) -> None:
+        storage.initialize_client()
+        super().__init__(**options)
+
     def get(self, request: Request, project, replay_id: str) -> Response:
         if not features.has(
             "organizations:session-replay", project.organization, actor=request.user

--- a/src/sentry/replays/lib/storage.py
+++ b/src/sentry/replays/lib/storage.py
@@ -114,6 +114,15 @@ class StorageBlob(Blob):
     bucket.  Keys are prefixed by their TTL.  Those TTLs are 30, 60, 90.  Measured in days.
     """
 
+    def initialize_client(self):
+        storage = get_storage(self._make_storage_options())
+        # acccess the storage client so it is initialized below.
+        # this will prevent race condition parallel credential getting during segment download
+        # when using many threads
+        # the storage client uses a global so we don't need to store it here.
+        if hasattr(storage, "client"):
+            storage.client
+
     def delete(self, segment: RecordingSegmentStorageMeta) -> None:
         storage = get_storage(self._make_storage_options())
         storage.delete(self.make_key(segment))

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -25,7 +25,7 @@ from snuba_sdk import (
 )
 
 from sentry.models.file import File, FileBlobIndex
-from sentry.replays.lib.storage import FilestoreBlob, RecordingSegmentStorageMeta, StorageBlob
+from sentry.replays.lib.storage import RecordingSegmentStorageMeta, filestore, storage
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.utils.snuba import raw_snql_query
 
@@ -283,7 +283,7 @@ def download_segment(
             op="download_segment",
             description="thread_task",
         ):
-            driver = FilestoreBlob() if segment.file_id else StorageBlob()
+            driver = filestore if segment.file_id else storage
             with sentry_sdk.start_span(
                 op="download_segment",
                 description="download",


### PR DESCRIPTION
- our current [spans](https://sentry.sentry.io/performance/sentry:7abe7aef195f40df8387bfa2b0a62ddd/?project=1&query=http.method%3AGET&referrer=performance-transaction-summary&statsPeriod=14d&transaction=ProjectReplayRecordingSegmentIndexEndpoint.download_segments&unselectedSeries=p100%28%29) show that there is a race condition where each thread tries to authenticate with google before downloading a replay segment (when using the GCS storage driver as getsentry does in production)
- this PR makes it so that when the endpoint is initialized for the first time, we initialize the client by accessing it if it exists. Copying the pattern here https://github.com/getsentry/sentry/blob/65d18c50f780fda34921aba4b3e4186c1c4ac19c/src/sentry/api/endpoints/client_state.py#L35

It would be nice to do this at boot time / initialization time so it doesn't have to happen when a user is trying to make a request, but I am unsure of side effects.