### PR TITLE
fix: Add coverage for UserIp logging

### DIFF
--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -1,5 +1,6 @@
 import base64
 from functools import cached_property
+from unittest.mock import patch
 
 from django.test import RequestFactory
 
@@ -130,3 +131,28 @@ class AuthenticationMiddlewareTestCase(TestCase):
         # Should swallow errors and pass on
         assert request.user.is_anonymous
         assert request.auth is None
+
+    @patch("sentry.models.userip.geo_by_addr")
+    def test_process_request_log_userip(self, mock_geo_by_addr):
+        mock_geo_by_addr.return_value = {
+            "country_code": "US",
+            "region": "CA",
+            "subdivision": "San Francisco",
+        }
+        request = self.request
+        request.META["REMOTE_ADDR"] = "8.8.8.8"
+        with exempt_from_silo_limits():
+            assert login(request, self.user)
+
+        with outbox_runner():
+            self.middleware.process_request(request)
+
+        # Should be logged in and have logged a UserIp record.
+        assert request.user.id == self.user.id
+        assert mock_geo_by_addr.call_count == 1
+
+        with exempt_from_silo_limits():
+            userip = UserIP.objects.get(user=self.user)
+        assert userip.ip_address == "8.8.8.8"
+        assert userip.country_code == "US"
+        assert userip.region_code == "CA"


### PR DESCRIPTION
Add coverage for a previously uncovered path by mocking geo ip lookups. This allows us to have coverage on the codepath that resulted in an incident.