### PR TITLE
feat(issue-platform): Make `GroupEventsEndpoint` able to read from the issue platform for perf issues

### DIFF
--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import eventstore
+from sentry import eventstore, features
 from sentry.api.serializers import serialize
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import GroupCategory
@@ -54,7 +54,9 @@ def get_query_builder_for_group(
     query: str, snuba_params: Mapping[str, Any], group: Group, limit: int, offset: int
 ) -> QueryBuilder:
     dataset = Dataset.IssuePlatform
-    if group.issue_category == GroupCategory.PERFORMANCE:
+    if group.issue_category == GroupCategory.PERFORMANCE and not features.has(
+        "organizations:issue-platform-search-perf-issues", group.project.organization
+    ):
         dataset = Dataset.Transactions
     elif group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -435,6 +435,24 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
+    def test_perf_issue_on_issue_platform(self):
+        # Just a duplicate of `test_perf_issue` to verify that perf issues read from
+        # the issue platform correctly here. Remove once we kill the related flags.
+        with self.options({"performance.issues.send_to_issues_platform": True}):
+            event_1 = self.create_performance_issue()
+            event_2 = self.create_performance_issue()
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{event_1.group.id}/events/"
+        with self.feature("organizations:issue-platform-search-perf-issues"):
+            response = self.do_request(url)
+
+        assert response.status_code == 200, response.content
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+            [str(event_1.event_id), str(event_2.event_id)]
+        )
+
     def test_generic_issue(self):
         event_1, _, group_info = self.store_search_issue(
             self.project.id,


### PR DESCRIPTION
This makes sure that once we're using issue platform for perf issues that we'll correctly use the issue platform dataset in `GroupEventsEndpoint`
