### PR TITLE
replay(ref): Replace calls to getPrevReplayEvent() in Replay Details console/network/dom tabs.

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -6,7 +6,6 @@ import Feature from 'sentry/components/acl/feature';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
-import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useOrganization from 'sentry/utils/useOrganization';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
@@ -53,37 +52,6 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
 
-  const itemLookup = useMemo(
-    () =>
-      items &&
-      items
-        .map(({timestamp}, i) => [+new Date(timestamp || ''), i])
-        .sort(([a], [b]) => a - b),
-    [items]
-  );
-
-  const current = useMemo(
-    () =>
-      getPrevReplayEvent({
-        itemLookup,
-        items,
-        targetTimestampMs: startTimestampMs + currentTime,
-      }),
-    [itemLookup, items, currentTime, startTimestampMs]
-  );
-
-  const hovered = useMemo(
-    () =>
-      currentHoverTime
-        ? getPrevReplayEvent({
-            itemLookup,
-            items,
-            targetTimestampMs: startTimestampMs + currentHoverTime,
-          })
-        : null,
-    [itemLookup, items, currentHoverTime, startTimestampMs]
-  );
-
   const gridRef = useRef<MultiGrid>(null);
   const deps = useMemo(() => [items, searchTerm], [items, searchTerm]);
   const {cache, getColumnWidth, onScrollbarPresenceChange, onWrapperResize} =
