### PR TITLE
feat(starfish): Allow span summary to render without a transaction

### DIFF
--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -123,7 +123,7 @@ export const getSpanInTransactionQuery = (groupId, transactionName) => {
     SELECT count() AS count, quantile(0.5)(exclusive_time) as p50, span_operation
     FROM spans_experimental_starfish
     WHERE groupId = '${groupId}'
-    AND transaction = '${transactionName}'
+    ${transactionName ? `AND transaction = '${transactionName}'` : ''}
     GROUP BY span_operation
  `;
 };

--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -131,13 +131,18 @@ export default function SpanSummary({location, params}: Props) {
                   <KeyValueList
                     data={[
                       {
+                        key: 'transaction',
+                        value: transactionName,
+                        subject: 'Transaction',
+                      },
+                      {
                         key: 'desc',
                         value: spanDescription,
                         subject: 'Description',
                       },
                       {key: 'count', value: data?.[0]?.count, subject: 'Count'},
                       {key: 'p50', value: data?.[0]?.p50, subject: 'p50'},
-                    ]}
+                    ].filter(Boolean)}
                     shouldSort={false}
                   />
                 )}
@@ -242,7 +247,7 @@ function renderBodyCell(column: GridColumnHeader, row: SpanTableRow): React.Reac
 
 type SpanInTransactionSlug = {
   groupId: string;
-  transactionName: string;
+  transactionName?: string;
 };
 
 function parseSlug(slug?: string): SpanInTransactionSlug | undefined {
@@ -252,7 +257,7 @@ function parseSlug(slug?: string): SpanInTransactionSlug | undefined {
 
   const delimiterPosition = slug.lastIndexOf(':');
   if (delimiterPosition < 0) {
-    return undefined;
+    return {groupId: slug};
   }
 
   const groupId = slug.slice(0, delimiterPosition);

--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -116,7 +116,7 @@ export default function SpanSummary({location, params}: Props) {
       <PageErrorProvider>
         <Layout.Header>
           <Layout.HeaderContent>
-            <Layout.Title>{transactionName}</Layout.Title>
+            <Layout.Title>{groupId}</Layout.Title>
           </Layout.HeaderContent>
         </Layout.Header>
 

--- a/static/app/views/starfish/views/spanSummary/queries.tsx
+++ b/static/app/views/starfish/views/spanSummary/queries.tsx
@@ -25,7 +25,7 @@ export const getSpanSamplesQuery = ({
     SELECT description, transaction_id, span_id, exclusive_time, count() as count
     FROM spans_experimental_starfish
     WHERE group_id = '${groupId}'
-    AND transaction = '${transactionName}'
+    ${transactionName ? `AND transaction = '${transactionName}'` : ''}
     ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
     ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
     GROUP BY description, transaction_id, span_id, exclusive_time


### PR DESCRIPTION
If the transaction isn't in the URL, render the page anyway, and skip the transaction filter.

- Set span ID as the heading
- Allow span summary to load without transaction
