### PR TITLE
Avoid loading/opening Bundles in Lookup API

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -86,21 +86,14 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
             else:
                 return Response(status=403)
 
-        debug_ids = []
-        for debug_id in request.GET.getlist("debug_id"):
-            try:
-                debug_ids.append(normalize_debug_id(debug_id))
-            except SymbolicError:
-                pass
-
-        urls = request.GET.getlist("url")
+        debug_id = request.GET.get("debug_id")
+        try:
+            debug_id = normalize_debug_id(debug_id)
+        except SymbolicError:
+            pass
+        url = request.GET.get("url")
         release_name = request.GET.get("release")
         dist_name = request.GET.get("dist")
-
-        url = next(iter(urls), None)
-        debug_id = next(iter(debug_ids), None)
-        # TODO: should we validate the list of `debug_ids`/`urls` we get?
-        # by validation I mean making sure we only get a single item, and the `url` is always defined?
 
         bundle_file_ids = set()
         if debug_id:

--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -104,7 +104,7 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
 
         bundle_file_ids = set()
         if debug_id:
-            bundle_file_ids = get_artifact_bundle_containing_debug_id(debug_id, project)
+            bundle_file_ids = get_artifact_bundles_containing_debug_id(debug_id, project)
 
         individual_files = set()
         if url and release_name and not bundle_file_ids:
@@ -152,7 +152,7 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
         return Response(serialize(found_artifacts, request.user))
 
 
-def get_artifact_bundle_containing_debug_id(debug_id: str, project: Project) -> Set[int]:
+def get_artifact_bundles_containing_debug_id(debug_id: str, project: Project) -> Set[int]:
     # We want to have the newest `File` for each `debug_id`.
     return set(
         DebugIdArtifactBundle.objects.filter(

--- a/tests/sentry/api/endpoints/test_project_artifact_lookup.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_lookup.py
@@ -167,14 +167,14 @@ class ArtifactLookupTest(APITestCase):
         assert response[0]["type"] == "bundle"
         self.assert_download_matches_file(response[0]["url"], file_ab)
 
-        # query by another debug-ids pointing to the same bundle
+        # query by another debug-id pointing to the same bundle
         response = self.client.get(f"{url}?debug_id={debug_id_b}").json()
 
         assert len(response) == 1
         assert response[0]["type"] == "bundle"
         self.assert_download_matches_file(response[0]["url"], file_ab)
 
-        # query by another debug-ids pointing to different bundles
+        # query by another debug-id pointing to different bundles
         response = self.client.get(f"{url}?debug_id={debug_id_c}").json()
 
         assert len(response) == 1


### PR DESCRIPTION
Loading and opening up bundles is extremely slow, we want to avoid that at any cost.
We rather do more DB queries, or return more results from the API, instead of filtering the results down to the smallest set.

We change the assumption of the API (which is already satisfied by symbolicator) to only provide a single `url` / `debug_id` combination of one file we are looking up. With that, we can take shortcuts if the file was already found by `debug_id`. However for the `url` case, we are now returning all the artifact and legacy release bundles, and query the release files directly without filtering further.