### PR TITLE
fix(escalating_issues): Make daily count tests resilient

### DIFF
--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -23,7 +23,7 @@ from sentry.types.group import GroupSubStatus
 from sentry.utils.cache import cache
 from sentry.utils.snuba import to_start_of_hour
 
-TIME_YESTERDAY = datetime.now() - timedelta(hours=24)
+TIME_YESTERDAY = (datetime.now() - timedelta(hours=24)).replace(hour=6)
 
 
 class BaseGroupCounts(TestCase):  # type: ignore[misc]
@@ -178,11 +178,10 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
         )
         escalating_forecast.save()
 
+    @freeze_time(TIME_YESTERDAY)
     def test_is_escalating_issue(self) -> None:
         """Test when an archived until escalating issue starts escalating"""
-        with self.feature("organizations:escalating-issues"), freeze_time(
-            TIME_YESTERDAY.replace(hour=6)
-        ):
+        with self.feature("organizations:escalating-issues"):
             # The group has 6 events today
             for i in range(7, 1, -1):
                 event = self._load_event_for_group(minutes_ago=i)
@@ -208,6 +207,7 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
                 == 6
             )
 
+    @freeze_time(TIME_YESTERDAY)
     def test_not_escalating_issue(self) -> None:
         """Test when an archived until escalating issue is not escalating"""
         with self.feature("organizations:escalating-issues"):
@@ -237,37 +237,31 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
             assert group.status == GroupStatus.IGNORED
             assert not GroupInbox.objects.filter(group=group).exists()
 
+    @freeze_time(TIME_YESTERDAY)
     def test_daily_count_query(self) -> None:
         """Test the daily count query only aggregates events from today"""
-        # Do not create events more than 6 hours before or it will move to the previous day
-        with freeze_time(TIME_YESTERDAY.replace(hour=6)):
-            # The group had 3 events two days ago
-            two_days_ago_mins = 48 * 60
-            for i in range(4, 1, -1):
-                event = self._load_event_for_group(minutes_ago=two_days_ago_mins + i)
+        # The group had 3 events two days ago
+        two_days_ago_mins = 48 * 60
+        for i in range(4, 1, -1):
+            event = self._load_event_for_group(minutes_ago=two_days_ago_mins + i)
 
-            # The group had 2 events yesterday
-            # Tests that events are aggregated in the daily count query by date, not by 24 hr periods
-            yesterday = datetime.now().date() - timedelta(days=1)
-            yesterday_midnight = datetime.combine(yesterday, datetime.min.time())
-            mins_since_yesterday_midnight = int(
-                ((datetime.now() - yesterday_midnight).total_seconds()) / 60
-            )
-            for i in range(3, 1, -1):
-                # Event occured i hours after yesterday midnight
-                event = self._load_event_for_group(
-                    minutes_ago=mins_since_yesterday_midnight + i * 60
-                )
+        # The group had 2 events yesterday
+        # Tests that events are aggregated in the daily count query by date, not by 24 hr periods
+        yesterday = datetime.now().date() - timedelta(days=1)
+        yesterday_midnight = datetime.combine(yesterday, datetime.min.time())
+        mins_since_yesterday_midnight = int(
+            ((datetime.now() - yesterday_midnight).total_seconds()) / 60
+        )
+        for i in range(3, 1, -1):
+            # Event occured i hours after yesterday midnight
+            event = self._load_event_for_group(minutes_ago=mins_since_yesterday_midnight + i * 60)
 
-            # The group has 1 event today
-            for i in range(2, 1, -1):
-                event = self._load_event_for_group(minutes_ago=i)
-                group = event.group
-            group.status = GroupStatus.IGNORED
-            group.substatus = GroupSubStatus.UNTIL_ESCALATING
-            group.save()
+        # The group has 1 event today
+        for i in range(2, 1, -1):
+            event = self._load_event_for_group(minutes_ago=i)
+            group = event.group
+        group.status = GroupStatus.IGNORED
+        group.substatus = GroupSubStatus.UNTIL_ESCALATING
+        group.save()
 
-            assert (
-                get_group_daily_count(group.project.organization.id, group.project.id, group.id)
-                == 1
-            )
+        assert get_group_daily_count(group.project.organization.id, group.project.id, group.id) == 1

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -23,6 +23,8 @@ from sentry.types.group import GroupSubStatus
 from sentry.utils.cache import cache
 from sentry.utils.snuba import to_start_of_hour
 
+TIME_YESTERDAY = datetime.now() - timedelta(hours=24)
+
 
 class BaseGroupCounts(TestCase):  # type: ignore[misc]
     def setUp(self) -> None:
@@ -178,7 +180,9 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
 
     def test_is_escalating_issue(self) -> None:
         """Test when an archived until escalating issue starts escalating"""
-        with self.feature("organizations:escalating-issues"), freeze_time("2023-04-25 06:21:34"):
+        with self.feature("organizations:escalating-issues"), freeze_time(
+            TIME_YESTERDAY.replace(hour=6)
+        ):
             # The group has 6 events today
             for i in range(7, 1, -1):
                 event = self._load_event_for_group(minutes_ago=i)
@@ -235,8 +239,8 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
 
     def test_daily_count_query(self) -> None:
         """Test the daily count query only aggregates events from today"""
-        # Do not create events more than 6 hours before or it would move to the previous day
-        with freeze_time("2023-04-25 06:21:34"):
+        # Do not create events more than 6 hours before or it will move to the previous day
+        with freeze_time(TIME_YESTERDAY.replace(hour=6)):
             # The group had 3 events two days ago
             two_days_ago_mins = 48 * 60
             for i in range(4, 1, -1):


### PR DESCRIPTION
Before the tests would intermittently fail depending on the time of execution.

Freeze gun helps making the tests resilient.