### PR TITLE
style(profiling): Shift profiling empty state image on xxlarge breakp…

### DIFF
--- a/static/app/views/profiling/profilingOnboardingPanel.tsx
+++ b/static/app/views/profiling/profilingOnboardingPanel.tsx
@@ -58,7 +58,7 @@ const HeroImage = styled('img')`
   }
 
   @media (min-width: ${p => p.theme.breakpoints.xxlarge}) {
-    transform: translateX(-60%);
+    transform: translateX(-65%);
     width: 420px;
     min-width: 420px;
   }


### PR DESCRIPTION
…oint

There was not enough space between the image and the text on xxlarge breakpoint.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/235217328-6a66e019-405e-40fb-bd7c-cfd492d59214.png)

## After

![image](https://user-images.githubusercontent.com/10239353/235217285-37d22701-0122-473b-a961-87f7bb6e9003.png)