### PR TITLE
fix(dynamic-sampling) Guard against desired sample rates returning None

### DIFF
--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -190,6 +190,8 @@ def rebalance_org(org_volume: OrganizationDataVolume) -> Optional[str]:
     # takes a project (not an org)
     # TODO RaduW is there a better way to get an org Project than filtering ?
     org_projects = Project.objects.filter(organization__id=org_volume.org_id)
+
+    desired_sample_rate = None
     for project in org_projects:
         desired_sample_rate = quotas.get_blended_sample_rate(project)
         break
@@ -197,6 +199,9 @@ def rebalance_org(org_volume: OrganizationDataVolume) -> Optional[str]:
         redis_client.delete(factor_key)  # cleanup just to be sure
         # org with no project this shouldn't happen
         return "no project found"
+
+    if desired_sample_rate is None:
+        return f"project with desired_sample_rate==None for {org_volume.org_id}"
 
     if org_volume.total == 0 or org_volume.indexed == 0:
         # not enough info to make adjustments ( we don't consider this an error)


### PR DESCRIPTION
This PR fixes a crash in the dynamic-sampling rebalancing task that happened when `quotas.get_blended_sample_rate(project)` returns None. 