### PR TITLE
feat(starfish): Introduce the spans dataset to the events api

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -29,6 +29,7 @@ from sentry.snuba import (
     metrics_enhanced_performance,
     metrics_performance,
     profiles,
+    spans_indexed,
 )
 from sentry.utils import snuba
 from sentry.utils.cursors import Cursor
@@ -45,7 +46,10 @@ DATASET_OPTIONS = {
     "profiles": profiles,
     "issuePlatform": issue_platform,
     "profile_functions": functions,
+    "spansIndexed": spans_indexed,
 }
+
+DATASET_LABELS = {value: key for key, value in DATASET_OPTIONS.items()}
 
 
 def resolve_axis_column(column: str, index: int = 0) -> str:
@@ -292,6 +296,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         organization: Organization,
         project_ids: Sequence[int],
         results: Dict[str, Any],
+        dataset: Optional[Any],
         standard_meta: Optional[bool] = False,
     ) -> Dict[str, Any]:
         with sentry_sdk.start_span(op="discover.endpoint", description="base.handle_results"):
@@ -308,6 +313,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     "isMetricsData": isMetricsData,
                     "tips": meta.get("tips", {}),
                 }
+                if dataset is not None:
+                    meta["dataset"] = DATASET_LABELS.get(dataset, "unknown")
             else:
                 meta = fields_meta
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -296,7 +296,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         organization: Organization,
         project_ids: Sequence[int],
         results: Dict[str, Any],
-        dataset: Optional[Any],
+        dataset: Optional[Any] = None,
         standard_meta: Optional[bool] = False,
     ) -> Dict[str, Any]:
         with sentry_sdk.start_span(op="discover.endpoint", description="base.handle_results"):

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -296,8 +296,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         organization: Organization,
         project_ids: Sequence[int],
         results: Dict[str, Any],
-        dataset: Optional[Any] = None,
         standard_meta: Optional[bool] = False,
+        dataset: Optional[Any] = None,
     ) -> Dict[str, Any]:
         with sentry_sdk.start_span(op="discover.endpoint", description="base.handle_results"):
             data = self.handle_data(request, organization, project_ids, results.get("data"))

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -120,6 +120,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             "organizations:profiling",
             "organizations:dynamic-sampling",
             "organizations:use-metrics-layer",
+            "organizations:starfish-view",
         ]
         batch_features = features.batch_has(
             feature_names,
@@ -255,7 +256,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
         use_metrics_layer = batch_features.get("organizations:use-metrics-layer", False)
 
-        use_custom_dataset = use_metrics or use_profiles or use_occurrences
+        starfish_view = batch_features.get("organizations:starfish-view", False)
+
+        use_custom_dataset = use_metrics or use_profiles or use_occurrences or starfish_view
         dataset = self.get_dataset(request) if use_custom_dataset else discover
         metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}
 
@@ -297,6 +300,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         organization,
                         params["project_id"],
                         data_fn(0, self.get_per_page(request)),
+                        dataset,
                         standard_meta=True,
                     )
                 )
@@ -309,6 +313,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         organization,
                         params["project_id"],
                         results,
+                        dataset,
                         standard_meta=True,
                     ),
                 )

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -300,8 +300,8 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         organization,
                         params["project_id"],
                         data_fn(0, self.get_per_page(request)),
-                        dataset,
                         standard_meta=True,
+                        dataset=dataset,
                     )
                 )
             else:
@@ -313,8 +313,8 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         organization,
                         params["project_id"],
                         results,
-                        dataset,
                         standard_meta=True,
+                        dataset=dataset,
                     ),
                 )
 

--- a/src/sentry/search/events/builder/__init__.py
+++ b/src/sentry/search/events/builder/__init__.py
@@ -22,6 +22,7 @@ from .sessions import (  # NOQA
     SessionsV2QueryBuilder,
     TimeseriesSessionsV2QueryBuilder,
 )
