### PR TITLE
chore(hybrid-cloud): Cascade Organization deletions to OrganizationMemberMapping

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -37,6 +37,9 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
 from sentry.models.team import Team
 from sentry.roles.manager import Role
+from sentry.services.hybrid_cloud.organizationmember_mapping import (
+    organizationmember_mapping_service,
+)
 from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.utils.http import is_using_customer_domain
 from sentry.utils.retries import TimedRetryPolicy
@@ -719,7 +722,9 @@ def organization_absolute_url(
 
 
 def delete_org_refs_at_control_silo(instance: Organization, **kwargs):
+    # Send RPC requests to the control silo
     Organization.remove_organization_mapping(instance)
+    organizationmember_mapping_service.delete_by_org_id(organization_id=instance.id)
 
 
 post_delete.connect(

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -82,6 +82,7 @@ def process_team_updates(
 @receiver(process_region_outbox, sender=OutboxCategory.ORGANIZATION_UPDATE)
 def process_organization_updates(object_identifier: int, **kwds: Any):
     if (org := maybe_process_tombstone(Organization, object_identifier)) is None:
+        organizationmember_mapping_service.delete_by_org_id(organization_id=object_identifier)
         return
 
     update = update_organization_mapping_from_instance(org)

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
@@ -98,6 +98,15 @@ class OrganizationMemberMappingService(RpcService):
     ) -> None:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def delete_by_org_id(
+        self,
+        *,
+        organization_id: int,
+    ) -> None:
+        pass
+
 
 def impl_with_db() -> OrganizationMemberMappingService:
     from sentry.services.hybrid_cloud.organizationmember_mapping.impl import (

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
@@ -68,6 +68,15 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
             organizationmember_id=organizationmember_id,
         ).delete()
 
+    def delete_by_org_id(
+        self,
+        *,
+        organization_id: int,
+    ) -> None:
+        OrganizationMemberMapping.objects.filter(
+            organization_id=organization_id,
+        ).delete()
+
     def close(self) -> None:
         pass
 

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -15,6 +15,7 @@ from sentry.models import (
     ExternalIssue,
     Group,
     Organization,
+    OrganizationMember,
     OrganizationStatus,
     PullRequest,
     Release,
@@ -24,19 +25,28 @@ from sentry.models import (
     ScheduledDeletion,
 )
 from sentry.models.organizationmapping import OrganizationMapping
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.snuba.models import SnubaQuery
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils import TransactionTestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
-class DeleteOrganizationTest(TransactionTestCase):
+class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):
     def test_simple(self):
-        org = self.create_organization(name="test")
+        org_owner = self.create_user()
+        org = self.create_organization(name="test", owner=org_owner)
+        org_member = OrganizationMember.objects.get(organization_id=org.id, user_id=org_owner.id)
+        self.assert_org_member_mapping(org_member=org_member)
+
+        org_owner2 = self.create_user()
+        org2 = self.create_organization(name="test2", owner=org_owner2)
+
         org_mapping = self.create_organization_mapping(org)
-        org2 = self.create_organization(name="test2")
         org_mapping2 = self.create_organization_mapping(org2)
+
         self.create_team(organization=org, name="test1")
         self.create_team(organization=org, name="test2")
         release = Release.objects.create(version="a" * 32, organization_id=org.id)
@@ -99,9 +109,11 @@ class DeleteOrganizationTest(TransactionTestCase):
 
         assert Organization.objects.filter(id=org2.id).exists()
         assert OrganizationMapping.objects.filter(id=org_mapping2.id).exists()
+        assert OrganizationMemberMapping.objects.filter(organization_id=org2.id).exists()
 
         assert not Organization.objects.filter(id=org.id).exists()
         assert not OrganizationMapping.objects.filter(id=org_mapping.id).exists()
+        assert not OrganizationMemberMapping.objects.filter(organization_id=org.id).exists()
         assert not Environment.objects.filter(id=env.id).exists()
         assert not ReleaseEnvironment.objects.filter(id=release_env.id).exists()
         assert not Repository.objects.filter(id=repo.id).exists()

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -30,6 +30,7 @@ from sentry.snuba.models import SnubaQuery
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils import TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import region_silo_test
 
 
@@ -104,7 +105,7 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):
         deletion = ScheduledDeletion.schedule(org, days=0)
         deletion.update(in_progress=True)
 
-        with self.tasks():
+        with self.tasks(), outbox_runner():
             run_deletion(deletion.id)
 
         assert Organization.objects.filter(id=org2.id).exists()


### PR DESCRIPTION
Builds upon https://github.com/getsentry/sentry/pull/47874 to cascade `Organizations` (region) deletes to `OrganizationMemberMapping` (control).