### PR TITLE
ref(starfish): cleanup db module a bit

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/index.tsx
@@ -12,19 +12,14 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
-import {useQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import {getMainTable} from 'sentry/views/starfish/modules/databaseModule/queries';
-import {getDateFilters} from 'sentry/views/starfish/utils/dates';
+import {useQueryMainTable} from 'sentry/views/starfish/modules/databaseModule/queries';
 
 import DatabaseChartView from './databaseChartView';
 import DatabaseTableView, {DataRow, TableColumnHeader} from './databaseTableView';
 import QueryDetail from './panel';
-
-const HOST = 'http://localhost:8080';
 
 function DatabaseModule() {
   const location = useLocation();
@@ -34,18 +29,6 @@ function DatabaseModule() {
   const [table, setTable] = useState<string>('ALL');
   const [filterNew, setFilterNew] = useState<boolean>(false);
   const [filterOld, setFilterOld] = useState<boolean>(false);
-  const toggleFilterNew = () => {
-    setFilterNew(!filterNew);
-    if (!filterNew) {
-      setFilterOld(false);
-    }
-  };
-  const toggleFilterOld = () => {
-    setFilterOld(!filterOld);
-    if (!filterOld) {
-      setFilterNew(false);
-    }
-  };
   const [transaction, setTransaction] = useState<string>('');
   const [sort, setSort] = useState<{
     direction: 'desc' | 'asc' | undefined;
@@ -56,16 +39,11 @@ function DatabaseModule() {
     next: undefined,
     prev: undefined,
   });
-
-  const tableFilter = table !== 'ALL' ? `domain = '${table}'` : undefined;
-  const actionFilter = action !== 'ALL' ? `action = '${action}'` : undefined;
-  const newFilter: string | undefined = filterNew ? 'newish = 1' : undefined;
-  const oldFilter: string | undefined = filterOld ? 'retired = 1' : undefined;
-
-  const pageFilter = usePageFilters();
-  const {startTime, endTime} = getDateFilters(pageFilter);
-  const transactionFilter =
-    transaction.length > 0 ? `transaction='${transaction}'` : null;
+  const {
+    isLoading: isTableDataLoading,
+    data: tableData,
+    isRefetching: isTableRefetching,
+  } = useQueryMainTable(transaction, table, action, sort.sortHeader?.key, sort.direction);
 
   useEffect(() => {
     function handleKeyDown({keyCode}) {
@@ -90,40 +68,18 @@ function DatabaseModule() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const {
-    isLoading: isTableDataLoading,
-    data: tableData,
-    isRefetching: isTableRefetching,
-  } = useQuery<DataRow[]>({
-    queryKey: [
-      'endpoints',
-      action,
-      table,
-      pageFilter.selection.datetime,
-      transaction,
-      sort.sortHeader?.key,
-      sort.direction,
-      newFilter,
-      oldFilter,
-    ],
-    cacheTime: 10000,
-    queryFn: () =>
-      fetch(
-        `${HOST}/?query=${getMainTable(
-          startTime,
-          endTime,
-          transactionFilter,
-          tableFilter,
-          actionFilter,
-          sort.sortHeader?.key,
-          sort.direction,
-          newFilter,
-          oldFilter
-        )}&format=sql`
-      ).then(res => res.json()),
-    retry: false,
-    initialData: [],
-  });
+  const toggleFilterNew = () => {
+    setFilterNew(!filterNew);
+    if (!filterNew) {
+      setFilterOld(false);
+    }
+  };
+  const toggleFilterOld = () => {
+    setFilterOld(!filterOld);
+    if (!filterOld) {
+      setFilterNew(false);
+    }
+  };
 
   const getUpdatedRows = (row: DataRow, rowIndex?: number) => {
     rowIndex ??= tableData.findIndex(data => data.group_id === row.group_id);

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -1,7 +1,6 @@
 import {CSSProperties, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {useQuery} from '@tanstack/react-query';
 import keyBy from 'lodash/keyBy';
 import moment from 'moment';
 import * as qs from 'query-string';
@@ -20,21 +19,17 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart from 'sentry/views/starfish/components/chart';
 import Detail from 'sentry/views/starfish/components/detailPanel';
 import {
-  getPanelEventCount,
-  getPanelGraphQuery,
-  getPanelTableQuery,
+  useQueryPanelEventCount,
+  useQueryPanelGraph,
+  useQueryPanelTable,
   useQueryTransactionByTPM,
 } from 'sentry/views/starfish/modules/databaseModule/queries';
-import {
-  datetimeToClickhouseFilterTimestamps,
-  getDateFilters,
-} from 'sentry/views/starfish/utils/dates';
+import {getDateFilters} from 'sentry/views/starfish/utils/dates';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
 import {DataRow} from './databaseTableView';
 
 const INTERVAL = 12;
-const HOST = 'http://localhost:8080';
 
 type EndpointDetailBodyProps = {
   isDataLoading: boolean;
@@ -44,7 +39,7 @@ type EndpointDetailBodyProps = {
   prevRow?: DataRow;
 };
 
-type TransactionListDataRow = {
+export type TransactionListDataRow = {
   count: number;
   frequency: number;
   group_id: string;
@@ -149,13 +144,6 @@ function QueryDetailBody({
   const location = useLocation();
   const pageFilter = usePageFilters();
   const {startTime, endTime} = getDateFilters(pageFilter);
-  const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(
-    pageFilter.selection.datetime
-  );
-  const DATE_FILTERS = `
-  ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
-  ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
-  `;
 
   const {isLoading: isP75GraphLoading, data: tpmTransactionGraphData} =
     useQueryTransactionByTPM(row);
@@ -165,56 +153,16 @@ function QueryDetailBody({
     sortHeader: TableColumnHeader | undefined;
   }>({direction: undefined, sortHeader: undefined});
 
-  const {isLoading, data: graphData} = useQuery({
-    queryKey: ['dbQueryDetailsGraph', row.group_id, pageFilter.selection.datetime],
-    queryFn: () =>
-      fetch(
-        `${HOST}/?query=${getPanelGraphQuery(
-          startTime,
-          endTime,
-          row,
-          INTERVAL
-        )}&format=sql`
-      ).then(res => res.json()),
-    retry: false,
-    initialData: [],
-  });
+  const {isLoading, data: graphData} = useQueryPanelGraph(row, INTERVAL);
 
-  const {isLoading: isTableLoading, data: tableData} = useQuery<TransactionListDataRow[]>(
-    {
-      queryKey: [
-        'dbQueryDetailsTable',
-        row.group_id,
-        pageFilter.selection.datetime,
-        sort.sortHeader?.key,
-        sort.direction,
-      ],
-      queryFn: () =>
-        fetch(
-          `${HOST}/?query=${getPanelTableQuery(
-            startTime,
-            endTime,
-            row,
-            sort.sortHeader?.key,
-            sort.direction
-          )}`
-        ).then(res => res.json()),
-      retry: true,
-      initialData: [],
-    }
+  const {isLoading: isTableLoading, data: tableData} = useQueryPanelTable(
+    row,
+    sort.sortHeader?.key,
+    sort.direction
   );
 
-  const {isLoading: isEventCountLoading, data: eventCountData} = useQuery<
-    Partial<TransactionListDataRow>[]
-  >({
-    queryKey: ['dbQueryDetailsEventCount', row.group_id, pageFilter.selection.datetime],
-    queryFn: () =>
-      fetch(`${HOST}/?query=${getPanelEventCount(DATE_FILTERS, row)}`).then(res =>
-        res.json()
-      ),
-    retry: true,
-    initialData: [],
-  });
+  const {isLoading: isEventCountLoading, data: eventCountData} =
+    useQueryPanelEventCount(row);
 
   const isDataLoading =
     isLoading ||
@@ -230,9 +178,9 @@ function QueryDetailBody({
     const eventData = eventCountMap[transaction];
     if (eventData?.uniqueEvents) {
       const frequency = data.count / eventData.uniqueEvents;
-      return {...data, frequency, ...eventData};
+      return {...data, frequency, ...eventData} as TransactionListDataRow;
     }
-    return data;
+    return data as TransactionListDataRow;
   });
 
   const minMax = calculateOutlierMinMax(mergedTableData);

--- a/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointDetails/index.tsx
@@ -22,9 +22,8 @@ import Chart from 'sentry/views/starfish/components/chart';
 import Detail from 'sentry/views/starfish/components/detailPanel';
 import EndpointTable from 'sentry/views/starfish/modules/APIModule/endpointTable';
 import DatabaseTableView from 'sentry/views/starfish/modules/databaseModule/databaseTableView';
-import {getMainTable} from 'sentry/views/starfish/modules/databaseModule/queries';
+import {useQueryMainTable} from 'sentry/views/starfish/modules/databaseModule/queries';
 import {HOST} from 'sentry/views/starfish/utils/constants';
-import {getDateFilters} from 'sentry/views/starfish/utils/dates';
 import {getModuleBreakdown} from 'sentry/views/starfish/views/webServiceView/queries';
 
 const EventsRequest = withApi(_EventsRequest);
@@ -154,23 +153,12 @@ function EndpointDetailBody({
     `transaction:${row.transaction}`,
     `http.method:${row.httpOp}`,
   ]);
-  const {startTime, endTime} = getDateFilters(pageFilter);
-  const transactionFilter =
-    row.transaction.length > 0 ? `transaction='${row.transaction}'` : null;
 
   const {
     isLoading: isTableDataLoading,
     data: tableData,
     isRefetching: isTableRefetching,
-  } = useQuery({
-    queryKey: ['endpoints', pageFilter.selection.datetime, row.transaction],
-    queryFn: () =>
-      fetch(
-        `${HOST}/?query=${getMainTable(startTime, endTime, transactionFilter)}&format=sql`
-      ).then(res => res.json()),
-    retry: false,
-    initialData: [],
-  });
+  } = useQueryMainTable(row.transaction);
   return (
     <div>
       <h2>{t('Endpoint Detail')}</h2>


### PR DESCRIPTION
In efforts to cleanup the module and make it easier to develop in as the module grows I quickly refactored the module to do the following.
1. Moves all the `useQuery` to query.ts - this was causing a bunch of bloat
2. Adds typings to all queries - This gives us some compilation errors, and type hinting.
I found these items added a decent amount to develop things, so decided to quickly refactor it.
