### PR TITLE
feat(compactSelect): Add `disableSearchFilter` prop

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -74,6 +74,12 @@ export interface ControlProps
    * If true, there will be a "Clear" button in the menu header.
    */
   clearable?: boolean;
+  /**
+   * Whether to disable the search input's filter function (applicable only when
+   * `searchable` is true). This is useful for implementing custom search behaviors,
+   * like fetching new options on search (via the onSearch() prop).
+   */
+  disableSearchFilter?: boolean;
   disabled?: boolean;
   /**
    * Message to be displayed when all options have been filtered out (via search).
@@ -171,6 +177,7 @@ export function Control({
   size = 'md',
   searchable = false,
   searchPlaceholder = 'Search…',
+  disableSearchFilter = false,
   onSearch,
   clearable = false,
   onClear,
@@ -197,13 +204,19 @@ export function Control({
    * Search/filter value, used to filter out the list of displayed elements
    */
   const [search, setSearch] = useState('');
+  const [searchInputValue, setSearchInputValue] = useState(search);
   const searchRef = useRef<HTMLInputElement>(null);
   const updateSearch = useCallback(
     (newValue: string) => {
-      setSearch(newValue);
       onSearch?.(newValue);
+
+      setSearchInputValue(newValue);
+      if (!disableSearchFilter) {
+        setSearch(newValue);
+        return;
+      }
     },
-    [onSearch]
+    [onSearch, disableSearchFilter]
   );
 
   const {keyboardProps: searchKeyboardProps} = useKeyboard({
@@ -275,7 +288,10 @@ export function Control({
 
       // On close
       onClose?.();
-      setSearch(''); // Clear search string
+
+      // Clear search string
+      setSearchInputValue('');
+      setSearch('');
 
       // Wait for overlay to appear/disappear
       await new Promise(resolve => resolve(null));
@@ -421,7 +437,7 @@ export function Control({
                 <SearchInput
                   ref={searchRef}
                   placeholder={searchPlaceholder}
-                  value={search}
+                  value={searchInputValue}
                   onFocus={onSearchFocus}
                   onBlur={onSearchBlur}
                   onChange={e => updateSearch(e.target.value)}


### PR DESCRIPTION
Add a `disableSearchFilter` prop to `CompactSelect`. When true, `CompactSelect` won't filter options based on the search input's value, so we can implement custom search/filter behaviors (with the `onSearch()` prop).

<img width="239" alt="image" src="https://user-images.githubusercontent.com/44172267/234135684-fc5aa61b-180b-49b9-87ad-da332cab2196.png">
