### PR TITLE
ref(sdk): Detect transaction scope bleed

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -13,13 +13,8 @@ from rest_framework.request import Request
 
 # Reexport sentry_sdk just in case we ever have to write another shim like we
 # did for raven
-from sentry_sdk import (  # NOQA
-    Scope,
-    capture_exception,
-    capture_message,
-    configure_scope,
-    push_scope,
-)
+from sentry_sdk import push_scope  # NOQA
+from sentry_sdk import Scope, capture_exception, capture_message, configure_scope
 from sentry_sdk.client import get_options
 from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
 from sentry_sdk.transport import make_transport
@@ -525,6 +520,31 @@ def check_current_scope_transaction(
                 "scope_transaction": scope._transaction,
                 "request_transaction": transaction_from_request,
             }
+
+
+def capture_exception_with_scope_check(
+    error, scope: Scope | None = None, request: Request | None = None, **scope_args
+):
+    """
+    A wrapper around `sentry_sdk.capture_exception` which checks scope `transaction` against the
+    given Request object, to help debug scope bleed problems.
+    """
+
+    # The SDK's version of `capture_exception` accepts either a `Scope` object or scope kwargs.
+    # Regardless of which one the caller passed, convert the data into a `Scope` object
+    extra_scope = scope or Scope()
+    extra_scope.update_from_kwargs(**scope_args)
+
+    # We've got a weird scope bleed problem, where, among other things, errors are getting tagged
+    # with the wrong transaction value, so record any possible mismatch.
+    transaction_mismatch = check_current_scope_transaction(request) if request else None
+    if transaction_mismatch:
+        # TODO: We probably should add this data to the scope in `check_current_scope_transaction`
+        # instead, but the whole point is that right now it's unclear how trustworthy ambient scope is
+        extra_scope.set_tag("scope_bleed.transaction", True)
+        merge_context_into_scope("scope_bleed", transaction_mismatch, extra_scope)
+
+    return sentry_sdk.capture_exception(error, scope=extra_scope)
 
 
 def bind_organization_context(organization):

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -1,10 +1,17 @@
 from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
+from django.http import HttpRequest
+from rest_framework.request import Request
 from sentry_sdk import Scope
 
 from sentry.testutils import TestCase
-from sentry.utils.sdk import check_tag, merge_context_into_scope
+from sentry.utils.sdk import (
+    capture_exception_with_scope_check,
+    check_current_scope_transaction,
+    check_tag,
+    merge_context_into_scope,
+)
 
 
 # TODO: This is kind of gross, but no other way seemed to work
@@ -100,3 +107,160 @@ class CheckTagTest(TestCase):
         mock_logger_warning.assert_called_with(
             "Tag already set and different (org.slug).", extra=extra
         )
