### PR TITLE
feat(loader): Show Loader Script on DSN overview

### DIFF
--- a/fixtures/js-stubs/projectKeys.js
+++ b/fixtures/js-stubs/projectKeys.js
@@ -7,6 +7,7 @@ export function ProjectKeys(params = []) {
         minidump:
           'http://dev.getsentry.net:8000/api/1/minidump?sentry_key=188ee45a58094d939428d8585aa6f661',
         public: 'http://188ee45a58094d939428d8585aa6f661@dev.getsentry.net:8000/1',
+        cdn: 'http://dev.getsentry.net:800/js-sdk-loader/188ee45a58094d939428d8585aa6f661.min.js',
         csp: 'http://dev.getsentry.net:8000/api/1/csp-report/?sentry_key=188ee45a58094d939428d8585aa6f661',
         security:
           'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f661',

--- a/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.spec.tsx
@@ -44,7 +44,7 @@ describe('Key Settings', function () {
     );
 
     // Panel title
-    expect(screen.getByText('JavaScript Loader')).toBeInTheDocument();
+    expect(screen.getByText('JavaScript Loader Script')).toBeInTheDocument();
 
     // SDK loader options
     for (const key of Object.keys(sdkLoaderOptions)) {

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -102,7 +102,7 @@ export function KeySettings({onRemove, organization, params, data}: Props) {
           />
 
           <Panel>
-            <PanelHeader>{t('JavaScript Loader')}</PanelHeader>
+            <PanelHeader>{t('JavaScript Loader Script')}</PanelHeader>
             <PanelBody>
               <PanelAlert type="info" showIcon>
                 {t('Note that it can take a few minutes until changed options are live.')}

--- a/static/app/views/settings/project/projectKeys/list/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.jsx
@@ -123,6 +123,14 @@ describe('ProjectKeys', function () {
     expect(minidumpEndpoint).not.toBeInTheDocument();
     expect(unrealEndpoint).not.toBeInTheDocument();
     expect(securityHeaderEndpoint).not.toBeInTheDocument();
+
+    // Loader Script is rendered
+    expect(screen.getByText('Loader Script')).toBeInTheDocument();
+    const loaderScript = screen.queryByRole('textbox', {
+      name: 'Loader Script',
+    });
+    const loaderScriptValue = loaderScript.value;
+    expect(loaderScriptValue).toEqual(expect.stringContaining(projectKeys[0].dsn.cdn));
   });
 
   it('renders for javascript-react project', function () {
@@ -152,6 +160,7 @@ describe('ProjectKeys', function () {
     expect(minidumpEndpoint).not.toBeInTheDocument();
     expect(unrealEndpoint).not.toBeInTheDocument();
     expect(securityHeaderEndpoint).not.toBeInTheDocument();
+    expect(screen.queryByText('Loader Script')).not.toBeInTheDocument();
   });
 
   it('renders multiple keys', function () {

--- a/static/app/views/settings/project/projectKeys/list/index.spec.jsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.jsx
@@ -126,7 +126,7 @@ describe('ProjectKeys', function () {
 
     // Loader Script is rendered
     expect(screen.getByText('Loader Script')).toBeInTheDocument();
-    const loaderScript = screen.queryByRole('textbox', {
+    const loaderScript = screen.getByRole('textbox', {
       name: 'Loader Script',
     });
     const loaderScriptValue = loaderScript.value;

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -43,7 +43,7 @@ function KeyRow({
 
   const platform = project.platform || 'other';
   const isBrowserJavaScript = platform === 'javascript';
-  const isJsPlatform = isBrowserJavaScript || platform.startsWith('javascript-');
+  const isJsPlatform = platform.startsWith('javascript');
 
   return (
     <Panel>

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -11,6 +11,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Project, Scope} from 'sentry/types';
 import recreateRoute from 'sentry/utils/recreateRoute';
+import {LoaderScript} from 'sentry/views/settings/project/projectKeys/list/loaderScript';
 import ProjectKeyCredentials from 'sentry/views/settings/project/projectKeys/projectKeyCredentials';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
@@ -41,7 +42,8 @@ function KeyRow({
   const controlActive = access.has('project:write');
 
   const platform = project.platform || 'other';
-  const isJsPlatform = platform === 'javascript' || platform.startsWith('javascript-');
+  const isBrowserJavaScript = platform === 'javascript';
+  const isJsPlatform = isBrowserJavaScript || platform.startsWith('javascript-');
 
   return (
     <Panel>
@@ -103,6 +105,15 @@ function KeyRow({
             showUnreal={!isJsPlatform}
             showSecurityEndpoint={!isJsPlatform}
           />
+
+          {isBrowserJavaScript && (
+            <LoaderScript
+              projectKey={data}
+              routes={routes}
+              location={location}
+              params={params}
+            />
+          )}
         </StyledPanelBody>
       </StyledClippedBox>
     </Panel>

--- a/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
+++ b/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
@@ -1,0 +1,58 @@
+import {Fragment} from 'react';
+import {RouteComponentProps} from 'react-router';
+
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import FieldHelp from 'sentry/components/forms/fieldGroup/fieldHelp';
+import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t, tct} from 'sentry/locale';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import recreateRoute from 'sentry/utils/recreateRoute';
+import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
+
+type Props = {
+  projectKey: ProjectKey;
+} & Pick<RouteComponentProps<{}, {}>, 'routes' | 'location' | 'params'>;
+
+export function LoaderScript({projectKey, routes, params, location}: Props) {
+  const loaderLink = getDynamicText({
+    value: projectKey.dsn.cdn,
+    fixed: '__JS_SDK_LOADER_URL__',
+  });
+
+  const editUrl = recreateRoute(`${projectKey.id}/`, {routes, params, location});
+
+  return (
+    <Fragment>
+      <FieldGroup
+        label={t('Loader Script')}
+        help={tct(
+          'Copy this script into your website to setup your JavaScript SDK without any additional configuration. [link]',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/lazy-load-sentry/">
+                {t(' What does the script provide?')}
+              </ExternalLink>
+            ),
+          }
+        )}
+        inline={false}
+        flexibleControlStateSize
+      >
+        <TextCopyInput aria-label={t('Loader Script')}>
+          {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
+        </TextCopyInput>
+
+        <FieldHelp style={{marginTop: 10, marginBottom: 0}}>
+          {tct(
+            'You can [configureLink] the Loader Script to enable/disable Performance, Replay, and more.',
+            {
+              configureLink: <Link to={editUrl}>{t('configure')}</Link>,
+            }
+          )}
+        </FieldHelp>
+      </FieldGroup>
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
+++ b/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
@@ -48,9 +48,9 @@ export function LoaderScript({projectKey, routes, params, location}: Props) {
 
         <HelpFooter>
           {tct(
-            'You can [configureLink] the Loader Script to enable/disable Performance, Replay, and more.',
+            'You can [configureLink:configure] the Loader Script to enable/disable Performance, Replay, and more.',
             {
-              configureLink: <Link to={editUrl}>{t('configure')}</Link>,
+              configureLink: <Link to={editUrl} />,
             }
           )}
         </HelpFooter>

--- a/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
+++ b/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import FieldHelp from 'sentry/components/forms/fieldGroup/fieldHelp';
@@ -7,6 +8,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
@@ -44,15 +46,19 @@ export function LoaderScript({projectKey, routes, params, location}: Props) {
           {`<script src='${loaderLink}' crossorigin="anonymous"></script>`}
         </TextCopyInput>
 
-        <FieldHelp style={{marginTop: 10, marginBottom: 0}}>
+        <HelpFooter>
           {tct(
             'You can [configureLink] the Loader Script to enable/disable Performance, Replay, and more.',
             {
               configureLink: <Link to={editUrl}>{t('configure')}</Link>,
             }
           )}
-        </FieldHelp>
+        </HelpFooter>
       </FieldGroup>
     </Fragment>
   );
 }
+
+const HelpFooter = styled(FieldHelp)`
+  margin-top: ${space(1)};
+`;


### PR DESCRIPTION
This updates the DSN overview page for Browser JS projects to show the Loader Script in there.

it also aligns the naming to be "Loader Script" (or "JavaScript Loader Script" on the detail page - as there it is also shown for non-JS projects. 🤔 )

![image](https://user-images.githubusercontent.com/2411343/234541732-e9b8b98d-5ca9-4d7a-9b18-5cd63c907ce1.png)

The "configure" link just sends to "Configure", but I figured it would be nice to indicate that it _can_ even be configured at all.