### PR TITLE
feat(replays): fetch replay data without projectSlug

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -61,7 +61,7 @@ describe('useReplayData', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/`,
+      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
       body: {data: mockReplayResponse},
     });
 
@@ -103,7 +103,7 @@ describe('useReplayData', () => {
     ];
 
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/`,
+      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
       body: {data: mockReplayResponse},
     });
     const mockedSegmentsCall1 = MockApiClient.addMockResponse({
@@ -171,7 +171,7 @@ describe('useReplayData', () => {
     ];
 
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/`,
+      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
       body: {data: mockReplayResponse},
     });
     const mockedErrorsCall1 = MockApiClient.addMockResponse({
@@ -230,7 +230,7 @@ describe('useReplayData', () => {
 
     const mockedReplayCall = MockApiClient.addMockResponse({
       asyncDelay: 1,
-      url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/`,
+      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
       body: {data: mockReplayResponse},
     });
 


### PR DESCRIPTION
## Summary
Adds support for fetching replay details without requiring `projectSlug` in the `replaySlug`. In other words we only need to pass `replayId`. 

With this change we make linking to the replay details page from backend errors and other events simpler.

Relates to: https://github.com/getsentry/sentry/pull/47859
Closes: https://github.com/getsentry/sentry/issues/47863