### PR TITLE
fix(discover): Pass the dataset query param to chart query

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -13,6 +13,7 @@ import {
   OrganizationSummary,
 } from 'sentry/types';
 import {LocationQuery} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getPeriod} from 'sentry/utils/getPeriod';
 import {PERFORMANCE_URL_PARAM} from 'sentry/utils/performance/constants';
 import {QueryBatching} from 'sentry/utils/performance/contexts/genericQueryBatcher';
@@ -32,6 +33,7 @@ type Options = {
   organization: OrganizationSummary;
   partial: boolean;
   comparisonDelta?: number;
+  dataset?: DiscoverDatasets;
   end?: DateString;
   environment?: Readonly<string[]>;
   excludeOther?: boolean;
@@ -100,6 +102,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
     queryExtras,
     excludeOther,
     includeAllArgs,
+    dataset,
   }: {includeAllArgs?: IncludeAllArgsType} & Options
 ): IncludeAllArgsType extends true
   ? Promise<
@@ -127,6 +130,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
       withoutZerofill: withoutZerofill ? '1' : undefined,
       referrer: referrer ? referrer : 'api.organization-event-stats',
       excludeOther: excludeOther ? '1' : undefined,
+      dataset,
     }).filter(([, value]) => typeof value !== 'undefined')
   );
 
@@ -154,6 +158,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
 export type EventQuery = {
   field: string[];
   query: string;
+  dataset?: DiscoverDatasets;
   environment?: string[];
   equation?: string[];
   noPagination?: boolean;

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -44,6 +44,7 @@ import {
   getEquation,
   isEquation,
 } from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeList} from 'sentry/utils/queryString';
 
 import EventsGeoRequest from './eventsGeoRequest';
@@ -404,6 +405,10 @@ export type EventsChartProps = {
    */
   currentSeriesName?: string;
   /**
+   * Specifies the dataset to query from. Defaults to discover.
+   */
+  dataset?: DiscoverDatasets;
+  /**
    * Don't show the previous period's data. Will automatically disable
    * when start/end are used.
    */
@@ -548,6 +553,7 @@ class EventsChart extends React.Component<EventsChartProps> {
       additionalSeries,
       loadingAdditionalSeries,
       reloadingAdditionalSeries,
+      dataset,
       ...props
     } = this.props;
 
@@ -679,6 +685,7 @@ class EventsChart extends React.Component<EventsChartProps> {
                 end={end}
                 environments={environments}
                 referrer={props.referrer}
+                dataset={dataset}
               >
                 {({errored, loading, reloading, tableData}) =>
                   chartImplementation({
@@ -715,6 +722,7 @@ class EventsChart extends React.Component<EventsChartProps> {
               partial
               // Cannot do interpolation when stacking series
               withoutZerofill={withoutZerofill && !this.isStacked()}
+              dataset={dataset}
             >
               {eventData => {
                 return chartImplementation({

--- a/static/app/components/charts/eventsGeoRequest.tsx
+++ b/static/app/components/charts/eventsGeoRequest.tsx
@@ -6,6 +6,7 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import {TableData, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import toArray from 'sentry/utils/toArray';
 import usePrevious from 'sentry/utils/usePrevious';
 
@@ -26,6 +27,7 @@ export interface EventsGeoRequestProps {
   query: string;
   start: DateString;
   yAxis: string | string[];
+  dataset?: DiscoverDatasets;
   orderby?: string;
   period?: string | null;
   referrer?: string;
@@ -44,6 +46,7 @@ const EventsGeoRequest = ({
   environments,
   referrer,
   children,
+  dataset,
 }: EventsGeoRequestProps) => {
   const eventView = useMemo(
     () =>
@@ -59,8 +62,9 @@ const EventsGeoRequest = ({
         start: start ? getUtcDateString(start) : undefined,
         end: end ? getUtcDateString(end) : undefined,
         environment: environments,
+        dataset,
       }),
-    [yAxis, query, orderby, projects, period, start, end, environments]
+    [yAxis, query, orderby, projects, period, start, end, environments, dataset]
   );
   const [results, setResults] = useState(undefined as ChildrenRenderProps['tableData']);
   const [reloading, setReloading] = useState(false);

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -27,6 +27,7 @@ import {
   getAggregateAlias,
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {QueryBatching} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 
 export type TimeSeriesData = {
@@ -138,6 +139,10 @@ type EventsRequestPartialProps = {
    * Optional callback to further process raw events request response data
    */
   dataLoadedCallback?: (any: EventsStats | MultiSeriesEventsStats | null) => void;
+  /**
+   * Specify the dataset to query from. Defaults to discover.
+   */
+  dataset?: DiscoverDatasets;
   /**
    * List of environments to query
    */

--- a/static/app/utils/performance/constants.tsx
+++ b/static/app/utils/performance/constants.tsx
@@ -2,4 +2,4 @@ import {URL_PARAM} from 'sentry/constants/pageFilters';
 
 export const MAX_TEAM_KEY_TRANSACTIONS = 100;
 
-export const PERFORMANCE_URL_PARAM = ['team', ...Object.values(URL_PARAM)];
+export const PERFORMANCE_URL_PARAM = ['team', 'dataset', ...Object.values(URL_PARAM)];

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -36,7 +36,7 @@ import {
   isMeasurement,
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
-import {DisplayModes} from 'sentry/utils/discover/types';
+import {DiscoverDatasets, DisplayModes} from 'sentry/utils/discover/types';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import {decodeList} from 'sentry/utils/queryString';
 import {
@@ -355,7 +355,7 @@ export function flattenErrors(
 export function getDashboardsMEPQueryParams(isMEPEnabled: boolean) {
   return isMEPEnabled
     ? {
-        dataset: 'metricsEnhanced',
+        dataset: DiscoverDatasets.METRICS_ENHANCED,
       }
     : {};
 }

--- a/static/app/views/discover/resultsChart.tsx
+++ b/static/app/views/discover/resultsChart.tsx
@@ -138,6 +138,7 @@ class ResultsChart extends Component<ResultsChartProps> {
               api={api}
               router={router}
               query={apiPayload.query}
+              dataset={apiPayload.dataset}
               organization={organization}
               showLegend
               yAxis={yAxisValue}


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/47401

Hopefully we can dynamically search the correct dataset soon, but until then this will make sure that the chart query is querying the same dataset as the table beneath it.

Before:

![CleanShot 2023-04-20 at 15 56 55](https://user-images.githubusercontent.com/10888943/233503867-720c6f9d-80ec-4c51-b561-83bd57dc0324.png)

After:

![CleanShot 2023-04-20 at 15 54 53](https://user-images.githubusercontent.com/10888943/233503647-9c45ca01-fcb0-48bc-ba0e-b03b77a9c106.png)
