### PR TITLE
fix(starfish): update db query details to use group_id

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -94,7 +94,7 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
   SELECT transaction, count(DISTINCT transaction_id) as uniqueEvents
     FROM spans_experimental_starfish
     WHERE transaction
-      IN (SELECT transaction FROM spans_experimental_starfish WHERE module='db' AND description='${row.description}')
+      IN (SELECT transaction FROM spans_experimental_starfish WHERE module='db' AND group_id='${row.group_id}')
     GROUP BY transaction
    `;
 
@@ -220,24 +220,26 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
           />
         </FlexRowItem>
       </FlexRowContainer>
-      <FlexRowContainer>
-        <FlexRowItem>
-          <SubHeader>{t('Percentiles')}</SubHeader>
-          <Chart
-            statsPeriod="24h"
-            height={140}
-            data={[percentileSeries]}
-            start=""
-            end=""
-            loading={isLoading}
-            utc={false}
-            disableMultiAxis
-            stacked
-            isBarChart
-            hideYAxisSplitLine
-          />
-        </FlexRowItem>
-      </FlexRowContainer>
+      {row.transactions > 1 && (
+        <FlexRowContainer>
+          <FlexRowItem>
+            <SubHeader>{t('Percentiles')}</SubHeader>
+            <Chart
+              statsPeriod="24h"
+              height={140}
+              data={[percentileSeries]}
+              start=""
+              end=""
+              loading={isLoading}
+              utc={false}
+              disableMultiAxis
+              stacked
+              isBarChart
+              hideYAxisSplitLine
+            />
+          </FlexRowItem>
+        </FlexRowContainer>
+      )}
       <GridEditable
         isLoading={isDataLoading}
         data={mergedTableData}

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -220,26 +220,24 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
           />
         </FlexRowItem>
       </FlexRowContainer>
-      {row.transactions > 1 && (
-        <FlexRowContainer>
-          <FlexRowItem>
-            <SubHeader>{t('Percentiles')}</SubHeader>
-            <Chart
-              statsPeriod="24h"
-              height={140}
-              data={[percentileSeries]}
-              start=""
-              end=""
-              loading={isLoading}
-              utc={false}
-              disableMultiAxis
-              stacked
-              isBarChart
-              hideYAxisSplitLine
-            />
-          </FlexRowItem>
-        </FlexRowContainer>
-      )}
+      <FlexRowContainer>
+        <FlexRowItem>
+          <SubHeader>{t('Percentiles')}</SubHeader>
+          <Chart
+            statsPeriod="24h"
+            height={140}
+            data={[percentileSeries]}
+            start=""
+            end=""
+            loading={isLoading}
+            utc={false}
+            disableMultiAxis
+            stacked
+            isBarChart
+            hideYAxisSplitLine
+          />
+        </FlexRowItem>
+      </FlexRowContainer>
       <GridEditable
         isLoading={isDataLoading}
         data={mergedTableData}


### PR DESCRIPTION
Now that we have group_id, we should use that to query rather then the description. 
I only found one case of this in the db module, @wmak updated the others.