### PR TITLE
feat(starfish): add link between query details and span in transactions

### DIFF
--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -60,8 +60,7 @@ export const getSpanInTransactionQuery = (spanDescription, transactionName) => {
   return `
     SELECT count() AS count, quantile(0.5)(exclusive_time) as p50
     FROM spans_experimental_starfish
-    WHERE module = 'http'
-    AND description = '${spanDescription}'
+    WHERE description = '${spanDescription}'
     AND transaction = '${transactionName}'
  `;
 };

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -57,6 +57,7 @@ export const getEndpointDetailTableQuery = description => {
 };
 
 export const getSpanInTransactionQuery = (spanDescription, transactionName) => {
+  // TODO - add back `module = <moudle> to filter data
   return `
     SELECT count() AS count, quantile(0.5)(exclusive_time) as p50
     FROM spans_experimental_starfish

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Series} from 'sentry/types/echarts';
@@ -16,6 +17,12 @@ const HOST = 'http://localhost:8080';
 
 type EndpointDetailBodyProps = {
   row: DataRow;
+};
+
+type TransactionListDataRow = {
+  count: number;
+  p50: number;
+  transaction: string;
 };
 
 const COLUMN_ORDER = [
@@ -88,6 +95,28 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
 
   const [countSeries, p50Series] = throughputQueryToChartData(graphData);
 
+  function renderHeadCell(column: GridColumnHeader): React.ReactNode {
+    return <span>{column.name}</span>;
+  }
+
+  const renderBodyCell = (
+    column: GridColumnHeader,
+    dataRow: TransactionListDataRow
+  ): React.ReactNode => {
+    if (column.key === 'transaction') {
+      return (
+        <Link
+          to={`/starfish/span/${encodeURIComponent(row.desc)}:${encodeURIComponent(
+            dataRow.transaction
+          )}`}
+        >
+          {dataRow[column.key]}
+        </Link>
+      );
+    }
+    return <span>{dataRow[column.key]}</span>;
+  };
+
   return (
     <div>
       <h2>{t('Query Detail')}</h2>
@@ -144,7 +173,7 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
         columnSortBy={[]}
         grid={{
           renderHeadCell,
-          renderBodyCell: (column: GridColumnHeader, dataRow: DataRow) =>
+          renderBodyCell: (column: GridColumnHeader, dataRow: TransactionListDataRow) =>
             renderBodyCell(column, dataRow),
         }}
         location={location}
@@ -152,14 +181,6 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
     </div>
   );
 }
-
-function renderHeadCell(column: GridColumnHeader): React.ReactNode {
-  return <span>{column.name}</span>;
-}
-
-const renderBodyCell = (column: GridColumnHeader, row: DataRow): React.ReactNode => {
-  return <span>{row[column.key]}</span>;
-};
 
 const throughputQueryToChartData = (data: any): Series[] => {
   const countSeries: Series = {seriesName: 'count()', data: [] as any[]};


### PR DESCRIPTION
Completes the flow from query details -> samples
Had to remove the `module='http'` to make it module agnostic, but we can find some other solution to get that going later down to road!