### PR TITLE
ref(pageFilters): Add new `DatePageFilter` w/ updated UI

### DIFF
--- a/static/app/components/organizations/datePageFilter.spec.tsx
+++ b/static/app/components/organizations/datePageFilter.spec.tsx
@@ -1,0 +1,125 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+
+const {organization, router, routerContext} = initializeOrg({
+  organization: {},
+  project: undefined,
+  projects: undefined,
+  router: {
+    location: {
+      query: {},
+      pathname: '/test',
+    },
+    params: {},
+  },
+});
+
+describe('DatePageFilter', function () {
+  beforeEach(() => {
+    PageFiltersStore.init();
+    OrganizationStore.init();
+
+    OrganizationStore.onUpdate(organization, {replace: true});
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [],
+        environments: [],
+        datetime: {
+          period: '7d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+      },
+      new Set()
+    );
+  });
+
+  it('can change period', async function () {
+    render(<DatePageFilter />, {context: routerContext, organization});
+
+    // Open time period dropdown
+    await userEvent.click(screen.getByRole('button', {name: '7D', expanded: false}));
+
+    // Click 30 day period
+    await userEvent.click(screen.getByRole('option', {name: 'Last 30 days'}));
+
+    // Confirm selection changed visible text and query params
+    expect(
+      screen.getByRole('button', {name: '30D', expanded: false})
+    ).toBeInTheDocument();
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({query: {statsPeriod: '30d'}})
+    );
+    expect(PageFiltersStore.getState()).toEqual({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      selection: {
+        datetime: {
+          period: '30d',
+          end: undefined,
+          start: undefined,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    });
+  });
+
+  it('can change absolute range', async function () {
+    render(<DatePageFilter />, {context: routerContext, organization});
+
+    // Open time period dropdown
+    await userEvent.click(screen.getByRole('button', {name: '7D', expanded: false}));
+
+    // Click 30 day period
+    await userEvent.click(screen.getByRole('option', {name: 'Absolute date'}));
+
+    const fromDateInput = screen.getByTestId('date-range-primary-from');
+    const toDateInput = screen.getByTestId('date-range-primary-to');
+    fireEvent.change(fromDateInput, {target: {value: '2017-10-03'}});
+    fireEvent.change(toDateInput, {target: {value: '2017-10-04'}});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    // Confirm selection changed visible text and query params
+    expect(
+      screen.getByRole('button', {name: 'Oct 3 – Oct 4', expanded: false})
+    ).toBeInTheDocument();
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {start: '2017-10-03T00:00:00', end: '2017-10-04T23:59:59'},
+      })
+    );
+    expect(PageFiltersStore.getState()).toEqual({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      selection: {
+        datetime: {
+          period: null,
+          end: new Date('2017-10-04T23:59:59.000Z'),
+          start: new Date('2017-10-03T00:00:00.000Z'),
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    });
+
+    // Absolute option is marked as selected
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Oct 3 – Oct 4', expanded: false})
+    );
+    expect(screen.getByRole('option', {name: 'Absolute date'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+});

--- a/static/app/components/organizations/datePageFilter.tsx
+++ b/static/app/components/organizations/datePageFilter.tsx
@@ -1,0 +1,37 @@
+import {updateDateTime} from 'sentry/actionCreators/pageFilters';
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
+import {t} from 'sentry/locale';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useRouter from 'sentry/utils/useRouter';
+
+interface DatePageFilterProps {
+  /**
+   * Reset these URL params when we fire actions (custom routing only)
+   */
+  resetParamsOnChange?: string[];
+}
+
+export function DatePageFilter({resetParamsOnChange}: DatePageFilterProps) {
+  const router = useRouter();
+  const {selection} = usePageFilters();
+  const {start, end, period, utc} = selection.datetime;
+
+  return (
+    <TimeRangeSelector
+      start={start}
+      end={end}
+      utc={utc}
+      relative={period}
+      onChange={timePeriodUpdate => {
+        const {relative, ...startEndUtc} = timePeriodUpdate;
+        const newTimePeriod = {period: relative, ...startEndUtc};
+
+        updateDateTime(newTimePeriod, router, {
+          save: true,
+          resetParams: resetParamsOnChange,
+        });
+      }}
+      menuTitle={t('Filter Time Range')}
+    />
+  );
+}

--- a/static/app/components/timeRangeSelector.spec.tsx
+++ b/static/app/components/timeRangeSelector.spec.tsx
@@ -1,0 +1,303 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
+import ConfigStore from 'sentry/stores/configStore';
+
+const {organization, routerContext} = initializeOrg({
+  organization: {features: ['global-views', 'open-membership']},
+  project: undefined,
+  projects: [
+    {id: 1, slug: 'project-1', isMember: true},
+    {id: 2, slug: 'project-2', isMember: true},
+    {id: 3, slug: 'project-3', isMember: false},
+  ],
+  router: {
+    location: {
+      pathname: '/organizations/org-slug/issues/',
+      query: {},
+    },
+    params: {},
+  },
+});
+
+describe('TimeRangeSelector', function () {
+  const onChange = jest.fn();
+
+  function getComponent(props = {}) {
+    return <TimeRangeSelector showAbsolute showRelative onChange={onChange} {...props} />;
+  }
+
+  function renderComponent(props = {}) {
+    return render(getComponent(props), {context: routerContext});
+  }
+
+  beforeEach(function () {
+    ConfigStore.loadInitialData(
+      TestStubs.Config({
+        user: {options: {timezone: 'America/New_York'}},
+      })
+    );
+    onChange.mockReset();
+  });
+
+  it('renders when given relative period', function () {
+    renderComponent({relative: '9d'});
+    expect(screen.getByRole('button', {name: '9D'})).toBeInTheDocument();
+  });
+
+  it('renders when given an invalid relative period', function () {
+    render(<TimeRangeSelector relative="1y" />, {context: routerContext, organization});
+    expect(screen.getByRole('button', {name: 'Invalid Period'})).toBeInTheDocument();
+  });
+
+  it('hides relative options', async function () {
+    renderComponent({showRelative: false, start: '0', end: '0'});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+    // Ensure none of the relative options are shown
+    expect(screen.queryByRole('option', {name: 'Last 1 hour'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 24 hours'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 7 days'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 14 days'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 30 days'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 90 days'})).not.toBeInTheDocument();
+
+    // Absolute selector is shown
+    expect(screen.getByTestId('date-range')).toBeInTheDocument();
+  });
+
+  it('hides absolute selector', async function () {
+    renderComponent({showAbsolute: false});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+    // Absolute option & selector are shown
+    expect(screen.queryByRole('option', {name: 'Absolute date'})).not.toBeInTheDocument();
+    expect(screen.queryByTestId('date-range')).not.toBeInTheDocument();
+  });
+
+  it('can select an absolute date range', async function () {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+    await userEvent.click(screen.getByRole('option', {name: 'Absolute date'}));
+    expect(screen.getByTestId('date-range')).toBeInTheDocument();
+
+    const fromDateInput = screen.getByTestId('date-range-primary-from');
+    const toDateInput = screen.getByTestId('date-range-primary-to');
+    expect(fromDateInput).toHaveValue('2017-10-02');
+    expect(toDateInput).toHaveValue('2017-10-16');
+    expect(screen.getByTestId('startTime')).toHaveValue('22:41');
+    expect(screen.getByTestId('endTime')).toHaveValue('22:41');
+
+    fireEvent.change(fromDateInput, {target: {value: '2017-10-03'}});
+    fireEvent.change(toDateInput, {target: {value: '2017-10-04'}});
+
+    // Selecting new date range resets time inputs to start/end of day
+    expect(screen.getByTestId('startTime')).toHaveValue('00:00');
+    expect(screen.getByTestId('endTime')).toHaveValue('23:59');
+
+    // onChange is called after clicking Apply
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: null,
+      start: new Date('2017-10-03T00:00:00'), // local time
+      end: new Date('2017-10-04T23:59:59'), // local time
+      utc: false,
+    });
+  });
+
+  it('can select an absolute range with utc enabled', async function () {
+    renderComponent({utc: true});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+    await userEvent.click(screen.getByRole('option', {name: 'Absolute date'}));
+    expect(await screen.findByTestId('date-range')).toBeInTheDocument();
+
+    const fromDateInput = screen.getByTestId('date-range-primary-from');
+    const toDateInput = screen.getByTestId('date-range-primary-to');
+    expect(fromDateInput).toHaveValue('2017-10-02');
+    expect(toDateInput).toHaveValue('2017-10-16');
+
+    expect(screen.getByTestId('startTime')).toHaveValue('22:41');
+    expect(screen.getByTestId('endTime')).toHaveValue('22:41');
+
+    fireEvent.change(fromDateInput, {target: {value: '2017-10-03'}});
+    fireEvent.change(toDateInput, {target: {value: '2017-10-04'}});
+
+    // Selecting new date range resets time inputs to start/end of day
+    expect(screen.getByTestId('startTime')).toHaveValue('00:00');
+    expect(screen.getByTestId('endTime')).toHaveValue('23:59');
+
+    // onChange is called after clicking Apply
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: null,
+      start: new Date('2017-10-03T00:00:00Z'), // utc time
+      end: new Date('2017-10-04T23:59:59Z'), // utc time
+      utc: true,
+    });
+  });
+
+  it('keeps time inputs focused while interacting with them', async function () {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+    await userEvent.click(screen.getByRole('option', {name: 'Absolute date'}));
+
+    await userEvent.click(screen.getByTestId('startTime'));
+    fireEvent.change(screen.getByTestId('startTime'), {target: {value: '05:00'}});
+    expect(screen.getByTestId('startTime')).toHaveFocus();
+
+    await userEvent.click(screen.getByTestId('endTime'));
+    fireEvent.change(screen.getByTestId('endTime'), {target: {value: '05:00'}});
+    expect(screen.getByTestId('endTime')).toHaveFocus();
+  });
+
+  it('switches from relative to absolute and then toggling UTC (starting with UTC)', async function () {
+    renderComponent({relative: '7d', utc: true});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+    await userEvent.click(screen.getByRole('option', {name: 'Absolute date'}));
+
+    // Local time is 22:41:20-0500 -- this is what date picker should show
+    expect(screen.getByTestId('startTime')).toHaveValue('22:41');
+    expect(screen.getByTestId('endTime')).toHaveValue('22:41');
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'UTC'}));
+
+    // onChange is called after clicking Apply
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: null,
+      start: new Date('2017-10-10T02:41:20.000Z'),
+      end: new Date('2017-10-17T02:41:20.000Z'),
+      utc: false,
+    });
+  });
+
+  it('switches from relative to absolute and then toggling UTC (starting with non-UTC)', async function () {
+    renderComponent({relative: '7d', utc: false});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+    await userEvent.click(screen.getByRole('option', {name: 'Absolute date'}));
+
+    // Local time is 22:41:20-0500 -- this is what date picker should show
+    expect(screen.getByTestId('startTime')).toHaveValue('22:41');
+    expect(screen.getByTestId('endTime')).toHaveValue('22:41');
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'UTC'}));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: null,
+      start: new Date('2017-10-09T22:41:20.000Z'),
+      end: new Date('2017-10-16T22:41:20.000Z'),
+      utc: true,
+    });
+  });
+  ``;
+
+  it('uses the default absolute date', async function () {
+    renderComponent({
+      defaultAbsolute: {
+        start: new Date('2017-10-10T00:00:00.000Z'),
+        end: new Date('2017-10-17T23:59:59.000Z'),
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+    await userEvent.click(screen.getByRole('option', {name: 'Absolute date'}));
+
+    // Time inputs show local time
+    expect(screen.getByTestId('startTime')).toHaveValue('20:00');
+    expect(screen.getByTestId('endTime')).toHaveValue('19:59');
+  });
+
+  it('can select arbitrary relative time ranges', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, '5');
+
+    // With just the number "5", all unit options should be present
+    expect(screen.getByRole('option', {name: 'Last 5 minutes'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Last 5 hours'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Last 5 days'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Last 5 weeks'})).toBeInTheDocument();
+
+    await userEvent.type(input, 'd');
+
+    // With "5d", only "Last 5 days" should be shown
+    expect(screen.getByRole('option', {name: 'Last 5 days'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {name: 'Last 5 minutes'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 5 hours'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 5 weeks'})).not.toBeInTheDocument();
+
+    await userEvent.type(input, 'ays');
+
+    // "5days" Should still show "Last 5 days" option
+    expect(screen.getByText('Last 5 days')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('option', {name: 'Last 5 days'}));
+    expect(onChange).toHaveBeenLastCalledWith({
+      relative: '5d',
+      start: undefined,
+      end: undefined,
+    });
+  });
+
+  it('respects maxPickableDays for arbitrary time ranges', async () => {
+    renderComponent({maxPickableDays: 30});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, '3');
+
+    // With just the number "3", all unit options should be present
+    expect(screen.getByRole('option', {name: 'Last 3 minutes'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Last 3 hours'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Last 3 days'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Last 3 weeks'})).toBeInTheDocument();
+
+    await userEvent.type(input, '1');
+
+    // With "31", days and weeks should not be suggested
+    expect(screen.getByRole('option', {name: 'Last 31 minutes'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Last 31 hours'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 31 days'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 31 weeks'})).not.toBeInTheDocument();
+
+    await userEvent.type(input, 'd');
+
+    // "31d" should return nothing
+    expect(screen.getByText('No options found')).toBeInTheDocument();
+  });
+
+  it('cannot select arbitrary relative time ranges with disallowArbitraryRelativeRanges', async () => {
+    renderComponent({disallowArbitraryRelativeRanges: true});
+
+    await userEvent.click(screen.getByRole('button', {expanded: false}));
+
+    const input = screen.getByRole('textbox');
+
+    // Search filter still works normally
+    await userEvent.type(input, '24');
+    expect(screen.getByRole('option', {name: 'Last 24 hours'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 1 hour'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 7 days'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 14 days'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 90 days'})).not.toBeInTheDocument();
+
+    // But no arbitrary relative range will be suggested
+    await userEvent.type(input, '5');
+    expect(screen.getByText('No options found')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/timeRangeSelector.tsx
+++ b/static/app/components/timeRangeSelector.tsx
@@ -1,0 +1,396 @@
+import {useCallback, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {
+  CompactSelect,
+  SelectOption,
+  SingleSelectProps,
+} from 'sentry/components/compactSelect';
+import {Item} from 'sentry/components/dropdownAutoComplete/types';
+import DropdownButton from 'sentry/components/dropdownButton';
+import HookOrDefault from 'sentry/components/hookOrDefault';
+import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
+import DateRange from 'sentry/components/organizations/timeRangeSelector/dateRange';
+import SelectorItems from 'sentry/components/organizations/timeRangeSelector/selectorItems';
+import {
+  getAbsoluteSummary,
+  getDefaultRelativePeriods,
+  timeRangeAutoCompleteFilter,
+} from 'sentry/components/organizations/timeRangeSelector/utils';
+import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {IconArrow, IconCalendar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {DateString} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {
+  getDateWithTimezoneInUtc,
+  getInternalDate,
+  getLocalToSystem,
+  getPeriodAgo,
+  getUserTimezone,
+  getUtcToSystem,
+  parsePeriodToHours,
+} from 'sentry/utils/dates';
+import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import useOrganization from 'sentry/utils/useOrganization';
+import useRouter from 'sentry/utils/useRouter';
+
+const ABSOLUTE_OPTION_VALUE = 'absolute';
+
+const DateRangeHook = HookOrDefault({
+  hookName: 'component:header-date-range',
+  defaultComponent: DateRange,
+});
+
+const SelectorItemsHook = HookOrDefault({
+  hookName: 'component:header-selector-items',
+  defaultComponent: SelectorItems,
+});
+
+interface TimeRangeSelectorProps
+  extends Omit<
+    SingleSelectProps<string>,
+    'options' | 'onChange' | 'closeOnSelect' | 'value' | 'defaultValue' | 'multiple'
+  > {
+  /**
+   * Set an optional default value to prefill absolute date with
+   */
+  defaultAbsolute?: {end?: Date; start?: Date};
+  /**
+   * When the default period is selected, it is visually dimmed and makes the selector
+   * unclearable.
+   */
+  defaultPeriod?: string;
+  /**
+   * Forces the user to select from the set of defined relative options
+   */
+  disallowArbitraryRelativeRanges?: boolean;
+  /**
+   * End date value for absolute date selector
+   */
+  end?: DateString;
+  /**
+   * The maximum number of days in the past you can pick
+   */
+  maxPickableDays?: number;
+  onChange?: (data: ChangeData) => void;
+  /**
+   * Relative date value
+   */
+  relative?: string | null;
+  /**
+   * Override defaults from DEFAULT_RELATIVE_PERIODS
+   */
+  relativeOptions?: Record<string, React.ReactNode>;
+  /**
+   * Show absolute date selectors
+   */
+  showAbsolute?: boolean;
+  /**
+   * Show relative date selectors
+   */
+  showRelative?: boolean;
+  /**
+   * Start date value for absolute date selector
+   */
+  start?: DateString;
+  /**
+   * Default initial value for using UTC
+   */
+  utc?: boolean | null;
+}
+
+export function TimeRangeSelector({
+  start,
+  end,
+  utc,
+  relative,
+  relativeOptions,
+  onChange,
+  showAbsolute = true,
+  showRelative = true,
+  defaultAbsolute,
+  defaultPeriod = DEFAULT_STATS_PERIOD,
+  maxPickableDays = 90,
+  disallowArbitraryRelativeRanges = false,
+  ...selectProps
+}: TimeRangeSelectorProps) {
+  const router = useRouter();
+  const organization = useOrganization();
+
+  const [search, setSearch] = useState('');
+  const [hasChanges, setHasChanges] = useState(false);
+  const [hasDateRangeErrors, setHasDateRangeErrors] = useState(false);
+  const [showAbsoluteSelector, setShowAbsoluteSelector] = useState(!showRelative);
+
+  const [internalValue, setInternalValue] = useState<ChangeData>(() => {
+    const internalUtc = utc ?? getUserTimezone() === 'UTC';
+
+    return {
+      start: start ? getInternalDate(start, internalUtc) : undefined,
+      end: end ? getInternalDate(end, internalUtc) : undefined,
+      utc: internalUtc,
+      relative: relative ?? null,
+    };
+  });
+
+  const getOptions = useCallback(
+    (items: Item[]): SelectOption<string>[] => {
+      // Return the default options if there's nothing in search
+      if (!search) {
+        return items.map(item => {
+          if (item.value === 'absolute') {
+            return {
+              value: item.value,
+              // Wrap inside OptionLabel to offset custom margins from SelectorItemLabel
+              // TODO: Remove SelectorItemLabel & OptionLabel
+              label: <OptionLabel>{item.label}</OptionLabel>,
+              details:
+                start && end ? (
+                  <AbsoluteSummary>{getAbsoluteSummary(start, end, utc)}</AbsoluteSummary>
+                ) : null,
+              trailingItems: ({isFocused, isSelected}) => (
+                <IconArrow
+                  direction="right"
+                  size="xs"
+                  color={isFocused || isSelected ? undefined : 'subText'}
+                />
+              ),
+              textValue: item.searchKey,
+            };
+          }
+
+          return {
+            value: item.value,
+            label: <OptionLabel>{item.label}</OptionLabel>,
+            textValue: item.searchKey,
+          };
+        });
+      }
+
+      const filteredItems = disallowArbitraryRelativeRanges
+        ? items.filter(i => i.searchKey?.includes(search))
+        : // If arbitrary relative ranges are allowed, then generate a list of them based
+          // on the search query
+          timeRangeAutoCompleteFilter(items, search, {
+            maxDays: maxPickableDays,
+          });
+
+      return filteredItems.map(item => ({
+        value: item.value,
+        label: item.label,
+        textValue: item.searchKey,
+      }));
+    },
+    [start, end, utc, search, maxPickableDays, disallowArbitraryRelativeRanges]
+  );
+
+  const commitChanges = useCallback(() => {
+    showRelative && setShowAbsoluteSelector(false);
+    setSearch('');
+
+    if (!hasChanges) {
+      return;
+    }
+
+    setHasChanges(false);
+    onChange?.(
+      internalValue.start && internalValue.end
+        ? {
+            ...internalValue,
+            start: getDateWithTimezoneInUtc(internalValue.start, internalValue.utc),
+            end: getDateWithTimezoneInUtc(internalValue.end, internalValue.utc),
+          }
+        : internalValue
+    );
+  }, [showRelative, onChange, internalValue, hasChanges]);
+
+  const handleChange = useCallback<NonNullable<SingleSelectProps<string>['onChange']>>(
+    option => {
+      // The absolute option was selected -> open absolute selector
+      if (option.value === ABSOLUTE_OPTION_VALUE) {
+        setInternalValue(current => ({
+          ...current,
+          // Update default values for absolute selector
+          start: defaultAbsolute?.start
+            ? defaultAbsolute.start
+            : getPeriodAgo(
+                'hours',
+                parsePeriodToHours(relative || defaultPeriod || DEFAULT_STATS_PERIOD)
+              ).toDate(),
+          end: defaultAbsolute?.end ? defaultAbsolute.end : new Date(),
+        }));
+        setShowAbsoluteSelector(true);
+        return;
+      }
+
+      setInternalValue(current => ({...current, relative: option.value}));
+      onChange?.({relative: option.value, start: undefined, end: undefined});
+    },
+    [defaultAbsolute, defaultPeriod, relative, onChange]
+  );
+
+  return (
+    <SelectorItemsHook
+      shouldShowAbsolute={showAbsolute}
+      shouldShowRelative={showRelative}
+      relativePeriods={relativeOptions ?? getDefaultRelativePeriods(relative)}
+      handleSelectRelative={value => handleChange({value})}
+    >
+      {items => (
+        <CompactSelect
+          searchable={!showAbsoluteSelector}
+          disableSearchFilter
+          onSearch={setSearch}
+          searchPlaceholder={
+            disallowArbitraryRelativeRanges
+              ? t('Search…')
+              : t('Custom range: 2h, 4d, 8w…')
+          }
+          options={getOptions(items)}
+          hideOptions={showAbsoluteSelector}
+          value={start && end ? ABSOLUTE_OPTION_VALUE : relative ?? ''}
+          onChange={handleChange}
+          // Keep menu open when clicking on absolute range option
+          closeOnSelect={opt => opt.value !== ABSOLUTE_OPTION_VALUE}
+          onClose={() => {
+            setHasChanges(false);
+            setSearch('');
+          }}
+          onInteractOutside={commitChanges}
+          onKeyDown={e => e.key === 'Escape' && commitChanges()}
+          trigger={triggerProps => {
+            const relativeSummary =
+              items.findIndex(item => item.value === relative) > -1
+                ? relative?.toUpperCase()
+                : t('Invalid Period');
+            const defaultLabel =
+              start && end ? getAbsoluteSummary(start, end, utc) : relativeSummary;
+
+            return (
+              <DropdownButton {...triggerProps} icon={<IconCalendar />}>
+                <TriggerLabel>{selectProps.triggerLabel ?? defaultLabel}</TriggerLabel>
+              </DropdownButton>
+            );
+          }}
+          menuWidth={showAbsoluteSelector ? undefined : '16em'}
+          menuBody={
+            showAbsoluteSelector && (
+              <AbsoluteDateRangeWrap>
+                <StyledDateRangeHook
+                  start={internalValue.start ?? null}
+                  end={internalValue.end ?? null}
+                  utc={internalValue.utc}
+                  organization={organization}
+                  showTimePicker
+                  onChange={val => {
+                    val.hasDateRangeErrors && setHasDateRangeErrors(true);
+                    setInternalValue(cur => ({
+                      ...cur,
+                      relative: null,
+                      start: val.start,
+                      end: val.end,
+                    }));
+                    setHasChanges(true);
+                  }}
+                  onChangeUtc={() => {
+                    setHasChanges(true);
+                    setInternalValue(current => {
+                      const newUtc = !current.utc;
+                      const newStart =
+                        start ?? getDateWithTimezoneInUtc(current.start, current.utc);
+                      const newEnd =
+                        end ?? getDateWithTimezoneInUtc(current.end, current.utc);
+
+                      trackAnalytics('dateselector.utc_changed', {
+                        utc: newUtc,
+                        path: getRouteStringFromRoutes(router.routes),
+                        organization,
+                      });
+
+                      return {
+                        relative: null,
+                        start: newUtc
+                          ? getLocalToSystem(newStart)
+                          : getUtcToSystem(newStart),
+                        end: newUtc ? getLocalToSystem(newEnd) : getUtcToSystem(newEnd),
+                        utc: newUtc,
+                      };
+                    });
+                  }}
+                  maxPickableDays={maxPickableDays}
+                />
+              </AbsoluteDateRangeWrap>
+            )
+          }
+          menuFooter={
+            showAbsoluteSelector &&
+            (({closeOverlay}) => (
+              <AbsoluteSelectorFooter>
+                {showRelative && (
+                  <Button
+                    size="xs"
+                    borderless
+                    icon={<IconArrow size="xs" direction="left" />}
+                    onClick={() => setShowAbsoluteSelector(false)}
+                  >
+                    {t('Back')}
+                  </Button>
+                )}
+                <Button
+                  size="xs"
+                  priority="primary"
+                  disabled={!hasChanges || hasDateRangeErrors}
+                  onClick={() => {
+                    commitChanges();
+                    closeOverlay();
+                  }}
+                >
+                  {t('Apply')}
+                </Button>
+              </AbsoluteSelectorFooter>
+            ))
+          }
+          {...selectProps}
+        />
+      )}
+    </SelectorItemsHook>
+  );
+}
+
+const TriggerLabel = styled('span')`
+  ${p => p.theme.overflowEllipsis}
+  width: auto;
+`;
+
+const OptionLabel = styled('span')`
+  /* Remove custom margin added by SelectorItemLabel. Once we update custom hooks and
+  remove SelectorItemLabel, we can delete this. */
+  div {
+    margin: 0;
+  }
+`;
+
+const AbsoluteSummary = styled('span')`
+  time {
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+`;
+
+const AbsoluteDateRangeWrap = styled('div')`
+  overflow: auto;
+`;
+
+const StyledDateRangeHook = styled(DateRangeHook)`
+  border: none;
+  width: max-content;
+`;
+
+const AbsoluteSelectorFooter = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  justify-content: flex-end;
+`;


### PR DESCRIPTION
**Before ——**
<img width="263" alt="image" src="https://user-images.githubusercontent.com/44172267/235222032-d738803e-a6bf-4b33-b636-d0c752ca1b9a.png">
<img width="493" alt="image" src="https://user-images.githubusercontent.com/44172267/235221990-42ee1e49-3e18-4f60-b6cd-1559d1aec4b3.png">

**After ——** (this is what the new version will look like, this PR doesn't apply it to existing pages just yet)
<img width="239" alt="image" src="https://user-images.githubusercontent.com/44172267/235221107-57c63d2c-3d56-4232-b7ca-cf0a549cd7ee.png">
<img width="346" alt="image" src="https://user-images.githubusercontent.com/44172267/235221140-d5b7b643-ba1c-4784-a8b3-d45e61171aa6.png">


