### PR TITLE
fix(crons): Correct react key error in monitors list

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -87,7 +87,7 @@ export default function Monitors({location}: RouteComponentProps<{}, {}>) {
 
   const renderMonitorRow = (monitor: Monitor, monitorEnv?: MonitorEnvironment) => (
     <MonitorRow
-      key={monitor.slug}
+      key={`${monitor.slug}-${monitorEnv?.name ?? 'no-env'}`}
       monitor={monitor}
       monitorEnv={monitorEnv}
       onDelete={() => {


### PR DESCRIPTION
This was causing monitors some monitors to fail to be removed from the
list upon client side removal