### PR TITLE
fix(searchbar): reduce runtime to On when generating search items from tags

### DIFF
--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -388,11 +388,11 @@ const getItemTitle = (key: string, kind: FieldKind) => {
  * The parent will become interactive if there exists a key "device".
  */
 export const getTagItemsFromKeys = (
-  tagKeys: string[],
+  tagKeys: Readonly<Readonly<string>[]>,
   supportedTags: TagCollection,
   fieldDefinitionGetter: typeof getFieldDefinition = getFieldDefinition
 ) => {
-  return [...tagKeys].reduce<SearchItem[]>((groups, key) => {
+  return tagKeys.reduce<SearchItem[]>((groups: SearchItem[], key: string) => {
     const keyWithColon = `${key}:`;
     const sections = key.split('.');
 
@@ -448,8 +448,8 @@ export const getTagItemsFromKeys = (
         ];
       }
     }
-
-    return [...groups, item];
+    groups.push(item);
+    return groups;
   }, []);
 };
 


### PR DESCRIPTION
This came up from some eslint rule testing so I figured I'd fix it as the searchbar is somewhat of a vital piece of software at Sentry and this looks like a hot path? 

Initial shallow copy is unnecessary and return [...groups, item] from each iteration causes On^2 runtime