### PR TITLE
perf(sql-format): Add limits to size and quantity of SQL formats

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Sequence
+from typing import Any, Dict, Sequence
 
 import sentry_sdk
 import sqlparse
@@ -27,8 +27,11 @@ from sentry.utils.safe import get_path
 
 CRASH_FILE_TYPES = {"event.minidump"}
 RESERVED_KEYS = frozenset(["user", "sdk", "device", "contexts"])
+
 FORMATTED_BREADCRUMB_CATEGORIES = frozenset(["query", "sql.query"])
 SQL_DOUBLEQUOTES_REGEX = re.compile(r"\"([a-zA-Z0-9_]+?)\"")
+MAX_SQL_FORMAT_OPS = 20
+MAX_SQL_FORMAT_LENGTH = 1500
 
 
 def get_crash_files(events):
@@ -346,13 +349,32 @@ class SqlFormatEventSerializer(EventSerializer):
     Applies formatting to SQL queries in the serialized event.
     """
 
+    formatted_sql_cache: Dict[str, str] = {}
+
+    # Various checks to ensure that we don't spend too much time formatting
+    def _should_skip_formatting(self, query: str):
+        if (len(self.formatted_sql_cache) >= MAX_SQL_FORMAT_OPS) | (
+            len(query) > MAX_SQL_FORMAT_LENGTH
+        ):
+            return True
+
+        return False
+
     def _remove_doublequotes(self, message: str):
         return SQL_DOUBLEQUOTES_REGEX.sub(r"\1", message)
 
     def _format_sql_query(self, message: str):
+        formatted = self.formatted_sql_cache.get(message, None)
+        if formatted is not None:
+            return formatted
+        if self._should_skip_formatting(message):
+            return message
+
         formatted = sqlparse.format(message, reindent=True, wrap_after=80)
         if formatted != message:
             formatted = self._remove_doublequotes(formatted)
+        self.formatted_sql_cache[message] = formatted
+
         return formatted
 
     def _format_breadcrumb_messages(

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -349,7 +349,9 @@ class SqlFormatEventSerializer(EventSerializer):
     Applies formatting to SQL queries in the serialized event.
     """
 
-    formatted_sql_cache: Dict[str, str] = {}
+    def __init__(self) -> None:
+        super().__init__()
+        self.formatted_sql_cache: Dict[str, str] = {}
 
     # Various checks to ensure that we don't spend too much time formatting
     def _should_skip_formatting(self, query: str):

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -589,3 +589,50 @@ class SqlFormatEventSerializerTest(TestCase):
 
             # For span 2: Not a db span so no change
             assert result["entries"][0]["data"][1]["description"] == """http span"""
+
+    def test_db_formatting_perf_optimizations(self):
+        with self.feature("organizations:sql-format"):
+            SQL_QUERY_OK = """select * from table where something in (%s, %s, %s)"""
+            SQL_QUERY_TOO_LARGE = "a" * 1501
+
+            event = self.store_event(
+                data={
+                    "breadcrumbs": [
+                        {
+                            "category": "query",
+                            "message": SQL_QUERY_OK,
+                        },
+                        {
+                            "category": "query",
+                            "message": SQL_QUERY_OK,
+                        },
+                        {
+                            "category": "query",
+                            "message": SQL_QUERY_TOO_LARGE,
+                        },
+                    ]
+                    + [{"category": "query", "message": str(i)} for i in range(0, 30)]
+                },
+                project_id=self.project.id,
+            )
+
+            with mock.patch("sqlparse.format", return_value="") as mock_format:
+                serialize(event, None, SqlFormatEventSerializer())
+
+                assert (
+                    len(
+                        list(
+                            filter(
+                                lambda args: SQL_QUERY_OK in args[0],
+                                mock_format.call_args_list,
+                            )
+                        )
+                    )
+                    == 1
+                ), "SQL_QUERY_OK should have been formatted a single time"
+
+                assert not any(
+                    SQL_QUERY_TOO_LARGE in args[0] for args in mock_format.call_args_list
+                ), "SQL_QUERY_TOO_LARGE should not have been formatted"
+
+                assert mock_format.call_count == 20, "Format should have been called 20 times"


### PR DESCRIPTION
Some events have _very_ large SQL queries in the performance spans, so we need to limit the number of formats we are doing. I'm starting with relatively conservative numbers, a maximum query length of 1500 characters, and a maximum of 20 unique formats per event. I think this is a reasonable tradeoff and will work for the majority of use cases while putting an upper bound on the amount of time spent formatting.

Some benchmarking I did with an event that was causing the most issues (before and after these optimizations):

Before: ~6.5s
After: ~80ms