### PR TITLE
feat(crons): Add timeout count to monitor details graph

### DIFF
--- a/static/app/views/monitors/components/monitorStats.tsx
+++ b/static/app/views/monitors/components/monitorStats.tsx
@@ -72,19 +72,25 @@ const MonitorStats = ({monitor, monitorEnv, orgId}: Props) => {
     yAxisIndex: 0,
     data: [],
   };
+  const timeout: BarChartSeries = {
+    seriesName: t('Timeout'),
+    yAxisIndex: 0,
+    data: [],
+  };
   const durationData = [] as [number, number][];
 
   data.stats?.forEach(p => {
-    if (p.ok || p.error || p.missed) {
+    if (p.ok || p.error || p.missed || p.timeout) {
       emptyStats = false;
     }
     const timestamp = p.ts * 1000;
     success.data.push({name: timestamp, value: p.ok});
     failed.data.push({name: timestamp, value: p.error});
+    timeout.data.push({name: timestamp, value: p.timeout});
     missed.data.push({name: timestamp, value: p.missed});
     durationData.push([timestamp, Math.trunc(p.duration)]);
   });
-  const colors = [theme.green200, theme.red200, theme.yellow200];
+  const colors = [theme.green200, theme.red200, theme.red200, theme.yellow200];
 
   const durationTitle = t('Average Duration');
   const additionalSeries: LineSeriesOption[] = [
@@ -118,7 +124,7 @@ const MonitorStats = ({monitor, monitorEnv, orgId}: Props) => {
             isGroupedByDate
             showTimeInTooltip
             useShortDate
-            series={[success, failed, missed]}
+            series={[success, failed, timeout, missed]}
             stacked
             additionalSeries={additionalSeries}
             height={height}

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -93,5 +93,6 @@ export interface MonitorStat {
   error: number;
   missed: number;
   ok: number;
+  timeout: number;
   ts: number;
 }


### PR DESCRIPTION
Not the prettiest right now, as the color is the same as error, but works to show timeout vs error counts in the graph

<img width="395" alt="Screenshot 2023-05-02 at 12 07 52 PM" src="https://user-images.githubusercontent.com/9372512/235763708-cf63c84e-48a0-4d2d-9204-c24aaeacac45.png">

Reliant on: https://github.com/getsentry/sentry/pull/48367