### PR TITLE
fix(hybridcloud) Fix N queries and integrity error from actors

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, cast
 
 import sentry_sdk
+from django.contrib.auth.models import AnonymousUser
 from django.db import connection
 from django.db.models import prefetch_related_objects
 from django.db.models.aggregates import Count
@@ -350,7 +351,10 @@ class ProjectSerializer(Serializer):  # type: ignore
 
         with measure_span("other"):
             # Avoid duplicate queries for actors.
-            recipient_actor = RpcActor.from_object(user)
+            if isinstance(user, AnonymousUser):
+                recipient_actor = user
+            else:
+                recipient_actor = RpcActor.from_object(user)
             for project, serialized in result.items():
                 value = get_most_specific_notification_setting_value(
                     notification_settings_by_scope,

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -46,6 +46,7 @@ from sentry.notifications.helpers import (
     transform_to_notification_settings_by_scope,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.notifications import notifications_service
 from sentry.snuba import discover
 from sentry.tasks.symbolication import should_demote_symbolication
@@ -348,10 +349,12 @@ class ProjectSerializer(Serializer):  # type: ignore
                 serialized["features"] = features_by_project[project]
 
         with measure_span("other"):
+            # Avoid duplicate queries for actors.
+            recipient_actor = RpcActor.from_object(user)
             for project, serialized in result.items():
                 value = get_most_specific_notification_setting_value(
                     notification_settings_by_scope,
-                    recipient=user,
+                    recipient=recipient_actor,
                     parent_id=project.id,
                     type=NotificationSettingTypes.ISSUE_ALERTS,
                 )

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -325,12 +325,16 @@ def get_groups_for_query(
     that to know if a user is subscribed or not, as long as notifications aren't
     disabled for the project.
     """
+
+    # Avoid n queries for actors.
+    actor = RpcActor.from_object(user)
+
     # Although this can be done with a comprehension, looping for clarity.
     output = set()
     for project_id, groups in groups_by_project.items():
         value = get_most_specific_notification_setting_value(
             notification_settings_by_scope,
-            recipient=user,
+            recipient=actor,
             parent_id=project_id,
             type=NotificationSettingTypes.WORKFLOW,
         )


### PR DESCRIPTION
* Fix a few of the N query issues that actor changes have introduced. Thanks to @JoshFerge for raising these up.
* Capture integrity errors from actor generation. These errors were bubbling up to the endpoint and causing 500 responses. Those errors should now be gracefully captured and handled.