### PR TITLE
feat(generic metrics): Implement use case logic in IndexerBatch

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -121,16 +121,6 @@ class IndexerBatch:
                 )
                 continue
             try:
-                parsed_payload["use_case_id"] = extract_use_case_id(parsed_payload["name"])
-            except ValidationError:
-                self.skipped_offsets.add(partition_offset)
-                logger.error(
-                    "process_messages.invalid_metric_resource_identifier",
-                    extra={"payload_value": str(msg.payload.value)},
-                    exc_info=True,
-                )
-                continue
-            try:
                 if self.__input_codec:
                     self.__input_codec.validate(parsed_payload)
             except ValidationError:
@@ -144,6 +134,16 @@ class IndexerBatch:
                     extra={"payload_value": str(msg.payload.value)},
                     exc_info=True,
                 )
+            try:
+                parsed_payload["use_case_id"] = extract_use_case_id(parsed_payload["name"])
+            except ValidationError:
+                self.skipped_offsets.add(partition_offset)
+                logger.error(
+                    "process_messages.invalid_metric_resource_identifier",
+                    extra={"payload_value": str(msg.payload.value)},
+                    exc_info=True,
+                )
+                continue
             self.parsed_payloads_by_offset[partition_offset] = parsed_payload
 
     @metrics.wraps("process_messages.filter_messages")

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 from collections import defaultdict
 from typing import (
     Any,
@@ -22,14 +23,14 @@ from arroyo.codecs import ValidationError
 from arroyo.codecs.json import JsonCodec
 from arroyo.types import BrokerValue, Message
 from django.conf import settings
-from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMetric
 from sentry_kafka_schemas.schema_types.snuba_metrics_v1 import Metric
 
-from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.consumers.indexer.common import IndexerOutputMessageBatch, MessageBatch
+from sentry.sentry_metrics.consumers.indexer.parsed_message import ParsedMessage
 from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingPayload
 from sentry.sentry_metrics.indexer.base import Metadata
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,9 @@ MAX_TAG_KEY_LENGTH = 200
 MAX_TAG_VALUE_LENGTH = 200
 
 ACCEPTED_METRIC_TYPES = {"s", "c", "d"}  # set, counter, distribution
+MRI_RE_PATTERN = re.compile("^([c|s|d|g|e]):([a-zA-Z0-9_]+)/.*$")
+
+OrgId = int
 
 
 class PartitionIdxOffset(NamedTuple):
@@ -71,16 +75,26 @@ def invalid_metric_tags(tags: Mapping[str, str]) -> Sequence[str]:
     return invalid_strs
 
 
+# TODO: Move this to where we do use case registration
+def extract_use_case_id(mri: str) -> Optional[UseCaseID]:
+    """
+    Returns the use case ID given the MRI, returns None if MRI is invalid.
+    """
+    if matched := MRI_RE_PATTERN.match(mri):
+        use_case_str = matched.group(2)
+        if use_case_str in {id.value for id in UseCaseID}:
+            return UseCaseID(use_case_str)
+    raise ValidationError(f"Invalid mri: {mri}")
+
+
 class IndexerBatch:
     def __init__(
         self,
-        use_case_id: UseCaseKey,
         outer_message: Message[MessageBatch],
         should_index_tag_values: bool,
         is_output_sliced: bool,
         arroyo_input_codec: Optional[JsonCodec[Any]],
     ) -> None:
-        self.use_case_id = use_case_id
         self.outer_message = outer_message
         self.__should_index_tag_values = should_index_tag_values
         self.is_output_sliced = is_output_sliced
@@ -91,14 +105,13 @@ class IndexerBatch:
     @metrics.wraps("process_messages.extract_messages")
     def _extract_messages(self) -> None:
         self.skipped_offsets: Set[PartitionIdxOffset] = set()
-        self.parsed_payloads_by_offset: MutableMapping[PartitionIdxOffset, IngestMetric] = {}
+        self.parsed_payloads_by_offset: MutableMapping[PartitionIdxOffset, ParsedMessage] = {}
 
         for msg in self.outer_message.payload:
             assert isinstance(msg.value, BrokerValue)
             partition_offset = PartitionIdxOffset(msg.value.partition.index, msg.value.offset)
             try:
                 parsed_payload = json.loads(msg.payload.value.decode("utf-8"), use_rapid_json=True)
-                self.parsed_payloads_by_offset[partition_offset] = parsed_payload
             except rapidjson.JSONDecodeError:
                 self.skipped_offsets.add(partition_offset)
                 logger.error(
@@ -107,7 +120,16 @@ class IndexerBatch:
                     exc_info=True,
                 )
                 continue
-
+            try:
+                parsed_payload["use_case_id"] = extract_use_case_id(parsed_payload["name"])
+            except ValidationError:
+                self.skipped_offsets.add(partition_offset)
+                logger.error(
+                    "process_messages.invalid_metric_resource_identifier",
+                    extra={"payload_value": str(msg.payload.value)},
+                    exc_info=True,
+                )
+                continue
             try:
                 if self.__input_codec:
                     self.__input_codec.validate(parsed_payload)
@@ -122,6 +144,7 @@ class IndexerBatch:
                     extra={"payload_value": str(msg.payload.value)},
                     exc_info=True,
                 )
