### PR TITLE
fix(monitors): Fixes deletions for monitors and monitor environments w/lots of check-ins

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -90,6 +90,7 @@ def load_defaults():
     from sentry import models
     from sentry.discover.models import DiscoverSavedQuery
     from sentry.incidents.models import AlertRule
+    from sentry.monitors import models as monitor_models
 
     from . import defaults
 
@@ -125,6 +126,10 @@ def load_defaults():
     default_manager.register(models.GroupShare, BulkModelDeletionTask)
     default_manager.register(models.GroupSnooze, BulkModelDeletionTask)
     default_manager.register(models.GroupSubscription, BulkModelDeletionTask)
+    default_manager.register(monitor_models.Monitor, defaults.MonitorDeletionTask)
+    default_manager.register(
+        monitor_models.MonitorEnvironment, defaults.MonitorEnvironmentDeletionTask
+    )
     default_manager.register(models.Organization, defaults.OrganizationDeletionTask)
     default_manager.register(
         models.OrganizationIntegration, defaults.OrganizationIntegrationDeletionTask

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -4,6 +4,8 @@ from .commit import *  # noqa: F401,F403
 from .commitauthor import *  # noqa: F401,F403
 from .discoversavedquery import *  # noqa: F401,F403
 from .group import *  # noqa: F401,F403
+from .monitor import *  # noqa: F401,F403
+from .monitor_environment import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403
 from .organizationintegration import *  # noqa: F401,F403
 from .platform_external_issue import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -1,0 +1,15 @@
+from ..base import BulkModelDeletionTask, ModelDeletionTask, ModelRelation
+
+
+class MonitorDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.monitors import models
+
+        relations = [
+            ModelRelation(
+                models.MonitorCheckIn, {"monitor_id": instance.id}, BulkModelDeletionTask
+            ),
+            ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
+        ]
+
+        return relations

--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -5,11 +5,9 @@ class MonitorDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry.monitors import models
 
-        relations = [
+        return [
             ModelRelation(
                 models.MonitorCheckIn, {"monitor_id": instance.id}, BulkModelDeletionTask
             ),
             ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
         ]
-
-        return relations

--- a/src/sentry/deletions/defaults/monitor_environment.py
+++ b/src/sentry/deletions/defaults/monitor_environment.py
@@ -5,12 +5,10 @@ class MonitorEnvironmentDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry.monitors import models
 
-        relations = [
+        return [
             ModelRelation(
                 models.MonitorCheckIn,
                 {"monitor_environment_id": instance.id},
                 BulkModelDeletionTask,
             ),
         ]
-
-        return relations

--- a/src/sentry/deletions/defaults/monitor_environment.py
+++ b/src/sentry/deletions/defaults/monitor_environment.py
@@ -1,0 +1,16 @@
+from ..base import BulkModelDeletionTask, ModelDeletionTask, ModelRelation
+
+
+class MonitorEnvironmentDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.monitors import models
+
+        relations = [
+            ModelRelation(
+                models.MonitorCheckIn,
+                {"monitor_environment_id": instance.id},
+                BulkModelDeletionTask,
+            ),
+        ]
+
+        return relations

--- a/tests/sentry/deletions/test_monitor.py
+++ b/tests/sentry/deletions/test_monitor.py
@@ -1,0 +1,47 @@
+from sentry.models import Environment, ScheduledDeletion
+from sentry.monitors.models import (
+    CheckInStatus,
+    Monitor,
+    MonitorCheckIn,
+    MonitorEnvironment,
+    MonitorType,
+    ScheduleType,
+)
+from sentry.tasks.deletion.scheduled import run_deletion
+from sentry.testutils import APITestCase, TransactionTestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class DeleteMonitorTest(APITestCase, TransactionTestCase):
+    def test_simple(self):
+        project = self.create_project(name="test")
+        env = Environment.objects.create(organization_id=project.organization_id, name="foo")
+
+        monitor = Monitor.objects.create(
+            organization_id=project.organization.id,
+            project_id=project.id,
+            type=MonitorType.CRON_JOB,
+            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+        )
+        monitor_env = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment=env,
+        )
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_env,
+            project_id=project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.OK,
+        )
+
+        deletion = ScheduledDeletion.schedule(monitor, days=0)
+        deletion.update(in_progress=True)
+
+        with self.tasks():
+            run_deletion(deletion.id)
+
+        assert not Monitor.objects.filter(id=monitor.id).exists()
+        assert not MonitorEnvironment.objects.filter(id=monitor_env.id).exists()
+        assert not MonitorCheckIn.objects.filter(id=checkin.id).exists()

--- a/tests/sentry/deletions/test_monitor.py
+++ b/tests/sentry/deletions/test_monitor.py
@@ -1,4 +1,4 @@
-from sentry.models import Environment, ScheduledDeletion
+from sentry.models import Environment, Project, ScheduledDeletion
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -45,3 +45,7 @@ class DeleteMonitorTest(APITestCase, TransactionTestCase):
         assert not Monitor.objects.filter(id=monitor.id).exists()
         assert not MonitorEnvironment.objects.filter(id=monitor_env.id).exists()
         assert not MonitorCheckIn.objects.filter(id=checkin.id).exists()
+
+        # Shared objects should continue to exist.
+        assert Environment.objects.filter(id=env.id).exists()
+        assert Project.objects.filter(id=project.id).exists()

--- a/tests/sentry/deletions/test_monitor_environment.py
+++ b/tests/sentry/deletions/test_monitor_environment.py
@@ -1,0 +1,47 @@
+from sentry.models import Environment, ScheduledDeletion
+from sentry.monitors.models import (
+    CheckInStatus,
+    Monitor,
+    MonitorCheckIn,
+    MonitorEnvironment,
+    MonitorType,
+    ScheduleType,
+)
+from sentry.tasks.deletion.scheduled import run_deletion
+from sentry.testutils import APITestCase, TransactionTestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase):
+    def test_simple(self):
+        project = self.create_project(name="test")
+        env = Environment.objects.create(organization_id=project.organization_id, name="foo")
+
+        monitor = Monitor.objects.create(
+            organization_id=project.organization.id,
+            project_id=project.id,
+            type=MonitorType.CRON_JOB,
+            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+        )
+        monitor_env = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment=env,
+        )
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_env,
+            project_id=project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.OK,
+        )
+
+        deletion = ScheduledDeletion.schedule(monitor_env, days=0)
+        deletion.update(in_progress=True)
+
+        with self.tasks():
+            run_deletion(deletion.id)
+
+        assert Monitor.objects.filter(id=monitor.id).exists()
+        assert not MonitorEnvironment.objects.filter(id=monitor_env.id).exists()
+        assert not MonitorCheckIn.objects.filter(id=checkin.id).exists()

