### PR TITLE
feat(ui): Sanitize org replays endpoint on error

### DIFF
--- a/static/app/utils/requestError/sanitizePath.spec.tsx
+++ b/static/app/utils/requestError/sanitizePath.spec.tsx
@@ -70,9 +70,14 @@ describe('sanitizePath', function () {
     ['/customers/sentry-test/issues/', '/customers/{orgSlug}/issues/'],
     ['/customers/sentry-test/issues/123/', '/customers/{orgSlug}/issues/123/'],
 
+    // replays endpionts
     [
       '/projects/sentry/javascript/replays/123/',
       '/projects/{orgSlug}/{projectSlug}/replays/{replayId}/',
+    ],
+    [
+      '/organizations/sentry/replays/abc123/',
+      '/organizations/{orgSlug}/replays/{replayId}/',
     ],
   ])('sanitizes %s', (path, expected) => {
     expect(sanitizePath(path)).toBe(expected);

--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -44,11 +44,12 @@ export function sanitizePath(path: string) {
         suffix = `${tertiarySlug}{teamSlug}/`;
       } else if (
         (isProject && tertiarySlug === 'replays/') ||
-        contentType === 'replays/'
+        (isOrg && contentType === 'replays/')
       ) {
         // Projct replays endpoint
         // https://github.com/getsentry/sentry/blob/82074148753c21abf37f6f33408bb95691ed1597/src/sentry/api/urls.py#L2076
         // r"^(?P<organization_slug>[^/]+)/(?P<project_slug>[^\/]+)/replays/(?P<replay_id>[\w-]+)/$",
+
         // Org replays endpoint
         // https://github.com/getsentry/sentry/blob/e45aafb8a62b5728129aed67574cb37a4bd69075/src/sentry/api/urls.py#L1658
         // r"^(?P<organization_slug>[^/]+)/replays/(?P<replay_id>[\w-]+)/$"

--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -8,6 +8,7 @@ const SHORTENED_TYPE = {
   projects: 'projectSlug',
   teams: 'teamSlug',
   issues: 'issueId',
+  replays: 'replayId',
 };
 
 export function sanitizePath(path: string) {
@@ -41,10 +42,17 @@ export function sanitizePath(path: string) {
         // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1894
         // r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
         suffix = `${tertiarySlug}{teamSlug}/`;
-      } else if (isProject && tertiarySlug === 'replays/') {
+      } else if (
+        (isProject && tertiarySlug === 'replays/') ||
+        contentType === 'replays/'
+      ) {
+        // Projct replays endpoint
         // https://github.com/getsentry/sentry/blob/82074148753c21abf37f6f33408bb95691ed1597/src/sentry/api/urls.py#L2076
         // r"^(?P<organization_slug>[^/]+)/(?P<project_slug>[^\/]+)/replays/(?P<replay_id>[\w-]+)/$",
-        suffix = `${tertiarySlug}{replayId}/`;
+        // Org replays endpoint
+        // https://github.com/getsentry/sentry/blob/e45aafb8a62b5728129aed67574cb37a4bd69075/src/sentry/api/urls.py#L1658
+        // r"^(?P<organization_slug>[^/]+)/replays/(?P<replay_id>[\w-]+)/$"
+        suffix = isOrg ? `{replayId}/` : `replays/{replayId}/`;
       } else if (isRuleConditions) {
         // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1595
         // r"^(?P<organization_slug>[^\/]+)/rule-conditions/$",


### PR DESCRIPTION
fixes grouping for errors on the org replays endpoint by removing the replay id `/replays/abc123/` to `/replays/{replayId}/`

resolves JAVASCRIPT-2KA1

related to #48302