+            self.parsed_payloads_by_offset[partition_offset] = parsed_payload
 
     @metrics.wraps("process_messages.filter_messages")
     def filter_messages(self, keys_to_remove: Sequence[PartitionIdxOffset]) -> None:
@@ -149,8 +172,10 @@ class IndexerBatch:
         self.skipped_offsets.update(keys_to_remove)
 
     @metrics.wraps("process_messages.extract_strings")
-    def extract_strings(self) -> Mapping[int, Set[str]]:
-        org_strings = defaultdict(set)
+    def extract_strings(self) -> Mapping[UseCaseID, Mapping[OrgId, Set[str]]]:
+        strings: Mapping[UseCaseID, Mapping[OrgId, Set[str]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
 
         for partition_offset, message in self.parsed_payloads_by_offset.items():
             if partition_offset in self.skipped_offsets:
@@ -160,6 +185,7 @@ class IndexerBatch:
 
             metric_name = message["name"]
             metric_type = message["type"]
+            use_case_id = message["use_case_id"]
             org_id = message["org_id"]
             tags = message.get("tags", {})
 
@@ -167,6 +193,7 @@ class IndexerBatch:
                 logger.error(
                     "process_messages.invalid_metric_name",
                     extra={
+                        "use_case_id": use_case_id,
                         "org_id": org_id,
                         "metric_name": metric_name,
                         "partition": partition_idx,
@@ -179,19 +206,23 @@ class IndexerBatch:
             if metric_type not in ACCEPTED_METRIC_TYPES:
                 logger.error(
                     "process_messages.invalid_metric_type",
-                    extra={"org_id": org_id, "metric_type": metric_type, "offset": offset},
+                    extra={
+                        "use_case_id": use_case_id,
+                        "org_id": org_id,
+                        "metric_type": metric_type,
+                        "offset": offset,
+                    },
                 )
                 self.skipped_offsets.add(partition_offset)
                 continue
 
-            invalid_strs = invalid_metric_tags(tags)
-
-            if invalid_strs:
+            if invalid_strs := invalid_metric_tags(tags):
                 # sentry doesn't seem to actually capture nested logger.error extra args
                 sentry_sdk.set_extra("all_metric_tags", tags)
                 logger.error(
                     "process_messages.invalid_tags",
                     extra={
+                        "use_case_id": use_case_id,
                         "org_id": org_id,
                         "metric_name": metric_name,
                         "invalid_tags": invalid_strs,
@@ -202,28 +233,30 @@ class IndexerBatch:
                 self.skipped_offsets.add(partition_offset)
                 continue
 
-            parsed_strings = {
+            strings_in_message = {
                 metric_name,
                 *tags.keys(),
             }
 
             if self.__should_index_tag_values:
-                parsed_strings.update(tags.values())
+                strings_in_message.update(tags.values())
 
-            org_strings[org_id].update(parsed_strings)
+            strings[use_case_id][org_id].update(strings_in_message)
 
-        string_count = 0
-        for org_set in org_strings:
-            string_count += len(org_strings[org_set])
-        metrics.gauge("process_messages.lookups_per_batch", value=string_count)
+        for use_case_id, org_mapping in strings.items():
+            metrics.gauge(
+                "process_messages.lookups_per_batch",
+                value=sum(len(parsed_strings) for parsed_strings in org_mapping.values()),
+                tags={"use_case": use_case_id.value},
+            )
 
-        return org_strings
+        return strings
 
     @metrics.wraps("process_messages.reconstruct_messages")
     def reconstruct_messages(
         self,
-        mapping: Mapping[int, Mapping[str, Optional[int]]],
-        bulk_record_meta: Mapping[int, Mapping[str, Metadata]],
+        mapping: Mapping[OrgId, Mapping[str, Optional[int]]],
+        bulk_record_meta: Mapping[OrgId, Mapping[str, Metadata]],
     ) -> IndexerOutputMessageBatch:
         new_messages: IndexerOutputMessageBatch = []
 
@@ -358,7 +391,7 @@ class IndexerBatch:
                     # XXX: relay actually sends this value unconditionally
                     "retention_days": old_payload_value.get("retention_days", 90),
                     "mapping_meta": output_message_meta,
-                    "use_case_id": self.use_case_id.value,
+                    "use_case_id": old_payload_value["use_case_id"].value,
                     "metric_id": numeric_metric_id,
                     "org_id": old_payload_value["org_id"],
                     "timestamp": old_payload_value["timestamp"],
@@ -377,7 +410,7 @@ class IndexerBatch:
                     "version": 2,
                     "retention_days": old_payload_value.get("retention_days", 90),
                     "mapping_meta": output_message_meta,
-                    "use_case_id": self.use_case_id.value,
+                    "use_case_id": old_payload_value["use_case_id"].value,
                     "metric_id": numeric_metric_id,
                     "org_id": old_payload_value["org_id"],
                     "timestamp": old_payload_value["timestamp"],

--- a/src/sentry/sentry_metrics/consumers/indexer/parsed_message.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parsed_message.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Literal, TypedDict, Union
+
+from typing_extensions import Required
+
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+
+
+class ParsedMessage(TypedDict, total=False):
+    """Internal representation of a parsed ingest metric message for indexer to support generic metrics"""
+
+    use_case_id: Required[UseCaseID]
+    org_id: Required[int]
+    project_id: Required[int]
+    name: Required[str]
+    type: Required["_IngestMetricType"]
+    timestamp: Required[int]
+    tags: Required[Dict[str, str]]
+    value: Required[Union["CounterMetricValue", "SetMetricValue", "DistributionMetricValue"]]
+    retention_days: Required[int]
+
+
+_IngestMetricType = Union[Literal["c"], Literal["d"], Literal["s"]]
+CounterMetricValue = Union[int, float]
+DistributionMetricValue = List[Union[int, float]]
+SetMetricValue = List["_SetMetricValueItem"]
+_SetMetricValueItem = int

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -1,6 +1,8 @@
 import logging
 from collections.abc import MutableMapping
 from datetime import datetime, timezone
+from enum import Enum
+from unittest.mock import patch
 
 import pytest
 import sentry_kafka_schemas
@@ -8,11 +10,18 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.codecs.json import JsonCodec
 from arroyo.types import BrokerValue, Message, Partition, Topic, Value
 
-from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.consumers.indexer.batch import IndexerBatch, PartitionIdxOffset
 from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, Metadata
-from sentry.snuba.metrics.naming_layer.mri import SessionMRI
+from sentry.snuba.metrics.naming_layer.mri import SessionMRI, TransactionMRI
 from sentry.utils import json
+
+
+class MockUseCaseID(Enum):
+    TRANSACTIONS = "transactions"
+    SESSIONS = "sessions"
+    USE_CASE_1 = "use_case_1"
+    USE_CASE_2 = "use_case_2"
+
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -60,16 +69,18 @@ set_payload = {
 }
 
 extracted_string_output = {
-    1: {
-        "c:sessions/session@none",
-        "d:sessions/duration@second",
-        "environment",
-        "errored",
-        "healthy",
-        "init",
-        "production",
-        "s:sessions/error@none",
-        "session.status",
+    MockUseCaseID.SESSIONS: {
+        1: {
+            "c:sessions/session@none",
+            "d:sessions/duration@second",
+            "environment",
+            "errored",
+            "healthy",
+            "init",
+            "production",
+            "s:sessions/error@none",
+            "session.status",
+        }
     }
 }
 
@@ -169,36 +180,41 @@ def _get_string_indexer_log_records(caplog):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 @pytest.mark.parametrize(
     "should_index_tag_values, expected",
     [
         pytest.param(
             True,
             {
-                1: {
-                    "c:sessions/session@none",
-                    "d:sessions/duration@second",
-                    "environment",
-                    "errored",
-                    "healthy",
-                    "init",
-                    "production",
-                    "s:sessions/error@none",
-                    "session.status",
-                },
+                MockUseCaseID.SESSIONS: {
+                    1: {
+                        "c:sessions/session@none",
+                        "d:sessions/duration@second",
+                        "environment",
+                        "errored",
+                        "healthy",
+                        "init",
+                        "production",
+                        "s:sessions/error@none",
+                        "session.status",
+                    },
+                }
             },
             id="index tag values true",
         ),
         pytest.param(
             False,
             {
-                1: {
-                    "c:sessions/session@none",
-                    "d:sessions/duration@second",
-                    "environment",
-                    "s:sessions/error@none",
-                    "session.status",
-                },
+                MockUseCaseID.SESSIONS: {
+                    1: {
+                        "c:sessions/session@none",
+                        "d:sessions/duration@second",
+                        "environment",
+                        "s:sessions/error@none",
+                        "session.status",
+                    },
+                }
             },
             id="index tag values false",
         ),
@@ -217,7 +233,6 @@ def test_extract_strings_with_rollout(should_index_tag_values, expected):
         ]
     )
     batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE,
         outer_message,
         should_index_tag_values,
         False,
@@ -227,6 +242,284 @@ def test_extract_strings_with_rollout(should_index_tag_values, expected):
     assert batch.extract_strings() == expected
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
+def test_extract_strings_with_multiple_use_case_ids():
+    """
+    Verify that the extract string method can handle payloads that has multiple
+    (generic) uses cases
+    """
+    counter_payload = {
+        "name": "c:use_case_1/session@none",
+        "tags": {
+            "environment": "production",
+            "session.status": "init",
+        },
+        "timestamp": ts,
+        "type": "c",
+        "value": 1,
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+
+    distribution_payload = {
+        "name": "d:use_case_2/duration@second",
+        "tags": {
+            "environment": "production",
+            "session.status": "healthy",
+        },
+        "timestamp": ts,
+        "type": "d",
+        "value": [4, 5, 6],
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+
+    set_payload = {
+        "name": "s:use_case_2/error@none",
+        "tags": {
+            "environment": "production",
+            "session.status": "errored",
+        },
+        "timestamp": ts,
+        "type": "s",
+        "value": [3],
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+
+    outer_message = _construct_outer_message(
+        [
+            (counter_payload, []),
+            (distribution_payload, []),
+            (set_payload, []),
+        ]
+    )
+    batch = IndexerBatch(
+        outer_message,
+        True,
+        False,
+        arroyo_input_codec=_INGEST_SCHEMA,
+    )
+    assert batch.extract_strings() == {
+        MockUseCaseID.USE_CASE_1: {
+            1: {
+                "c:use_case_1/session@none",
+                "environment",
+                "production",
+                "session.status",
+                "init",
+            }
+        },
+        MockUseCaseID.USE_CASE_2: {
+            1: {
+                "d:use_case_2/duration@second",
+                "environment",
+                "production",
+                "session.status",
+                "healthy",
+                "s:use_case_2/error@none",
+                "environment",
+                "production",
+                "session.status",
+                "errored",
+            }
+        },
+    }
+
+
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
+def test_extract_strings_with_invalid_mri():
+    """
+    Verify that extract strings will drop payload that has invalid MRI in name field but continue processing the rest
+    """
+    bad_counter_payload = {
+        "name": "invalid_MRI",
+        "tags": {
+            "environment": "production",
+            "session.status": "init",
+        },
+        "timestamp": ts,
+        "type": "c",
+        "value": 1,
+        "org_id": 100,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+    counter_payload = {
+        "name": "c:use_case_1/session@none",
+        "tags": {
+            "environment": "production",
+            "session.status": "init",
+        },
+        "timestamp": ts,
+        "type": "c",
+        "value": 1,
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+
+    distribution_payload = {
+        "name": "d:use_case_2/duration@second",
+        "tags": {
+            "environment": "production",
+            "session.status": "healthy",
+        },
+        "timestamp": ts,
+        "type": "d",
+        "value": [4, 5, 6],
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+
+    set_payload = {
+        "name": "s:use_case_2/error@none",
+        "tags": {
+            "environment": "production",
+            "session.status": "errored",
+        },
+        "timestamp": ts,
+        "type": "s",
+        "value": [3],
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+
+    outer_message = _construct_outer_message(
+        [
+            (bad_counter_payload, []),
+            (counter_payload, []),
+            (distribution_payload, []),
+            (set_payload, []),
+        ]
+    )
+    batch = IndexerBatch(
+        outer_message,
+        True,
+        False,
+        arroyo_input_codec=_INGEST_SCHEMA,
+    )
+    assert batch.extract_strings() == {
+        MockUseCaseID.USE_CASE_1: {
+            1: {
+                "c:use_case_1/session@none",
+                "environment",
+                "production",
+                "session.status",
+                "init",
+            }
+        },
+        MockUseCaseID.USE_CASE_2: {
+            1: {
+                "d:use_case_2/duration@second",
+                "environment",
+                "production",
+                "session.status",
+                "healthy",
+                "s:use_case_2/error@none",
+                "environment",
+                "production",
+                "session.status",
+                "errored",
+            }
+        },
+    }
+
+
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
+def test_extract_strings_with_multiple_use_case_ids_and_org_ids():
+    """
+    Verify that the extract string method can handle payloads that has multiple
+    (generic) uses cases and from different orgs
+    """
+    custom_uc_counter_payload = {
+        "name": "c:use_case_1/session@none",
+        "tags": {
+            "environment": "production",
+            "session.status": "init",
+        },
+        "timestamp": ts,
+        "type": "c",
+        "value": 1,
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+    perf_distribution_payload = {
+        "name": TransactionMRI.MEASUREMENTS_FCP.value,
+        "tags": {
+            "environment": "production",
+            "session.status": "healthy",
+        },
+        "timestamp": ts,
+        "type": "d",
+        "value": [4, 5, 6],
+        "org_id": 1,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+    custom_uc_set_payload = {
+        "name": "s:use_case_1/error@none",
+        "tags": {
+            "environment": "production",
+            "session.status": "errored",
+        },
+        "timestamp": ts,
+        "type": "s",
+        "value": [3],
+        "org_id": 2,
+        "retention_days": 90,
+        "project_id": 3,
+    }
+
+    outer_message = _construct_outer_message(
+        [
+            (custom_uc_counter_payload, []),
+            (perf_distribution_payload, []),
+            (custom_uc_set_payload, []),
+        ]
+    )
+    batch = IndexerBatch(
+        outer_message,
+        True,
+        False,
+        arroyo_input_codec=_INGEST_SCHEMA,
+    )
+    assert batch.extract_strings() == {
+        MockUseCaseID.USE_CASE_1: {
+            1: {
+                "c:use_case_1/session@none",
+                "environment",
+                "production",
+                "session.status",
+                "init",
+            },
+            2: {
+                "s:use_case_1/error@none",
+                "environment",
+                "production",
+                "session.status",
+                "errored",
+            },
+        },
+        MockUseCaseID.TRANSACTIONS: {
+            1: {
+                TransactionMRI.MEASUREMENTS_FCP.value,
+                "environment",
+                "production",
+                "session.status",
+                "healthy",
+            }
+        },
+    }
+
+
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_all_resolved(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -238,7 +531,6 @@ def test_all_resolved(caplog, settings):
     )
 
     batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE,
         outer_message,
         True,
         False,
@@ -246,16 +538,18 @@ def test_all_resolved(caplog, settings):
     )
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "d:sessions/duration@second",
-                "environment",
-                "errored",
-                "healthy",
-                "init",
-                "production",
-                "s:sessions/error@none",
-                "session.status",
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "d:sessions/duration@second",
+                    "environment",
+                    "errored",
+                    "healthy",
+                    "init",
+                    "production",
+                    "s:sessions/error@none",
+                    "session.status",
+                }
             }
         }
     )
@@ -310,7 +604,7 @@ def test_all_resolved(caplog, settings):
                 "tags": {"3": 7, "9": 6},
                 "timestamp": ts,
                 "type": "c",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": 1.0,
             },
             [("mapping_sources", b"ch"), ("metric_type", "c")],
@@ -333,7 +627,7 @@ def test_all_resolved(caplog, settings):
                 "tags": {"3": 7, "9": 5},
                 "timestamp": ts,
                 "type": "d",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [4, 5, 6],
             },
             [("mapping_sources", b"ch"), ("metric_type", "d")],
@@ -356,7 +650,7 @@ def test_all_resolved(caplog, settings):
                 "tags": {"3": 7, "9": 4},
                 "timestamp": ts,
                 "type": "s",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [3],
             },
             [("mapping_sources", b"cd"), ("metric_type", "s")],
@@ -364,6 +658,7 @@ def test_all_resolved(caplog, settings):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_all_resolved_with_routing_information(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -375,7 +670,6 @@ def test_all_resolved_with_routing_information(caplog, settings):
     )
 
     batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE,
         outer_message,
         True,
         True,
@@ -383,16 +677,18 @@ def test_all_resolved_with_routing_information(caplog, settings):
     )
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "d:sessions/duration@second",
-                "environment",
-                "errored",
-                "healthy",
-                "init",
-                "production",
-                "s:sessions/error@none",
-                "session.status",
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "d:sessions/duration@second",
+                    "environment",
+                    "errored",
+                    "healthy",
+                    "init",
+                    "production",
+                    "s:sessions/error@none",
+                    "session.status",
+                }
             }
         }
     )
@@ -448,7 +744,7 @@ def test_all_resolved_with_routing_information(caplog, settings):
                 "tags": {"3": 7, "9": 6},
                 "timestamp": ts,
                 "type": "c",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": 1.0,
             },
             [("mapping_sources", b"ch"), ("metric_type", "c")],
@@ -472,7 +768,7 @@ def test_all_resolved_with_routing_information(caplog, settings):
                 "tags": {"3": 7, "9": 5},
                 "timestamp": ts,
                 "type": "d",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [4, 5, 6],
             },
             [("mapping_sources", b"ch"), ("metric_type", "d")],
@@ -496,7 +792,7 @@ def test_all_resolved_with_routing_information(caplog, settings):
                 "tags": {"3": 7, "9": 4},
                 "timestamp": ts,
                 "type": "s",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [3],
             },
             [("mapping_sources", b"cd"), ("metric_type", "s")],
@@ -504,6 +800,7 @@ def test_all_resolved_with_routing_information(caplog, settings):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_all_resolved_retention_days_honored(caplog, settings):
     """
     Tests that the indexer batch honors the incoming retention_days values
@@ -523,7 +820,6 @@ def test_all_resolved_retention_days_honored(caplog, settings):
     )
 
     batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE,
         outer_message,
         True,
         False,
@@ -531,16 +827,18 @@ def test_all_resolved_retention_days_honored(caplog, settings):
     )
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "d:sessions/duration@second",
-                "environment",
-                "errored",
-                "healthy",
-                "init",
-                "production",
-                "s:sessions/error@none",
-                "session.status",
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "d:sessions/duration@second",
+                    "environment",
+                    "errored",
+                    "healthy",
+                    "init",
+                    "production",
+                    "s:sessions/error@none",
+                    "session.status",
+                }
             }
         }
     )
@@ -595,7 +893,7 @@ def test_all_resolved_retention_days_honored(caplog, settings):
                 "tags": {"3": 7, "9": 6},
                 "timestamp": ts,
                 "type": "c",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": 1.0,
             },
             [("mapping_sources", b"ch"), ("metric_type", "c")],
@@ -618,7 +916,7 @@ def test_all_resolved_retention_days_honored(caplog, settings):
                 "tags": {"3": 7, "9": 5},
                 "timestamp": ts,
                 "type": "d",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [4, 5, 6],
             },
             [("mapping_sources", b"ch"), ("metric_type", "d")],
@@ -641,7 +939,7 @@ def test_all_resolved_retention_days_honored(caplog, settings):
                 "tags": {"3": 7, "9": 4},
                 "timestamp": ts,
                 "type": "s",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [3],
             },
             [("mapping_sources", b"cd"), ("metric_type", "s")],
@@ -649,6 +947,7 @@ def test_all_resolved_retention_days_honored(caplog, settings):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_batch_resolve_with_values_not_indexed(caplog, settings):
     """
     Tests that the indexer batch skips resolving tag values for indexing and
@@ -669,7 +968,6 @@ def test_batch_resolve_with_values_not_indexed(caplog, settings):
     )
 
     batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE,
         outer_message,
         False,
         False,
