### PR TITLE
feat(generic-metrics): Implement use case awareness for RawSimpleIndexer

### DIFF
--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -457,6 +457,43 @@ class StringIndexer(Service):
         """
         raise NotImplementedError()
 
+    def _uca_bulk_record(
+        self, strings: Mapping[UseCaseID, Mapping[OrgId, Set[str]]]
+    ) -> UseCaseKeyResults:
+        """
+        Takes in a mapping with use case IDs mapped to Org IDs mapped to set of strings.
+        Ultimately returns a mapping of those use case IDs mapped to Org IDs mapped to
+        string -> ID mapping, for each string in the each set.
+        There are three steps to getting the ids for strings:
+            0. ids from static strings (StaticStringIndexer)
+            1. ids from cache (CachingIndexer)
+            2. ids from existing db records (postgres/spanner)
+            3. ids that have been rate limited (postgres/spanner)
+            4. ids from newly created db records (postgres/spanner)
+        Each step will start off with a UseCaseKeyCollection and UseCaseKeyResults:
+            keys = UseCaseKeyCollection(mapping)
+            results = UseCaseKeyResults()
+        Then the work to get the ids (either from cache, db, etc)
+            .... # work to add results to UseCaseKeyResults()
+        Those results will be added to `mapped_results` which can
+        be retrieved
+            results.get_mapped_results()
+        Remaining unmapped keys get turned into a new
+        UseCaseKeyCollection for the next step:
+            new_keys = results.get_unmapped_keys(mapping)
+        When the last step is reached or a step resolves all the remaining
+        unmapped keys the key_results objects are merged and returned:
+            e.g. return cache_key_results.merge(db_read_key_results)
+        """
+        raise NotImplementedError()
+
+    def _uca_record(self, use_case_id: UseCaseID, org_id: int, string: str) -> Optional[int]:
+        """Store a string and return the integer ID generated for it
+        With every call to this method, the lifetime of the entry will be
+        prolonged.
+        """
+        raise NotImplementedError()
+
     def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
         """Lookup the integer ID for a string.
 

--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -5,12 +5,15 @@ from typing import DefaultDict, Dict, Mapping, Optional, Set
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.base import (
     FetchType,
-    KeyCollection,
-    KeyResult,
     KeyResults,
+    OrgId,
     StringIndexer,
+    UseCaseKeyCollection,
+    UseCaseKeyResult,
+    UseCaseKeyResults,
 )
 from sentry.sentry_metrics.indexer.strings import StaticStringIndexer
+from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPING, UseCaseID
 
 
 class RawSimpleIndexer(StringIndexer):
@@ -19,50 +22,67 @@ class RawSimpleIndexer(StringIndexer):
 
     def __init__(self) -> None:
         self._counter = itertools.count(start=10000)
-        self._strings: DefaultDict[int, DefaultDict[str, Optional[int]]] = defaultdict(
-            lambda: defaultdict(self._counter.__next__)
-        )
+        self._strings: DefaultDict[
+            UseCaseID, DefaultDict[OrgId, DefaultDict[str, Optional[int]]]
+        ] = defaultdict(lambda: defaultdict(lambda: defaultdict(self._counter.__next__)))
         self._reverse: Dict[int, str] = {}
 
     def bulk_record(
         self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
     ) -> KeyResults:
-        db_read_keys = KeyCollection(org_strings)
-        db_read_key_results = KeyResults()
-        for org_id, strs in org_strings.items():
-            for string in strs:
-                id = self.resolve(use_case_id, org_id, string)
-                if id is not None:
-                    db_read_key_results.add_key_result(
-                        KeyResult(org_id=org_id, string=string, id=id), fetch_type=FetchType.DB_READ
-                    )
+        res = self._uca_bulk_record({REVERSE_METRIC_PATH_MAPPING[use_case_id]: org_strings})
+        return res.results[REVERSE_METRIC_PATH_MAPPING[use_case_id]]
 
