### PR TITLE
feat(perf-issues): Add consecutive HTTP span setting to UI

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -249,6 +249,12 @@ class ProjectPerformance extends AsyncView<Props, State> {
         step: 0.01,
         defaultValue: 0,
       },
+      {
+        name: 'consecutive_http_spans_detection_enabled',
+        type: 'boolean',
+        label: t('Consecutive HTTP Spans Detection Enabled'),
+        defaultValue: true,
+      },
     ];
   }
 


### PR DESCRIPTION
Adds a boolean field for consecutive HTTP span detection to the project settings UI.

To be merged after #47927