### PR TITLE
feat(starfish): Improve span details page

### DIFF
--- a/static/app/constants/ios-device-list.tsx
+++ b/static/app/constants/ios-device-list.tsx
@@ -4,6 +4,7 @@
 // and discard the rest of the JSON so we do not end up bloating bundle size.
 
 const iOSDeviceMapping: Record<string, string> = {
+  '': 'Siri Remote (2nd generation)',
   'iPod1,1': 'iPod touch',
   'iPod2,1': 'iPod touch (2nd generation)',
   'iPod3,1': 'iPod touch (3rd generation)',

--- a/static/app/constants/ios-device-list.tsx
+++ b/static/app/constants/ios-device-list.tsx
@@ -4,7 +4,6 @@
 // and discard the rest of the JSON so we do not end up bloating bundle size.
 
 const iOSDeviceMapping: Record<string, string> = {
-  '': 'Siri Remote (2nd generation)',
   'iPod1,1': 'iPod touch',
   'iPod2,1': 'iPod touch (2nd generation)',
   'iPod3,1': 'iPod touch (3rd generation)',

--- a/static/app/views/starfish/views/spanInTransactionView/index.tsx
+++ b/static/app/views/starfish/views/spanInTransactionView/index.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 import {Location} from 'history';
 
+import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
@@ -73,17 +74,17 @@ export default function SpanInTransactionView({location, params}: Props) {
         <Layout.Body>
           <Layout.Main fullWidth>
             <PageErrorAlert />
-            <h2>Span Description</h2>
-            Description: {spanDescription}
             {isLoading ? (
               <span>LOADING</span>
             ) : (
-              <div>
-                <h2>Span Stats</h2>
-                <span>Count: {data?.[0]?.count}</span>
-                <br />
-                <span>p50: {data?.[0]?.p50}</span>
-              </div>
+              <KeyValueList
+                data={[
+                  {key: 'desc', value: spanDescription, subject: 'Description'},
+                  {key: 'count', value: data?.[0]?.count, subject: 'Count'},
+                  {key: 'p50', value: data?.[0]?.p50, subject: 'p50'},
+                ]}
+                shouldSort={false}
+              />
             )}
             {areSpanSamplesLoading ? (
               <span>LOADING SAMPLE LIST</span>


### PR DESCRIPTION
- Render events in a table
- Use KeyValue list for span info

**e.g.,**
<img width="866" alt="Screenshot 2023-04-20 at 9 28 51 AM" src="https://user-images.githubusercontent.com/989898/233381683-0261e125-571e-4538-a2a3-4803ff7d93dd.png">
