### PR TITLE
feat(starfish): Span summary facets

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1732,7 +1732,7 @@ function buildRoutes() {
         component={make(() => import('sentry/views/starfish/modules/cacheModule'))}
       />
       <Route
-        path="span/:slug/"
+        path="span/:groupId/"
         component={make(() => import('sentry/views/starfish/views/spanSummary'))}
       />
     </Fragment>

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -141,3 +141,15 @@ export const getSpanInTransactionQuery = ({groupId, transactionName, datetime}) 
     GROUP BY span_operation
  `;
 };
+
+export const getSpanFacetBreakdownQuery = ({groupId, datetime}) => {
+  const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
+  // TODO - add back `module = <moudle> to filter data
+  return `
+    SELECT transaction, user, domain
+    FROM spans_experimental_starfish
+    WHERE group_id = '${groupId}'
+    ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
+    ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
+ `;
+};

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -128,14 +128,13 @@ export const getEndpointDetailTableQuery = ({
  `;
 };
 
-export const getSpanInTransactionQuery = ({groupId, transactionName, datetime}) => {
+export const getSpanInTransactionQuery = ({groupId, datetime}) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   // TODO - add back `module = <moudle> to filter data
   return `
     SELECT count() AS count, quantile(0.5)(exclusive_time) as p50, span_operation
     FROM spans_experimental_starfish
     WHERE group_id = '${groupId}'
-    ${transactionName ? `AND transaction = '${transactionName}'` : ''}
     ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
     ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
     GROUP BY span_operation

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -4,6 +4,7 @@ import {useQuery} from '@tanstack/react-query';
 import keyBy from 'lodash/keyBy';
 import merge from 'lodash/merge';
 import values from 'lodash/values';
+import * as qs from 'query-string';
 
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
@@ -157,9 +158,9 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
     if (key === 'transaction') {
       return (
         <Link
-          to={`/starfish/span/${encodeURIComponent(row.group_id)}:${encodeURIComponent(
-            dataRow.transaction
-          )}`}
+          to={`/starfish/span/${encodeURIComponent(row.group_id)}?${qs.stringify({
+            transaction: dataRow.transaction,
+          })}`}
         >
           {dataRow[column.key]}
         </Link>

--- a/static/app/views/starfish/views/endpointDetails/index.tsx
+++ b/static/app/views/starfish/views/endpointDetails/index.tsx
@@ -2,6 +2,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 import moment from 'moment';
+import * as qs from 'query-string';
 
 import Duration from 'sentry/components/duration';
 import GridEditable, {
@@ -204,9 +205,7 @@ function renderBodyCell(
     return (
       <OverflowEllipsisTextContainer>
         <Link
-          to={`/starfish/span/${encodeURIComponent(groupId)}:${encodeURIComponent(
-            row.transaction
-          )}`}
+          to={`/starfish/span/${groupId}?${qs.stringify({transaction: row.transaction})}`}
         >
           {row[column.key]}
         </Link>

--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -61,16 +61,13 @@ type Transaction = {
 
 type Props = {
   location: Location;
-} & RouteComponentProps<{slug: string}, {}>;
+} & RouteComponentProps<{groupId: string}, {}>;
 
 export default function SpanSummary({location, params}: Props) {
   const pageFilter = usePageFilters();
-  const slug = parseSlug(params.slug);
 
-  const {groupId, transactionName} = slug || {
-    groupId: '',
-    transactionName: '',
-  };
+  const groupId = params.groupId;
+  const transactionName = location.query.transaction;
 
   const query = getSpanInTransactionQuery({
     groupId,
@@ -117,9 +114,6 @@ export default function SpanSummary({location, params}: Props) {
     [key: Transaction['id']]: Transaction;
   };
 
-  if (!slug) {
-    return <div>ERROR</div>;
-  }
   const spanDescription = spanSampleData?.[0]?.description;
   const spanDomain = spanSampleData?.[0]?.domain;
 
@@ -259,27 +253,6 @@ function renderBodyCell(column: GridColumnHeader, row: SpanTableRow): React.Reac
   }
 
   return <span>{row[column.key]}</span>;
-}
-
-type SpanInTransactionSlug = {
-  groupId: string;
-  transactionName?: string;
-};
-
-function parseSlug(slug?: string): SpanInTransactionSlug | undefined {
-  if (!slug) {
-    return undefined;
-  }
-
-  const delimiterPosition = slug.lastIndexOf(':');
-  if (delimiterPosition < 0) {
-    return {groupId: slug};
-  }
-
-  const groupId = slug.slice(0, delimiterPosition);
-  const transactionName = slug.slice(delimiterPosition + 1);
-
-  return {groupId, transactionName};
 }
 
 function SpanGroupKeyValueList({

--- a/static/app/views/starfish/views/spanSummary/queries.tsx
+++ b/static/app/views/starfish/views/spanSummary/queries.tsx
@@ -4,21 +4,24 @@ import {datetimeToClickhouseFilterTimestamps} from 'sentry/views/starfish/utils/
 export const getSpanSamplesQuery = ({
   groupId,
   transactionName,
+  user,
   datetime,
 }: {
   groupId;
   transactionName;
+  user;
   datetime?: DateTimeObject;
 }) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `
-    SELECT description, transaction_id, span_id, exclusive_time, count() as count, domain
+    SELECT transaction_id, transaction, description, user, domain, span_id, sum(exclusive_time) as exclusive_time
     FROM spans_experimental_starfish
     WHERE group_id = '${groupId}'
     ${transactionName ? `AND transaction = '${transactionName}'` : ''}
+    ${user ? `AND user = '${user}'` : ''}
     ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
     ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
-    GROUP BY description, transaction_id, span_id, exclusive_time, domain
+    GROUP BY transaction_id, transaction, description, user, domain, span_id
     ORDER BY exclusive_time desc
     LIMIT 10
  `;


### PR DESCRIPTION
Adds a new feature to the span summary page: breakdown facets. Just transaction and query for now, but I'll expore more.

## Changes

- Pass span summary transaction as a parameter instead of splitting the slug
- Add facet breakdown UI
- Allow filtering using facet breakdown

**e.g.,**
<img width="1152" alt="Screenshot 2023-04-26 at 1 33 07 PM" src="https://user-images.githubusercontent.com/989898/234656895-9213abd4-678f-46bd-8129-3fc0095eb86e.png">
