### PR TITLE
feat: Scraping configuration for js symbolication

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -185,7 +185,6 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         modules=modules,
         release=data.get("release"),
         dist=data.get("dist"),
-        allow_scraping=allow_scraping,
         scraping_config=scraping_config,
     )
 

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -9,6 +9,7 @@ from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models import EventError
 from sentry.stacktraces.processing import find_stacktraces_in_data
+from sentry.utils.http import get_origins
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -146,6 +147,22 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     allow_scraping_project_level = project.get_option("sentry:scrape_javascript", True)
     allow_scraping = allow_scraping_org_level and allow_scraping_project_level
 
+    allowed_origins = []
+    scraping_headers = {}
+    if allow_scraping:
+        allowed_origins = list(get_origins(project))
+
+        token = project.get_option("sentry:token")
+        if token:
+            token_header = project.get_option("sentry:token_header") or "X-Sentry-Token"
+            scraping_headers[token_header] = token
+
+    scraping_config = {
+        "enabled": allow_scraping,
+        "headers": scraping_headers,
+        "allowed_origins": allowed_origins,
+    }
+
     modules = sourcemap_images_from_data(data)
 
     stacktrace_infos = find_stacktraces_in_data(data)
@@ -169,6 +186,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         release=data.get("release"),
         dist=data.get("dist"),
         allow_scraping=allow_scraping,
+        scraping_config=scraping_config,
     )
 
     if not _handle_response_status(data, response):

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -161,7 +161,9 @@ class Symbolicator:
         res = self._process("symbolicate_stacktraces", "symbolicate", json=json)
         return process_response(res)
 
-    def process_js(self, stacktraces, modules, release, dist, allow_scraping=True):
+    def process_js(
+        self, stacktraces, modules, release, dist, allow_scraping=True, scraping_config=None
+    ):
         source = get_internal_artifact_lookup_source(self.project)
 
         json = {
@@ -175,6 +177,8 @@ class Symbolicator:
             json["release"] = release
         if dist is not None:
             json["dist"] = dist
+        if scraping_config is not None:
+            json["scraping"] = scraping_config
 
         return self._process("symbolicate_js_stacktraces", "symbolicate-js", json=json)
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -161,16 +161,13 @@ class Symbolicator:
         res = self._process("symbolicate_stacktraces", "symbolicate", json=json)
         return process_response(res)
 
-    def process_js(
-        self, stacktraces, modules, release, dist, allow_scraping=True, scraping_config=None
-    ):
+    def process_js(self, stacktraces, modules, release, dist, scraping_config=None):
         source = get_internal_artifact_lookup_source(self.project)
 
         json = {
             "source": source,
             "stacktraces": stacktraces,
             "modules": modules,
-            "allow_scraping": allow_scraping,
         }
 
         if release is not None:


### PR DESCRIPTION
This sends the scraping configuration introduced in https://github.com/getsentry/symbolicator/pull/1161 to Symbolicator.