### PR TITLE
feat(perf-issues): Accept http.method as key for span data

### DIFF
--- a/fixtures/events/performance_problems/consecutive-http/consecutive-http-basic.json
+++ b/fixtures/events/performance_problems/consecutive-http/consecutive-http-basic.json
@@ -1176,7 +1176,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "xhr",
         "url": "https://my-api.io/api/users?page=1"
       },
@@ -1205,7 +1205,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "xhr",
         "url": "https://my-api.io/api/users?page=2"
       },
@@ -1223,7 +1223,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "xhr",
         "url": "https://my-api.io/api/users?page=3"
       },
@@ -1241,7 +1241,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "xhr",
         "url": "https://my-api.io/api/users?page=4"
       },
@@ -1259,7 +1259,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "xhr",
         "url": "https://my-api.io/api/users?page=5"
       },
@@ -1277,7 +1277,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "xhr",
         "url": "https://my-api.io/api/users?page=6"
       },

--- a/fixtures/events/performance_problems/n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream.json
+++ b/fixtures/events/performance_problems/n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream.json
@@ -66,7 +66,7 @@
       "trace_id": "0102834d0bf74d388ce0b1e15329f731",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/api/0/organizations/?member=1"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/organizations/?member=1"},
       "hash": "cbc1d1c7a6500a75"
     },
     {
@@ -81,7 +81,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/client-state/"
       },
@@ -98,7 +98,7 @@
       "trace_id": "0102834d0bf74d388ce0b1e15329f731",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/api/0/subscriptions/sentry/"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/subscriptions/sentry/"},
       "hash": "51a97bb49057facc"
     },
     {
@@ -113,7 +113,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/broadcasts/"
       },
@@ -153,7 +153,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/searches/"
       },
@@ -170,7 +170,7 @@
       "trace_id": "0102834d0bf74d388ce0b1e15329f731",
       "status": "cancelled",
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/tags/?statsPeriod=14d&use_cache=1"
       },
@@ -188,7 +188,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/users/"
       },
@@ -240,7 +240,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/processingissues/"
       },
@@ -258,7 +258,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/issues/?collapse=stats&expand=owners&expand=inbox&limit=25&query=is%3Aunresolved&shortIdLookup=1&statsPeriod=14d"
       },
@@ -323,7 +323,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/issues-stats/?groups=3357551786&groups=3653952005&groups=3632201767&groups=3615922758&groups=1816441087&groups=2735845732&groups=2021019829&groups=3708674711&groups=3635082165&groups=1888630303&groups=2615251187&groups=3476760148&groups=3254685754&groups=2364324326&groups=3677909695&groups=1816441096&groups=3708657138&groups=3146776098&groups=3542232742&groups=2636653063&groups=2615489334&groups=3696257335&groups=3696257277&groups=3693916318&groups=3696257055&query=is%3Aunresolved&statsPeriod=14d"
       },
@@ -341,7 +341,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/issues-count/?query=is%3Aunresolved%20is%3Afor_review%20assigned_or_suggested%3A%5Bme%2C%20none%5D&query=is%3Aignored&query=is%3Areprocessing&statsPeriod=14d"
       },
@@ -370,7 +370,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3357551786%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -388,7 +388,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3653952005%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -406,7 +406,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3632201767%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -424,7 +424,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3615922758%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -442,7 +442,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A1816441087%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -460,7 +460,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A2735845732%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -478,7 +478,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A2021019829%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -496,7 +496,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3708674711%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -514,7 +514,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3635082165%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -532,7 +532,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A1888630303%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -550,7 +550,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A2615251187%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -568,7 +568,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3476760148%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -586,7 +586,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3254685754%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -604,7 +604,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A2364324326%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -622,7 +622,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3677909695%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -640,7 +640,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A1816441096%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -658,7 +658,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3708657138%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -676,7 +676,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3146776098%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -694,7 +694,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3542232742%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -712,7 +712,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A2636653063%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -730,7 +730,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A2615489334%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -748,7 +748,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3696257335%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -766,7 +766,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3696257277%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -784,7 +784,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3693916318%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -802,7 +802,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A3696257055%20%21replayId%3A%22%22&statsPeriod=14d"
       },

