### PR TITLE
fix(searchDropdown): render titleBadge in pristine state

### DIFF
--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -252,6 +252,7 @@ function ItemTitle({item, searchSubstring, isChild}: ItemTitleProps) {
           .{combinedRestWords}
         </RestOfWordsContainer>
       )}
+      {item.titleBadge}
     </SearchItemTitleWrapper>
   );
 }


### PR DESCRIPTION
## Summary
In a pristine dropdown state, without searching a matching field, we were not rendering an item's titleBadge. This fixes that behaviour.

before:
(notice the badge)

|  pristine | dirty   |   
|---|---|
| ![image](https://user-images.githubusercontent.com/7349258/234678631-7f9df331-3b77-4a7a-afc8-6491e9bbcf2b.png) | ![image](https://user-images.githubusercontent.com/7349258/234678659-1b42ebc8-6be2-48ef-9e7f-08bad1de6b37.png) |


after:
![image](https://user-images.githubusercontent.com/7349258/234679176-469348db-a061-493e-9e66-e587b50c9a83.png)



