### PR TITLE
chore(relay): Use version 0.8.21

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -59,7 +59,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo[json]>=2.9.1
 sentry-kafka-schemas>=0.0.19
-sentry-relay>=0.8.20
+sentry-relay>=0.8.21
 sentry-sdk>=1.19.1
 snuba-sdk>=1.0.5
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -166,7 +166,7 @@ selenium==4.3.0
 sentry-arroyo==2.9.1
 sentry-cli==2.16.0
 sentry-kafka-schemas==0.0.27
-sentry-relay==0.8.20
+sentry-relay==0.8.21
 sentry-sdk==1.19.1
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -117,7 +117,7 @@ s3transfer==0.5.2
 selenium==4.3.0
 sentry-arroyo==2.9.1
 sentry-kafka-schemas==0.0.27
-sentry-relay==0.8.20
+sentry-relay==0.8.21
 sentry-sdk==1.19.1
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
This allows us to use the new `DataCategory.PROFILE_INDEXED`.