### PR TITLE
feat(sourcemaps): Add guard to avoid refetching failed urls

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -1186,10 +1186,12 @@ class Fetcher:
         if result is None:
             if not url.startswith(("http:", "https:")):
                 error = {"type": EventError.JS_MISSING_SOURCE, "url": http.expose_url(url)}
+                self.failed_urls.add(url)
                 raise http.CannotFetch(error)
 
             if not self.allow_scraping:
                 error = {"type": EventError.JS_SCRAPING_DISABLED, "url": http.expose_url(url)}
+                self.failed_urls.add(url)
                 raise http.CannotFetch(error)
 
             logger.debug("Checking cache for url %r", url)

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -1853,6 +1853,11 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             # a valid file to cache
             return None, FetcherSource.NONE
         else:
+            # In case the fetch_by_url call returns None, it means we weren't able to fetch the data or that the
+            # request failed in the past, and we shouldn't retry it.
+            if result is None:
+                return None, FetcherSource.NONE
+
             sourceview = SourceView.from_bytes(result.body)
             self.fetch_by_url_sourceviews[url] = sourceview
 


### PR DESCRIPTION
This PR adds a small improvement to the processing logic, which will avoid subsequent `url` lookups to be done in case one failed.