### PR TITLE
feat(dynamic-sampling): Disable replay_id bias

### DIFF
--- a/src/sentry/dynamic_sampling/rules/combine.py
+++ b/src/sentry/dynamic_sampling/rules/combine.py
@@ -4,7 +4,6 @@ from sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias import Boos
 from sentry.dynamic_sampling.rules.biases.boost_rare_transactions_rule import (
     RareTransactionsRulesBias,
 )
-from sentry.dynamic_sampling.rules.biases.boost_replay_id_bias import BoostReplayIdBias
 from sentry.dynamic_sampling.rules.biases.ignore_health_checks_bias import IgnoreHealthChecksBias
 from sentry.dynamic_sampling.rules.biases.recalibration_bias import RecalibrationBias
 from sentry.dynamic_sampling.rules.biases.uniform_bias import UniformBias
@@ -19,7 +18,6 @@ def get_relay_biases_combinator(organization: Organization) -> BiasesCombinator:
 
     default_combinator.add(RuleType.IGNORE_HEALTH_CHECKS_RULE, IgnoreHealthChecksBias())
 
-    default_combinator.add(RuleType.BOOST_REPLAY_ID_RULE, BoostReplayIdBias())
     default_combinator.add_if(
         RuleType.RECALIBRATION_RULE,
         RecalibrationBias(),

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_replay_id_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_replay_id_bias.py
@@ -1,24 +1,24 @@
-import pytest
-
-from sentry.dynamic_sampling.rules.biases.boost_replay_id_bias import BoostReplayIdBias
-
-
-@pytest.mark.django_db
-def test_generate_bias_rules_v2(default_project):
-    rules = BoostReplayIdBias().generate_rules(project=default_project, base_sample_rate=0.1)
-    assert rules == [
-        {
-            "condition": {
-                "inner": {
-                    "name": "trace.replay_id",
-                    "op": "eq",
-                    "value": None,
-                    "options": {"ignoreCase": True},
-                },
-                "op": "not",
-            },
-            "id": 1005,
-            "samplingValue": {"type": "sampleRate", "value": 1.0},
-            "type": "trace",
-        },
-    ]
+# import pytest
+#
+# from sentry.dynamic_sampling.rules.biases.boost_replay_id_bias import BoostReplayIdBias
+#
+#
+# @pytest.mark.django_db
+# def test_generate_bias_rules_v2(default_project):
+#     rules = BoostReplayIdBias().generate_rules(project=default_project, base_sample_rate=0.1)
+#     assert rules == [
+#         {
+#             "condition": {
+#                 "inner": {
+#                     "name": "trace.replay_id",
+#                     "op": "eq",
+#                     "value": None,
+#                     "options": {"ignoreCase": True},
+#                 },
+#                 "op": "not",
+#             },
+#             "id": 1005,
+#             "samplingValue": {"type": "sampleRate", "value": 1.0},
+#             "type": "trace",
+#         },
+#     ]

--- a/tests/sentry/dynamic_sampling/rules/biases/test_boost_replay_id_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_boost_replay_id_bias.py
@@ -1,24 +1,25 @@
-# import pytest
-#
-# from sentry.dynamic_sampling.rules.biases.boost_replay_id_bias import BoostReplayIdBias
-#
-#
-# @pytest.mark.django_db
-# def test_generate_bias_rules_v2(default_project):
-#     rules = BoostReplayIdBias().generate_rules(project=default_project, base_sample_rate=0.1)
-#     assert rules == [
-#         {
-#             "condition": {
-#                 "inner": {
-#                     "name": "trace.replay_id",
-#                     "op": "eq",
-#                     "value": None,
-#                     "options": {"ignoreCase": True},
-#                 },
-#                 "op": "not",
-#             },
-#             "id": 1005,
-#             "samplingValue": {"type": "sampleRate", "value": 1.0},
-#             "type": "trace",
-#         },
-#     ]
+import pytest
+
+from sentry.dynamic_sampling.rules.biases.boost_replay_id_bias import BoostReplayIdBias
+
+
+@pytest.mark.skip("The replay bias is temporarily disabled.")
+@pytest.mark.django_db
+def test_generate_bias_rules_v2(default_project):
+    rules = BoostReplayIdBias().generate_rules(project=default_project, base_sample_rate=0.1)
+    assert rules == [
+        {
+            "condition": {
+                "inner": {
+                    "name": "trace.replay_id",
+                    "op": "eq",
+                    "value": None,
+                    "options": {"ignoreCase": True},
+                },
+                "op": "not",
+            },
+            "id": 1005,
+            "samplingValue": {"type": "sampleRate", "value": 1.0},
+            "type": "trace",
+        },
+    ]

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -606,42 +606,42 @@ def test_generate_rules_return_uniform_rules_and_rebalance_factor_rule(
     _validate_rules(default_project)
 
 
-@pytest.mark.django_db
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
-def test_generate_rules_return_boost_replay_id(get_blended_sample_rate, default_project):
-    get_blended_sample_rate.return_value = 0.5
-    default_project.update_option(
-        "sentry:dynamic_sampling_biases",
-        [
-            {"id": RuleType.BOOST_ENVIRONMENTS_RULE.value, "active": False},
-            {"id": RuleType.IGNORE_HEALTH_CHECKS_RULE.value, "active": False},
-            {"id": RuleType.BOOST_LATEST_RELEASES_RULE.value, "active": False},
-            {"id": RuleType.BOOST_KEY_TRANSACTIONS_RULE.value, "active": False},
-            {"id": RuleType.BOOST_LOW_VOLUME_TRANSACTIONS.value, "active": False},
-        ],
-    )
-
-    assert generate_rules(default_project) == [
-        {
-            "condition": {
-                "inner": {
-                    "name": "trace.replay_id",
-                    "op": "eq",
-                    "value": None,
-                    "options": {"ignoreCase": True},
-                },
-                "op": "not",
-            },
-            "id": 1005,
-            "samplingValue": {"type": "sampleRate", "value": 1.0},
-            "type": "trace",
-        },
-        {
-            "condition": {"inner": [], "op": "and"},
-            "id": 1000,
-            "samplingValue": {"type": "sampleRate", "value": 0.5},
-            "type": "trace",
-        },
-    ]
-
-    _validate_rules(default_project)
+# @pytest.mark.django_db
+# @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+# def test_generate_rules_return_boost_replay_id(get_blended_sample_rate, default_project):
+#     get_blended_sample_rate.return_value = 0.5
+#     default_project.update_option(
+#         "sentry:dynamic_sampling_biases",
+#         [
+#             {"id": RuleType.BOOST_ENVIRONMENTS_RULE.value, "active": False},
+#             {"id": RuleType.IGNORE_HEALTH_CHECKS_RULE.value, "active": False},
+#             {"id": RuleType.BOOST_LATEST_RELEASES_RULE.value, "active": False},
+#             {"id": RuleType.BOOST_KEY_TRANSACTIONS_RULE.value, "active": False},
+#             {"id": RuleType.BOOST_LOW_VOLUME_TRANSACTIONS.value, "active": False},
+#         ],
+#     )
+#
+#     assert generate_rules(default_project) == [
+#         {
+#             "condition": {
+#                 "inner": {
+#                     "name": "trace.replay_id",
+#                     "op": "eq",
+#                     "value": None,
+#                     "options": {"ignoreCase": True},
+#                 },
+#                 "op": "not",
+#             },
+#             "id": 1005,
+#             "samplingValue": {"type": "sampleRate", "value": 1.0},
+#             "type": "trace",
+#         },
+#         {
+#             "condition": {"inner": [], "op": "and"},
+#             "id": 1000,
+#             "samplingValue": {"type": "sampleRate", "value": 0.5},
+#             "type": "trace",
+#         },
+#     ]
+#
+#     _validate_rules(default_project)

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -606,42 +606,43 @@ def test_generate_rules_return_uniform_rules_and_rebalance_factor_rule(
     _validate_rules(default_project)
 
 
-# @pytest.mark.django_db
-# @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
-# def test_generate_rules_return_boost_replay_id(get_blended_sample_rate, default_project):
-#     get_blended_sample_rate.return_value = 0.5
-#     default_project.update_option(
-#         "sentry:dynamic_sampling_biases",
-#         [
-#             {"id": RuleType.BOOST_ENVIRONMENTS_RULE.value, "active": False},
-#             {"id": RuleType.IGNORE_HEALTH_CHECKS_RULE.value, "active": False},
-#             {"id": RuleType.BOOST_LATEST_RELEASES_RULE.value, "active": False},
-#             {"id": RuleType.BOOST_KEY_TRANSACTIONS_RULE.value, "active": False},
-#             {"id": RuleType.BOOST_LOW_VOLUME_TRANSACTIONS.value, "active": False},
-#         ],
-#     )
-#
-#     assert generate_rules(default_project) == [
-#         {
-#             "condition": {
-#                 "inner": {
-#                     "name": "trace.replay_id",
-#                     "op": "eq",
-#                     "value": None,
-#                     "options": {"ignoreCase": True},
-#                 },
-#                 "op": "not",
-#             },
-#             "id": 1005,
-#             "samplingValue": {"type": "sampleRate", "value": 1.0},
-#             "type": "trace",
-#         },
-#         {
-#             "condition": {"inner": [], "op": "and"},
-#             "id": 1000,
-#             "samplingValue": {"type": "sampleRate", "value": 0.5},
-#             "type": "trace",
-#         },
-#     ]
-#
-#     _validate_rules(default_project)
+@pytest.mark.skip("The replay bias is temporarily disabled.")
+@pytest.mark.django_db
+@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+def test_generate_rules_return_boost_replay_id(get_blended_sample_rate, default_project):
+    get_blended_sample_rate.return_value = 0.5
+    default_project.update_option(
+        "sentry:dynamic_sampling_biases",
+        [
+            {"id": RuleType.BOOST_ENVIRONMENTS_RULE.value, "active": False},
+            {"id": RuleType.IGNORE_HEALTH_CHECKS_RULE.value, "active": False},
+            {"id": RuleType.BOOST_LATEST_RELEASES_RULE.value, "active": False},
+            {"id": RuleType.BOOST_KEY_TRANSACTIONS_RULE.value, "active": False},
+            {"id": RuleType.BOOST_LOW_VOLUME_TRANSACTIONS.value, "active": False},
+        ],
+    )
+
+    assert generate_rules(default_project) == [
+        {
+            "condition": {
+                "inner": {
+                    "name": "trace.replay_id",
+                    "op": "eq",
+                    "value": None,
+                    "options": {"ignoreCase": True},
+                },
+                "op": "not",
+            },
+            "id": 1005,
+            "samplingValue": {"type": "sampleRate", "value": 1.0},
+            "type": "trace",
+        },
+        {
+            "condition": {"inner": [], "op": "and"},
+            "id": 1000,
+            "samplingValue": {"type": "sampleRate", "value": 0.5},
+            "type": "trace",
+        },
+    ]
+
+    _validate_rules(default_project)

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -322,20 +322,20 @@ def test_project_config_with_all_biases_enabled(
                 },
                 "id": 1002,
             },
-            {
-                "condition": {
-                    "inner": {
-                        "name": "trace.replay_id",
-                        "op": "eq",
-                        "options": {"ignoreCase": True},
-                        "value": None,
-                    },
-                    "op": "not",
-                },
-                "id": 1005,
-                "samplingValue": {"type": "sampleRate", "value": 1.0},
-                "type": "trace",
-            },
+            # {
+            #     "condition": {
+            #         "inner": {
+            #             "name": "trace.replay_id",
+            #             "op": "eq",
+            #             "options": {"ignoreCase": True},
+            #             "value": None,
+            #         },
+            #         "op": "not",
+            #     },
+            #     "id": 1005,
+            #     "samplingValue": {"type": "sampleRate", "value": 1.0},
+            #     "type": "trace",
+            # },
             {
                 "condition": {"inner": [], "op": "and"},
                 "id": 1004,


### PR DESCRIPTION
This PR turns off the `replay_id` bias which was sampling all traces with `replay_id` at 100%.