### PR TITLE
ref(sidebar): Add expandable accordion & use for Starfish

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -50,6 +50,7 @@ import Broadcasts from './broadcasts';
 import SidebarHelp from './help';
 import OnboardingStatus from './onboardingStatus';
 import ServiceIncidents from './serviceIncidents';
+import {SidebarAccordion} from './sidebarAccordion';
 import SidebarDropdown from './sidebarDropdown';
 import SidebarItem from './sidebarItem';
 import {SidebarOrientation, SidebarPanelKey} from './types';
@@ -227,35 +228,37 @@ function Sidebar({location, organization}: Props) {
       features={['starfish-view']}
       organization={organization}
     >
-      <SidebarItem
+      <SidebarAccordion
         {...sidebarItemProps}
         icon={<IconStar />}
+        aria-label={t('Starfish')}
         label={<GuideAnchor target="starfish">{t('Starfish')}</GuideAnchor>}
         to={`/organizations/${organization.slug}/starfish/`}
         id="starfish"
         exact
-      />
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconStar />}
-        label={<GuideAnchor target="starfish">{t('Api')}</GuideAnchor>}
-        to={`/organizations/${organization.slug}/starfish/api/`}
-        id="starfish"
-      />
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconStar />}
-        label={<GuideAnchor target="starfish">{t('Cache')}</GuideAnchor>}
-        to={`/organizations/${organization.slug}/starfish/cache/`}
-        id="starfish"
-      />
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconStar />}
-        label={<GuideAnchor target="starfish">{t('Database')}</GuideAnchor>}
-        to={`/organizations/${organization.slug}/starfish/database/`}
-        id="starfish"
-      />
+      >
+        <SidebarItem
+          {...sidebarItemProps}
+          label={<GuideAnchor target="starfish">{t('Api')}</GuideAnchor>}
+          to={`/organizations/${organization.slug}/starfish/api/`}
+          id="starfish"
+          icon={<SubitemDot collapsed={collapsed} />}
+        />
+        <SidebarItem
+          {...sidebarItemProps}
+          label={<GuideAnchor target="starfish">{t('Cache')}</GuideAnchor>}
+          to={`/organizations/${organization.slug}/starfish/cache/`}
+          id="starfish"
+          icon={<SubitemDot collapsed={collapsed} />}
+        />
+        <SidebarItem
+          {...sidebarItemProps}
+          label={<GuideAnchor target="starfish">{t('Database')}</GuideAnchor>}
+          to={`/organizations/${organization.slug}/starfish/database/`}
+          id="starfish"
+          icon={<SubitemDot collapsed={collapsed} />}
+        />
+      </SidebarAccordion>
     </Feature>
   );
 
