### PR TITLE
fix(starfish): update cache module queries to use action

### DIFF
--- a/static/app/views/starfish/modules/cacheModule/cacheChartView.tsx
+++ b/static/app/views/starfish/modules/cacheModule/cacheChartView.tsx
@@ -13,24 +13,23 @@ type Props = {
 
 export default function CacheModuleView({}: Props) {
   const GRAPH_QUERY = `
-  select operation,
+  select action,
        count() as count,
        toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval
   from default.spans_experimental_starfish
   where module = 'cache'
- group by interval,
-          operation
-  order by interval, operation
+ group by interval, action
+  order by interval, action
   `;
   const TOTALS_QUERY = `
-  select operation,
+  select action,
        sum(exclusive_time) as count,
        toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval
   from default.spans_experimental_starfish
   where module = 'cache'
  group by interval,
-          operation
-  order by interval, operation
+          action
+  order by interval, action
   `;
 
   const {isLoading: isGraphLoading, data: graphData} = useQuery({
@@ -46,16 +45,16 @@ export default function CacheModuleView({}: Props) {
     initialData: [],
   });
 
-  const seriesByOperation: {[operation: string]: Series} = {};
+  const seriesByOperation: {[action: string]: Series} = {};
   graphData.forEach(datum => {
-    seriesByOperation[datum.operation] = {
-      seriesName: datum.operation,
+    seriesByOperation[datum.action] = {
+      seriesName: datum.action,
       data: [],
     };
   });
 
   graphData.forEach(datum => {
-    seriesByOperation[datum.operation].data.push({
+    seriesByOperation[datum.action].data.push({
       value: datum.count,
       name: datum.interval,
     });
@@ -63,16 +62,16 @@ export default function CacheModuleView({}: Props) {
 
   const data = Object.values(seriesByOperation);
 
-  const seriesByOperation2: {[operation: string]: Series} = {};
+  const seriesByOperation2: {[action: string]: Series} = {};
   totalsQueryGraphData.forEach(datum => {
-    seriesByOperation2[datum.operation] = {
-      seriesName: datum.operation,
+    seriesByOperation2[datum.action] = {
+      seriesName: datum.action,
       data: [],
     };
   });
 
   totalsQueryGraphData.forEach(datum => {
-    seriesByOperation2[datum.operation].data.push({
+    seriesByOperation2[datum.action].data.push({
       value: datum.count,
       name: datum.interval,
     });

--- a/static/app/views/starfish/modules/cacheModule/cacheTableView.tsx
+++ b/static/app/views/starfish/modules/cacheModule/cacheTableView.tsx
@@ -16,8 +16,8 @@ export type DataRow = {
 };
 
 type Props = {
+  action: string;
   location: Location;
-  operation: string;
   setSelectedRow: (row: DataRow) => void;
   transaction: string;
 };
@@ -48,15 +48,15 @@ const COLUMN_ORDER = [
 
 export default function CacheModuleView({
   location,
-  operation,
+  action,
   transaction,
   setSelectedRow,
 }: Props) {
-  const ENDPOINT_QUERY = `select description as desc, (divide(count(), divide(1209600.0, 60)) AS epm), quantile(0.75)(exclusive_time) as p75,
+  const CACHE_TABLE_QUERY = `select description as desc, (divide(count(), divide(1209600.0, 60)) AS epm), quantile(0.75)(exclusive_time) as p75,
   uniq(transaction) as transactions,
   sum(exclusive_time) as total_time
     from default.spans_experimental_starfish
-    where module == 'cache' and operation='${operation}'
+    where module == 'cache' and action='${action}'
     group by description
     limit 100
   `;
@@ -76,9 +76,9 @@ export default function CacheModuleView({
     return <span>{row[column.key]}</span>;
   };
 
-  const {isLoading: areEndpointsLoading, data: endpointsData} = useQuery({
-    queryKey: ['endpoints', operation, transaction],
-    queryFn: () => fetch(`${HOST}/?query=${ENDPOINT_QUERY}`).then(res => res.json()),
+  const {isLoading: areEndpointsLoading, data: cacheTableData} = useQuery({
+    queryKey: ['endpoints', action, transaction],
+    queryFn: () => fetch(`${HOST}/?query=${CACHE_TABLE_QUERY}`).then(res => res.json()),
     retry: false,
     initialData: [],
   });
@@ -86,7 +86,7 @@ export default function CacheModuleView({
   return (
     <GridEditable
       isLoading={areEndpointsLoading}
-      data={endpointsData}
+      data={cacheTableData}
       columnOrder={COLUMN_ORDER}
       columnSortBy={[]}
       grid={{

--- a/static/app/views/starfish/modules/cacheModule/index.tsx
+++ b/static/app/views/starfish/modules/cacheModule/index.tsx
@@ -46,14 +46,14 @@ function getOptions() {
 }
 
 function CacheModule(props: Props) {
-  const [operation, setOperation] = useState<string>('SET');
+  const [action, setAction] = useState<string>('SET');
   const [transaction, setTransaction] = useState<string>('');
   const [selectedRow, setSelectedRow] = useState<DataRow | null>(null);
   const {location, organization} = props;
   const eventView = EventView.fromLocation(location);
 
   const handleOptionChange = value => {
-    setOperation(value);
+    setAction(value);
   };
 
   const handleSearch = query => {
@@ -84,7 +84,7 @@ function CacheModule(props: Props) {
             <PageErrorAlert />
             <CacheChartView location={location} />
             <CompactSelect
-              value={operation}
+              value={action}
               options={getOptions()}
               onChange={opt => handleOptionChange(opt.value)}
             />
@@ -96,7 +96,7 @@ function CacheModule(props: Props) {
             />
             <CacheTableView
               location={location}
-              operation={operation}
+              action={action}
               transaction={transaction}
               setSelectedRow={setSelectedRow}
             />


### PR DESCRIPTION
New starfish data generator uses action instead of operation.
Also did some super quick variable naming refactor 