### PR TITLE
ref(indexer): writes limiter takes UseCaseKeyCollection

### DIFF
--- a/src/sentry/sentry_metrics/indexer/limiters/writes.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/writes.py
@@ -98,7 +98,7 @@ class RateLimitState:
     _grants: Sequence[GrantedQuota]
     _timestamp: Timestamp
 
-    accepted_keys: KeyCollection
+    accepted_keys: UseCaseKeyCollection
     dropped_strings: Sequence[DroppedString]
 
     def __enter__(self) -> RateLimitState:
@@ -179,7 +179,9 @@ class WritesLimiter:
             _requests=requests,
             _grants=grants,
             _timestamp=timestamp,
-            accepted_keys=KeyCollection(granted_key_collection),
+            accepted_keys=UseCaseKeyCollection(
+                {use_case_id: KeyCollection(granted_key_collection)}
+            ),
             dropped_strings=dropped_strings,
         )
         return state

--- a/src/sentry/sentry_metrics/indexer/limiters/writes.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/writes.py
@@ -12,7 +12,14 @@ from sentry.ratelimits.sliding_windows import (
     Timestamp,
 )
 from sentry.sentry_metrics.configuration import MetricsIngestConfiguration, UseCaseKey
-from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, KeyCollection, KeyResult
+from sentry.sentry_metrics.indexer.base import (
+    FetchType,
+    FetchTypeExt,
+    KeyCollection,
+    KeyResult,
+    UseCaseKeyCollection,
+)
+from sentry.sentry_metrics.use_case_id_registry import METRIC_PATH_MAPPING
 from sentry.utils import metrics
 
 OrgId = int
@@ -116,8 +123,7 @@ class WritesLimiter:
     @metrics.wraps("sentry_metrics.indexer.check_write_limits")
     def check_write_limits(
         self,
-        use_case_id: UseCaseKey,
-        keys: KeyCollection,
+        use_case_keys: UseCaseKeyCollection,
     ) -> RateLimitState:
         """
         Takes a KeyCollection and applies DB write limits as configured via sentry.options.
@@ -131,7 +137,13 @@ class WritesLimiter:
 
         Upon (successful) exit, rate limits are consumed.
         """
-        org_ids, requests = _construct_quota_requests(use_case_id, self.namespace, keys)
+        use_case_id = next(iter(use_case_keys.mapping.keys()))
+        keys = next(iter(use_case_keys.mapping.values()))
+        org_ids, requests = _construct_quota_requests(
+            METRIC_PATH_MAPPING[use_case_id],
+            self.namespace,
+            keys,
+        )
         timestamp, grants = self.rate_limiter.check_within_quotas(requests)
 
         granted_key_collection = dict(keys.mapping)
@@ -162,7 +174,7 @@ class WritesLimiter:
 
         state = RateLimitState(
             _writes_limiter=self,
-            _use_case_id=use_case_id,
+            _use_case_id=METRIC_PATH_MAPPING[use_case_id],
             _namespace=self.namespace,
             _requests=requests,
             _grants=grants,

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -131,7 +131,10 @@ class PGStringIndexerV2(StringIndexer):
             # After the DB has successfully committed writes, we exit this
             # context manager and consume quotas. If the DB crashes we
             # shouldn't consume quota.
-            filtered_db_write_keys = writes_limiter_state.accepted_keys
+            use_case_collection = writes_limiter_state.accepted_keys
+            # TODO: later we will use the whole use case collection instead
+            # of pulling out the key collection
+            filtered_db_write_keys = use_case_collection.mapping[new_use_case_id]
             del db_write_keys
 
             rate_limited_key_results = KeyResults()

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -16,11 +16,13 @@ from sentry.sentry_metrics.indexer.base import (
     KeyResult,
     KeyResults,
     StringIndexer,
+    UseCaseKeyCollection,
 )
 from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCache
 from sentry.sentry_metrics.indexer.limiters.writes import writes_limiter_factory
 from sentry.sentry_metrics.indexer.postgres.models import TABLE_MAPPING, BaseIndexer, IndexerTable
 from sentry.sentry_metrics.indexer.strings import StaticStringIndexer
+from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPING
 from sentry.utils import metrics
 
 __all__ = ["PostgresIndexer"]
@@ -122,7 +124,10 @@ class PGStringIndexerV2(StringIndexer):
         config = get_ingest_config(use_case_id, IndexerStorage.POSTGRES)
         writes_limiter = writes_limiter_factory.get_ratelimiter(config)
 
-        with writes_limiter.check_write_limits(use_case_id, db_write_keys) as writes_limiter_state:
+        new_use_case_id = REVERSE_METRIC_PATH_MAPPING[use_case_id]
+        with writes_limiter.check_write_limits(
+            UseCaseKeyCollection({new_use_case_id: db_write_keys})
+        ) as writes_limiter_state:
             # After the DB has successfully committed writes, we exit this
             # context manager and consume quotas. If the DB crashes we
             # shouldn't consume quota.

--- a/tests/sentry/sentry_metrics/limiters/test_writes_limiter.py
+++ b/tests/sentry/sentry_metrics/limiters/test_writes_limiter.py
@@ -30,12 +30,10 @@ def test_writes_limiter_no_limits(set_sentry_option):
                 2: {"a", "b", "c"},
             }
         )
-
-        with writes_limiter.check_write_limits(
-            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
-        ) as state:
+        use_case_keys = UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        with writes_limiter.check_write_limits(use_case_keys) as state:
             assert not state.dropped_strings
