### PR TITLE
replay(feat): Make the url walker hovercards consistent

### DIFF
--- a/static/app/components/replays/walker/splitCrumbs.spec.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.spec.tsx
@@ -1,6 +1,6 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import type {BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
+import type {Crumb} from 'sentry/types/breadcrumbs';
 
 import splitCrumbs from './splitCrumbs';
 
@@ -9,7 +9,7 @@ const PAGELOAD_CRUMB = TestStubs.Breadcrumb({
   data: {
     to: 'https://sourcemaps.io/',
   },
-}) as BreadcrumbTypeNavigation;
+}) as Crumb;
 
 const NAV_CRUMB_BOOTSTRAP = TestStubs.Breadcrumb({
   id: 5,
@@ -17,7 +17,7 @@ const NAV_CRUMB_BOOTSTRAP = TestStubs.Breadcrumb({
     from: '/',
     to: '/report/1655300817078_https%3A%2F%2Fmaxcdn.bootstrapcdn.com%2Fbootstrap%2F3.3.7%2Fjs%2Fbootstrap.min.js',
   },
-}) as BreadcrumbTypeNavigation;
+}) as Crumb;
 
 const NAV_CRUMB_UNDERSCORE = TestStubs.Breadcrumb({
   id: 6,
@@ -25,7 +25,7 @@ const NAV_CRUMB_UNDERSCORE = TestStubs.Breadcrumb({
     from: '/report/1655300817078_https%3A%2F%2Fmaxcdn.bootstrapcdn.com%2Fbootstrap%2F3.3.7%2Fjs%2Fbootstrap.min.js',
     to: '/report/1669088273097_http%3A%2F%2Funderscorejs.org%2Funderscore-min.js',
   },
-}) as BreadcrumbTypeNavigation;
+}) as Crumb;
 
 describe('splitCrumbs', () => {
   const onClick = null;

--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import first from 'lodash/first';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';

--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -106,9 +106,7 @@ function SummarySegment({
   );
 
   const label =
-    crumbs.length === 1
-      ? getUrl(crumbs[0])
-      : tn('%s Page', '%s Pages', crumbs.length);
+    crumbs.length === 1 ? getUrl(crumbs[0]) : tn('%s Page', '%s Pages', crumbs.length);
   return (
     <Span>
       <HalfPaddingHovercard body={summaryItems} position="right">

--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -1,31 +1,22 @@
 import styled from '@emotion/styled';
 import first from 'lodash/first';
-import last from 'lodash/last';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
 import TextOverflow from 'sentry/components/textOverflow';
-import {Tooltip} from 'sentry/components/tooltip';
 import {tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {
-  BreadcrumbType,
-  BreadcrumbTypeInit,
-  BreadcrumbTypeNavigation,
-  Crumb,
-} from 'sentry/types/breadcrumbs';
+import {BreadcrumbType, Crumb} from 'sentry/types/breadcrumbs';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 
 type MaybeOnClickHandler = null | ((crumb: Crumb) => void);
 
-type InitOrNavCrumb = BreadcrumbTypeNavigation | BreadcrumbTypeInit;
-
-function getUrl(crumb: undefined | InitOrNavCrumb) {
+function getUrl(crumb: undefined | Crumb) {
   if (crumb?.type === BreadcrumbType.NAVIGATION) {
     return crumb.data?.to?.split('?')?.[0];
   }
   if (crumb?.type === BreadcrumbType.INIT) {
-    return crumb.data.url;
+    return crumb.data?.url;
   }
   return undefined;
 }
@@ -35,13 +26,13 @@ function splitCrumbs({
   onClick,
   startTimestampMs,
 }: {
-  crumbs: InitOrNavCrumb[];
+  crumbs: Crumb[];
   onClick: MaybeOnClickHandler;
   startTimestampMs: number;
 }) {
-  const firstUrl = getUrl(first(crumbs));
+  const firstCrumb = crumbs.slice(0, 1) as Crumb[];
   const summarizedCrumbs = crumbs.slice(1, -1) as Crumb[];
-  const lastUrl = getUrl(last(crumbs));
+  const lastCrumb = crumbs.slice(-1) as Crumb[];
 
   if (crumbs.length === 0) {
     // This one shouldn't overflow, but by including the component css stays
@@ -55,10 +46,11 @@ function splitCrumbs({
 
   if (crumbs.length > 3) {
     return [
-      <SingleLinkSegment
+      <SummarySegment
         key="first"
-        path={firstUrl}
-        onClick={onClick ? () => onClick(first(crumbs) as Crumb) : null}
+        crumbs={firstCrumb}
+        startTimestampMs={startTimestampMs}
+        handleOnClick={onClick}
       />,
       <SummarySegment
         key="summary"
@@ -66,43 +58,23 @@ function splitCrumbs({
         startTimestampMs={startTimestampMs}
         handleOnClick={onClick}
       />,
-      <SingleLinkSegment
+      <SummarySegment
         key="last"
-        path={lastUrl}
-        onClick={onClick ? () => onClick(last(crumbs) as Crumb) : null}
+        crumbs={lastCrumb}
+        startTimestampMs={startTimestampMs}
+        handleOnClick={onClick}
       />,
     ];
   }
 
   return crumbs.map((crumb, i) => (
-    <SingleLinkSegment
+    <SummarySegment
       key={i}
-      path={getUrl(crumb)}
-      onClick={onClick ? () => onClick(crumb as Crumb) : null}
+      crumbs={[crumb] as Crumb[]}
+      startTimestampMs={startTimestampMs}
+      handleOnClick={onClick}
     />
   ));
-}
-
-function SingleLinkSegment({
-  onClick,
-  path,
-}: {
-  onClick: null | (() => void);
-  path: undefined | string;
-}) {
-  if (!path) {
-    return null;
-  }
-  const content = (
-    <Tooltip title={path}>
-      <TextOverflow ellipsisDirection="left">{path}</TextOverflow>
-    </Tooltip>
-  );
-  if (onClick) {
-    // TODO(replays): Add a href that deeplinks to `crumb.timestamp`
-    return <Link onClick={onClick}>{content}</Link>;
-  }
-  return <Span>{content}</Span>;
 }
 
 function SummarySegment({
@@ -134,10 +106,14 @@ function SummarySegment({
     </ScrollingList>
   );
 
+  const label =
+    crumbs.length === 1
+      ? getUrl(first(crumbs))
+      : tn('%s Page', '%s Pages', crumbs.length);
   return (
     <Span>
       <HalfPaddingHovercard body={summaryItems} position="right">
-        <TextOverflow>{tn('%s Page', '%s Pages', crumbs.length)}</TextOverflow>
+        <TextOverflow>{label}</TextOverflow>
       </HalfPaddingHovercard>
     </Span>
   );
@@ -155,13 +131,6 @@ const Span = styled('span')`
   color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: 0;
-`;
-
-const Link = styled('a')`
-  color: ${p => p.theme.gray500};
-  font-size: ${p => p.theme.fontSizeMedium};
-  line-height: 0;
-  text-decoration: underline;
 `;
 
 const HalfPaddingHovercard = styled(

--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -108,7 +108,7 @@ function SummarySegment({
 
   const label =
     crumbs.length === 1
-      ? getUrl(first(crumbs))
+      ? getUrl(crumbs[0])
       : tn('%s Page', '%s Pages', crumbs.length);
   return (
     <Span>

--- a/static/app/components/replays/walker/urlWalker.tsx
+++ b/static/app/components/replays/walker/urlWalker.tsx
@@ -2,12 +2,7 @@ import {memo} from 'react';
 
 import ChevronDividedList from 'sentry/components/replays/walker/chevronDividedList';
 import splitCrumbs from 'sentry/components/replays/walker/splitCrumbs';
-import {
-  BreadcrumbLevelType,
-  BreadcrumbType,
-  BreadcrumbTypeNavigation,
-  Crumb,
-} from 'sentry/types/breadcrumbs';
+import {BreadcrumbLevelType, BreadcrumbType, Crumb} from 'sentry/types/breadcrumbs';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -26,7 +21,7 @@ export const CrumbWalker = memo(function CrumbWalker({crumbs, replayRecord}: Cru
 
   const navCrumbs = crumbs.filter(crumb =>
     [BreadcrumbType.INIT, BreadcrumbType.NAVIGATION].includes(crumb.type)
-  ) as BreadcrumbTypeNavigation[];
+  ) as Crumb[];
 
   return (
     <ChevronDividedList
@@ -62,5 +57,5 @@ function urlToCrumb(url: string) {
     color: 'green300',
     timestamp: undefined,
     data: {to: url},
-  } as BreadcrumbTypeNavigation;
+  } as Crumb;
 }

--- a/static/app/components/replays/walker/urlWalker.tsx
+++ b/static/app/components/replays/walker/urlWalker.tsx
@@ -46,7 +46,7 @@ export const StringWalker = memo(function StringWalker({urls}: StringProps) {
   );
 });
 
-function urlToCrumb(url: string) {
+function urlToCrumb(url: string): Crumb {
   return {
     type: BreadcrumbType.NAVIGATION,
     category: BreadcrumbType.NAVIGATION,
@@ -57,5 +57,5 @@ function urlToCrumb(url: string) {
     color: 'green300',
     timestamp: undefined,
     data: {to: url},
-  } as Crumb;
+  };
 }


### PR DESCRIPTION
Make the hover state for the url walker consistent, whether there's one url in the segment, or many.

| | Replay Index (no links) | Replay Details (timestamp link) |
| --- | --- | --- |
| Before | ![before - table](https://user-images.githubusercontent.com/187460/234936636-dc4b869a-d110-48af-aafc-789f3492542f.png) | ![before - links](https://user-images.githubusercontent.com/187460/234936635-31ad83e3-8737-4ade-a0cc-e15e44766e1b.png) |
| After | ![after - table](https://user-images.githubusercontent.com/187460/234936639-5eb2fe9f-4202-40c4-b0cb-e7e3b86ea498.png) | ![after - links](https://user-images.githubusercontent.com/187460/234936640-1801ff49-c6b2-4b42-bd57-576fca63617c.png) |
