### PR TITLE
feat(issue-details): Allow full date/time of event to be selected

### DIFF
--- a/static/app/views/issueDetails/eventCreatedTooltip.tsx
+++ b/static/app/views/issueDetails/eventCreatedTooltip.tsx
@@ -45,9 +45,7 @@ export default function EventCreatedTooltip({event}: Props) {
       <dd>
         {dateCreated ? (
           <Fragment>
-            {dateCreated.format('ll')}
-            <br />
-            {dateCreated.format(format)}
+            {dateCreated.format('ll')} {dateCreated.format(format)}
           </Fragment>
         ) : (
           <NotApplicableText>{t('n/a')}</NotApplicableText>
@@ -57,9 +55,7 @@ export default function EventCreatedTooltip({event}: Props) {
         <Fragment>
           <dt>{t('Received')}</dt>
           <dd>
-            {dateReceived.format('ll')}
-            <br />
-            {dateReceived.format(format)}
+            {dateReceived.format('ll')} {dateReceived.format(format)}
           </dd>
           <dt>{t('Latency')}</dt>
           <dd>

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -164,7 +164,12 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
             {getDynamicText({
               fixed: 'Jan 1, 12:00 AM',
               value: (
-                <Tooltip showUnderline title={<EventCreatedTooltip event={event} />}>
+                <Tooltip
+                  isHoverable
+                  showUnderline
+                  title={<EventCreatedTooltip event={event} />}
+                  overlayStyle={{maxWidth: 300}}
+                >
                   <DateTime date={event.dateCreated ?? event.dateReceived} />
                 </Tooltip>
               ),


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/48171

A couple changes to make the full event datetime to be selected and copied:

- Add `isHoverable` to tooltip so it sticks around when trying to hover over it
- Remove `<br>` between date and time so you can triple-click to select

Before:

![CleanShot 2023-04-28 at 15 15 51](https://user-images.githubusercontent.com/10888943/235262932-fef8bad8-ac6e-4a42-bf80-caa87b1fdda9.png)

After:

![CleanShot 2023-04-28 at 15 15 28](https://user-images.githubusercontent.com/10888943/235262939-29fa798e-187b-4022-85c7-6c110be44ceb.png)
