### PR TITLE
fix(transaction): Scale CPU chart to 100%

### DIFF
--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -88,6 +88,7 @@ function Chart({data, type, transactionDuration}: ChartProps) {
         show: false,
         axisLabel: {show: false},
         axisTick: {show: false},
+        max: type === CPU_USAGE ? 100 : undefined,
       }}
       xAxis={{
         show: false,


### PR DESCRIPTION
It's misleading to allow the CPU chart to auto-scale because activity looks higher than it actually is. The solution is to fix the max value for CPU usage to 100% so users don't need to second guess whether the usage is high or not.