### PR TITLE
feat(perf): Decrease the topN limit to 50 in new trends

### DIFF
--- a/src/sentry/api/endpoints/organization_events_new_trends.py
+++ b/src/sentry/api/endpoints/organization_events_new_trends.py
@@ -85,7 +85,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 params=params,
                 rollup=rollup,
                 # high limit is set to validate the regression analysis
-                limit=100,
+                limit=50,
                 organization=organization,
                 referrer=Referrer.API_TRENDS_GET_EVENT_STATS_NEW.value,
                 allow_empty=False,
@@ -100,7 +100,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 request,
                 organization,
                 get_event_stats,
-                top_events=100,
+                top_events=50,
                 query_column=trend_function,
                 params=params,
                 query=query,


### PR DESCRIPTION
with 100 topN events, we're hitting 10,000 limit in snuba. Brining it down to 50.

Fixes SENTRY-10JC