### PR TITLE
feat(alerts): Allow delete on alert without incidents feature

### DIFF
--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -15,7 +15,10 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
         args, kwargs = super().convert_args(request, *args, **kwargs)
         project = kwargs["project"]
 
-        if not features.has("organizations:incidents", project.organization, actor=request.user):
+        # Allow orgs that have downgraded plans to delete metric alerts
+        if request.method != "DELETE" and not features.has(
+            "organizations:incidents", project.organization, actor=request.user
+        ):
             raise ResourceDoesNotExist
 
         if not request.access.has_project_access(project):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -106,7 +106,7 @@ class AlertRuleDetailsBase(APITestCase):
     def test_no_feature(self):
         self.login_as(self.owner_user)
         resp = self.get_response(self.organization.slug, self.project.slug, self.alert_rule.id)
-        assert resp.status_code == 404
+        assert resp.status_code == 204
 
 
 @region_silo_test(stable=True)

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -106,7 +106,9 @@ class AlertRuleDetailsBase(APITestCase):
     def test_no_feature(self):
         self.login_as(self.owner_user)
         resp = self.get_response(self.organization.slug, self.project.slug, self.alert_rule.id)
-        assert resp.status_code == 204
+        # Without incidents feature flag, allow delete
+        status = 204 if self.method == "delete" else 404
+        assert resp.status_code == status
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
Allows the deletion of metric alerts even after orgs have lost the incidents feature flag

fixes #47761
