### PR TITLE
fix(starfish): sort direction not resetting in db module

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
@@ -142,10 +142,10 @@ export default function APIModuleView({
 
   function onSortClick(col: TableColumnHeader) {
     let direction: 'desc' | 'asc' | undefined = undefined;
-    if (sort.direction === 'desc') {
-      direction = 'asc';
-    } else if (!sort.direction) {
+    if (!sort.direction || col.key !== sort.sortHeader?.key) {
       direction = 'desc';
+    } else if (sort.direction === 'desc') {
+      direction = 'asc';
     }
     if (onSortChange) {
       setSort({direction, sortHeader: col});

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -251,10 +251,10 @@ function QueryDetailBody({
 
   const onSortClick = (col: TableColumnHeader) => {
     let direction: 'desc' | 'asc' | undefined = undefined;
-    if (sort.direction === 'desc') {
-      direction = 'asc';
-    } else if (!sort.direction) {
+    if (!sort.direction || col.key !== sort.sortHeader?.key) {
       direction = 'desc';
+    } else if (sort.direction === 'desc') {
+      direction = 'asc';
     }
     setSort({direction, sortHeader: col});
   };


### PR DESCRIPTION
Fixes an issue where something was already sorted in a db module table, and you try to sort by another column, it would not reset the sort direction. 