### PR TITLE
feat(starfish): Add percentile_range to arithmetic allow list

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -184,6 +184,7 @@ class ArithmeticVisitor(NodeVisitor):
         "epm",
         "count_miserable",
         "count_web_vitals",
+        "percentile_range",
     }
 
     def __init__(self, max_operators: int, custom_measurements: Optional[Set[str]]):


### PR DESCRIPTION
This allows us to use percentile range in equations
to allow quick prototyping of deltas off the indexed
transactions table