### PR TITLE
feat(issue-platform): Make issue rule preview use issue platform for perf issues

### DIFF
--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Sequence
 
+from sentry import features
 from sentry.issues.grouptype import GroupCategory
+from sentry.models import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
 
@@ -15,10 +17,12 @@ To add support for a new issue category/dataset:
 """
 
 
-def get_dataset_from_category(category: int) -> Dataset:
+def get_dataset_from_category(category: int, organization: Organization) -> Dataset:
     if category == GroupCategory.ERROR.value:
         return Dataset.Events
-    elif category == GroupCategory.PERFORMANCE.value:
+    elif category == GroupCategory.PERFORMANCE.value and not features.has(
+        "organizations:issue-platform-search-perf-issues", organization
+    ):
         return Dataset.Transactions
     return Dataset.IssuePlatform
 


### PR DESCRIPTION
This converts the issue rule preview code to respect the `organizations:issue-platform-search-perf-issues` flag and switch to the issue platform for perf issue when it's enabled.
