### PR TITLE
fix(perf): Fix percentiles chart in transaction summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
@@ -50,7 +50,7 @@ export function transformData(
 
 export function getPercentiles(organization: Organization) {
   const isUsingMetrics = canUseMetricsData(organization);
-  const METRICS_PERCENTILES = ['0.25', '0.5', '0.75', '0.9', '0.95', '0.99', '1'];
+  const METRICS_PERCENTILES = ['0.25', '0.50', '0.75', '0.90', '0.95', '0.99', '1'];
   const INDEXED_PERCENTILES = [
     '0.10',
     '0.25',


### PR DESCRIPTION
0.5 and 0.9 percentiles were converted into 5% and 9%. This PR fixes that.

Before:
<img width="738" alt="Screenshot 2023-04-21 at 9 24 07 PM" src="https://user-images.githubusercontent.com/23648387/233754474-c5495b8e-5c9b-47d5-87db-873265907da8.png">

After:
<img width="747" alt="Screenshot 2023-04-21 at 9 23 43 PM" src="https://user-images.githubusercontent.com/23648387/233754473-968af098-54cc-48e8-a48f-0ab8833e4ef4.png">