### PR TITLE
chore(tests): Move helper for mocking context managers into `testutils`

### DIFF
--- a/src/sentry/testutils/helpers/__init__.py
+++ b/src/sentry/testutils/helpers/__init__.py
@@ -1,5 +1,6 @@
 from .auth_header import *  # NOQA
 from .auth_providers import *  # NOQA
+from .context_manager import *  # NOQA
 from .features import *  # NOQA
 from .link_header import *  # NOQA
 from .options import *  # NOQA

--- a/src/sentry/testutils/helpers/context_manager.py
+++ b/src/sentry/testutils/helpers/context_manager.py
@@ -1,0 +1,18 @@
+from typing import Any, Callable
+
+
+# TODO: This is kind of gross, but no other way seemed to work
+def set_mock_context_manager_return_value(
+    context_manager_constructor: Callable, as_value: Any
+) -> None:
+    """
+    Ensure that if the code being tested includes something like
+
+        with some_func() as some_value:
+
+    then `some_value` will equal `as_value`.
+
+    Note: `context_manager_constructor` should be `some_func`, not `some_func()`.
+    """
+
+    context_manager_constructor.return_value.__enter__.return_value = as_value

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -1,4 +1,3 @@
-from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
 from django.http import HttpRequest
@@ -6,29 +5,13 @@ from rest_framework.request import Request
 from sentry_sdk import Scope
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers import set_mock_context_manager_return_value
 from sentry.utils.sdk import (
     capture_exception_with_scope_check,
     check_current_scope_transaction,
     check_tag,
     merge_context_into_scope,
 )
-
-
-# TODO: This is kind of gross, but no other way seemed to work
-def set_mock_context_manager_return_value(
-    context_manager_constructor: Callable, as_value: Any
-) -> None:
-    """
-    Ensure that if the code being tested includes something like
-
-        with some_func() as some_value:
-
-    then `some_value` will equal `as_value`.
-
-    Note: `context_manager_constructor` should be `some_func`, not `some_func()`.
-    """
-
-    context_manager_constructor.return_value.__enter__.return_value = as_value
 
 
 class SDKUtilsTest(TestCase):


### PR DESCRIPTION
This moves the `set_mock_context_manager_return_value` out of `test_sdk` and into `testutils.helpers` so it can be used in other test files.

Note: I still don't love the implementation here, and am open to suggestions of a better alternative.