### PR TITLE
perf(issue-details): updates group details to use new endpoint

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -85,7 +85,7 @@ class GroupDetails extends Component<Props, State> {
   }
 
   componentDidMount() {
-    this.fetchData();
+    this.fetchData(true);
     this.updateReprocessingProgress();
 
     // Fetch environments early - used in GroupEventDetailsContainer
@@ -102,6 +102,19 @@ class GroupDetails extends Component<Props, State> {
     ) {
       // Skip tracking for other navigation events like switching events
       this.fetchData(globalSelectionReadyChanged);
+    }
+
+    if (prevProps.params?.eventId !== this.props.params?.eventId) {
+      // if we are loading events we should record analytics after it's loaded
+      this.getEvent().then(() => {
+        if (!this.state.group?.project) {
+          return;
+        }
+        const project = this.props.projects.find(
+          p => p.id === this.state.group?.project.id
+        );
+        project && this.trackView(project);
+      });
     }
   }
 
@@ -365,7 +378,7 @@ class GroupDetails extends Component<Props, State> {
     GroupStore.onPopulateReleases(this.props.params.groupId, releases);
   }
 
-  async fetchData(trackView = true) {
+  async fetchData(trackView = false) {
     const {api, isGlobalSelectionReady, organization, params} = this.props;
 
     // Need to wait for global selection store to be ready before making request

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -103,19 +103,6 @@ class GroupDetails extends Component<Props, State> {
       // Skip tracking for other navigation events like switching events
       this.fetchData(globalSelectionReadyChanged);
     }
-
-    if (prevProps.params?.eventId !== this.props.params?.eventId) {
-      // if we are loading events we should record analytics after it's loaded
-      this.getEvent().then(() => {
-        if (!this.state.group?.project) {
-          return;
-        }
-        const project = this.props.projects.find(
-          p => p.id === this.state.group?.project.id
-        );
-        project && this.trackView(project);
-      });
-    }
   }
 
   componentWillUnmount() {

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -181,6 +181,7 @@ class GroupDetails extends Component<Props, State> {
   }
 
   async getEvent() {
+    this.setState({loadingEvent: true, eventError: false});
     const {params, environments, api} = this.props;
     const groupId = params.groupId;
     const eventId = params.eventId ?? 'latest';

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -17,16 +17,11 @@ import {Event} from 'sentry/types/event';
  */
 export async function fetchGroupEvent(
   api: Client,
-  orgId: string,
   groupId: string,
   eventId: string,
-  envNames: string[],
-  projectId?: string
+  envNames: string[]
 ): Promise<Event> {
-  const url =
-    eventId === 'latest' || eventId === 'oldest'
-      ? `/issues/${groupId}/events/${eventId}/`
-      : `/projects/${orgId}/${projectId}/events/${eventId}/?group_id=${groupId}`;
+  const url = `/issues/${groupId}/events/${eventId}/`;
 
   const query: {environment?: string[]} = {};
   if (envNames.length !== 0) {


### PR DESCRIPTION
this pr updates the `groupDetails.tsx` file to use the new endpoint from https://github.com/getsentry/sentry/pull/47679 . Previously, we had to wait on the initial issue response to get the group and project before making this call ,but with the new endpoint, we no longer have to wait to get that response and can fire off the call much earlier, hopefully allowing the event to load faster.

Closes: https://github.com/getsentry/sentry/issues/47521