### PR TITLE
feat(starfish): Add an old column too

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
@@ -30,8 +30,10 @@ export type DataRow = {
   firstSeen: string;
   formatted_desc: string;
   group_id: string;
+  lastSeen: string;
   newish: number;
   p75: number;
+  retired: number;
   total_time: number;
   transactions: number;
 };
@@ -116,17 +118,21 @@ export default function APIModuleView({
     }
     if (column.key === 'description') {
       const value = row[column.key];
+      let headerExtra = '';
+      if (row.newish === 1) {
+        headerExtra = `Query (First seen ${row.firstSeen})`;
+      } else if (row.retired === 1) {
+        headerExtra = `Query (Last seen ${row.lastSeen})`;
+      }
       return (
-        <Hovercard
-          header={`Query ${row.newish === 1 ? `(First seen ${row.firstSeen})` : ''}`}
-          body={value}
-        >
+        <Hovercard header={headerExtra} body={value}>
           <Link onClick={() => onSelect(row)} to="">
             {value.substring(0, 30)}
             {value.length > 30 ? '...' : ''}
             {value.length > 30 ? value.substring(value.length - 30) : ''}
           </Link>
           {row?.newish === 1 && <StyledBadge type="new" text="new" />}
+          {row?.retired === 1 && <StyledBadge type="warning" text="old" />}
         </Hovercard>
       );
     }

--- a/static/app/views/starfish/modules/databaseModule/queries.js
+++ b/static/app/views/starfish/modules/databaseModule/queries.js
@@ -39,6 +39,8 @@ const getDomainSubquery = (date_filters, action) => {
 
 const getActionQuery = action => (action !== 'ALL' ? `and action = '${action}'` : '');
 
+const SEVEN_DAYS = 7 * 24 * 60 * 60;
+
 export const getOperations = date_filters => {
   return `
   select
@@ -168,11 +170,17 @@ export const getMainTable = (
   ].filter(fil => !!fil);
   const duration = endTime.unix() - startTime.unix();
   const newColumn =
-    duration > 7 * 24 * 60 * 60
+    duration > SEVEN_DAYS
       ? `min(start_timestamp) > fromUnixTimestamp(${
-          endTime.unix() - duration / 2
+          startTime.unix() + duration / 10
         }) as newish`
       : '0 as newish';
+  const retiredColumn =
+    duration > SEVEN_DAYS
+      ? `max(start_timestamp) < fromUnixTimestamp(${
+          endTime.unix() - duration / 10
+        }) as retired`
+      : '0 as retired';
 
   return `
     select
@@ -187,7 +195,9 @@ export const getMainTable = (
       data_keys,
       data_values,
       min(start_timestamp) as firstSeen,
-      ${newColumn}
+      max(start_timestamp) as lastSeen,
+      ${newColumn},
+      ${retiredColumn}
     from default.spans_experimental_starfish
     where
       ${filters.join(' and ')}


### PR DESCRIPTION
- This adds an old badge that shows that a query is likely no longer being used anymore
- This tunes to badges to show up more easily using a tenth of the selected duration instead