### PR TITLE
feat(crons): Allows individual monitor environments to be deleted

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -20,7 +20,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.parameters import GLOBAL_PARAMS, MONITOR_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models import ScheduledDeletion
-from sentry.monitors.models import Monitor, MonitorStatus
+from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
 from sentry.monitors.serializers import MonitorSerializer, MonitorSerializerResponse
 from sentry.monitors.validators import MonitorValidator
 
@@ -122,7 +122,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         return self.respond(serialize(monitor, request.user))
 
     @extend_schema(
-        operation_id="Delete a monitor",
+        operation_id="Delete a monitor or monitor environment",
         parameters=[
             GLOBAL_PARAMS.ORG_SLUG,
             MONITOR_PARAMS.MONITOR_SLUG,
@@ -137,26 +137,53 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
     )
     def delete(self, request: Request, organization, project, monitor) -> Response:
         """
-        Delete a monitor.
+        Delete a monitor or monitor environment.
         """
+        environment_name = request.query_params.get("environment")
         with transaction.atomic():
-            affected = (
-                Monitor.objects.filter(id=monitor.id)
-                .exclude(
-                    status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS]
+            monitor_object = monitor
+
+            if environment_name:
+                monitor_object = (
+                    MonitorEnvironment.objects.filter(
+                        environment__name=environment_name, monitor__id=monitor.id
+                    )
+                    .exclude(
+                        monitor__status__in=[
+                            MonitorStatus.PENDING_DELETION,
+                            MonitorStatus.DELETION_IN_PROGRESS,
+                        ]
+                    )
+                    .exclude(
+                        status__in=[
+                            MonitorStatus.PENDING_DELETION,
+                            MonitorStatus.DELETION_IN_PROGRESS,
+                        ]
+                    )
+                    .first()
                 )
-                .update(status=MonitorStatus.PENDING_DELETION)
-            )
+                affected = monitor_object.update(status=MonitorStatus.PENDING_DELETION)
+            else:
+                affected = (
+                    Monitor.objects.filter(id=monitor.id)
+                    .exclude(
+                        status__in=[
+                            MonitorStatus.PENDING_DELETION,
+                            MonitorStatus.DELETION_IN_PROGRESS,
+                        ]
+                    )
+                    .update(status=MonitorStatus.PENDING_DELETION)
+                )
             if not affected:
                 return self.respond(status=404)
 
-            schedule = ScheduledDeletion.schedule(monitor, days=0, actor=request.user)
+            schedule = ScheduledDeletion.schedule(monitor_object, days=0, actor=request.user)
             self.create_audit_entry(
                 request=request,
                 organization=project.organization,
-                target_object=monitor.id,
+                target_object=monitor_object.id,
                 event=audit_log.get_event_id("MONITOR_REMOVE"),
-                data=monitor.get_audit_log_data(),
+                data=monitor_object.get_audit_log_data(),
                 transaction_id=schedule.guid,
             )
 

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -361,6 +361,9 @@ class MonitorEnvironment(Model):
 
     __repr__ = sane_repr("monitor_id", "environment_id")
 
+    def get_audit_log_data(self):
+        return {"name": self.environment.name, "status": self.status, "monitor": self.monitor.name}
+
     def mark_failed(self, last_checkin=None, reason=MonitorFailure.UNKNOWN):
         from sentry.coreapi import insert_data_to_database_legacy
         from sentry.event_manager import EventManager

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -375,3 +375,14 @@ class DeleteMonitorTest(MonitorTestCase):
         assert ScheduledDeletion.objects.filter(
             object_id=monitor_environment.id, model_name="MonitorEnvironment"
         ).exists()
+
+    def test_bad_environment(self):
+        monitor = self._create_monitor()
+        self._create_monitor_environment(monitor)
+
+        self.get_error_response(
+            self.organization.slug,
+            monitor.slug,
+            status_code=404,
+            qs_params={"environment": "jungle"},
+        )


### PR DESCRIPTION
Can delete individual monitor environments by sending an `environment` query param with the `DELETE` request

Closes https://github.com/getsentry/sentry/issues/47854