### PR TITLE
ref(crons): Remove related issue alert

### DIFF
--- a/static/app/views/monitors/components/monitorIssues.tsx
+++ b/static/app/views/monitors/components/monitorIssues.tsx
@@ -1,13 +1,7 @@
-import {Fragment} from 'react';
-import styled from '@emotion/styled';
-
-import Alert from 'sentry/components/alert';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import GroupList from 'sentry/components/issues/groupList';
-import Link from 'sentry/components/links/link';
 import {Panel, PanelBody} from 'sentry/components/panels';
-import {t, tct} from 'sentry/locale';
-import space from 'sentry/styles/space';
+import {t} from 'sentry/locale';
 import {getUtcDateString} from 'sentry/utils/dates';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -46,43 +40,25 @@ function MonitorIssues({orgId, monitor}: Props) {
 
   // TODO(epurkhiser): We probably want to filter on envrionemnt
 
-  const issueStreamLink = {
-    pathname: '/issues',
-    query: {query: `monitor.id:"${monitor.id}"`},
-  };
   return (
-    <Fragment>
-      <StyledAlert type="warning" showIcon>
-        {tct(
-          'Some older issues may be missing from this list, visit the [link:issue stream] for older related issues.',
-          {
-            link: <Link to={issueStreamLink} />,
-          }
-        )}
-      </StyledAlert>
-      <GroupList
-        orgId={orgId}
-        endpointPath={`/organizations/${orgId}/issues/`}
-        queryParams={{
-          query: `monitor.slug:"${monitor.slug}"`,
-          project: monitor.project.id,
-          limit: 5,
-          ...timeProps,
-        }}
-        query=""
-        renderEmptyMessage={MonitorIssuesEmptyMessage}
-        canSelectGroups={false}
-        withPagination={false}
-        withChart={false}
-        useTintRow={false}
-        source="monitors"
-      />
-    </Fragment>
+    <GroupList
+      orgId={orgId}
+      endpointPath={`/organizations/${orgId}/issues/`}
+      queryParams={{
+        query: `monitor.slug:"${monitor.slug}"`,
+        project: monitor.project.id,
+        limit: 5,
+        ...timeProps,
+      }}
+      query=""
+      renderEmptyMessage={MonitorIssuesEmptyMessage}
+      canSelectGroups={false}
+      withPagination={false}
+      withChart={false}
+      useTintRow={false}
+      source="monitors"
+    />
   );
 }
-
-const StyledAlert = styled(Alert)`
-  margin-bottom: ${space(0.5)};
-`;
 
 export default MonitorIssues;


### PR DESCRIPTION
Remove this, should no longer be needed as most issues will be tagged with `monitor.slug: ...` Previous alert was linking to issue query with `monitor.id ...`

![image](https://user-images.githubusercontent.com/9372512/234102681-e4fcb576-7040-47ff-bd65-3aac6f219857.png)
