### PR TITLE
fix(dynamic-sampling)n Change rebalance factor redis name

### DIFF
--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -216,7 +216,7 @@ def get_redis_client_for_ds() -> Any:
 
 
 def generate_cache_key_rebalance_factor(org_id: int) -> str:
-    return f"ds::o:{org_id}:rate_rebalance_factor"
+    return f"ds::o:{org_id}:rate_rebalance_factor2"
 
 
 def adjusted_factor(prev_factor: float, actual_rate: float, desired_sample_rate: float) -> float:

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -608,7 +608,7 @@ def test_generate_rules_return_uniform_rules_and_rebalance_factor_rule(
     # Set factor
     default_factor = 0.5
     redis_client.set(
-        f"ds::o:{default_project.organization.id}:rate_rebalance_factor",
+        f"ds::o:{default_project.organization.id}:rate_rebalance_factor2",
         default_factor,
     )
     assert generate_rules(default_project) == [

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -287,7 +287,7 @@ def test_project_config_with_all_biases_enabled(
     # Set factor
     default_factor = 0.5
     redis_client.set(
-        f"ds::o:{default_project.organization.id}:rate_rebalance_factor", default_factor
+        f"ds::o:{default_project.organization.id}:rate_rebalance_factor2", default_factor
     )
 
     with Feature(


### PR DESCRIPTION
This PR changes the name under which the rebalance name is stored so it does not clash
with the old name ( which used a different type).