### PR TITLE
feat(trends): Fetch count timeseries and pass it to breakpoint microservice

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -385,7 +385,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         allow_partial_buckets: bool = False,
         zerofill_results: bool = True,
         comparison_delta: Optional[timedelta] = None,
-        additional_query_column: str = None,
+        additional_query_column: Optional[str] = None,
     ) -> Dict[str, Any]:
         with self.handle_query_errors():
             with sentry_sdk.start_span(

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -385,12 +385,19 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         allow_partial_buckets: bool = False,
         zerofill_results: bool = True,
         comparison_delta: Optional[timedelta] = None,
+        additional_query_column: str = None,
     ) -> Dict[str, Any]:
         with self.handle_query_errors():
             with sentry_sdk.start_span(
                 op="discover.endpoint", description="base.stats_query_creation"
             ):
-                columns = request.GET.getlist("yAxis", [query_column])
+                _columns = [query_column]
+                # temporary change to make topN query work for multi-axes requests
+                if additional_query_column is not None:
+                    _columns.append(additional_query_column)
+
+                columns = request.GET.getlist("yAxis", _columns)
+
                 if query is None:
                     query = request.GET.get("query")
                 if params is None:

--- a/src/sentry/api/endpoints/organization_events_new_trends.py
+++ b/src/sentry/api/endpoints/organization_events_new_trends.py
@@ -87,7 +87,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 params=params,
                 rollup=rollup,
                 # high limit is set to validate the regression analysis
-                limit=2,
+                limit=50,
                 organization=organization,
                 referrer=Referrer.API_TRENDS_GET_EVENT_STATS_NEW.value,
                 allow_empty=False,
@@ -102,7 +102,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 request,
                 organization,
                 get_event_stats,
-                top_events=2,
+                top_events=50,
                 query_column=trend_function,
                 params=params,
                 query=query,


### PR DESCRIPTION
To display counts before and after breakpoint, microservice needs event counts for each bucket. This will cause errors in microservice since the request shape is changing cc: @npusarla 