-        db_write_keys = db_read_key_results.get_unmapped_keys(db_read_keys)
+    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+        res = self._uca_bulk_record({REVERSE_METRIC_PATH_MAPPING[use_case_id]: {org_id: {string}}})
+        return res.results[REVERSE_METRIC_PATH_MAPPING[use_case_id]][org_id][string]
+
+    def _uca_bulk_record(
+        self, strings: Mapping[UseCaseID, Mapping[OrgId, Set[str]]]
+    ) -> UseCaseKeyResults:
+        db_read_keys = UseCaseKeyCollection(strings)
+        db_read_key_results = UseCaseKeyResults()
+        for use_case_id, org_strs in strings.items():
+            for org_id, strs in org_strs.items():
+                for string in strs:
+                    id = self._strings[use_case_id][org_id].get(string)
+                    if id is not None:
+                        db_read_key_results.add_use_case_key_result(
+                            UseCaseKeyResult(use_case_id, org_id=org_id, string=string, id=id),
+                            fetch_type=FetchType.DB_READ,
+                        )
+
+        db_write_keys = db_read_key_results.get_unmapped_use_case_keys(db_read_keys)
 
         if db_write_keys.size == 0:
             return db_read_key_results
 
-        db_write_key_results = KeyResults()
-        for org_id, string in db_write_keys.as_tuples():
-            db_write_key_results.add_key_result(
-                KeyResult(org_id=org_id, string=string, id=self._record(org_id, string)),
+        db_write_key_results = UseCaseKeyResults()
+        for use_case_id, org_id, string in db_write_keys.as_tuples():
+            db_write_key_results.add_use_case_key_result(
+                UseCaseKeyResult(
+                    use_case_id=use_case_id,
+                    org_id=org_id,
+                    string=string,
+                    id=self._record(use_case_id, org_id, string),
+                ),
                 fetch_type=FetchType.FIRST_SEEN,
             )
 
         return db_read_key_results.merge(db_write_key_results)
 
-    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
-        return self._record(org_id, string)
+    def _uca_record(self, use_case_id: UseCaseID, org_id: int, string: str) -> Optional[int]:
+        return self._record(use_case_id, org_id, string)
 
     def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
-        strs = self._strings[org_id]
+        strs = self._strings[REVERSE_METRIC_PATH_MAPPING[use_case_id]][org_id]
         return strs.get(string)
 
     def reverse_resolve(self, use_case_id: UseCaseKey, org_id: int, id: int) -> Optional[str]:
         return self._reverse.get(id)
 
-    def _record(self, org_id: int, string: str) -> Optional[int]:
-        index = self._strings[org_id][string]
+    def _record(self, use_case_id: UseCaseID, org_id: OrgId, string: str) -> Optional[int]:
+        index = self._strings[use_case_id][org_id][string]
         if index is not None:
             self._reverse[index] = string
         return index

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -21,6 +21,7 @@ from sentry.sentry_metrics.indexer.limiters.cardinality import (
     cardinality_limiter_factory,
 )
 from sentry.sentry_metrics.indexer.mock import MockIndexer
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.utils import json
 
@@ -479,7 +480,7 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
         get_ingest_config(UseCaseKey.RELEASE_HEALTH, IndexerStorage.MOCK)
     )
     # Insert a None-value into the mock-indexer to simulate a rate-limit.
-    message_processor._indexer.indexer._strings[1]["rate_limited_test"] = None
+    message_processor._indexer.indexer._strings[UseCaseID.SESSIONS][1]["rate_limited_test"] = None
 
     with caplog.at_level(logging.ERROR):
         new_batch = message_processor.process_messages(outer_message=outer_message)


### PR DESCRIPTION
### Stack PR Chain

| PR                                                   | Changes                                                | Status        | Branch From                                          |
| ---------------------------------------------------- | ------------------------------------------------------ | ------------- | ---------------------------------------------------- |
| [#1](https://github.com/getsentry/sentry/pull/48309) | ➤ Implements use case awareness to RawSimpleIndexer        | Merged          | Master                                               |
| [#2](https://github.com/getsentry/sentry/pull/48350) | Implements use case awareness for Postgres Indexer       | Merged          | [#1](https://github.com/getsentry/sentry/pull/48309) |
| [#3](https://github.com/getsentry/sentry/pull/48475) | Implements use case awareness for Caching Indexer        | Merged | [#2](https://github.com/getsentry/sentry/pull/48350) |
| [#4](https://github.com/getsentry/sentry/pull/48355) | Implement use case awareness for Static String Indexer | Merged | [#3](https://github.com/getsentry/sentry/pull/48475) |
| [#5](https://github.com/getsentry/sentry/pull/49019) | Replace `bulk_record`/`record` with `_uca_bulk_record`/`_uca_record`      | Merged | [#4](https://github.com/getsentry/sentry/pull/48355) |

### Overview

See #47284
