### PR TITLE
feat(issue-platform): Allow performance issues to be queried via the new issues search dataset

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -26,7 +26,7 @@ import sentry_sdk
 from django.conf import settings
 from django.db.models import Min, prefetch_related_objects
 
-from sentry import analytics, tagstore
+from sentry import analytics, features, tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
@@ -475,16 +475,26 @@ class GroupSerializerBase(Serializer, ABC):
         if self._collapse("stats"):
             return None
 
+        if not item_list:
+            return
+
+        organization = item_list[0].organization
+        search_perf_issues = features.has(
+            "organizations:issue-platform-search-perf-issues", organization, actor=user
+        )
         # partition the item_list by type
         error_issues = [group for group in item_list if GroupCategory.ERROR == group.issue_category]
         perf_issues = [
-            group for group in item_list if GroupCategory.PERFORMANCE == group.issue_category
+            group
+            for group in item_list
+            if GroupCategory.PERFORMANCE == group.issue_category and not search_perf_issues
         ]
         generic_issues = [
             group
             for group in item_list
             if group.issue_category
-            and group.issue_category not in (GroupCategory.ERROR, GroupCategory.PERFORMANCE)
+            and group.issue_category != GroupCategory.ERROR
+            and (group.issue_category != GroupCategory.PERFORMANCE or search_perf_issues)
         ]
 
         # bulk query for the seen_stats by type

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence
 
 from django.utils import timezone
 
-from sentry import release_health, tsdb
+from sentry import features, release_health, tsdb
 from sentry.api.serializers.models.group import (
     BaseGroupSerializerResponse,
     GroupSerializer,
@@ -53,7 +53,9 @@ class GroupStatsMixin:
     CUSTOM_ROLLUP_6H = timedelta(hours=6).total_seconds()  # rollups should be increments of 6hs
 
     @abstractmethod
-    def query_tsdb(self, groups: Sequence[Group], query_params: MutableMapping[str, Any]):
+    def query_tsdb(
+        self, groups: Sequence[Group], query_params: MutableMapping[str, Any], user=None
+    ):
         pass
 
     def get_stats(
@@ -99,7 +101,7 @@ class GroupStatsMixin:
                     "rollup": int(interval.total_seconds()),
                 }
 
-            return self.query_tsdb(item_list, query_params, **kwargs)
+            return self.query_tsdb(item_list, query_params, user=user, **kwargs)
 
 
 class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
@@ -147,7 +149,7 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
 
         return result
 
-    def query_tsdb(self, groups: Sequence[Group], query_params, **kwargs):
+    def query_tsdb(self, groups: Sequence[Group], query_params, user=None, **kwargs):
         try:
             environment = self.environment_func()
         except Environment.DoesNotExist:
@@ -334,15 +336,29 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         return result
 
     def query_tsdb(
-        self, groups: Sequence[Group], query_params, conditions=None, environment_ids=None, **kwargs
+        self,
+        groups: Sequence[Group],
+        query_params,
+        conditions=None,
+        environment_ids=None,
+        user=None,
+        **kwargs,
     ):
+        if not groups:
+            return
+
+        organization = groups[0].organization
+        search_perf_issues = features.has(
+            "organizations:issue-platform-search-perf-issues", organization, actor=user
+        )
+
         error_issue_ids, perf_issue_ids, generic_issue_ids = [], [], []
         for group in groups:
             if GroupCategory.ERROR == group.issue_category:
                 error_issue_ids.append(group.id)
-            elif GroupCategory.PERFORMANCE == group.issue_category:
+            elif GroupCategory.PERFORMANCE == group.issue_category and not search_perf_issues:
                 perf_issue_ids.append(group.id)
-            elif group.issue_category not in (GroupCategory.ERROR, GroupCategory.PERFORMANCE):
+            else:
                 generic_issue_ids.append(group.id)
 
         results = {}

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -93,6 +93,7 @@ default_manager.add("organizations:issue-details-tag-improvements", Organization
 default_manager.add("organizations:issue-list-removal-action", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-platform", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:issue-platform-search-perf-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-secondary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -379,3 +379,9 @@ class GroupSerializerTest(TestCase):
         assert serialized["count"] == "1"
         assert serialized["issueCategory"] == "performance"
         assert serialized["issueType"] == "performance_n_plus_one_db_queries"
+
+        with self.feature("organizations:issue-platform-search-perf-issues"):
+            serialized = serialize(perf_group)
+            assert serialized["count"] == "1"
+            assert serialized["issueCategory"] == "performance"
+            assert serialized["issueType"] == "performance_n_plus_one_db_queries"

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -456,22 +456,23 @@ class PerformanceGroupSerializerSnubaTest(
         first_group_fingerprint = f"{PerformanceRenderBlockingAssetSpanGroupType.type_id}-group1"
         timestamp = timezone.now() - timedelta(days=5)
         times = 5
-        for _ in range(0, times):
-            self.store_transaction(
+        with self.options({"performance.issues.send_to_issues_platform": True}):
+            for _ in range(0, times):
+                self.store_transaction(
+                    proj.id,
+                    "user1",
+                    [first_group_fingerprint],
+                    environment.name,
+                    timestamp=timestamp + timedelta(minutes=1),
+                )
+
+            event = self.store_transaction(
                 proj.id,
-                "user1",
+                "user2",
                 [first_group_fingerprint],
                 environment.name,
-                timestamp=timestamp + timedelta(minutes=1),
+                timestamp=timestamp + timedelta(minutes=2),
             )
-
-        event = self.store_transaction(
-            proj.id,
-            "user2",
-            [first_group_fingerprint],
-            environment.name,
-            timestamp=timestamp + timedelta(minutes=2),
-        )
 
         first_group = event.groups[0]
 
@@ -488,6 +489,21 @@ class PerformanceGroupSerializerSnubaTest(
         assert iso_format(result["lastSeen"]) == iso_format(timestamp + timedelta(minutes=2))
         assert iso_format(result["firstSeen"]) == iso_format(timestamp + timedelta(minutes=1))
         assert result["count"] == str(times + 1)
+
+        with self.feature("organizations:issue-platform-search-perf-issues"):
+            result = serialize(
+                first_group,
+                serializer=GroupSerializerSnuba(
+                    environment_ids=[environment.id],
+                    start=timestamp - timedelta(hours=1),
+                    end=timestamp + timedelta(hours=1),
+                ),
+            )
+
+            assert result["userCount"] == 2
+            assert iso_format(result["lastSeen"]) == iso_format(timestamp + timedelta(minutes=2))
+            assert iso_format(result["firstSeen"]) == iso_format(timestamp + timedelta(minutes=1))
+            assert result["count"] == str(times + 1)
 
 
 @region_silo_test

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2510,7 +2510,7 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         group_type = PerformanceNPlusOneGroupType
         self.project.update_option("sentry:performance_issue_create_issue_through_platform", True)
 
-        with self.options(
+        with self.feature("organizations:issue-platform-search-perf-issues"), self.options(
             {"performance.issues.create_issues_through_platform": True}
         ), mock.patch.object(
             PerformanceNPlusOneGroupType, "noise_config", new=NoiseConfig(0, timedelta(minutes=1))


### PR DESCRIPTION
Adds a feature flag so that we can switch performance issues over to use the issue platform dataset. Changes the group serializers to be able to query performance issue stats from the issue platform, and also changes search to use the new feature flag so that we can test this out via flagr.

