### PR TITLE
feat(crons): Add sidebar with cron monitor information in details page

### DIFF
--- a/static/app/views/monitors/components/detailsSidebar.tsx
+++ b/static/app/views/monitors/components/detailsSidebar.tsx
@@ -8,7 +8,7 @@ import Text from 'sentry/components/text';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCopy} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
-import space from 'sentry/styles/space';
+import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {DEFAULT_MAX_RUNTIME} from 'sentry/views/monitors/components/monitorForm';

--- a/static/app/views/monitors/components/detailsSidebar.tsx
+++ b/static/app/views/monitors/components/detailsSidebar.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {SectionHeading} from 'sentry/components/charts/styles';
+import Clipboard from 'sentry/components/clipboard';
+import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import Text from 'sentry/components/text';
+import TimeSince from 'sentry/components/timeSince';
+import {IconCopy} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {getFormattedDate} from 'sentry/utils/dates';
+import {DEFAULT_MAX_RUNTIME} from 'sentry/views/monitors/components/monitorForm';
+import MonitorIcon from 'sentry/views/monitors/components/monitorIcon';
+import {
+  IntervalConfig,
+  Monitor,
+  MonitorEnvironment,
+  MonitorStatus,
+  ScheduleType,
+} from 'sentry/views/monitors/types';
+
+interface Props {
+  monitor: Monitor;
+  monitorEnv?: MonitorEnvironment;
+}
+
+function getIntervalScheduleText(schedule: IntervalConfig['schedule']) {
+  const [n, period] = schedule;
+  const intervalTextMap = {
+    minute: tn('Every %s minute', 'Every %s minutes', n),
+    hour: tn('Every %s hour', 'Every %s hours', n),
+    day: tn('Every %s day', 'Every %s days', n),
+    week: tn('Every %s week', 'Every %s weeks', n),
+    month: tn('Every %s month', 'Every %s months', n),
+    year: tn('Every %s year', 'Every %s years', n),
+  };
+  return intervalTextMap[period];
+}
+
+export default function DetailsSidebar({monitorEnv, monitor}: Props) {
+  const {checkin_margin, schedule, schedule_type, max_runtime, timezone} = monitor.config;
+
+  const slug = (
+    <Clipboard value={monitor.slug}>
+      <MonitorSlug>
+        <SlugText>{monitor.slug}</SlugText>
+        <IconCopy size="xs" />
+      </MonitorSlug>
+    </Clipboard>
+  );
+
+  return (
+    <React.Fragment>
+      <CheckIns>
+        <SectionHeading>{t('Last Check-In')}</SectionHeading>
+        <SectionHeading>{t('Next Check-In')}</SectionHeading>
+        <div>
+          {monitorEnv?.lastCheckIn ? (
+            <TimeSince
+              unitStyle="regular"
+              liveUpdateInterval="second"
+              date={monitorEnv.lastCheckIn}
+            />
+          ) : (
+            '-'
+          )}
+        </div>
+        <div>
+          {monitorEnv?.nextCheckIn ? (
+            <TimeSince
+              unitStyle="regular"
+              liveUpdateInterval="second"
+              date={monitorEnv.nextCheckIn}
+            />
+          ) : (
+            '-'
+          )}
+        </div>
+      </CheckIns>
+      <SectionHeading>{t('Schedule')}</SectionHeading>
+      <Schedule>
+        <MonitorIcon status={MonitorStatus.OK} size={12} />
+        <Text>
+          {schedule_type === ScheduleType.CRONTAB
+            ? schedule
+            : getIntervalScheduleText(schedule as IntervalConfig['schedule'])}
+        </Text>
+        <MonitorIcon status={MonitorStatus.MISSED_CHECKIN} size={12} />
+        <Text>
+          {defined(checkin_margin)
+            ? tn('Check-ins %s min late', 'Check-ins %s mins late', checkin_margin)
+            : t('Check-ins that are late')}
+        </Text>
+        <MonitorIcon status={MonitorStatus.ERROR} size={12} />
+        <Text>
+          {tn(
+            'Check-ins longer than %s min or errors',
+            'Check-ins longer than %s mins or errors',
+            max_runtime ?? DEFAULT_MAX_RUNTIME
+          )}
+        </Text>
+      </Schedule>
+      <SectionHeading>{t('Cron Details')}</SectionHeading>
+      <KeyValueTable>
+        <CronTableRow keyName={t('Monitor Slug')} value={slug} />
+        {schedule_type === ScheduleType.CRONTAB && (
+          <KeyValueTableRow keyName={t('Timezone')} value={timezone} />
+        )}
+        <KeyValueTableRow
+          keyName={t('Date created')}
+          value={getFormattedDate(monitor.dateCreated, 'MMM D, YYYY')}
+        />
+      </KeyValueTable>
+    </React.Fragment>
+  );
+}
+
+const CheckIns = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: ${space(2)};
+`;
+
+const Schedule = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  margin-bottom: ${space(2)};
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const MonitorSlug = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  align-items: center;
+  gap: ${space(0.5)};
+  cursor: pointer;
+`;
+
+const SlugText = styled(Text)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const CronTableRow = styled(KeyValueTableRow)`
+  dd: {
+    overflow: hidden;
+    white-space: nowrap;
+  }
+`;

