### PR TITLE
fix: Fix actor_id constraint migration to account for duplicates

### DIFF
--- a/src/sentry/migrations/0418_add_actor_constraints.py
+++ b/src/sentry/migrations/0418_add_actor_constraints.py
@@ -30,7 +30,7 @@ WITH duplicate_users AS (
   SELECT user_id FROM sentry_actor WHERE user_id IS NOT NULL GROUP BY user_id HAVING count(*) > 1
 ),
 cleanup_actors AS (
-    SELECT * FROM sentry_actor AS actor
+    SELECT actor.id AS id FROM sentry_actor AS actor
     LEFT JOIN auth_user AS u ON u.actor_id = actor.id
     WHERE actor.user_id IN (SELECT user_id FROM duplicate_users)
     AND u.actor_id IS NULL


### PR DESCRIPTION
When reworking the foreign keys on the actor table we missed a race condition that resulted in 96 users getting an duplicate actor generated. Each actor that is generated would update `user.actor_id`. The value in `user.actor_id` is used to set notification settings and attach actors to issues.

The additional query performs the following steps:

1. Find users that have more than one actor.
2. Combine actor + user to find the actors that aren't the authoritative ones. These records can be identified by the left join not matching.
3. Null out the user_id for all results from the join failure in 2. I was concerned about integrity errors from other usage, and nulling out actor.user_id is how the application code works too.

We aren't creating any *new* duplicate actors so these changes should resolve the integrity errors blocking constraint creation.
