### PR TITLE
feat(issue-platform): Make perf issues read from issue platform when using tsdb

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -125,7 +125,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             environment_ids=environment_ids,
             tenant_ids={"organization_id": group.project.organization_id},
         )
-        model = get_issue_tsdb_group_model(group.issue_category)
+        model = get_issue_tsdb_group_model(group.issue_category, group.project)
         now = timezone.now()
         hourly_stats = tsdb.rollup(
             get_range(model=model, keys=[group.id], end=now, start=now - timedelta(days=1)),

--- a/src/sentry/issues/constants.py
+++ b/src/sentry/issues/constants.py
@@ -1,6 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sentry import tsdb
 from sentry.issues.grouptype import GroupCategory
+from sentry.issues.utils import issue_category_can_create_group
 from sentry.tsdb.base import TSDBModel
+
+if TYPE_CHECKING:
+    from sentry.models import Project
 
 ISSUE_TSDB_GROUP_MODELS = {
     GroupCategory.ERROR: tsdb.models.group,
@@ -12,11 +20,24 @@ ISSUE_TSDB_USER_GROUP_MODELS = {
 }
 
 
-def get_issue_tsdb_group_model(issue_category: GroupCategory) -> TSDBModel:
+def get_issue_tsdb_group_model(issue_category: GroupCategory, project: Project) -> TSDBModel:
+    # TODO: Remove this entire branch when we remove the option, and remove `PERFORMANCE` from
+    # ISSUE_TSDB_GROUP_MODELS
+    if issue_category == GroupCategory.PERFORMANCE and issue_category_can_create_group(
+        GroupCategory.PERFORMANCE, project
+    ):
+        return tsdb.models.group_generic
+    # TODO: Need to get generic when perf search issue flag is true and perf issue
     return ISSUE_TSDB_GROUP_MODELS.get(issue_category, tsdb.models.group_generic)
 
 
-def get_issue_tsdb_user_group_model(issue_category: GroupCategory) -> TSDBModel:
+def get_issue_tsdb_user_group_model(issue_category: GroupCategory, project: Project) -> TSDBModel:
+    # TODO: Remove this entire branch when we remove the option, and remove `PERFORMANCE` from
+    # ISSUE_TSDB_USER_GROUP_MODELS
+    if issue_category == GroupCategory.PERFORMANCE and issue_category_can_create_group(
+        GroupCategory.PERFORMANCE, project
+    ):
+        return tsdb.models.users_affected_by_generic_group
     return ISSUE_TSDB_USER_GROUP_MODELS.get(
         issue_category, tsdb.models.users_affected_by_generic_group
     )

--- a/src/sentry/issues/utils.py
+++ b/src/sentry/issues/utils.py
@@ -1,11 +1,15 @@
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
 
 from sentry import options
 from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
-from sentry.models import Project
 from sentry.models.group import Group
 from sentry.utils.performance_issues.performance_problem import PerformanceProblem
+
+if TYPE_CHECKING:
+    from sentry.models import Project
 
 
 def can_create_group(
@@ -17,10 +21,14 @@ def can_create_group(
         group_type = entity.issue_type
     else:
         group_type = entity.type
+    return issue_category_can_create_group(GroupCategory(group_type.category), project)
+
+
+def issue_category_can_create_group(category: GroupCategory, project: Project) -> bool:
     return bool(
-        group_type.category != GroupCategory.PERFORMANCE.value
+        category != GroupCategory.PERFORMANCE
         or (
-            group_type.category == GroupCategory.PERFORMANCE.value
+            category == GroupCategory.PERFORMANCE
             # system-wide option
             and options.get("performance.issues.create_issues_through_platform", False)
             # more-granular per-project option

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -96,7 +96,7 @@ class GroupSnooze(Model):
         start = end - timedelta(minutes=self.window)
 
         rate = tsdb.get_sums(
-            model=get_issue_tsdb_group_model(self.group.issue_category),
+            model=get_issue_tsdb_group_model(self.group.issue_category, self.group.project),
             keys=[self.group_id],
             start=start,
             end=end,
@@ -118,7 +118,7 @@ class GroupSnooze(Model):
         start = end - timedelta(minutes=self.user_window)
 
         rate = tsdb.get_distinct_counts_totals(
-            model=get_issue_tsdb_user_group_model(self.group.issue_category),
+            model=get_issue_tsdb_user_group_model(self.group.issue_category, self.group.project),
             keys=[self.group_id],
             start=start,
             end=end,

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -228,7 +228,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         self, event: GroupEvent, start: datetime, end: datetime, environment_id: str
     ) -> int:
         sums: Mapping[int, int] = self.tsdb.get_sums(
-            model=get_issue_tsdb_group_model(event.group.issue_category),
+            model=get_issue_tsdb_group_model(event.group.issue_category, event.group.project),
             keys=[event.group_id],
             start=start,
             end=end,
@@ -252,7 +252,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
         self, event: GroupEvent, start: datetime, end: datetime, environment_id: str
     ) -> int:
         totals: Mapping[int, int] = self.tsdb.get_distinct_counts_totals(
-            model=get_issue_tsdb_user_group_model(event.group.issue_category),
+            model=get_issue_tsdb_user_group_model(event.group.issue_category, event.group.project),
             keys=[event.group_id],
             start=start,
             end=end,
@@ -361,7 +361,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
             avg_sessions_in_interval = session_count_last_hour / (60 / interval_in_minutes)
 
             issue_count = self.tsdb.get_sums(
-                model=get_issue_tsdb_group_model(event.group.issue_category),
+                model=get_issue_tsdb_group_model(event.group.issue_category, event.group.project),
                 keys=[event.group_id],
                 start=start,
                 end=end,

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -91,6 +91,18 @@ class PerfEventMixin(PerfIssueTransactionTestMixin):
         return event.for_group(event.groups[0])
 
 
+class PerfIssuePlatformEventMixin(PerfEventMixin):
+    def add_event(self, data, project_id, timestamp):
+        with self.options({"performance.issues.send_to_issues_platform": True}):
+            return super().add_event(data, project_id, timestamp)
+
+    def assertPasses(self, rule, event=None, **kwargs):
+        self.project.update_option("sentry:performance_issue_create_issue_through_platform", True)
+        with self.options({"performance.issues.create_issues_through_platform": True}):
+            super().assertPasses(rule, event=event, **kwargs)
+        self.project.update_option("sentry:performance_issue_create_issue_through_platform", False)
+
+
 class StandardIntervalMixin:
     def test_one_minute_with_events(self):
         data = {"interval": "1m", "value": 6}
@@ -432,6 +444,18 @@ class PerfIssueFrequencyConditionTestCase(
 
 @freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
 @region_silo_test
+class PerfIssuePlatformIssueFrequencyConditionTestCase(
+    PerfIssuePlatformEventMixin,
+    EventFrequencyConditionTestCase,
+    RuleTestCase,
+):
+    # TODO: Remove this once we've finished migrating perf issues to issue platform and removed
+    # related options
+    pass
+
+
+@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@region_silo_test
 class ErrorIssueUniqueUserFrequencyConditionTestCase(
     EventUniqueUserFrequencyConditionTestCase, RuleTestCase, ErrorEventMixin
 ):
@@ -448,6 +472,18 @@ class PerfIssueUniqueUserFrequencyConditionTestCase(
 
 @freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
 @region_silo_test
+class PerfIssuePlatformIssueUniqueUserFrequencyConditionTestCase(
+    PerfIssuePlatformEventMixin,
+    EventUniqueUserFrequencyConditionTestCase,
+    RuleTestCase,
+):
+    # TODO: Remove this once we've finished migrating perf issues to issue platform and removed
+    # related options
+    pass
+
+
+@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@region_silo_test
 class ErrorIssueEventFrequencyPercentConditionTestCase(
     EventFrequencyPercentConditionTestCase, RuleTestCase, ErrorEventMixin
 ):
@@ -459,4 +495,16 @@ class ErrorIssueEventFrequencyPercentConditionTestCase(
 class PerfIssueEventFrequencyPercentConditionTestCase(
     EventFrequencyPercentConditionTestCase, RuleTestCase, PerfEventMixin
 ):
+    pass
+
+
+@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@region_silo_test
+class PerfIssuePlatformIssueEventFrequencyPercentConditionTestCase(
+    PerfIssuePlatformEventMixin,
+    EventFrequencyPercentConditionTestCase,
+    RuleTestCase,
+):
+    # TODO: Remove this once we've finished migrating perf issues to issue platform and removed
+    # related options
     pass


### PR DESCRIPTION
This makes sure that once we're using issue platform for perf issues that we'll correctly use the issue platform dataset when querying tsdb.
