### PR TITLE
fix(search): fallback to searching for errors if the bulk search across multiple datasets fails

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -366,36 +366,52 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         if not features.has("organizations:performance-issues-search", organization):
             group_categories.discard(GroupCategory.PERFORMANCE.value)
 
-        query_params_for_categories = []
+        query_params_for_categories = {}
 
         for gc in group_categories:
             try:
-                query_params_for_categories.append(
-                    self._prepare_params_for_category(
-                        gc,
-                        query_partial,
-                        organization,
-                        project_ids,
-                        environments,
-                        group_ids,
-                        filters,
-                        snuba_search_filters,
-                        sort_field,
-                        start,
-                        end,
-                        cursor,
-                        get_sample,
-                        actor,
-                    )
+                query_params_for_categories[gc] = self._prepare_params_for_category(
+                    gc,
+                    query_partial,
+                    organization,
+                    project_ids,
+                    environments,
+                    group_ids,
+                    filters,
+                    snuba_search_filters,
+                    sort_field,
+                    start,
+                    end,
+                    cursor,
+                    get_sample,
+                    actor,
                 )
             except UnsupportedSearchQuery:
                 pass
 
-        query_params_for_categories = [
-            query_params for query_params in query_params_for_categories if query_params is not None
-        ]
+        query_params_for_categories = {
+            gc: query_params
+            for gc, query_params in query_params_for_categories
+            if query_params is not None
+        }
 
-        bulk_query_results = bulk_raw_query(query_params_for_categories, referrer=referrer)
+        try:
+            bulk_query_results = bulk_raw_query(
+                list(query_params_for_categories.values()), referrer=referrer
+            )
+        except Exception as e:
+            metrics.incr(
+                "snuba.search.group_category_bulk",
+                tags={gc.name.lower(): True for gc, _ in query_params_for_categories},
+            )
+            # one of the parallel bulk raw queries failed (maybe the issue platform dataset),
+            # we'll fallback to querying for errors only
+            if GroupCategory.ERROR.value in query_params_for_categories.keys():
+                bulk_query_results = bulk_raw_query(
+                    query_params_for_categories[GroupCategory.ERROR.value], referrer=referrer
+                )
+            else:
+                raise e
 
         rows: list[MergeableRow] = []
         total = 0

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -391,7 +391,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
 
         query_params_for_categories = {
             gc: query_params
-            for gc, query_params in query_params_for_categories
+            for gc, query_params in query_params_for_categories.items()
             if query_params is not None
         }
 
@@ -402,7 +402,10 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         except Exception as e:
             metrics.incr(
                 "snuba.search.group_category_bulk",
-                tags={gc.name.lower(): True for gc, _ in query_params_for_categories},
+                tags={
+                    GroupCategory(gc_val).name.lower(): True
+                    for gc_val, _ in query_params_for_categories.items()
+                },
             )
             # one of the parallel bulk raw queries failed (maybe the issue platform dataset),
             # we'll fallback to querying for errors only


### PR DESCRIPTION
The search code fans-out and searches multiple datasets if the search criteria calls for it. But someones we encounter errors in the search when targetting the issue platform dataset and it errors the entire issue search. Instead, we should attempt the search, and fallback to only searching the errors dataset when we encounter an error.