### PR TITLE
feat(starfish): API Module host table

### DIFF
--- a/static/app/views/starfish/components/sparkline.tsx
+++ b/static/app/views/starfish/components/sparkline.tsx
@@ -1,0 +1,54 @@
+import {LineChart} from 'echarts/charts';
+import * as echarts from 'echarts/core';
+import {SVGRenderer} from 'echarts/renderers';
+import ReactEChartsCore from 'echarts-for-react/lib/core';
+
+import {Series} from 'sentry/types/echarts';
+
+export const HOST = 'http://localhost:8080';
+
+echarts.use([LineChart, SVGRenderer]);
+
+type SparklineProps = {
+  series: Series;
+};
+
+export default function Sparkline({series}: SparklineProps) {
+  const valueSeries = {
+    data: series.data.map(datum => datum.value),
+    type: 'line',
+    showSymbol: false,
+    smooth: true,
+  };
+
+  return (
+    <ReactEChartsCore
+      echarts={echarts}
+      option={{
+        series: [valueSeries],
+        xAxis: {
+          show: false,
+          data: series.data.map(datum => datum.name),
+          type: 'category',
+        },
+        yAxis: {
+          show: false,
+          type: 'value',
+        },
+        grid: {
+          left: 3,
+          top: 3,
+          right: 3,
+          bottom: 3,
+        },
+      }}
+      notMerge
+      style={{
+        height: 30,
+        width: 400,
+      }}
+      lazyUpdate
+      theme="theme_name"
+    />
+  );
+}

--- a/static/app/views/starfish/components/sparkline.tsx
+++ b/static/app/views/starfish/components/sparkline.tsx
@@ -7,13 +7,13 @@ import {Series} from 'sentry/types/echarts';
 
 export const HOST = 'http://localhost:8080';
 
