### PR TITLE
feat(issues): Return the escalating forecast for an issue

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import tagstore, tsdb
+from sentry import features, tagstore, tsdb
 from sentry.api import client
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
@@ -22,6 +22,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
 from sentry.api.serializers.models.plugin import PluginSerializer, is_plugin_deprecated
 from sentry.issues.constants import get_issue_tsdb_group_model
+from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.grouptype import GroupCategory
 from sentry.models import Activity, Group, GroupSeen, GroupSubscriptionManager, UserReport
 from sentry.models.groupinbox import get_inbox_details
@@ -211,6 +212,21 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 owner_details = get_owner_details([group], request.user)
                 owners = owner_details.get(group.id)
                 data.update({"owners": owners})
+
+            if "forecast" in expand and features.has(
+                "organizations:escalating-issues", group.organization
+            ):
+                fetched_forecast = EscalatingGroupForecast.fetch(
+                    group.project_id, group.id
+                ).to_dict()
+                data.update(
+                    {
+                        "forecast": {
+                            "data": fetched_forecast.get("forecast"),
+                            "date_added": fetched_forecast.get("date_added"),
+                        }
+                    }
+                )
 
             action_list = self._get_actions(request, group)
             data.update(

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -12,6 +12,7 @@ from sentry.models import (
 )
 from sentry.models.groupinbox import add_group_to_inbox, remove_group_from_inbox
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
@@ -191,6 +192,22 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert len(response.data["owners"]) == 1
         assert response.data["owners"][0]["owner"] == f"user:{self.user.id}"
         assert response.data["owners"][0]["type"] == GROUP_OWNER_TYPE[GroupOwnerType.SUSPECT_COMMIT]
+
+    def test_group_expand_forecasts(self):
+        with Feature("organizations:escalating-issues"):
+            self.login_as(user=self.user)
+            event = self.store_event(
+                data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
+                project_id=self.project.id,
+            )
+            group = event.group
+            url = f"/api/0/issues/{group.id}/?expand=forecast"
+
+            response = self.client.get(url, format="json")
+            assert response.status_code == 200, response.content
+            assert response.data["forecast"] is not None
+            assert response.data["forecast"]["data"] is not None
+            assert response.data["forecast"]["date_added"] is not None
 
     def test_assigned_to_unknown(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry/issues/48169

## Objective:
We want to return the escalating forecast of an issue in the API response.