### PR TITLE
feat(issue-search): Query for archived issues

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -159,6 +159,7 @@ STATUS_QUERY_CHOICES: Mapping[str, int] = {
     "resolved": GroupStatus.RESOLVED,
     "unresolved": GroupStatus.UNRESOLVED,
     "ignored": GroupStatus.IGNORED,
+    "archived": GroupStatus.IGNORED,
     # TODO(dcramer): remove in 9.0
     "muted": GroupStatus.IGNORED,
     "reprocessing": GroupStatus.REPROCESSING,


### PR DESCRIPTION
## Objective:
Update the API to allow the Issue Search to query to issues by archived status. The underlying query to should use GroupStatus.IGNORED.

We should be able to query for is:archived or !is:archived in the Issue Search bar