### PR TITLE
feat(replays): generate replay links without a project slug

### DIFF
--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -184,11 +184,9 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
       return {};
     }
 
-    const replaySlug = `${tableRow['project.name']}:${replayId}`;
-
     if (!tableRow.timestamp) {
       return {
-        pathname: `/organizations/${organization.slug}/replays/${replaySlug}/`,
+        pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
         query: {
           referrer,
         },
@@ -201,7 +199,7 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
       : undefined;
 
     return {
-      pathname: `/organizations/${organization.slug}/replays/${replaySlug}/`,
+      pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
       query: {
         event_t: transactionStartTimestamp,
         referrer,


### PR DESCRIPTION
## Summary
Generate replay links without a projectSlug.

Depends on: https://github.com/getsentry/sentry/pull/47949
Note: for the sake of legibility i've created this PR to merge into [elias/replays/use-replay-data-without-project](https://github.com/getsentry/sentry/tree/elias/replays/use-replay-data-without-project)