### PR TITLE
feat(integrations): Add `bind_org_context_from_integration` helper

### DIFF
--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 import logging
+from typing import cast
 
 from sentry_sdk import configure_scope
+
+from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.integration import integration_service
 
 logger = logging.getLogger(__name__)
 
@@ -20,3 +26,23 @@ def clear_tags_and_context() -> None:
 
         if reset_values:
             logger.info("We've reset the context and tags.")
+
+
+def get_orgs_from_integration(integration_id: int) -> list[Organization]:
+    """
+    Given the id of an `Integration`, return a list of associated `Organization` objects.
+
+    Note: An `Integration` is an instance of given provider's integration, tied to a single entity
+    on the provider's end (for example, an instance of the GitHub integration tied to a particular
+    GitHub org, or an instance of the Slack integration tied to a particular Slack workspace), which
+    can be shared by multiple orgs.
+    """
+
+    _, org_integrations = integration_service.get_organization_contexts(
+        integration_id=integration_id
+    )
+    orgs = Organization.objects.get_many_from_cache(
+        [org_integration.organization_id for org_integration in org_integrations]
+    )
+
+    return cast("list[Organization]", orgs)

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -7,6 +7,8 @@ from sentry_sdk import configure_scope
 
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.utils.sdk import bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -46,3 +48,24 @@ def get_orgs_from_integration(integration_id: int) -> list[Organization]:
     )
 
     return cast("list[Organization]", orgs)
+
+
+def bind_org_context_from_integration(integration_id: int) -> None:
+    """
+    Given the id of an Integration, get the associated org(s) and bind that data to the scope.
+
+    Note: An `Integration` is an instance of given provider's integration, tied to a single entity
+    on the provider's end (for example, an instance of the GitHub integration tied to a particular
+    GitHub org, or an instance of the Slack integration tied to a particular Slack workspace), which
+    can be shared by multiple orgs.
+    """
+
+    orgs = get_orgs_from_integration(integration_id)
+
+    if len(orgs) == 0:
+        raise IntegrationError(f"No orgs are associated with integration id={integration_id}")
+    elif len(orgs) == 1:
+        bind_organization_context(orgs[0])
+    else:
+        # skip this case for now
+        pass

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -1,5 +1,13 @@
-from sentry.integrations.utils.scope import get_orgs_from_integration
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sentry.integrations.utils.scope import (
+    bind_org_context_from_integration,
+    get_orgs_from_integration,
+)
 from sentry.models.integrations.integration import Integration
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import TestCase
 
 
@@ -30,3 +38,23 @@ class GetOrgsFromIntegrationTest(TestCase):
         found_orgs = get_orgs_from_integration(integration.id)
 
         assert found_orgs == []
+
+
+class BindOrgContextFromIntegrationTest(TestCase):
+    @patch("sentry.integrations.utils.scope.bind_organization_context")
+    def test_binds_org_context_with_single_org(self, mock_bind_org_context: MagicMock):
+        org = self.create_organization(slug="dogsaregreat")
+        integration = Integration.objects.create(name="squirrelChasers")
+        integration.add_organization(org)
+
+        bind_org_context_from_integration(integration.id)
+
+        mock_bind_org_context.assert_called_with(org)
+
+    def test_raises_error_if_no_orgs_found(self):
+        integration = Integration.objects.create(name="squirrelChasers")
+
+        with pytest.raises(
+            IntegrationError, match=f"No orgs are associated with integration id={integration.id}"
+        ):
+            bind_org_context_from_integration(integration.id)

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -1,0 +1,32 @@
+from sentry.integrations.utils.scope import get_orgs_from_integration
+from sentry.models.integrations.integration import Integration
+from sentry.testutils import TestCase
+
+
+class GetOrgsFromIntegrationTest(TestCase):
+    def test_finds_single_org(self):
+        org = self.create_organization(slug="dogsaregreat")
+        integration = Integration.objects.create(name="squirrelChasers")
+        integration.add_organization(org)
+
+        found_orgs = get_orgs_from_integration(integration.id)
+
+        assert found_orgs == [org]
+
+    def test_finds_multiple_orgs(self):
+        maisey_org = self.create_organization(slug="themaiseymaiseydog")
+        charlie_org = self.create_organization(slug="charliebear")
+        integration = Integration.objects.create(name="squirrelChasers")
+        integration.add_organization(maisey_org)
+        integration.add_organization(charlie_org)
+
+        found_orgs = get_orgs_from_integration(integration.id)
+
+        assert found_orgs == [maisey_org, charlie_org]
+
+    def test_finds_no_orgs_without_erroring(self):
+        integration = Integration.objects.create(name="squirrelChasers")
+
+        found_orgs = get_orgs_from_integration(integration.id)
+
+        assert found_orgs == []


### PR DESCRIPTION
This adds a utility function which, given the id of an `Integration`, will attempt to look up the associated org(s) and add org context to the scope. For now, for ease of review, the case in which multiple orgs are retrieved isn't handled. (That will come in a follow-up PR. Until then, nothing will go wrong, but no org data will be added to the scope, either.) In the vast majority of cases there's only one org anyway, though. (At last count, only 4049 of 129202 `Integration` instances - roughly 3.1% - are associated with multiple orgs.) 

Also to come in a later PR: adding this functionality to various integration endpoints.