### PR TITLE
feat(replays): add loading indicator to trace tab

### DIFF
--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import Loading from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -23,7 +24,11 @@ function Trace({replayRecord}: Props) {
   useFetchTransactions();
 
   if (!replayRecord || !state.traces?.length) {
-    return <StyledPlaceholder height="100%" />;
+    return (
+      <StyledPlaceholder height="100%">
+        {state.isFetching && <Loading />}
+      </StyledPlaceholder>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
Adds a loading indicator to the `trace` tab in replays. Note; this is not a blocking UI condition, the moment we have a single trace to render we display it and incrementally load traces in the background still.