### PR TITLE
fix(rulesnooze): Add access check to mute alert button

### DIFF
--- a/static/app/components/alerts/snoozeAlert.tsx
+++ b/static/app/components/alerts/snoozeAlert.tsx
@@ -13,6 +13,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
+  hasAccess: boolean;
   isSnoozed: boolean;
   onSnooze: (nextState: {
     snooze: boolean;
@@ -23,12 +24,12 @@ type Props = {
   ruleId: string;
 };
 
-function SnoozeAlert({isSnoozed, onSnooze, projectSlug, ruleId}: Props) {
+function SnoozeAlert({isSnoozed, onSnooze, projectSlug, ruleId, hasAccess}: Props) {
   const organization = useOrganization();
   const api = useApi();
   const location = useLocation();
 
-  const [disabled, setDisabled] = useState(false);
+  const [disabled, setDisabled] = useState(!hasAccess);
 
   const handleMute = useCallback(
     async (target: 'me' | 'everyone', autoMute = false) => {

--- a/static/app/components/alerts/snoozeAlert.tsx
+++ b/static/app/components/alerts/snoozeAlert.tsx
@@ -29,7 +29,7 @@ function SnoozeAlert({isSnoozed, onSnooze, projectSlug, ruleId, hasAccess}: Prop
   const api = useApi();
   const location = useLocation();
 
-  const [disabled, setDisabled] = useState(!hasAccess);
+  const [disabled, setDisabled] = useState(false);
 
   const handleMute = useCallback(
     async (target: 'me' | 'everyone', autoMute = false) => {
@@ -128,7 +128,7 @@ function SnoozeAlert({isSnoozed, onSnooze, projectSlug, ruleId, hasAccess}: Prop
       <Button
         size="sm"
         icon={<IconMute />}
-        disabled={disabled}
+        disabled={disabled || !hasAccess}
         onClick={() => handleUnmute()}
       >
         {t('Unmute')}
@@ -140,7 +140,7 @@ function SnoozeAlert({isSnoozed, onSnooze, projectSlug, ruleId, hasAccess}: Prop
       <MuteButton
         size="sm"
         icon={<IconSound />}
-        disabled={disabled}
+        disabled={disabled || !hasAccess}
         onClick={() => handleMute('me')}
       >
         {t('Mute')}
@@ -155,7 +155,7 @@ function SnoozeAlert({isSnoozed, onSnooze, projectSlug, ruleId, hasAccess}: Prop
           />
         )}
         items={dropdownItems}
-        isDisabled={disabled}
+        isDisabled={disabled || !hasAccess}
       />
     </ButtonBar>
   );

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
@@ -241,8 +241,7 @@ describe('AlertRuleDetails', () => {
 
     createWrapper({}, contextWithoutAccess);
 
-    expect(await screen.findByText('Mute')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Mute'})).toBeDisabled();
+    expect(await screen.findByRole('button', {name: 'Mute'})).toBeDisabled();
   });
 
   it('inserts user email into rule notify action', async () => {

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
@@ -19,17 +19,15 @@ describe('AlertRuleDetails', () => {
   });
   const member = TestStubs.Member();
 
-  const createWrapper = (props = {}, contextWithQueryParam) => {
+  const createWrapper = (props = {}, newContext) => {
     const params = {
       orgId: organization.slug,
       projectId: project.slug,
       ruleId: rule.id,
     };
 
-    const router = contextWithQueryParam ? contextWithQueryParam.router : context.router;
-    const routerContext = contextWithQueryParam
-      ? contextWithQueryParam.routerContext
-      : context.routerContext;
+    const router = newContext ? newContext.router : context.router;
+    const routerContext = newContext ? newContext.routerContext : context.routerContext;
 
     return render(
       <RuleDetailsContainer params={params} location={{query: {}}} router={router}>
@@ -231,6 +229,20 @@ describe('AlertRuleDetails', () => {
 
     expect(await screen.findByText('Unmute')).toBeInTheDocument();
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('mute button is disabled if no alert:edit permission', async () => {
+    const contextWithoutAccess = initializeOrg({
+      organization: {
+        features: ['issue-alert-incompatible-rules', 'mute-alerts'],
+        access: [],
+      },
+    });
+
+    createWrapper({}, contextWithoutAccess);
+
+    expect(await screen.findByText('Mute')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Mute'})).toBeDisabled();
   });
 
   it('inserts user email into rule notify action', async () => {

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
@@ -231,7 +231,7 @@ describe('AlertRuleDetails', () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
-  it('mute button is disabled if no alert:edit permission', async () => {
+  it('mute button is disabled if no alerts:write permission', async () => {
     const contextWithoutAccess = initializeOrg({
       organization: {
         features: ['issue-alert-incompatible-rules', 'mute-alerts'],

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 import moment from 'moment';
 
+import Access from 'sentry/components/acl/access';
 import {Alert} from 'sentry/components/alert';
 import SnoozeAlert from 'sentry/components/alerts/snoozeAlert';
 import AsyncComponent from 'sentry/components/asyncComponent';
@@ -303,12 +304,17 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
               {hasSnoozeFeature && (
-                <SnoozeAlert
-                  isSnoozed={isSnoozed}
-                  onSnooze={this.onSnooze}
-                  ruleId={rule.id}
-                  projectSlug={projectId}
-                />
+                <Access access={['alerts:write']}>
+                  {({hasAccess}) => (
+                    <SnoozeAlert
+                      isSnoozed={isSnoozed}
+                      onSnooze={this.onSnooze}
+                      ruleId={rule.id}
+                      projectSlug={projectId}
+                      hasAccess={hasAccess}
+                    />
+                  )}
+                </Access>
               )}
               <Button size="sm" icon={<IconCopy />} to={duplicateLink}>
                 {t('Duplicate')}


### PR DESCRIPTION
this pr adds in an access check to the mute alert button to check that the user has 'alerts:write'. If not, we will disable the mute alert button, so they are unable to mute any alerts. 