### PR TITLE
fix(starfish): chrome doesn't like '<' or '>' in the url

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/queries.js
+++ b/static/app/views/starfish/modules/databaseModule/queries.js
@@ -171,15 +171,15 @@ export const getMainTable = (
   const duration = endTime.unix() - startTime.unix();
   const newColumn =
     duration > SEVEN_DAYS
-      ? `min(start_timestamp) > fromUnixTimestamp(${
+      ? `greater(min(start_timestamp), fromUnixTimestamp(${
           startTime.unix() + duration / 10
-        }) as newish`
+        })) as newish`
       : '0 as newish';
   const retiredColumn =
     duration > SEVEN_DAYS
-      ? `max(start_timestamp) < fromUnixTimestamp(${
+      ? `less(max(start_timestamp), fromUnixTimestamp(${
           endTime.unix() - duration / 10
-        }) as retired`
+        })) as retired`
       : '0 as retired';
 
   return `


### PR DESCRIPTION
Fixes db module queries in chrome