### PR TITLE
ref(replays): stream segment downloads in replay segment index endpoint

### DIFF
--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -266,6 +266,7 @@ def download_segments(segments: List[RecordingSegmentStorageMeta]) -> Iterator[b
 
             if i < len(segments) - 1:
                 yield b","
+    yield b"]"
     transaction.finish()
 
 

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -253,23 +253,19 @@ def download_segments(segments: List[RecordingSegmentStorageMeta]) -> Iterator[b
         download_segment, transaction=transaction, current_hub=sentry_sdk.Hub.current
     )
 
-    # use a threadpool to download each segment from storage.
-    # stream the downloaded segments as they come in, in order.
     yield b"["
-    with ThreadPoolExecutor(max_workers=4) as exe:
-        futures = [exe.submit(download_segment_with_fixed_args, segment) for segment in segments]
+    # Map all of the segments to a worker process for download.
+    with ThreadPoolExecutor(max_workers=10) as exe:
+        results = exe.map(download_segment_with_fixed_args, segments)
 
-        while len(futures) > 0:
-            result = futures.pop(0).result()
+        for i, result in enumerate(results):
             if result is None:
                 yield b"[]"
             else:
                 yield result
-            if len(futures) > 0:
-                # on the last element don't add a comma as it results in invalid json
-                yield b","
-    yield b"]"
 
+            if i < len(segments) - 1:
+                yield b","
     transaction.finish()
 
 


### PR DESCRIPTION
this should help a bit for larger replays as the server can stream as the segments are downloaded, instead of having to wait for all of them to finish.