### PR TITLE
fix(workflow): Parse url encoded environment names for hiding

### DIFF
--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import unquote
 
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
@@ -121,4 +122,4 @@ class Environment(Model):
         # environment name for historic reasons (see commit b09858f.) In all
         # other contexts (incl. request query string parameters), the empty
         # string should be used.
-        return segment if segment != "none" else ""
+        return unquote(segment) if segment != "none" else ""

--- a/tests/sentry/api/endpoints/test_project_environment_details.py
+++ b/tests/sentry/api/endpoints/test_project_environment_details.py
@@ -94,7 +94,7 @@ class ProjectEnvironmentsTest(APITestCase):
             == 404
         )
 
-    def test_escaped_slash_hide(self):
+    def test_escaped_character_put(self):
         project = self.create_project()
 
         env_name = "PROD/STAGE"

--- a/tests/sentry/api/endpoints/test_project_environment_details.py
+++ b/tests/sentry/api/endpoints/test_project_environment_details.py
@@ -97,6 +97,7 @@ class ProjectEnvironmentsTest(APITestCase):
     def test_escaped_character_put(self):
         project = self.create_project()
 
+        # "/" character will have to be escaped in url path
         env_name = "PROD/STAGE"
         environment = Environment.objects.create(
             organization_id=project.organization_id, name=env_name


### PR DESCRIPTION
environment names with special characters are encoded in the frontend and not parsed on the backend. If the environment had a `/` in it, previously it would return a 404.