--- a/fixtures/events/performance_problems/n-plus-one-api-calls/n-plus-one-api-calls-in-weather-app.json
+++ b/fixtures/events/performance_problems/n-plus-one-api-calls/n-plus-one-api-calls-in-weather-app.json
@@ -55,7 +55,7 @@
       "trace_id": "5e4bea914d3944d3b2d0e31b079d1db5",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/cities.json"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/cities.json"},
       "hash": "743372e8fa81c1b0"
     },
     {
@@ -70,7 +70,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1001"
       },
@@ -88,7 +88,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1002"
       },
@@ -106,7 +106,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1003"
       },
@@ -124,7 +124,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1004"
       },
@@ -142,7 +142,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1005"
       },
@@ -160,7 +160,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1006"
       },
@@ -178,7 +178,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1007"
       },
@@ -196,7 +196,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1008"
       },
@@ -214,7 +214,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1009"
       },
@@ -232,7 +232,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/country/canada/weather?city_id=1010"
       },

--- a/fixtures/events/performance_problems/n-plus-one-api-calls/not-n-plus-one-api-calls.json
+++ b/fixtures/events/performance_problems/n-plus-one-api-calls/not-n-plus-one-api-calls.json
@@ -70,7 +70,7 @@
       "trace_id": "98be611cb95e24f72813487f12922a01",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/api/0/organizations/?member=1"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/organizations/?member=1"},
       "hash": "cbc1d1c7a6500a75"
     },
     {
@@ -84,7 +84,7 @@
       "trace_id": "98be611cb95e24f72813487f12922a01",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/api/0/internal/health/"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/internal/health/"},
       "hash": "61f17e17e6e505c4"
     },
     {
@@ -98,7 +98,7 @@
       "trace_id": "98be611cb95e24f72813487f12922a01",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/api/0/assistant/"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/assistant/"},
       "hash": "df65e7b0208b5678"
     },
     {
@@ -113,7 +113,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/client-state/"
       },
@@ -141,7 +141,7 @@
       "trace_id": "98be611cb95e24f72813487f12922a01",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"method": "GET", "type": "fetch", "url": "/api/0/subscriptions/sentry/"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/subscriptions/sentry/"},
       "hash": "d09dea4693554039"
     },
     {
@@ -156,7 +156,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/broadcasts/"
       },
@@ -207,7 +207,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/events/?field=replayId&field=count%28%29&per_page=50&query=issue.id%3A1888481%20%21replayId%3A%22%22&statsPeriod=14d"
       },
@@ -225,7 +225,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/environments/"
       },
@@ -290,7 +290,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/issues/1888481/events/latest/"
       },
@@ -308,7 +308,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/issues/1888481/?collapse=release&expand=inbox&expand=owners"
       },
@@ -326,7 +326,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/issues/1888481/first-last-release/"
       },
@@ -344,7 +344,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "PUT",
+        "http.method": "PUT",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/issues/?id=1888481"
       },
@@ -399,7 +399,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/"
       },
@@ -504,7 +504,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/events/2df376c1caa4352bdf3426d05af90bb8/grouping-info/"
       },
@@ -522,7 +522,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/events/2df376c1caa4352bdf3426d05af90bb8/attachments/?query=rrweb"
       },
@@ -540,7 +540,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/events/2df376c1caa4352bdf3426d05af90bb8/owners/"
       },
@@ -558,7 +558,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/codeowners/"
       },
@@ -587,7 +587,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/groups/1888481/integrations/"
       },
@@ -605,7 +605,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/groups/1888481/external-issues/"
       },
@@ -634,7 +634,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/repos/"
       },
@@ -652,7 +652,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/releases/x/"
       },
@@ -670,7 +670,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/releases/[x]/deploys/"
       },
@@ -688,7 +688,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/prompts-activity/?feature=stacktrace_link&organization_id=97234&project_id=555"
       },
@@ -706,7 +706,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/issues/1888481/?collapse=release"
       },
@@ -724,7 +724,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/issues/1888481/current-release/"
       },
