### PR TITLE
feat(hybrid-cloud): Add organization_service.reset_idp_flags

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -330,5 +330,10 @@ class OrganizationService(RpcService):
     def remove_user(self, *, organization_id: int, user_id: int) -> RpcOrganizationMember:
         pass
 
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def reset_idp_flags(self, *, organization_id: int) -> None:
+        pass
+
 
 organization_service = cast(OrganizationService, OrganizationService.create_delegation())

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Iterable, List, MutableMapping, Optional, Set, cast
 
-from django.db import transaction
+from django.db import models, transaction
 
 from sentry import roles
 from sentry.db.postgres.roles import in_test_psql_role_override
@@ -394,3 +394,13 @@ class DatabaseBackedOrganizationService(OrganizationService):
         if region_outbox:
             region_outbox.drain_shard(max_updates_to_drain=10)
         return self.serialize_member(org_member)
+
+    def reset_idp_flags(self, *, organization_id: int) -> None:
+        OrganizationMember.objects.filter(
+            organization_id=organization_id,
+            flags=models.F("flags").bitor(OrganizationMember.flags["idp:provisioned"]),
+        ).update(
+            flags=models.F("flags")
+            .bitand(~OrganizationMember.flags["idp:provisioned"])
+            .bitand(~OrganizationMember.flags["idp:role-restricted"])
+        )


### PR DESCRIPTION
Since the `AuthProvider` model only resides in the control silo, I'm replacing the reference to the `OrganizationMember` model with the RPC call `organization_service.reset_idp_flags()`.

Tests for the IdP flag reset resides in https://github.com/getsentry/sentry/blob/master/tests/sentry/web/frontend/test_organization_auth_settings.py