+
+
+class CheckScopeTransactionTest(TestCase):
+    @patch("sentry.utils.sdk.LEGACY_RESOLVER.resolve", return_value="/dogs/{name}/")
+    def test_scope_has_correct_transaction(self, mock_resolve: MagicMock):
+        mock_scope = Scope()
+        mock_scope._transaction = "/dogs/{name}/"
+
+        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
+            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+
+            mismatch = check_current_scope_transaction(Request(HttpRequest()))
+            assert mismatch is None
+
+    @patch("sentry.utils.sdk.LEGACY_RESOLVER.resolve", return_value="/dogs/{name}/")
+    def test_scope_has_wrong_transaction(self, mock_resolve: MagicMock):
+        mock_scope = Scope()
+        mock_scope._transaction = "/tricks/{trick_name}/"
+
+        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
+            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+
+            mismatch = check_current_scope_transaction(Request(HttpRequest()))
+            assert mismatch == {
+                "scope_transaction": "/tricks/{trick_name}/",
+                "request_transaction": "/dogs/{name}/",
+            }
+
+    @patch("sentry.utils.sdk.LEGACY_RESOLVER.resolve", return_value="/dogs/{name}/")
+    def test_custom_transaction_name(self, mock_resolve: MagicMock):
+        mock_scope = Scope()
+        mock_scope._transaction = "/tricks/{trick_name}/"
+        mock_scope._transaction_info["source"] = "custom"
+
+        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
+            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+
+            mismatch = check_current_scope_transaction(Request(HttpRequest()))
+            # custom transaction names shouldn't be flagged even if they don't match
+            assert mismatch is None
+
+
+@patch("sentry_sdk.capture_exception")
+class CaptureExceptionTest(TestCase):
+    def test_passes_along_exception(self, mock_sdk_capture_exception: MagicMock):
+        err = Exception()
+
+        with patch("sentry.utils.sdk.check_current_scope_transaction", return_value=None):
+            capture_exception_with_scope_check(err)
+
+        assert mock_sdk_capture_exception.call_args.args[0] == err
+
+    @patch("sentry.utils.sdk.check_current_scope_transaction")
+    def test_doesnt_check_transaction_if_no_request(
+        self,
+        mock_check_transaction: MagicMock,
+        mock_sdk_capture_exception: MagicMock,
+    ):
+        capture_exception_with_scope_check(Exception())
+
+        assert mock_check_transaction.call_count == 0
+
+    def test_no_transaction_mismatch(self, mock_sdk_capture_exception: MagicMock):
+        with patch("sentry.utils.sdk.check_current_scope_transaction", return_value=None):
+            capture_exception_with_scope_check(Exception(), request=Request(HttpRequest()))
+
+        passed_scope = mock_sdk_capture_exception.call_args.kwargs["scope"]
+
+        assert isinstance(passed_scope, Scope)
+        assert "scope_bleed.transaction" not in passed_scope._tags
+        assert "scope_bleed" not in passed_scope._contexts
+
+    def test_with_transaction_mismatch(self, mock_sdk_capture_exception: MagicMock):
+        scope_bleed_data = {
+            "scope_transaction": "/tricks/{trick_name}/",
+            "request_transaction": "/dogs/{name}/",
+        }
+
+        with patch(
+            "sentry.utils.sdk.check_current_scope_transaction", return_value=scope_bleed_data
+        ):
+            capture_exception_with_scope_check(Exception(), request=Request(HttpRequest()))
+
+        passed_scope = mock_sdk_capture_exception.call_args.kwargs["scope"]
+
+        assert isinstance(passed_scope, Scope)
+        assert passed_scope._tags["scope_bleed.transaction"] is True
+        assert passed_scope._contexts["scope_bleed"] == scope_bleed_data
+
+    def test_no_scope_data_passed(self, mock_sdk_capture_exception: MagicMock):
+        capture_exception_with_scope_check(Exception())
+
+        passed_scope = mock_sdk_capture_exception.call_args.kwargs["scope"]
+        empty_scope = Scope()
+
+        for entry in empty_scope.__slots__:
+            # No new scope data should be passed
+            assert getattr(passed_scope, entry) == getattr(empty_scope, entry)
+
+    def test_passes_along_incoming_scope_object(self, mock_sdk_capture_exception: MagicMock):
+        incoming_scope_arg = Scope()
+
+        capture_exception_with_scope_check(Exception(), scope=incoming_scope_arg)
+
+        passed_scope = mock_sdk_capture_exception.call_args.kwargs["scope"]
+
+        assert passed_scope == incoming_scope_arg
+
+    def test_merges_incoming_scope_obj_and_args(self, mock_sdk_capture_exception: MagicMock):
+        incoming_scope_arg = Scope()
+        incoming_scope_arg.set_level("info")
+
+        capture_exception_with_scope_check(
+            Exception(), scope=incoming_scope_arg, fingerprint="pawprint"
+        )
+
+        passed_scope = mock_sdk_capture_exception.call_args.kwargs["scope"]
+
+        assert passed_scope._level == "info"
+        assert passed_scope._fingerprint == "pawprint"
+
+    def test_passes_along_incoming_scope_args(self, mock_sdk_capture_exception: MagicMock):
+        capture_exception_with_scope_check(Exception(), fingerprint="pawprint")
+
+        passed_scope = mock_sdk_capture_exception.call_args.kwargs["scope"]
+
+        assert passed_scope._fingerprint == "pawprint"
+
+    def test_doesnt_overwrite_incoming_scope_bleed_context(
+        self, mock_sdk_capture_exception: MagicMock
+    ):
+        existing_scope_bleed_data = {
+            "previous_org.slug_tag": "good_dogs",
+            "new_org.slug_tag": "squirrel_chasers",
+        }
+        transaction_scope_bleed_data = {
+            "scope_transaction": "/tricks/{trick_name}/",
+            "request_transaction": "/dogs/{name}/",
+        }
+        incoming_scope_arg = Scope()
+        incoming_scope_arg.set_context("scope_bleed", existing_scope_bleed_data)
+
+        with patch(
+            "sentry.utils.sdk.check_current_scope_transaction",
+            return_value=transaction_scope_bleed_data,
+        ):
+            capture_exception_with_scope_check(
+                Exception(), request=Request(HttpRequest()), scope=incoming_scope_arg
+            )
+
+        passed_scope = mock_sdk_capture_exception.call_args.kwargs["scope"]
+
+        # both old and new data should be included
+        assert "previous_org.slug_tag" in passed_scope._contexts["scope_bleed"]
+        assert "new_org.slug_tag" in passed_scope._contexts["scope_bleed"]
+        assert "scope_transaction" in passed_scope._contexts["scope_bleed"]
+        assert "request_transaction" in passed_scope._contexts["scope_bleed"]


### PR DESCRIPTION
It is a known issue (see https://github.com/getsentry/sentry/pull/45374) that sometimes org tags leak between requests. It turns out, that can happen with `transaction`, too - for example, in the screenshot below, an event whose transaction (according to the URL) _ought_ to be `/api/0/projects/{organization_slug}/{project_slug}/replays/{replay_id}/recording-segments` is instead labeled as a transaction on a Jira integration endpoint.

![image](https://user-images.githubusercontent.com/14812505/234177549-7dba9e5a-0f95-4d33-b120-5d6d1c6312cc.png)

In order to help debug this, it's helpful to know how often it's happening, and to which events. This PR therefore adds the ability to detect such a mismatch, and tags events where it occurs accordingly.

Key changes:

- Add helpers to derive transaction name from a `Request` object and to check that name against the current scope's `transaction` value.
- Add a wrapper around `sentry_sdk.capture_exception` which does the check and adds tags and context data before calling the original `capture_exception`.

Changes to actually use these helpers will come in follow-up PRs.

Ref: WOR-2999