### PR TITLE
feat(replays): show replay tab for backend errors

### DIFF
--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -7,8 +7,8 @@ import useApi from 'sentry/utils/useApi';
 
 type Options = {
   organization: Organization;
-  projectIds: number[];
   groupIds?: string | string[];
+  projectIds?: number[] | undefined;
   replayIds?: string | string[];
   transactionNames?: string | string[];
 };

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -131,7 +131,7 @@ describe('GroupReplays', () => {
                 'user',
               ],
               per_page: 50,
-              project: [],
+              project: ['2'],
               query: `id:[${REPLAY_ID_1},${REPLAY_ID_2}]`,
               sort: '-started_at',
               statsPeriod: '14d',

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -107,7 +107,6 @@ describe('GroupReplays', () => {
               returnIds: true,
               query: `issue.id:[${mockGroup.id}]`,
               statsPeriod: '14d',
-              project: '2',
             },
           })
         );
@@ -132,7 +131,7 @@ describe('GroupReplays', () => {
                 'user',
               ],
               per_page: 50,
-              project: ['2'],
+              project: [],
               query: `id:[${REPLAY_ID_1},${REPLAY_ID_2}]`,
               sort: '-started_at',
               statsPeriod: '14d',

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -34,7 +34,6 @@ function useReplayFromIssue({
             returnIds: true,
             query: `issue.id:[${group.id}]`,
             statsPeriod: '14d',
-            project: group.project.id,
           },
         }
       );
@@ -43,7 +42,7 @@ function useReplayFromIssue({
       Sentry.captureException(error);
       setFetchError(error);
     }
-  }, [api, organization.slug, group.id, group.project.id]);
+  }, [api, organization.slug, group.id]);
 
   const eventView = useMemo(() => {
     if (!replayIds) {
@@ -54,12 +53,12 @@ function useReplayFromIssue({
       name: '',
       version: 2,
       fields: REPLAY_LIST_FIELDS,
-      projects: [Number(group.project.id)],
+      projects: [],
       query: `id:[${String(replayIds)}]`,
       range: '14d',
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
     });
-  }, [location.query.sort, group.project.id, replayIds]);
+  }, [location.query.sort, replayIds]);
 
   useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor']});
   useEffect(() => {

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -29,6 +29,7 @@ import {space} from 'sentry/styles/space';
 import {Event, Group, IssueType, Organization, Project} from 'sentry/types';
 import {getMessage} from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -71,6 +72,9 @@ function GroupHeaderTabs({
   const hasSimilarView = projectFeatures.has('similarity-view');
   const hasEventAttachments = organizationFeatures.has('event-attachments');
   const hasSessionReplay = organizationFeatures.has('session-replay');
+  const hasMultiProjectSupport = organizationFeatures.has('global-views');
+  const hasReplaySupport =
+    hasSessionReplay && (hasMultiProjectSupport || projectSupportsReplay(project));
 
   const issueTypeConfig = getConfigForIssueType(group);
 
@@ -153,7 +157,7 @@ function GroupHeaderTabs({
       <TabList.Item
         key={Tab.REPLAYS}
         textValue={t('Replays')}
-        hidden={!hasSessionReplay || !issueTypeConfig.replays.enabled}
+        hidden={!hasReplaySupport || !issueTypeConfig.replays.enabled}
         to={`${baseUrl}replays/${location.search}`}
       >
         {t('Replays')}

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -29,7 +29,6 @@ import {space} from 'sentry/styles/space';
 import {Event, Group, IssueType, Organization, Project} from 'sentry/types';
 import {getMessage} from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -60,14 +59,10 @@ function GroupHeaderTabs({
   project,
 }: GroupHeaderTabsProps) {
   const organization = useOrganization();
-  const projectIds = useMemo(
-    () => (project.id ? [Number(project.id)] : []),
-    [project.id]
-  );
+
   const replaysCount = useReplaysCount({
     groupIds: group.id,
     organization,
-    projectIds,
   })[group.id];
   const projectFeatures = new Set(project ? project.features : []);
   const organizationFeatures = new Set(organization ? organization.features : []);
@@ -75,8 +70,7 @@ function GroupHeaderTabs({
   const hasGroupingTreeUI = organizationFeatures.has('grouping-tree-ui');
   const hasSimilarView = projectFeatures.has('similarity-view');
   const hasEventAttachments = organizationFeatures.has('event-attachments');
-  const hasSessionReplay =
-    organizationFeatures.has('session-replay') && projectSupportsReplay(project);
+  const hasSessionReplay = organizationFeatures.has('session-replay');
 
   const issueTypeConfig = getConfigForIssueType(group);
 


### PR DESCRIPTION
## Summary

This change introduces the replay tab for backend errors.

Before -> After
![image](https://user-images.githubusercontent.com/7349258/234965375-d6271cbb-7c45-4d81-81dc-3b053f830d8d.png)

![image](https://user-images.githubusercontent.com/7349258/234965455-6cbe8b82-46c3-4148-889b-047dc077b409.png)
