### PR TITLE
fix(starfish): Fix Chrome blocked request errors

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
@@ -53,8 +53,8 @@ export default function APIModuleView({action, table, onChange}: Props) {
   const pageFilter = usePageFilters();
   const {startTime, endTime} = getDateFilters(pageFilter);
   const DATE_FILTERS = `
-    start_timestamp > fromUnixTimestamp(${startTime.unix()}) and
-    start_timestamp < fromUnixTimestamp(${endTime.unix()})
+    greater(start_timestamp, fromUnixTimestamp(${startTime.unix()})) and
+    less(start_timestamp, fromUnixTimestamp(${endTime.unix()}))
   `;
 
   const {data: operationData} = useQuery({

--- a/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
@@ -80,8 +80,8 @@ export default function APIModuleView({
   const pageFilter = usePageFilters();
   const {startTime, endTime} = getDateFilters(pageFilter);
   const DATE_FILTERS = `
-    start_timestamp > fromUnixTimestamp(${startTime.unix()}) and
-    start_timestamp < fromUnixTimestamp(${endTime.unix()})
+    greater(start_timestamp, fromUnixTimestamp(${startTime.unix()})) and
+    less(start_timestamp, fromUnixTimestamp(${endTime.unix()}))
   `;
 
   const {isLoading: areEndpointsLoading, data: endpointsData} = useQuery({

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -82,8 +82,8 @@ function QueryDetailBody({row}: EndpointDetailBodyProps) {
   const pageFilter = usePageFilters();
   const {startTime, endTime} = getDateFilters(pageFilter);
   const DATE_FILTERS = `
-    start_timestamp > fromUnixTimestamp(${startTime.unix()}) and
-    start_timestamp < fromUnixTimestamp(${endTime.unix()})
+    greater(start_timestamp, fromUnixTimestamp(${startTime.unix()})) and
+    less(start_timestamp, fromUnixTimestamp(${endTime.unix()}))
   `;
 
   const {isLoading, data: graphData} = useQuery({


### PR DESCRIPTION
Chrome hates it when you have angle brackets in the URL, apparently. I'll figure out why ... later maybe. Highly mysterious. I think it hates having angle brackets in the URL of `fetch` requests, but it's unclear why, since they work fine in the URL bar. We need to improve escaping, I'll circle back to this.