### PR TITLE
fix(dynamic-sampling):Disable prioritise transactions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -904,11 +904,6 @@ CELERYBEAT_SCHEDULE = {
         # Run job every 5 minutes
         "schedule": timedelta(minutes=5),
     },
-    "dynamic-sampling-prioritize-transactions": {
-        "task": "sentry.dynamic_sampling.tasks.prioritise_transactions",
-        # Run every 5 minutes
-        "schedule": timedelta(minutes=6),
-    },
     "weekly-escalating-forecast": {
         "task": "sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",
         # TODO: Change this to run weekly once we verify the results

--- a/src/sentry/dynamic_sampling/rules/combine.py
+++ b/src/sentry/dynamic_sampling/rules/combine.py
@@ -3,9 +3,6 @@ from sentry.dynamic_sampling.rules.biases.boost_key_transactions_bias import (
     BoostKeyTransactionsBias,
 )
 from sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias import BoostLatestReleasesBias
-from sentry.dynamic_sampling.rules.biases.boost_rare_transactions_rule import (
-    RareTransactionsRulesBias,
-)
 from sentry.dynamic_sampling.rules.biases.factor_bias import AdjustmentFactorBias
 from sentry.dynamic_sampling.rules.biases.ignore_health_checks_bias import IgnoreHealthChecksBias
 from sentry.dynamic_sampling.rules.biases.uniform_bias import UniformBias
@@ -22,7 +19,6 @@ def get_relay_biases_combinator() -> BiasesCombinator:
 
     default_combinator.add(RuleType.BOOST_ENVIRONMENTS_RULE, BoostEnvironmentsBias())
     default_combinator.add(RuleType.BOOST_LATEST_RELEASES_RULE, BoostLatestReleasesBias())
-    default_combinator.add(RuleType.BOOST_LOW_VOLUME_TRANSACTIONS, RareTransactionsRulesBias())
     default_combinator.add(RuleType.ADJUSTMENT_FACTOR_RULE, AdjustmentFactorBias())
     default_combinator.add(RuleType.UNIFORM_RULE, UniformBias())
 

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -662,7 +662,6 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
     get_transactions_resampling_rates.return_value = {
         "t1": t1_rate,
     }, implicit_rate
-    boost_low_transactions_id = RESERVED_IDS[RuleType.BOOST_LOW_VOLUME_TRANSACTIONS]
     uniform_id = RESERVED_IDS[RuleType.UNIFORM_RULE]
     default_project.update_option(
         "sentry:dynamic_sampling_biases",
@@ -686,29 +685,6 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
     t1_rate /= project_sample_rate
     t1_rate /= implicit_rate
     assert rules == [
-        # transaction boosting rule
-        {
-            "condition": {
-                "inner": [
-                    {
-                        "name": "event.transaction",
-                        "op": "eq",
-                        "options": {"ignoreCase": True},
-                        "value": ["t1"],
-                    }
-                ],
-                "op": "or",
-            },
-            "id": boost_low_transactions_id,
-            "samplingValue": {"type": "factor", "value": t1_rate},
-            "type": "transaction",
-        },
-        {
-            "condition": {"inner": [], "op": "and"},
-            "id": 1401,
-            "samplingValue": {"type": "factor", "value": implicit_rate},
-            "type": "transaction",
-        },
         {
             "condition": {"inner": [], "op": "and"},
             "id": uniform_id,


### PR DESCRIPTION
This PR disable the execution for prioritise transactions.

After team discussions it was decided that the priority is to obtain complete traces in preference to
having samples from all transactions.

We will enable the prioritise transactions or some form of this after we figure out how to identify and separate
full traces from orphaned transactions so that we can present a better user experience by first displaying transactions
from full traces and then orphaned transactions. 