### PR TITLE
ref(perf): Adding a couple tags for perf detection on node

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -375,7 +375,8 @@ def report_metrics_for_detectors(
         )
 
     for allowed_sdk_name in SDKS_OF_INTEREST:
-        detected_tags["sdk_" + allowed_sdk_name.lower()] = allowed_sdk_name == sdk_name
+        if allowed_sdk_name == sdk_name:
+            detected_tags["sdk_" + allowed_sdk_name.lower()] = True
 
     for detector in detectors:
         detector_key = detector.type.value

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -39,6 +39,12 @@ INTEGRATIONS_OF_INTEREST = [
     "sqlalchemy",
     "Mongo",  # Node
     "Postgres",  # Node
+    "Mysql",  # Node
+    "Prisma",  # Node
+    "GraphQL",  # Node
+]
+SDKS_OF_INTEREST = [
+    "sentry.javascript.node",
 ]
 
 
@@ -367,6 +373,9 @@ def report_metrics_for_detectors(
         detected_tags["integration_" + integration_name.lower()] = (
             integration_name in event_integrations
         )
+
+    for allowed_sdk_name in SDKS_OF_INTEREST:
+        detected_tags["sdk_" + allowed_sdk_name.lower()] = allowed_sdk_name == sdk_name
 
     for detector in detectors:
         detector_key = detector.type.value

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -370,9 +370,8 @@ def report_metrics_for_detectors(
     event_integrations = event.get("sdk", {}).get("integrations", []) or []
 
     for integration_name in INTEGRATIONS_OF_INTEREST:
-        detected_tags["integration_" + integration_name.lower()] = (
-            integration_name in event_integrations
-        )
+        if integration_name in event_integrations:
+            detected_tags["integration_" + integration_name.lower()] = True
 
     for allowed_sdk_name in SDKS_OF_INTEREST:
         if allowed_sdk_name == sdk_name:

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -392,11 +392,6 @@ class PerformanceDetectionTest(TestCase):
                 instance="True",
                 tags={
                     "sdk_name": "sentry.javascript.react",
-                    "integration_django": False,
-                    "integration_flask": False,
-                    "integration_sqlalchemy": False,
-                    "integration_mongo": False,
-                    "integration_postgres": False,
                     "consecutive_db": False,
                     "large_http_payload": False,
                     "consecutive_http": False,


### PR DESCRIPTION
### Summary
We are looking at nodejs and integrations for it to check the problem space, adding these tags. Doesn't significantly increase consumed metrics since we're only turning these on temporarily (this metric is only using 'ingested only')


