### PR TITLE
fix(replays): add tags to subquery

### DIFF
--- a/src/sentry/replays/lib/query.py
+++ b/src/sentry/replays/lib/query.py
@@ -308,7 +308,9 @@ class Tag(Field):
     _negation_map = [False, True, False, True]
     _python_type = str
 
-    def __init__(self, **kwargs):
+    def __init__(self, tag_key_alias="tk", tag_value_alias="tv", **kwargs):
+        self.tag_key_alias = tag_key_alias
+        self.tag_value_alias = tag_value_alias
         kwargs.pop("operators", None)
         return super().__init__(**kwargs)
 
@@ -342,7 +344,9 @@ class Tag(Field):
                     Lambda(
                         ["tag_value"], _wildcard_search_function(value, Identifier("tag_value"))
                     ),
-                    all_values_for_tag_key(field_alias, Column("tk"), Column("tv")),
+                    all_values_for_tag_key(
+                        field_alias, Column(self.tag_key_alias), Column(self.tag_value_alias)
+                    ),
                 ],
             ),
             operator,
@@ -358,11 +362,43 @@ class Tag(Field):
         return Condition(
             Function(
                 function,
-                parameters=[all_values_for_tag_key(key, Column("tk"), Column("tv")), values],
+                parameters=[
+                    all_values_for_tag_key(
+                        key, Column(self.tag_key_alias), Column(self.tag_value_alias)
+                    ),
+                    values,
+                ],
             ),
             Op.EQ,
             expected,
         )
+
+
+class InvalidField(Field):
+    _operators = [Op.EQ, Op.NEQ, Op.IN, Op.NOT_IN]
+    _python_type = str
+
+    def as_condition(
+        self, _: str, operator: Op, value: Union[List[str], str], is_wildcard: bool = False
+    ) -> Condition:
+        raise ParseError()
+
+    def _wildcard_condition(self, operator: Op, value: str):
+        raise ParseError()
+
+    def _has_condition(
+        self,
+        operator: Op,
+        value: Union[List[str], str],
+    ) -> Condition:
+        raise ParseError()
+
+    def _has_any_condition(
+        self,
+        operator: Op,
+        values: Union[List[str], str],
+    ) -> Condition:
+        raise ParseError()
 
 
 class QueryConfig:
