### PR TITLE
feat(exception-group): Move related exceptions out of the stack trace and sort properly

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -161,7 +161,7 @@ describe('Exception Content', function () {
       projectSlug: project.slug,
     };
 
-    it('displays exception group tree in first frame', function () {
+    it('displays exception group tree under first exception', function () {
       render(<Content {...defaultProps} />);
 
       const exceptions = screen.getAllByTestId('exception-value');
@@ -169,14 +169,10 @@ describe('Exception Content', function () {
       // There are 4 exceptions in the exception group fixture
       expect(exceptions).toHaveLength(4);
 
-      // First exception should be the parent ExceptionGroup and the tree should be visible
-      // in the top frame context
+      // First exception should be the parent ExceptionGroup
+      expect(within(exceptions[0]).getByText('ExceptionGroup 1')).toBeInTheDocument();
       expect(
         within(exceptions[0]).getByRole('heading', {name: 'ExceptionGroup 1'})
-      ).toBeInTheDocument();
-      const exception1FrameContext = within(exceptions[0]).getByTestId('frame-context');
-      expect(
-        within(exception1FrameContext).getByRole('cell', {name: 'Related Exceptions'})
       ).toBeInTheDocument();
     });
 
@@ -185,14 +181,10 @@ describe('Exception Content', function () {
 
       const exceptions = screen.getAllByTestId('exception-value');
 
-      // Last exception should be the parent ExceptionGroup and the tree should be visible
-      // in the top frame context
+      // Last exception should be the parent ExceptionGroup
+      expect(within(exceptions[3]).getByText('ExceptionGroup 1')).toBeInTheDocument();
       expect(
         within(exceptions[3]).getByRole('heading', {name: 'ExceptionGroup 1'})
-      ).toBeInTheDocument();
-      const exception1FrameContext = within(exceptions[3]).getByTestId('frame-context');
-      expect(
-        within(exception1FrameContext).getByRole('cell', {name: 'Related Exceptions'})
       ).toBeInTheDocument();
     });
 
@@ -203,9 +195,7 @@ describe('Exception Content', function () {
 
       const exceptionGroupWithNoContext = exceptions[2];
       expect(
-        within(exceptionGroupWithNoContext).getByRole('cell', {
-          name: 'Related Exceptions',
-        })
+        within(exceptionGroupWithNoContext).getByText('Related Exceptions')
       ).toBeInTheDocument();
     });
   });

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -13,6 +13,7 @@ import {defined} from 'sentry/utils';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {Mechanism} from './mechanism';
+import {RelatedExceptions} from './relatedExceptions';
 import {SourceMapDebug} from './sourceMapDebug';
 import StackTrace from './stackTrace';
 import {debugFramesEnabled, getUniqueFilesFromException} from './useSourceMapDebug';
@@ -93,6 +94,11 @@ export function Content({
         {exc.mechanism && (
           <Mechanism data={exc.mechanism} meta={meta?.[excIdx]?.mechanism} />
         )}
+        <RelatedExceptions
+          mechanism={exc.mechanism}
+          allExceptions={values}
+          newestFirst={newestFirst}
+        />
         <ErrorBoundary mini>
           {hasSourcemapDebug && (
             <SourceMapDebug debugFrames={debugFrames} event={event} />
@@ -115,7 +121,6 @@ export function Content({
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta?.[excIdx]?.stacktrace}
           debugFrames={hasSourcemapDebug ? debugFrames : undefined}
-          mechanism={exc.mechanism}
         />
       </div>
     );

--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -106,7 +106,7 @@ export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
 }
 
 const Wrapper = styled('div')`
-  margin: ${space(2)} 0;
+  margin: ${space(2)} 0 ${space(0.5)} 0;
 `;
 
 const iconStyle = (p: {theme: Theme}) => css`

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
@@ -88,7 +88,6 @@ const props: React.ComponentProps<typeof ExceptionStacktraceContent> = {
   hasHierarchicalGrouping: false,
   groupingCurrentLevel: undefined,
   meta: undefined,
-  mechanism: null,
 };
 
 describe('ExceptionStacktraceContent', function () {

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -5,7 +5,7 @@ import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ExceptionValue, Group, PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {STACK_VIEW, StackTraceMechanism} from 'sentry/types/stacktrace';
+import {STACK_VIEW} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {isNativePlatform} from 'sentry/utils/platform';
 
@@ -18,7 +18,6 @@ type Props = {
   data: ExceptionValue['stacktrace'];
   event: Event;
   hasHierarchicalGrouping: boolean;
-  mechanism: StackTraceMechanism | null;
   platform: PlatformType;
   stacktrace: ExceptionValue['stacktrace'];
   debugFrames?: StacktraceFilenameQuery[];
@@ -42,7 +41,6 @@ function StackTrace({
   expandFirstFrame,
   event,
   meta,
-  mechanism,
 }: Props) {
   if (!defined(stacktrace)) {
     return null;
@@ -111,7 +109,6 @@ function StackTrace({
         event={event}
         meta={meta}
         debugFrames={debugFrames}
-        mechanism={mechanism}
       />
     );
   }
@@ -126,7 +123,6 @@ function StackTrace({
       event={event}
       meta={meta}
       debugFrames={debugFrames}
-      mechanism={mechanism}
     />
   );
 }

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -147,7 +147,6 @@ class Content extends Component<Props, State> {
       meta,
       debugFrames,
       hideIcon,
-      mechanism,
     } = this.props;
 
     const {showingAbsoluteAddresses, showCompleteFunctionName} = this.state;
@@ -240,11 +239,9 @@ class Content extends Component<Props, State> {
             onFunctionNameToggle={this.handleToggleFunctionName}
             showCompleteFunctionName={showCompleteFunctionName}
             isHoverPreviewed={isHoverPreviewed}
-            isNewestFrame={frameIdx === lastFrameIdx}
             frameMeta={meta?.frames?.[frameIdx]}
             registersMeta={meta?.registers}
             debugFrames={debugFrames}
-            mechanism={mechanism}
           />
         );
       }

--- a/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
@@ -7,7 +7,7 @@ import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {Frame, Group, PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {StackTraceMechanism, StacktraceType} from 'sentry/types/stacktrace';
+import {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 
 import Line from '../../frame/line';
@@ -28,7 +28,6 @@ type Props = {
   includeSystemFrames?: boolean;
   isHoverPreviewed?: boolean;
   maxDepth?: number;
-  mechanism?: StackTraceMechanism | null;
   meta?: Record<any, any>;
   newestFirst?: boolean;
 };
@@ -47,7 +46,6 @@ export function HierarchicalGroupingContent({
   hideIcon,
   includeSystemFrames = true,
   expandFirstFrame = true,
-  mechanism,
 }: Props) {
   const [showingAbsoluteAddresses, setShowingAbsoluteAddresses] = useState(false);
   const [showCompleteFunctionName, setShowCompleteFunctionName] = useState(false);
@@ -207,8 +205,6 @@ export function HierarchicalGroupingContent({
             frameMeta: meta?.frames?.[frameIndex],
             registersMeta: meta?.registers,
             debugFrames,
-            mechanism,
-            isNewestFrame: frameIndex === lastFrameIndex,
           };
 
           nRepeats = 0;

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -4,9 +4,7 @@ import keyBy from 'lodash/keyBy';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {ExceptionGroupContext} from 'sentry/components/events/interfaces/frame/exceptionGroupContext';
 import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktraceLink';
-import {hasExceptionGroupTree} from 'sentry/components/events/interfaces/frame/utils';
 import {IconFlag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -17,7 +15,6 @@ import {
   LineCoverage,
   Organization,
   SentryAppComponent,
-  StackTraceMechanism,
 } from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -49,8 +46,6 @@ type Props = {
   hasContextVars?: boolean;
   isExpanded?: boolean;
   isFirst?: boolean;
-  isNewestFrame?: boolean;
-  mechanism?: StackTraceMechanism | null;
   organization?: Organization;
   registersMeta?: Record<any, any>;
 };
@@ -86,8 +81,6 @@ function Context({
   className,
   frameMeta,
   registersMeta,
-  mechanism,
-  isNewestFrame,
 }: Props) {
   const {projects} = useProjects();
   const project = useMemo(
@@ -135,13 +128,7 @@ function Context({
       : {}
   );
 
-  if (
-    !hasContextSource &&
-    !hasContextVars &&
-    !hasContextRegisters &&
-    !hasAssembly &&
-    !hasExceptionGroupTree({isNewestFrame, mechanism})
-  ) {
+  if (!hasContextSource && !hasContextVars && !hasContextRegisters && !hasAssembly) {
     return emptySourceNotation ? (
       <EmptyContext>
         <StyledIconFlag size="xs" />
@@ -206,8 +193,6 @@ function Context({
             </ContextLine>
           );
         })}
-
-      <ExceptionGroupContext {...{event, isNewestFrame, mechanism}} />
 
       {hasContextVars && (
         <StyledClippedBox clipHeight={100}>

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -17,13 +17,7 @@ import {IconChevron, IconRefresh, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
-import {
-  Frame,
-  Organization,
-  PlatformType,
-  SentryAppComponent,
-  StackTraceMechanism,
-} from 'sentry/types';
+import {Frame, Organization, PlatformType, SentryAppComponent} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import withOrganization from 'sentry/utils/withOrganization';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
@@ -63,10 +57,8 @@ type Props = {
    * Is the stack trace being previewed in a hovercard?
    */
   isHoverPreviewed?: boolean;
-  isNewestFrame?: boolean;
   isOnlyFrame?: boolean;
   maxLengthOfRelativeAddress?: number;
-  mechanism?: StackTraceMechanism | null;
   nextFrame?: Frame;
   onAddressToggle?: (event: React.MouseEvent<SVGElement>) => void;
   onFunctionNameToggle?: (event: React.MouseEvent<SVGElement>) => void;
@@ -153,23 +145,13 @@ export class DeprecatedLine extends Component<Props, State> {
   }
 
   isExpandable() {
-    const {
-      registers,
-      platform,
-      emptySourceNotation,
-      isOnlyFrame,
-      data,
-      isNewestFrame,
-      mechanism,
-    } = this.props;
+    const {registers, platform, emptySourceNotation, isOnlyFrame, data} = this.props;
     return isExpandable({
       frame: data,
       registers,
       platform,
       emptySourceNotation,
       isOnlyFrame,
-      isNewestFrame,
-      mechanism,
     });
   }
 
@@ -415,8 +397,6 @@ export class DeprecatedLine extends Component<Props, State> {
           isExpanded={this.state.isExpanded}
           registersMeta={this.props.registersMeta}
           frameMeta={this.props.frameMeta}
-          mechanism={this.props.mechanism}
-          isNewestFrame={this.props.isNewestFrame}
         />
       </StyledLi>
     );

--- a/static/app/components/events/interfaces/frame/line/index.tsx
+++ b/static/app/components/events/interfaces/frame/line/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import ListItem from 'sentry/components/list/listItem';
 import StrictClick from 'sentry/components/strictClick';
-import {PlatformType, SentryAppComponent, StackTraceMechanism} from 'sentry/types';
+import {PlatformType, SentryAppComponent} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
@@ -37,9 +37,7 @@ type Props = Omit<
     registers: Record<string, string>;
     emptySourceNotation?: boolean;
     frameMeta?: Record<string, any>;
-    isNewestFrame?: boolean;
     isOnlyFrame?: boolean;
-    mechanism?: StackTraceMechanism | null;
     registersMeta?: Record<string, any>;
   };
 
@@ -61,8 +59,6 @@ function Line({
   frameMeta,
   registersMeta,
   emptySourceNotation = false,
-  mechanism,
-  isNewestFrame,
   /**
    * Is the stack trace being previewed in a hovercard?
    */
@@ -168,8 +164,6 @@ function Line({
         isExpanded={isExpanded}
         registersMeta={registersMeta}
         frameMeta={frameMeta}
-        mechanism={mechanism}
-        isNewestFrame={isNewestFrame}
       />
     </StyleListItem>
   );

--- a/static/app/components/events/interfaces/frame/utils.tsx
+++ b/static/app/components/events/interfaces/frame/utils.tsx
@@ -1,12 +1,6 @@
 import {IconQuestion, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {
-  Event,
-  EventOrGroupType,
-  Frame,
-  PlatformType,
-  StackTraceMechanism,
-} from 'sentry/types';
+import {Event, EventOrGroupType, Frame, PlatformType} from 'sentry/types';
 import {defined, objectIsEmpty} from 'sentry/utils';
 
 import {SymbolicatorStatus} from '../types';
@@ -92,31 +86,17 @@ export function hasAssembly(frame: Frame, platform?: string) {
   );
 }
 
-export function hasExceptionGroupTree({
-  isNewestFrame,
-  mechanism,
-}: {
-  isNewestFrame?: boolean;
-  mechanism?: StackTraceMechanism | null;
-}) {
-  return Boolean(isNewestFrame && mechanism?.is_exception_group);
-}
-
 export function isExpandable({
   frame,
   registers,
   emptySourceNotation,
   platform,
   isOnlyFrame,
-  isNewestFrame,
-  mechanism,
 }: {
   frame: Frame;
   registers: Record<string, string>;
   emptySourceNotation?: boolean;
-  isNewestFrame?: boolean;
   isOnlyFrame?: boolean;
-  mechanism?: StackTraceMechanism | null;
   platform?: string;
 }) {
   return (
@@ -124,8 +104,7 @@ export function isExpandable({
     hasContextSource(frame) ||
     hasContextVars(frame) ||
     hasContextRegisters(registers) ||
-    hasAssembly(frame, platform) ||
-    hasExceptionGroupTree({isNewestFrame, mechanism})
+    hasAssembly(frame, platform)
   );
 }
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/48115, https://github.com/getsentry/sentry/issues/47957

- Related exceptions are now above the stack trace. This simplified the code quite a bit and means we don't need to prop-drill `mechanism` and `isNewestFrame` any longer, which is the reason for so many deleted lines.
- The child exceptions in the tree are now sorted according to the selected stack trace order preference (newest vs oldest first).

Before:

![CleanShot 2023-04-28 at 10 30 01](https://user-images.githubusercontent.com/10888943/235214565-6330e3b0-16a2-411c-977a-364f514cec07.png)

After:

![CleanShot 2023-04-28 at 10 29 45](https://user-images.githubusercontent.com/10888943/235214593-acbc849c-b758-46b2-abba-e13a4ba34dbe.png)
