### PR TITLE
feat(generic-metrics): Implement use case awareness for Static String Indexer

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -3,11 +3,14 @@ from typing import Mapping, Optional, Set
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.base import (
     FetchType,
-    KeyCollection,
-    KeyResult,
     KeyResults,
+    OrgId,
     StringIndexer,
+    UseCaseKeyCollection,
+    UseCaseKeyResult,
+    UseCaseKeyResults,
 )
+from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPING, UseCaseID
 
 # !!! DO NOT CHANGE THESE VALUES !!!
 #
@@ -167,30 +170,42 @@ class StaticStringIndexer(StringIndexer):
     def bulk_record(
         self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
     ) -> KeyResults:
-        static_keys = KeyCollection(org_strings)
-        static_key_results = KeyResults()
-        for org_id, string in static_keys.as_tuples():
+        res = self._uca_bulk_record({REVERSE_METRIC_PATH_MAPPING[use_case_id]: org_strings})
+        return res.results[REVERSE_METRIC_PATH_MAPPING[use_case_id]]
+
+    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+        return self._uca_record(REVERSE_METRIC_PATH_MAPPING[use_case_id], org_id, string)
+
+    def _uca_bulk_record(
+        self, strings: Mapping[UseCaseID, Mapping[OrgId, Set[str]]]
+    ) -> UseCaseKeyResults:
+        static_keys = UseCaseKeyCollection(strings)
+        static_key_results = UseCaseKeyResults()
+        for use_case_id, org_id, string in static_keys.as_tuples():
             if string in SHARED_STRINGS:
                 id = SHARED_STRINGS[string]
-                static_key_results.add_key_result(
-                    KeyResult(org_id, string, id), FetchType.HARDCODED
+                static_key_results.add_use_case_key_result(
+                    UseCaseKeyResult(use_case_id, org_id, string, id), FetchType.HARDCODED
                 )
 
-        org_strings_left = static_key_results.get_unmapped_keys(static_keys)
+        org_strings_left = static_key_results.get_unmapped_use_case_keys(static_keys)
 
         if org_strings_left.size == 0:
             return static_key_results
 
-        indexer_results = self.indexer.bulk_record(
-            use_case_id=use_case_id, org_strings=org_strings_left.mapping
+        indexer_results = self.indexer._uca_bulk_record(
+            {
+                use_case_id: key_collection.mapping
+                for use_case_id, key_collection in org_strings_left.mapping.items()
+            }
         )
 
         return static_key_results.merge(indexer_results)
 
-    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+    def _uca_record(self, use_case_id: UseCaseID, org_id: int, string: str) -> Optional[int]:
         if string in SHARED_STRINGS:
             return SHARED_STRINGS[string]
-        return self.indexer.record(use_case_id=use_case_id, org_id=org_id, string=string)
+        return self.indexer._uca_record(use_case_id=use_case_id, org_id=org_id, string=string)
 
     def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
         if string in SHARED_STRINGS:


### PR DESCRIPTION
### Stack PR Chain

| PR                                                   | Changes                                                  | Status        | Branch From                                          |
| ---------------------------------------------------- | -------------------------------------------------------- | ------------- | ---------------------------------------------------- |
| [#1](https://github.com/getsentry/sentry/pull/48309) | Implements use case awareness to RawSimpleIndexer        | Merged          | Master                                               |
| [#2](https://github.com/getsentry/sentry/pull/48350) | Implements use case awareness for Postgres Indexer       | Merged          | [#1](https://github.com/getsentry/sentry/pull/48309) |
| [#3](https://github.com/getsentry/sentry/pull/48475) | Implements use case awareness for Caching Indexer        | Merged | [#2](https://github.com/getsentry/sentry/pull/48350) |
| [#4](https://github.com/getsentry/sentry/pull/48355) | ➤ Implement use case awareness for Static String Indexer | Merged | [#3](https://github.com/getsentry/sentry/pull/48475) |
| [#5](https://github.com/getsentry/sentry/pull/49019) | Replace `bulk_record`/`record` with `_uca_bulk_record`/`_uca_record`      | Merged | [#4](https://github.com/getsentry/sentry/pull/48355) |

### Overview

See #47284
