### PR TITLE
fix(hybridcloud) Further optimize avatar queries

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -206,7 +206,7 @@ def serialize_rpc_user(user: User) -> RpcUser:
     args["password_usable"] = user.has_usable_password()
 
     # Prefer eagerloaded attributes from _base_query
-    if hasattr(user, "useremails"):
+    if hasattr(user, "useremails") and user.useremails is not None:
         args["emails"] = frozenset([e["email"] for e in user.useremails if e["is_verified"]])
     else:
         args["emails"] = frozenset([email.email for email in user.get_verified_emails()])

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -232,15 +232,16 @@ def serialize_rpc_user(user: User) -> RpcUser:
 
     avatar = None
     # Use eagerloaded attributes from _base_query() if available.
-    if hasattr(user, "useravatar") and user.useravatar is not None:
-        avatar_dict = user.useravatar[0]
-        avatar_type_map = dict(UserAvatar.AVATAR_TYPES)
-        avatar = RpcAvatar(
-            id=avatar_dict["id"],
-            file_id=avatar_dict["file_id"],
-            ident=avatar_dict["ident"],
-            avatar_type=avatar_type_map.get(avatar_dict["avatar_type"], "letter_avatar"),
-        )
+    if hasattr(user, "useravatar"):
+        if user.useravatar is not None:
+            avatar_dict = user.useravatar[0]
+            avatar_type_map = dict(UserAvatar.AVATAR_TYPES)
+            avatar = RpcAvatar(
+                id=avatar_dict["id"],
+                file_id=avatar_dict["file_id"],
+                ident=avatar_dict["ident"],
+                avatar_type=avatar_type_map.get(avatar_dict["avatar_type"], "letter_avatar"),
+            )
     else:
         orm_avatar = user.avatar.first()
         if orm_avatar is not None:


### PR DESCRIPTION
In my previous change I missed the scenario where users with no avatars would fall through to the `else` case and still do N queries. Now if the bulk load attribute `useravatar` is set it will be used even if it is null.
