### PR TITLE
ref(integrations): Stop creating new transaction in integrations client during server requests

### DIFF
--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -62,8 +62,6 @@ class SlackClient(IntegrationProxyClient):
         except ValueError:
             span.set_status(str(code))
 
-        span.set_tag("integration", "slack")
-
         is_ok = False
         # If Slack gives us back a 200 we still want to check the 'ok' param
         if resp:

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from typing import Any, Mapping, Optional, Union
 
 from requests import PreparedRequest, Response
-from sentry_sdk.tracing import Transaction
+from sentry_sdk.tracing import Span
 
 from sentry.constants import ObjectStatus
 from sentry.models.integrations.integration import Integration
@@ -47,10 +49,14 @@ class SlackClient(IntegrationProxyClient):
     def track_response_data(
         self,
         code: Union[str, int],
-        span: Transaction,
+        span: Span | None = None,
         error: Optional[str] = None,
         resp: Optional[Response] = None,
     ) -> None:
+        # if no span was passed, create a dummy to which to add data to avoid having to wrap every
+        # span call in `if span`
+        span = span or Span()
+
         try:
             span.set_http_status(int(code))
         except ValueError:

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -116,6 +116,9 @@ class BaseApiClient(TrackResponseMixin):
         currently_in_server_transaction = False
 
         with sentry_sdk.configure_scope() as scope:
+            if self.integration_type:
+                scope.set_tag(self.integration_type, self.name)
+
             if scope.span is not None:
                 parent_span_id = scope.span.span_id
                 trace_id = scope.span.trace_id

--- a/src/sentry/shared_integrations/track_response.py
+++ b/src/sentry/shared_integrations/track_response.py
@@ -57,8 +57,6 @@ class TrackResponseMixin:
         except ValueError:
             span.set_status(str(code))
 
-        span.set_tag(self.integration_type, self.name)
-
         extra = {
             "status_string": str(code),
             "error": str(error)[:256] if error else None,


### PR DESCRIPTION
Currently, if a request is made to an integration endpoint, and if as part of handling that request we use the `ApiClient` to make an outgoing request, two transactions are created: one for the incoming request to the endpoint (named after the endpoint in question), and one for the outgoing request to the external API (named `integration.http_response.<integration-name>` - more on that below under "Notes").

As a result, any errors which occur while making the API request are tagged with the latter `transaction` value, which for any given integration is the same no matter which of our endpoints was originally hit or what external endpoint the API request is to. In theory, the two transactions should be linked in a single trace, to which the error is also linked, making it possible to figure out the endpoints involved. In practice, though, most often the only one of those three events to come through is the error event. Sometimes the two endpoints can be found by digging through the stacktraces and local variables of the linked errors, or by looking at the `url` tag (if it's set), but it's not guaranteed. It also isn't data upon which snuba queries can be based, so it can't be used in Discover, dashboards, alerts, suggested assignees, etc.

It's also the case that the SDK already automatically creates a span for every outgoing request, and tags it with the same data the second transaction is tagged with in `track_response_data` (mostly - more on this below as well). So in these cases, the second transaction isn't really needed, and the consensus decision was to remove it. That said, I realized that such an outgoing request could be triggered under other circumstances (during tasks, for example), so in order to confine my changes to the use case described above, instead of simply removing the `start_transaction` call, I made it conditional on not already being in an incoming request transaction.

Key changes:

- Only start a transaction if there isn't already an incoming request transaction happening. Because this means `span` might therefore be `None`, make `span` argument optional in `track_response_data`.
- Move setting of `integration` tag from `track_response_data` into `_request`, and set it on the scope rather than on the span, so that it will get attached to both the transaction(s) _and_ any error events which occur, rather than just the second transaction.
- In cases where the second transaction _is_ created, annotate it with the name and `op` of the transaction it's replacing, so we can see if we should make this change (not creating the second transaction) in those cases as well.

Notes:

- It doesn't make a ton of sense that a transaction corresponding to an outgoing _request_ is called `<...>.http_response.<...>` rather than `<...>.http_request.<...>`, but in the interest of not making this PR too broad (and of not disrupting things other than the intended use case), I've left it alone for now.
- When I say "the automatically-created span is tagged with the same stuff as `track_response_data` adds," that is true in the general case, but not actually true in the case of the slack integration, which has its own `track_response_data` method which adds two more tags than the SDK adds automatically. Depending on how much we care about these tags (`ok` and `slack_error`), we can either choose to fix this separately or leave it be.

Ref: WOR-2953