@@ -677,12 +975,14 @@ def test_batch_resolve_with_values_not_indexed(caplog, settings):
     )
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "d:sessions/duration@second",
-                "environment",
-                "s:sessions/error@none",
-                "session.status",
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "d:sessions/duration@second",
+                    "environment",
+                    "s:sessions/error@none",
+                    "session.status",
+                }
             }
         }
     )
@@ -728,7 +1028,7 @@ def test_batch_resolve_with_values_not_indexed(caplog, settings):
                 "tags": {"3": "production", "5": "init"},
                 "timestamp": ts,
                 "type": "c",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": 1.0,
             },
             [("mapping_sources", b"c"), ("metric_type", "c")],
@@ -750,7 +1050,7 @@ def test_batch_resolve_with_values_not_indexed(caplog, settings):
                 "tags": {"3": "production", "5": "healthy"},
                 "timestamp": ts,
                 "type": "d",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [4, 5, 6],
             },
             [("mapping_sources", b"c"), ("metric_type", "d")],
@@ -772,7 +1072,7 @@ def test_batch_resolve_with_values_not_indexed(caplog, settings):
                 "tags": {"3": "production", "5": "errored"},
                 "timestamp": ts,
                 "type": "s",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [3],
             },
             [("mapping_sources", b"c"), ("metric_type", "s")],
