### PR TITLE
feat(starfish): Add a cumulative time breakdown of modules

### DIFF
--- a/static/app/views/starfish/components/breakdownBar.tsx
+++ b/static/app/views/starfish/components/breakdownBar.tsx
@@ -1,0 +1,307 @@
+import {Fragment, useState} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {percent} from 'sentry/utils';
+import {useQuery} from 'sentry/utils/queryClient';
+import {DatabaseDurationChart} from 'sentry/views/starfish/views/webServiceView/databaseDurationChart';
+import {HttpBreakdownChart} from 'sentry/views/starfish/views/webServiceView/httpBreakdownChart';
+import {
+  DB_TIME_SPENT,
+  OTHER_DOMAINS,
+  TOP_DOMAINS,
+} from 'sentry/views/starfish/views/webServiceView/queries';
+
+const COLORS = ['#402A65', '#694D99', '#9A81C4', '#BBA6DF', '#EAE2F8'];
+const TOOLTIP_DELAY = 800;
+const HOST = 'http://localhost:8080';
+
+type ModuleSegment = {
+  module: string;
+  sum: number;
+};
+type Props = {
+  segments: ModuleSegment[];
+  title: string;
+};
+
+function FacetBreakdownBar({segments, title}: Props) {
+  const [hoveredValue, setHoveredValue] = useState<ModuleSegment | null>(null);
+  const [currentSegment, setCurrentSegment] = useState<
+    ModuleSegment['module'] | undefined
+  >(segments[0]?.module);
+  const totalValues = segments.reduce((acc, segment) => acc + segment.sum, 0);
+
+  const {isLoading: isDurationDataLoading, data: moduleDurationData} = useQuery({
+    queryKey: ['topDomains'],
+    queryFn: () => fetch(`${HOST}/?query=${TOP_DOMAINS}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+
+  const {isLoading: isOtherDurationDataLoading, data: moduleOtherDurationData} = useQuery(
+    {
+      queryKey: ['otherDomains'],
+      queryFn: () => fetch(`${HOST}/?query=${OTHER_DOMAINS}`).then(res => res.json()),
+      retry: false,
+      initialData: [],
+    }
+  );
+
+  const {isLoading: isDbDurationLoading, data: dbDurationData} = useQuery({
+    queryKey: ['databaseDuration'],
+    queryFn: () => fetch(`${HOST}/?query=${DB_TIME_SPENT}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+
+  function renderTitle() {
+    return (
+      <Title>
+        <TitleType>{title}</TitleType>
+      </Title>
+    );
+  }
+
+  function renderSegments() {
+    if (totalValues === 0) {
+      return (
+        <SegmentBar>
+          <p>{t('No recent data.')}</p>
+        </SegmentBar>
+      );
+    }
+
+    return (
+      <SegmentBar>
+        {segments.map((value, index) => {
+          const pct = percent(value.sum, totalValues);
+          const pctLabel = Math.floor(pct);
+          const segmentProps = {
+            index,
+            onClick: () => {
+              setCurrentSegment(value.module);
+            },
+          };
+          return (
+            <div
+              key={`segment-${value.module}`}
+              style={{width: pct + '%'}}
+              onMouseOver={() => {
+                setHoveredValue(value);
+              }}
+              onMouseLeave={() => setHoveredValue(null)}
+            >
+              <Tooltip skipWrapper delay={TOOLTIP_DELAY} title={value.module}>
+                <Segment
+                  aria-label={`${value.module} ${t('segment')}`}
+                  color={COLORS[index]}
+                  {...segmentProps}
+                >
+                  {/* if the first segment is 6% or less, the label won't fit cleanly into the segment, so don't show the label */}
+                  {index === 0 && pctLabel > 6 ? `${pctLabel}%` : null}
+                </Segment>
+              </Tooltip>
+            </div>
+          );
+        })}
+      </SegmentBar>
+    );
+  }
+
+  function renderLegend() {
+    return (
+      <LegendAnimateContainer expanded animate={{height: '100%', opacity: 1}}>
+        <LegendContainer>
+          {segments.map((segment, index) => {
+            const pctLabel = Math.floor(percent(segment.sum, totalValues));
+            const unfocus = !!hoveredValue && hoveredValue.module !== segment.module;
+            const focus = hoveredValue?.module === segment.module;
+
+            return (
+              <li key={`segment-${segment.module}-${index}`}>
+                <LegendRow
+                  onMouseOver={() => setHoveredValue(segment)}
+                  onMouseLeave={() => setHoveredValue(null)}
+                  onClick={() => setCurrentSegment(segment.module)}
+                >
+                  <LegendDot color={COLORS[index]} focus={focus} />
+                  <LegendText unfocus={unfocus}>
+                    {segment.module ?? (
+                      <NotApplicableLabel>{t('n/a')}</NotApplicableLabel>
+                    )}
+                  </LegendText>
+                  {<LegendPercent>{`${pctLabel}%`}</LegendPercent>}
+                </LegendRow>
+              </li>
+            );
+          })}
+        </LegendContainer>
+      </LegendAnimateContainer>
+    );
+  }
+
+  function renderChart(mod: string | undefined) {
+    switch (mod) {
+      case 'http':
+        return (
+          <HttpBreakdownChart
+            isDurationDataLoading={isDurationDataLoading}
+            isOtherDurationDataLoading={isOtherDurationDataLoading}
+            moduleDurationData={moduleDurationData}
+            moduleOtherDurationData={moduleOtherDurationData}
+          />
+        );
+      case 'db':
+      default:
+        return (
+          <DatabaseDurationChart
+            isDbDurationLoading={isDbDurationLoading}
+            dbDurationData={dbDurationData}
+          />
+        );
+    }
+  }
+
+  return (
+    <Fragment>
+      <TagSummary>
+        <details open aria-expanded onClick={e => e.preventDefault()}>
+          <StyledSummary>
+            <TagHeader>
+              {renderTitle()}
+              {renderSegments()}
+            </TagHeader>
+          </StyledSummary>
+          {renderLegend()}
+        </details>
+      </TagSummary>
+      {renderChart(currentSegment)}
+    </Fragment>
+  );
+}
+
+export default FacetBreakdownBar;
+
+const TagSummary = styled('div')`
+  margin-bottom: ${space(2)};
+`;
+
+const TagHeader = styled('span')<{clickable?: boolean}>`
+  ${p => (p.clickable ? 'cursor: pointer' : null)};
+`;
+
+const SegmentBar = styled('div')`
+  display: flex;
+  overflow: hidden;
+`;
+
+const Title = styled('div')`
+  display: flex;
+  font-size: ${p => p.theme.fontSizeMedium};
+  justify-content: space-between;
+  margin-bottom: ${space(1)};
+  line-height: 1.1;
+`;
+
+const TitleType = styled('div')`
+  flex: none;
+  color: ${p => p.theme.textColor};
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-right: ${space(1)};
+  align-self: center;
+`;
+
+const Segment = styled('span', {shouldForwardProp: isPropValid})<{color: string}>`
+  &:hover {
+    color: ${p => p.theme.white};
+  }
+  display: block;
+  width: 100%;
+  height: ${space(2)};
+  color: ${p => p.theme.white};
+  outline: none;
+  background-color: ${p => p.color};
+  text-align: right;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: 1px ${space(0.5)} 0 0;
+`;
+
+const LegendAnimateContainer = styled(motion.div, {
+  shouldForwardProp: prop =>
+    prop === 'animate' || (prop !== 'expanded' && isPropValid(prop)),
+})<{expanded: boolean}>`
+  height: 0;
+  opacity: 0;
+  ${p => (!p.expanded ? 'overflow: hidden;' : '')}
+`;
+
+const LegendContainer = styled('ol')`
+  list-style: none;
+  padding: 0;
+  margin: ${space(1)} 0;
+`;
+
+const LegendRow = styled('div')`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: ${space(0.5)} 0;
+`;
+
+const LegendDot = styled('span')<{color: string; focus: boolean}>`
+  padding: 0;
+  position: relative;
+  width: 11px;
+  height: 11px;
+  text-indent: -9999em;
+  display: inline-block;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background-color: ${p => p.color};
+  &:after {
+    content: '';
+    border-radius: 50%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    outline: ${p => p.theme.gray100} ${space(0.5)} solid;
+    opacity: ${p => (p.focus ? '1' : '0')};
+    transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+`;
+
+const LegendText = styled('span')<{unfocus: boolean}>`
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin-left: ${space(1)};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  transition: color 0.3s;
+  color: ${p => (p.unfocus ? p.theme.gray300 : p.theme.gray400)};
+`;
+
+const LegendPercent = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin-left: ${space(1)};
+  color: ${p => p.theme.gray300};
+  text-align: right;
+  flex-grow: 1;
+`;
+
+const NotApplicableLabel = styled('span')`
+  color: ${p => p.theme.gray300};
+`;
+
+const StyledSummary = styled('summary')`
+  &::-webkit-details-marker {
+    display: none;
+  }
+`;

--- a/static/app/views/starfish/views/webServiceView/databaseDurationChart.tsx
+++ b/static/app/views/starfish/views/webServiceView/databaseDurationChart.tsx
@@ -3,7 +3,6 @@ import moment from 'moment';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {t} from 'sentry/locale';
 import {Series} from 'sentry/types/echarts';
-import {useQuery} from 'sentry/utils/queryClient';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
@@ -13,19 +12,9 @@ import {
   ModuleButtonType,
   ModuleLinkButton,
 } from 'sentry/views/starfish/views/webServiceView/moduleLinkButton';
-import {DB_TIME_SPENT} from 'sentry/views/starfish/views/webServiceView/queries';
 
-const HOST = 'http://localhost:8080';
-
-export function DatabaseDurationChart() {
+export function DatabaseDurationChart({isDbDurationLoading, dbDurationData}) {
   const pageFilter = usePageFilters();
-
-  const {isLoading: isDbDurationLoading, data: dbDurationData} = useQuery({
-    queryKey: ['databaseDuration'],
-    queryFn: () => fetch(`${HOST}/?query=${DB_TIME_SPENT}`).then(res => res.json()),
-    retry: false,
-    initialData: [],
-  });
 
   const series: {[module: string]: Series} = {};
   if (!isDbDurationLoading) {
@@ -54,7 +43,7 @@ export function DatabaseDurationChart() {
   const button = <ModuleLinkButton type={ModuleButtonType.DB} />;
 
   return (
-    <ChartPanel title={t('p75 of Time Spent in Database')} button={button}>
+    <ChartPanel title={t('p75 of database spans')} button={button}>
       <Chart
         statsPeriod="24h"
         height={180}

--- a/static/app/views/starfish/views/webServiceView/failureRateChart.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureRateChart.tsx
@@ -6,13 +6,11 @@ import {AreaChartProps} from 'sentry/components/charts/areaChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import {LineChart} from 'sentry/components/charts/lineChart';
 import CHART_PALETTE from 'sentry/constants/chartPalette';
-import {t} from 'sentry/locale';
 import {DateString} from 'sentry/types';
 import {EChartClickHandler, Series} from 'sentry/types/echarts';
 import {tooltipFormatter} from 'sentry/utils/discover/charts';
 import {formatPercentage} from 'sentry/utils/formatters';
 import useRouter from 'sentry/utils/useRouter';
-import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 
 type Props = {
   data: Series[];
@@ -97,22 +95,20 @@ function FailureRateChart({
     : undefined;
 
   return (
-    <ChartPanel title={t('Error Rate')}>
-      <ChartZoom router={router} period={statsPeriod} start={start} end={end} utc={utc}>
-        {zoomRenderProps => (
-          <LineChart
-            onClick={handleSpikeAreaClick}
-            height={height}
-            {...zoomRenderProps}
-            series={data}
-            previousPeriod={previousData}
-            xAxis={xAxis}
-            yAxis={yAxis}
-            tooltip={chartProps.tooltip}
-          />
-        )}
-      </ChartZoom>
-    </ChartPanel>
+    <ChartZoom router={router} period={statsPeriod} start={start} end={end} utc={utc}>
+      {zoomRenderProps => (
+        <LineChart
+          onClick={handleSpikeAreaClick}
+          height={height}
+          {...zoomRenderProps}
+          series={data}
+          previousPeriod={previousData}
+          xAxis={xAxis}
+          yAxis={yAxis}
+          tooltip={chartProps.tooltip}
+        />
+      )}
+    </ChartZoom>
   );
 }
 

--- a/static/app/views/starfish/views/webServiceView/httpBreakdownChart.tsx
+++ b/static/app/views/starfish/views/webServiceView/httpBreakdownChart.tsx
@@ -1,45 +1,26 @@
+import isNil from 'lodash/isNil';
 import moment from 'moment';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {t} from 'sentry/locale';
 import {Series} from 'sentry/types/echarts';
-import {useQuery} from 'sentry/utils/queryClient';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
-import {PERIOD_REGEX} from 'sentry/views/starfish/utils/dates';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 import {
   ModuleButtonType,
   ModuleLinkButton,
 } from 'sentry/views/starfish/views/webServiceView/moduleLinkButton';
-import {
-  OTHER_DOMAINS,
-  TOP_DOMAINS,
-} from 'sentry/views/starfish/views/webServiceView/queries';
 
-const HOST = 'http://localhost:8080';
-
-export function HttpBreakdownChart() {
-  const pageFilter = usePageFilters();
-
-  const {isLoading: isDurationDataLoading, data: moduleDurationData} = useQuery({
-    queryKey: ['topDomains'],
-    queryFn: () => fetch(`${HOST}/?query=${TOP_DOMAINS}`).then(res => res.json()),
-    retry: false,
-    initialData: [],
-  });
-
-  const {isLoading: isOtherDurationDataLoading, data: moduleOtherDurationData} = useQuery(
-    {
-      queryKey: ['otherDomains'],
-      queryFn: () => fetch(`${HOST}/?query=${OTHER_DOMAINS}`).then(res => res.json()),
-      retry: false,
-      initialData: [],
-    }
-  );
-
+export function HttpBreakdownChart({
+  isDurationDataLoading,
+  moduleDurationData,
+  isOtherDurationDataLoading,
+  moduleOtherDurationData,
+}) {
   const seriesByDomain: {[module: string]: Series} = {};
+  let start: moment.Moment | undefined = undefined;
+  let end: moment.Moment | undefined = undefined;
   if (!isDurationDataLoading && !isOtherDurationDataLoading) {
     moduleDurationData.forEach(series => {
       seriesByDomain[series.domain] = {
@@ -49,6 +30,12 @@ export function HttpBreakdownChart() {
     });
 
     moduleDurationData.forEach(value => {
+      if (isNil(start) || moment(value.inteval) < start) {
+        start = moment(value.interval);
+      }
+      if (isNil(end) || moment(value.inteval) > end) {
+        end = moment(value.interval);
+      }
       seriesByDomain[value.domain].data.push({value: value.p75, name: value.interval});
     });
 
@@ -58,18 +45,15 @@ export function HttpBreakdownChart() {
     };
 
     moduleOtherDurationData.forEach(value => {
+      if (isNil(start) || moment(value.inteval) < start) {
+        start = moment(value.interval);
+      }
+      if (isNil(end) || moment(value.inteval) > end) {
+        end = moment(value.interval);
+      }
       seriesByDomain.Other.data.push({value: value.p75, name: value.interval});
     });
   }
-
-  // TODO: Add to a util instead, copied from APIModuleView
-  const [_, num, unit] = pageFilter.selection.datetime.period?.match(PERIOD_REGEX) ?? [];
-  const start =
-    num && unit
-      ? moment().subtract(num, unit as 'h' | 'd')
-      : moment(pageFilter.selection.datetime.start);
-  const end = moment(pageFilter.selection.datetime.end ?? undefined);
-
   const data = Object.values(seriesByDomain).map(series =>
     zeroFillSeries(series, moment.duration(1, 'day'), start, end)
   );
@@ -77,7 +61,7 @@ export function HttpBreakdownChart() {
   const button = <ModuleLinkButton type={ModuleButtonType.API} />;
 
   return (
-    <ChartPanel title={t('p75 of Time Spent in HTTP Ops')} button={button}>
+    <ChartPanel title={t('p75 of HTTP spans')} button={button}>
       <Chart
         statsPeriod="24h"
         height={180}

--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -1,3 +1,11 @@
+export const MODULE_BREAKDOWN = `SELECT
+ sum(exclusive_time) as sum, module
+ FROM spans_experimental_starfish
+ WHERE module != 'none'
+ GROUP BY module
+ ORDER BY -sum
+`;
+
 export const TOP_DOMAINS = `SELECT
  quantile(0.75)(exclusive_time) as p75, domain,
  toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval


### PR DESCRIPTION
Cumulative time is kinda like "load", it can help you prioritize which parts of the app you should look into speeding up for the biggest impact.
What I'm doing is basically an initial breakdown by cumulative load to help prioritize the module duration chart we should show. The chart will be a pXX(duration) chart, because that's the metric you want to see if it got worse, and want to fix.

Also added a throughput chart.

![Screenshot 2023-04-26 at 11 11 35 AM](https://user-images.githubusercontent.com/63818634/234620850-a6ff6aa9-653d-4d2e-ae91-2db637496d17.png)
