### PR TITLE
ref(sidebar): Add 1px gap between items

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -549,6 +549,7 @@ export const SidebarWrapper = styled('nav')<{collapsed: boolean}>`
 const SidebarSectionGroup = styled('div')`
   ${responsiveFlex};
   flex-shrink: 0; /* prevents shrinking on Safari */
+  gap: 1px;
 `;
 
 const SidebarSectionGroupPrimary = styled('div')`
@@ -569,6 +570,7 @@ const PrimaryItems = styled('div')`
   flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 1px;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints.medium}) {
     border-bottom: 1px solid ${p => p.theme.gray400};

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -65,6 +65,7 @@ export {SidebarAccordion};
 const SidebarAccordionWrapper = styled('div')`
   display: flex;
   flex-direction: column;
+  gap: 1px;
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     flex-direction: row;
@@ -102,6 +103,7 @@ const SidebarAccordionExpandButton = styled(Button)<{sidebarCollapsed?: boolean}
 const SidebarAccordionSubitemsWrap = styled('div')`
   display: flex;
   flex-direction: column;
+  gap: 1px;
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     flex-direction: row;

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -262,7 +262,6 @@ const StyledSidebarItem = styled(Link, {
   flex-shrink: 0;
   border-radius: ${p => p.theme.borderRadius};
   transition: none;
-  margin-bottom: 1px;
 
   &:before {
     display: block;
@@ -278,9 +277,6 @@ const StyledSidebarItem = styled(Link, {
   }
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    margin-bottom: 0;
-    margin-right: 1px;
-
     &:before {
       top: auto;
       left: 5px;

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -262,6 +262,7 @@ const StyledSidebarItem = styled(Link, {
   flex-shrink: 0;
   border-radius: ${p => p.theme.borderRadius};
   transition: none;
+  margin-bottom: 1px;
 
   &:before {
     display: block;
@@ -277,6 +278,9 @@ const StyledSidebarItem = styled(Link, {
   }
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    margin-bottom: 0;
+    margin-right: 1px;
+
     &:before {
       top: auto;
       left: 5px;


### PR DESCRIPTION
**Before ——**
<img width="216" alt="image" src="https://user-images.githubusercontent.com/44172267/233219596-91dc31bd-e037-4ab3-9997-4fd22558e181.png">

**After ——**
<img width="216" alt="image" src="https://user-images.githubusercontent.com/44172267/233219607-c003cffa-c9a3-40c7-b378-7ceb118aad15.png">
