### PR TITLE
fix(plugins) Fix asana account link URL from issue details

### DIFF
--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -408,7 +408,9 @@ class IssueTrackingPlugin2(Plugin):
         if self.needs_auth(project=group.project, request=request):
             return {
                 "error_type": "auth",
-                "auth_url": reverse("socialauth_associate", args=[self.auth_provider]),
+                "auth_url": absolute_uri(
+                    reverse("socialauth_associate", args=[self.auth_provider])
+                ),
             }
 
     # TODO: should we get rid of this (move it to react?)


### PR DESCRIPTION
This should resolve the invalid redirect_uri errors customers are encountering when their project has Asana setup, but they haven't paired their account yet.

Refs HC-663