-            assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
+            assert state.accepted_keys.as_tuples() == use_case_keys.as_tuples()
 
 
 def test_writes_limiter_doesnt_limit(set_sentry_option):
@@ -52,11 +50,10 @@ def test_writes_limiter_doesnt_limit(set_sentry_option):
             }
         )
 
-        with writes_limiter.check_write_limits(
-            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
-        ) as state:
+        use_case_keys = UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        with writes_limiter.check_write_limits(use_case_keys) as state:
             assert not state.dropped_strings
-            assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
+            assert state.accepted_keys.as_tuples() == use_case_keys.as_tuples()
 
 
 def test_writes_limiter_org_limit(set_sentry_option):
@@ -72,13 +69,13 @@ def test_writes_limiter_org_limit(set_sentry_option):
                 2: {"a", "b", "c"},
             }
         )
-
-        with writes_limiter.check_write_limits(
-            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
-        ) as state:
+        use_case_keys = UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        with writes_limiter.check_write_limits(use_case_keys) as state:
             assert len(state.dropped_strings) == 2
             assert sorted(ds.key_result.org_id for ds in state.dropped_strings) == [1, 2]
-            assert sorted(org_id for org_id, string in state.accepted_keys.as_tuples()) == [
+            assert sorted(
+                org_id for use_case_id, org_id, string in state.accepted_keys.as_tuples()
+            ) == [
                 1,
                 1,
                 2,

--- a/tests/sentry/sentry_metrics/limiters/test_writes_limiter.py
+++ b/tests/sentry/sentry_metrics/limiters/test_writes_limiter.py
@@ -3,13 +3,15 @@ from sentry.sentry_metrics.configuration import (
     RELEASE_HEALTH_PG_NAMESPACE,
     UseCaseKey,
 )
-from sentry.sentry_metrics.indexer.base import KeyCollection
+from sentry.sentry_metrics.indexer.base import KeyCollection, UseCaseKeyCollection
 from sentry.sentry_metrics.indexer.limiters.writes import WritesLimiter
+from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPING
 
 WRITES_LIMITERS = {
     RELEASE_HEALTH_PG_NAMESPACE: WritesLimiter(RELEASE_HEALTH_PG_NAMESPACE, **{}),
     PERFORMANCE_PG_NAMESPACE: WritesLimiter(PERFORMANCE_PG_NAMESPACE, **{}),
 }
+NEW_USE_CASE_ID = REVERSE_METRIC_PATH_MAPPING[UseCaseKey.PERFORMANCE]
 
 
 def get_writes_limiter(namespace: str):
@@ -29,7 +31,9 @@ def test_writes_limiter_no_limits(set_sentry_option):
             }
         )
 
-        with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+        with writes_limiter.check_write_limits(
+            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        ) as state:
             assert not state.dropped_strings
             assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
 
@@ -48,7 +52,9 @@ def test_writes_limiter_doesnt_limit(set_sentry_option):
             }
         )
 
-        with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+        with writes_limiter.check_write_limits(
+            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        ) as state:
             assert not state.dropped_strings
             assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
 
@@ -67,7 +73,9 @@ def test_writes_limiter_org_limit(set_sentry_option):
             }
         )
 
-        with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+        with writes_limiter.check_write_limits(
+            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        ) as state:
             assert len(state.dropped_strings) == 2
             assert sorted(ds.key_result.org_id for ds in state.dropped_strings) == [1, 2]
             assert sorted(org_id for org_id, string in state.accepted_keys.as_tuples()) == [
@@ -96,7 +104,9 @@ def test_writes_limiter_global_limit(set_sentry_option):
             }
         )
 
-        with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+        with writes_limiter.check_write_limits(
+            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        ) as state:
             assert len(state.dropped_strings) == 2
 
 
@@ -123,7 +133,7 @@ def test_writes_limiter_respects_namespaces(set_sentry_option):
         )
 
         with writes_limiter_perf.check_write_limits(
-            UseCaseKey.PERFORMANCE, key_collection
+            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
         ) as state:
             assert len(state.dropped_strings) == 2
 
@@ -135,11 +145,13 @@ def test_writes_limiter_respects_namespaces(set_sentry_option):
         )
 
         with writes_limiter_perf.check_write_limits(
-            UseCaseKey.PERFORMANCE, key_collection
+            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
         ) as state:
             assert len(state.dropped_strings) == 4
 
         writes_limiter_rh = get_writes_limiter(RELEASE_HEALTH_PG_NAMESPACE)
 
-        with writes_limiter_rh.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+        with writes_limiter_rh.check_write_limits(
+            UseCaseKeyCollection({NEW_USE_CASE_ID: key_collection})
+        ) as state:
             assert not state.dropped_strings


### PR DESCRIPTION
In an attempt to split up code in https://github.com/getsentry/sentry/pull/48210, this PR just focuses on updating the writes limiter to take a `UseCaseKeyCollection` and also to have the `accepted_keys` be a `UseCaseKeyCollection` (although we won't use the full `UseCaseKeyCollection` until the changes in https://github.com/getsentry/sentry/pull/48350) 

This currently assumes that there will only be one `use case` (`TRANSACTIONS` or `SESSIONS`) per pipeline, and future PRs would need to be added to writes limiter split up by multiple use cases 

**what's actually getting rate limited?**
Rate limiting is still happening by the old use case key which is either `performance` or `release-health`. So there should be no change in how the rate limits are applied as of this PR. Rate-limiting based on the new use case id (`transactions`, `sessions`, `spans`, etc) will happen later
