### PR TITLE
feat(starfish): disable percentile bar graph in db query summary

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -220,24 +220,26 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
           />
         </FlexRowItem>
       </FlexRowContainer>
-      <FlexRowContainer>
-        <FlexRowItem>
-          <SubHeader>{t('Percentiles')}</SubHeader>
-          <Chart
-            statsPeriod="24h"
-            height={140}
-            data={[percentileSeries]}
-            start=""
-            end=""
-            loading={isLoading}
-            utc={false}
-            disableMultiAxis
-            stacked
-            isBarChart
-            hideYAxisSplitLine
-          />
-        </FlexRowItem>
-      </FlexRowContainer>
+      {row.transactions > 1 && (
+        <FlexRowContainer>
+          <FlexRowItem>
+            <SubHeader>{t('Percentiles')}</SubHeader>
+            <Chart
+              statsPeriod="24h"
+              height={140}
+              data={[percentileSeries]}
+              start=""
+              end=""
+              loading={isLoading}
+              utc={false}
+              disableMultiAxis
+              stacked
+              isBarChart
+              hideYAxisSplitLine
+            />
+          </FlexRowItem>
+        </FlexRowContainer>
+      )}
       <GridEditable
         isLoading={isDataLoading}
         data={mergedTableData}


### PR DESCRIPTION
If there's only one transaction, there's no reason to show a percentile graph grouped by transaction
<img width="710" alt="image" src="https://user-images.githubusercontent.com/44422760/234402277-5b9e685f-ba12-4ddf-9b1b-6dd0ab8e0f1c.png">
