### PR TITLE
feat(dynamic-sampling): Add optional org parameter to get_blended_sample_rate

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -13,7 +13,7 @@ from sentry.utils.json import prune_empty_keys
 from sentry.utils.services import Service
 
 if typing.TYPE_CHECKING:
-    from sentry.models import Project
+    from sentry.models import Organization, Project
 
 
 logger = logging.getLogger(__name__)
@@ -484,7 +484,9 @@ class Quota(Service):
         """
         return (_limit_from_settings(options.get("system.rate-limit")), 60)
 
-    def get_blended_sample_rate(self, project: "Project") -> Optional[float]:
+    def get_blended_sample_rate(
+        self, organization: Optional["Organization"], project: Optional["Project"]
+    ) -> Optional[float]:
         """
         Returns the blended sample rate for an org based on the package that they are currently on. Returns ``None``
         if the creation of a uniform rule with blended sample rate is not supported for that project.

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -491,6 +491,10 @@ class Quota(Service):
         Returns the blended sample rate for an org based on the package that they are currently on. Returns ``None``
         if the creation of a uniform rule with blended sample rate is not supported for that project or organization.
 
+        The reasoning for having two params as `Optional` is because this method was first designed to work with
+        `Project` but due to requirements change the `Organization` was needed and since we can get the `Organization`
+        from the `Project` we allow one or the other to be passed.
+
         :param project: The project model.
         :param organization: The organization model.
         """

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -13,7 +13,7 @@ from sentry.utils.json import prune_empty_keys
 from sentry.utils.services import Service
 
 if typing.TYPE_CHECKING:
-    from sentry.models import Organization, Project
+    from sentry.models import Project
 
 
 logger = logging.getLogger(__name__)
@@ -485,7 +485,7 @@ class Quota(Service):
         return (_limit_from_settings(options.get("system.rate-limit")), 60)
 
     def get_blended_sample_rate(
-        self, project: Optional["Project"], organization: Optional["Organization"] = None
+        self, project: Optional["Project"], organization_id: Optional[int] = None
     ) -> Optional[float]:
         """
         Returns the blended sample rate for an org based on the package that they are currently on. Returns ``None``
@@ -496,5 +496,5 @@ class Quota(Service):
         from the `Project` we allow one or the other to be passed.
 
         :param project: The project model.
-        :param organization: The organization model.
+        :param organization_id: The organization id.
         """

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -485,11 +485,12 @@ class Quota(Service):
         return (_limit_from_settings(options.get("system.rate-limit")), 60)
 
     def get_blended_sample_rate(
-        self, organization: Optional["Organization"], project: Optional["Project"]
+        self, project: Optional["Project"], organization: Optional["Organization"] = None
     ) -> Optional[float]:
         """
         Returns the blended sample rate for an org based on the package that they are currently on. Returns ``None``
-        if the creation of a uniform rule with blended sample rate is not supported for that project.
+        if the creation of a uniform rule with blended sample rate is not supported for that project or organization.
 
         :param project: The project model.
+        :param organization: The organization model.
         """


### PR DESCRIPTION
This PR adds support for the org in the `get_blended_sample_rate` call. It is connected to the `getsentry` PR https://github.com/getsentry/getsentry/pull/10409.

Closes https://github.com/getsentry/sentry/issues/48344