@@ -780,6 +1080,7 @@ def test_batch_resolve_with_values_not_indexed(caplog, settings):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_metric_id_rate_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -790,21 +1091,21 @@ def test_metric_id_rate_limited(caplog, settings):
         ]
     )
 
-    batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE, outer_message, True, False, arroyo_input_codec=_INGEST_SCHEMA
-    )
+    batch = IndexerBatch(outer_message, True, False, arroyo_input_codec=_INGEST_SCHEMA)
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "d:sessions/duration@second",
-                "environment",
-                "errored",
-                "healthy",
-                "init",
-                "production",
-                "s:sessions/error@none",
-                "session.status",
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "d:sessions/duration@second",
+                    "environment",
+                    "errored",
+                    "healthy",
+                    "init",
+                    "production",
+                    "s:sessions/error@none",
+                    "session.status",
+                }
             }
         }
     )
@@ -859,7 +1160,7 @@ def test_metric_id_rate_limited(caplog, settings):
                 "tags": {"3": 7, "9": 4},
                 "timestamp": ts,
                 "type": "s",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [3],
             },
             [("mapping_sources", b"cd"), ("metric_type", "s")],
@@ -878,6 +1179,7 @@ def test_metric_id_rate_limited(caplog, settings):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_tag_key_rate_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -888,21 +1190,21 @@ def test_tag_key_rate_limited(caplog, settings):
         ]
     )
 
