### PR TITLE
feat(js): Map new Symbolicator 'scraping disabled' error

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -111,7 +111,6 @@ def map_symbolicator_process_js_errors(errors):
             mapped_errors.append({"type": EventError.JS_MISSING_SOURCE, "url": abs_path})
         elif ty == "missing_sourcemap" and not should_skip_missing_source_error(abs_path):
             mapped_errors.append({"type": EventError.JS_MISSING_SOURCE, "url": abs_path})
-        # TODO: Should we check for should_skip_missing_source_error here?
         elif ty == "scraping_disabled":
             mapped_errors.append({"type": EventError.JS_SCRAPING_DISABLED, "url": abs_path})
         elif ty == "malformed_sourcemap":

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -111,6 +111,9 @@ def map_symbolicator_process_js_errors(errors):
             mapped_errors.append({"type": EventError.JS_MISSING_SOURCE, "url": abs_path})
         elif ty == "missing_sourcemap" and not should_skip_missing_source_error(abs_path):
             mapped_errors.append({"type": EventError.JS_MISSING_SOURCE, "url": abs_path})
+        # TODO: Should we check for should_skip_missing_source_error here?
+        elif ty == "scraping_disabled":
+            mapped_errors.append({"type": EventError.JS_SCRAPING_DISABLED, "url": abs_path})
         elif ty == "malformed_sourcemap":
             mapped_errors.append({"type": EventError.JS_INVALID_SOURCEMAP, "url": error["url"]})
         elif ty == "missing_source_content":


### PR DESCRIPTION
https://github.com/getsentry/symbolicator/pull/1168 adds a "scraping disabled" error to Symbolicator's JS symbolication. We map this to the `sentry` JS_SCRAPING_DISABLED` error here.