@@ -498,6 +534,10 @@ def get_valid_sort_commands(
     field = query_config.get(field_name)
     if not field:
         raise ParseError(f"Invalid field specified: {field_name}.")
+
+    if isinstance(field, InvalidField):
+        raise ParseError("field can't be used to sort query")
+
     else:
         return [OrderBy(Column(field.query_alias or field.attribute_name), strategy)]
 

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -26,6 +26,7 @@ from sentry import features
 from sentry.api.event_search import ParenExpression, SearchConfig, SearchFilter
 from sentry.models.organization import Organization
 from sentry.replays.lib.query import (
+    InvalidField,
     IPAddress,
     ListField,
     Number,
@@ -254,7 +255,6 @@ def query_replays_dataset_with_subquery(
     if len(replay_ids_to_filter_results["data"]) == 0:
         # if no results, no need to carry on
         return {"data": []}
-
     max_subquery_ts = 0
     min_subquery_ts = datetime.now().timestamp()
     replay_ids_to_filter = []
@@ -624,7 +624,35 @@ class ReplaySubqueryConfig(QueryConfig):
     user_id = String(field_alias="user.id")
     user_ip_address = IPAddress(field_alias="user.ip", query_alias="ip_address_v4")
     user_name = String(field_alias="user.username")
-    tags = Tag(field_alias="*")
+
+    tags = Tag(field_alias="*", tag_key_alias="tags.key", tag_value_alias="tags.value")
+
+    # we have to explicitly define the rest of the fields as invalid fields or else
+    # they will be parsed as tags for the subquery
+    releases = InvalidField()
+    release = InvalidField()
+    click_alt = InvalidField(field_alias="click.alt")
+    click_class = InvalidField(field_alias="click.class", query_alias="clickClass")
+    click_id = InvalidField(field_alias="click.id")
+    click_aria_label = InvalidField(field_alias="click.label")
+    click_role = InvalidField(field_alias="click.role")
+    click_tag = InvalidField(field_alias="click.tag")
+    click_testid = InvalidField(field_alias="click.testid")
+    click_text = InvalidField(field_alias="click.textContent")
+    click_title = InvalidField(field_alias="click.title")
+    click_selector = InvalidField(field_alias="click.selector")
+    duration = InvalidField()
+    count_errors = InvalidField(query_alias="count_errors")
+    count_segments = InvalidField(query_alias="count_segments")
+    count_urls = InvalidField(query_alias="count_urls")
+    activity = InvalidField()
+    error_ids = InvalidField(query_alias="errorIds")
+    error_id = InvalidField(query_alias="errorIds")
+    trace_ids = InvalidField(query_alias="traceIds")
+    trace_id = InvalidField(query_alias="traceIds")
+    trace = InvalidField(query_alias="traceIds")
+    urls = InvalidField(query_alias="urls_sorted")
+    url = InvalidField(query_alias="urls_sorted")
 
 
 # Pagination.

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -624,6 +624,7 @@ class ReplaySubqueryConfig(QueryConfig):
     user_id = String(field_alias="user.id")
     user_ip_address = IPAddress(field_alias="user.ip", query_alias="ip_address_v4")
     user_name = String(field_alias="user.username")
+    tags = Tag(field_alias="*")
 
 
 # Pagination.

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -578,7 +578,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             # Assert returns empty result sets.
             null_queries = [
                 "!replay_type:session",
-                "!!a3a62ef6ac86415b83c2416fc2f76db1",
+                "!error_ids:a3a62ef6ac86415b83c2416fc2f76db1",
                 "error_ids:123",
                 "!error_id:a3a62ef6ac86415b83c2416fc2f76db1",
                 "error_id:123",

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -385,6 +385,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         with self.feature(REPLAYS_FEATURES):
             # Smallest duration first.
             response = self.client.get(self.url + "?sort=duration")
+            assert response.status_code == 200, response
             response_data = response.json()
             assert response_data["data"][0]["id"] == replay1_id
             assert response_data["data"][1]["id"] == replay2_id
@@ -475,6 +476,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_model="10",
                 tags={"a": "m", "b": "q", "c": "test"},
                 urls=["example.com"],
+                segment_id=0,
             )
         )
         self.store_replays(
@@ -496,6 +498,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_model=None,
                 tags={"a": "n", "b": "o"},
                 error_ids=[],
+                segment_id=1,
             )
         )
 
@@ -550,7 +553,6 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 # Tag filters.
                 "tags[a]:m",
                 "a:m",
-                "a:[n,o]",
                 "c:*st",
                 "!c:*zz",
                 "urls:example.com",
@@ -576,7 +578,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             # Assert returns empty result sets.
             null_queries = [
                 "!replay_type:session",
-                "!error_ids:a3a62ef6ac86415b83c2416fc2f76db1",
+                "!!a3a62ef6ac86415b83c2416fc2f76db1",
                 "error_ids:123",
                 "!error_id:a3a62ef6ac86415b83c2416fc2f76db1",
                 "error_id:123",
@@ -638,6 +640,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_brand="b",
                 device_family="b",
                 device_model="b",
+                segment_id=0,
             )
         )
         self.store_replays(
@@ -661,6 +664,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_brand="b",
                 device_family="b",
                 device_model="b",
+                segment_id=1,
             )
         )
 
@@ -689,6 +693,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_brand="a",
                 device_family="a",
                 device_model="a",
+                segment_id=0,
             )
         )
         self.store_replays(
@@ -712,6 +717,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_brand="a",
                 device_family="a",
                 device_model="a",
+                segment_id=1,
             )
         )
 


### PR DESCRIPTION
- fixes tags so they can be used in subquery logic, preventing OOM errors when filtering on them.
- note that at the moment tags are "frozen" after the replay starts with respect to this search.