### PR TITLE
feat(replay): add data-test-id to click search

### DIFF
--- a/src/sentry/replays/lib/selector/parse.py
+++ b/src/sentry/replays/lib/selector/parse.py
@@ -83,6 +83,8 @@ def visit_attribute(query: QueryType, attribute: Attrib) -> None:
         query.role = attribute.value
     elif attrib == "data-testid":
         query.testid = attribute.value
+    elif attrib == "data-test-id":
+        query.testid = attribute.value
     elif attrib == "title":
         query.title = attribute.value
 

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -918,6 +918,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "click.selector:div[alt=Alt]",
                 "click.selector:div[title=MyTitle]",
                 "click.selector:div[data-testid='1']",
+                "click.selector:div[data-test-id='1']",
                 "click.selector:div[role=button]",
                 "click.selector:div#myid.class1.class2",
                 # Single quotes around attribute value.


### PR DESCRIPTION
Adds `data-test-id` as a valid selector attribute.