### PR TITLE
feat(roles): Access checks for Team and Project

### DIFF
--- a/fixtures/js-stubs/project.js
+++ b/fixtures/js-stubs/project.js
@@ -3,6 +3,7 @@ export function Project(params = {}) {
     id: '2',
     slug: 'project-slug',
     name: 'Project Name',
+    access: [],
     hasAccess: true,
     isMember: true,
     isBookmarked: false,

--- a/fixtures/js-stubs/team.js
+++ b/fixtures/js-stubs/team.js
@@ -3,7 +3,9 @@ export function Team(params = {}) {
     id: '1',
     slug: 'team-slug',
     name: 'Team Name',
-    orgRole: null,
+    access: [],
+    orgRole: null, // TODO(cathy): Rename this
+    teamRole: null,
     isMember: true,
     memberCount: 0,
     flags: {

--- a/static/app/components/acl/access.spec.jsx
+++ b/static/app/components/acl/access.spec.jsx
@@ -42,13 +42,14 @@ describe('Access', function () {
 
     it('read access from team', function () {
       const org = TestStubs.Organization({access: []});
-      const team1 = TestStubs.Team({access: []});
+      const nextRouterContext = TestStubs.routerContext([{organization: org}]);
 
+      const team1 = TestStubs.Team({access: []});
       render(
-        <Access access={['team:admin']} organization={org} team={team1}>
+        <Access access={['team:admin']} team={team1}>
           {childrenMock}
         </Access>,
-        {context: routerContext}
+        {context: nextRouterContext, organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(
@@ -61,12 +62,11 @@ describe('Access', function () {
       const team2 = TestStubs.Team({
         access: ['team:read', 'team:write', 'team:admin'],
       });
-
       render(
-        <Access access={['team:admin']} organization={org} team={team2}>
+        <Access access={['team:admin']} team={team2}>
           {childrenMock}
         </Access>,
-        {context: routerContext}
+        {context: nextRouterContext, organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(
@@ -79,13 +79,14 @@ describe('Access', function () {
 
     it('read access from project', function () {
       const org = TestStubs.Organization({access: []});
-      const proj1 = TestStubs.Project({access: []});
+      const nextRouterContext = TestStubs.routerContext([{organization: org}]);
 
+      const proj1 = TestStubs.Project({access: []});
       render(
-        <Access access={['project:read']} organization={org} project={proj1}>
+        <Access access={['project:read']} project={proj1}>
           {childrenMock}
         </Access>,
-        {context: routerContext}
+        {context: nextRouterContext, organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(
@@ -96,12 +97,11 @@ describe('Access', function () {
       );
 
       const proj2 = TestStubs.Project({access: ['project:read']});
-
       render(
-        <Access access={['project:read']} organization={org} project={proj2}>
+        <Access access={['project:read']} project={proj2}>
           {childrenMock}
         </Access>,
-        {context: routerContext}
+        {context: nextRouterContext, organization: org}
       );
 
       expect(childrenMock).toHaveBeenCalledWith(

--- a/static/app/components/acl/access.spec.jsx
+++ b/static/app/components/acl/access.spec.jsx
@@ -40,7 +40,79 @@ describe('Access', function () {
       });
     });
 
-    it('handles no org/project', function () {
+    it('read access from team', function () {
+      const org = TestStubs.Organization({access: []});
+      const team1 = TestStubs.Team({access: []});
+
+      render(
+        <Access access={['team:admin']} organization={org} team={team1}>
+          {childrenMock}
+        </Access>,
+        {context: routerContext}
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasAccess: false,
+          hasSuperuser: false,
+        })
+      );
+
+      const team2 = TestStubs.Team({
+        access: ['team:read', 'team:write', 'team:admin'],
+      });
+
+      render(
+        <Access access={['team:admin']} organization={org} team={team2}>
+          {childrenMock}
+        </Access>,
+        {context: routerContext}
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasAccess: true,
+          hasSuperuser: false,
+        })
+      );
+    });
+
+    it('read access from project', function () {
+      const org = TestStubs.Organization({access: []});
+      const proj1 = TestStubs.Project({access: []});
+
+      render(
+        <Access access={['project:read']} organization={org} project={proj1}>
+          {childrenMock}
+        </Access>,
+        {context: routerContext}
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasAccess: false,
+          hasSuperuser: false,
+        })
+      );
+
+      const proj2 = TestStubs.Project({access: ['project:read']});
+
+      render(
+        <Access access={['project:read']} organization={org} project={proj2}>
+          {childrenMock}
+        </Access>,
+        {context: routerContext}
+      );
+
+      expect(childrenMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasAccess: true,
+          hasSuperuser: false,
+        })
+      );
+    });
+
+    it('handles no org', function () {
       render(<Access access={['org:write']}>{childrenMock}</Access>, {
         context: routerContext,
         organization,
@@ -111,6 +183,17 @@ describe('Access', function () {
       expect(screen.getByText('The Child')).toBeInTheDocument();
     });
 
+    it('has no access', function () {
+      render(
+        <Access access={['org:write']}>
+          <p>The Child</p>
+        </Access>,
+        {context: routerContext, organization}
+      );
+
+      expect(screen.queryByText('The Child')).not.toBeInTheDocument();
+    });
+
     it('has superuser', function () {
       ConfigStore.config = {
         user: {isSuperuser: true},
@@ -123,17 +206,6 @@ describe('Access', function () {
       );
 
       expect(screen.getByText('The Child')).toBeInTheDocument();
-    });
-
-    it('has no access', function () {
-      render(
-        <Access access={['org:write']}>
-          <p>The Child</p>
-        </Access>,
-        {context: routerContext, organization}
-      );
-
-      expect(screen.queryByText('The Child')).not.toBeInTheDocument();
     });
 
     it('has no superuser', function () {

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -71,7 +71,8 @@ export interface Organization extends OrganizationSummary {
   orgRole?: string;
 }
 
-export type Team = {
+export interface Team {
+  access: Scope[];
   avatar: Avatar;
   externalTeams: ExternalTeam[];
   flags: {
@@ -86,7 +87,7 @@ export type Team = {
   orgRole: string | null;
   slug: string;
   teamRole: string | null;
-};
+}
 
 // TODO: Rename to BaseRole
 export interface MemberRole {

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -1,6 +1,6 @@
 import type {PlatformKey} from 'sentry/data/platformCategories';
 
-import type {TimeseriesValue} from './core';
+import type {Scope, TimeseriesValue} from './core';
 import type {SDKUpdatesSuggestion} from './event';
 import type {Plugin} from './integrations';
 import type {Organization, Team} from './organization';
@@ -15,6 +15,7 @@ export type AvatarProject = {
 };
 
 export type Project = {
+  access: Scope[];
   dateCreated: string;
   digestsMaxDelay: number;
   digestsMinDelay: number;

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -36,6 +36,7 @@ export default function ProjectSecurityAndPrivacy({organization, project}: Props
     <Fragment>
       <SentryDocumentTitle title={title} projectSlug={projectSlug} />
       <SettingsPageHeader title={title} />
+
       <Form
         saveOnBlur
         allowUndo


### PR DESCRIPTION
Depends on #47698 and #47448

With team-level roles, an "org-member" can be a "team-admin". This will grant them additional access scopes for specific teams and projects (i.e. I can have `project:admin` for a few projects, but not all the projects in my org)