### PR TITLE
feat(consecutive-http): Add lcp threshold option to frontend

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -47,6 +47,7 @@ const optionsAvailable = [
   'performance.issues.m_n_plus_one_db.la-rollout',
   'performance.issues.m_n_plus_one_db.ea-rollout',
   'performance.issues.m_n_plus_one_db.ga-rollout',
+  'performance.issues.consecutive_http.lcp_ratio_threshold',
   'profile.issues.blocked_main_thread-ingest.la-rollout',
   'profile.issues.blocked_main_thread-ingest.ea-rollout',
   'profile.issues.blocked_main_thread-ingest.ga-rollout',
@@ -184,6 +185,12 @@ export default class AdminSettings extends AsyncView<{}, State> {
               {fields['performance.issues.m_n_plus_one_db.la-rollout']}
               {fields['performance.issues.m_n_plus_one_db.ea-rollout']}
               {fields['performance.issues.m_n_plus_one_db.ga-rollout']}
+            </Panel>
+            <Panel>
+              <PanelHeader>
+                Performance Issues - Consecutive HTTP Span Detector
+              </PanelHeader>
+              {fields['performance.issues.consecutive_http.lcp_ratio_threshold']}
             </Panel>
             <Panel>
               <PanelHeader>

--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -48,6 +48,7 @@ const optionsAvailable = [
   'performance.issues.m_n_plus_one_db.ea-rollout',
   'performance.issues.m_n_plus_one_db.ga-rollout',
   'performance.issues.consecutive_http.lcp_ratio_threshold',
+  'performance.issues.consecutive_http.max_duration_between_spans',
   'profile.issues.blocked_main_thread-ingest.la-rollout',
   'profile.issues.blocked_main_thread-ingest.ea-rollout',
   'profile.issues.blocked_main_thread-ingest.ga-rollout',
@@ -191,6 +192,7 @@ export default class AdminSettings extends AsyncView<{}, State> {
                 Performance Issues - Consecutive HTTP Span Detector
               </PanelHeader>
               {fields['performance.issues.consecutive_http.lcp_ratio_threshold']}
+              {fields['performance.issues.consecutive_http.max_duration_between_spans']}
             </Panel>
             <Panel>
               <PanelHeader>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -381,6 +381,18 @@ const performanceOptionDefinitions: Field[] = [
     defaultValue: () => '0.33',
   },
   {
+    key: 'performance.issues.consecutive_http.max_duration_between_spans',
+    label: t('Time Between Spans'),
+    help: t(
+      'Maximum time between consecutive HTTP spans to be considered part of the same problem.'
+    ),
+    defaultValue: () => '5000',
+    component: NumberField,
+    min: 0,
+    max: Number.MAX_SAFE_INTEGER,
+    step: 1,
+  },
+  {
     key: 'profile.issues.blocked_main_thread-ingest.la-rollout',
     label: t('Limited Availability Detection Rate'),
     help: t(

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -384,7 +384,7 @@ const performanceOptionDefinitions: Field[] = [
     key: 'performance.issues.consecutive_http.max_duration_between_spans',
     label: t('Time Between Spans'),
     help: t(
-      'Maximum time between consecutive HTTP spans to be considered part of the same problem.'
+      'Maximum time, in ms, between consecutive HTTP spans to be considered part of the same problem.'
     ),
     defaultValue: () => '5000',
     component: NumberField,

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -372,6 +372,15 @@ const performanceOptionDefinitions: Field[] = [
     ),
   },
   {
+    key: 'performance.issues.consecutive_http.lcp_ratio_threshold',
+    label: t('LCP Ratio Threshold'),
+    help: t(
+      'The sum of consecutive HTTP spans must be larger than this percentage of the LCP to be considered a problem.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+    defaultValue: () => '0.33',
+  },
+  {
     key: 'profile.issues.blocked_main_thread-ingest.la-rollout',
     label: t('Limited Availability Detection Rate'),
     help: t(

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -386,7 +386,7 @@ const performanceOptionDefinitions: Field[] = [
     help: t(
       'Maximum time, in ms, between consecutive HTTP spans to be considered part of the same problem.'
     ),
-    defaultValue: () => '5000',
+    defaultValue: () => '1000',
     component: NumberField,
     min: 0,
     max: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
Adds the option introduced in https://github.com/getsentry/sentry/pull/48269 to the frontend options UI