### PR TITLE
feat(api): Add datadog login_attempt metrics to password and 2fa

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -67,6 +67,7 @@ class AuthIndexEndpoint(Endpoint):
 
     @staticmethod
     def _verify_user_via_inputs(validator, request):
+        # See if we have a u2f challenge/response
         if "challenge" in validator.validated_data and "response" in validator.validated_data:
             try:
                 metrics.incr("2fa.login_attempt", sample_rate=1.0, skip_internal=False)

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -70,6 +70,7 @@ class AuthIndexEndpoint(Endpoint):
         # See if we have a u2f challenge/response
         if "challenge" in validator.validated_data and "response" in validator.validated_data:
             try:
+                metrics.incr("2fa.login_attempt", sample_rate=1.0, skip_internal=False)
                 interface = Authenticator.objects.get_interface(request.user, "u2f")
                 if not interface.is_enrolled():
                     raise LookupError()
@@ -94,6 +95,7 @@ class AuthIndexEndpoint(Endpoint):
                 )
         # attempt password authentication
         elif "password" in validator.validated_data:
+            metrics.incr("password.login_attempt", sample_rate=1.0, skip_internal=False)
             authenticated = promote_request_rpc_user(request).check_password(
                 validator.validated_data["password"]
             )

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -67,7 +67,6 @@ class AuthIndexEndpoint(Endpoint):
 
     @staticmethod
     def _verify_user_via_inputs(validator, request):
-        # See if we have a u2f challenge/response
         if "challenge" in validator.validated_data and "response" in validator.validated_data:
             try:
                 metrics.incr("2fa.login_attempt", sample_rate=1.0, skip_internal=False)

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -280,7 +280,6 @@ def login(
     Returns boolean indicating if the user was logged in.
     """
     if passed_2fa is None:
-        metrics.incr("2fa.login_attempt", sample_rate=1.0, skip_internal=False)
         passed_2fa = request.session.get(MFA_SESSION_KEY, "") == str(user.id)
 
     if user.has_2fa() and not passed_2fa:

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -280,6 +280,7 @@ def login(
     Returns boolean indicating if the user was logged in.
     """
     if passed_2fa is None:
+        metrics.incr("2fa.login_attempt", sample_rate=1.0, skip_internal=False)
         passed_2fa = request.session.get(MFA_SESSION_KEY, "") == str(user.id)
 
     if user.has_2fa() and not passed_2fa:


### PR DESCRIPTION
Create datadog metrics for password and 2FA in order to create SLOs. After talking with @leedongwei, we decided having the SLOs track logins and ensure we have a certain number per day is better than tracking `successful logins / errors`. 