### PR TITLE
ref(integrations): Handle multiple orgs in `bind_org_context_from_integration`

### DIFF
--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -8,7 +8,7 @@ from sentry_sdk import configure_scope
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.utils.sdk import bind_organization_context
+from sentry.utils.sdk import bind_ambiguous_org_context, bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -67,5 +67,4 @@ def bind_org_context_from_integration(integration_id: int) -> None:
     elif len(orgs) == 1:
         bind_organization_context(orgs[0])
     else:
-        # skip this case for now
-        pass
+        bind_ambiguous_org_context(orgs, f"integration (id={integration_id})")

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -51,6 +51,22 @@ class BindOrgContextFromIntegrationTest(TestCase):
 
         mock_bind_org_context.assert_called_with(org)
 
+        @patch("sentry.integrations.utils.scope.bind_ambiguous_org_context")
+        def test_binds_org_context_with_multiple_orgs(
+            self, mock_bind_ambiguous_org_context: MagicMock
+        ):
+            maisey_org = self.create_organization(slug="themaiseymaiseydog")
+            charlie_org = self.create_organization(slug="charliebear")
+            integration = Integration.objects.create(name="squirrelChasers")
+            integration.add_organization(maisey_org)
+            integration.add_organization(charlie_org)
+
+            bind_org_context_from_integration(integration.id)
+
+            mock_bind_ambiguous_org_context.assert_called_with(
+                [maisey_org, charlie_org], f"integration (id={integration.id})"
+            )
+
     def test_raises_error_if_no_orgs_found(self):
         integration = Integration.objects.create(name="squirrelChasers")
 


### PR DESCRIPTION
This uses the helper added in https://github.com/getsentry/sentry/pull/48365, `bind_ambiguous_org_context`, to add org scope data in `bind_org_context_from_integration` when the given `Integration` instance is associated with multiple orgs.