-    batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE, outer_message, True, False, arroyo_input_codec=_INGEST_SCHEMA
-    )
+    batch = IndexerBatch(outer_message, True, False, arroyo_input_codec=_INGEST_SCHEMA)
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "d:sessions/duration@second",
-                "environment",
-                "errored",
-                "healthy",
-                "init",
-                "production",
-                "s:sessions/error@none",
-                "session.status",
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "d:sessions/duration@second",
+                    "environment",
+                    "errored",
+                    "healthy",
+                    "init",
+                    "production",
+                    "s:sessions/error@none",
+                    "session.status",
+                }
             }
         }
     )
@@ -958,6 +1260,7 @@ def test_tag_key_rate_limited(caplog, settings):
     assert _deconstruct_messages(snuba_payloads) == []
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_tag_value_rate_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -968,21 +1271,21 @@ def test_tag_value_rate_limited(caplog, settings):
         ]
     )
 
-    batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE, outer_message, True, False, arroyo_input_codec=_INGEST_SCHEMA
-    )
+    batch = IndexerBatch(outer_message, True, False, arroyo_input_codec=_INGEST_SCHEMA)
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "d:sessions/duration@second",
-                "environment",
-                "errored",
-                "healthy",
-                "init",
-                "production",
-                "s:sessions/error@none",
-                "session.status",
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "d:sessions/duration@second",
+                    "environment",
+                    "errored",
+                    "healthy",
+                    "init",
+                    "production",
+                    "s:sessions/error@none",
+                    "session.status",
+                }
             }
         }
     )
