### PR TITLE
feat(compactSelect): Add `closeOnSelect` callback function

### DIFF
--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -48,6 +48,7 @@ function OptionSelector({
   featureType,
   multiple,
   defaultValue,
+  closeOnSelect,
   ...rest
 }: SingleProps | MultipleProps) {
   const mappedOptions = useMemo(() => {
@@ -68,6 +69,7 @@ function OptionSelector({
         onChange: (sel: SelectOption<string>[]) => {
           onChange?.(sel.map(o => o.value));
         },
+        closeOnSelect,
       };
     }
 
@@ -76,8 +78,9 @@ function OptionSelector({
       value: selected,
       defaultValue,
       onChange: opt => onChange?.(opt.value),
+      closeOnSelect,
     };
-  }, [multiple, selected, defaultValue, onChange]);
+  }, [multiple, selected, defaultValue, onChange, closeOnSelect]);
 
   function isOptionDisabled(option) {
     return (

--- a/static/app/components/compactSelect/composite.tsx
+++ b/static/app/components/compactSelect/composite.tsx
@@ -69,12 +69,6 @@ export interface CompositeSelectProps extends ControlProps {
    * whose values don't interfere with one another.
    */
   children: CompositeSelectChild | CompositeSelectChild[];
-  /**
-   * Whether to close the menu upon selection. This prop applies to the entire selector
-   * and functions as a fallback value. Each composite region also accepts the same
-   * prop, which will take precedence over this one.
-   */
-  closeOnSelect?: SingleListProps<React.Key>['closeOnSelect'];
 }
 
 /**
@@ -87,7 +81,6 @@ function CompositeSelect({
   disabled,
   emptyMessage,
   size = 'md',
-  closeOnSelect,
   ...controlProps
 }: CompositeSelectProps) {
   return (
@@ -100,13 +93,7 @@ function CompositeSelect({
             }
 
             return (
-              <Region
-                {...child.props}
-                grid={grid}
-                size={size}
-                compositeIndex={index}
-                closeOnSelect={child.props.closeOnSelect ?? closeOnSelect}
-              />
+              <Region {...child.props} grid={grid} size={size} compositeIndex={index} />
             );
           })}
 

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -33,11 +33,6 @@ interface BaseListProps<Value extends React.Key>
     > {
   items: SelectOptionOrSectionWithKey<Value>[];
   /**
-   * Whether the menu should close upon selection/deselection. In general, only
-   * single-selection menus should close on select (this is the default behavior).
-   */
-  closeOnSelect?: boolean;
-  /**
    * This list's index number inside composite select menus.
    */
   compositeIndex?: number;
@@ -81,6 +76,11 @@ interface BaseListProps<Value extends React.Key>
 }
 
 export interface SingleListProps<Value extends React.Key> extends BaseListProps<Value> {
+  /**
+   * Whether to close the menu. Accepts either a boolean value or a callback function
+   * that receives the newly selected option and returns whether to close the menu.
+   */
+  closeOnSelect?: boolean | ((selectedOption: SelectOption<Value>) => boolean);
   defaultValue?: Value;
   multiple?: false;
   onChange?: (selectedOption: SelectOption<Value>) => void;
@@ -89,6 +89,11 @@ export interface SingleListProps<Value extends React.Key> extends BaseListProps<
 
 export interface MultipleListProps<Value extends React.Key> extends BaseListProps<Value> {
   multiple: true;
+  /**
+   * Whether to close the menu. Accepts either a boolean value or a callback function
+   * that receives the newly selected options and returns whether to close the menu.
+   */
+  closeOnSelect?: boolean | ((selectedOptions: SelectOption<Value>[]) => boolean);
   defaultValue?: Value[];
   onChange?: (selectedOptions: SelectOption<Value>[]) => void;
   value?: Value[];
@@ -151,7 +156,11 @@ function List<Value extends React.Key>({
           onChange?.(selectedOptions);
 
           // Close menu if closeOnSelect is true
-          if (closeOnSelect) {
+          if (
+            typeof closeOnSelect === 'function'
+              ? closeOnSelect(selectedOptions)
+              : closeOnSelect
+          ) {
             overlayState?.close();
           }
         },
@@ -174,7 +183,12 @@ function List<Value extends React.Key>({
 
         // Close menu if closeOnSelect is true or undefined (by default single-selection
         // menus will close on selection)
-        if (closeOnSelect || !defined(closeOnSelect)) {
+        if (
+          !defined(closeOnSelect) ||
+          (typeof closeOnSelect === 'function'
+            ? closeOnSelect(selectedOption)
+            : closeOnSelect)
+        ) {
           overlayState?.close();
         }
       },


### PR DESCRIPTION
In addition to a boolean value, the `closeOnSelect` prop in `CompactSelect` should also accept a callback function of the form `(selectedOptions) => boolean`.

The functional form is useful for complex menus that should close when some, but not all, of the options are selected. For example, the following menu closes when selecting any but the last option ("Absolute range"). It remains open when selecting "Absolute range":

https://user-images.githubusercontent.com/44172267/234097665-1daee8e5-a2b3-419d-bee4-f8cbb4102989.mov

