### PR TITLE
fix(search): skip timestamp search term when querying for issues and issues-stats

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -900,7 +900,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
         *SKIP_SNUBA_FIELDS,
         "last_seen",
         "times_seen",
-        "date",  # We merge this with start/end, so don't want to include it as its own
+        "date",
+        "timestamp",  # We merge this with start/end, so don't want to include it as its own
         # condition
         # We don't need to filter by release stage again here since we're
         # filtering to specific groups. Saves us making a second query to
@@ -928,12 +929,28 @@ class GroupSerializerSnuba(GroupSerializerBase):
         # should try and encapsulate this logic, but if you're changing this, change it
         # there as well.
         self.start = None
-        start_params = [_f for _f in [start, get_search_filter(search_filters, "date", ">")] if _f]
+        start_params = [
+            _f
+            for _f in [
+                start,
+                get_search_filter(search_filters, "date", ">"),
+                get_search_filter(search_filters, "timestamp", ">"),
+            ]
+            if _f
+        ]
         if start_params:
             self.start = max(_f for _f in start_params if _f)
 
         self.end = None
-        end_params = [_f for _f in [end, get_search_filter(search_filters, "date", "<")] if _f]
+        end_params = [
+            _f
+            for _f in [
+                end,
+                get_search_filter(search_filters, "date", "<"),
+                get_search_filter(search_filters, "timestamp", "<"),
+            ]
+            if _f
+        ]
         if end_params:
             self.end = min(end_params)
 

--- a/tests/snuba/api/serializers/test_group_stream.py
+++ b/tests/snuba/api/serializers/test_group_stream.py
@@ -2,13 +2,15 @@ import time
 from datetime import timedelta
 from unittest import mock
 
+import pytz
 from django.utils import timezone
 
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba, snuba_tsdb
 from sentry.models import Environment
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.testutils.helpers.datetime import iso_format
+from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import hash_values
@@ -226,3 +228,33 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
         assert result[0]["sessionCount"] == 2
         # No sessions in project2
         assert result[1]["sessionCount"] is None
+
+    def test_skipped_date_timestamp_filters(self):
+        group = self.create_group()
+        serializer = StreamGroupSerializerSnuba(
+            search_filters=[
+                SearchFilter(
+                    SearchKey("timestamp"),
+                    ">",
+                    SearchValue(before_now(hours=1).replace(tzinfo=pytz.UTC)),
+                ),
+                SearchFilter(
+                    SearchKey("timestamp"),
+                    "<",
+                    SearchValue(before_now(seconds=1).replace(tzinfo=pytz.UTC)),
+                ),
+                SearchFilter(
+                    SearchKey("date"),
+                    ">",
+                    SearchValue(before_now(hours=1).replace(tzinfo=pytz.UTC)),
+                ),
+                SearchFilter(
+                    SearchKey("date"),
+                    "<",
+                    SearchValue(before_now(seconds=1).replace(tzinfo=pytz.UTC)),
+                ),
+            ]
+        )
+        assert not serializer.conditions
+        result = serialize([group], self.user, serializer=serializer)
+        assert result[0]["id"] == str(group.id)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -328,6 +328,15 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         )
         assert set(results) == set()
 
+    def test_query_timestamp(self):
+        results = self.make_query(
+            [self.project],
+            environments=[self.environments["production"]],
+            search_filter_query=f"timestamp:>{iso_format(self.event1.datetime)} timestamp:<{iso_format(self.event3.datetime)}",
+        )
+
+        assert set(results) == {self.group1}
+
     def test_sort(self):
         results = self.make_query(sort_by="date")
         assert list(results) == [self.group1, self.group2]


### PR DESCRIPTION
Saw some invalid queries where users search on `timestamp:>2023-04-19T19:57:00+05:30 timestamp:<2023-04-19T20:10:00+05:30`. This resulted in a 500 internal server error when querying for issue-stats (not totally sure why querying for issues worked here). The cause of the internal error was due to duplicate and overlapping `timestamp` where clauses in the snuba query. 

This PR special-cases when filtering on `timestamp`, similar to what we do with `date`, by excluding the timestamp search filter and merges it with the `start` and `end` times.

Resolves: SENTRY-Y4Q