### PR TITLE
feat(crons): Split out timeout status from error status

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -78,6 +78,7 @@ class MonitorStatus(ObjectStatus):
     OK = 4
     ERROR = 5
     MISSED_CHECKIN = 6
+    TIMEOUT = 7
 
     @classmethod
     def as_choices(cls):
@@ -89,6 +90,7 @@ class MonitorStatus(ObjectStatus):
             (cls.OK, "ok"),
             (cls.ERROR, "error"),
             (cls.MISSED_CHECKIN, "missed_checkin"),
+            (cls.TIMEOUT, "timeout"),
         )
 
 
@@ -108,7 +110,10 @@ class CheckInStatus:
     MISSED = 4
     """Monitor did not check in on time"""
 
-    FINISHED_VALUES = (OK, ERROR)
+    TIMEOUT = 5
+    """Checkin was left in-progress past max_runtime"""
+
+    FINISHED_VALUES = (OK, ERROR, TIMEOUT)
     """Sentient values used to indicate a monitor is finished running"""
 
     @classmethod
@@ -119,6 +124,7 @@ class CheckInStatus:
             (cls.ERROR, "error"),
             (cls.IN_PROGRESS, "in_progress"),
             (cls.MISSED, "missed"),
+            (cls.TIMEOUT, "timeout"),
         )
 
 
@@ -353,6 +359,8 @@ class MonitorEnvironment(Model):
         new_status = MonitorStatus.ERROR
         if reason == MonitorFailure.MISSED_CHECKIN:
             new_status = MonitorStatus.MISSED_CHECKIN
+        elif reason == MonitorFailure.DURATION:
+            new_status = MonitorStatus.TIMEOUT
 
         affected = (
             type(self)

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -93,7 +93,7 @@ def check_monitors(current_datetime=None):
         )
         affected = MonitorCheckIn.objects.filter(
             id=checkin.id, status=CheckInStatus.IN_PROGRESS
-        ).update(status=CheckInStatus.ERROR)
+        ).update(status=CheckInStatus.TIMEOUT)
         if not affected:
             continue
 

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -189,14 +189,14 @@ class CheckMonitorsTest(TestCase):
 
         check_monitors(current_datetime=current_datetime + timedelta(hours=12, minutes=1))
 
-        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.ERROR).exists()
+        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
 
         assert MonitorCheckIn.objects.filter(
             id=checkin2.id, status=CheckInStatus.IN_PROGRESS
         ).exists()
 
         assert MonitorEnvironment.objects.filter(
-            id=monitor_environment.id, status=MonitorStatus.ERROR
+            id=monitor_environment.id, status=MonitorStatus.TIMEOUT
         ).exists()
 
     def test_timeout_with_future_complete_checkin(self):
@@ -241,7 +241,7 @@ class CheckMonitorsTest(TestCase):
 
         check_monitors(current_datetime=current_datetime + timedelta(hours=12, minutes=1))
 
-        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.ERROR).exists()
+        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
 
         assert MonitorCheckIn.objects.filter(id=checkin2.id, status=CheckInStatus.OK).exists()
 
@@ -283,10 +283,10 @@ class CheckMonitorsTest(TestCase):
 
         check_monitors(current_datetime=current_datetime + timedelta(hours=1, minutes=1))
 
-        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.ERROR).exists()
+        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
 
         assert MonitorEnvironment.objects.filter(
-            id=monitor_environment.id, status=MonitorStatus.ERROR
+            id=monitor_environment.id, status=MonitorStatus.TIMEOUT
         ).exists()
 
     def test_killswitch(self):


### PR DESCRIPTION
Currently the monitor check-in status `ERROR` can represent two separate situations

1. User manually sent `{'status': 'error'}` or reported an error via SDK in their scheduled task
2. The user sent an `in-progress` check-in and never reported it as successfully or unsuccessfully completing

This makes it harder for users to understand if something in their task failed, timed out, or perhaps was even misinstrumented as we have seen many instances of users repeatedly hitting our `POST` endpoint to create new check-ins without realizing they have to "close" them with our `PUT` endpoint.

Hopefully this change will make it easier to spot/differentiate between these different scenarios.

FE work captured in https://github.com/getsentry/sentry/pull/47944

fixes https://github.com/getsentry/sentry/issues/47956