### PR TITLE
fix(hybrid-cloud): Fix org mapping deletes

### DIFF
--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -79,6 +79,7 @@ def process_team_updates(
 @receiver(process_region_outbox, sender=OutboxCategory.ORGANIZATION_UPDATE)
 def process_organization_updates(object_identifier: int, **kwds: Any):
     if (org := maybe_process_tombstone(Organization, object_identifier)) is None:
+        organization_mapping_service.delete(organization_id=object_identifier)
         return
 
     update = update_organization_mapping_from_instance(org)

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -27,6 +27,7 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.snuba.models import SnubaQuery
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils import TransactionTestCase
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import region_silo_test
 
 
@@ -94,7 +95,7 @@ class DeleteOrganizationTest(TransactionTestCase):
         deletion = ScheduledDeletion.schedule(org, days=0)
         deletion.update(in_progress=True)
 
-        with self.tasks():
+        with self.tasks(), outbox_runner():
             run_deletion(deletion.id)
 
         assert Organization.objects.filter(id=org2.id).exists()


### PR DESCRIPTION
Move the `organization_mapping_service.delete()` RPC call to the region outbox receiver, `process_organization_updates`.

This is a better location for this RPC call than using the `post_delete` signal.