@@ -592,6 +595,18 @@ const PrimaryItems = styled('div')`
     ::-webkit-scrollbar {
       display: none;
     }
+  }
+`;
+
+const SubitemDot = styled('div')<{collapsed: boolean}>`
+  width: 3px;
+  height: 3px;
+  background: currentcolor;
+  border-radius: 50%;
+
+  opacity: ${p => (p.collapsed ? 1 : 0)};
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    opacity: 1;
   }
 `;
 

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -239,7 +239,7 @@ function Sidebar({location, organization}: Props) {
       >
         <SidebarItem
           {...sidebarItemProps}
-          label={<GuideAnchor target="starfish">{t('Api')}</GuideAnchor>}
+          label={<GuideAnchor target="starfish">{t('API')}</GuideAnchor>}
           to={`/organizations/${organization.slug}/starfish/api/`}
           id="starfish"
           icon={<SubitemDot collapsed={collapsed} />}

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -1,0 +1,104 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import domId from 'sentry/utils/domId';
+
+import SidebarItem, {SidebarItemProps} from './sidebarItem';
+
+type SidebarAccordionProps = SidebarItemProps & {
+  children?: React.ReactNode;
+};
+
+function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
+  const [expanded, setExpanded] = useState(true);
+  const {collapsed: sidebarCollapsed} = itemProps;
+
+  const mainItemId = useMemo(() => domId('sidebar-accordion-item-'), []);
+  const contentId = useMemo(() => domId('sidebar-accordion-content-'), []);
+
+  return (
+    <SidebarAccordionWrapper>
+      <SidebarAccordionHeaderWrap>
+        <SidebarItem
+          {...itemProps}
+          id={mainItemId}
+          aria-expanded={expanded}
+          aria-owns={contentId}
+          trailingItems={
+            <SidebarItemExandButton
+              size="zero"
+              borderless
+              onClick={() => setExpanded(cur => !cur)}
+              aria-controls={mainItemId}
+              aria-label={expanded ? t('Collapse') : t('Expand')}
+              sidebarCollapsed={sidebarCollapsed}
+            >
+              <IconChevron
+                size="xs"
+                direction={expanded ? 'up' : 'down'}
+                role="presentation"
+              />
+            </SidebarItemExandButton>
+          }
+        />
+      </SidebarAccordionHeaderWrap>
+      {expanded && (
+        <SidebarAccordionSubitemsWrap id={contentId}>
+          {children}
+        </SidebarAccordionSubitemsWrap>
+      )}
+    </SidebarAccordionWrapper>
+  );
+}
+
+export {SidebarAccordion};
+
+const SidebarAccordionWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    flex-direction: row;
+  }
+`;
+
+const SidebarAccordionHeaderWrap = styled('div')`
+  position: relative;
+  display: flex;
+  & > *:first-child {
+    width: 100%;
+    flex-shrink: 1;
+  }
+`;
+
+const SidebarItemExandButton = styled(Button)<{sidebarCollapsed?: boolean}>`
+  height: calc(100% - ${space(1)});
+  margin: 0 -${space(0.5)};
+  padding: 0 ${space(0.75)};
+  border-radius: calc(${p => p.theme.borderRadius} - 2px);
+  color: ${p => p.theme.subText};
+
+  &:hover,
+  a:hover &,
+  a[active] & {
+    color: ${p => p.theme.white};
+  }
+
+  ${p => p.sidebarCollapsed && `display: none;`}
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    display: none;
+  }
+`;
+
+const SidebarAccordionSubitemsWrap = styled('div')`
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    flex-direction: row;
+  }
+`;

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -1,11 +1,10 @@
-import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import domId from 'sentry/utils/domId';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 import SidebarItem, {SidebarItemProps} from './sidebarItem';
 
@@ -14,11 +13,14 @@ type SidebarAccordionProps = SidebarItemProps & {
 };
 
 function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
-  const [expanded, setExpanded] = useState(true);
-  const {collapsed: sidebarCollapsed} = itemProps;
+  const {id, collapsed: sidebarCollapsed} = itemProps;
+  const [expanded, setExpanded] = useLocalStorageState(
+    `sidebar-accordion-${id}:expanded`,
+    true
+  );
 
-  const mainItemId = useMemo(() => domId('sidebar-accordion-item-'), []);
-  const contentId = useMemo(() => domId('sidebar-accordion-content-'), []);
+  const mainItemId = `sidebar-accordion-${id}-item`;
+  const contentId = `sidebar-accordion-${id}-content`;
 
   return (
     <SidebarAccordionWrapper>
@@ -32,7 +34,10 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
             <SidebarItemExandButton
               size="zero"
               borderless
-              onClick={() => setExpanded(cur => !cur)}
+              onClick={e => {
+                e.preventDefault();
+                setExpanded(!expanded);
+              }}
               aria-controls={mainItemId}
               aria-label={expanded ? t('Collapse') : t('Expand')}
               sidebarCollapsed={sidebarCollapsed}

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -31,7 +31,7 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
           aria-expanded={expanded}
           aria-owns={contentId}
           trailingItems={
-            <SidebarItemExandButton
+            <SidebarAccordionExpandButton
               size="zero"
               borderless
               onClick={e => {
@@ -47,7 +47,7 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
                 direction={expanded ? 'up' : 'down'}
                 role="presentation"
               />
-            </SidebarItemExandButton>
+            </SidebarAccordionExpandButton>
           }
         />
       </SidebarAccordionHeaderWrap>
@@ -80,7 +80,7 @@ const SidebarAccordionHeaderWrap = styled('div')`
   }
 `;
 
-const SidebarItemExandButton = styled(Button)<{sidebarCollapsed?: boolean}>`
+const SidebarAccordionExpandButton = styled(Button)<{sidebarCollapsed?: boolean}>`
   height: calc(100% - ${space(1)});
   margin: 0 -${space(0.5)};
   padding: 0 ${space(0.75)};

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -1,4 +1,5 @@
 import {Fragment, isValidElement} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import {css, Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -249,7 +250,9 @@ const getActiveStyle = ({active, theme}: {active?: string; theme?: Theme}) => {
   `;
 };
 
