### PR TITLE
fix(quota): Max limit of 2**32 - 1

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -90,7 +90,7 @@ class QuotaConfig:
                         {
                             "id": id,
                             "categories": categories,
-                            # "scope": scope,
+                            "scope": scope,
                             "scope_id": scope_id,
                             "limit": limit,
                             "window": window,

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -128,6 +128,24 @@ class QuotaTest(TestCase):
                 "reasonCode": "go_away",
             },
         ),
+        (
+            QuotaConfig(
+                id="p",
+                scope=QuotaScope.PROJECT,
+                scope_id=1,
+                limit=2**32,
+                window=1,
+                reason_code="go_away",
+            ),
+            {
+                "id": "p",
+                "scope": "project",
+                "scopeId": "1",
+                "limit": 2**32 - 1,
+                "window": 1,
+                "reasonCode": "go_away",
+            },
+        ),
     ],
 )
 def test_quotas_to_json(obj, json):


### PR DESCRIPTION
Relay cannot parse limits larger than `2**32 - 1`, because its internal type is `u32`.

This is a hotfix to resolve `INC-362`.