### PR TITLE
feat(replays): add replay preview to issue details page

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -2,11 +2,9 @@ import {useCallback} from 'react';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import LazyLoad from 'sentry/components/lazyLoad';
-import {PlatformKey} from 'sentry/data/platformCategories';
 import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
-import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
+import {useHasOrganizationSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 
 type Props = {
   event: Event;
@@ -17,22 +15,16 @@ type Props = {
 
 export default function EventReplay({replayId, organization, projectSlug, event}: Props) {
   const hasReplaysFeature = organization.features.includes('session-replay');
-  const {hasSentOneReplay, fetching} = useHaveSelectedProjectsSentAnyReplayEvents();
+  const {hasOrgSentReplays, fetching} = useHasOrganizationSentAnyReplayEvents();
 
   const onboardingPanel = useCallback(() => import('./replayInlineOnboardingPanel'), []);
   const replayPreview = useCallback(() => import('./replayPreview'), []);
 
-  const supportsReplay = projectSupportsReplay({
-    id: event.projectID,
-    slug: event.projectSlug || '',
-    platform: event.platform as PlatformKey,
-  });
-
-  if (!hasReplaysFeature || fetching || !supportsReplay) {
+  if (!hasReplaysFeature || fetching) {
     return null;
   }
 
-  if (!hasSentOneReplay) {
+  if (!hasOrgSentReplays) {
     return (
       <ErrorBoundary mini>
         <LazyLoad component={onboardingPanel} />

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -6,7 +6,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Breadcrumbs} from 'sentry/components/events/interfaces/breadcrumbs';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 import {
-  useHaveSelectedProjectsSentAnyReplayEvents,
+  useHasOrganizationSentAnyReplayEvents,
   useReplayOnboardingSidebarPanel,
 } from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import ReplayReader from 'sentry/utils/replays/replayReader';
@@ -48,14 +48,14 @@ describe('Breadcrumbs', () => {
       typeof useReplayOnboardingSidebarPanel
     >;
 
-  const MockUseHaveSelectedProjectsSentAnyReplayEvents =
-    useHaveSelectedProjectsSentAnyReplayEvents as jest.MockedFunction<
-      typeof useHaveSelectedProjectsSentAnyReplayEvents
+  const MockUseHasOrganizationSentAnyReplayEvents =
+    useHasOrganizationSentAnyReplayEvents as jest.MockedFunction<
+      typeof useHasOrganizationSentAnyReplayEvents
     >;
 
   beforeEach(() => {
-    MockUseHaveSelectedProjectsSentAnyReplayEvents.mockReturnValue({
-      hasSentOneReplay: false,
+    MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
+      hasOrgSentReplays: false,
       fetching: false,
     });
     MockUseReplayOnboardingSidebarPanel.mockReturnValue({
@@ -207,8 +207,8 @@ describe('Breadcrumbs', () => {
 
   describe('replay', () => {
     it('should render the replay inline onboarding component when replays are enabled and the project supports replay', async function () {
-      MockUseHaveSelectedProjectsSentAnyReplayEvents.mockReturnValue({
-        hasSentOneReplay: false,
+      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
+        hasOrgSentReplays: false,
         fetching: false,
       });
       MockUseReplayOnboardingSidebarPanel.mockReturnValue({
@@ -233,8 +233,8 @@ describe('Breadcrumbs', () => {
     });
 
     it('should not render the replay inline onboarding component when the project is not JS', async function () {
-      MockUseHaveSelectedProjectsSentAnyReplayEvents.mockReturnValue({
-        hasSentOneReplay: false,
+      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
+        hasOrgSentReplays: false,
         fetching: false,
       });
       MockUseReplayOnboardingSidebarPanel.mockReturnValue({
@@ -260,9 +260,9 @@ describe('Breadcrumbs', () => {
       expect(container).toSnapshot();
     });
 
-    it('should render a replay when there is a replayId', async function () {
-      MockUseHaveSelectedProjectsSentAnyReplayEvents.mockReturnValue({
-        hasSentOneReplay: true,
+    it('should render a replay when there is a replayId from tags', async function () {
+      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
+        hasOrgSentReplays: true,
         fetching: false,
       });
       MockUseReplayOnboardingSidebarPanel.mockReturnValue({
@@ -274,6 +274,37 @@ describe('Breadcrumbs', () => {
           event={TestStubs.Event({
             entries: [],
             tags: [{key: 'replayId', value: '761104e184c64d439ee1014b72b4d83b'}],
+            platform: 'javascript',
+          })}
+          organization={TestStubs.Organization({
+            features: ['session-replay'],
+          })}
+        />
+      );
+
+      expect(await screen.findByTestId('player-container')).toBeInTheDocument();
+      expect(container).toSnapshot();
+    });
+
+    it('should render a replay when there is a replay_id from contexts', async function () {
+      MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
+        hasOrgSentReplays: true,
+        fetching: false,
+      });
+      MockUseReplayOnboardingSidebarPanel.mockReturnValue({
+        activateSidebar: jest.fn(),
+      });
+      const {container} = render(
+        <Breadcrumbs
+          {...props}
+          event={TestStubs.Event({
+            entries: [],
+            tags: [],
+            contexts: {
+              replay: {
+                replay_id: '761104e184c64d439ee1014b72b4d83b',
+              },
+            },
             platform: 'javascript',
           })}
           organization={TestStubs.Organization({

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -21,6 +21,7 @@ import {Organization} from 'sentry/types';
 import {BreadcrumbLevelType, RawCrumb} from 'sentry/types/breadcrumbs';
 import {EntryType, Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 import SearchBarAction from '../searchBarAction';
@@ -287,7 +288,7 @@ function BreadcrumbsContainer({data, event, organization, projectSlug, isShare}:
     };
   }
 
-  const replayId = event?.tags?.find(({key}) => key === 'replayId')?.value;
+  const replayId = getReplayIdFromEvent(event);
   const showReplay = !isShare && organization.features.includes('session-replay');
 
   const actions = (

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -591,6 +591,10 @@ export interface ProfileContext {
   [ProfileContextKey.PROFILE_ID]?: string;
 }
 
+export interface ReplayContext {
+  replay_id: string;
+  type: string;
+}
 export interface BrowserContext {
   name: string;
   version: string;
@@ -609,6 +613,7 @@ type EventContexts = {
   // TODO (udameli): add better types here
   // once perf issue data shape is more clear
   performance_issue?: any;
+  replay?: ReplayContext;
   runtime?: RuntimeContext;
   threadpool_info?: ThreadPoolInfoContext;
   trace?: TraceContextType;

--- a/static/app/utils/replays/getReplayIdFromEvent.tsx
+++ b/static/app/utils/replays/getReplayIdFromEvent.tsx
@@ -1,0 +1,8 @@
+import {Event} from 'sentry/types';
+
+export function getReplayIdFromEvent(event?: Event) {
+  const replayTagId = event?.tags?.find(({key}) => key === 'replayId')?.value;
+  const replayContextId = event?.contexts.replay?.replay_id;
+
+  return replayContextId ?? replayTagId;
+}

--- a/static/app/utils/replays/getReplayIdFromEvent.tsx
+++ b/static/app/utils/replays/getReplayIdFromEvent.tsx
@@ -2,7 +2,7 @@ import {Event} from 'sentry/types';
 
 export function getReplayIdFromEvent(event?: Event) {
   const replayTagId = event?.tags?.find(({key}) => key === 'replayId')?.value;
-  const replayContextId = event?.contexts.replay?.replay_id;
+  const replayContextId = event?.contexts?.replay?.replay_id;
 
   return replayContextId ?? replayTagId;
 }

--- a/static/app/utils/replays/hooks/useReplayOnboarding.tsx
+++ b/static/app/utils/replays/hooks/useReplayOnboarding.tsx
@@ -26,6 +26,12 @@ function getSelectedProjectList(
   return selectedProjects.map(id => projectsByProjectId[id]).filter(Boolean);
 }
 
+export function useHasOrganizationSentAnyReplayEvents() {
+  const {projects, fetching} = useProjects();
+  const hasOrgSentReplays = useMemo(() => projects.some(p => p.hasReplays), [projects]);
+  return {hasOrgSentReplays, fetching};
+}
+
 export function useHaveSelectedProjectsSentAnyReplayEvents() {
   const {projects, fetching} = useProjects();
   const {selection} = usePageFilters();


### PR DESCRIPTION
## Summary
This change adds the replay preview to the issue details page for backend errors

![image](https://user-images.githubusercontent.com/7349258/234974812-23427c10-4a8d-496f-a755-08164029d773.png)
