### PR TITLE
fix(mute alerts): Mute digests

### DIFF
--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -119,6 +119,7 @@ def get_participants_by_event(
     target_type: ActionTargetType = ActionTargetType.ISSUE_OWNERS,
     target_identifier: int | None = None,
     fallthrough_choice: FallthroughChoiceType | None = None,
+    rules: Sequence[Rule] | None = None,
 ) -> Mapping[Event, Mapping[ExternalProviders, set[RpcActor]]]:
     """
     This is probably the slowest part in sending digests because we do a lot of
@@ -132,6 +133,7 @@ def get_participants_by_event(
             target_identifier=target_identifier,
             event=event,
             fallthrough_choice=fallthrough_choice,
+            rules=rules,
         )
         for event in get_event_from_groups_in_digest(digest)
     }

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -121,8 +121,7 @@ def build_custom_digest(
             if user_group_records:
                 user_rule_groups[group] = user_group_records
         if user_rule_groups:
-            if not skip:
-                user_digest[rule] = user_rule_groups
+            user_digest[rule] = user_rule_groups
     return user_digest
     # TODO add test for the digest being empty, I think it gets pretty mad about that
 

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -104,15 +104,14 @@ def build_custom_digest(
 ) -> Digest:
     """Given a digest and a set of events, filter the digest to only records that include the events."""
     user_digest: Digest = {}
-    skip = False
     for rule, rule_groups in original_digest.items():
+        skip = False
         rule_snoozes = RuleSnooze.objects.filter(Q(rule=rule))
         for snooze in rule_snoozes:
             if snooze.user_id is None or snooze.user_id == participant.id:
                 skip = True
                 break
         if skip:
-            skip = False
             continue
         user_rule_groups = {}
         for group, group_records in rule_groups.items():

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -110,16 +110,12 @@ def build_custom_digest(
     """Given a digest and a set of events, filter the digest to only records that include the events."""
     user_digest: Digest = {}
     rule_snoozes = RuleSnooze.objects.filter(
-        Q(Q(user_id=participant.id) | Q(user_id__isnull=True)), rule__in=original_digest.keys()
-    )
+        Q(user_id=participant.id) | Q(user_id__isnull=True), rule__in=original_digest.keys()
+    ).values_list("rule", flat=True)
+    snoozed_rule_ids = {rule for rule in rule_snoozes}
 
     for rule, rule_groups in original_digest.items():
-        skip = False
-        for snooze in rule_snoozes:
-            if snooze.rule == rule:
-                skip = True
-                break
-        if skip:
+        if rule.id in snoozed_rule_ids:
             continue
         user_rule_groups = {}
         for group, group_records in rule_groups.items():

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -167,6 +167,7 @@ class DigestNotification(ProjectNotification):
             self.target_type,
             self.target_identifier,
             self.fallthrough_choice,
+            list(self.digest.keys()),
         )
 
         # Get every actor ID for every provider as a set.

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -203,7 +203,7 @@ class DigestNotification(ProjectNotification):
                 # remove participants if the digest is empty
                 participants_to_remove = set()
                 for participant in participants:
-                    if participant.actor_id not in set(extra_context.keys()):
+                    if participant.actor_id not in extra_context:
                         participants_to_remove.add(participant)
                 participants -= participants_to_remove
             notify(provider, self, participants, shared_context, extra_context)

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -193,16 +193,17 @@ class DigestNotification(ProjectNotification):
 
         # Calculate the per-participant context.
         extra_context: Mapping[int, Mapping[str, Any]] = {}
-        if should_get_personalized_digests(self.target_type, self.project.id):
+        personalized_digests = should_get_personalized_digests(self.target_type, self.project.id)
+
+        if personalized_digests:
             extra_context = self.get_extra_context(participants_by_provider_by_event)
 
         for provider, participants in combined_participants_by_provider.items():
-            # remove participants if the digest is empty
-            participants_to_remove = set()
-            for participant in participants:
-                if participant.actor_id not in set(extra_context.keys()):
-                    participants_to_remove.add(participant)
-
-            participants -= participants_to_remove
-
+            if personalized_digests:
+                # remove participants if the digest is empty
+                participants_to_remove = set()
+                for participant in participants:
+                    if participant.actor_id not in set(extra_context.keys()):
+                        participants_to_remove.add(participant)
+                participants -= participants_to_remove
             notify(provider, self, participants, shared_context, extra_context)

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -167,7 +167,6 @@ class DigestNotification(ProjectNotification):
             self.target_type,
             self.target_identifier,
             self.fallthrough_choice,
-            list(self.digest.keys()),
         )
 
         # Get every actor ID for every provider as a set.

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -197,4 +197,12 @@ class DigestNotification(ProjectNotification):
             extra_context = self.get_extra_context(participants_by_provider_by_event)
 
         for provider, participants in combined_participants_by_provider.items():
+            # remove participants if the digest is empty
+            participants_to_remove = set()
+            for participant in participants:
+                if participant.actor_id not in set(extra_context.keys()):
+                    participants_to_remove.add(participant)
+
+            participants -= participants_to_remove
+
             notify(provider, self, participants, shared_context, extra_context)

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -393,6 +393,7 @@ def get_send_to(
     recipients = determine_eligible_recipients(
         project, target_type, target_identifier, event, fallthrough_choice
     )
+
     if rules:
         rule_snoozes = RuleSnooze.objects.filter(Q(rule__in=rules))
         muted_user_ids = []

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -393,7 +393,6 @@ def get_send_to(
     recipients = determine_eligible_recipients(
         project, target_type, target_identifier, event, fallthrough_choice
     )
-
     if rules:
         rule_snoozes = RuleSnooze.objects.filter(Q(rule__in=rules))
         muted_user_ids = []

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1191,6 +1191,48 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest):
         assert notify.call_count == 0
         assert len(mail.outbox) == 0
 
+    @with_feature("organizations:mute-alerts")
+    @mock.patch.object(mail_adapter, "notify", side_effect=mail_adapter.notify, autospec=True)
+    def test_dont_notify_digest_snoozed_multiple_rules(self, notify):
+        """Test that a digest is sent containing only notifications about an unsnoozed alert."""
+        user2 = self.create_user(email="baz@example.com", is_active=True)
+        self.create_member(user=user2, organization=self.organization, teams=[self.team])
+        project = self.project
+        timestamp = iso_format(before_now(minutes=1))
+        event = self.store_event(
+            data={"timestamp": timestamp, "fingerprint": ["group-1"]},
+            project_id=project.id,
+        )
+        event2 = self.store_event(
+            data={"timestamp": timestamp, "fingerprint": ["group-2"]},
+            project_id=project.id,
+        )
+
+        rule = project.rule_set.all()[0]
+        rule2 = Rule.objects.create(project=project, label="my rule")
+        # mute the first rule only for self.user, not user2
+        RuleSnooze.objects.create(user_id=self.user.id, owner_id=self.user.id, rule=rule)
+
+        ProjectOwnership.objects.create(project_id=project.id, fallthrough=True)
+        digest = build_digest(
+            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule2,)))
+        )[0]
+
+        with self.tasks():
+            self.adapter.notify_digest(project, digest, ActionTargetType.ISSUE_OWNERS)
+
+        assert notify.call_count == 0
+        assert len(mail.outbox) == 2  # we send it to 2 users
+        message1 = mail.outbox[0]
+        message2 = mail.outbox[1]
+        # self.user only receives a digest about one alert, since a rule was muted
+        assert message2.to[0] == self.user.email
+        assert "1 new alert since" in message2.subject
+
+        # user2 receives a digest about both alerts, since no rules were muted
+        assert message1.to[0] == user2.email
+        assert "2 new alerts since" in message1.subject
+
     @mock.patch.object(mail_adapter, "notify", side_effect=mail_adapter.notify, autospec=True)
     @mock.patch.object(MessageBuilder, "send_async", autospec=True)
     def test_notify_digest_single_record(self, send_async, notify):


### PR DESCRIPTION
Make sure that we don't send digest notifications for rules that have been muted.