### PR TITLE
feat(starfish): small styling improvements db module

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
@@ -228,9 +228,9 @@ export default function APIModuleView({action, table, onChange}: Props) {
         </ChartsContainerItem>
       </ChartsContainer>
       <Selectors>
-        Operation:
         <CompactSelect
           value={action}
+          triggerProps={{prefix: t('Operation')}}
           options={parseOptions(operationData, 'query')}
           menuTitle="Operation"
           onChange={opt => onChange('action', opt.value)}
@@ -287,9 +287,9 @@ export default function APIModuleView({action, table, onChange}: Props) {
             </ChartsContainerItem>
           </ChartsContainer>
           <Selectors>
-            Table:
             <CompactSelect
               value={table}
+              triggerProps={{prefix: t('Table')}}
               options={parseOptions(tableData, 'p75')}
               menuTitle="Table"
               onChange={opt => onChange('table', opt.value)}

--- a/static/app/views/starfish/modules/databaseModule/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/index.tsx
@@ -181,16 +181,28 @@ function DatabaseModule() {
                 }
               }}
             />
-            Filter New Queries
-            <Switch isActive={filterNew} size="lg" toggle={toggleFilterNew} />
-            Filter Old Queries
-            <Switch isActive={filterOld} size="lg" toggle={toggleFilterOld} />
-            <TransactionNameSearchBar
-              organization={organization}
-              eventView={eventView}
-              onSearch={(query: string) => handleSearch(query)}
-              query={transaction}
-            />
+            <SearchFilterContainer>
+              <LabelledSwitch
+                label="Filter New Queries"
+                isActive={filterNew}
+                size="lg"
+                toggle={toggleFilterNew}
+              />
+              <LabelledSwitch
+                label="Filter Old Queries"
+                isActive={filterOld}
+                size="lg"
+                toggle={toggleFilterOld}
+              />
+            </SearchFilterContainer>
+            <SearchFilterContainer>
+              <TransactionNameSearchBar
+                organization={organization}
+                eventView={eventView}
+                onSearch={(query: string) => handleSearch(query)}
+                query={transaction}
+              />
+            </SearchFilterContainer>
             <DatabaseTableView
               location={location}
               data={tableData}
@@ -224,3 +236,23 @@ const FilterOptionsContainer = styled('div')`
   gap: ${space(1)};
   margin-bottom: ${space(2)};
 `;
+
+const SearchFilterContainer = styled('div')`
+  margin-bottom: ${space(2)};
+`;
+
+function LabelledSwitch(props) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        gap: space(1),
+        paddingRight: space(2),
+        alignItems: 'center',
+      }}
+    >
+      <span>{props.label}</span>
+      <Switch {...props} />
+    </span>
+  );
+}

--- a/static/app/views/starfish/modules/databaseModule/panel.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel.tsx
@@ -314,15 +314,20 @@ function QueryDetailBody({
 
   return (
     <div>
-      <Paginator>
-        <SimplePagination
-          disableLeft={!prevRow}
-          disableRight={!nextRow}
-          onLeftClick={() => onRowChange(prevRow)}
-          onRightClick={() => onRowChange(nextRow)}
-        />
-      </Paginator>
-      <h2>{t('Query Detail')}</h2>
+      <FlexRowContainer>
+        <FlexRowItem>
+          <h2>{t('Query Detail')}</h2>
+        </FlexRowItem>
+        <FlexRowItem>
+          <SimplePagination
+            disableLeft={!prevRow}
+            disableRight={!nextRow}
+            onLeftClick={() => onRowChange(prevRow)}
+            onRightClick={() => onRowChange(nextRow)}
+          />
+        </FlexRowItem>
+      </FlexRowContainer>
+
       <FlexRowContainer>
         <FlexRowItem>
           <SubHeader>
@@ -343,6 +348,7 @@ function QueryDetailBody({
           <SubSubHeader>{row.total_time.toFixed(2)}ms</SubSubHeader>
         </FlexRowItem>
       </FlexRowContainer>
+
       <SubHeader>{t('Query Description')}</SubHeader>
       <FormattedCode>{formatRow(row.formatted_desc, row)}</FormattedCode>
       <FlexRowContainer>
@@ -548,6 +554,7 @@ const FlexRowContainer = styled('div')`
   & > div:last-child {
     padding-right: ${space(1)};
   }
+  padding-bottom: ${space(2)};
 `;
 
 const FlexRowItem = styled('div')`
@@ -579,10 +586,4 @@ const Keyword = styled('b')`
 
 const Bracket = styled('b')`
   color: ${p => p.theme.pink400};
-`;
-
-const Paginator = styled('div')`
-  width: 33%;
-  position: absolute;
-  right: 0;
 `;


### PR DESCRIPTION
Some small styling improvements to make the db module look a bit better, these aren't final changes.

1. The Table and Operation label is now part of the compact select
<img width="158" alt="image" src="https://user-images.githubusercontent.com/44422760/235792611-74917417-48c6-4b2c-a8f1-4a2831c73d27.png">

2. The left right arrows on the db query details is no longer placed right in the corner, and some spacing has been added between the rows
<img width="712" alt="image" src="https://user-images.githubusercontent.com/44422760/235792826-2ef19d1e-ed40-46f9-a984-64a579b2668d.png">

3. Spacing has been added between the filtering elements
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/44422760/235792887-d49fe7c7-3a0a-40e2-89fc-2556c2431e2b.png">
