### PR TITLE
feat(generic-metrics): Complete switchover from old to new cache keys

### DIFF
--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -101,7 +101,7 @@ def test_indexer(indexer, indexer_cache):
     assert list(
         indexer_cache.get_many(
             [f"{org1_id}:{string}" for string in strings],
-            cache_namespace=use_case_id.value,
+            cache_namespace=REVERSE_METRIC_PATH_MAPPING[use_case_id].value,
         ).values()
     ) == [None, None, None]
 
@@ -131,7 +131,12 @@ def test_indexer(indexer, indexer_cache):
 
     # verify org2 results and cache values
     assert results[org2_id]["sup"] == org2_string_id
-    assert indexer_cache.get(f"{org2_id}:sup", cache_namespace=use_case_id.value) == org2_string_id
+    assert (
+        indexer_cache.get(
+            f"{org2_id}:sup", cache_namespace=REVERSE_METRIC_PATH_MAPPING[use_case_id].value
+        )
+        == org2_string_id
+    )
 
     # we should have no results for org_id 999
     assert not results.get(999)

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -16,6 +16,7 @@ from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCac
 from sentry.sentry_metrics.indexer.mock import RawSimpleIndexer
 from sentry.sentry_metrics.indexer.postgres.postgres_v2 import PGStringIndexerV2
 from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS, StaticStringIndexer
+from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPING
 from sentry.testutils.helpers.options import override_options
 
 BACKENDS = [
@@ -124,7 +125,7 @@ def test_indexer(indexer, indexer_cache):
 
     for cache_value in indexer_cache.get_many(
         [f"{org1_id}:{string}" for string in strings],
-        cache_namespace=use_case_id.value,
+        cache_namespace=REVERSE_METRIC_PATH_MAPPING[use_case_id].value,
     ).values():
         assert cache_value in org1_string_ids
 
@@ -213,7 +214,7 @@ def test_already_cached_plus_read_results(indexer, indexer_cache) -> None:
     """
     org_id = 8
     cached = {f"{org_id}:beep": 10, f"{org_id}:boop": 11}
-    indexer_cache.set_many(cached, use_case_id.value)
+    indexer_cache.set_many(cached, REVERSE_METRIC_PATH_MAPPING[use_case_id].value)
 
     raw_indexer = indexer
     indexer = CachingIndexer(indexer_cache, indexer)

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.cache import StringIndexerCache
-from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPING
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 
@@ -37,15 +36,6 @@ def test_cache_many(use_case_id: str) -> None:
     assert indexer_cache.get_many(list(values.keys()), use_case_id) == {"hello": None, "bye": None}
     indexer_cache.set_many(values, use_case_id)
     assert indexer_cache.get_many(list(values.keys()), use_case_id) == values
-
-    new_use_case_id = REVERSE_METRIC_PATH_MAPPING[UseCaseKey(use_case_id)]
-    new_values = {"yes": 4, "no": 5}
-    assert indexer_cache.get_many(list(new_values.keys()), new_use_case_id.value) == {
-        "yes": None,
-        "no": None,
-    }
-    indexer_cache.set_many_new(new_values, use_case_id)
-    assert indexer_cache.get_many(list(new_values.keys()), new_use_case_id.value) == new_values
 
     indexer_cache.delete_many(list(values.keys()), use_case_id)
     assert indexer_cache.get_many(list(values.keys()), use_case_id) == {"hello": None, "bye": None}


### PR DESCRIPTION
After having double-written cache keys for some time (https://github.com/getsentry/sentry/pull/47964), we are now only going to `get` and `set` the new cache key, which uses the namespace/use case instead of the metric path key. 