### PR TITLE
ref(crons): Remove unnecessary status update logic

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -99,11 +99,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
         if "slug" in result:
             params["slug"] = result["slug"]
         if "status" in result:
-            if result["status"] == MonitorStatus.ACTIVE:
-                if monitor.status not in (MonitorStatus.OK, MonitorStatus.ERROR):
-                    params["status"] = MonitorStatus.ACTIVE
-            else:
-                params["status"] = result["status"]
+            params["status"] = result["status"]
         if "config" in result:
             params["config"] = result["config"]
         if "project" in result and result["project"].id != monitor.project_id:

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -1,5 +1,6 @@
+from sentry.constants import ObjectStatus
 from sentry.models import ScheduledDeletion
-from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus, ScheduleType
+from sentry.monitors.models import Monitor, MonitorEnvironment, ScheduleType
 from sentry.testutils import MonitorTestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -97,12 +98,12 @@ class UpdateMonitorTest(MonitorTestCase):
         assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.DISABLED
+        assert monitor.status == ObjectStatus.DISABLED
 
     def test_can_enable(self):
         monitor = self._create_monitor()
 
-        monitor.update(status=MonitorStatus.DISABLED)
+        monitor.update(status=ObjectStatus.DISABLED)
 
         resp = self.get_success_response(
             self.organization.slug, monitor.slug, method="PUT", **{"status": "active"}
@@ -110,20 +111,7 @@ class UpdateMonitorTest(MonitorTestCase):
         assert resp.data["slug"] == monitor.slug
 
         monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.ACTIVE
-
-    def test_cannot_enable_if_enabled(self):
-        monitor = self._create_monitor()
-
-        monitor.update(status=MonitorStatus.OK)
-
-        resp = self.get_success_response(
-            self.organization.slug, monitor.slug, method="PUT", **{"status": "active"}
-        )
-        assert resp.data["slug"] == monitor.slug
-
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.OK
+        assert monitor.status == ObjectStatus.ACTIVE
 
     def test_timezone(self):
         monitor = self._create_monitor()
@@ -346,7 +334,7 @@ class DeleteMonitorTest(MonitorTestCase):
         )
 
         monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.PENDING_DELETION
+        assert monitor.status == ObjectStatus.PENDING_DELETION
         # ScheduledDeletion only available in control silo
         assert ScheduledDeletion.objects.filter(object_id=monitor.id, model_name="Monitor").exists()
 
@@ -367,10 +355,10 @@ class DeleteMonitorTest(MonitorTestCase):
         )
 
         monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.ACTIVE
+        assert monitor.status == ObjectStatus.ACTIVE
 
         monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
-        assert monitor_environment.status == MonitorStatus.PENDING_DELETION
+        assert monitor_environment.status == ObjectStatus.PENDING_DELETION
         # ScheduledDeletion only available in control silo
         assert ScheduledDeletion.objects.filter(
             object_id=monitor_environment.id, model_name="MonitorEnvironment"


### PR DESCRIPTION
We no longer need this since the monitor status will no longer be marked
as anything except ObjectStatus.