@@ -1046,7 +1349,7 @@ def test_tag_value_rate_limited(caplog, settings):
                 "tags": {"3": 7, "9": 6},
                 "timestamp": ts,
                 "type": "c",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": 1.0,
             },
             [("mapping_sources", b"ch"), ("metric_type", "c")],
@@ -1069,7 +1372,7 @@ def test_tag_value_rate_limited(caplog, settings):
                 "tags": {"3": 7, "9": 5},
                 "timestamp": ts,
                 "type": "d",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [4, 5, 6],
             },
             [("mapping_sources", b"ch"), ("metric_type", "d")],
@@ -1077,6 +1380,7 @@ def test_tag_value_rate_limited(caplog, settings):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_one_org_limited(caplog, settings):
     settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
@@ -1087,7 +1391,6 @@ def test_one_org_limited(caplog, settings):
     )
 
     batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE,
         outer_message,
         True,
         False,
@@ -1095,20 +1398,22 @@ def test_one_org_limited(caplog, settings):
     )
     assert batch.extract_strings() == (
         {
-            1: {
-                "c:sessions/session@none",
-                "environment",
-                "init",
-                "production",
-                "session.status",
-            },
-            2: {
-                "d:sessions/duration@second",
-                "environment",
-                "healthy",
-                "production",
-                "session.status",
-            },
+            MockUseCaseID.SESSIONS: {
+                1: {
+                    "c:sessions/session@none",
+                    "environment",
+                    "init",
+                    "production",
+                    "session.status",
+                },
+                2: {
+                    "d:sessions/duration@second",
+                    "environment",
+                    "healthy",
+                    "production",
+                    "session.status",
+                },
+            }
         }
     )
 
