### PR TITLE
chore(deps): Upgrade sqlparse to 0.4.4

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -64,6 +64,7 @@ sentry-relay>=0.8.21
 sentry-sdk>=1.21.0
 snuba-sdk>=1.0.5
 simplejson>=3.17.6
+sqlparse>=0.4.4
 statsd>=3.3
 structlog>=22
 symbolic>=12.1.2
@@ -105,6 +106,5 @@ phabricator>=0.7.0
 # test dependencies, but unable to move to requirements-test until
 # sentry.utils.pytest and sentry.testutils are moved to tests/
 selenium>=4.1.5
-sqlparse>=0.2.4,<=0.3.0
 
 openai==0.27.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -175,7 +175,7 @@ sniffio==1.2.0
 snuba-sdk==1.0.5
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
-sqlparse==0.3.0
+sqlparse==0.4.4
 statsd==3.3
 stripe==2.61.0
 structlog==22.1.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -126,7 +126,7 @@ sniffio==1.2.0
 snuba-sdk==1.0.5
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
-sqlparse==0.3.0
+sqlparse==0.4.4
 statsd==3.3
 stripe==2.61.0
 structlog==22.1.0

--- a/src/sentry/testutils/helpers/query.py
+++ b/src/sentry/testutils/helpers/query.py
@@ -12,14 +12,15 @@ def parse_queries(captured_queries):
     for query in captured_queries:
         raw_sql = query["sql"]
         parsed = sqlparse.parse(raw_sql)
-        for token in parsed[0].tokens:
+        for token_index, token in enumerate(parsed[0].tokens):
             if token.ttype is DML:
                 if token.value.upper() in write_ops:
-                    table_name = parsed[0].get_real_name()
-                    if parsed[0].get_real_name() == "*":  # DELETE * FROM ...
-                        table_name = parsed[0].get_name()
-                    if real_queries.get(table_name) is None:
-                        real_queries[table_name] = 0
-                    real_queries[table_name] += 1
+                    for t in parsed[0].tokens[token_index + 1 :]:
+                        if isinstance(t, sqlparse.sql.Identifier):
+                            table_name = t.get_real_name()
+                            if real_queries.get(table_name) is None:
+                                real_queries[table_name] = 0
+                            real_queries[table_name] += 1
+                            break
 
     return real_queries


### PR DESCRIPTION
- Upgrade `sqlparse` to latest version which fixes a couple ReDOS vulnerabilities. [See changelog](https://sqlparse.readthedocs.io/en/latest/changes/#changelog)
- Move `sqlparse` up with the rest of the dependencies because it is no longer only used in test utils
- Modifies the `parse_queries` test util to work with the new major version of sqlparse