### PR TITLE
fix(dynamic-sampling): Fix get_rule_type for low volume transactions

### DIFF
--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -131,6 +131,12 @@ def get_rule_type(rule: Rule) -> Optional[RuleType]:
         < RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE] + BOOSTED_RELEASES_LIMIT
     ):
         return RuleType.BOOST_LATEST_RELEASES_RULE
+    elif (
+        RESERVED_IDS[RuleType.BOOST_LOW_VOLUME_TRANSACTIONS]
+        <= rule["id"]
+        < RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE]
+    ):
+        return RuleType.BOOST_LOW_VOLUME_TRANSACTIONS
 
     return REVERSE_RESERVED_IDS.get(rule["id"], None)
 
@@ -225,7 +231,8 @@ def actual_sample_rate(count_keep: int, count_drop: int) -> float:
 
 def adjusted_factor(prev_factor: float, actual_rate: float, desired_sample_rate: float) -> float:
     """
-    Calculates an adjustment factor in order to bring the actual sample rate to the blended_sample rate (i.e. desired_sample_rate)
+    Calculates an adjustment factor in order to bring the actual sample rate to the blended_sample rate (i.e.
+    desired_sample_rate)
     """
     assert prev_factor != 0.0
     return prev_factor * (desired_sample_rate / actual_rate)


### PR DESCRIPTION
This PR fixes the get_rule_type which was not functioning correctly for low volume transactions rules