### PR TITLE
feat(issue-details): Convert perf grouping to look up span hashes

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
@@ -1,0 +1,66 @@
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {EventGroupVariantType} from 'sentry/types';
+
+import GroupingVariant from './groupingVariant';
+
+describe('Grouping Variant', () => {
+  const event = {
+    ...TestStubs.Event(),
+    entries: [
+      {
+        type: 'spans',
+        data: [
+          {
+            span_id: '1',
+            hash: 'hash1',
+          },
+          {
+            span_id: '2',
+            hash: 'hash2',
+          },
+        ],
+      },
+    ],
+  };
+  const performanceIssueVariant = {
+    type: EventGroupVariantType.PERFORMANCE_PROBLEM,
+    description: 'performance issue',
+    hash: 'hash3',
+    hashMismatch: false,
+    key: 'perf-issue',
+    evidence: {
+      desc: 'performance issue',
+      fingerprint: 'a',
+      cause_span_ids: ['1'],
+      offender_span_ids: ['2'],
+      parent_span_ids: [],
+    },
+  };
+
+  it('renders the span hashes for performance issues from event data', () => {
+    render(
+      <GroupingVariant
+        showGroupingConfig={false}
+        variant={performanceIssueVariant}
+        event={event}
+      />
+    );
+
+    expect(
+      within(screen.getByText('Parent Span Hashes').closest('tr') as HTMLElement)
+        .getByText('[')
+        .closest('td')
+    ).toHaveTextContent('[]');
+    expect(
+      within(
+        screen.getByText('Source Span Hashes').closest('tr') as HTMLElement
+      ).getByText('hash1')
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByText('Offender Span Hashes').closest('tr') as HTMLElement
+      ).getByText('hash2')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
 
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -159,7 +160,7 @@ class GroupVariant extends Component<Props, State> {
         const spansToHashes = Object.fromEntries(
           event.entries
             .find((c): c is EntrySpans => c.type === 'spans')
-            ?.data?.map(span => [span.span_id, span.hash])
+            ?.data?.map((span: RawSpanType) => [span.span_id, span.hash]) ?? []
         );
         data.push([
           t('Type'),
@@ -183,7 +184,7 @@ class GroupVariant extends Component<Props, State> {
         ]);
         data.push([
           'Source Span Hashes',
-          variant.evidence?.cause_span_ids?.map(id => spansToHashes[id]),
+          variant.evidence?.cause_span_ids?.map(id => spansToHashes[id]) ?? [],
         ]);
         data.push([
           'Offender Span Hashes',

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -101,7 +101,7 @@ class GroupingInfo extends AsyncComponent<Props, State> {
 
   renderGroupInfo() {
     const {groupInfo, loading} = this.state;
-    const {showGroupingConfig} = this.props;
+    const {event, showGroupingConfig} = this.props;
 
     const variants = groupInfo
       ? Object.values(groupInfo).sort((a, b) =>
@@ -129,7 +129,11 @@ class GroupingInfo extends AsyncComponent<Props, State> {
         ) : (
           variants.map((variant, index) => (
             <Fragment key={variant.key}>
-              <GroupVariant variant={variant} showGroupingConfig={showGroupingConfig} />
+              <GroupVariant
+                event={event}
+                variant={variant}
+                showGroupingConfig={showGroupingConfig}
+              />
               {index < variants.length - 1 && <VariantDivider />}
             </Fragment>
           ))

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -41,9 +41,12 @@ export type VariantEvidence = {
   desc: string;
   fingerprint: string;
   cause_span_hashes?: string[];
+  cause_span_ids?: string[];
   offender_span_hashes?: string[];
+  offender_span_ids?: string[];
   op?: string;
   parent_span_hashes?: string[];
+  parent_span_ids?: string[];
 };
 
 type EventGroupVariantKey = 'custom-fingerprint' | 'app' | 'default' | 'system';


### PR DESCRIPTION
With the migration to the issues platform, the hashes will no longer be sent in the `/grouping-info` payload. Instead, use the span IDs to look up the hashes in the event entries span object.

This doesn't need a feature flag or conditional logic because the endpoint already serves up `cause_span_ids`, `offender_span_ids`, `parent_span_ids` for performance issues.