### PR TITLE
feat(escalating-issues): Add status to issue action analytics

### DIFF
--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -7,7 +7,7 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconArchive, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {GroupStatusResolution, ResolutionStatus} from 'sentry/types';
+import {GroupStatusResolution, GroupSubstatus, ResolutionStatus} from 'sentry/types';
 
 interface ArchiveActionProps {
   onUpdate: (params: GroupStatusResolution) => void;
@@ -25,7 +25,7 @@ interface ArchiveActionProps {
 const ARCHIVE_UNTIL_ESCALATING: GroupStatusResolution = {
   status: ResolutionStatus.IGNORED,
   statusDetails: {},
-  substatus: 'until_escalating',
+  substatus: GroupSubstatus.UNTIL_ESCALATING,
 };
 const ARCHIVE_FOREVER: GroupStatusResolution = {
   status: ResolutionStatus.IGNORED,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -170,6 +170,16 @@ export type TagWithTopValues = {
   canDelete?: boolean;
 };
 
+export const enum GroupSubstatus {
+  UNTIL_ESCALATING = 'until_escalating',
+  UNTIL_CONDITION_MET = 'until_condition_met',
+  FOREVER = 'forever',
+  ESCALATING = 'escalating',
+  ONGOING = 'ongoing',
+  REGRESSED = 'regressed',
+  NEW = 'new',
+}
+
 /**
  * Inbox, issue owners and Activity
  */
@@ -497,7 +507,7 @@ export type ResolutionStatusDetails = {
 export type GroupStatusResolution = {
   status: ResolutionStatus;
   statusDetails: ResolutionStatusDetails;
-  substatus?: 'until_escalating';
+  substatus?: GroupSubstatus;
 };
 
 export type GroupRelease = {
@@ -544,6 +554,7 @@ export interface BaseGroup extends GroupRelease {
   userReportCount: number;
   inbox?: InboxDetails | null | false;
   owners?: SuggestedOwner[] | null;
+  substatus?: GroupSubstatus;
 }
 
 export interface GroupReprocessing

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -74,6 +74,8 @@ export type TeamInsightsEventParameters = {
       | 'open_in_discover'
       | 'assign'
       | ResolutionStatus;
+    action_status_details?: string;
+    action_substatus?: string;
     assigned_suggestion_reason?: string;
     assigned_type?: string;
   };

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -340,6 +340,7 @@ export type CommonGroupAnalyticsData = {
   is_assigned?: boolean;
   issue_level?: string;
   issue_status?: string;
+  issue_substatus?: string;
 };
 
 export function getAnalyticsDataForGroup(group?: Group | null): CommonGroupAnalyticsData {
@@ -353,6 +354,7 @@ export function getAnalyticsDataForGroup(group?: Group | null): CommonGroupAnaly
     issue_category: group?.issueCategory ?? IssueCategory.ERROR,
     issue_type: group?.issueType ?? IssueType.ERROR,
     issue_status: group?.status,
+    issue_substatus: group?.substatus,
     issue_age: group?.firstSeen ? getDaysSinceDatePrecise(group.firstSeen) : -1,
     days_since_last_seen: group?.lastSeen ? getDaysSinceDatePrecise(group.lastSeen) : -1,
     issue_level: group?.level,

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -45,7 +45,7 @@ describe('GroupActions', function () {
   });
   afterEach(function () {
     MockApiClient.clearMockResponses();
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('render()', function () {

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -13,6 +13,7 @@ import GlobalModal from 'sentry/components/globalModal';
 import ConfigStore from 'sentry/stores/configStore';
 import ModalStore from 'sentry/stores/modalStore';
 import {IssueCategory} from 'sentry/types';
+import * as analytics from 'sentry/utils/analytics';
 import GroupActions from 'sentry/views/issueDetails/actions';
 
 const project = TestStubs.ProjectDetails({
@@ -36,10 +37,15 @@ const organization = TestStubs.Organization({
 });
 
 describe('GroupActions', function () {
+  const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+
   beforeEach(function () {
     ConfigStore.init();
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => []);
+  });
+  afterEach(function () {
     MockApiClient.clearMockResponses();
+    jest.resetAllMocks();
   });
 
   describe('render()', function () {
@@ -269,6 +275,12 @@ describe('GroupActions', function () {
       `/projects/${organization.slug}/project/issues/`,
       expect.objectContaining({data: {status: 'resolved', statusDetails: {}}})
     );
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'issue_details.action_clicked',
+      expect.objectContaining({
+        action_type: 'resolved',
+      })
+    );
 
     rerender(
       <GroupActions
@@ -284,6 +296,41 @@ describe('GroupActions', function () {
     expect(issuesApi).toHaveBeenCalledWith(
       `/projects/${organization.slug}/project/issues/`,
       expect.objectContaining({data: {status: 'unresolved', statusDetails: {}}})
+    );
+  });
+
+  it('can archive issue', async () => {
+    const org = {...organization, features: ['escalating-issues-ui']};
+    const issuesApi = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/project/issues/`,
+      method: 'PUT',
+      body: {...group, status: 'resolved'},
+    });
+
+    render(
+      <GroupActions
+        group={group}
+        project={project}
+        organization={org}
+        disabled={false}
+      />,
+      {organization: org}
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Archive'}));
+
+    expect(issuesApi).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {status: 'ignored', statusDetails: {}, substatus: 'until_escalating'},
+      })
+    );
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'issue_details.action_clicked',
+      expect.objectContaining({
+        action_substatus: 'until_escalating',
+        action_type: 'ignored',
+      })
     );
   });
 });

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -56,6 +56,16 @@ import withOrganization from 'sentry/utils/withOrganization';
 import ShareIssueModal from './shareModal';
 import SubscribeAction from './subscribeAction';
 
+type UpdateData =
+  | {isBookmarked: boolean}
+  | {isSubscribed: boolean}
+  | {inbox: boolean}
+  | GroupStatusResolution;
+
+const isResolutionStatus = (data: UpdateData): data is GroupStatusResolution => {
+  return (data as GroupStatusResolution).status !== undefined;
+};
+
 type Props = {
   api: Client;
   disabled: boolean;
@@ -108,7 +118,9 @@ class Actions extends Component<Props> {
       | 'mark_reviewed'
       | 'discarded'
       | 'open_in_discover'
-      | ResolutionStatus
+      | ResolutionStatus,
+    substatus?: string,
+    statusDetailsKey?: string
   ) {
     const {group, project, organization, query = {}} = this.props;
     const {alert_date, alert_rule_id, alert_type} = query;
@@ -116,6 +128,8 @@ class Actions extends Component<Props> {
       organization,
       project_id: parseInt(project.id, 10),
       action_type: action,
+      action_substatus: substatus,
+      action_status_details: statusDetailsKey,
       // Alert properties track if the user came from email/slack alerts
       alert_date:
         typeof alert_date === 'string' ? getUtcDateString(Number(alert_date)) : undefined,
@@ -154,13 +168,7 @@ class Actions extends Component<Props> {
     this.trackIssueAction('deleted');
   };
 
-  onUpdate = (
-    data:
-      | {isBookmarked: boolean}
-      | {isSubscribed: boolean}
-      | {inbox: boolean}
-      | GroupStatusResolution
-  ) => {
+  onUpdate = (data: UpdateData) => {
     const {group, project, organization, api} = this.props;
 
     addLoadingMessage(t('Saving changes\u2026'));
@@ -178,8 +186,12 @@ class Actions extends Component<Props> {
       }
     );
 
-    if ((data as GroupStatusResolution).status) {
-      this.trackIssueAction((data as GroupStatusResolution).status);
+    if (isResolutionStatus(data)) {
+      this.trackIssueAction(
+        data.status,
+        data.substatus,
+        Object.keys(data.statusDetails || {})[0]
+      );
     }
     if ((data as {inbox: boolean}).inbox !== undefined) {
       this.trackIssueAction('mark_reviewed');


### PR DESCRIPTION
Adds the new group substatus and existing status_details to the issue action analytics on the issue details page.

[WOR-2991](https://getsentry.atlassian.net/browse/WOR-2991)

[WOR-2991]: https://getsentry.atlassian.net/browse/WOR-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