### PR TITLE
fix(replays): correctly construct cursors

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -93,12 +93,12 @@ describe('useReplayData', () => {
     const mockedSegmentsCall1 = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/recording-segments/`,
       body: mockSegmentResponse1,
-      match: [(_url, options) => options.query?.cursor === '1:0:1'],
+      match: [(_url, options) => options.query?.cursor === '0:0:0'],
     });
     const mockedSegmentsCall2 = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/recording-segments/`,
       body: mockSegmentResponse2,
-      match: [(_url, options) => options.query?.cursor === '1:1:0'],
+      match: [(_url, options) => options.query?.cursor === '0:1:0'],
     });
 
     const {waitForNextUpdate} = reactHooks.renderHook(useReplayData, {

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -124,9 +124,7 @@ function useReplayData({
     }
 
     const pages = Math.ceil(replayRecord.count_segments / segmentsPerPage);
-    const cursors = new Array(pages)
-      .fill(0)
-      .map((_, i) => `${segmentsPerPage}:${i}:${i === 0 ? 1 : 0}`);
+    const cursors = new Array(pages).fill(0).map((_, i) => `0:${segmentsPerPage * i}:0`);
 
     await Promise.allSettled(
       cursors.map(cursor => {


### PR DESCRIPTION
right now we are not constructing paginators correctly. this results in us fetching the 0th-99th segments on first request, the 1st-100th segments on second request, and 2nd-101st segments on the third request, if there were say ~320 segments.

This is because our cursor is constructed as so: `CURSOR_ID:OFFSET:IS_PREV`. Previously, we were setting offset to page number, but in https://github.com/getsentry/sentry/pull/44659 when we switched from `OffsetPaginator` to `GenericOffSetPaginator`.

`OffsetPaginator` uses page number, (limit * page number for offset) while `GenericOffSetPaginator` uses raw offset. By bad luck, our test case happened to pass for both paginators.

Resolves https://github.com/getsentry/sentry/issues/47922