### PR TITLE
chore: Disable django signal spans

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -411,7 +411,7 @@ def configure_sdk():
         transport=MultiplexingTransport(),
         integrations=[
             DjangoAtomicIntegration(),
-            DjangoIntegration(),
+            DjangoIntegration(signals_spans=False),
             CeleryIntegration(),
             # This makes it so all levels of logging are recorded as breadcrumbs,
             # but none are captured as events (that's handled by the `internal`


### PR DESCRIPTION
These spans are clogging up our tracing as some endpoints are collecting 700+ spans from signals, which results in us lacking visibility into useful spans.