@@ -742,7 +742,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/issues/1888481/tags/?key=browser&key=browser.name&key=client_os&key=client_os.name&key=device&key=device.family&key=environment&key=level&key=python_version&key=release&key=request_id&key=server_name&key=site&key=transaction&key=url&key=user"
       },
@@ -760,7 +760,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/releases/completion/"
       },
@@ -778,7 +778,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/sentry-app-installations/"
       },
@@ -796,7 +796,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/sentry-app-components/?projectId=555"
       },
@@ -825,7 +825,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/"
       },
@@ -843,7 +843,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/events/2df376c1caa4352bdf3426d05af90bb8/committers/"
       },
@@ -861,7 +861,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/events/2df376c1caa4352bdf3426d05af90bb8/attachments/"
       },
@@ -879,7 +879,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/users/?project=555"
       },
@@ -1030,7 +1030,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/releases/x/"
       },
@@ -1048,7 +1048,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "GET",
+        "http.method": "GET",
         "type": "fetch",
         "url": "/api/0/organizations/sentry/releases/x/deploys/"
       },
@@ -1140,7 +1140,7 @@
       "status": "ok",
       "tags": {"http.status_code": "200"},
       "data": {
-        "method": "PUT",
+        "http.method": "PUT",
         "type": "fetch",
         "url": "/api/0/projects/sentry/javascript/issues/?id=1888481"
       },

--- a/fixtures/events/performance_problems/n-plus-one-in-rails-index-view.json
+++ b/fixtures/events/performance_problems/n-plus-one-in-rails-index-view.json
@@ -191,7 +191,7 @@
           "controller": "BooksController",
           "db_runtime": 3405.640000164509,
           "format": "html",
-          "method": "GET",
+          "http.method": "GET",
           "params": {"action": "index", "controller": "books"},
           "path": "/books",
           "status": 200,

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -216,6 +216,8 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
 
         if request:
             url = request.get("url", "") or ""
+            # TODO(nar): `method` can be removed once SDK adoption has increased and
+            # we are receiving `http.method` consistently, likely beyond October 2023
             method = request.get("http.method", "") or request.get("method", "") or ""
             if url.endswith("/graphql") and method.lower() in ["post", "get"]:
                 return False

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -216,7 +216,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
 
         if request:
             url = request.get("url", "") or ""
-            method = request.get("method", "") or ""
+            method = request.get("http.method") or request.get("method", "") or ""
             if url.endswith("/graphql") and method.lower() in ["post", "get"]:
                 return False
 

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -216,7 +216,7 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
 
         if request:
             url = request.get("url", "") or ""
-            method = request.get("http.method") or request.get("method", "") or ""
+            method = request.get("http.method", "") or request.get("method", "") or ""
             if url.endswith("/graphql") and method.lower() in ["post", "get"]:
                 return False
 

--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -24,6 +24,8 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
             return
 
         data = span.get("data", None)
+        # TODO(nar): `Encoded Body Size` can be removed once SDK adoption has increased and
+        # we are receiving `http.response_content_length` consistently, likely beyond October 2023
         encoded_body_size = data and (
             data.get("http.response_content_length", None) or data.get("Encoded Body Size")
         )

--- a/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
@@ -100,6 +100,8 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
             return False
 
         minimum_size_bytes = self.settings.get("minimum_size_bytes")
+        # TODO(nar): `Encoded Body Size` can be removed once SDK adoption has increased and
+        # we are receiving `http.response_content_length` consistently, likely beyond October 2023
         encoded_body_size = (
             data
             and (data.get("http.response_content_length", 0) or data.get("Encoded Body Size", 0))

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -36,6 +36,8 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
             return
 
         data = span.get("data", None)
+        # TODO(nar): The sentence-style keys can be removed once SDK adoption has increased and
+        # we are receiving snake_case keys consistently, likely beyond October 2023
         transfer_size = data and (
             data.get("http.transfer_size", None) or data.get("Transfer Size", None)
         )


### PR DESCRIPTION
Span data is renaming `method` -> `http.method` so this PR checks for both in the backend. I was only able to find one perf issue that relied on `method`. Could there be other places I need to update to use `http.method`?

SDK PR: https://github.com/getsentry/sentry-javascript/pull/7990