### PR TITLE
fix(rulesnooze): fix mute alert button when alert name is long

### DIFF
--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -215,14 +215,14 @@
     {% endif %}
 
     <p class="info-box">
-        This email was triggered by
-        {% for rule in rules %}
-            <a href="{% absolute_uri rule.status_url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
-        {% endfor %}
-        {% if snooze_alert %}
+      {% if snooze_alert %}
          <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute for me</a>
-        {% endif %}
-    </p>
+      {% endif %}
+      This email was triggered by
+      {% for rule in rules %}
+          <a href="{% absolute_uri rule.status_url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
+      {% endfor %}
+  </p>
 
     {% if not has_integrations %}
         <div class="logo-container">


### PR DESCRIPTION
this pr fixes a problem where the position of the mute alert button gets messed up if the alert name is really long 

before: 
<img width="1149" alt="Screenshot 2023-04-25 at 11 28 55 AM" src="https://user-images.githubusercontent.com/46740234/234369336-d7c0e04c-1440-4441-a857-8d9415a641b0.png">


after:
<img width="1098" alt="Screenshot 2023-04-25 at 11 28 50 AM" src="https://user-images.githubusercontent.com/46740234/234369301-0e66b028-a2c6-42ba-a997-8ff5d4479b49.png">
