### PR TITLE
feat(profiling): Enable time limits for the profiles.process Celery task

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -42,7 +42,10 @@ class VroomTimeout(Exception):
     task_time_limit=60,
     task_acks_on_failure_or_timeout=False,
 )
-def process_profile_work(profile: Profile) -> None:
+def process_profile_task(
+    profile: Profile,
+    **kwargs: Any,
+) -> None:
     organization = Organization.objects.get_from_cache(id=profile["organization_id"])
 
     sentry_sdk.set_tag("organization", organization.id)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -40,7 +40,6 @@ class VroomTimeout(Exception):
     default_retry_delay=5,  # retries after 5s
     max_retries=5,
     acks_late=True,
-    task_soft_time_limit=30,
     task_time_limit=60,
     task_acks_on_failure_or_timeout=False,
 )

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -6,7 +6,6 @@ from time import sleep, time
 from typing import Any, List, Mapping, MutableMapping, Optional, Tuple
 
 import sentry_sdk
-from celery.exceptions import TimeLimitExceeded
 from django.conf import settings
 from pytz import UTC
 from symbolic import ProguardMapper  # type: ignore
@@ -43,17 +42,6 @@ class VroomTimeout(Exception):
     task_time_limit=60,
     task_acks_on_failure_or_timeout=False,
 )
-def process_profile_task(
-    profile: Profile,
-    **kwargs: Any,
-) -> None:
-    try:
-        process_profile_work(profile=profile)
-    except TimeLimitExceeded as e:
-        sentry_sdk.capture_exception(e)
-        raise e
-
-
 def process_profile_work(profile: Profile) -> None:
     organization = Organization.objects.get_from_cache(id=profile["organization_id"])
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -6,7 +6,7 @@ from time import sleep, time
 from typing import Any, List, Mapping, MutableMapping, Optional, Tuple
 
 import sentry_sdk
-from celery.exceptions import SoftTimeLimitExceeded
+from celery.exceptions import TimeLimitExceeded
 from django.conf import settings
 from pytz import UTC
 from symbolic import ProguardMapper  # type: ignore
@@ -50,13 +50,9 @@ def process_profile_task(
 ) -> None:
     try:
         process_profile_work(profile=profile)
-    except SoftTimeLimitExceeded as e:
+    except TimeLimitExceeded as e:
         sentry_sdk.capture_exception(e)
-        metrics.incr(
-            "process_profile.soft_time_limit_exceeded",
-            tags={"platform": profile["platform"]},
-            sample_rate=1.0,
-        )
+        raise e
 
 
 def process_profile_work(profile: Profile) -> None:


### PR DESCRIPTION
We keep having some issues where the workers somehow "disconnect" from the queue and don't receive any work. We're not sure if it's because a task is blocking them or something else.

To try to get more information about this issue, we'd like to enable some time limits on the tasks so workers are recycled if a task takes too long. This will:
- recycle the worker after a task is in processing for more than 60s (using [`task_time_limit`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-time-limit))
- not acknowledge the task if the worker is killed or times out (using [`task_acks_on_failure_or_timeout`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-acks-on-failure-or-timeout))