### PR TITLE
fix(tags): Handle boolean keys in tags search

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -69,8 +69,10 @@ SEEN_COLUMN = "timestamp"
 # all values for a given tag/column
 BLACKLISTED_COLUMNS = frozenset(["project_id"])
 
+BOOLEAN_KEYS = frozenset(["error.handled", "error.unhandled", "error.main_thread", "stack.in_app"])
+
 FUZZY_NUMERIC_KEYS = frozenset(
-    ["stack.colno", "stack.in_app", "stack.lineno", "stack.stack_level", "transaction.duration"]
+    ["stack.colno", "stack.lineno", "stack.stack_level", "transaction.duration"]
 )
 FUZZY_NUMERIC_DISTANCE = 50
 
@@ -80,6 +82,10 @@ FUZZY_NUMERIC_DISTANCE = 50
 DEFAULT_TYPE_CONDITION = ["type", "!=", "transaction"]
 
 tag_value_data_transformers = {"first_seen": parse_datetime, "last_seen": parse_datetime}
+
+
+def is_boolean_key(key):
+    return key in BOOLEAN_KEYS
 
 
 def is_fuzzy_numeric_key(key):
@@ -1302,7 +1308,7 @@ class SnubaTagStorage(TagStorage):
 
         # These columns have fixed values and we don't need to emit queries to find out the
         # potential options.
-        if key in {"error.handled", "error.unhandled"}:
+        if is_boolean_key(key):
             return SequencePaginator(
                 [
                     (

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -561,6 +561,8 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
     def test_boolean_fields(self):
         self.run_test("error.handled", expected=[("true", None), ("false", None)])
         self.run_test("error.unhandled", expected=[("true", None), ("false", None)])
+        self.run_test("error.main_thread", expected=[("true", None), ("false", None)])
+        self.run_test("stack.in_app", expected=[("true", None), ("false", None)])
 
 
 @region_silo_test


### PR DESCRIPTION
There's a couple more boolean keys that need to be handled correctly when we're searching for the tag values.

Fixes SENTRY-YEP