### PR TITLE
feat(hybrid-cloud): OrganizationMemberMapping deletes

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -595,15 +595,3 @@ class OrganizationMember(Model):
             .exists()
         )
         return is_only_owner
-
-
-def organization_member_post_delete(instance: OrganizationMember, **kwargs):
-    region_outbox = None
-    with transaction.atomic():
-        region_outbox = instance.outbox_for_update()
-        region_outbox.save()
-    if region_outbox:
-        region_outbox.drain_shard(max_updates_to_drain=10)
-
-
-post_delete.connect(organization_member_post_delete, sender=OrganizationMember)

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Q, QuerySet
-from django.db.models.signals import post_delete
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -64,6 +64,9 @@ def process_organization_member_updates(
             identity_service.delete_identities(
                 user_id=payload["user_id"], organization_id=shard_identifier
             )
+        organizationmember_mapping_service.delete_with_organization_member(
+            organizationmember_id=object_identifier, organization_id=shard_identifier
+        )
         return
 
     organizationmember_mapping_service.create_with_organization_member(org_member=org_member)

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -58,7 +58,7 @@ def process_user_ip_event(payload: Any, **kwds: Any):
 def process_organization_member_updates(
     object_identifier: int, payload: Any, shard_identifier: int, **kwds: Any
 ):
-    if (org_member := maybe_process_tombstone(OrganizationMember, object_identifier)) is None:
+    if (org_member := OrganizationMember.objects.filter(id=object_identifier).last()) is None:
         # Delete all identities that may have been associated.  This is an implicit cascade.
         if payload and "user_id" in payload:
             identity_service.delete_identities(

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
@@ -88,6 +88,16 @@ class OrganizationMemberMappingService(RpcService):
     ) -> RpcOrganizationMemberMapping:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def delete_with_organization_member(
+        self,
+        *,
+        organizationmember_id: int,
+        organization_id: int,
+    ) -> None:
+        pass
+
 
 def impl_with_db() -> OrganizationMemberMappingService:
     from sentry.services.hybrid_cloud.organizationmember_mapping.impl import (

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
@@ -57,6 +57,17 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
             invite_status=org_member.invite_status,
         )
 
+    def delete_with_organization_member(
+        self,
+        *,
+        organizationmember_id: int,
+        organization_id: int,
+    ) -> None:
+        OrganizationMemberMapping.objects.filter(
+            organization_id=organization_id,
+            organizationmember_id=organizationmember_id,
+        ).delete()
+
     def close(self) -> None:
         pass
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -104,6 +104,9 @@ from sentry.sentry_apps import SentryAppInstallationCreator, SentryAppInstallati
 from sentry.sentry_apps.apps import SentryAppCreator
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.hook import hook_service
+from sentry.services.hybrid_cloud.organizationmember_mapping import (
+    organizationmember_mapping_service,
+)
 from sentry.signals import project_created
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.silo import exempt_from_silo_limits
@@ -289,6 +292,7 @@ class Factories:
         teamRole = kwargs.pop("teamRole", None)
 
         om = OrganizationMember.objects.create(**kwargs)
+        organizationmember_mapping_service.create_with_organization_member(org_member=om)
 
         if team_roles:
             for team, role in team_roles:

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -14,11 +14,12 @@ from sentry.models import (
 )
 from sentry.testutils import TestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 
 
 @region_silo_test
-class AcceptInviteTest(TestCase):
+class AcceptInviteTest(TestCase, HybridCloudTestMixin):
     def setUp(self):
         super().setUp()
         self.organization = self.create_organization(owner=self.create_user("foo@example.com"))
@@ -256,10 +257,12 @@ class AcceptInviteTest(TestCase):
                 token="abcd",
                 organization=self.organization,
             )
+            self.assert_org_member_mapping(org_member=om2)
             path = self._get_path(url, [om2.id, om2.token])
             resp = self.client.post(path)
             assert resp.status_code == 400
             assert not OrganizationMember.objects.filter(id=om2.id).exists()
+            self.assert_org_member_mapping_not_exists(org_member=om2)
 
     def test_can_accept_when_user_has_2fa(self):
         urls = self._get_urls()

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -234,13 +234,11 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
             )
         )
 
-        org_member = OrganizationMember.objects.filter(
+        org_member = OrganizationMember.objects.get(
             organization=self.organization,
             user=self.user,
         )
-        assert org_member.exists()
-        org_member = org_member.get()
-        self.assert_org_member_mapping_not_exists(org_member=org_member)
+        self.assert_org_member_mapping(org_member=org_member)
 
         for team in self.auth_provider.default_teams.all():
             assert OrganizationMemberTeam.objects.create(

--- a/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
@@ -5,6 +5,7 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
 )
 from sentry.testutils import TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits, region_silo_test
 
 
@@ -186,7 +187,8 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
             for om in OrganizationMember.objects.all().iterator():
                 self.assert_org_member_mapping(org_member=om)
 
-        org_member.delete()
+        with outbox_runner():
+            org_member.delete()
 
         with exempt_from_silo_limits():
             assert OrganizationMember.objects.all().count() == 1


### PR DESCRIPTION
It was identified in https://github.com/getsentry/sentry/pull/47779 that we cannot use `HybridCloudForeignKey` on `OrganizationMemberMapping.organizationmember_id` since `organizationmember_id`s are not Snowflake ids (i.e. unique across all region silos).

Thus, rather than using tombstones, we will rely on outbox messages to perform `OrganizationMemberMapping` deletes with the tuple: `(organization_id, organizationmember_id)`.

There are few `OrganizationMember.delete()` calls in code, so we make use of the `post_delete` signal to generate the update outbox message to induce the deletion of the associated `OrganizationMemberMapping` record.  