### PR TITLE
Submit a `process_event` task from `symbolicate`

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -64,6 +64,7 @@ def submit_process(
     event_id: Optional[str],
     start_time: Optional[int],
     data_has_changed: bool = False,
+    from_symbolicate: bool = False,
     has_attachments: bool = False,
 ) -> None:
     task = process_event_from_reprocessing if from_reprocessing else process_event
@@ -72,6 +73,7 @@ def submit_process(
         start_time=start_time,
         event_id=event_id,
         data_has_changed=data_has_changed,
+        from_symbolicate=from_symbolicate,
         has_attachments=has_attachments,
     )
 
@@ -461,6 +463,8 @@ def process_event(
     start_time: Optional[int] = None,
     event_id: Optional[str] = None,
     data_has_changed: bool = False,
+    from_symbolicate: bool = False,
+    has_attachments: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -479,6 +483,8 @@ def process_event(
         event_id=event_id,
         process_task=process_event,
         data_has_changed=data_has_changed,
+        from_symbolicate=from_symbolicate,
+        has_attachments=has_attachments,
     )
 
 
@@ -493,6 +499,8 @@ def process_event_from_reprocessing(
     start_time: Optional[int] = None,
     event_id: Optional[str] = None,
     data_has_changed: bool = False,
+    from_symbolicate: bool = False,
+    has_attachments: bool = False,
     **kwargs: Any,
 ) -> None:
     return do_process_event(
@@ -501,6 +509,8 @@ def process_event_from_reprocessing(
         event_id=event_id,
         process_task=process_event_from_reprocessing,
         data_has_changed=data_has_changed,
+        from_symbolicate=from_symbolicate,
+        has_attachments=has_attachments,
     )
 
 

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -128,17 +128,11 @@ def _do_symbolicate_event(
             return
 
     def _continue_to_process_event() -> None:
-        process_task = (
-            store.process_event_from_reprocessing
-            if task_kind.is_reprocessing
-            else store.process_event
-        )
-        store.do_process_event(
+        store.submit_process(
+            from_reprocessing=task_kind.is_reprocessing,
             cache_key=cache_key,
-            start_time=start_time,
             event_id=event_id,
-            process_task=process_task,
-            data=data,
+            start_time=start_time,
             data_has_changed=has_changed,
             from_symbolicate=True,
             has_attachments=has_attachments,

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -141,7 +141,7 @@ def test_move_to_symbolicate_event_low_priority(
 
 
 @pytest.mark.django_db
-def test_symbolicate_event_call_process_inline(
+def test_symbolicate_event_doesnt_call_process_inline(
     default_project,
     mock_event_processing_store,
     mock_process_event,
@@ -172,17 +172,8 @@ def test_symbolicate_event_call_process_inline(
     assert event == symbolicated_data
 
     assert mock_save_event.delay.call_count == 0
-    assert mock_process_event.delay.call_count == 0
-    mock_do_process_event.assert_called_once_with(
-        cache_key="e:1",
-        start_time=1,
-        event_id=EVENT_ID,
-        process_task=mock_process_event,
-        data=symbolicated_data,
-        data_has_changed=True,
-        from_symbolicate=True,
-        has_attachments=False,
-    )
+    assert mock_process_event.delay.call_count == 1
+    mock_do_process_event.assert_not_called()
 
 
 @pytest.fixture(params=["org", "project"])


### PR DESCRIPTION
Instead of calling `do_process_event` directly at the end of symbolication, we want to rather schedule it as a separate task.

The reason for this is that events that are flowing through symbolicator can have some more costly processing also as part of `process_event`, even though the `symbolicate` workers should be extremely lightweight.

This change practically reverts https://github.com/getsentry/sentry/pull/18081