### PR TITLE
feat(issue-states): Update substatus with status change

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -131,6 +131,7 @@ from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.process_buffer import buffer_incr
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.canonical import CanonicalKeyDict
@@ -1778,6 +1779,7 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
             # at the value
             last_seen=date,
             status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.REGRESSED,
         )
     )
     issue_unresolved.send_robust(
@@ -1790,6 +1792,8 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
 
     group.active_at = date
     group.status = GroupStatus.UNRESOLVED
+    group.substatus = GroupSubStatus.REGRESSED
+    group.save()
 
     if is_regression and release:
         resolution = None

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -10,6 +10,7 @@ from sentry.models import Activity
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import inbox_in, inbox_out
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 
 INBOX_REASON_DETAILS = {
     "type": ["object", "null"],
@@ -83,8 +84,15 @@ def add_group_to_inbox(group, reason, reason_details=None):
         },
     )
 
-    # Ignore new issues, too many events
-    if reason is not GroupInboxReason.NEW:
+    if reason == GroupInboxReason.REGRESSION:
+        group.substatus = GroupSubStatus.REGRESSED
+        group.save()
+
+    if reason is GroupInboxReason.NEW:
+        group.substatus = GroupSubStatus.NEW
+        group.save()
+    else:
+        # Ignore new issues, too many events
         inbox_in.send_robust(
             project=group.project,
             user=None,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -16,6 +16,7 @@ from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.event_frames import get_sdk_name
@@ -699,7 +700,9 @@ def process_snoozes(job: PostProcessJob) -> None:
             )
 
             snooze.delete()
-            group.update(status=GroupStatus.UNRESOLVED)
+            group.status = GroupStatus.UNRESOLVED
+            group.substatus = GroupSubStatus.ONGOING
+            group.save()
             issue_unignored.send_robust(
                 project=group.project,
                 user_id=None,

--- a/tests/sentry/models/test_groupinbox.py
+++ b/tests/sentry/models/test_groupinbox.py
@@ -11,6 +11,7 @@ from sentry.models import (
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 
 
 @region_silo_test(stable=True)
@@ -22,10 +23,12 @@ class GroupInboxTestCase(TestCase):
             group=self.group, reason=GroupInboxReason.NEW.value
         ).exists()
         assert not inbox_in.called
+
         add_group_to_inbox(self.group, GroupInboxReason.REGRESSION)
         assert GroupInbox.objects.filter(
             group=self.group, reason=GroupInboxReason.NEW.value
         ).exists()
+        assert self.group.substatus == GroupSubStatus.REGRESSED
         assert inbox_in.called
 
     @patch("sentry.signals.inbox_out.send_robust")

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -61,6 +61,7 @@ from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 from sentry.utils.cache import cache
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
@@ -679,6 +680,8 @@ class InboxTestMixin(BasePostProgressGroupMixin):
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         group = event.group
+        group.status = GroupStatus.RESOLVED
+        group.save()
 
         self.call_post_process_group(
             is_new=True,
@@ -705,6 +708,7 @@ class InboxTestMixin(BasePostProgressGroupMixin):
 
         group = Group.objects.get(id=group.id)
         assert group.status == GroupStatus.UNRESOLVED
+        assert group.substatus == GroupSubStatus.REGRESSED
         assert GroupInbox.objects.filter(
             group=group, reason=GroupInboxReason.REGRESSION.value
         ).exists()


### PR DESCRIPTION
Update the group substatus to NEW/REGRESSED when the status is changed. 

- For NEW issues, we don't add a row to GroupHistory. We can set the GroupSubStatus when we add a NEW group to GroupInbox.
- For REGRESSED issues, we handle the substatus in a coupe locations, so wee can set REGRESSED with every update as well as in GroupInbox if anything is missed.

WOR-2993 WOR-2994