### PR TITLE
fix(sidebar): Only show focus state on `:focus-visible`

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -285,8 +285,12 @@ const StyledSidebarItem = styled(Link)`
   }
 
   &:hover,
-  &:focus {
+  &.focus-visible {
     color: ${p => p.theme.white};
+  }
+
+  &:focus {
+    outline: none;
   }
 
   &.focus-visible {


### PR DESCRIPTION
We should only show focus states on `:focus-visible` sidebar items.

**Before ——** click on "Projects" and then navigate back —> "Projects" is still highlighted even though it's no longer the active item, because it retains `:focus` through browser navigation

https://user-images.githubusercontent.com/44172267/233205145-29b50707-cba7-4ded-b5d9-75ab9145a6ed.mov

**After ——** do the same thing —> "Projects" is unhighlighted

https://user-images.githubusercontent.com/44172267/233205155-7d86b04d-6ea6-493b-b774-5fef4553e60c.mov

