### PR TITLE
feat(compactSelect): Add `menuBody` & `hideOptions` props

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -1,4 +1,12 @@
-import {createContext, Fragment, useCallback, useMemo, useRef, useState} from 'react';
+import {
+  createContext,
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -18,6 +26,7 @@ import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {FormSize} from 'sentry/utils/theme';
 import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
+import usePrevious from 'sentry/utils/usePrevious';
 
 import {SingleListProps} from './list';
 import {SelectOption} from './types';
@@ -91,11 +100,21 @@ export interface ControlProps
    */
   grid?: boolean;
   /**
+   * If true, all select options will be hidden. This should only be used on a temporary
+   * basis in conjunction with `menuBody` to display special views/states (e.g. a
+   * secondary date range selector).
+   */
+  hideOptions?: boolean;
+  /**
    * If true, there will be a loading indicator in the menu header.
    */
   loading?: boolean;
   maxMenuHeight?: number | string;
   maxMenuWidth?: number | string;
+  /**
+   * Optional content to display below the menu's header and above the options.
+   */
+  menuBody?: React.ReactNode | ((actions: {closeOverlay: () => void}) => React.ReactNode);
   /**
    * Footer to be rendered at the bottom of the menu.
    */
@@ -161,10 +180,12 @@ export function Control({
   disabled,
   position = 'bottom-start',
   offset,
+  hideOptions,
   menuTitle,
   maxMenuHeight = '32rem',
   maxMenuWidth,
   menuWidth,
+  menuBody,
   menuFooter,
 
   // Select props
@@ -234,6 +255,7 @@ export function Control({
   const {
     isOpen: overlayIsOpen,
     state: overlayState,
+    update: updateOverlay,
     triggerRef,
     triggerProps: overlayTriggerProps,
     overlayRef,
@@ -282,6 +304,23 @@ export function Control({
       triggerRef.current?.focus();
     },
   });
+
+  // Recalculate overlay position when its main content changes
+  const prevMenuBody = usePrevious(menuBody);
+  const prevHideOptions = usePrevious(hideOptions);
+  useEffect(() => {
+    if (
+      // Don't update when the content inside `menuBody` changes. We should only update
+      // when `menuBody` itself appears/disappears.
+      ((!prevMenuBody && !menuBody) || (!!prevMenuBody && !!menuBody)) &&
+      prevHideOptions === hideOptions
+    ) {
+      return;
+    }
+
+    updateOverlay?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [menuBody, hideOptions]);
 
   /**
    * The menu's full width, before any option has been filtered out. Used to maintain a
@@ -429,7 +468,10 @@ export function Control({
                   {...searchKeyboardProps}
                 />
               )}
-              <OptionsWrap>{children}</OptionsWrap>
+              {typeof menuBody === 'function'
+                ? menuBody({closeOverlay: overlayState.close})
+                : menuBody}
+              {!hideOptions && <OptionsWrap>{children}</OptionsWrap>}
               {menuFooter && (
                 <MenuFooter>
                   {typeof menuFooter === 'function'


### PR DESCRIPTION
Add 2 optional props to `CompactSelect`: `menuBody` and `hideOptions`, which can be used together to compose special views such as this date range selector:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/44172267/234122082-58b88cb8-b1a3-49be-907b-ff633a75bf1e.png">
