### PR TITLE
feat(exception-group): Add new mechanism fields to Exception interface

### DIFF
--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -128,7 +128,19 @@ class Mechanism(Interface):
 
     @classmethod
     def to_python(cls, data, **kwargs):
-        for key in ("type", "synthetic", "description", "help_link", "handled", "data", "meta"):
+        for key in (
+            "type",
+            "synthetic",
+            "description",
+            "help_link",
+            "handled",
+            "data",
+            "meta",
+            "source",
+            "is_exception_group",
+            "exception_id",
+            "parent_id",
+        ):
             data.setdefault(key, None)
 
         return super().to_python(data, **kwargs)
@@ -143,6 +155,10 @@ class Mechanism(Interface):
                 "handled": self.handled,
                 "data": self.data or None,
                 "meta": prune_empty_keys(self.meta) or None,
+                "source": self.source,
+                "is_exception_group": self.is_exception_group,
+                "exception_id": self.exception_id,
+                "parent_id": self.parent_id,
             }
         )
 

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mechanism.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-30T08:25:08.436911Z'
+created: '2023-04-19T16:08:28.133847Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
@@ -9,6 +9,10 @@ get_api_context:
   hasSystemFrames: true
   values:
   - mechanism:
+      exception_id: 1
+      is_exception_group: true
+      parent_id: 0
+      source: __context__
       type: generic
     module: foo.bar
     rawStacktrace: null
@@ -40,6 +44,10 @@ get_api_context:
 to_json:
   values:
   - mechanism:
+      exception_id: 1
+      is_exception_group: true
+      parent_id: 0
+      source: __context__
       type: generic
     module: foo.bar
     stacktrace:

--- a/tests/sentry/event_manager/interfaces/test_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_exception.py
@@ -206,7 +206,13 @@ def test_context_with_mechanism(make_exception_snapshot):
                     "stacktrace": {
                         "frames": [{"filename": "foo/baz.py", "lineno": 1, "in_app": True}]
                     },
-                    "mechanism": {"type": "generic"},
+                    "mechanism": {
+                        "type": "generic",
+                        "source": "__context__",
+                        "is_exception_group": True,
+                        "exception_id": 1,
+                        "parent_id": 0,
+                    },
                 }
             ]
         )


### PR DESCRIPTION
Mirrors the properties added in https://github.com/getsentry/relay/pull/2020

Without this change the event endpoints will strip these values.