### PR TITLE
Fix http.status_code search on Issues page

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -289,7 +289,7 @@ class Columns(Enum):
         event_name="contexts[response.status_code]",
         transaction_name="contexts[response.status_code]",
         discover_name="contexts[response.status_code]",
-        issue_platform_name="contexts[response.status_code",
+        issue_platform_name="contexts[response.status_code]",
         alias="http.status_code",
     )
     OS_BUILD = Column(


### PR DESCRIPTION
Fix:

> InvalidColumnError
> column 'contexts[response.status_code' is empty or contains invalid characters

Feature added here https://github.com/getsentry/sentry/pull/39913
Regressed here https://github.com/getsentry/sentry/pull/42647