@@ -123,13 +91,13 @@ function NetworkList({networkSpans, startTimestampMs}: Props) {
             />
           ) : (
             <NetworkTableCell
-              ref={e => e && registerChild?.(e)}
               columnIndex={columnIndex}
+              currentHoverTime={currentHoverTime}
+              currentTime={currentTime}
               handleClick={handleClick}
               handleMouseEnter={handleMouseEnter}
               handleMouseLeave={handleMouseLeave}
-              isCurrent={network.id === current?.id}
-              isHovered={network.id === hovered?.id}
+              ref={e => e && registerChild?.(e)}
               rowIndex={rowIndex}
               sortConfig={sortConfig}
               span={network}
@@ -208,6 +176,42 @@ const OverflowHidden = styled('div')`
 const NetworkTable = styled(OverflowHidden)`
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
+
+  .beforeHoverTime + .afterHoverTime:before {
+    border-top: 1px solid ${p => p.theme.purple200};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeHoverTime:last-child:before {
+    border-bottom: 1px solid ${p => p.theme.purple200};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime + .afterCurrentTime:before {
+    border-top: 1px solid ${p => p.theme.purple300};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime:last-child:before {
+    border-bottom: 1px solid ${p => p.theme.purple300};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
 `;
 
 export default NetworkList;

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -1,8 +1,8 @@
-import {CSSProperties, forwardRef, MouseEvent} from 'react';
+import {CSSProperties, forwardRef, MouseEvent, useMemo} from 'react';
 import styled from '@emotion/styled';
+import classNames from 'classnames';
 
 import FileSize from 'sentry/components/fileSize';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
@@ -16,11 +16,11 @@ const EMPTY_CELL = '\u00A0';
 
 type Props = {
   columnIndex: number;
+  currentHoverTime: number | undefined;
+  currentTime: number;
   handleClick: (span: NetworkSpan) => void;
   handleMouseEnter: (span: NetworkSpan) => void;
   handleMouseLeave: (span: NetworkSpan) => void;
-  isCurrent: boolean;
-  isHovered: boolean;
   rowIndex: number;
   sortConfig: ReturnType<typeof useSortNetwork>['sortConfig'];
   span: NetworkSpan;
@@ -28,15 +28,24 @@ type Props = {
   style: CSSProperties;
 };
 
+type CellProps = {
+  hasOccurred: boolean | undefined;
+  isDetailsOpen: boolean;
+  isStatusError: boolean;
+  className?: string;
+  numeric?: boolean;
+  onClick?: undefined | (() => void);
+};
+
 const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
   (
     {
       columnIndex,
+      currentHoverTime,
+      currentTime,
       handleClick,
       handleMouseEnter,
       handleMouseLeave,
-      isCurrent,
-      isHovered,
       rowIndex,
       sortConfig,
       span,
@@ -48,7 +57,6 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
     // Rows include the sortable header, the dataIndex does not
     const dataIndex = String(rowIndex - 1);
 
-    const {currentTime} = useReplayContext();
     const {getParamValue, setParamValue} = useUrlParams('n_detail_row', '');
     const isDetailsOpen = getParamValue() === dataIndex;
 
@@ -56,22 +64,49 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
     const endMs = span.endTimestamp * 1000;
     const statusCode = span.data.statusCode;
 
+    const spanTime = useMemo(
+      () => relativeTimeInMs(span.startTimestamp * 1000, startTimestampMs),
+      [span.startTimestamp, startTimestampMs]
+    );
+    const hasOccurred = currentTime >= spanTime;
+    const isBeforeHover = currentHoverTime === undefined || currentHoverTime >= spanTime;
+
     const isByTimestamp = sortConfig.by === 'startTimestamp';
+    const isAsc = isByTimestamp ? sortConfig.asc : undefined;
     const columnProps = {
-      hasOccurred: isByTimestamp
-        ? currentTime >= relativeTimeInMs(span.startTimestamp * 1000, startTimestampMs)
-        : undefined,
-      hasOccurredAsc: isByTimestamp ? sortConfig.asc : undefined,
-      isCurrent,
+      className: classNames({
+        beforeCurrentTime: isByTimestamp
+          ? isAsc
+            ? hasOccurred
+            : !hasOccurred
+          : undefined,
+        afterCurrentTime: isByTimestamp
+          ? isAsc
+            ? !hasOccurred
+            : hasOccurred
+          : undefined,
+        beforeHoverTime:
+          isByTimestamp && currentHoverTime !== undefined
+            ? isAsc
+              ? isBeforeHover
+              : !isBeforeHover
+            : undefined,
+        afterHoverTime:
+          isByTimestamp && currentHoverTime !== undefined
+            ? isAsc
+              ? !isBeforeHover
+              : isBeforeHover
+            : undefined,
+      }),
+      hasOccurred: isByTimestamp ? hasOccurred : undefined,
       isDetailsOpen,
-      isHovered,
       isStatusError: typeof statusCode === 'number' && statusCode >= 400,
       onClick: () => setParamValue(dataIndex),
       onMouseEnter: () => handleMouseEnter(span),
       onMouseLeave: () => handleMouseLeave(span),
       ref,
       style,
-    };
+    } as CellProps;
 
     // `data.responseBodySize` is from SDK version 7.44-7.45
     const size = span.data.size ?? span.data.response?.size ?? span.data.responseBodySize;
@@ -144,20 +179,6 @@ const cellBackground = p => {
   return `background-color: ${color};`;
 };
 
-const cellBorder = p => {
-  if (p.hasOccurred === undefined) {
-    return null;
-  }
-  const color = p.isCurrent
-    ? p.theme.purple300
-    : p.isHovered
-    ? p.theme.purple200
-    : 'transparent';
-  return p.hasOccurredAsc
-    ? `border-bottom: 1px solid ${color};`
-    : `border-top: 1px solid ${color};`;
-};
-
 const cellColor = p => {
   if (p.isDetailsOpen) {
     const colors = p.isStatusError
@@ -172,16 +193,7 @@ const cellColor = p => {
   return `color: ${p.hasOccurred !== false ? colors[0] : colors[1]};`;
 };
 
-const Cell = styled('div')<{
-  hasOccurred: boolean | undefined;
-  hasOccurredAsc: boolean | undefined;
-  isCurrent: boolean;
-  isDetailsOpen: boolean;
-  isHovered: boolean;
-  isStatusError: boolean;
-  numeric?: boolean;
-  onClick?: undefined | (() => void);
-}>`
+const Cell = styled('div')<CellProps>`
   display: flex;
   align-items: center;
   padding: ${space(0.75)} ${space(1.5)};
@@ -189,7 +201,6 @@ const Cell = styled('div')<{
   cursor: ${p => (p.onClick ? 'pointer' : 'inherit')};
 
   ${cellBackground}
-  ${cellBorder}
   ${cellColor}
 
   ${p =>

--- a/static/app/views/replays/detail/tabItemContainer.tsx
+++ b/static/app/views/replays/detail/tabItemContainer.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+const TabItemContainer = styled('div')`
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+
+  .beforeHoverTime + .afterHoverTime {
+    border-top-color: ${p => p.theme.purple200};
+  }
+  .beforeHoverTime:last-child {
+    border-bottom-color: ${p => p.theme.purple200};
+  }
+
+  .beforeCurrentTime + .afterCurrentTime {
+    border-top-color: ${p => p.theme.purple300};
+  }
+  .beforeCurrentTime:last-child {
+    border-bottom-color: ${p => p.theme.purple300};
+  }
+`;
+
+export default TabItemContainer;


### PR DESCRIPTION
This fixes some issues where the current/hover line wasn't appearing for the first & last items in console/network/dom lists

Example where I've clicked on the first Console item in the list, at time 0:00:
| Before | After |
| --- | --- |
| ![SCR-20230425-kjek](https://user-images.githubusercontent.com/187460/234368251-273010d3-61d7-420f-8f92-b0e4ff25410c.png) | ![SCR-20230425-kjhj](https://user-images.githubusercontent.com/187460/234368275-bbfba4bf-6c92-412a-915f-356252ba3d53.png) |

Now with the css powering things the line appears!

It's also more reliable to show the purple line when timestamps are the 'same', and near errors:
| Before | After |
| --- | --- |
| ![SCR-20230425-kkor](https://user-images.githubusercontent.com/187460/234369066-c3594771-96b0-459c-8e0f-864803d3620c.png) | ![SCR-20230425-kktn](https://user-images.githubusercontent.com/187460/234369073-c61ff466-f578-4c63-ba2a-c2cec4431af9.png) |

Havn't done any profiling, but i hope that there's a savings from not calling `getPrevReplayEvent`.
Also, as a followup we should really be caching all the  `new Date(breadcrumb.timestamp)` and `relativeTimeInMs()` calls. This should happen inside breadcrumbFactory probably and would affect the type we're using, which is why it's a good followup and not part of this. 