### PR TITLE
feat(issue-states): manual transitions from and to ONGOING 

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -537,11 +537,17 @@ def update_groups(
         new_substatus = (
             SUBSTATUS_UPDATE_CHOICES[result.get("substatus")] if result.get("substatus") else None
         )
+        if new_substatus is None and new_status == GroupStatus.UNRESOLVED:
+            new_substatus = GroupSubStatus.ONGOING
+
         has_escalating_issues = features.has(
             "organizations:escalating-issues", group_list[0].organization
         )
 
         with transaction.atomic():
+            # TODO(gilbert): update() doesn't call pre_save and bypasses any substatus defaulting we have there
+            #                we should centralize the logic for validating and defaulting substatus values
+            #                and refactor pre_save and the above new_substatus assignment to account for this
             status_updated = queryset.exclude(status=new_status).update(
                 status=new_status, substatus=new_substatus
             )

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -95,7 +95,6 @@ def handle_status_update(
     for group in group_list:
         group.status = new_status
         group.substatus = new_substatus
-        group.save()
 
         activity = Activity.objects.create(
             project=project_lookup[group.project_id],

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -95,6 +95,7 @@ def handle_status_update(
     for group in group_list:
         group.status = new_status
         group.substatus = new_substatus
+        group.save()
 
         activity = Activity.objects.create(
             project=project_lookup[group.project_id],

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -178,7 +178,7 @@ class UpdateGroupsTest(TestCase):  # type: ignore[misc]
         assert GroupSnooze.objects.filter(group=group).exists()
 
     @patch("sentry.signals.issue_unignored.send_robust")
-    def test_unignoring_group(self, send_robust) -> None:
+    def test_unignoring_group(self, send_robust: Mock) -> None:
         for group, request_data in [
             (self.create_group(status=GroupStatus.IGNORED), {"status": "unresolved"}),
             (

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -178,7 +178,7 @@ class UpdateGroupsTest(TestCase):  # type: ignore[misc]
         assert GroupSnooze.objects.filter(group=group).exists()
 
     @patch("sentry.signals.issue_unignored.send_robust")
-    def test_unignoring_group(self, send_robust):
+    def test_unignoring_group(self, send_robust) -> None:
         for group, request_data in [
             (self.create_group(status=GroupStatus.IGNORED), {"status": "unresolved"}),
             (

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -186,9 +186,8 @@ class UpdateGroupsTest(TestCase):  # type: ignore[misc]
         request.data = {"status": "unresolved"}
         request.GET = QueryDict(query_string=f"id={group.id}")
 
-        search_fn = Mock()
         update_groups(
-            request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
+            request, request.GET.getlist("id"), [self.project], self.organization.id, Mock()
         )
 
         group.refresh_from_db()
@@ -239,26 +238,6 @@ class UpdateGroupsTest(TestCase):  # type: ignore[misc]
         assert group.substatus == GroupSubStatus.UNTIL_ESCALATING
         assert send_robust.called
         assert not GroupInbox.objects.filter(group=group).exists()
-
-    @patch("sentry.signals.issue_unignored.send_robust")
-    def test_unresolve_ongoing_ignored_group(self, send_robust):
-        group = self.create_group(status=GroupStatus.IGNORED)
-
-        request = self.make_request(user=self.user, method="GET")
-        request.user = self.user
-        request.data = {"status": "unresolved", "substatus": "ongoing"}
-        request.GET = QueryDict(query_string=f"id={group.id}")
-
-        search_fn = Mock()
-        update_groups(
-            request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
-        )
-
-        group.refresh_from_db()
-
-        assert group.status == GroupStatus.UNRESOLVED
-        assert group.substatus is GroupSubStatus.ONGOING
-        assert send_robust.called
 
 
 class TestHandleIsSubscribed(TestCase):  # type: ignore[misc]

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -194,6 +194,7 @@ class UpdateGroupsTest(TestCase):  # type: ignore[misc]
         group.refresh_from_db()
 
         assert group.status == GroupStatus.UNRESOLVED
+        assert group.substatus is GroupSubStatus.ONGOING
         assert send_robust.called
 
     @patch("sentry.signals.issue_mark_reviewed.send_robust")

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -178,23 +178,28 @@ class UpdateGroupsTest(TestCase):  # type: ignore[misc]
         assert GroupSnooze.objects.filter(group=group).exists()
 
     @patch("sentry.signals.issue_unignored.send_robust")
-    def test_unignoring_group(self, send_robust: Mock) -> None:
-        group = self.create_group(status=GroupStatus.IGNORED)
+    def test_unignoring_group(self, send_robust):
+        for group, request_data in [
+            (self.create_group(status=GroupStatus.IGNORED), {"status": "unresolved"}),
+            (
+                self.create_group(status=GroupStatus.IGNORED),
+                {"status": "unresolved", "substatus": "ongoing"},
+            ),
+        ]:
+            request = self.make_request(user=self.user, method="GET")
+            request.user = self.user
+            request.data = request_data
+            request.GET = QueryDict(query_string=f"id={group.id}")
 
-        request = self.make_request(user=self.user, method="GET")
-        request.user = self.user
-        request.data = {"status": "unresolved"}
-        request.GET = QueryDict(query_string=f"id={group.id}")
+            update_groups(
+                request, request.GET.getlist("id"), [self.project], self.organization.id, Mock()
+            )
 
-        update_groups(
-            request, request.GET.getlist("id"), [self.project], self.organization.id, Mock()
-        )
+            group.refresh_from_db()
 
-        group.refresh_from_db()
-
-        assert group.status == GroupStatus.UNRESOLVED
-        assert group.substatus is GroupSubStatus.ONGOING
-        assert send_robust.called
+            assert group.status == GroupStatus.UNRESOLVED
+            assert group.substatus is GroupSubStatus.ONGOING
+            assert send_robust.called
 
     @patch("sentry.signals.issue_mark_reviewed.send_robust")
     def test_mark_reviewed_group(self, send_robust: Mock) -> None:

--- a/tests/sentry/issues/test_status_change.py
+++ b/tests/sentry/issues/test_status_change.py
@@ -10,7 +10,7 @@ from sentry.types.group import GroupSubStatus
 
 
 class HandleStatusChangeTest(TestCase):  # type:ignore
-    def create_issue(self, status: str) -> None:
+    def create_issue(self, status: GroupStatus, substatus: GroupSubStatus = None) -> None:
         self.group = self.create_group(status=status)
         self.group_list = [self.group]
         self.group_ids = [self.group]


### PR DESCRIPTION
This was mostly being handled already, we just need to explicitly set the `substatus` to a default when a user requests to transition to `Group(status=UNRESOLVED, substatus=None)`