### PR TITLE
feat(starfish): Add Throughput sparklines for API endpoint table

### DIFF
--- a/static/app/views/starfish/components/sparkline.tsx
+++ b/static/app/views/starfish/components/sparkline.tsx
@@ -8,9 +8,10 @@ import {Series} from 'sentry/types/echarts';
 type SparklineProps = {
   series: Series;
   color?: string | string[];
+  width?: number;
 };
 
-export default function Sparkline({series, color}: SparklineProps) {
+export default function Sparkline({series, width, color}: SparklineProps) {
   echarts.use([LineChart, SVGRenderer]);
 
   const valueSeries = {
@@ -45,7 +46,7 @@ export default function Sparkline({series, color}: SparklineProps) {
       notMerge
       style={{
         height: 25,
-        width: 300,
+        width: width ?? 300,
       }}
       lazyUpdate
       theme="theme_name"

--- a/static/app/views/starfish/components/sparkline.tsx
+++ b/static/app/views/starfish/components/sparkline.tsx
@@ -14,6 +14,10 @@ type SparklineProps = {
 export default function Sparkline({series, width, color}: SparklineProps) {
   echarts.use([LineChart, SVGRenderer]);
 
+  if (!series.data) {
+    return null;
+  }
+
   const valueSeries = {
     data: series.data.map(datum => datum.value),
     type: 'line',

--- a/static/app/views/starfish/modules/APIModule/endpointTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/endpointTable.tsx
@@ -51,7 +51,7 @@ const COLUMN_ORDER = [
   {
     key: 'tpm',
     name: 'tpm',
-    width: COL_WIDTH_UNDEFINED,
+    width: 200,
   },
   {
     key: 'p50(exclusive_time)',
@@ -169,7 +169,13 @@ export function renderBodyCell(
   }
 
   if (column.key === 'tpm') {
-    return <Sparkline color={CHART_PALETTE[3][0]} series={row[column.key]} width={100} />;
+    return (
+      <Sparkline
+        color={CHART_PALETTE[3][0]}
+        series={row[column.key]}
+        width={column.width ? column.width - column.width / 5 : undefined}
+      />
+    );
   }
 
   // TODO: come up with a better way to identify number columns to align to the right

--- a/static/app/views/starfish/modules/APIModule/endpointTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/endpointTable.tsx
@@ -169,7 +169,7 @@ export function renderBodyCell(
   }
 
   if (column.key === 'tpm') {
-    return <Sparkline color={CHART_PALETTE[3][1]} series={row[column.key]} />;
+    return <Sparkline color={CHART_PALETTE[3][0]} series={row[column.key]} width={100} />;
   }
 
   // TODO: come up with a better way to identify number columns to align to the right

--- a/static/app/views/starfish/modules/APIModule/endpointTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/endpointTable.tsx
@@ -93,7 +93,7 @@ export default function EndpointTable({
 
   const {isLoading: isEndpointsThroughputLoading, data: endpointsThroughputData} =
     useQuery({
-      queryKey: ['endpoints2', filterOptions],
+      queryKey: ['endpointsThroughput', filterOptions],
       queryFn: () =>
         fetch(`${HOST}/?query=${getEndpointsThroughputQuery(filterOptions)}`).then(res =>
           res.json()

--- a/static/app/views/starfish/modules/APIModule/endpointTable.tsx
+++ b/static/app/views/starfish/modules/APIModule/endpointTable.tsx
@@ -140,15 +140,23 @@ export default function EndpointTable({
 }
 
 export function renderHeadCell(column: GridColumnHeader): React.ReactNode {
+  if (column.key === 'throughput') {
+    return (
+      <TextAlignLeft>
+        <OverflowEllipsisTextContainer>{column.name}</OverflowEllipsisTextContainer>
+      </TextAlignLeft>
+    );
+  }
+
   // TODO: come up with a better way to identify number columns to align to the right
   if (
     column.key.toString().match(/^p\d\d/) ||
     !['description', 'transaction'].includes(column.key.toString())
   ) {
     return (
-      <TextAlignLeft>
+      <TextAlignRight>
         <OverflowEllipsisTextContainer>{column.name}</OverflowEllipsisTextContainer>
-      </TextAlignLeft>
+      </TextAlignRight>
     );
   }
   return <OverflowEllipsisTextContainer>{column.name}</OverflowEllipsisTextContainer>;
@@ -180,11 +188,16 @@ export function renderBodyCell(
   }
 
   // TODO: come up with a better way to identify number columns to align to the right
-  if (column.key.toString().match(/^p\d\d/) || column.key === 'total_exclusive_time') {
+  if (
+    column.key.toString().match(/^p\d\d/) ||
+    column.key === 'total_exclusive_time' ||
+    column.key === 'user_count' ||
+    column.key === 'transaction_count'
+  ) {
     return (
-      <TextAlignLeft>
+      <TextAlignRight>
         <Duration seconds={row[column.key] / 1000} fixedDigits={2} abbreviation />
-      </TextAlignLeft>
+      </TextAlignRight>
     );
   }
   if (!['description', 'transaction'].includes(column.key.toString())) {
@@ -202,6 +215,11 @@ export const OverflowEllipsisTextContainer = styled('span')`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+`;
+
+export const TextAlignRight = styled('span')`
+  text-align: right;
+  width: 100%;
 `;
 
 export const TextAlignLeft = styled('span')`

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -179,7 +179,7 @@ export const getHostStatusBreakdownQuery = ({domain, datetime}) => {
   `;
 };
 
-export const getEndpointsThroughputQuery = ({datetime}) => {
+export const getEndpointsThroughputQuery = ({datetime, transaction}) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `
     SELECT
@@ -188,6 +188,7 @@ export const getEndpointsThroughputQuery = ({datetime}) => {
     count() AS count
     FROM spans_experimental_starfish
     WHERE module = 'http'
+    ${transaction ? `AND transaction = '${transaction}'` : ''}
     ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
     ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
     GROUP BY description, interval

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -179,7 +179,7 @@ export const getHostStatusBreakdownQuery = ({domain, datetime}) => {
   `;
 };
 
-export const getEndpointsTPMQuery = ({datetime}) => {
+export const getEndpointsThroughputQuery = ({datetime}) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `
     SELECT

--- a/static/app/views/starfish/modules/APIModule/queries.js
+++ b/static/app/views/starfish/modules/APIModule/queries.js
@@ -178,3 +178,19 @@ export const getHostStatusBreakdownQuery = ({domain, datetime}) => {
     ORDER BY count DESC
   `;
 };
+
+export const getEndpointsTPMQuery = ({datetime}) => {
+  const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
+  return `
+    SELECT
+    description,
+    toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
+    count() AS count
+    FROM spans_experimental_starfish
+    WHERE module = 'http'
+    ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
+    ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
+    GROUP BY description, interval
+    ORDER BY interval asc
+  `;
+};

--- a/static/app/views/starfish/views/endpointDetails/index.tsx
+++ b/static/app/views/starfish/views/endpointDetails/index.tsx
@@ -19,7 +19,7 @@ import Detail from 'sentry/views/starfish/components/detailPanel';
 import {
   OverflowEllipsisTextContainer,
   renderHeadCell,
-  TextAlignRight,
+  TextAlignLeft,
 } from 'sentry/views/starfish/modules/APIModule/endpointTable';
 import {
   getEndpointDetailSeriesQuery,
@@ -224,19 +224,18 @@ function renderBodyCell(
     );
   }
 
-  // TODO: come up with a better way to identify number columns to align to the right
   if (column.key.toString().match(/^p\d\d/)) {
     return (
-      <TextAlignRight>
+      <TextAlignLeft>
         <Duration seconds={row[column.key] / 1000} fixedDigits={2} abbreviation />
-      </TextAlignRight>
+      </TextAlignLeft>
     );
   }
   if (!['description', 'transaction'].includes(column.key.toString())) {
     return (
-      <TextAlignRight>
+      <TextAlignLeft>
         <OverflowEllipsisTextContainer>{row[column.key]}</OverflowEllipsisTextContainer>
-      </TextAlignRight>
+      </TextAlignLeft>
     );
   }
 

--- a/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
@@ -58,8 +58,8 @@ const HTTP_SPAN_COLUMN_ORDER = [
     width: 400,
   },
   {
-    key: 'tpm',
-    name: 'TPM',
+    key: 'throughput',
+    name: 'Throughput',
     width: 125,
   },
   {

--- a/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
@@ -58,6 +58,11 @@ const HTTP_SPAN_COLUMN_ORDER = [
     width: 400,
   },
   {
+    key: 'tpm',
+    name: 'TPM',
+    width: 125,
+  },
+  {
     key: 'p50(exclusive_time)',
     name: 'p50',
     width: COL_WIDTH_UNDEFINED,
@@ -67,6 +72,7 @@ const HTTP_SPAN_COLUMN_ORDER = [
     name: 'Transactions',
     width: COL_WIDTH_UNDEFINED,
   },
+
   {
     key: 'total_exclusive_time',
     name: 'Total Time',


### PR DESCRIPTION
Updates the API endpoint table to include a sparkline for throughput

### API Module View
![image](https://user-images.githubusercontent.com/16740047/235758217-04b17143-04f3-4794-ac27-1ca79e0b216d.png)

### Endpoint Detail Panel (in webservice view)
![image](https://user-images.githubusercontent.com/16740047/235758485-6c32d5c1-66b3-4860-8d9f-093ff9c6f093.png)
