### PR TITLE
ref(js): spring cleaning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,10 @@ const strictRulesNotCi = {
 };
 
 module.exports = {
-  extends: [isRelaxed ? 'sentry-app' : 'sentry-app/strict'],
+  extends: [
+    isRelaxed ? 'sentry-app' : 'sentry-app/strict',
+    'plugin:eslint-performance/recommended',
+  ],
   globals: {
     require: false,
     expect: false,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,10 +18,7 @@ const strictRulesNotCi = {
 };
 
 module.exports = {
-  extends: [
-    isRelaxed ? 'sentry-app' : 'sentry-app/strict',
-    'plugin:eslint-performance/recommended',
-  ],
+  extends: [isRelaxed ? 'sentry-app' : 'sentry-app/strict'],
   globals: {
     require: false,
     expect: false,

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -245,7 +245,9 @@ export function initializeUrlState({
       // the organization slug is consistent with the URL param--Sentry will
       // get the first project from the organization that the user is a member
       // of.
-      newProject = [getProjectIdFromProject(memberProjects[0])];
+      newProject = memberProjects?.[0]
+        ? [getProjectIdFromProject(memberProjects[0])]
+        : [];
     }
   }
 

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -245,7 +245,7 @@ export function initializeUrlState({
       // the organization slug is consistent with the URL param--Sentry will
       // get the first project from the organization that the user is a member
       // of.
-      newProject = [...memberProjects].slice(0, 1).map(getProjectIdFromProject);
+      newProject = [getProjectIdFromProject(memberProjects[0])];
     }
   }
 

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -287,7 +287,7 @@ export const getPreviousSeriesName = (seriesName: string) => {
 
 function formatList(items: Array<string | number | undefined>) {
   const filteredItems = items.filter(item => !!item);
-  return [[...filteredItems].slice(0, -1).join(', '), [...filteredItems].slice(-1)]
+  return [filteredItems.slice(0, -1).join(', '), filteredItems.slice(-1)]
     .filter(type => !!type)
     .join(' and ');
 }

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -213,7 +213,7 @@ function BreadcrumbsContainer({data, event, organization, projectSlug, isShare}:
         .map(option => option.value.split('-')[1])
     );
 
-    if (!![...checkedTypeOptions].length && !![...checkedLevelOptions].length) {
+    if (checkedTypeOptions.size && !!checkedLevelOptions.size) {
       return breadcrumbs.filter(
         ({breadcrumb}) =>
           checkedTypeOptions.has(breadcrumb.type) &&
@@ -221,13 +221,13 @@ function BreadcrumbsContainer({data, event, organization, projectSlug, isShare}:
       );
     }
 
-    if ([...checkedTypeOptions].length) {
+    if (checkedTypeOptions.size) {
       return breadcrumbs.filter(({breadcrumb}) =>
         checkedTypeOptions.has(breadcrumb.type)
       );
     }
 
-    if ([...checkedLevelOptions].length) {
+    if (checkedLevelOptions.size) {
       return breadcrumbs.filter(({breadcrumb}) =>
         checkedLevelOptions.has(breadcrumb.level)
       );

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -355,7 +355,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
   ) {
     const checkedOptions = new Set(filterOptions.map(option => option.value));
 
-    if (![...checkedOptions].length) {
+    if (!checkedOptions.size) {
       return filteredImages;
     }
 

--- a/static/app/components/events/interfaces/spans/filter.tsx
+++ b/static/app/components/events/interfaces/spans/filter.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {CompactSelect} from 'sentry/components/compactSelect';
+import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {IconFilter} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -48,16 +48,19 @@ function Filter({
 
   // Memoize menuOptions to prevent CompactSelect from re-rendering every time
   // the value changes
-  const menuOptions = useMemo(
-    () =>
-      [...operationNameCounts].map(([operationName, operationCount]) => ({
+  const menuOptions = useMemo(() => {
+    const options: SelectOption<string>[] = [];
+
+    for (const [operationName, operationCount] of operationNameCounts.entries()) {
+      options.push({
         value: operationName,
         label: operationName,
         leadingItems: <OperationDot backgroundColor={pickBarColor(operationName)} />,
         trailingItems: <OperationCount>{operationCount}</OperationCount>,
-      })),
-    [operationNameCounts]
-  );
+      });
+    }
+    return options;
+  }, [operationNameCounts]);
 
   function onChange(selectedOpts) {
     const mappedValues = selectedOpts.map(opt => opt.value);
@@ -87,7 +90,8 @@ function Filter({
         selectedOpts.length !== 0 &&
           trackAnalytics('performance_views.event_details.filter_by_op', {
             organization,
-            operation: opt.label,
+            // @TODO the type here is wrong, label expects a react node and we are passing a string
+            operation: opt.label as string,
           });
       }
     });

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -125,7 +125,10 @@ export default class ChoiceMapperField extends Component<ChoiceMapperFieldProps>
     } = props;
 
     const mappedKeys = Object.keys(columnLabels);
-    const emptyValue = mappedKeys.reduce((a, v) => ({...a, [v]: null}), {});
+    const emptyValue = mappedKeys.reduce((a, v) => {
+      a[v] = null;
+      return a;
+    }, {});
 
     const valueIsEmpty = this.hasValue(props.value);
     const value = valueIsEmpty ? props.value : {};

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -125,9 +125,9 @@ export default class ChoiceMapperField extends Component<ChoiceMapperFieldProps>
     } = props;
 
     const mappedKeys = Object.keys(columnLabels);
-    const emptyValue = mappedKeys.reduce((a, v) => {
-      a[v] = null;
-      return a;
+    const emptyValue = mappedKeys.reduce((acc, key) => {
+      acc[key] = null;
+      return acc;
     }, {});
 
     const valueIsEmpty = this.hasValue(props.value);

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -56,7 +56,13 @@ export default class TableField extends Component<InputFieldProps> {
     } = props;
 
     const mappedKeys = columnKeys || [];
-    const emptyValue = mappedKeys.reduce((a, v) => ({...a, [v]: null}), {id: ''});
+    const emptyValue = mappedKeys.reduce(
+      (a, v) => {
+        a[v] = null;
+        return a;
+      },
+      {id: ''}
+    );
 
     const valueIsEmpty = this.hasValue(props.value);
     const value = valueIsEmpty ? (props.value as any[]) : [];

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -57,9 +57,9 @@ export default class TableField extends Component<InputFieldProps> {
 
     const mappedKeys = columnKeys || [];
     const emptyValue = mappedKeys.reduce(
-      (a, v) => {
-        a[v] = null;
-        return a;
+      (acc, key) => {
+        acc[key] = null;
+        return acc;
       },
       {id: ''}
     );

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -208,13 +208,16 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
   }
 
   get invites(): NormalizedInvite[] {
-    return this.state.pendingInvites.reduce<NormalizedInvite[]>(
-      (acc, row) => [
-        ...acc,
-        ...[...row.emails].map(email => ({email, teams: row.teams, role: row.role})),
-      ],
-      []
-    );
+    return this.state.pendingInvites.reduce<NormalizedInvite[]>((acc, row) => {
+      for (const email of row.emails) {
+        acc.push({
+          email,
+          teams: row.teams,
+          role: row.role,
+        });
+      }
+      return acc;
+    }, []);
   }
 
   get hasDuplicateEmails() {

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -31,9 +31,7 @@ type Props = {
 };
 
 const flattenSuggestions = (list: ProjectSdkUpdates[]) =>
-  list.reduce<SDKUpdatesSuggestion[]>((suggestions, sdk) => {
-    return suggestions.concat(sdk.suggestions);
-  }, []);
+  list.flatMap<SDKUpdatesSuggestion[]>(l => l.suggestions);
 
 function BroadcastSdkUpdates({projects, sdkUpdates, organization}: Props) {
   if (!sdkUpdates) {

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -31,10 +31,9 @@ type Props = {
 };
 
 const flattenSuggestions = (list: ProjectSdkUpdates[]) =>
-  list.reduce<SDKUpdatesSuggestion[]>(
-    (suggestions, sdk) => [...suggestions, ...sdk.suggestions],
-    []
-  );
+  list.reduce<SDKUpdatesSuggestion[]>((suggestions, sdk) => {
+    return suggestions.concat(sdk.suggestions);
+  }, []);
 
 function BroadcastSdkUpdates({projects, sdkUpdates, organization}: Props) {
   if (!sdkUpdates) {

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -68,13 +68,10 @@ function useOverflowTabs({
     return () => observer.disconnect();
   }, [tabListRef, tabItemsRef]);
 
-  const tabItemKeyToHiddenMap = tabItems.reduce(
-    (acc, next) => ({
-      ...acc,
-      [next.key]: next.hidden,
-    }),
-    {}
-  );
+  const tabItemKeyToHiddenMap = tabItems.reduce((acc, next) => {
+    acc[next.key] = next.hidden;
+    return acc;
+  }, {});
 
   // Tabs that are hidden will be rendered with display: none so won't intersect,
   // but we don't want to show them in the overflow menu

--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -26,7 +26,7 @@ export const experimentList = [
   },
 ] as const;
 
-export const experimentConfig = experimentList.reduce(
-  (acc, exp) => ({...acc, [exp.key]: exp}),
-  {}
-) as Experiments;
+export const experimentConfig = experimentList.reduce((acc, exp) => {
+  acc[exp.key] = exp;
+  return acc;
+}, {}) as Experiments;

--- a/static/app/utils/profiling/profile/jsSelfProfile.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.tsx
@@ -7,7 +7,9 @@ import {resolveJSSelfProfilingStack} from './../jsSelfProfiling';
 import {Profile} from './profile';
 import {createFrameIndex} from './utils';
 
-function sortJSSelfProfileSamples(samples: Readonly<JSSelfProfiling.Trace['samples']>) {
+function sortJSSelfProfileSamples(
+  samples: ReadonlyArray<JSSelfProfiling.Trace['samples'][0]>
+) {
   return [...samples].sort((a, b) => {
     return a.stackId - b.stackId;
   });

--- a/static/app/utils/profiling/profile/sentrySampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.tsx
@@ -9,7 +9,7 @@ type WeightedSample = Profiling.SentrySampledProfile['profile']['samples'][0] & 
   weight: number;
 };
 
-function sortSentrySampledProfileSamples(samples: Readonly<WeightedSample[]>) {
+function sortSentrySampledProfileSamples(samples: ReadonlyArray<WeightedSample>) {
   return [...samples].sort((a, b) => {
     return a.stack_id - b.stack_id;
   });

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -99,7 +99,7 @@ class SpanTree {
     return this === SpanTree.Empty;
   }
 
-  buildCollapsedSpanTree(spans: RawSpanType[]) {
+  buildCollapsedSpanTree(spans: ReadonlyArray<RawSpanType>) {
     const spansSortedByStartTime = [...spans].sort(sortByStartTimeAndDuration);
     const MISSING_INSTRUMENTATION_THRESHOLD_S = 0.1;
 

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -60,14 +60,12 @@ function ActionSet({
   const label = getLabel(numIssues, allInQuerySelected);
 
   const selectedIssues: BaseGroup[] = [];
-  for (const issue of issues) {
-    const resolvedIssue = GroupStore.get(issue);
-
-    if (resolvedIssue) {
-      // @TODO use a type guard here
-      selectedIssues.push(resolvedIssue as BaseGroup);
+  issues.forEach(issueId => {
+    const issue = GroupStore.get(issueId);
+    if (issue) {
+      selectedIssues.push(issue as BaseGroup);
     }
-  }
+  });
 
   // Merges require multiple issues of a single project type
   const multipleIssueProjectsSelected = multiSelected && !selectedProjectSlug;

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -59,9 +59,15 @@ function ActionSet({
 
   const label = getLabel(numIssues, allInQuerySelected);
 
-  const selectedIssues = [...issues]
-    .map(issueId => GroupStore.get(issueId))
-    .filter(issue => issue) as BaseGroup[];
+  const selectedIssues: BaseGroup[] = [];
+  for (const issue of issues) {
+    const resolvedIssue = GroupStore.get(issue);
+
+    if (resolvedIssue) {
+      // @TODO use a type guard here
+      selectedIssues.push(resolvedIssue as BaseGroup);
+    }
+  }
 
   // Merges require multiple issues of a single project type
   const multipleIssueProjectsSelected = multiSelected && !selectedProjectSlug;

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -275,13 +275,13 @@ function useSelectedGroupsState() {
   const selected = SelectedGroupStore.getSelectedIds();
   const projects: string[] = [];
 
-  for (const selectedGroup of selected) {
+  selected.forEach(selectedGroup => {
     const group = GroupStore.get(selectedGroup);
 
     if (group && group.project) {
       projects.push(group.project.slug);
     }
-  }
+  });
 
   const uniqProjects = uniq(projects);
   // we only want selectedProjectSlug set if there is 1 project

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -11,7 +11,7 @@ import GroupStore from 'sentry/stores/groupStore';
 import SelectedGroupStore from 'sentry/stores/selectedGroupStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
-import {Group, PageFilters} from 'sentry/types';
+import {PageFilters} from 'sentry/types';
 import theme from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
 import useMedia from 'sentry/utils/useMedia';
@@ -273,10 +273,15 @@ function useSelectedGroupsState() {
   const selectedIds = useLegacyStore(SelectedGroupStore);
 
   const selected = SelectedGroupStore.getSelectedIds();
-  const projects = [...selected]
-    .map(id => GroupStore.get(id))
-    .filter((group): group is Group => !!(group && group.project))
-    .map(group => group.project.slug);
+  const projects: string[] = [];
+
+  for (const selectedGroup of selected) {
+    const group = GroupStore.get(selectedGroup);
+
+    if (group && group.project) {
+      projects.push(group.project.slug);
+    }
+  }
 
   const uniqProjects = uniq(projects);
   // we only want selectedProjectSlug set if there is 1 project

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -289,7 +289,7 @@ export class TagValueTable extends Component<Props, State> {
       onCursor,
     } = this.props;
 
-    const newColumns = [...TAGS_TABLE_COLUMN_ORDER].map(c => {
+    const newColumns = TAGS_TABLE_COLUMN_ORDER.map(c => {
       const newColumn = {...c};
       if (c.key === 'tagValue' && tagKey) {
         newColumn.name = tagKey;

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -89,13 +89,18 @@ export enum PROJECT_PERFORMANCE_TYPE {
 
 // The native SDK is equally used on clients and end-devices as on
 // backend, the default view should be "All Transactions".
-const FRONTEND_PLATFORMS: string[] = frontend.filter(
+
+// Next, Remix and Sveltekit habe both, frontend and backend transactions.
+const FRONTEND_PLATFORMS: ReadonlyArray<string> = frontend.filter(
   platform =>
-    // Next, Remix and Sveltekit habe both, frontend and backend transactions.
-    !['javascript-nextjs', 'javascript-remix', 'javascript-sveltekit'].includes(platform)
+    platform !== 'javascript-nextjs' &&
+    platform !== 'javascript-remix' &&
+    platform !== 'javascript-sveltekit' // Next has both frontend and backend transactions.
 );
-const BACKEND_PLATFORMS: string[] = backend.filter(platform => platform !== 'native');
-const MOBILE_PLATFORMS: string[] = [...mobile];
+const BACKEND_PLATFORMS: ReadonlyArray<string> = backend.filter(
+  platform => platform !== 'native'
+);
+const MOBILE_PLATFORMS: ReadonlyArray<string> = mobile;
 
 export function platformToPerformanceType(
   projects: (Project | ReleaseProject)[],

--- a/static/app/views/replays/detail/network/useSortNetwork.tsx
+++ b/static/app/views/replays/detail/network/useSortNetwork.tsx
@@ -68,7 +68,10 @@ function useSortNetwork({items}: Opts) {
   };
 }
 
-function sortNetwork(network: NetworkSpan[], sortConfig: SortConfig): NetworkSpan[] {
+function sortNetwork(
+  network: ReadonlyArray<NetworkSpan>,
+  sortConfig: SortConfig
+): NetworkSpan[] {
   return [...network].sort((a, b) => {
     let valueA = sortConfig.getValue(a);
     let valueB = sortConfig.getValue(b);


### PR DESCRIPTION
I have been experimenting with some eslint rules to detect performance issues as per https://github.com/getsentry/sentry-javascript/pull/7910 and https://github.com/getsentry/sentry/pull/47629. All of this is pretty much in the same spirit where we try to find On^2 code + unnecessary array rest/spread.

Figured it wouldn't hurt to clean some of the code in Sentry anyways so I'm opening this as draft and awareness. I would not expect any of these to be actual performance issues, but the code is still wasteful and in some cases just less readable (like the ...set.length vs just checking set.size)

Lmk what you think, I'd be curious to hear some thoughts and opinions, the only thing to cleanup is just the chang to eslintrc which was linked for testing purposes