### PR TITLE
ref(replays): link with replayId instead of replaySlug

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -10,6 +10,7 @@ import ReplayPreview from './replayPreview';
 
 const mockOrgSlug = 'sentry-emerging-tech';
 const mockReplaySlug = 'replays:761104e184c64d439ee1014b72b4d83b';
+const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
 
 const mockEvent = {
   ...TestStubs.Event(),
@@ -17,7 +18,7 @@ const mockEvent = {
 };
 
 const mockButtonHref =
-  '/organizations/sentry-emerging-tech/replays/replays:761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=console';
+  '/organizations/sentry-emerging-tech/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=console';
 
 // Mock screenfull library
 jest.mock('screenfull', () => ({
@@ -51,6 +52,7 @@ jest.mock('sentry/utils/replays/hooks/useReplayData', () => {
       return {
         replay: mockReplay,
         fetching: false,
+        replayId: mockReplayId,
       };
     }),
   };

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 function ReplayPreview({orgSlug, replaySlug, event}: Props) {
   const routes = useRoutes();
-  const {fetching, replay, fetchError} = useReplayData({
+  const {fetching, replay, fetchError, replayId} = useReplayData({
     orgSlug,
     replaySlug,
   });
@@ -87,7 +87,7 @@ function ReplayPreview({orgSlug, replaySlug, event}: Props) {
   }
 
   const fullReplayUrl = {
-    pathname: `/organizations/${orgSlug}/replays/${replaySlug}/`,
+    pathname: `/organizations/${orgSlug}/replays/${replayId}/`,
     query: {
       referrer: getRouteStringFromRoutes(routes),
       t_main: 'console',

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -184,11 +184,9 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
       return {};
     }
 
-    const replaySlug = `${tableRow['project.name']}:${replayId}`;
-
     if (!tableRow.timestamp) {
       return {
-        pathname: `/organizations/${organization.slug}/replays/${replaySlug}/`,
+        pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
         query: {
           referrer,
         },
@@ -201,7 +199,7 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
       : undefined;
 
     return {
-      pathname: `/organizations/${organization.slug}/replays/${replaySlug}/`,
+      pathname: `/organizations/${organization.slug}/replays/${replayId}/`,
       query: {
         event_t: transactionStartTimestamp,
         referrer,


### PR DESCRIPTION
## Summary
Link to replay details using the new url schema; using `replayId` in place of `replaySlug`