### PR TITLE
feat(starfish): Add more details to the failure rate panel 

### DIFF
--- a/static/app/views/starfish/views/webServiceView/failureDetailPanel/focusedFailureRateChart.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureDetailPanel/focusedFailureRateChart.tsx
@@ -1,0 +1,93 @@
+import {useTheme} from '@emotion/react';
+import {YAXisOption} from 'echarts/types/dist/shared';
+
+import {AreaChartProps} from 'sentry/components/charts/areaChart';
+import MarkArea from 'sentry/components/charts/components/markArea';
+import {LineChart} from 'sentry/components/charts/lineChart';
+import {Series} from 'sentry/types/echarts';
+import {tooltipFormatter} from 'sentry/utils/discover/charts';
+import {formatPercentage} from 'sentry/utils/formatters';
+import {FailureSpike} from 'sentry/views/starfish/views/webServiceView/types';
+
+type Props = {
+  data: Series[];
+  spike: FailureSpike;
+};
+
+function FocusedFailureRateChart({data, spike}: Props) {
+  const theme = useTheme();
+  const color = theme.red300;
+  const SPIKE_RANGE_OFFSET = 10000000;
+
+  if (!data || data.length <= 0 || !spike) {
+    return null;
+  }
+
+  const clampedData = data[0].data.filter(
+    bucket =>
+      spike?.startTimestamp - SPIKE_RANGE_OFFSET <= parseInt(bucket.name as string, 10) &&
+      parseInt(bucket.name as string, 10) <= spike?.endTimestamp + SPIKE_RANGE_OFFSET
+  );
+
+  const series = [
+    {
+      color,
+      data: clampedData,
+      seriesName: 'Failure Rate',
+    },
+    {
+      seriesName: 'Focused Area',
+      color,
+      data: [],
+      silent: false,
+      emphasis: {disabled: false},
+      markArea: MarkArea({
+        silent: true,
+        itemStyle: {
+          color,
+          opacity: 0.2,
+        },
+        label: {
+          show: false,
+        },
+        data: [
+          [
+            {name: 'start', xAxis: spike.startTimestamp, emphasis: {disabled: false}},
+            {name: 'end', xAxis: spike.endTimestamp, emphasis: {disabled: false}},
+          ],
+        ],
+      }),
+    },
+  ];
+
+  const yAxis: YAXisOption = {
+    splitNumber: 3,
+    type: 'value',
+    axisLabel: {
+      color: theme.chartLabel,
+      formatter: (value: number) => formatPercentage(value, 1),
+    },
+  };
+
+  const chartProps = {
+    seriesOptions: {
+      showSymbol: false,
+    },
+    isGroupedByDate: true,
+    showTimeInTooltip: true,
+    color,
+    tooltip: {
+      trigger: 'axis',
+      valueFormatter: value => {
+        return tooltipFormatter(value, 'percentage');
+      },
+    },
+    xAxis: {
+      show: false,
+    },
+  } as Omit<AreaChartProps, 'series'>;
+
+  return <LineChart height={120} series={series} yAxis={yAxis} {...chartProps} />;
+}
+
+export default FocusedFailureRateChart;