-echarts.use([LineChart, SVGRenderer]);
-
 type SparklineProps = {
   series: Series;
 };
 
 export default function Sparkline({series}: SparklineProps) {
+  echarts.use([LineChart, SVGRenderer]);
+
   const valueSeries = {
     data: series.data.map(datum => datum.value),
     type: 'line',
@@ -44,8 +44,8 @@ export default function Sparkline({series}: SparklineProps) {
       }}
       notMerge
       style={{
-        height: 30,
-        width: 400,
+        height: 25,
+        width: 300,
       }}
       lazyUpdate
       theme="theme_name"

--- a/static/app/views/starfish/components/sparkline.tsx
+++ b/static/app/views/starfish/components/sparkline.tsx
@@ -9,9 +9,10 @@ export const HOST = 'http://localhost:8080';
 
 type SparklineProps = {
   series: Series;
+  color?: string | string[];
 };
 
-export default function Sparkline({series}: SparklineProps) {
+export default function Sparkline({series, color}: SparklineProps) {
   echarts.use([LineChart, SVGRenderer]);
 
   const valueSeries = {
@@ -25,6 +26,7 @@ export default function Sparkline({series}: SparklineProps) {
     <ReactEChartsCore
       echarts={echarts}
       option={{
+        color,
         series: [valueSeries],
         xAxis: {
           show: false,

--- a/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
+++ b/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
@@ -190,13 +190,14 @@ export default function APIModuleView({location, onSelect}: Props) {
           onChange={({value}) => setDomain(value)}
         />
       </FilterOptionsContainer>
-      <HostTable location={location} />
 
       <EndpointTable
         location={location}
         onSelect={onSelect}
         filterOptions={{...state, datetime: pageFilter.selection.datetime}}
       />
+
+      <HostTable location={location} />
     </Fragment>
   );
 }

--- a/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
+++ b/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
@@ -17,6 +17,7 @@ import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 import {EndpointDataRow} from 'sentry/views/starfish/views/endpointDetails';
 
 import EndpointTable from './endpointTable';
+import HostTable from './hostTable';
 import {getEndpointDomainsQuery, getEndpointGraphQuery, PERIOD_REGEX} from './queries';
 
 export const HOST = 'http://localhost:8080';
@@ -189,6 +190,8 @@ export default function APIModuleView({location, onSelect}: Props) {
           onChange={({value}) => setDomain(value)}
         />
       </FilterOptionsContainer>
+      <HostTable location={location} />
+
       <EndpointTable
         location={location}
         onSelect={onSelect}

--- a/static/app/views/starfish/modules/APIModule/hostTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/hostTable.tsx
@@ -61,7 +61,7 @@ export default function HostTable({location}: Props) {
           seriesName: host,
           data: dataByHost[host].map(datum => ({
             name: datum.interval,
-            value: datum.p50,
+            value: datum.p99,
           })),
         },
         moment.duration(12, 'hours'),

--- a/static/app/views/starfish/modules/APIModule/hostTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/hostTable.tsx
@@ -1,6 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {Location} from 'history';
 import groupBy from 'lodash/groupBy';
+import orderBy from 'lodash/orderBy';
 import moment from 'moment';
 
 import GridEditable, {
@@ -50,6 +51,9 @@ export default function HostTable({location}: Props) {
   const dataByHost = groupBy(hostsData, 'domain');
   const hosts = Object.keys(dataByHost);
 
+  const startDate = moment(orderBy(hostsData, 'interval', 'asc')[0]?.interval);
+  const endDate = moment(orderBy(hostsData, 'interval', 'desc')[0]?.interval);
+
   const tableData: HostTableRow[] = hosts
     .map(host => {
       const durationSeries: Series = zeroFillSeries(
@@ -60,7 +64,9 @@ export default function HostTable({location}: Props) {
             value: datum.p50,
           })),
         },
-        moment.duration(12, 'hours')
+        moment.duration(12, 'hours'),
+        startDate,
+        endDate
       );
 
       return {

--- a/static/app/views/starfish/modules/APIModule/hostTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/hostTable.tsx
@@ -22,6 +22,7 @@ type Props = {
 
 type HostTableRow = {
   duration: Series;
+  failure_rate: Series;
   host: string;
 };
 
@@ -29,11 +30,16 @@ const COLUMN_ORDER = [
   {
     key: 'host',
     name: 'Host',
-    width: 600,
+    width: COL_WIDTH_UNDEFINED,
   },
   {
     key: 'duration',
     name: 'Response Time',
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: 'failure_rate',
+    name: 'Failure Rate',
     width: COL_WIDTH_UNDEFINED,
   },
 ];
@@ -69,9 +75,23 @@ export default function HostTable({location}: Props) {
         endDate
       );
 
+      const failureRateSeries: Series = zeroFillSeries(
+        {
+          seriesName: host,
+          data: dataByHost[host].map(datum => ({
+            name: datum.interval,
+            value: datum.failure_rate,
+          })),
+        },
+        moment.duration(12, 'hours'),
+        startDate,
+        endDate
+      );
+
       return {
         host,
         duration: durationSeries,
+        failure_rate: failureRateSeries,
       };
     })
     .filter(row => {
@@ -104,6 +124,15 @@ function renderBodyCell(column: GridColumnHeader, row: HostTableRow): React.Reac
   }
 
   if (column.key === 'duration') {
+    const series: Series = row[column.key];
+    if (series) {
+      return <Sparkline series={series} />;
+    }
+
+    return 'Loading';
+  }
+
+  if (column.key === 'failure_rate') {
     const series: Series = row[column.key];
     if (series) {
       return <Sparkline series={series} />;

--- a/static/app/views/starfish/modules/APIModule/hostTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/hostTable.tsx
@@ -35,12 +35,12 @@ const COLUMN_ORDER = [
   {
     key: 'duration',
     name: 'Response Time',
-    width: COL_WIDTH_UNDEFINED,
+    width: 320,
   },
   {
     key: 'failure_rate',
     name: 'Failure Rate',
-    width: COL_WIDTH_UNDEFINED,
+    width: 320,
   },
 ];
 
@@ -126,7 +126,7 @@ function renderBodyCell(column: GridColumnHeader, row: HostTableRow): React.Reac
   if (column.key === 'duration') {
     const series: Series = row[column.key];
     if (series) {
-      return <Sparkline series={series} />;
+      return <Sparkline color="rgb(242, 183, 18)" series={series} />;
     }
 
     return 'Loading';
@@ -135,7 +135,7 @@ function renderBodyCell(column: GridColumnHeader, row: HostTableRow): React.Reac
   if (column.key === 'failure_rate') {
     const series: Series = row[column.key];
     if (series) {
-      return <Sparkline series={series} />;
+      return <Sparkline color="#ef7061" series={series} />;
     }
 
     return 'Loading';

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -5,7 +5,7 @@ export const getHostListQuery = () => {
   return `SELECT
     domain,
     toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
-    quantile(0.99)(exclusive_time) as p50
+    quantile(0.99)(exclusive_time) as p99
     FROM spans_experimental_starfish
     WHERE module = 'http'
     AND domain != ''

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -5,7 +5,10 @@ export const getHostListQuery = () => {
   return `SELECT
     domain,
     toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
-    quantile(0.99)(exclusive_time) as p99
+    quantile(0.99)(exclusive_time) as p99,
+    count() as count,
+    countIf(greaterOrEquals(status, 400) AND lessOrEquals(status, 599)) as failure_count,
+    failure_count / count as failure_rate
     FROM spans_experimental_starfish
     WHERE module = 'http'
     AND domain != ''

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -1,6 +1,19 @@
 export const PERIOD_REGEX = /^(\d+)([h,d])$/;
 const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
+export const getHostListQuery = () => {
+  return `SELECT
+    domain,
+    toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
+    quantile(0.99)(exclusive_time) as p50
+    FROM spans_experimental_starfish
+    WHERE module = 'http'
+    AND domain != ''
+    GROUP BY domain, interval
+    ORDER BY domain, interval asc
+ `;
+};
+
 export const getEndpointListQuery = ({domain, action, datetime}) => {
   const [_, num, unit] = datetime.period?.match(PERIOD_REGEX) ?? [];
   const start_timestamp =


### PR DESCRIPTION
Add a host table that shows simple sparklines of the response time and error rate per host. Useful to determine if any specific host is currently having trouble.

**e.g.,**
![Screenshot 2023-04-25 at 10 42 02 AM](https://user-images.githubusercontent.com/989898/234313476-fef23a76-fc2e-41cc-b148-8a1d63a36ffd.png)

