### PR TITLE
ref: store last_received datetime as str for issue ingest

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -25,7 +25,7 @@ from sentry.issues.grouptype import should_create_group
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
 from sentry.models import GroupHash, Release
 from sentry.ratelimits.sliding_windows import Quota, RedisSlidingWindowRateLimiter, RequestedQuota
-from sentry.utils import metrics, redis
+from sentry.utils import json, metrics, redis
 
 from .utils import can_create_group
 
@@ -113,7 +113,7 @@ def _create_issue_kwargs(
         "first_release": release,
         "data": materialize_metadata(occurrence, event),
     }
-    kwargs["data"]["last_received"] = event.datetime
+    kwargs["data"]["last_received"] = json.datetime_to_str(event.datetime)
     return kwargs
 
 
@@ -123,7 +123,7 @@ class OccurrenceMetadata(TypedDict):
     metadata: Mapping[str, Any]
     title: str
     location: Optional[str]
-    last_received: datetime
+    last_received: str
 
 
 def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> OccurrenceMetadata:
@@ -143,7 +143,7 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
         "culprit": occurrence.culprit,
         "metadata": event_metadata,
         "location": event.location,
-        "last_received": event.datetime,
+        "last_received": json.datetime_to_str(event.datetime),
     }
 
 

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -33,6 +33,7 @@ from sentry.ratelimits.sliding_windows import Quota
 from sentry.snuba.dataset import Dataset
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.utils import json
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import raw_query
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -250,7 +251,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):  # type: ignore
             "metadata": {"title": occurrence.issue_title, "value": occurrence.subtitle},
             "title": occurrence.issue_title,
             "location": event.location,
-            "last_received": event.datetime,
+            "last_received": json.datetime_to_str(event.datetime),
         }
 
 


### PR DESCRIPTION
in an effort to remove pickling -- this needs to be json serializable and round-trippable