### PR TITLE
ref(sdk): Refactor `check_tags` for scope bleed

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -464,10 +464,12 @@ def check_tag(tag_key: str, expected_value: str) -> None:
     with configure_scope() as scope:
         if scope._tags and tag_key in scope._tags and scope._tags[tag_key] != expected_value:
             scope.set_tag("possible_mistag", True)
+            scope.set_tag(f"scope_bleed.{tag_key}", True)
             extra = {
                 f"previous_{tag_key}_tag": scope._tags[tag_key],
                 f"new_{tag_key}_tag": expected_value,
             }
+            merge_context_into_scope("scope_bleed", extra, scope)
             logger.warning(f"Tag already set and different ({tag_key}).", extra=extra)
 
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -465,8 +465,8 @@ def check_tag(tag_key: str, expected_value: str) -> None:
         if scope._tags and tag_key in scope._tags and scope._tags[tag_key] != expected_value:
             scope.set_tag("possible_mistag", True)
             extra = {
-                f"previous_{tag_key}": scope._tags[tag_key],
-                f"new_{tag_key}": expected_value,
+                f"previous_{tag_key}_tag": scope._tags[tag_key],
+                f"new_{tag_key}_tag": expected_value,
             }
             logger.warning(f"Tag already set and different ({tag_key}).", extra=extra)
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -462,7 +462,9 @@ def check_tag(tag_key: str, expected_value: str) -> None:
     from what we want to set it to.
     """
     with configure_scope() as scope:
-        if scope._tags and tag_key in scope._tags and scope._tags[tag_key] != expected_value:
+        # First check that the tag exists, because though it's true that "no value yet" doesn't
+        # match "some new value," we don't want to flag that as a mismatch.
+        if tag_key in scope._tags and scope._tags[tag_key] != expected_value:
             scope.set_tag("possible_mistag", True)
             scope.set_tag(f"scope_bleed.{tag_key}", True)
             extra = {

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -1,7 +1,27 @@
+from typing import Any, Callable
+from unittest.mock import MagicMock, patch
+
 from sentry_sdk import Scope
 
 from sentry.testutils import TestCase
-from sentry.utils.sdk import merge_context_into_scope
+from sentry.utils.sdk import check_tag, merge_context_into_scope
+
+
+# TODO: This is kind of gross, but no other way seemed to work
+def set_mock_context_manager_return_value(
+    context_manager_constructor: Callable, as_value: Any
+) -> None:
+    """
+    Ensure that if the code being tested includes something like
+
+        with some_func() as some_value:
+
+    then `some_value` will equal `as_value`.
+
+    Note: `context_manager_constructor` should be `some_func`, not `some_func()`.
+    """
+
+    context_manager_constructor.return_value.__enter__.return_value = as_value
 
 
 class SDKUtilsTest(TestCase):
@@ -32,3 +52,51 @@ class SDKUtilsTest(TestCase):
             "maisey": "silly",
             "charlie": "goofy",
         }
+
+
+@patch("sentry.utils.sdk.logger.warning")
+class CheckTagTest(TestCase):
+    def test_no_exiting_tag(self, mock_logger_warning: MagicMock):
+        mock_scope = Scope()
+        mock_scope._tags = {}
+
+        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
+            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+            check_tag("org.slug", "squirrel_chasers")
+
+        assert "possible_mistag" not in mock_scope._tags
+        assert "scope_bleed.tag.org.slug" not in mock_scope._tags
+        assert "scope_bleed" not in mock_scope._contexts
+        assert mock_logger_warning.call_count == 0
+
+    def test_matching_exiting_tag(self, mock_logger_warning: MagicMock):
+        mock_scope = Scope()
+        mock_scope._tags = {"org.slug": "squirrel_chasers"}
+
+        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
+            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+            check_tag("org.slug", "squirrel_chasers")
+
+        assert "possible_mistag" not in mock_scope._tags
+        assert "scope_bleed.tag.org.slug" not in mock_scope._tags
+        assert "scope_bleed" not in mock_scope._contexts
+        assert mock_logger_warning.call_count == 0
+
+    def test_different_exiting_tag(self, mock_logger_warning: MagicMock):
+        mock_scope = Scope()
+        mock_scope._tags = {"org.slug": "good_dogs"}
+
+        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
+            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+            check_tag("org.slug", "squirrel_chasers")
+
+        extra = {
+            "previous_org.slug_tag": "good_dogs",
+            "new_org.slug_tag": "squirrel_chasers",
+        }
+        assert "possible_mistag" in mock_scope._tags
+        assert "scope_bleed.org.slug" in mock_scope._tags
+        assert mock_scope._contexts["scope_bleed"] == extra
+        mock_logger_warning.assert_called_with(
+            "Tag already set and different (org.slug).", extra=extra
+        )


### PR DESCRIPTION
This is a small refactor of the `check_tags` function we use to make sure we don't have the wrong org data in the scope, in preparation for doing the same thing for transactions. 

Key changes:

- Move the `possibe_mistag` tag-adding from the caller into `check_tags`, since we'd want it if we use this function anywhere else.

- Add a new tag specifying that it's specifically a tag mismatch. (Soon there will also be one for transaction mismatch.) I thought about just replacing the `possible_mistag` tag rather than adding a new one, but I figured this is temporary and it's nice to have the continuity of data with all the events which have already been tagged that way.

- Simplify the `if` statement checking for a mismatch. (We don't need to check for the existence of `scope._tags` because scopes are always initialized with an empty dictionary as their `_tags` value.) Also, add a comment explaining why we can't simplify further to just using `.get()`,  a trap I nearly fell into.

- Include the before and after values in a new `scope_bleed` context, so we don't have to dig into logs to find them.

- Add tests for `check_tag`.