### PR TITLE
fix(meps): filter histogram outliers when using metrics dataset

### DIFF
--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -76,6 +76,8 @@ class OrganizationEventsHistogramEndpoint(OrganizationEventsV2EndpointBase):
                 data_filter = data.get("dataFilter")
                 query = data.get("query")
                 if data_filter == "exclude_outliers" and metrics_enhanced:
+                    if query is None:
+                        query = ""
                     query += " histogram_outlier:inlier"
 
                 with self.handle_query_errors():

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -221,6 +221,7 @@ FILTERABLE_TAGS = {
     "tags[browser.name]",
     "tags[os.name]",
     "tags[release]",
+    "tags[histogram_outlier]",
 }
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -15,7 +15,9 @@ from sentry.utils.snuba import get_array_column_alias
 
 pytestmark = pytest.mark.sentry_metrics
 
-HistogramSpec = namedtuple("HistogramSpec", ["start", "end", "fields"])
+HistogramSpec = namedtuple(
+    "HistogramSpec", ["start", "end", "fields", "tags"], defaults=[None, None, [], {}]
+)
 
 ARRAY_COLUMNS = ["measurements", "span_op_breakdowns"]
 
@@ -898,8 +900,8 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
     def test_histogram_exclude_outliers_data_filter(self):
         specs = [
-            (0, 0, [("foo", 4)]),
-            (4000, 4001, [("foo", 1)]),
+            (0, 0, [("foo", 4)], {"histogram_outlier": "inlier"}),
+            (4000, 4001, [("foo", 1)], {"histogram_outlier": "outlier"}),
         ]
         self.populate_events(specs)
 
@@ -1041,7 +1043,7 @@ class OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTest(
                     self.store_transaction_metric(
                         (spec.end + spec.start) / 2,
                         metric=suffix_key,
-                        tags={"transaction": suffix_key},
+                        tags={"transaction": suffix_key, **spec.tags},
                         timestamp=start,
                     )
 
@@ -1129,9 +1131,9 @@ class OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTest(
 
     def test_histogram_exclude_outliers_data_filter(self):
         specs = [
-            (0, 0, [("transaction.duration", 4)]),
-            (1, 1, [("transaction.duration", 4)]),
-            (4000, 4001, [("transaction.duration", 1)]),
+            (0, 0, [("transaction.duration", 4)], {"histogram_outlier": "inlier"}),
+            (1, 1, [("transaction.duration", 4)], {"histogram_outlier": "inlier"}),
+            (4000, 4001, [("transaction.duration", 1)], {"histogram_outlier": "outlier"}),
         ]
         self.populate_events(specs)
 

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -900,8 +900,8 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
     def test_histogram_exclude_outliers_data_filter(self):
         specs = [
-            (0, 0, [("foo", 4)], {"histogram_outlier": "inlier"}),
-            (4000, 4001, [("foo", 1)], {"histogram_outlier": "outlier"}),
+            (0, 0, [("foo", 4)]),
+            (4000, 4001, [("foo", 1)]),
         ]
         self.populate_events(specs)
 
@@ -1151,9 +1151,6 @@ class OrganizationEventsMetricsEnhancedPerformanceHistogramEndpointTest(
         expected = [
             (0, 0, [("transaction.duration", 8)]),
             (1, 2, [("transaction.duration", 0)]),
-            (2, 3, [("transaction.duration", 0)]),
-            (3, 4, [("transaction.duration", 0)]),
-            (4, 5, [("transaction.duration", 0)]),
         ]
         expected_response = self.as_response_data(expected)
         expected_response["meta"] = {"isMetricsData": True}


### PR DESCRIPTION
Histograms in production are still using the Discover (indexed) dataset. We would like to switch them to use the metrics (processed) dataset instead, but the data coming back is incorrect. This should be fixed by excluding outliers, which can be done with a `histogram_outlier:inlier` clause in the user query.

Normally I would update the frontend to pass this in the query directly, but the final decision of which dataset to use is still done on the backend and I don't want to accidentally affect any real user queries - only users with the `organizations:performance-use-metrics` and
`organizations:performance-mep-reintroduce-histograms` flags will see these changes.

Confirmed in production that by manually adding the `histogram_outlier:inlier` clause to a histogram query (with the right feature flags) returns much more representative data than the current version without outlier detection.