### PR TITLE
fix(ui): Remove router props from JsonForm div

### DIFF
--- a/static/app/components/forms/jsonForm.tsx
+++ b/static/app/components/forms/jsonForm.tsx
@@ -139,6 +139,9 @@ class JsonForm extends Component<Props, State> {
       renderFooter,
       renderHeader,
       location: _location,
+      params: _params,
+      router: _router,
+      routes: _routes,
       ...otherProps
     } = this.props;
 


### PR DESCRIPTION
Removes these large props from being rendered for no reason

![image](https://user-images.githubusercontent.com/1400464/233226358-7970b2d7-14e6-4111-a13b-3ba562c7174e.png)