-const StyledSidebarItem = styled(Link)`
+const StyledSidebarItem = styled(Link, {
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p),
+})`
   display: flex;
   color: inherit;
   position: relative;

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -22,7 +22,7 @@ const LabelHook = HookOrDefault({
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
 
-type Props = {
+export type SidebarItemProps = {
   /**
    * Icon to display
    */
@@ -86,8 +86,11 @@ type Props = {
    * The current organization. Useful for analytics.
    */
   organization?: Organization;
-
   to?: string;
+  /**
+   * Content to render at the end of the item.
+   */
+  trailingItems?: React.ReactNode;
 };
 
 function SidebarItem({
@@ -109,8 +112,9 @@ function SidebarItem({
   isNewSeenKeySuffix,
   organization,
   onClick,
+  trailingItems,
   ...props
-}: Props) {
+}: SidebarItemProps) {
   const router = useRouter();
   // label might be wrapped in a guideAnchor
   let labelString = label;
@@ -170,7 +174,7 @@ function SidebarItem({
   return (
     <Tooltip disabled={!collapsed} title={tooltipLabel} position={placement}>
       <StyledSidebarItem
-        data-test-id={props['data-test-id']}
+        {...props}
         id={`sidebar-item-${id}`}
         active={isActive ? 'true' : undefined}
         to={(to ? to : href) || '#'}
@@ -182,11 +186,7 @@ function SidebarItem({
           showIsNew && localStorage.setItem(isNewSeenKey, 'true');
         }}
       >
-        <InteractionStateLayer
-          isPressed={isActive ? true : undefined}
-          color="white"
-          higherOpacity
-        />
+        <InteractionStateLayer isPressed={isActive} color="white" higherOpacity />
         <SidebarItemWrapper collapsed={collapsed}>
           <SidebarItemIcon>{icon}</SidebarItemIcon>
           {!collapsed && !isTop && (
@@ -221,6 +221,7 @@ function SidebarItem({
           {badge !== undefined && badge > 0 && (
             <SidebarItemBadge collapsed={collapsed}>{badge}</SidebarItemBadge>
           )}
+          {trailingItems}
         </SidebarItemWrapper>
       </StyledSidebarItem>
     </Tooltip>
@@ -292,12 +293,6 @@ const StyledSidebarItem = styled(Link)`
   &.focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px ${p => p.theme.purple300};
-    padding: 0 ${space(1)} 0 ${space(0.25)};
-    margin: 0 -${space(1)} 0 -${space(0.25)};
-
-    &:before {
-      left: -18px;
-    }
   }
 
   ${getActiveStyle};
@@ -316,6 +311,9 @@ const SidebarItemWrapper = styled('div')<{collapsed?: boolean}>`
 `;
 
 const SidebarItemIcon = styled('span')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   width: 37px;
 


### PR DESCRIPTION
**Before ——**
<img width="217" alt="image" src="https://user-images.githubusercontent.com/44172267/233173360-60b06675-01bb-4111-8543-739b1f30ee15.png">
<img width="67" alt="image" src="https://user-images.githubusercontent.com/44172267/233173816-7945db8a-cbe2-45f1-9c70-9fe016b51300.png">


**After ——**
<img width="217" alt="image" src="https://user-images.githubusercontent.com/44172267/233173611-64154484-8da0-47ec-95bf-113ca6af669e.png">
<img width="217" alt="image" src="https://user-images.githubusercontent.com/44172267/233173384-f59d70d3-a951-428c-96d3-dbf8bec54156.png">
<img width="67" alt="image" src="https://user-images.githubusercontent.com/44172267/233173902-cccf9eb3-d217-4929-8780-dec3479e0be9.png">

