### PR TITLE
fix field name for trace.transaction

### DIFF
--- a/src/sentry/dynamic_sampling/rules/biases/boost_rare_transactions_rule.py
+++ b/src/sentry/dynamic_sampling/rules/biases/boost_rare_transactions_rule.py
@@ -45,7 +45,7 @@ class RareTransactionsRulesBias(Bias):
                         "inner": [
                             {
                                 "op": "eq",
-                                "name": "event.transaction",
+                                "name": "trace.transaction",
                                 "value": [name],
                                 "options": {"ignoreCase": True},
                             }

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_rare_transactions_rule.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_rare_transactions_rule.py
@@ -59,7 +59,7 @@ def test_transaction_boost_known_projects(get_transactions_resampling_rates):
                 "inner": [
                     {
                         "op": "eq",
-                        "name": "event.transaction",
+                        "name": "trace.transaction",
                         "value": ["t1"],
                         "options": {"ignoreCase": True},
                     }
@@ -75,7 +75,7 @@ def test_transaction_boost_known_projects(get_transactions_resampling_rates):
                 "inner": [
                     {
                         "op": "eq",
-                        "name": "event.transaction",
+                        "name": "trace.transaction",
                         "value": ["t2"],
                         "options": {"ignoreCase": True},
                     }

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -518,7 +518,7 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
             "condition": {
                 "inner": [
                     {
-                        "name": "event.transaction",
+                        "name": "trace.transaction",
                         "op": "eq",
                         "options": {"ignoreCase": True},
                         "value": ["t1"],


### PR DESCRIPTION
This PR fixes the transaction rules field name ( it was using event.transaction instead of trace.transaction) for the
trace name