### PR TITLE
fix(integrations): change logic for showing pending deletions

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -6,6 +6,7 @@ import type {
   INSTALLED,
   NOT_INSTALLED,
   PENDING,
+  PENDING_DELETION,
 } from 'sentry/views/settings/organizationIntegrations/constants';
 
 import type {Avatar, Choice, Choices, ObjectStatus, Scope} from './core';
@@ -289,7 +290,8 @@ export type IntegrationInstallationStatus =
   | typeof INSTALLED
   | typeof NOT_INSTALLED
   | typeof PENDING
-  | typeof DISABLED_STATUS;
+  | typeof DISABLED_STATUS
+  | typeof PENDING_DELETION;
 
 type IntegrationDialog = {
   actionText: string;

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -268,3 +268,11 @@ export const sentryNameToOption = ({id, name}): Result => ({
   value: id,
   label: name,
 });
+
+export function getIntegrationStatus(integration: Integration) {
+  // there are multiple status fields for an integration we consider
+  const statusList = [integration.organizationIntegrationStatus, integration.status];
+  const firstNotActive = statusList.find(s => s !== 'active');
+  // Active if everything is active, otherwise the first inactive status
+  return firstNotActive ?? 'active';
+}

--- a/static/app/views/settings/organizationIntegrations/constants.tsx
+++ b/static/app/views/settings/organizationIntegrations/constants.tsx
@@ -2,12 +2,14 @@ export const INSTALLED = 'Installed' as const;
 export const NOT_INSTALLED = 'Not Installed' as const;
 export const PENDING = 'Pending' as const;
 export const DISABLED = 'Disabled' as const;
+export const PENDING_DELETION = 'Pending Deletion' as const;
 export const LEARN_MORE = 'Learn More' as const;
 
 export const COLORS = {
   [INSTALLED]: 'success',
   [NOT_INSTALLED]: 'gray300',
   [DISABLED]: 'gray300',
+  [PENDING_DELETION]: 'gray300',
   [PENDING]: 'pink300',
   [LEARN_MORE]: 'gray300',
 } as const;

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -13,6 +13,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Integration, IntegrationProvider, ObjectStatus, Organization} from 'sentry/types';
 import {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
+import {getIntegrationStatus} from 'sentry/utils/integrationUtil';
 
 import {AddIntegrationButton} from './addIntegrationButton';
 import IntegrationItem from './integrationItem';
@@ -54,11 +55,7 @@ export default class InstalledIntegration extends Component<Props> {
 
   get integrationStatus() {
     const {integration} = this.props;
-    // there are multiple status fields for an integration we consider
-    const statusList = [integration.organizationIntegrationStatus, integration.status];
-    const firstNotActive = statusList.find(s => s !== 'active');
-    // Active if everything is active, otherwise the first inactive status
-    return firstNotActive ?? 'active';
+    return getIntegrationStatus(integration);
   }
 
   get removeConfirmProps() {

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -55,7 +55,7 @@ export default class InstalledIntegration extends Component<Props> {
   get integrationStatus() {
     const {integration} = this.props;
     // there are multiple status fields for an integration we consider
-    const statusList = [integration.status, integration.organizationIntegrationStatus];
+    const statusList = [integration.organizationIntegrationStatus, integration.status];
     const firstNotActive = statusList.find(s => s !== 'active');
     // Active if everything is active, otherwise the first inactive status
     return firstNotActive ?? 'active';
@@ -216,9 +216,11 @@ function IntegrationStatus(
       <IntegrationStatusText data-test-id="integration-status">{`${
         status === 'active'
           ? t('enabled')
+          : status === 'pending_deletion'
+          ? t('pending deletion')
           : status === 'disabled'
           ? t('disabled')
-          : t('pending deletion')
+          : t('unknown')
       }`}</IntegrationStatusText>
     </div>
   );

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -11,7 +11,7 @@ import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Integration, IntegrationProvider, ObjectStatus} from 'sentry/types';
-import {getAlertText} from 'sentry/utils/integrationUtil';
+import {getAlertText, getIntegrationStatus} from 'sentry/utils/integrationUtil';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -107,13 +107,20 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get installationStatus() {
+    // TODO: add transations
     const {configurations} = this.state;
-    if (
-      configurations.filter(i => i.organizationIntegrationStatus === 'disabled').length
-    ) {
+    const statusList = configurations.map(getIntegrationStatus);
+    // if we have conflicting statuses, we have a priority order
+    if (statusList.includes('active')) {
+      return 'Installed';
+    }
+    if (statusList.includes('disabled')) {
       return 'Disabled';
     }
-    return configurations.length ? 'Installed' : 'Not Installed';
+    if (statusList.includes('pending_deletion')) {
+      return 'Pending Deletion';
+    }
+    return 'Not Installed';
   }
 
   get integrationName() {


### PR DESCRIPTION
This fixes a bug where if you try to uninstall a disabled integration, it doesn't show it as `pending deletion` as shown below
![Screen Shot 2023-04-26 at 12 04 09 PM](https://user-images.githubusercontent.com/8533851/234677342-e192ee18-19f5-4e73-a928-5470f464fc99.png)



