### PR TITLE
replay(bug): Fix spacing around TimestampButton so it is easier to click in tables

### DIFF
--- a/static/app/components/replays/replayTagsTableRow.tsx
+++ b/static/app/components/replays/replayTagsTableRow.tsx
@@ -40,14 +40,14 @@ function ReplayTagsTableRow({name, values, generateUrl}: Props) {
   return (
     <KeyValueTableRow
       keyName={
-        <StyledTooltip title={name} showOnlyOnOverflow>
+        <KeyTooltip title={name} showOnlyOnOverflow>
           {name}
-        </StyledTooltip>
+        </KeyTooltip>
       }
       value={
-        <StyledTooltip title={renderTagValue} isHoverable showOnlyOnOverflow>
+        <ValueTooltip title={renderTagValue} isHoverable showOnlyOnOverflow>
           {renderTagValue}
-        </StyledTooltip>
+        </ValueTooltip>
       }
     />
   );
@@ -55,6 +55,11 @@ function ReplayTagsTableRow({name, values, generateUrl}: Props) {
 
 export default ReplayTagsTableRow;
 
-const StyledTooltip = styled(Tooltip)`
+const KeyTooltip = styled(Tooltip)`
   ${p => p.theme.overflowEllipsis};
+`;
+
+const ValueTooltip = styled(KeyTooltip)`
+  display: flex;
+  justify-content: flex-end;
 `;

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -196,7 +196,6 @@ const cellColor = p => {
 const Cell = styled('div')<CellProps>`
   display: flex;
   align-items: center;
-  padding: ${space(0.75)} ${space(1.5)};
   font-size: ${p => p.theme.fontSizeSmall};
   cursor: ${p => (p.onClick ? 'pointer' : 'inherit')};
 
@@ -215,6 +214,7 @@ const Text = styled('div')`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  padding: ${space(0.75)} ${space(1.5)};
 `;
 
 export default NetworkTableCell;

--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -23,7 +23,7 @@ function TimestampButton({
   timestampMs,
 }: Props) {
   return (
-    <Tooltip title={<DateTime date={timestampMs} />}>
+    <Tooltip title={<DateTime date={timestampMs} />} skipWrapper>
       <StyledButton
         as={onClick ? 'button' : 'span'}
         onClick={onClick}
@@ -46,6 +46,7 @@ const StyledButton = styled('button')`
   align-items: center;
   gap: ${space(0.25)};
   padding: 0;
+  height: 100%;
 `;
 
 export default TimestampButton;


### PR DESCRIPTION
**Before:**
the button wasn't quite the same height as the Replay Network table row, so it was possible to mis-click
![SCR-20230427-izmu](https://user-images.githubusercontent.com/187460/234932375-f5070b7d-f7de-4d45-8aff-f45eb799c398.png)

**After:**
the button fills the available height, so clicking in that column is consistent
![SCR-20230427-iztk](https://user-images.githubusercontent.com/187460/234932535-fc87f1a2-8b60-47a4-b841-3deb425e8189.png)


I checked that other places which use TimestampButton continue working ok, including the breadcrumbs, and uses inside of <KeyValueTable>