### PR TITLE
ref(replays): updates search by click documentation copy

### DIFF
--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -128,7 +128,7 @@ function ReplaySearchBar(props: Props) {
       fieldDefinitionGetter={getReplayFieldDefinition}
       mergeSearchGroupWith={{
         click: {
-          documentation: t('Requires SDK version >= 7.44.0'),
+          documentation: t('Search by click selector. (Requires SDK version >= 7.44.0)'),
           titleBadge: <FeatureBadge type="new">{t('New')}</FeatureBadge>,
         },
       }}


### PR DESCRIPTION
## Summary
Adds some context around what searching by `click` actually means.