@@ -1178,7 +1483,7 @@ def test_one_org_limited(caplog, settings):
                 "tags": {"2": 4, "5": 3},
                 "timestamp": ts,
                 "type": "d",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [4, 5, 6],
             },
             [("mapping_sources", b"ch"), ("metric_type", "d")],
@@ -1186,6 +1491,7 @@ def test_one_org_limited(caplog, settings):
     ]
 
 
+@patch("sentry.sentry_metrics.consumers.indexer.batch.UseCaseID", MockUseCaseID)
 def test_cardinality_limiter(caplog, settings):
     """
     Test functionality of the indexer batch related to cardinality-limiting. More concretely, assert that `IndexerBatch.filter_messages`:
@@ -1206,7 +1512,6 @@ def test_cardinality_limiter(caplog, settings):
     )
 
     batch = IndexerBatch(
-        UseCaseKey.PERFORMANCE,
         outer_message,
         True,
         False,
@@ -1221,15 +1526,17 @@ def test_cardinality_limiter(caplog, settings):
     ]
     batch.filter_messages(keys_to_remove)
     assert batch.extract_strings() == {
-        1: {
-            "environment",
-            "errored",
-            "production",
-            # Note, we only extracted one MRI, of the one metric that we didn't
-            # drop
-            "s:sessions/error@none",
-            "session.status",
-        },
+        MockUseCaseID.SESSIONS: {
+            1: {
+                "environment",
+                "errored",
+                "production",
+                # Note, we only extracted one MRI, of the one metric that we didn't
+                # drop
+                "s:sessions/error@none",
+                "session.status",
+            },
+        }
     }
 
     snuba_payloads = batch.reconstruct_messages(
@@ -1272,7 +1579,7 @@ def test_cardinality_limiter(caplog, settings):
                 "tags": {"1": 3, "5": 2},
                 "timestamp": ts,
                 "type": "s",
-                "use_case_id": "performance",
+                "use_case_id": "sessions",
                 "value": [3],
             },
             [

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -282,7 +282,7 @@ def __translated_payload(
     )
     payload["retention_days"] = 90
     payload["tags"] = new_tags
-    payload["use_case_id"] = "release-health"
+    payload["use_case_id"] = "sessions"
 
     payload.pop("unit", None)
     del payload["name"]
@@ -443,9 +443,6 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
     rate_limited_payload = deepcopy(distribution_payload)
     rate_limited_payload["tags"]["custom_tag"] = "rate_limited_test"
 
-    rate_limited_payload2 = deepcopy(distribution_payload)
-    rate_limited_payload2["name"] = "rate_limited_test"
-
     message_batch = [
         Message(
             BrokerValue(
@@ -460,14 +457,6 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
                 KafkaPayload(None, json.dumps(rate_limited_payload).encode("utf-8"), []),
                 Partition(Topic("topic"), 0),
                 1,
-                datetime.now(),
-            )
-        ),
-        Message(
-            BrokerValue(
-                KafkaPayload(None, json.dumps(rate_limited_payload2).encode("utf-8"), []),
-                Partition(Topic("topic"), 0),
-                2,
                 datetime.now(),
             )
         ),


### PR DESCRIPTION
### Overview
- Implement use case logic in `IndexerBatch`

### Changes
- Use `ParsedMessage` type instead of `IngestMetric` to serve as internal representation of a parsed ingest metric message for indexing pipeline to support generic metrics.
- `_extract_messages` method now parse metric name to obtain the use case ID for each `ParsedMessage`, and inserts the use case ID into the `use_case_id` field.
- `extract_strings` method now returns mapping with a higher level of indirection with `use_case_id` on top

Closes [SNS-2214](https://getsentry.atlassian.net/browse/SNS-2214)
Closes [SNS-2215](https://getsentry.atlassian.net/browse/SNS-2215)

[SNS-2214]: https://getsentry.atlassian.net/browse/SNS-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNS-2126]: https://getsentry.atlassian.net/browse/SNS-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNS-2215]: https://getsentry.atlassian.net/browse/SNS-2215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