### PR TITLE
feat(replays): check queryReferrer to allow multi-project queries

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -31,7 +31,7 @@ This document is structured by resource with each resource having actions that c
   - offset (optional, number)
     Default: 0
   - query (optional, string) - Search query with space-separated field/value pairs. ie: `?query=count_errors:>2 AND duration:<1h`.
-
+  - queryReferrer(optional, string) - Specify the page which this query is being made from. Used for cross project query on issue replays page. pass `queryReferrer=issueReplays` for this query.
     Some fields in the API response have their own dedicated parameters, or are otherwide not supported in the `query` param. They are:
 
     | Response Field      | Parameter       |

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -17,11 +17,16 @@ from sentry.replays.validators import ReplayValidator
 @region_silo_endpoint
 class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
     def get_replay_filter_params(self, request, organization):
+
+        query_referrer = request.GET.get("queryReferrer", None)
+
         filter_params = self.get_filter_params(request, organization)
 
-        has_global_views = features.has(
-            "organizations:global-views", organization, actor=request.user
+        has_global_views = (
+            features.has("organizations:global-views", organization, actor=request.user)
+            or query_referrer == "issueReplays"
         )
+
         if not has_global_views and len(filter_params.get("project_id", [])) > 1:
             raise ParseError(detail="You cannot view events from multiple projects.")
 

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -797,6 +797,20 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
             assert response.status_code == 400
             assert response.data["detail"] == "You cannot view events from multiple projects."
 
+    def test_get_replays_no_multi_project_select_query_referrer(self):
+        self.create_project(teams=[self.team])
+        self.create_project(teams=[self.team])
+
+        user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.login_as(user)
+
+        with self.feature(REPLAYS_FEATURES), self.feature({"organizations:global-views": False}):
+            response = self.client.get(self.url + "?queryReferrer=issueReplays")
+            assert response.status_code == 200
+
     def test_get_replays_unknown_field(self):
         """Test replays unknown fields raise a 400 error."""
         project = self.create_project(teams=[self.team])


### PR DESCRIPTION
- add a query parameter `queryReferrer` that is by default `None`. 
- `queryReferrer=issueReplays` can be passed in to allow the replay issues page to make a cross project replays query