### PR TITLE
fix(integrations) Fix json encode errors in pagerduty integrations

### DIFF
--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -227,7 +227,7 @@ class NotificationActionSerializer(CamelSnakeModelSerializer):
                 for pds in PagerDutyService.objects.filter(
                     organization_id=self.context["organization"].id,
                     integration_id=self.integration.id,
-                )
+                ).values("id", "service_name")
             ]
 
             raise serializers.ValidationError(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -42,7 +42,7 @@ def build_action_response(
 
         if registered_type.type == AlertRuleTriggerAction.Type.PAGERDUTY:
             action_response["options"] = [
-                {"value": service.id, "label": service.service_name}
+                {"value": service["id"], "label": service["service_name"]}
                 for service in get_pagerduty_services(organization.id, integration.id)
             ]
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1344,7 +1344,7 @@ def get_pagerduty_services(organization_id, integration_id):
     return PagerDutyService.objects.filter(
         organization_id=organization_id,
         integration_id=integration_id,
-    )
+    ).values("id", "service_name")
 
 
 # TODO: This is temporarily needed to support back and forth translations for snuba / frontend.

--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -91,7 +91,7 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
             service
             for service in PagerDutyService.objects.filter(
                 organization_id=self.project.organization_id, integration_id__in=integration_ids
-            )
+            ).values_list("id", "service_name")
         ]
 
     def render_label(self):
@@ -106,5 +106,5 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
         return self.form_cls(
             self.data,
             integrations=self.get_integrations(),
-            services=[(service.id, service.service_name) for service in self.get_services()],
+            services=self.get_services(),
         )

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -167,9 +167,9 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         rule = self.get_rule(data={"account": self.integration.id})
 
         service_options = rule.get_services()
-        assert [(s.id, s.service_name) for s in service_options] == [
-            (new_service.id, new_service.service_name)
-        ]
+        assert service_options == [(new_service.id, new_service.service_name)]
+        assert "choice" == rule.form_fields["service"]["type"]
+        assert service_options == rule.form_fields["service"]["choices"]
 
     @responses.activate
     def test_valid_service_selected(self):


### PR DESCRIPTION
Revert the changes made to pagerduty in #46960 as a usage of get_services() was missed. I didn't want to revert the entirety of the previous changes as there are migrations in it and I would still need to separate out these changes.

Fixes SENTRY-10VZ