--- a/static/app/views/starfish/views/webServiceView/failureDetailPanel/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureDetailPanel/index.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
+import {SectionHeading} from 'sentry/components/charts/styles';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -54,10 +55,26 @@ export default function FailureDetailPanel({
 
   return (
     <Detail detailKey={spike?.startTimestamp.toString()} onClose={onClose}>
-      <TimeRangeHeading>{`${moment(spike?.startTimestamp).format('LLL')} - ${moment(
-        spike?.endTimestamp
-      ).format('LLL')}`}</TimeRangeHeading>
-      <h3>{t('Error Spike Detail')}</h3>
+      <TimeRangeHeading>{`${moment(spike?.startTimestamp).format(
+        'MMMM Do YYYY, hh:mm:ss z'
+      )} - ${moment(spike?.endTimestamp).format(
+        'MMMM Do YYYY, hh:mm:ss z'
+      )}`}</TimeRangeHeading>
+      <h4>{t('Error Spike Detail')}</h4>
+      <OverviewStatsSection>
+        <StatBlock>
+          <SectionHeading>Events</SectionHeading>
+          <h4>6.2k</h4>
+        </StatBlock>
+        <StatBlock>
+          <SectionHeading>Users</SectionHeading>
+          <h4>1.2k</h4>
+        </StatBlock>
+        <StatBlock>
+          <SectionHeading>Crashes</SectionHeading>
+          <h4>885</h4>
+        </StatBlock>
+      </OverviewStatsSection>
 
       {spike && (
         <DiscoverQuery
@@ -103,4 +120,15 @@ const Title = styled('h5')`
 const TimeRangeHeading = styled('div')`
   color: ${p => p.theme.red300};
   margin-bottom: ${space(4)};
+`;
+
+const OverviewStatsSection = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+const StatBlock = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin-right: ${space(4)};
 `;

--- a/static/app/views/starfish/views/webServiceView/failureDetailPanel/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureDetailPanel/index.tsx
@@ -7,6 +7,7 @@ import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {NewQuery} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -14,13 +15,16 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import Detail from 'sentry/views/starfish/components/detailPanel';
 import FailureDetailTable from 'sentry/views/starfish/views/webServiceView/failureDetailPanel/failureDetailTable';
+import FocusedFailureRateChart from 'sentry/views/starfish/views/webServiceView/failureDetailPanel/focusedFailureRateChart';
 import IssueTable from 'sentry/views/starfish/views/webServiceView/failureDetailPanel/issueTable';
 import {FailureSpike} from 'sentry/views/starfish/views/webServiceView/types';
 
 export default function FailureDetailPanel({
+  chartData,
   spike,
   onClose,
 }: {
+  chartData: Series[];
   onClose: () => void;
   spike: FailureSpike;
 }) {
@@ -136,9 +140,9 @@ export default function FailureDetailPanel({
   return (
     <Detail detailKey={spike?.startTimestamp.toString()} onClose={onClose}>
       <TimeRangeHeading>{`${moment(spike?.startTimestamp).format(
-        'MMMM Do YYYY, hh:mm:ss z'
+        'MMMM Do YYYY, h:mm:ss a'
       )} - ${moment(spike?.endTimestamp).format(
-        'MMMM Do YYYY, hh:mm:ss z'
+        'MMMM Do YYYY, h:mm:ss a'
       )}`}</TimeRangeHeading>
       <h4>{t('Error Spike Detail')}</h4>
 
@@ -156,7 +160,7 @@ export default function FailureDetailPanel({
             return (
               <Fragment>
                 {renderStatsOverview()}
-
+                <FocusedFailureRateChart data={chartData} spike={spike} />
                 <Title>{t('Failing Endpoints')}</Title>
                 <FailureDetailTable
                   {...results}

--- a/static/app/views/starfish/views/webServiceView/failureDetailPanel/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureDetailPanel/index.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import moment from 'moment';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -53,12 +54,11 @@ export default function FailureDetailPanel({
 
   return (
     <Detail detailKey={spike?.startTimestamp.toString()} onClose={onClose}>
-      <h2>{t('Error Spike Detail')}</h2>
-      <p>
-        {t(
-          'Detailed summary of failure rate spike. Detailed summary of failure rate spike. Detailed summary of failure rate spike. Detailed summary of failure rate spike. Detailed summary of failure rate spike. Detailed summary of failure rate spike.'
-        )}
-      </p>
+      <TimeRangeHeading>{`${moment(spike?.startTimestamp).format('LLL')} - ${moment(
+        spike?.endTimestamp
+      ).format('LLL')}`}</TimeRangeHeading>
+      <h3>{t('Error Spike Detail')}</h3>
+
       {spike && (
         <DiscoverQuery
           eventView={eventView}
@@ -98,4 +98,9 @@ export default function FailureDetailPanel({
 
 const Title = styled('h5')`
   margin-bottom: ${space(1)};
+`;
+
+const TimeRangeHeading = styled('div')`
+  color: ${p => p.theme.red300};
+  margin-bottom: ${space(4)};
 `;

--- a/static/app/views/starfish/views/webServiceView/failureDetailPanel/issueTable.tsx
+++ b/static/app/views/starfish/views/webServiceView/failureDetailPanel/issueTable.tsx
@@ -41,13 +41,13 @@ export default function IssueTable({organization, location, spike, transactions}
       width: 280,
     },
     {
-      key: 'count()',
-      name: 'Count',
+      key: 'count_unique(user)',
+      name: 'Users',
       width: 50,
     },
     {
-      key: 'count_unique(user)',
-      name: 'Users',
+      key: 'count()',
+      name: 'Count',
       width: 50,
     },
   ];

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -91,30 +91,37 @@ export function StarfishView(props: BasePerformanceViewProps) {
           insertClickableAreasIntoSeries(transformedData, theme.red300);
 
           return (
-            <FailureRateChart
-              statsPeriod={eventView.statsPeriod}
-              height={120}
-              data={transformedData}
-              start={eventView.start as string}
-              end={eventView.end as string}
-              loading={eventData.loading}
-              utc={false}
-              grid={{
-                left: '0',
-                right: '0',
-                top: '16px',
-                bottom: '8px',
-              }}
-              definedAxisTicks={2}
-              handleSpikeAreaClick={e => {
-                if (e.componentType === 'markArea') {
-                  setSelectedSpike({
-                    startTimestamp: e.data.coord[0][0],
-                    endTimestamp: e.data.coord[1][0],
-                  });
-                }
-              }}
-            />
+            <Fragment>
+              <FailureDetailPanel
+                onClose={() => setSelectedSpike(null)}
+                chartData={transformedData}
+                spike={selectedSpike}
+              />
+              <FailureRateChart
+                statsPeriod={eventView.statsPeriod}
+                height={120}
+                data={transformedData}
+                start={eventView.start as string}
+                end={eventView.end as string}
+                loading={eventData.loading}
+                utc={false}
+                grid={{
+                  left: '0',
+                  right: '0',
+                  top: '16px',
+                  bottom: '8px',
+                }}
+                definedAxisTicks={2}
+                handleSpikeAreaClick={e => {
+                  if (e.componentType === 'markArea') {
+                    setSelectedSpike({
+                      startTimestamp: e.data.coord[0][0],
+                      endTimestamp: e.data.coord[1][0],
+                    });
+                  }
+                }}
+              />
+            </Fragment>
           );
         }}
       </EventsRequest>
@@ -187,7 +194,6 @@ export function StarfishView(props: BasePerformanceViewProps) {
 
   return (
     <div data-test-id="starfish-view">
-      <FailureDetailPanel onClose={() => setSelectedSpike(null)} spike={selectedSpike} />
       <StyledRow minSize={200}>
         <ChartsContainer>
           <ChartsContainerItem>


### PR DESCRIPTION
Adds some goodies to the failure rate detail panel:

- Selected date range
- Transaction event and error event counts
- Zoomed in chart to highlight the selected area

The mocks have "users" as a count value, I presume to count the number of unique users who are affected by the errors in the spike. We can't query for this at the moment, since there is no `count_unique_if()` function in Discover -- we will have to add support for this eventually so we can fetch that data.
![image](https://user-images.githubusercontent.com/16740047/235258576-c6b17ff8-fa7b-422e-8ec1-daaa24af0f17.png)

