### PR TITLE
Revert "fix(quota): Max limit of 2**32 - 1"

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -1,9 +1,7 @@
-import logging
 import typing
 from enum import IntEnum, unique
 from typing import Optional
 
-import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
 
@@ -14,9 +12,6 @@ from sentry.utils.services import Service
 
 if typing.TYPE_CHECKING:
     from sentry.models import Project
-
-
-logger = logging.getLogger(__name__)
 
 
 @unique
@@ -82,23 +77,6 @@ class QuotaConfig:
         if limit is not None:
             assert reason_code, "reason code required for fallible quotas"
             assert type(limit) == int, "limit must be an integer"
-
-            if limit >= 2**32:
-                with sentry_sdk.configure_scope() as sentry_scope:
-                    sentry_scope.set_context(
-                        "quota_limit",
-                        {
-                            "id": id,
-                            "categories": categories,
-                            "scope": scope,
-                            "scope_id": scope_id,
-                            "limit": limit,
-                            "window": window,
-                            "reason_code": reason_code,
-                        },
-                    )
-                    logging.error("Quota limit too large for Relay to parse: %s", limit)
-                limit = 2**32 - 1
 
         if limit == 0:
             assert id is None, "reject-all quotas cannot be tracked"

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -128,24 +128,6 @@ class QuotaTest(TestCase):
                 "reasonCode": "go_away",
             },
         ),
-        (
-            QuotaConfig(
-                id="p",
-                scope=QuotaScope.PROJECT,
-                scope_id=1,
-                limit=2**32,
-                window=1,
-                reason_code="go_away",
-            ),
-            {
-                "id": "p",
-                "scope": "project",
-                "scopeId": "1",
-                "limit": 2**32 - 1,
-                "window": 1,
-                "reasonCode": "go_away",
-            },
-        ),
     ],
 )
 def test_quotas_to_json(obj, json):


### PR DESCRIPTION
Reverts getsentry/sentry#48057

As of https://github.com/getsentry/relay/pull/2079, Relay is able to parse any positive integer `< 2**64`, so this workaround is no longer necessary.