### PR TITLE
ref(crons): Remove monitor slug from monitor listing page

### DIFF
--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -142,10 +142,7 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
     <Fragment>
       <MonitorName>
         <MonitorBadge status={monitorStatus} />
-        <NameAndSlug>
-          <Link to={monitorDetailUrl}>{monitor.name}</Link>
-          <MonitorSlug>{monitor.slug}</MonitorSlug>
-        </NameAndSlug>
+        <Link to={monitorDetailUrl}>{monitor.name}</Link>
       </MonitorName>
       <MonitorColumn>
         <TextOverflow>
@@ -205,17 +202,6 @@ const MonitorName = styled('div')`
   align-items: center;
   gap: ${space(2)};
   font-size: ${p => p.theme.fontSizeLarge};
-`;
-
-const NameAndSlug = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(0.25)};
-`;
-
-const MonitorSlug = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.subText};
 `;
 
 const MonitorColumn = styled('div')`

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -135,7 +135,7 @@ export default function Monitors({location}: RouteComponentProps<{}, {}>) {
               </PageFilterBar>
               <SearchBar
                 query={decodeScalar(qs.parse(location.search)?.query, '')}
-                placeholder={t('Search by name')}
+                placeholder={t('Search by name or slug')}
                 onSearch={handleSearch}
               />
             </Filters>


### PR DESCRIPTION
Request from Robin, the slug is just a detail and shouldn't clutter the view of names here when users want to quickly scan their list of monitors. You can still find monitors by slug by using the searchbar [with updated placeholder]

Before:
<img width="1268" alt="image" src="https://user-images.githubusercontent.com/9372512/235513799-3b7901c9-2777-4dd3-ae80-b4e80fb5ab91.png">

After:
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/9372512/235798485-fd8ff79a-a547-4d19-833e-712b747e803b.png">

