### PR TITLE
feat(escalating-issues): New group substatuses for ignored groups

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -436,6 +436,8 @@ class Group(Model):
             (GroupSubStatus.UNTIL_ESCALATING, _("Until escalating")),
             (GroupSubStatus.ONGOING, _("Ongoing")),
             (GroupSubStatus.ESCALATING, _("Escalating")),
+            (GroupSubStatus.UNTIL_CONDITION_MET, _("Until condition met")),
+            (GroupSubStatus.FOREVER, _("Forever")),
         ),
     )
     times_seen = BoundedPositiveIntegerField(default=1, db_index=True)

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -1,6 +1,10 @@
 class GroupSubStatus:
     # GroupStatus.IGNORED
     UNTIL_ESCALATING = 1
+    # Group is ignored/archived for a count/user count/duration
+    UNTIL_CONDITION_MET = 4
+    # Group is ignored/archived forever
+    FOREVER = 5
 
     # GroupStatus.UNRESOLVED
     ESCALATING = 2


### PR DESCRIPTION
## Objective:
Add new substatuses for GroupStatus.IGNORED:

UNTIL_CONDITION_MET: issue is ignored/archived for a count/user count/duration

FOREVER: issue is ignored/archived forever