### PR TITLE
feat(perf): Stop zerofilling data in trends

### DIFF
--- a/src/sentry/api/endpoints/organization_events_new_trends.py
+++ b/src/sentry/api/endpoints/organization_events_new_trends.py
@@ -104,6 +104,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 query_column=trend_function,
                 params=params,
                 query=query,
+                zerofill_results=False,
             )
 
             # handle empty response


### PR DESCRIPTION
it doesn't make sense to zerofill metrics since that can be interpreted as the metric equaling to zero