### PR TITLE
fix(starfish): onclose gets ran when already closed

### DIFF
--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -42,8 +42,8 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
     if (escapeKeyPressed) {
       if (!state.collapsed) {
         onClose?.();
+        setState({collapsed: true});
       }
-      setState({collapsed: true});
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [escapeKeyPressed]);

--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -6,7 +6,6 @@ import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useKeyPress from 'sentry/utils/useKeyPress';
-import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 import SlideOverPanel from 'sentry/views/starfish/components/slideOverPanel';
 
 type DetailProps = {
@@ -30,12 +29,6 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
     }
   }, [detailKey]);
 
-  const panelRef = useRef<HTMLDivElement>(null);
-  useOnClickOutside(panelRef, () => {
-    onClose?.();
-    setState({collapsed: true});
-  });
-
   useEffect(() => {
     if (escapeKeyPressed) {
       onClose?.();
@@ -45,7 +38,7 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
   }, [escapeKeyPressed]);
 
   return (
-    <SlideOverPanel collapsed={state.collapsed} ref={panelRef}>
+    <SlideOverPanel collapsed={state.collapsed}>
       <CloseButtonWrapper>
         <CloseButton
           priority="link"

--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -40,7 +40,9 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
 
   useEffect(() => {
     if (escapeKeyPressed) {
-      onClose?.();
+      if (!state.collapsed) {
+        onClose?.();
+      }
       setState({collapsed: true});
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -32,7 +32,9 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
 
   const panelRef = useRef<HTMLDivElement>(null);
   useOnClickOutside(panelRef, () => {
-    onClose?.();
+    if (!state.collapsed) {
+      onClose?.();
+    }
     setState({collapsed: true});
   });
 

--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -34,8 +34,8 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
   useOnClickOutside(panelRef, () => {
     if (!state.collapsed) {
       onClose?.();
+      setState({collapsed: true});
     }
-    setState({collapsed: true});
   });
 
   useEffect(() => {

--- a/static/app/views/starfish/components/detailPanel.tsx
+++ b/static/app/views/starfish/components/detailPanel.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -6,6 +6,7 @@ import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useKeyPress from 'sentry/utils/useKeyPress';
+import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 import SlideOverPanel from 'sentry/views/starfish/components/slideOverPanel';
 
 type DetailProps = {
@@ -29,6 +30,12 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
     }
   }, [detailKey]);
 
+  const panelRef = useRef<HTMLDivElement>(null);
+  useOnClickOutside(panelRef, () => {
+    onClose?.();
+    setState({collapsed: true});
+  });
+
   useEffect(() => {
     if (escapeKeyPressed) {
       onClose?.();
@@ -38,7 +45,7 @@ export default function Detail({children, detailKey, onClose}: DetailProps) {
   }, [escapeKeyPressed]);
 
   return (
-    <SlideOverPanel collapsed={state.collapsed}>
+    <SlideOverPanel collapsed={state.collapsed} ref={panelRef}>
       <CloseButtonWrapper>
         <CloseButton
           priority="link"

--- a/static/app/views/starfish/components/slideOverPanel.tsx
+++ b/static/app/views/starfish/components/slideOverPanel.tsx
@@ -1,4 +1,3 @@
-import {ForwardedRef, forwardRef} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
@@ -10,15 +9,9 @@ type SlideOverPanelProps = {
   collapsed: boolean;
 };
 
-export default forwardRef(SlideOverPanel);
-
-function SlideOverPanel(
-  {collapsed, children}: SlideOverPanelProps,
-  ref: ForwardedRef<HTMLDivElement>
-) {
+export default function SlideOverPanel({collapsed, children}: SlideOverPanelProps) {
   return (
     <_SlideOverPanel
-      ref={ref}
       collapsed={collapsed}
       initial={{opacity: 0, x: PANEL_WIDTH}}
       animate={!collapsed ? {opacity: 1, x: 0} : {opacity: 0, x: PANEL_WIDTH}}

--- a/static/app/views/starfish/components/slideOverPanel.tsx
+++ b/static/app/views/starfish/components/slideOverPanel.tsx
@@ -1,3 +1,4 @@
+import {ForwardedRef, forwardRef} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
@@ -9,9 +10,15 @@ type SlideOverPanelProps = {
   collapsed: boolean;
 };
 
-export default function SlideOverPanel({collapsed, children}: SlideOverPanelProps) {
+export default forwardRef(SlideOverPanel);
+
+function SlideOverPanel(
+  {collapsed, children}: SlideOverPanelProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
   return (
     <_SlideOverPanel
+      ref={ref}
       collapsed={collapsed}
       initial={{opacity: 0, x: PANEL_WIDTH}}
       animate={!collapsed ? {opacity: 1, x: 0} : {opacity: 0, x: PANEL_WIDTH}}


### PR DESCRIPTION
The onclose in the sidebar got ran even when it was already closed, this somehow caused the legends in the db module to stop working.