### PR TITLE
feat(ecosystem): Hide project ownership changes from audit log

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -232,13 +232,21 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
         )
         if serializer.is_valid():
             ownership = serializer.save()
+
+            change_data = {**serializer.validated_data}
+            # Ownership rules can be large (3 MB) and we don't want to store them in the audit log
+            if "raw" in change_data and "schema" in change_data:
+                del change_data["schema"]
+                del change_data["raw"]
+                change_data["ownership_rules"] = "edited"
+
             create_audit_entry(
                 request=self.request,
                 actor=request.user,
                 organization=project.organization,
                 target_object=project.id,
                 event=audit_log.get_event_id("PROJECT_EDIT"),
-                data={**serializer.validated_data, **project.get_audit_log_data()},
+                data={**change_data, **project.get_audit_log_data()},
             )
             ownership_rule_created.send_robust(project=project, sender=self.__class__)
             return Response(

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -238,7 +238,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
             if "raw" in change_data and "schema" in change_data:
                 del change_data["schema"]
                 del change_data["raw"]
-                change_data["ownership_rules"] = "edited"
+                change_data["ownership_rules"] = "modified"
 
             create_audit_entry(
                 request=self.request,

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -123,9 +123,22 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         auditlog = AuditLogEntry.objects.filter(
             organization_id=self.project.organization.id,
             event=audit_log.get_event_id("PROJECT_EDIT"),
+            target_object=self.project.id,
         )
         assert len(auditlog) == 1
         assert "Auto Assign to Issue Owner" in auditlog[0].data["autoAssignment"]
+
+    def test_audit_log_ownership_change(self):
+        resp = self.client.put(self.path, {"raw": "*.js admin@localhost #tiger-team"})
+        assert resp.status_code == 200
+
+        auditlog = AuditLogEntry.objects.filter(
+            organization_id=self.project.organization.id,
+            event=audit_log.get_event_id("PROJECT_EDIT"),
+            target_object=self.project.id,
+        )
+        assert len(auditlog) == 1
+        assert "edited" in auditlog[0].data["ownership_rules"]
 
     @with_feature("organizations:streamline-targeting-context")
     def test_update_with_streamline_targeting(self):

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -138,7 +138,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             target_object=self.project.id,
         )
         assert len(auditlog) == 1
-        assert "edited" in auditlog[0].data["ownership_rules"]
+        assert "modified" in auditlog[0].data["ownership_rules"]
 
     @with_feature("organizations:streamline-targeting-context")
     def test_update_with_streamline_targeting(self):


### PR DESCRIPTION
it will look like this now instead of including the entire file inline, along with the parsed object
![image](https://user-images.githubusercontent.com/1400464/233730129-c6228375-8c7c-4347-a2c9-0094fc164b8d.png)

[ISSUE-1658](https://getsentry.atlassian.net/browse/ISSUE-1658)

[ISSUE-1658]: https://getsentry.atlassian.net/browse/ISSUE-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