### PR TITLE
feat(starfish): Calculate failure rate from local database

### DIFF
--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -7,3 +7,14 @@ export const MODULE_DURATION_QUERY = `SELECT
  GROUP BY interval, module
  ORDER BY interval asc
  `;
+
+export const FAILURE_RATE_QUERY = `SELECT
+ toStartOfInterval(start_timestamp, INTERVAL 5 MINUTE) as interval,
+ countIf(greaterOrEquals(status, 200) AND less(status, 300)) as successCount,
+ countIf(greaterOrEquals(status, 500)) as failureCount,
+ divide(failureCount, plus(successCount, failureCount)) as failureRate
+ FROM spans_experimental_starfish
+ WHERE module = 'http'
+ GROUP BY interval
+ ORDER BY interval asc
+ `;

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -1,25 +1,24 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
+import moment from 'moment';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {PerformanceLayoutBodyRow} from 'sentry/components/performance/layouts';
 import CHART_PALETTE from 'sentry/constants/chartPalette';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import EventView from 'sentry/utils/discover/eventView';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import withApi from 'sentry/utils/withApi';
-import FailureRateChart from 'sentry/views/starfish/views/webServiceView/failureRateChart';
-
-const EventsRequest = withApi(_EventsRequest);
-
 import {useQuery} from 'sentry/utils/queryClient';
 import Chart from 'sentry/views/starfish/components/chart';
-import {MODULE_DURATION_QUERY} from 'sentry/views/starfish/views/webServiceView/queries';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
+import FailureRateChart from 'sentry/views/starfish/views/webServiceView/failureRateChart';
+import {
+  FAILURE_RATE_QUERY,
+  MODULE_DURATION_QUERY,
+} from 'sentry/views/starfish/views/webServiceView/queries';
 
 import EndpointList from './endpointList';
 
@@ -33,12 +32,19 @@ type BasePerformanceViewProps = {
 const HOST = 'http://localhost:8080';
 
 export function StarfishView(props: BasePerformanceViewProps) {
-  const {organization, eventView} = props;
+  const {eventView} = props;
 
   const {isLoading: isDurationDataLoading, data: moduleDurationData} = useQuery({
-    queryKey: ['graph'],
+    queryKey: ['durationBreakdown'],
     queryFn: () =>
       fetch(`${HOST}/?query=${MODULE_DURATION_QUERY}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+
+  const {isLoading: isFailureRateDataLoading, data: failureRateData} = useQuery({
+    queryKey: ['failureRate'],
+    queryFn: () => fetch(`${HOST}/?query=${FAILURE_RATE_QUERY}`).then(res => res.json()),
     retry: false,
     initialData: [],
   });
@@ -81,60 +87,17 @@ export function StarfishView(props: BasePerformanceViewProps) {
 
   const data = Object.values(seriesByModule);
 
-  function renderFailureRateChart() {
-    const query = new MutableSearch(['event.type:transaction']);
-
-    return (
-      <EventsRequest
-        query={query.formatString()}
-        includePrevious={false}
-        partial
-        interval="1h"
-        includeTransformedData
-        limit={1}
-        environment={eventView.environment}
-        project={eventView.project}
-        period={eventView.statsPeriod}
-        referrer="starfish-homepage-failure-rate"
-        start={eventView.start}
-        end={eventView.end}
-        organization={organization}
-        yAxis="equation|count_if(http.status_code,greaterOrEquals,500)/(count_if(http.status_code,equals,200)+count_if(http.status_code,greaterOrEquals,500))"
-      >
-        {eventData => {
-          const transformedData: Series[] | undefined = eventData.timeseriesData?.map(
-            series => ({
-              data: series.data,
-              seriesName: t('Failure Rate'),
-              color: CHART_PALETTE[5][3],
-            })
-          );
-
-          if (!transformedData) {
-            return null;
-          }
-
-          return (
-            <FailureRateChart
-              statsPeriod={eventView.statsPeriod}
-              height={180}
-              data={transformedData}
-              start={eventView.start as string}
-              end={eventView.end as string}
-              loading={eventData.loading}
-              utc={false}
-              grid={{
-                left: '0',
-                right: '0',
-                top: '16px',
-                bottom: '8px',
-              }}
-            />
-          );
-        }}
-      </EventsRequest>
-    );
-  }
+  const failureRateSeries = zeroFillSeries(
+    {
+      seriesName: 'Failure Rate',
+      color: CHART_PALETTE[5][3],
+      data: failureRateData.map(entry => ({
+        value: entry.failureRate,
+        name: entry.interval,
+      })),
+    },
+    moment.duration(5, 'minutes')
+  );
 
   return (
     <div data-test-id="starfish-view">
@@ -159,7 +122,22 @@ export function StarfishView(props: BasePerformanceViewProps) {
             stacked
             chartColors={['#444674', '#7a5088', '#b85586']}
           />
-          {renderFailureRateChart()}
+
+          <FailureRateChart
+            statsPeriod={eventView.statsPeriod}
+            height={180}
+            data={[failureRateSeries]}
+            start={eventView.start as string}
+            end={eventView.end as string}
+            loading={isFailureRateDataLoading}
+            utc={false}
+            grid={{
+              left: '0',
+              right: '0',
+              top: '16px',
+              bottom: '8px',
+            }}
+          />
         </Fragment>
       </StyledRow>
 


### PR DESCRIPTION
Calculates failure rate by fetching directly from the Clickhouse spans table, instead of from Discover