### PR TITLE
ref(replays): remove references to replaySlug in useInitialTimeOffsetMs

### DIFF
--- a/static/app/utils/replays/hooks/useInitialTimeOffsetMs.spec.tsx
+++ b/static/app/utils/replays/hooks/useInitialTimeOffsetMs.spec.tsx
@@ -44,7 +44,8 @@ describe('useInitialTimeOffsetMs', () => {
       const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
-          replaySlug: `${project.slug}:${replay.id}`,
+          projectSlug: project.slug,
+          replayId: replay.id,
           replayStartTimestampMs: undefined,
         },
       });
@@ -64,7 +65,8 @@ describe('useInitialTimeOffsetMs', () => {
       const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
-          replaySlug: `${project.slug}:${replay.id}`,
+          projectSlug: project.slug,
+          replayId: replay.id,
           replayStartTimestampMs: undefined,
         },
       });
@@ -85,7 +87,8 @@ describe('useInitialTimeOffsetMs', () => {
       const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
-          replaySlug: `${project.slug}:${replay.id}`,
+          projectSlug: project.slug,
+          replayId: replay.id,
           replayStartTimestampMs: new Date(noon).getTime(),
         },
       });
@@ -103,7 +106,8 @@ describe('useInitialTimeOffsetMs', () => {
         {
           initialProps: {
             orgSlug: organization.slug,
-            replaySlug: `${project.slug}:${replay.id}`,
+            projectSlug: project.slug,
+            replayId: replay.id,
             replayStartTimestampMs: undefined,
           },
         }
@@ -114,7 +118,8 @@ describe('useInitialTimeOffsetMs', () => {
 
       rerender({
         orgSlug: organization.slug,
-        replaySlug: `${project.slug}:${replay.id}`,
+        projectSlug: project.slug,
+        replayId: replay.id,
         replayStartTimestampMs: new Date(NOON).getTime(),
       });
       await waitForNextUpdate();
@@ -137,7 +142,8 @@ describe('useInitialTimeOffsetMs', () => {
       const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
-          replaySlug: `${project.slug}:${replay.id}`,
+          projectSlug: project.slug,
+          replayId: replay.id,
           replayStartTimestampMs: new Date(NOON).getTime(),
         },
       });
@@ -155,7 +161,8 @@ describe('useInitialTimeOffsetMs', () => {
       const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
-          replaySlug: `${project.slug}:${replay.id}`,
+          projectSlug: project.slug,
+          replayId: replay.id,
           replayStartTimestampMs: new Date(NOON).getTime(),
         },
       });
@@ -176,7 +183,8 @@ describe('useInitialTimeOffsetMs', () => {
       const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
-          replaySlug: `${project.slug}:${replay.id}`,
+          projectSlug: project.slug,
+          replayId: replay.id,
           replayStartTimestampMs: new Date(NOON).getTime(),
         },
       });
@@ -200,7 +208,8 @@ describe('useInitialTimeOffsetMs', () => {
         {
           initialProps: {
             orgSlug: organization.slug,
-            replaySlug: `${project.slug}:${replay.id}`,
+            projectSlug: project.slug,
+            replayId: replay.id,
             replayStartTimestampMs: undefined,
           },
         }
@@ -212,7 +221,8 @@ describe('useInitialTimeOffsetMs', () => {
 
       rerender({
         orgSlug: organization.slug,
-        replaySlug: `${project.slug}:${replay.id}`,
+        projectSlug: project.slug,
+        replayId: replay.id,
         replayStartTimestampMs: new Date(NOON).getTime(),
       });
       await waitForNextUpdate();

--- a/static/app/utils/replays/hooks/useInitialTimeOffsetMs.tsx
+++ b/static/app/utils/replays/hooks/useInitialTimeOffsetMs.tsx
@@ -33,9 +33,13 @@ type Opts = {
    */
   orgSlug: string;
   /**
-   * The concatenation of: `${projectSlug}:${replayId}`
+   * The project slug of the replayRecord
    */
-  replaySlug: string;
+  projectSlug: string | null;
+  /**
+   * The replayId
+   */
+  replayId: string;
 
   /**
    * The start timestamp of the replay.
@@ -73,7 +77,8 @@ async function fromListPageQuery({
   api,
   listPageQuery,
   orgSlug,
-  replaySlug,
+  replayId,
+  projectSlug,
   replayStartTimestampMs,
 }) {
   if (listPageQuery === undefined) {
@@ -94,7 +99,9 @@ async function fromListPageQuery({
     return 0;
   }
 
-  const [projectSlug, replayId] = replaySlug.split(':');
+  if (!projectSlug) {
+    return undefined;
+  }
 
   const results = await fetchReplayClicks({
     api,
@@ -115,7 +122,12 @@ async function fromListPageQuery({
   }
 }
 
-function useInitialTimeOffsetMs({orgSlug, replaySlug, replayStartTimestampMs}: Opts) {
+function useInitialTimeOffsetMs({
+  orgSlug,
+  replayId,
+  projectSlug,
+  replayStartTimestampMs,
+}: Opts) {
   const api = useApi();
   const {
     query: {event_t: eventTimestamp, query: listPageQuery, t: offsetSec},
@@ -137,11 +149,20 @@ function useInitialTimeOffsetMs({orgSlug, replaySlug, replayStartTimestampMs}: O
             api,
             listPageQuery,
             orgSlug,
-            replaySlug,
+            replayId,
+            projectSlug,
             replayStartTimestampMs,
           })
         : undefined,
-    [api, eventTimestamp, listPageQuery, orgSlug, replaySlug, replayStartTimestampMs]
+    [
+      api,
+      eventTimestamp,
+      listPageQuery,
+      orgSlug,
+      replayId,
+      projectSlug,
+      replayStartTimestampMs,
+    ]
   );
 
   useEffect(() => {
@@ -151,7 +172,7 @@ function useInitialTimeOffsetMs({orgSlug, replaySlug, replayStartTimestampMs}: O
       .then(definedOrDefault(queryTimeMs))
       .then(definedOrDefault(0))
       .then(setTimestamp);
-  }, [offsetTimeMs, eventTimeMs, queryTimeMs]);
+  }, [offsetTimeMs, eventTimeMs, queryTimeMs, projectSlug]);
 
   return timestamp;
 }

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -80,6 +80,8 @@ describe('useReplayData', () => {
       onRetry: expect.any(Function),
       replay: expect.any(ReplayReader),
       replayRecord: expectedReplay,
+      projectSlug: project.slug,
+      replayId: expectedReplay.id,
     });
   });
 
@@ -259,6 +261,8 @@ describe('useReplayData', () => {
       onRetry: expect.any(Function),
       replay: null,
       replayRecord: undefined,
+      projectSlug: null,
+      replayId: expectedReplay.id,
     } as Record<string, unknown>;
 
     // Immediately we will see the replay call is made
@@ -285,6 +289,7 @@ describe('useReplayData', () => {
       errors: [],
     });
     expectedReplayData.replayRecord = expectedReplay;
+    expectedReplayData.projectSlug = project.slug;
     expectedReplayData.replay = expect.any(ReplayReader);
     expect(result.current).toEqual(expectedReplayData);
 
@@ -336,6 +341,8 @@ describe('useReplayData', () => {
       onRetry: expect.any(Function),
       replay: expect.any(ReplayReader),
       replayRecord: expectedReplay,
+      projectSlug: project.slug,
+      replayId: expectedReplay.id,
     });
   });
 });

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -54,7 +54,9 @@ interface Result {
   fetchError: undefined | RequestError;
   fetching: boolean;
   onRetry: () => void;
+  projectSlug: string | null;
   replay: ReplayReader | null;
+  replayId: string;
   replayRecord: ReplayRecord | undefined;
 }
 
@@ -109,7 +111,7 @@ function useReplayData({
     if (!replayRecord) {
       return null;
     }
-    return projects.projects.find(p => p.id === replayRecord.project_id)?.slug;
+    return projects.projects.find(p => p.id === replayRecord.project_id)?.slug ?? null;
   }, [replayRecord, projects.projects]);
 
   // Fetch every field of the replay. We're overfetching, not every field is used
@@ -235,6 +237,8 @@ function useReplayData({
     onRetry: loadData,
     replay,
     replayRecord,
+    projectSlug,
+    replayId,
   };
 }
 

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -35,14 +35,18 @@ function ReplayDetails({params: {replaySlug}}: Props) {
   const organization = useOrganization();
   const {slug: orgSlug} = organization;
 
-  const {fetching, onRetry, replay, replayRecord, fetchError} = useReplayData({
-    replaySlug,
-    orgSlug,
-  });
+  // TODO: replayId is known ahead of time and useReplayData is parsing it from the replaySlug
+  // once we fix the route params and links we should fix this to accept replayId and stop returning it
+  const {fetching, onRetry, replay, replayRecord, fetchError, projectSlug, replayId} =
+    useReplayData({
+      replaySlug,
+      orgSlug,
+    });
 
   const initialTimeOffsetMs = useInitialTimeOffsetMs({
     orgSlug,
-    replaySlug,
+    projectSlug,
+    replayId,
     replayStartTimestampMs: replayRecord?.started_at.getTime(),
   });
 


### PR DESCRIPTION
## Summary
Update `useInitialTimeOffsetMs` to accept `projectSlug` and `replayId` instead of relying on `replaySlug` which changes in https://github.com/getsentry/sentry/pull/47949