### PR TITLE
feat(starfish): format sql

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
@@ -21,6 +21,7 @@ export type DataRow = {
   data_values: Array<string>;
   desc: string;
   epm: number;
+  formatted_desc: string;
   p75: number;
   total_time: number;
   transactions: number;

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -126,7 +126,7 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
         )}
       </p>
       <SubHeader>{t('Query Description')}</SubHeader>
-      <pre>{row.desc}</pre>
+      <FormattedCode>{row.formatted_desc}</FormattedCode>
       <FlexRowContainer>
         <FlexRowItem>
           <SubHeader>{t('Throughput')}</SubHeader>
@@ -212,4 +212,12 @@ const FlexRowContainer = styled('div')`
 const FlexRowItem = styled('div')`
   padding-right: ${space(4)};
   flex: 1;
+`;
+
+const FormattedCode = styled('div')`
+  padding: ${space(1)};
+  background: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.borderRadius};
+  overflow-x: auto;
+  white-space: pre;
 `;

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -79,7 +79,8 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
 
   const {isLoading, data: graphData} = useQuery({
     queryKey: ['dbQueryDetailsGraph', row.desc],
-    queryFn: () => fetch(`${HOST}/?query=${GRAPH_QUERY}`).then(res => res.json()),
+    queryFn: () =>
+      fetch(`${HOST}/?query=${GRAPH_QUERY}?format=sql`).then(res => res.json()),
     retry: false,
     initialData: [],
   });


### PR DESCRIPTION
Use existing query formatting that is used for breadcrumbs in the db module sidepanel. Plan is to add this anywhere else needed as well.
The query gets formatted by the backend.

depends on https://github.com/getsentry/Starfish-sample-generator/pull/13

![image](https://user-images.githubusercontent.com/44422760/233727905-01929fbe-8443-4aa4-81bc-1f2a19747e81.png)
