### PR TITLE
feat(trends): Display breakpoint in the UI

### DIFF
--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -239,7 +239,7 @@ function ChangedTransactions(props: Props) {
 
   const trendView = props.trendView.clone();
   const chartTitle = getChartTitle(trendChangeType);
-  modifyTrendView(trendView, location, trendChangeType, projects);
+  modifyTrendView(trendView, location, trendChangeType, projects, organization);
 
   const onCursor = makeTrendsCursorHandler(trendChangeType);
   const cursor = decodeScalar(location.query[trendCursorNames[trendChangeType]]);

--- a/static/app/views/performance/trends/types.tsx
+++ b/static/app/views/performance/trends/types.tsx
@@ -77,6 +77,7 @@ export type TrendsTransaction = {
   transaction: string;
   trend_difference: number;
   trend_percentage: number;
+  breakpoint?: number;
 };
 
 export type TrendsDataEvents = {


### PR DESCRIPTION
Display the breakpoint instead of the middle point in trends.

Before (old trends):
<img width="529" alt="Screenshot 2023-04-21 at 10 47 09 PM" src="https://user-images.githubusercontent.com/23648387/233758025-409712a8-0ad3-4f18-8210-cef47c2d1229.png">


After (new trends):
<img width="530" alt="Screenshot 2023-04-21 at 10 47 15 PM" src="https://user-images.githubusercontent.com/23648387/233758030-0ef86587-1b3a-47a2-9319-d4316adba561.png">
