### PR TITLE
fix(anr): Change 'Crashed in' to 'Occurred in' for ANR events

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -270,5 +270,40 @@ describe('StackTrace', function () {
       );
       expect(frameTitles[1]).toHaveTextContent('raven/base.py in build_msg at line 303');
     });
+
+    it('displays "occurred in" when event is an ANR error', function () {
+      const dataFrames = [...data.frames];
+
+      const newData = {
+        ...data,
+        hasSystemFrames: true,
+        frames: [
+          {...dataFrames[0], inApp: true},
+          ...dataFrames.splice(1, dataFrames.length),
+        ],
+      };
+
+      renderedComponent({
+        data: newData,
+        event: {
+          ...event,
+          entries: [{...event.entries[0], stacktrace: newData.frames}],
+          type: EventOrGroupType.ERROR,
+          tags: [{key: 'mechanism', value: 'ANR'}],
+        },
+        includeSystemFrames: false,
+      });
+
+      // clickable list item element
+      const frameTitles = screen.getAllByTestId('title');
+
+      // frame list - in app only
+      expect(frameTitles).toHaveLength(2);
+
+      expect(frameTitles[0]).toHaveTextContent(
+        'Occurred in non-app: raven/scripts/runner.py in main at line 112'
+      );
+      expect(frameTitles[1]).toHaveTextContent('raven/base.py in build_msg at line 303');
+    });
   });
 });

--- a/static/app/components/events/interfaces/frame/utils.tsx
+++ b/static/app/components/events/interfaces/frame/utils.tsx
@@ -121,8 +121,20 @@ export function getLeadHint({
 
   switch (event.type) {
     case EventOrGroupType.ERROR:
-      return t('Crashed in non-app');
+      // ANRs/AppHangs are errors, but not crashes, so "Crashed in non-app" might be confusing as if
+      // there was a crash prior to ANR, hence special-casing them
+      return isAnrEvent(event) ? t('Occurred in non-app') : t('Crashed in non-app');
     default:
       return t('Occurred in non-app');
   }
+}
+
+function isAnrEvent(event: Event) {
+  const mechanismTag = event.tags?.find(({key}) => key === 'mechanism')?.value;
+  const isANR =
+    mechanismTag === 'ANR' ||
+    mechanismTag === 'AppExitInfo' ||
+    mechanismTag === 'AppHang' ||
+    mechanismTag === 'mx_hang_diagnostic';
+  return isANR;
 }


### PR DESCRIPTION
Some customers were confused by the label, as in, they though that there was a crash prior to the ANR and the stacktrace actually belongs to that crash and not the ANR, so changing the label here, because ANRs are not really crashes.

Before:
![image](https://user-images.githubusercontent.com/4999776/233800945-39f4b6ab-254a-4a6f-ba98-1654c2d8c541.png)


After:
![image](https://user-images.githubusercontent.com/4999776/233800952-5318d58c-a47c-49c5-9a26-78d22838c77e.png)
