### PR TITLE
chore(sdk): Add `bind_organization_context` tests

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -552,7 +552,7 @@ def bind_organization_context(organization):
     helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
 
     # XXX(dcramer): this is duplicated in organizationContext.jsx on the frontend
-    with sentry_sdk.configure_scope() as scope, sentry_sdk.start_span(
+    with configure_scope() as scope, sentry_sdk.start_span(
         op="other", description="bind_organization_context"
     ):
         # This can be used to find errors that may have been mistagged


### PR DESCRIPTION
This adds unit tests for `bind_organization_context`, inspired by (but simpler and less integration-test-y than) the tests in `tests/relay_integration/test_sdk.py`. To keep things consistent with the rest of the test file, this also switches `bind_organization_context` from using `sentry_sdk.configure_scope` to the copy of `configure_scope` imported separately.