### PR TITLE
ref(metric-alerts): Disable indexed metrics warning

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -27,8 +27,6 @@ import Pagination from 'sentry/components/pagination';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {parseSearch} from 'sentry/components/searchSyntax/parser';
 import HighlightQuery from 'sentry/components/searchSyntax/renderer';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PageFilters, SelectValue} from 'sentry/types';
@@ -177,7 +175,8 @@ function WidgetViewerModal(props: Props) {
   const location = useLocation();
   const router = useRouter();
   const shouldShowSlider = organization.features.includes('widget-viewer-modal-minimap');
-  let widgetContentLoadingStatus: boolean | undefined = undefined;
+  // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
+  // let widgetContentLoadingStatus: boolean | undefined = undefined;
   // Get widget zoom from location
   // We use the start and end query params for just the initial state
   const start = decodeScalar(location.query[WidgetViewerQueryField.START]);
@@ -799,8 +798,9 @@ function WidgetViewerModal(props: Props) {
             dashboardFilters={getDashboardFiltersFromURL(location) ?? undefined}
           >
             {({tableResults, loading, pageLinks}) => {
+              // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
               // small hack that improves the concurrency render of the warning triangle
-              widgetContentLoadingStatus = loading;
+              // widgetContentLoadingStatus = loading;
               return (
                 <DiscoverTable
                   tableResults={tableResults}
@@ -994,23 +994,24 @@ function WidgetViewerModal(props: Props) {
                     <WidgetTitle>
                       <h3>{widget.title}</h3>
                       <DashboardsMEPConsumer>
-                        {({isMetricsData}) => {
-                          if (
-                            widgetContentLoadingStatus === false &&
-                            widget.widgetType === WidgetType.DISCOVER &&
-                            isMetricsData === false
-                          ) {
-                            return (
-                              <Tooltip
-                                containerDisplayMode="inline-flex"
-                                title={t(
-                                  'Based on your search criteria, the sampled events available may be limited and may not be representative of all events.'
-                                )}
-                              >
-                                <IconWarning color="warningText" size="md" />
-                              </Tooltip>
-                            );
-                          }
+                        {({}) => {
+                          // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
+                          // if (
+                          //   widgetContentLoadingStatus === false &&
+                          //   widget.widgetType === WidgetType.DISCOVER &&
+                          //   isMetricsData === false
+                          // ) {
+                          //   return (
+                          //     <Tooltip
+                          //       containerDisplayMode="inline-flex"
+                          //       title={t(
+                          //         'Based on your search criteria, the sampled events available may be limited and may not be representative of all events.'
+                          //       )}
+                          //     >
+                          //       <IconWarning color="warningText" size="md" />
+                          //     </Tooltip>
+                          //   );
+                          // }
 
                           return null;
                         }}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -298,22 +298,23 @@ class WidgetCard extends Component<Props, State> {
                     <WidgetTitle>{widget.title}</WidgetTitle>
                   </Tooltip>
                   <DashboardsMEPConsumer>
-                    {({isMetricsData}) => {
-                      if (
-                        isMetricsData === false &&
-                        widget.widgetType === WidgetType.DISCOVER
-                      ) {
-                        return (
-                          <Tooltip
-                            containerDisplayMode="inline-flex"
-                            title={t(
-                              'Based on your search criteria, the sampled events available may be limited and may not be representative of all events.'
-                            )}
-                          >
-                            <IconWarning color="warningText" />
-                          </Tooltip>
-                        );
-                      }
+                    {({}) => {
+                      // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
+                      // if (
+                      //   isMetricsData === false &&
+                      //   widget.widgetType === WidgetType.DISCOVER
+                      // ) {
+                      //   return (
+                      //     <Tooltip
+                      //       containerDisplayMode="inline-flex"
+                      //       title={t(
+                      //         'Based on your search criteria, the sampled events available may be limited and may not be representative of all events.'
+                      //       )}
+                      //     >
+                      //       <IconWarning color="warningText" />
+                      //     </Tooltip>
+                      //   );
+                      // }
                       return null;
                     }}
                   </DashboardsMEPConsumer>


### PR DESCRIPTION
We are disabling the feature implemented for the task https://github.com/getsentry/sentry/issues/47006, until we find a better way to determine if the widget data is of type transaction only.