### PR TITLE
ref(suggested-solution): Merge perf resources and suggested fix under one section

### DIFF
--- a/static/app/components/events/aiSuggestedSolution/banner.tsx
+++ b/static/app/components/events/aiSuggestedSolution/banner.tsx
@@ -50,12 +50,17 @@ const Wrapper = styled(Panel)`
 `;
 
 const Body = styled(PanelBody)`
-  display: grid;
-  grid-template-columns: 1fr max-content;
+  display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: ${space(1)};
 
+  > *:first-child {
+    flex: 1;
+  }
+
   @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    display: grid;
     grid-template-columns: 42% 1fr;
   }
 `;
@@ -69,6 +74,7 @@ const Title = styled('div')`
   /* to be consistent with the feature badge size */
   height: ${space(2)};
   line-height: ${space(2)};
+  white-space: nowrap;
 `;
 
 const Description = styled(TextBlock)`

--- a/static/app/components/events/aiSuggestedSolution/index.tsx
+++ b/static/app/components/events/aiSuggestedSolution/index.tsx
@@ -1,10 +1,5 @@
 import {useState} from 'react';
-import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
-import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import ExternalLink from 'sentry/components/links/externalLink';
-import {t, tct} from 'sentry/locale';
 import {Event, Project} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForEvent} from 'sentry/utils/events';
@@ -12,7 +7,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import {Banner} from './banner';
 import {Suggestion} from './suggestion';
-import {useOpenAISuggestionLocalStorage} from './useOpenAISuggestionLocalStorage';
 
 type Props = {
   event: Event;
@@ -23,97 +17,40 @@ export function AiSuggestedSolution({projectSlug, event}: Props) {
   const organization = useOrganization();
 
   const [openSuggestion, setOpenSuggestion] = useState(false);
-  const [suggestedSolutionLocalConfig, setSuggestedSolutionLocalConfig] =
-    useOpenAISuggestionLocalStorage();
 
   if (!organization.features.includes('open-ai-suggestion')) {
     return null;
   }
 
   return (
-    <StyledEventDataSection
-      type="ai-suggested-solution"
-      guideTarget="ai-suggested-solution"
-      title={t('Resources and Maybe Solutions')}
-      help={tct(
-        'This is an OpenAI generated solution that suggests a fix for this issue. Be aware that this may not be accurate. [learnMore:Learn more]',
-        {
-          learnMore: (
-            <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/ai-suggested-solution/" />
-          ),
-        }
-      )}
-      isHelpHoverable
-      actions={
-        <ToggleButton
-          onClick={() => {
-            setSuggestedSolutionLocalConfig({
-              hideDetails: !suggestedSolutionLocalConfig.hideDetails,
+    <div>
+      {!openSuggestion ? (
+        <Banner
+          onViewSuggestion={() => {
+            trackAnalytics('ai_suggested_solution.view_suggestion_button_clicked', {
+              organization,
+              project_id: event.projectID,
+              group_id: event.groupID,
+              ...getAnalyticsDataForEvent(event),
             });
-            trackAnalytics(
-              !suggestedSolutionLocalConfig.hideDetails === false
-                ? 'ai_suggested_solution.show_details_button_clicked'
-                : 'ai_suggested_solution.hide_details_button_clicked',
-              {
-                organization,
-                project_id: event.projectID,
-                group_id: event.groupID,
-                ...getAnalyticsDataForEvent(event),
-              }
-            );
+            setOpenSuggestion(true);
           }}
-          priority="link"
-        >
-          {suggestedSolutionLocalConfig.hideDetails
-            ? t('Show Details')
-            : t('Hide Details')}
-        </ToggleButton>
-      }
-    >
-      {!suggestedSolutionLocalConfig.hideDetails ? (
-        !openSuggestion ? (
-          <Banner
-            onViewSuggestion={() => {
-              trackAnalytics('ai_suggested_solution.view_suggestion_button_clicked', {
-                organization,
-                project_id: event.projectID,
-                group_id: event.groupID,
-                ...getAnalyticsDataForEvent(event),
-              });
-              setOpenSuggestion(true);
-            }}
-          />
-        ) : (
-          <Suggestion
-            projectSlug={projectSlug}
-            event={event}
-            onHideSuggestion={() => {
-              trackAnalytics('ai_suggested_solution.hide_suggestion_button_clicked', {
-                organization,
-                project_id: event.projectID,
-                group_id: event.groupID,
-                ...getAnalyticsDataForEvent(event),
-              });
-              setOpenSuggestion(false);
-            }}
-          />
-        )
-      ) : null}
-    </StyledEventDataSection>
+        />
+      ) : (
+        <Suggestion
+          projectSlug={projectSlug}
+          event={event}
+          onHideSuggestion={() => {
+            trackAnalytics('ai_suggested_solution.hide_suggestion_button_clicked', {
+              organization,
+              project_id: event.projectID,
+              group_id: event.groupID,
+              ...getAnalyticsDataForEvent(event),
+            });
+            setOpenSuggestion(false);
+          }}
+        />
+      )}
+    </div>
   );
 }
-
-const ToggleButton = styled(Button)`
-  font-weight: 700;
-  color: ${p => p.theme.subText};
-  &:hover,
-  &:focus {
-    color: ${p => p.theme.textColor};
-  }
-`;
-
-const StyledEventDataSection = styled(EventDataSection)`
-  > *:first-child {
-    z-index: 1;
-  }
-`;

--- a/static/app/components/events/aiSuggestedSolution/useOpenAISuggestionLocalStorage.tsx
+++ b/static/app/components/events/aiSuggestedSolution/useOpenAISuggestionLocalStorage.tsx
@@ -4,7 +4,6 @@ import ConfigStore from 'sentry/stores/configStore';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 type LocalState = {
-  hideDetails: boolean;
   individualConsent: boolean;
 };
 
@@ -19,7 +18,6 @@ export function useOpenAISuggestionLocalStorage(): [
     {
       // agree forward data to OpenAI
       individualConsent: false,
-      hideDetails: false,
     }
   );
 

--- a/static/app/components/events/interfaces/performance/resources.tsx
+++ b/static/app/components/events/interfaces/performance/resources.tsx
@@ -1,12 +1,10 @@
 import styled from '@emotion/styled';
 
+import ExternalLink from 'sentry/components/links/externalLink';
 import {IconDocs} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Event, Group} from 'sentry/types';
-import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-
-import {EventDataSection} from '../../eventDataSection';
+import {Event} from 'sentry/types';
+import {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
 
 export type ResourceLink = {
   link: string;
@@ -14,45 +12,36 @@ export type ResourceLink = {
 };
 
 type Props = {
-  event: Event;
-  group: Group;
+  configResources: NonNullable<IssueTypeConfig['resources']>;
+  eventPlatform: Event['platform'];
 };
 
 // This section provides users with resources on how to resolve an issue
-export function Resources({group, event}: Props) {
-  const config = getConfigForIssueType(group);
-
-  if (!config.resources) {
-    return null;
-  }
-
+export function Resources({configResources, eventPlatform}: Props) {
   const links = [
-    ...config.resources.links,
-    ...(config.resources.linksByPlatform[event.platform ?? ''] ?? []),
+    ...configResources.links,
+    ...(configResources.linksByPlatform[eventPlatform ?? ''] ?? []),
   ];
 
   return (
-    <EventDataSection type="resources-and-whatever" title={t('Resources and Whatever')}>
-      {config.resources.description}
+    <div>
+      {configResources.description}
       <LinkSection>
         {links.map(({link, text}) => (
-          <a key={link} href={link} target="_blank" rel="noreferrer">
+          // Please note that the UI will not fit a very long text and if we need to support that we will need to update the UI
+          <ExternalLink key={link} href={link} openInNewTab>
             <IconDocs /> {text}
-          </a>
+          </ExternalLink>
         ))}
       </LinkSection>
-    </EventDataSection>
+    </div>
   );
 }
 
 const LinkSection = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-row-gap: ${space(1)};
-
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 1fr;
-  }
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
 
   margin-top: ${space(2)};
 

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {CommitRow} from 'sentry/components/commitRow';
-import {AiSuggestedSolution} from 'sentry/components/events/aiSuggestedSolution';
 import {EventContexts} from 'sentry/components/events/contexts';
 import {EventDevice} from 'sentry/components/events/device';
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
@@ -17,7 +16,6 @@ import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScree
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
 import {AnrRootCause} from 'sentry/components/events/interfaces/performance/anrRootCause';
-import {Resources} from 'sentry/components/events/interfaces/performance/resources';
 import {SpanEvidenceSection} from 'sentry/components/events/interfaces/performance/spanEvidence';
 import {EventPackageData} from 'sentry/components/events/packageData';
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
@@ -28,6 +26,7 @@ import {Event, Group, IssueCategory, Project} from 'sentry/types';
 import {EntryType, EventTransaction} from 'sentry/types/event';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {ResourcesAndMaybeSolutions} from 'sentry/views/issueDetails/resourcesAndMaybeSolutions';
 
 type GroupEventDetailsContentProps = {
   group: Group;
@@ -126,8 +125,11 @@ function GroupEventDetailsContent({
       <GroupEventEntry entryType={EntryType.EXPECTSTAPLE} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.TEMPLATE} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.BREADCRUMBS} {...eventEntryProps} />
-      <Resources {...{event, group}} />
-      <AiSuggestedSolution event={event} projectSlug={project.slug} />
+      <ResourcesAndMaybeSolutions
+        event={event}
+        projectSlug={project.slug}
+        group={group}
+      />
       <GroupEventEntry entryType={EntryType.DEBUGMETA} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.REQUEST} {...eventEntryProps} />
       <EventContexts group={group} event={event} />

--- a/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
@@ -1,0 +1,54 @@
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {AiSuggestedSolution} from 'sentry/components/events/aiSuggestedSolution';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {Resources} from 'sentry/components/events/interfaces/performance/resources';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Event, Group, Project} from 'sentry/types';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+
+type Props = {
+  event: Event;
+  group: Group;
+  projectSlug: Project['slug'];
+};
+
+// This section provides users with resources and maybe solutions on how to resolve an issue
+export function ResourcesAndMaybeSolutions({event, projectSlug, group}: Props) {
+  const config = getConfigForIssueType(group);
+
+  return (
+    <Wrapper
+      type="resources-and-maybe-solutions"
+      title={t('Resources and Maybe Solutions')}
+      configResources={!!config.resources}
+    >
+      <Content>
+        {config.resources && (
+          <Resources eventPlatform={event.platform} configResources={config.resources} />
+        )}
+        <AiSuggestedSolution event={event} projectSlug={projectSlug} />
+      </Content>
+    </Wrapper>
+  );
+}
+
+const Content = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(3)};
+`;
+
+const Wrapper = styled(EventDataSection)<{configResources: boolean}>`
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    ${p =>
+      !p.configResources &&
+      css`
+        && {
+          padding-top: ${space(3)};
+        }
+      `}
+  }
+`;

--- a/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Group, Project} from 'sentry/types';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   event: Event;
@@ -17,7 +18,12 @@ type Props = {
 
 // This section provides users with resources and maybe solutions on how to resolve an issue
 export function ResourcesAndMaybeSolutions({event, projectSlug, group}: Props) {
+  const organization = useOrganization();
   const config = getConfigForIssueType(group);
+
+  if (!config.resources && !organization.features.includes('open-ai-suggestion')) {
+    return null;
+  }
 
   return (
     <Wrapper


### PR DESCRIPTION
- Merge the event sections "resources and whatever" + "resources and maybe solutions" under the section "resources and maybe solutions"
- Add new paddings to fit all content
- Render resource links under each other instead of side by side, so we now have more room for the Sentaur

**Preview:**


https://user-images.githubusercontent.com/29228205/233341006-7b0f711b-15a1-402c-b37d-815344749231.mov


**Will do this in a follow-up:**
- Add read docs to the suggested solution

closes https://github.com/getsentry/sentry/issues/47695