### PR TITLE
feat(issue-platform): Make discover able to read from the issue platform for perf issues

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -17,6 +17,7 @@ from snuba_sdk import (
     OrderBy,
 )
 
+from sentry import features
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory
@@ -1617,8 +1618,13 @@ class DiscoverDatasetConfig(DatasetConfig):
             except Exception:
                 raise InvalidSearchQuery(f"Invalid value '{group_short_ids}' for 'issue:' filter")
             else:
+                org = None
+                if groups:
+                    org = groups[0].project.organization
                 for group in groups:
-                    if group.issue_category == GroupCategory.PERFORMANCE:
+                    if group.issue_category == GroupCategory.PERFORMANCE and not features.has(
+                        "organizations:issue-platform-search-perf-issues", org
+                    ):
                         performance_groups.append(group.id)
                     else:
                         general_groups.append(group.id)


### PR DESCRIPTION
This makes sure that once we're using issue platform for perf issues that we'll correctly use the issue platform dataset in discover




<!-- Describe your PR here. -->