### PR TITLE
fix(dyn-sampling): move factor bias to the top to apply all events.

### DIFF
--- a/src/sentry/dynamic_sampling/rules/combine.py
+++ b/src/sentry/dynamic_sampling/rules/combine.py
@@ -13,13 +13,13 @@ from sentry.dynamic_sampling.rules.utils import RuleType
 
 def get_relay_biases_combinator() -> BiasesCombinator:
     default_combinator = OrderedBiasesCombinator()
+    default_combinator.add(RuleType.ADJUSTMENT_FACTOR_RULE, AdjustmentFactorBias())
 
     default_combinator.add(RuleType.IGNORE_HEALTH_CHECKS_RULE, IgnoreHealthChecksBias())
     default_combinator.add(RuleType.BOOST_KEY_TRANSACTIONS_RULE, BoostKeyTransactionsBias())
 
     default_combinator.add(RuleType.BOOST_ENVIRONMENTS_RULE, BoostEnvironmentsBias())
     default_combinator.add(RuleType.BOOST_LATEST_RELEASES_RULE, BoostLatestReleasesBias())
-    default_combinator.add(RuleType.ADJUSTMENT_FACTOR_RULE, AdjustmentFactorBias())
     default_combinator.add(RuleType.UNIFORM_RULE, UniformBias())
 
     return default_combinator

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -314,6 +314,12 @@ def test_project_config_with_all_biases_enabled(
         "rules": [],
         "rulesV2": [
             {
+                "condition": {"inner": [], "op": "and"},
+                "id": 1004,
+                "samplingValue": {"type": "factor", "value": default_factor},
+                "type": "trace",
+            },
+            {
                 "samplingValue": {"type": "sampleRate", "value": 0.02},
                 "type": "transaction",
                 "condition": {
@@ -400,12 +406,6 @@ def test_project_config_with_all_biases_enabled(
                     "end": "2022-10-21T19:50:25Z",
                 },
                 "decayingFn": {"type": "linear", "decayedValue": 1.0},
-            },
-            {
-                "condition": {"inner": [], "op": "and"},
-                "id": 1004,
-                "samplingValue": {"type": "factor", "value": default_factor},
-                "type": "trace",
             },
             {
                 "samplingValue": {"type": "sampleRate", "value": 0.1},


### PR DESCRIPTION
This PR moves factor bias to the top based on https://github.com/getsentry/relay/pull/2049