### PR TITLE
feat(workflow): Hide mark reviewed action w/ flag

### DIFF
--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -159,13 +159,16 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
 
   const {tooltipText, tooltipDescription, reasonBadgeText, tagType} = getReasonDetails();
 
+  const disabledMarkReviewed = organization.features.includes('remove-mark-reviewed');
   const tooltip = (tooltipText || tooltipDescription) && (
     <TooltipWrapper>
       {tooltipText && <div>{tooltipText}</div>}
       {tooltipDescription && (
         <TooltipDescription>{tooltipDescription}</TooltipDescription>
       )}
-      <TooltipDescription>{t('Mark Reviewed to remove this label')}</TooltipDescription>
+      {disabledMarkReviewed ? null : (
+        <TooltipDescription>{t('Mark Reviewed to remove this label')}</TooltipDescription>
+      )}
     </TooltipWrapper>
   );
 

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -358,6 +358,7 @@ class Actions extends Component<Props> {
 
     const hasEscalatingIssues = organization.features.includes('escalating-issues-ui');
     const hasDeleteAccess = organization.access.includes('event:admin');
+    const disabledMarkReviewed = organization.features.includes('remove-mark-reviewed');
 
     const {dropdownItems, onIgnore} = getIgnoreActions({onUpdate: this.onUpdate});
     const {dropdownItems: archiveDropdownItems} = getArchiveActions({
@@ -420,14 +421,18 @@ class Actions extends Component<Props> {
               disabled: disabled || group.subscriptionDetails?.disabled,
               onAction: this.onToggleSubscribe,
             },
-            {
-              key: 'mark-review',
-              label: t('Mark reviewed'),
-              disabled: !group.inbox || disabled,
-              details:
-                !group.inbox || disabled ? t('Issue has been reviewed') : undefined,
-              onAction: () => this.onUpdate({inbox: false}),
-            },
+            ...(disabledMarkReviewed
+              ? []
+              : [
+                  {
+                    key: 'mark-review',
+                    label: t('Mark reviewed'),
+                    disabled: !group.inbox || disabled,
+                    details:
+                      !group.inbox || disabled ? t('Issue has been reviewed') : undefined,
+                    onAction: () => this.onUpdate({inbox: false}),
+                  },
+                ]),
             {
               key: 'share',
               label: t('Share'),

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -100,6 +100,7 @@ function ActionSet({
   // the dropdown menu based on the current screen size
   const theme = useTheme();
   const nestMergeAndReview = useMedia(`(max-width: ${theme.breakpoints.xlarge})`);
+  const disabledMarkReviewed = organization.features.includes('remove-mark-reviewed');
 
   const menuItems: MenuItemProps[] = [
     {
@@ -117,13 +118,17 @@ function ActionSet({
         });
       },
     },
-    {
-      key: 'mark-reviewed',
-      label: t('Mark Reviewed'),
-      hidden: !nestMergeAndReview,
-      disabled: !canMarkReviewed,
-      onAction: () => onUpdate({inbox: false}),
-    },
+    ...(disabledMarkReviewed
+      ? []
+      : [
+          {
+            key: 'mark-reviewed',
+            label: t('Mark Reviewed'),
+            hidden: !nestMergeAndReview,
+            disabled: !canMarkReviewed,
+            onAction: () => onUpdate({inbox: false}),
+          },
+        ]),
     {
       key: 'bookmark',
       label: t('Add to Bookmarks'),
@@ -249,7 +254,7 @@ function ActionSet({
           disabled={ignoreDisabled}
         />
       )}
-      {!nestMergeAndReview && (
+      {!nestMergeAndReview && !disabledMarkReviewed && (
         <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />
       )}
       {!nestMergeAndReview && (

--- a/static/app/views/issueList/actions/index.spec.jsx
+++ b/static/app/views/issueList/actions/index.spec.jsx
@@ -297,6 +297,16 @@ describe('IssueListActions', function () {
 
       expect(screen.getByRole('button', {name: 'Mark Reviewed'})).toBeDisabled();
     });
+
+    it('hides mark reviewed button with remove-mark-reviewed flag', function () {
+      render(<WrappedComponent {...defaultProps} />, {
+        organization: {...organization, features: ['remove-mark-reviewed']},
+      });
+
+      expect(
+        screen.queryByRole('button', {name: 'Mark Reviewed'})
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('sort', function () {

--- a/static/app/views/issueList/actions/reviewAction.tsx
+++ b/static/app/views/issueList/actions/reviewAction.tsx
@@ -2,6 +2,7 @@ import ActionLink from 'sentry/components/actions/actionLink';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   onUpdate: (data: {inbox: boolean}) => void;
@@ -14,6 +15,12 @@ type Props = {
 };
 
 function ReviewAction({disabled, onUpdate, tooltipProps, tooltip}: Props) {
+  const organization = useOrganization();
+
+  if (organization.features.includes('remove-mark-reviewed')) {
+    return null;
+  }
+
   return (
     <ActionLink
       type="button"


### PR DESCRIPTION
Hides the mark reviewed action when the remove-mark-reviewed flag is active.

[WOR-2902](https://getsentry.atlassian.net/browse/WOR-2902)

related #47689 

[WOR-2902]: https://getsentry.atlassian.net/browse/WOR-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