### PR TITLE
(chore) Bump self-hosted-e2e-action pin to limit docker image poll to 10 min

### DIFF
--- a/.github/workflows/self-hosted-e2e-tests.yml
+++ b/.github/workflows/self-hosted-e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
           filters: .github/file-filters.yml
       - name: Run Sentry self-hosted e2e CI
         if: steps.changes.outputs.backend_all == 'true'
-        uses: getsentry/action-self-hosted-e2e-tests@77805295ebff8a603def5970e18743ded72cb304
+        uses: getsentry/action-self-hosted-e2e-tests@f45ef07793b2cc805a9a9401819f486da449a90a
         with:
           project_name: sentry
           image_url: us.gcr.io/sentryio/sentry:${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Picks this change up: https://github.com/getsentry/action-self-hosted-e2e-tests/pull/11