--- a/static/app/views/monitors/components/detailsSidebar.tsx
+++ b/static/app/views/monitors/components/detailsSidebar.tsx
@@ -104,7 +104,7 @@ export default function DetailsSidebar({monitorEnv, monitor}: Props) {
       </Schedule>
       <SectionHeading>{t('Cron Details')}</SectionHeading>
       <KeyValueTable>
-        <CronTableRow keyName={t('Monitor Slug')} value={slug} />
+        <KeyValueTableRow keyName={t('Monitor Slug')} value={slug} />
         {schedule_type === ScheduleType.CRONTAB && (
           <KeyValueTableRow keyName={t('Timezone')} value={timezone} />
         )}
@@ -143,11 +143,4 @@ const SlugText = styled(Text)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-`;
-
-const CronTableRow = styled(KeyValueTableRow)`
-  dd: {
-    overflow: hidden;
-    white-space: nowrap;
-  }
 `;

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -42,6 +42,8 @@ const SCHEDULE_OPTIONS: RadioOption<string>[] = [
 const DEFAULT_MONITOR_TYPE = 'cron_job';
 const DEFAULT_CRONTAB = '0 0 * * *';
 
+export const DEFAULT_MAX_RUNTIME = 30;
+
 const getIntervals = (n: number): SelectValue<string>[] => [
   {value: 'minute', label: tn('minute', 'minutes', n)},
   {value: 'hour', label: tn('hour', 'hours', n)},
@@ -336,7 +338,7 @@ function MonitorForm({
         <InputGroup>
           <StyledNumberField
             name="config.max_runtime"
-            placeholder="Defaults to 30 minutes"
+            placeholder={`Defaults to ${DEFAULT_MAX_RUNTIME} minutes`}
             stacked
             inline={false}
           />

--- a/static/app/views/monitors/components/monitorHeader.tsx
+++ b/static/app/views/monitors/components/monitorHeader.tsx
@@ -1,37 +1,19 @@
-import styled from '@emotion/styled';
-
 import Breadcrumbs from 'sentry/components/breadcrumbs';
-import {SectionHeading} from 'sentry/components/charts/styles';
-import Clipboard from 'sentry/components/clipboard';
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
-import TimeSince from 'sentry/components/timeSince';
-import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
-import {Monitor, MonitorEnvironment, MonitorStatus} from '../types';
+import {Monitor} from '../types';
 
 import MonitorHeaderActions from './monitorHeaderActions';
-import MonitorIcon from './monitorIcon';
 
 interface Props {
   monitor: Monitor;
   onUpdate: (data: Monitor) => void;
   orgId: string;
-  monitorEnv?: MonitorEnvironment;
 }
 
-const statusToLabel: Record<MonitorStatus, string> = {
-  ok: t('Ok'),
-  error: t('Failed'),
-  disabled: t('Disabled'),
-  active: t('Active'),
-  missed_checkin: t('Missed'),
-  timeout: t('Timeout'),
-};
-
-function MonitorHeader({monitor, monitorEnv, orgId, onUpdate}: Props) {
+function MonitorHeader({monitor, orgId, onUpdate}: Props) {
   const crumbs = [
     {
       label: t('Crons'),
@@ -55,82 +37,12 @@ function MonitorHeader({monitor, monitorEnv, orgId, onUpdate}: Props) {
           />
           {monitor.name}
         </Layout.Title>
-        <Clipboard value={monitor.slug}>
-          <MonitorSlug>
-            {monitor.slug} <IconCopy size="xs" />
-          </MonitorSlug>
-        </Clipboard>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         <MonitorHeaderActions orgId={orgId} monitor={monitor} onUpdate={onUpdate} />
-        <MonitorStats>
-          <MonitorStatLabel>{t('Last Check-in')}</MonitorStatLabel>
-          <MonitorStatLabel>{t('Next Check-in')}</MonitorStatLabel>
-          <MonitorStatLabel>{t('Status')}</MonitorStatLabel>
-          <div>
-            {monitorEnv?.lastCheckIn && (
-              <TimeSince
-                unitStyle="regular"
-                liveUpdateInterval="second"
-                date={monitorEnv.lastCheckIn}
-              />
-            )}
-          </div>
-          <div>
-            {monitorEnv?.nextCheckIn && (
-              <TimeSince
-                unitStyle="regular"
-                liveUpdateInterval="second"
-                date={monitorEnv.nextCheckIn}
-              />
-            )}
-          </div>
-          <div>
-            {monitorEnv?.status && (
-              <Status>
-                <MonitorIcon status={monitorEnv.status} size={16} />
-                <MonitorStatusLabel>
-                  {statusToLabel[monitorEnv.status]}
-                </MonitorStatusLabel>
-              </Status>
-            )}
-          </div>
-        </MonitorStats>
       </Layout.HeaderActions>
     </Layout.Header>
   );
 }
-
-const MonitorSlug = styled('div')`
-  margin-top: ${space(1)};
-  color: ${p => p.theme.subText};
-  cursor: pointer;
-  width: max-content;
-`;
-
-const MonitorStats = styled('div')`
-  display: grid;
-  align-self: flex-end;
-  grid-template-columns: repeat(3, max-content);
-  grid-column-gap: ${space(4)};
-  grid-row-gap: ${space(0.5)};
-  margin-bottom: ${space(2)};
-  margin-top: ${space(1)};
-`;
-
-const MonitorStatLabel = styled(SectionHeading)`
-  text-transform: uppercase;
-  font-size: ${p => p.theme.fontSizeSmall};
-  text-align: center;
-`;
-
-const Status = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-const MonitorStatusLabel = styled('div')`
-  margin-left: ${space(1)};
-`;
 
 export default MonitorHeader;

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -11,6 +11,7 @@ import {space} from 'sentry/styles/space';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import DetailsSidebar from 'sentry/views/monitors/components/detailsSidebar';
 
 import MonitorCheckIns from './components/monitorCheckIns';
 import MonitorHeader from './components/monitorHeader';
@@ -62,14 +63,9 @@ function MonitorDetails({params, location}: Props) {
   return (
     <SentryDocumentTitle title={`Crons - ${monitor.name}`}>
       <Layout.Page>
-        <MonitorHeader
-          monitor={monitor}
-          monitorEnv={monitorEnv}
-          orgId={organization.slug}
-          onUpdate={onUpdate}
-        />
+        <MonitorHeader monitor={monitor} orgId={organization.slug} onUpdate={onUpdate} />
         <Layout.Body>
-          <Layout.Main fullWidth>
+          <Layout.Main>
             {!monitorEnv?.lastCheckIn ? (
               <MonitorOnboarding orgId={organization.slug} monitor={monitor} />
             ) : (
@@ -98,6 +94,9 @@ function MonitorDetails({params, location}: Props) {
               </Fragment>
             )}
           </Layout.Main>
+          <Layout.Side>
+            <DetailsSidebar monitorEnv={monitorEnv} monitor={monitor} />
+          </Layout.Side>
         </Layout.Body>
       </Layout.Page>
     </SentryDocumentTitle>


### PR DESCRIPTION
Before:
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/9372512/234376466-23bb9c25-2613-4bf8-be0e-2efd0f0d4503.png">


After:
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/9372512/234376380-e9831ee1-e432-42c7-8afd-f829599b5ffa.png">

Fixes https://github.com/getsentry/sentry/issues/47919