### PR TITLE
feat(starfish): Add initial scaffolding for endpoint detail

### DIFF
--- a/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
@@ -19,27 +19,27 @@ export type EndpointDataRow = {
   endpoint: string;
 };
 
-type FailureDetailBodyProps = {
+type EndpointDetailBodyProps = {
   row: EndpointDataRow;
 };
 
-export default function FailureDetail({
+export default function EndpointDetail({
   row,
   onClose,
-}: Partial<FailureDetailBodyProps> & {onClose: () => void}) {
+}: Partial<EndpointDetailBodyProps> & {onClose: () => void}) {
   return (
     <Detail detailKey={row?.endpoint} onClose={onClose}>
-      {row && <FailureDetailBody row={row} />}
+      {row && <EndpointDetailBody row={row} />}
     </Detail>
   );
 }
 
-function FailureDetailBody({row}: FailureDetailBodyProps) {
+function EndpointDetailBody({row}: EndpointDetailBodyProps) {
   const {aggregateDetails} = row;
   return (
     <div>
-      <h2>{t('Failure Detail')}</h2>
-      <p>{t('Details of endpoint failures')}</p>
+      <h2>{t('Endpoint Detail')}</h2>
+      <p>{t('Details of endpoint. More breakdowns, etc. Maybe some trends?')}</p>
       <SubHeader>{t('Endpoint URL')}</SubHeader>
       <pre>{row?.endpoint}</pre>
       <FlexRowContainer>

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -33,7 +33,7 @@ import {t, tct} from 'sentry/locale';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage} from 'sentry/utils/formatters';
 import {TIME_SPENT_IN_SERVICE} from 'sentry/views/starfish/utils/generatePerformanceEventView';
-import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/failureDetails';
+import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/endpointDetails';
 
 // HACK: Overrides ColumnType for TIME_SPENT_IN_SERVICE which is
 // returned as a number because it's an equation, but we

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -23,7 +23,6 @@ import {
   getAggregateAlias,
 } from 'sentry/utils/discover/fields';
 import {TableColumn} from 'sentry/views/discover/table/types';
-import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 const COLUMN_TITLES = ['endpoint', 'tpm', 'p50(duration)', 'p95(duration)'];
 
@@ -33,13 +32,8 @@ import Duration from 'sentry/components/duration';
 import {t, tct} from 'sentry/locale';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage} from 'sentry/utils/formatters';
-import {getProjectID} from 'sentry/views/performance/utils';
 import {TIME_SPENT_IN_SERVICE} from 'sentry/views/starfish/utils/generatePerformanceEventView';
-
-import {
-  createUnnamedTransactionsDiscoverTarget,
-  UNPARAMETERIZED_TRANSACTION,
-} from '../../utils/createUnnamedTransactionsDiscoverTarget';
+import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/failureDetails';
 
 // HACK: Overrides ColumnType for TIME_SPENT_IN_SERVICE which is
 // returned as a number because it's an equation, but we
@@ -51,6 +45,7 @@ const TABLE_META_OVERRIDES: Record<string, ColumnType> = {
 type Props = {
   eventView: EventView;
   location: Location;
+  onSelect: (row: EndpointDataRow) => void;
   organization: Organization;
   projects: Project[];
   setError: (msg: string | undefined) => void;
@@ -73,7 +68,7 @@ class EndpointList extends Component<Props, State> {
     dataRow: TableDataRow,
     deltaColumnMap: Record<string, string>
   ): React.ReactNode {
-    const {eventView, organization, projects, location} = this.props;
+    const {onSelect, organization, location} = this.props;
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
@@ -85,31 +80,27 @@ class EndpointList extends Component<Props, State> {
     const rendered = fieldRenderer(dataRow, {organization, location});
 
     if (field === 'transaction') {
-      const projectID = getProjectID(dataRow, projects);
-      const summaryView = eventView.clone();
       let prefix = '';
       if (dataRow['http.method']) {
-        summaryView.additionalConditions.setFilterValues('http.method', [
-          dataRow['http.method'] as string,
-        ]);
         prefix = `${dataRow['http.method']} `;
       }
-      summaryView.query = summaryView.getQueryWithAdditionalConditions();
-      const isUnparameterizedRow = dataRow.transaction === UNPARAMETERIZED_TRANSACTION;
-      const target = isUnparameterizedRow
-        ? createUnnamedTransactionsDiscoverTarget({
-            organization,
-            location,
-          })
-        : transactionSummaryRouteWithQuery({
-            orgSlug: organization.slug,
-            transaction: String(dataRow.transaction) || '',
-            query: summaryView.generateQueryStringObject(),
-            projectID,
-          });
+
+      const row = {
+        endpoint: `${prefix}${dataRow.transaction}`,
+        aggregateDetails: {
+          failureCount: dataRow['count_if(http.status_code,greaterOrEquals,500)'],
+          p50: dataRow['p50()'],
+          tpm: dataRow['tpm()'],
+          p50Delta: dataRow[deltaColumnMap['p50()']],
+        },
+      } as EndpointDataRow;
 
       return (
-        <Link to={target} style={{display: `block`, width: `100%`}}>
+        <Link
+          onClick={() => onSelect(row)}
+          to=""
+          style={{display: `block`, width: `100%`}}
+        >
           {prefix}
           {dataRow.transaction}
         </Link>

--- a/static/app/views/starfish/views/webServiceView/failureDetails/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureDetails/index.tsx
@@ -1,0 +1,91 @@
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {formatAbbreviatedNumber, getDuration} from 'sentry/utils/formatters';
+import Detail from 'sentry/views/starfish/components/detailPanel';
+
+type EndpointAggregateDetails = {
+  failureCount: number;
+  p50: number;
+  tpm: number;
+  failureRate?: number;
+  failureRateDelta?: number;
+  p50Delta?: number;
+};
+
+export type EndpointDataRow = {
+  aggregateDetails: EndpointAggregateDetails;
+  endpoint: string;
+};
+
+type FailureDetailBodyProps = {
+  row: EndpointDataRow;
+};
+
+export default function FailureDetail({
+  row,
+  onClose,
+}: Partial<FailureDetailBodyProps> & {onClose: () => void}) {
+  return (
+    <Detail detailKey={row?.endpoint} onClose={onClose}>
+      {row && <FailureDetailBody row={row} />}
+    </Detail>
+  );
+}
+
+function FailureDetailBody({row}: FailureDetailBodyProps) {
+  const {aggregateDetails} = row;
+  return (
+    <div>
+      <h2>{t('Failure Detail')}</h2>
+      <p>{t('Details of endpoint failures')}</p>
+      <SubHeader>{t('Endpoint URL')}</SubHeader>
+      <pre>{row?.endpoint}</pre>
+      <FlexRowContainer>
+        <FlexRowItem>
+          <SubHeader>{t('Throughput')}</SubHeader>
+          <SubSubHeader>{formatAbbreviatedNumber(aggregateDetails.tpm)}</SubSubHeader>
+        </FlexRowItem>
+        <FlexRowItem>
+          <SubHeader>{t('p50(duration)')}</SubHeader>
+          <SubSubHeader>{getDuration(aggregateDetails.p50 / 1000, 0, true)}</SubSubHeader>
+        </FlexRowItem>
+        <FlexRowItem>
+          <SubHeader>{t('Failure Count')}</SubHeader>
+          <SubSubHeader>
+            {formatAbbreviatedNumber(aggregateDetails.failureCount)}
+          </SubSubHeader>
+        </FlexRowItem>
+        <FlexRowItem>
+          <SubHeader>{t('Failure Rate')}</SubHeader>
+          <SubSubHeader>{'0.5%'}</SubSubHeader>
+        </FlexRowItem>
+      </FlexRowContainer>
+    </div>
+  );
+}
+
+const SubHeader = styled('h3')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeLarge};
+  margin: 0;
+  margin-bottom: ${space(1)};
+`;
+
+const SubSubHeader = styled('h4')`
+  margin: 0;
+  font-weight: normal;
+`;
+
+const FlexRowContainer = styled('div')`
+  display: flex;
+  & > div:last-child {
+    padding-right: ${space(1)};
+  }
+`;
+
+const FlexRowItem = styled('div')`
+  padding-right: ${space(4)};
+  flex: 1;
+`;

--- a/static/app/views/starfish/views/webServiceView/starfishLanding.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishLanding.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -15,8 +15,15 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import FailureDetail, {
+  EndpointDataRow,
+} from 'sentry/views/starfish/views/webServiceView/failureDetails';
 
 import {StarfishView} from './starfishView';
+
+type WebServiceViewState = {
+  selectedRow?: EndpointDataRow;
+};
 
 type Props = {
   eventView: EventView;
@@ -36,6 +43,11 @@ export function StarfishLanding(props: Props) {
     </PageFilterBar>
   );
 
+  const [state, setState] = useState<WebServiceViewState>({selectedRow: undefined});
+  const unsetSelectedEndpoint = () => setState({selectedRow: undefined});
+  const {selectedRow} = state;
+  const setSelectedEndpoint = (row: EndpointDataRow) => setState({selectedRow: row});
+
   return (
     <Layout.Page>
       <PageErrorProvider>
@@ -53,7 +65,8 @@ export function StarfishLanding(props: Props) {
                 {pageFilters}
               </SearchContainerWithFilterAndMetrics>
 
-              <StarfishView {...props} />
+              <StarfishView {...props} onSelect={setSelectedEndpoint} />
+              <FailureDetail row={selectedRow} onClose={unsetSelectedEndpoint} />
             </Fragment>
           </Layout.Main>
         </Layout.Body>

--- a/static/app/views/starfish/views/webServiceView/starfishLanding.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishLanding.tsx
@@ -15,9 +15,9 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
-import FailureDetail, {
+import EndpointDetail, {
   EndpointDataRow,
-} from 'sentry/views/starfish/views/webServiceView/failureDetails';
+} from 'sentry/views/starfish/views/webServiceView/endpointDetails';
 
 import {StarfishView} from './starfishView';
 
@@ -66,7 +66,7 @@ export function StarfishLanding(props: Props) {
               </SearchContainerWithFilterAndMetrics>
 
               <StarfishView {...props} onSelect={setSelectedEndpoint} />
-              <FailureDetail row={selectedRow} onClose={unsetSelectedEndpoint} />
+              <EndpointDetail row={selectedRow} onClose={unsetSelectedEndpoint} />
             </Fragment>
           </Layout.Main>
         </Layout.Body>

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -27,7 +27,7 @@ import {t} from 'sentry/locale';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
-import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/failureDetails';
+import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/endpointDetails';
 
 import EndpointList from './endpointList';
 

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -27,12 +27,14 @@ import {t} from 'sentry/locale';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/failureDetails';
 
 import EndpointList from './endpointList';
 
 type BasePerformanceViewProps = {
   eventView: EventView;
   location: Location;
+  onSelect: (row: EndpointDataRow) => void;
   organization: Organization;
   projects: Project[];
 };
@@ -40,7 +42,7 @@ type BasePerformanceViewProps = {
 const HOST = 'http://localhost:8080';
 
 export function StarfishView(props: BasePerformanceViewProps) {
-  const {organization, eventView} = props;
+  const {organization, eventView, onSelect} = props;
 
   const {isLoading: isDurationDataLoading, data: moduleDurationData} = useQuery({
     queryKey: ['durationBreakdown'],
@@ -158,7 +160,8 @@ export function StarfishView(props: BasePerformanceViewProps) {
       <EndpointList
         {...props}
         setError={usePageError().setPageError}
-        dataset="discover" // Metrics dataset can't do equations yet
+        dataset="discover" // Metrics dataset can't do total.transaction_duration yet
+        onSelect={onSelect}
         columnTitles={[
           'endpoint',
           'tpm',


### PR DESCRIPTION
Adds an initial slide out window with endpoint details.
Right now, clicking on an endpoint on the table view
slides it out, but we want this to open from whatever
the failure detail page/view ends up being.