+from .spans_indexed import SpansIndexedQueryBuilder  # NOQA
 
 __all__ = [
     "HistogramQueryBuilder",
@@ -40,5 +41,6 @@ __all__ = [
     "ProfileFunctionsTimeseriesQueryBuilder",
     "SessionsQueryBuilder",
     "SessionsV2QueryBuilder",
+    "SpansIndexedQueryBuilder",
     "TimeseriesSessionsV2QueryBuilder",
 ]

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -61,6 +61,7 @@ from sentry.search.events.datasets.metrics_layer import MetricsLayerDatasetConfi
 from sentry.search.events.datasets.profile_functions import ProfileFunctionsDatasetConfig
 from sentry.search.events.datasets.profiles import ProfilesDatasetConfig
 from sentry.search.events.datasets.sessions import SessionsDatasetConfig
+from sentry.search.events.datasets.spans_indexed import SpansIndexedDatasetConfig
 from sentry.search.events.types import (
     EventsResponse,
     HistogramParams,
@@ -346,6 +347,8 @@ class QueryBuilder(BaseQueryBuilder):
             self.config = ProfilesDatasetConfig(self)
         elif self.dataset == Dataset.Functions:
             self.config = ProfileFunctionsDatasetConfig(self)
+        elif self.dataset == Dataset.SpansIndexed:
+            self.config = SpansIndexedDatasetConfig(self)
         else:
             raise NotImplementedError(f"Data Set configuration not found for {self.dataset}.")
 

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from sentry.search.events.builder import QueryBuilder
+
+
+class SpansIndexedQueryBuilder(QueryBuilder):
+    requires_organization_condition = False
+
+    def get_field_type(self, field: str) -> Optional[str]:
+        if field in self.meta_resolver_map:
+            return self.meta_resolver_map[field]
+        if field in ["span.duration", "span.exclusive_time"]:
+            return "duration"
+
+        return None

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import Callable, Mapping, Optional, Union
+
+from snuba_sdk import Column, Direction, Function, OrderBy
+
+from sentry.api.event_search import SearchFilter
+from sentry.search.events import builder
+from sentry.search.events.datasets.base import DatasetConfig
+from sentry.search.events.fields import (
+    ColumnTagArg,
+    IntervalDefault,
+    NullColumn,
+    NumberRange,
+    NumericColumn,
+    SnQLFunction,
+    with_default,
+)
+from sentry.search.events.types import SelectType, WhereType
+
+
+class SpansIndexedDatasetConfig(DatasetConfig):
+    def __init__(self, builder: builder.QueryBuilder):
+        self.builder = builder
+        self.total_count: Optional[int] = None
+        self.total_sum_transaction_duration: Optional[float] = None
+
+    @property
+    def search_filter_converter(
+        self,
+    ) -> Mapping[str, Callable[[SearchFilter], Optional[WhereType]]]:
+        return {}
+
+    @property
+    def field_alias_converter(self) -> Mapping[str, Callable[[str], SelectType]]:
+        return {}
+
+    @property
+    def function_converter(self) -> Mapping[str, SnQLFunction]:
+        function_converter = {
+            function.name: function
+            for function in [
+                SnQLFunction(
+                    "count",
+                    optional_args=[NullColumn("column")],
+                    snql_aggregate=lambda _, alias: Function(
+                        "count",
+                        [],
+                        alias,
+                    ),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "count_unique",
+                    required_args=[ColumnTagArg("column")],
+                    snql_aggregate=lambda args, alias: Function("uniq", [args["column"]], alias),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "sum",
+                    required_args=[NumericColumn("column", spans=True)],
+                    snql_aggregate=lambda args, alias: Function("sum", [args["column"]], alias),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                ),
+                SnQLFunction(
+                    "percentile",
+                    required_args=[
+                        NumericColumn("column", spans=True),
+                        NumberRange("percentile", 0, 1),
+                    ],
+                    snql_aggregate=self._resolve_percentile,
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p50",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=lambda args, alias: self._resolve_percentile(args, alias, 0.5),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p75",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=lambda args, alias: self._resolve_percentile(args, alias, 0.75),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p95",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=lambda args, alias: self._resolve_percentile(args, alias, 0.95),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p99",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=lambda args, alias: self._resolve_percentile(args, alias, 0.99),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "p100",
+                    optional_args=[
+                        with_default("span.duration", NumericColumn("column", spans=True)),
+                    ],
+                    snql_aggregate=lambda args, alias: self._resolve_percentile(args, alias, 1),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="duration",
+                    redundant_grouping=True,
+                ),
+                SnQLFunction(
+                    "eps",
+                    snql_aggregate=lambda args, alias: Function(
+                        "divide", [Function("count", []), args["interval"]], alias
+                    ),
+                    optional_args=[IntervalDefault("interval", 1, None)],
+                    default_result_type="number",
+                ),
+                SnQLFunction(
+                    "epm",
+                    snql_aggregate=lambda args, alias: Function(
+                        "divide",
+                        [Function("count", []), Function("divide", [args["interval"], 60])],
+                        alias,
+                    ),
+                    optional_args=[IntervalDefault("interval", 1, None)],
+                    default_result_type="number",
+                ),
+            ]
+        }
+        return function_converter
+
+    @property
+    def orderby_converter(self) -> Mapping[str, Callable[[Direction], OrderBy]]:
+        return {}
+
+    def _resolve_percentile(
+        self,
+        args: Mapping[str, Union[str, Column, SelectType, int, float]],
+        alias: str,
+        fixed_percentile: Optional[float] = None,
+    ) -> SelectType:
+        return (
+            Function(
+                "max",
+                [args["column"]],
+                alias,
+            )
+            if fixed_percentile == 1
+            else Function(
+                f'quantile({fixed_percentile if fixed_percentile is not None else args["percentile"]})',
+                [args["column"]],
+                alias,
+            )
+        )

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1067,7 +1067,7 @@ class NumericColumn(ColumnArg):
         # Shortcutting this for now
         # TODO: handle different datasets better here
         if self.spans and value in ["span.duration", "span.self_time"]:
-            return True
+            return value
         snuba_column = SEARCH_MAP.get(value)
         if not snuba_column and is_measurement(value):
             return value

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1049,7 +1049,14 @@ class NumericColumn(ColumnArg):
         "spans_exclusive_time",
     }
 
-    def __init__(self, name: str, allow_array_value: Optional[bool] = False, **kwargs):
+    def __init__(
+        self,
+        name: str,
+        allow_array_value: Optional[bool] = False,
+        spans: Optional[bool] = False,
+        **kwargs,
+    ):
+        self.spans = spans
         super().__init__(name, **kwargs)
         self.allow_array_value = allow_array_value
 
@@ -1057,6 +1064,10 @@ class NumericColumn(ColumnArg):
         # This method is written in this way so that `get_type` can always call
         # this even in child classes where `normalize` have been overridden.
 
+        # Shortcutting this for now
+        # TODO: handle different datasets better here
+        if self.spans and value in ["span.duration", "span.self_time"]:
+            return True
         snuba_column = SEARCH_MAP.get(value)
         if not snuba_column and is_measurement(value):
             return value

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -16,6 +16,7 @@ class Dataset(Enum):
     Profiles = "profiles"
     IssuePlatform = "search_issues"
     Functions = "functions"
+    SpansIndexed = "spans"
 
 
 @unique

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -1,0 +1,51 @@
+from sentry.search.events.builder import SpansIndexedQueryBuilder
+from sentry.utils.snuba import Dataset
+
+
+def query(
+    selected_columns,
+    query,
+    params,
+    snuba_params=None,
+    equations=None,
+    orderby=None,
+    offset=None,
+    limit=50,
+    referrer=None,
+    auto_fields=False,
+    auto_aggregations=False,
+    include_equation_fields=False,
+    allow_metric_aggregates=False,
+    use_aggregate_conditions=False,
+    conditions=None,
+    functions_acl=None,
+    transform_alias_to_input_format=False,
+    sample=None,
+    has_metrics=False,
+    use_metrics_layer=False,
+    skip_tag_resolution=False,
+    extra_columns=None,
+):
+    builder = SpansIndexedQueryBuilder(
+        Dataset.SpansIndexed,
+        params,
+        snuba_params=snuba_params,
+        query=query,
+        selected_columns=selected_columns,
+        equations=equations,
+        orderby=orderby,
+        auto_fields=auto_fields,
+        auto_aggregations=auto_aggregations,
+        use_aggregate_conditions=use_aggregate_conditions,
+        functions_acl=functions_acl,
+        limit=limit,
+        offset=offset,
+        equation_config={"auto_add": include_equation_fields},
+        sample_rate=sample,
+        has_metrics=has_metrics,
+        transform_alias_to_input_format=transform_alias_to_input_format,
+        skip_tag_resolution=skip_tag_resolution,
+    )
+
+    result = builder.process_results(builder.run_query(referrer))
+    return result

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -90,6 +90,28 @@ ISSUE_PLATFORM_MAP = {
     if col.value.issue_platform_name is not None
 }
 
+SPAN_COLUMN_MAP = {
+    "action": "action",
+    "description": "description",
+    "domain": "domain",
+    "group": "group",
+    "id": "span_id",
+    "module": "module",
+    "parent_span": "parent_span_id",
+    "platform": "platform",
+    "project": "project_id",
+    "span.duration": "duration",
+    "span.self_time": "exclusive_time",
+    "span.op": "op",
+    "span.status": "span_status",
+    "timestamp": "end_timestamp",
+    "trace": "trace_id",
+    "transaction": "segment_name",
+    "transaction.id": "transaction_id",
+    "transaction.op": "transaction_op",
+    "user": "user",
+}
+
 SESSIONS_FIELD_LIST = [
     "release",
     "sessions",
@@ -137,6 +159,7 @@ DATASETS = {
     Dataset.Sessions: SESSIONS_SNUBA_MAP,
     Dataset.Metrics: METRICS_COLUMN_MAP,
     Dataset.PerformanceMetrics: METRICS_COLUMN_MAP,
+    Dataset.SpansIndexed: SPAN_COLUMN_MAP,
     Dataset.IssuePlatform: ISSUE_PLATFORM_MAP,
     Dataset.Replays: {},
 }
@@ -150,6 +173,7 @@ DATASET_FIELDS = {
     Dataset.Discover: list(DISCOVER_COLUMN_MAP.values()),
     Dataset.Sessions: SESSIONS_FIELD_LIST,
     Dataset.IssuePlatform: list(ISSUE_PLATFORM_MAP.values()),
+    Dataset.SpansIndexed: list(SPAN_COLUMN_MAP.values()),
 }
 
 SNUBA_OR = "or"


### PR DESCRIPTION
- This adds a new spans dataset to the events endpoint
- This does not change the stats endpoint yet
- Not heavily tested just getting the happy path working first
- Only a few functions have been implemented
    - Duration aggregates: `percentile`, `p50`, `p75`, `p95`, `p99`, `p100`, `sum`
    - `count`, `count_unique`, `eps` and `epm`
      - Huh, would the alias for eps be sps? Spans Per Second?
      
- Here's the table query for the DB module with the events endpoint:
http://dev.getsentry.net:8000/api/0/organizations/sentry/events/?field=description&field=domain&field=epm()&field=p75(span.self_time)&field=count_unique(transaction)&field=sum(span.self_time)&per_page=50&project=-1&query=&statsPeriod=14d&dataset=spansIndexed&orderby=-epm&per_page=50
