### PR TITLE
fix(crons): Key rate limits with environment

### DIFF
--- a/src/sentry/monitors/consumers/check_in.py
+++ b/src/sentry/monitors/consumers/check_in.py
@@ -85,9 +85,10 @@ def _process_message(wrapper: Dict) -> None:
     start_time = to_datetime(float(wrapper["start_time"]))
     project_id = int(wrapper["project_id"])
 
+    environment = params.get("environment")
     project = Project.objects.get_from_cache(id=project_id)
 
-    ratelimit_key = params["monitor_slug"]
+    ratelimit_key = f"{params['monitor_slug']}:{environment}"
 
     if ratelimits.is_limited(
         f"monitor-checkins:{ratelimit_key}",
@@ -111,7 +112,7 @@ def _process_message(wrapper: Dict) -> None:
                 return
 
             monitor_environment = MonitorEnvironment.objects.ensure_environment(
-                project, monitor, params.get("environment")
+                project, monitor, environment
             )
 
             status = getattr(CheckInStatus, params["status"].upper())

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -114,10 +114,18 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
         if not checkin_validator.is_valid():
             return self.respond(checkin_validator.errors, status=400)
 
+        result = checkin_validator.validated_data
+
+        # MonitorEnvironment.ensure_environment handles empty environments, but
+        # we don't wan to call that before the rate limit, for the rate limit
+        # key we don't care as much about a user not sending an environment, so
+        # let's be explicit about it not being production
+        env_rate_limit_key = result.get("environment", "-")
+
         if not monitor:
-            ratelimit_key = monitor_slug
+            ratelimit_key = f"{monitor_slug}:{env_rate_limit_key}"
         else:
-            ratelimit_key = monitor.id
+            ratelimit_key = f"{monitor.id}:{env_rate_limit_key}"
 
         if ratelimits.is_limited(
             f"monitor-checkins:{ratelimit_key}",
@@ -131,8 +139,6 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
             raise Throttled(
                 detail="Rate limited, please send no more than 5 checkins per minute per monitor"
             )
-
-        result = checkin_validator.validated_data
 
         with transaction.atomic():
             monitor_data = result.get("monitor")

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -315,3 +315,13 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
                 assert resp.status_code == 201, resp.content
                 resp = self.client.post(path, {"status": "ok"}, **self.token_auth_headers)
                 assert resp.status_code == 429, resp.content
+
+                # Keyed on environment
+                resp = self.client.post(
+                    path, {"status": "ok", "environment": "dev"}, **self.token_auth_headers
+                )
+                assert resp.status_code == 201, resp.content
+                resp = self.client.post(
+                    path, {"status": "ok", "environment": "dev"}, **self.token_auth_headers
+                )
+                assert resp.status_code == 429, resp.content

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -243,5 +243,11 @@ class MonitorConsumerTest(TestCase):
             _process_message(self.get_message("my-monitor"))
             _process_message(self.get_message("my-monitor"))
 
-        checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
-        assert len(checkins) == 1
+            checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
+            assert len(checkins) == 1
+
+            # Same monitor, diff environments
+            _process_message(self.get_message("my-monitor", environment="dev"))
+
+            checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
+            assert len(checkins) == 2


### PR DESCRIPTION
Without this a customer could only have 5 environments for a monitor
with a 1 min check-in interval before getting rate limited

Fixes: https://github.com/getsentry/sentry/issues/47673