--- a/tests/sentry/deletions/test_monitor_environment.py
+++ b/tests/sentry/deletions/test_monitor_environment.py
@@ -1,4 +1,4 @@
-from sentry.models import Environment, ScheduledDeletion
+from sentry.models import Environment, Project, ScheduledDeletion
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -42,6 +42,10 @@ class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase):
         with self.tasks():
             run_deletion(deletion.id)
 
-        assert Monitor.objects.filter(id=monitor.id).exists()
         assert not MonitorEnvironment.objects.filter(id=monitor_env.id).exists()
         assert not MonitorCheckIn.objects.filter(id=checkin.id).exists()
+
+        # Shared objects should continue to exist.
+        assert Monitor.objects.filter(id=monitor.id).exists()
+        assert Environment.objects.filter(id=env.id).exists()
+        assert Project.objects.filter(id=project.id).exists()

--- a/tests/sentry/deletions/test_monitor_environment.py
+++ b/tests/sentry/deletions/test_monitor_environment.py
@@ -17,6 +17,7 @@ class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase):
     def test_simple(self):
         project = self.create_project(name="test")
         env = Environment.objects.create(organization_id=project.organization_id, name="foo")
+        env_2 = Environment.objects.create(organization_id=project.organization_id, name="bar")
 
         monitor = Monitor.objects.create(
             organization_id=project.organization.id,
@@ -28,9 +29,20 @@ class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase):
             monitor=monitor,
             environment=env,
         )
+        monitor_env_2 = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment=env_2,
+        )
         checkin = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_env,
+            project_id=project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.OK,
+        )
+        checkin_2 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_env_2,
             project_id=project.id,
             date_added=monitor.date_added,
             status=CheckInStatus.OK,
@@ -47,5 +59,7 @@ class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase):
 
         # Shared objects should continue to exist.
         assert Monitor.objects.filter(id=monitor.id).exists()
+        assert MonitorEnvironment.objects.filter(id=monitor_env_2.id).exists()
+        assert MonitorCheckIn.objects.filter(id=checkin_2.id).exists()
         assert Environment.objects.filter(id=env.id).exists()
         assert Project.objects.filter(id=project.id).exists()

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -103,6 +103,7 @@ class DeleteProjectTest(APITestCase, TransactionTestCase):
         )
         checkin = MonitorCheckIn.objects.create(
             monitor=monitor,
+            monitor_environment=monitor_env,
             project_id=project.id,
             date_added=monitor.date_added,
             status=CheckInStatus.OK,


### PR DESCRIPTION
Fixes deletions for monitors where monitor environments were deleting out of order with check-ins, or monitor/monitor environment deletions that were timing out with large numbers of check-ins

Fixes SENTRY-10BS
Fixes SENTRY-103K
Fixes SENTRY-FOR-SENTRY-TSN
Fixes SENTRY-FOR-SENTRY-S36
Fixes SENTRY-FOR-SENTRY-TQ4
Fixes SENTRY-FOR-SENTRY-TQB
Fixes SENTRY-FOR-SENTRY-TDX

Closes https://github.com/getsentry/sentry/issues/48123