### PR TITLE
fix(rulesnooze): Add mute alert link to digest emails

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Sequence
+from urllib.parse import urlencode
 
+from sentry import features
 from sentry.db.models import Model
 from sentry.digests import Digest
 from sentry.digests.utils import (
@@ -97,12 +99,25 @@ class DigestNotification(ProjectNotification):
         return self.project
 
     def get_context(self) -> MutableMapping[str, Any]:
-        return DigestNotification.build_context(
-            self.digest,
-            self.project,
-            self.project.organization,
-            get_rules(list(self.digest.keys()), self.project.organization, self.project),
+        rule_details = get_rules(list(self.digest.keys()), self.project.organization, self.project)
+        context = DigestNotification.build_context(
+            self.digest, self.project, self.project.organization, rule_details
         )
+
+        sentry_query_params = self.get_sentry_query_params(ExternalProviders.EMAIL)
+
+        snooze_alert = (
+            features.has("organizations:mute-alerts", self.organization) and len(rule_details) > 0
+        )
+        snooze_alert_urls = {
+            rule.id: f"{rule.status_url}{sentry_query_params}&{urlencode({'mute': '1'})}"
+            for rule in rule_details
+        }
+
+        context["snooze_alert"] = snooze_alert
+        context["snooze_alert_urls"] = snooze_alert_urls
+
+        return context
 
     @staticmethod
     def build_context(

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -32,8 +32,11 @@
 
     <div class="rule">
       <div class="container">
-        {% with rule_details=rules_details|get_item:rule.id %}
-            You’re receiving this email because you’re subscribed to notifications for <a href="{% absolute_uri rule_details.status_url %}">{{ rule_details.label }}</a>
+        {% with rule_details=rules_details|get_item:rule.id snooze_alert_url=snooze_alert_urls|get_item:rule.id %}
+        {% if snooze_alert %}
+            <a class="mute" href="{% absolute_uri snooze_alert_url %}">Mute alert for me</a>
+        {% endif %}
+            This email was triggered by <a href="{% absolute_uri rule_details.status_url %}">{{ rule_details.label }}</a>
         {% endwith %}
       </div>
     </div>

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -683,6 +683,13 @@
     margin: 20px 0;
   }
 
+  .digest .rule a.mute {
+    float: right;
+    color: #4674ca;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
   .digest .rule div {
     font-weight: 600;
   }

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -560,6 +560,12 @@ def digest(request):
 
     rule_details = get_rules(list(rules.values()), org, project)
     context = DigestNotification.build_context(digest, project, org, rule_details, 1337)
+
+    context["snooze_alert"] = True
+    context["snooze_alert_urls"] = {
+        rule.id: f"{rule.status_url}?{urlencode({'mute': '1'})}" for rule in rule_details
+    }
+
     add_unsubscribe_link(context)
 
     return MailPreview(


### PR DESCRIPTION
this pr adds in the mute alert link to the digest emails. similar to the issue alert emails, this link will bring them to the alert details and automatically mute the alert for them. It also makes a change to the banner

![Screenshot 2023-04-26 at 4 38 29 PM](https://user-images.githubusercontent.com/46740234/234724911-5f3e37e1-65f3-4a97-9205-aa796bab18e1.png)
