### PR TITLE
feat(alerts): Move blocking member list request

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
@@ -17,6 +17,7 @@ describe('AlertRuleDetails', () => {
   const rule = TestStubs.ProjectAlertRule({
     lastTriggered: moment().subtract(2, 'day').format(),
   });
+  const member = TestStubs.Member();
 
   const createWrapper = (props = {}) => {
     const params = {
@@ -77,7 +78,7 @@ describe('AlertRuleDetails', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/users/`,
-      body: [],
+      body: [member],
     });
 
     ProjectsStore.init();
@@ -161,20 +162,11 @@ describe('AlertRuleDetails', () => {
 
   it('renders incompatible rule filter', async () => {
     const incompatibleRule = TestStubs.ProjectAlertRule({
-      lastTriggered: moment().subtract(2, 'day').format(),
       conditions: [
         {id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'},
         {id: 'sentry.rules.conditions.regression_event.RegressionEventCondition'},
       ],
     });
-    MockApiClient.mockResponses.splice(
-      MockApiClient.mockResponses.findIndex(
-        response =>
-          response.url ===
-          `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/`
-      ),
-      1
-    );
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/`,
       body: incompatibleRule,
@@ -190,9 +182,9 @@ describe('AlertRuleDetails', () => {
 
   it('incompatible rule banner hidden for good rule', async () => {
     createWrapper();
-    expect(await screen.getAllByText('My alert rule')).toHaveLength(2);
+    expect(await screen.findAllByText('My alert rule')).toHaveLength(2);
     expect(
-      await screen.queryByText(
+      screen.queryByText(
         'The conditions in this alert rule conflict and might not be working properly.'
       )
     ).not.toBeInTheDocument();
@@ -218,5 +210,29 @@ describe('AlertRuleDetails', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Unmute'}));
 
     expect(deleteRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('inserts user email into rule notify action', async () => {
+    // Alert rule with "send a notification to member" action
+    const sendNotificationRule = TestStubs.ProjectAlertRule({
+      actions: [
+        {
+          id: 'sentry.mail.actions.NotifyEmailAction',
+          name: 'Send a notification to Member and if none can be found then send a notification to ActiveMembers',
+          targetIdentifier: member.id,
+          targetType: 'Member',
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/`,
+      body: sendNotificationRule,
+    });
+
+    createWrapper();
+
+    expect(
+      await screen.findByText(`Send a notification to ${member.email}`)
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -22,7 +22,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconCopy, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {DateString, Member, Organization, Project} from 'sentry/types';
+import {DateString, Organization, Project} from 'sentry/types';
 import {IssueAlertRule} from 'sentry/types/alerts';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {findIncompatibleRules} from 'sentry/views/alerts/rules/issue';
@@ -38,7 +38,6 @@ type Props = AsyncComponent['props'] & {
 } & RouteComponentProps<{projectId: string; ruleId: string}, {}>;
 
 type State = AsyncComponent['state'] & {
-  memberList: Member[];
   rule: IssueAlertRule | null;
 };
 
@@ -78,7 +77,6 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
     return {
       ...super.getDefaultState(),
       rule: null,
-      memberList: [],
     };
   }
 
@@ -91,11 +89,6 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
         `/projects/${organization.slug}/${projectId}/rules/${ruleId}/`,
         {query: {expand: 'lastTriggered'}},
         {allowError: error => error.status === 404},
-      ],
-      [
-        'memberList',
-        `/organizations/${organization.slug}/users/`,
-        {query: {projectSlug: projectId}},
       ],
     ];
   }
@@ -239,7 +232,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
     const {ruleId, projectId} = params;
     const {cursor} = location.query;
     const {period, start, end, utc} = this.getDataDatetime();
-    const {rule, memberList} = this.state;
+    const {rule} = this.state;
 
     if (!rule) {
       return (
@@ -379,7 +372,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
             />
           </Layout.Main>
           <Layout.Side>
-            <Sidebar rule={rule} memberList={memberList} teams={project.teams} />
+            <Sidebar rule={rule} projectSlug={project.slug} teams={project.teams} />
           </Layout.Side>
         </Layout.Body>
       </PageFiltersContainer>

--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -73,14 +73,14 @@ export function TextAction({
       member => member.user.id === `${action.targetIdentifier}`
     );
     return (
-      <Fragment>{t('Send a notification to %s', user?.email ?? t('Unknown'))}</Fragment>
+      <Fragment>{t('Send a notification to %s', user?.email ?? t('unknown'))}</Fragment>
     );
   }
 
   if (action.targetType === 'Team') {
     const team = teams.find(tm => tm.id === `${action.targetIdentifier}`);
     return (
-      <Fragment>{t('Send a notification to #%s', team?.name ?? t('Unknown'))}</Fragment>
+      <Fragment>{t('Send a notification to #%s', team?.name ?? t('unknown'))}</Fragment>
     );
   }
 

--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -72,7 +72,9 @@ export function TextAction({
     const user = memberList.find(
       member => member.user.id === `${action.targetIdentifier}`
     );
-    return <Fragment>{t('Send a notification to %s', user?.email)}</Fragment>;
+    return (
+      <Fragment>{t('Send a notification to %s', user?.email ?? t('Unknown'))}</Fragment>
+    );
   }
 
   if (action.targetType === 'Team') {

--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -77,7 +77,9 @@ export function TextAction({
 
   if (action.targetType === 'Team') {
     const team = teams.find(tm => tm.id === `${action.targetIdentifier}`);
-    return <Fragment>{t('Send a notification to #%s', team?.name)}</Fragment>;
+    return (
+      <Fragment>{t('Send a notification to #%s', team?.name ?? t('Unknown'))}</Fragment>
+    );
   }
 
   if (action.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction') {


### PR DESCRIPTION
Move blocking member list request to the sidebar where its used. This request is used to display the member's name in the sidebar. eg - `Send a notification to Dave` if its a specific member.

speeds up the page by not blocking the page load on the users request. Could be 1-2 seconds for some orgs

The red line shows where the page was waiting for users request to finish before loading 2 more requests.
![image](https://user-images.githubusercontent.com/1400464/233156592-fc9cf4a4-4b08-495b-8e06-5efc0aea23dd.png)
