### PR TITLE
ref(starfish): Revert failure rate query

### DIFF
--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import moment from 'moment';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {PerformanceLayoutBodyRow} from 'sentry/components/performance/layouts';
@@ -13,12 +12,14 @@ import EventView from 'sentry/utils/discover/eventView';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {useQuery} from 'sentry/utils/queryClient';
 import Chart from 'sentry/views/starfish/components/chart';
-import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 import FailureRateChart from 'sentry/views/starfish/views/webServiceView/failureRateChart';
-import {
-  FAILURE_RATE_QUERY,
-  MODULE_DURATION_QUERY,
-} from 'sentry/views/starfish/views/webServiceView/queries';
+import {MODULE_DURATION_QUERY} from 'sentry/views/starfish/views/webServiceView/queries';
+
+const EventsRequest = withApi(_EventsRequest);
+
+import {t} from 'sentry/locale';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import withApi from 'sentry/utils/withApi';
 
 import EndpointList from './endpointList';
 
@@ -32,19 +33,12 @@ type BasePerformanceViewProps = {
 const HOST = 'http://localhost:8080';
 
 export function StarfishView(props: BasePerformanceViewProps) {
-  const {eventView} = props;
+  const {organization, eventView} = props;
 
   const {isLoading: isDurationDataLoading, data: moduleDurationData} = useQuery({
     queryKey: ['durationBreakdown'],
     queryFn: () =>
       fetch(`${HOST}/?query=${MODULE_DURATION_QUERY}`).then(res => res.json()),
-    retry: false,
-    initialData: [],
-  });
-
-  const {isLoading: isFailureRateDataLoading, data: failureRateData} = useQuery({
-    queryKey: ['failureRate'],
-    queryFn: () => fetch(`${HOST}/?query=${FAILURE_RATE_QUERY}`).then(res => res.json()),
     retry: false,
     initialData: [],
   });
@@ -87,17 +81,60 @@ export function StarfishView(props: BasePerformanceViewProps) {
 
   const data = Object.values(seriesByModule);
 
-  const failureRateSeries = zeroFillSeries(
-    {
-      seriesName: 'Failure Rate',
-      color: CHART_PALETTE[5][3],
-      data: failureRateData.map(entry => ({
-        value: entry.failureRate,
-        name: entry.interval,
-      })),
-    },
-    moment.duration(5, 'minutes')
-  );
+  function renderFailureRateChart() {
+    const query = new MutableSearch(['event.type:transaction']);
+
+    return (
+      <EventsRequest
+        query={query.formatString()}
+        includePrevious={false}
+        partial
+        interval="1h"
+        includeTransformedData
+        limit={1}
+        environment={eventView.environment}
+        project={eventView.project}
+        period={eventView.statsPeriod}
+        referrer="starfish-homepage-failure-rate"
+        start={eventView.start}
+        end={eventView.end}
+        organization={organization}
+        yAxis="equation|count_if(http.status_code,greaterOrEquals,500)/(count_if(http.status_code,equals,200)+count_if(http.status_code,greaterOrEquals,500))"
+      >
+        {eventData => {
+          const transformedData: Series[] | undefined = eventData.timeseriesData?.map(
+            series => ({
+              data: series.data,
+              seriesName: t('Failure Rate'),
+              color: CHART_PALETTE[5][3],
+            })
+          );
+
+          if (!transformedData) {
+            return null;
+          }
+
+          return (
+            <FailureRateChart
+              statsPeriod={eventView.statsPeriod}
+              height={180}
+              data={transformedData}
+              start={eventView.start as string}
+              end={eventView.end as string}
+              loading={eventData.loading}
+              utc={false}
+              grid={{
+                left: '0',
+                right: '0',
+                top: '16px',
+                bottom: '8px',
+              }}
+            />
+          );
+        }}
+      </EventsRequest>
+    );
+  }
 
   return (
     <div data-test-id="starfish-view">
@@ -122,22 +159,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
             stacked
             chartColors={['#444674', '#7a5088', '#b85586']}
           />
-
-          <FailureRateChart
-            statsPeriod={eventView.statsPeriod}
-            height={180}
-            data={[failureRateSeries]}
-            start={eventView.start as string}
-            end={eventView.end as string}
-            loading={isFailureRateDataLoading}
-            utc={false}
-            grid={{
-              left: '0',
-              right: '0',
-              top: '16px',
-              bottom: '8px',
-            }}
-          />
+          {renderFailureRateChart()}
         </Fragment>
       </StyledRow>
 


### PR DESCRIPTION
Reverting back to the old failure rate chart, since we can't be using span statuses to calculate it. Failure rate should be calculated using transaction metrics, since it needs to be focused specifically on how frequently the endpoints within the selected webservice are failing —  not all http spans in general.