### PR TITLE
ref(utils): Update docs re: not importing models

### DIFF
--- a/src/sentry/utils/__init__.py
+++ b/src/sentry/utils/__init__.py
@@ -1,10 +1,27 @@
 """
-This is the Utilities Module. It is the home to small, self-contained classes
-and functions that do useful things. This description is intentionally general
-because there are basically no limits to what functionality can be considered
-a util. However, within this directory we should avoid importing Sentry models
-or modules with side effects.
+This is the Utilities Module. It is the home to small, self-contained classes and functions that do
+useful things. This description is intentionally general because there are basically no limits to
+what functionality can be considered a util.
+
+WARNING:
+
+Within this directory, avoid importing Sentry models and modules with side effects, as we want any
+code importing a util to be able to run without having to pull in Django or other souces that might
+not exist.
+
+If you need to import a model purely for typing purposes, you can do the following:
+
+    from __future__ import annotations
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from sentry.models.organization import Organization
+
+    def do_org_stuff(orgs: list[Organization]) -> None:
+        # do some stuff with org objects
+
+Otherwise, consider putting your code in another location. If you *must* import a model for use in a
+utility function, and can't move the code, you can try moving the import inside the body of the
+function.
 """
-# Make sure to not import anything here.  We want modules below
-# sentry.utils to be able to import without having to pull in django
-# or other sources that might not exist.


### PR DESCRIPTION
Because many of our model modules import and use code from the `utils` folder, attempting to import a model into a `utils` file can lead to an infinite import loop. Though we do mention this in `__init__.py` for the `utils` folder, we don't do it in an especially noticeable way (it's easy to miss if you're skimming), nor yet in a way that makes it clear that what it's saying applies to all files in the folder, not just the `__init__.py` file itself. Further, it doesn't actually suggest any fixes for the problem. This PR fixes those problems.

In the long run, it would probably be good to have a lint rule for files in the `utils` folder, since people might not think to look in this file for an explanation.	