### PR TITLE
feat(escalating-issues): Use default forecast when no forecast is found

### DIFF
--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -48,7 +48,12 @@ class EscalatingGroupForecast:
         results = nodestore.get(cls.build_storage_identifier(project_id, group_id))
         if results:
             return EscalatingGroupForecast.from_dict(results)
-        return DEFAULT_MINIMUM_CEILING_FORECAST
+        return EscalatingGroupForecast(
+            project_id=project_id,
+            group_id=group_id,
+            forecast=DEFAULT_MINIMUM_CEILING_FORECAST,
+            date_added=datetime.now(),
+        )
 
     @classmethod
     def build_storage_identifier(cls, project_id: int, group_id: int) -> str:

--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -14,6 +14,7 @@ from sentry import nodestore
 from sentry.utils.dates import parse_timestamp
 
 TWO_WEEKS_IN_DAYS_TTL = 14
+DEFAULT_MINIMUM_CEILING_FORECAST = [200] * 14
 
 
 class EscalatingGroupForecastData(TypedDict):
@@ -47,7 +48,7 @@ class EscalatingGroupForecast:
         results = nodestore.get(cls.build_storage_identifier(project_id, group_id))
         if results:
             return EscalatingGroupForecast.from_dict(results)
-        return None
+        return DEFAULT_MINIMUM_CEILING_FORECAST
 
     @classmethod
     def build_storage_identifier(cls, project_id: int, group_id: int) -> str:

--- a/tests/sentry/issues/test_ignored.py
+++ b/tests/sentry/issues/test_ignored.py
@@ -1,12 +1,14 @@
 from unittest.mock import MagicMock, patch
 
-from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
+from sentry.issues.escalating_group_forecast import (
+    DEFAULT_MINIMUM_CEILING_FORECAST,
+    EscalatingGroupForecast,
+)
 from sentry.issues.ignored import handle_archived_until_escalating, handle_ignored
 from sentry.models import GroupInbox, GroupInboxReason, GroupSnooze, add_group_to_inbox
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from tests.sentry.issues.test_utils import get_mock_groups_past_counts_response
-from tests.sentry.tasks.test_weekly_escalating_forecast import DEFAULT_MINIMUM_CEILING_FORECAST
 
 
 class HandleIgnoredTest(TestCase):  # type: ignore
@@ -69,7 +71,7 @@ class HandleArchiveUntilEscalating(TestCase):  # type: ignore
         assert not GroupSnooze.objects.filter(group=self.group).exists()
 
         fetched_forecast = EscalatingGroupForecast.fetch(self.group.project.id, self.group.id)
-        assert fetched_forecast is None
+        assert fetched_forecast == DEFAULT_MINIMUM_CEILING_FORECAST
 
     @patch("sentry.issues.forecasts.query_groups_past_counts")
     def test_archive_until_escalating_with_counts(

--- a/tests/sentry/issues/test_ignored.py
+++ b/tests/sentry/issues/test_ignored.py
@@ -71,7 +71,10 @@ class HandleArchiveUntilEscalating(TestCase):  # type: ignore
         assert not GroupSnooze.objects.filter(group=self.group).exists()
 
         fetched_forecast = EscalatingGroupForecast.fetch(self.group.project.id, self.group.id)
-        assert fetched_forecast == DEFAULT_MINIMUM_CEILING_FORECAST
+        assert fetched_forecast is not None
+        assert fetched_forecast.project_id == self.group.project.id
+        assert fetched_forecast.group_id == self.group.id
+        assert fetched_forecast.forecast == DEFAULT_MINIMUM_CEILING_FORECAST
 
     @patch("sentry.issues.forecasts.query_groups_past_counts")
     def test_archive_until_escalating_with_counts(

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -36,7 +36,10 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):  # type: ignore
 
         run_escalating_forecast()
         fetched_forecast = EscalatingGroupForecast.fetch(group_list[0].project.id, group_list[0].id)
-        assert fetched_forecast == DEFAULT_MINIMUM_CEILING_FORECAST
+        assert fetched_forecast is not None
+        assert fetched_forecast.project_id == group_list[0].project.id
+        assert fetched_forecast.group_id == group_list[0].id
+        assert fetched_forecast.forecast == DEFAULT_MINIMUM_CEILING_FORECAST
 
     @patch("sentry.issues.forecasts.query_groups_past_counts")
     def test_single_group_escalating_forecast(

--- a/tests/sentry/tasks/test_weekly_escalating_forecast.py
+++ b/tests/sentry/tasks/test_weekly_escalating_forecast.py
@@ -4,15 +4,16 @@ from unittest.mock import MagicMock, patch
 
 import pytz
 
-from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
+from sentry.issues.escalating_group_forecast import (
+    DEFAULT_MINIMUM_CEILING_FORECAST,
+    EscalatingGroupForecast,
+)
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.tasks.weekly_escalating_forecast import run_escalating_forecast
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.types.group import GroupSubStatus
 from tests.sentry.issues.test_utils import get_mock_groups_past_counts_response
-
-DEFAULT_MINIMUM_CEILING_FORECAST = [200] * 14
 
 
 class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):  # type: ignore
@@ -35,7 +36,7 @@ class TestWeeklyEscalatingForecast(APITestCase, SnubaTestCase):  # type: ignore
 
         run_escalating_forecast()
         fetched_forecast = EscalatingGroupForecast.fetch(group_list[0].project.id, group_list[0].id)
-        assert fetched_forecast is None
+        assert fetched_forecast == DEFAULT_MINIMUM_CEILING_FORECAST
 
     @patch("sentry.issues.forecasts.query_groups_past_counts")
     def test_single_group_escalating_forecast(


### PR DESCRIPTION
Change the default per https://github.com/getsentry/sentry/pull/47681/files#r1172705032