### PR TITLE
feat(replays): Concat type+method in the Replay>Network table

### DIFF
--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -65,6 +65,12 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
     const startMs = span.startTimestamp * 1000;
     const endMs = span.endTimestamp * 1000;
     const statusCode = span.data.statusCode;
+    // `data.responseBodySize` is from SDK version 7.44-7.45
+    const size = span.data.size ?? span.data.response?.size ?? span.data.responseBodySize;
+    const typeLabel =
+      ['resource.fetch', 'resource.xhr'].includes(span.op) && span.data.method
+        ? `${operationName(span.op)} [${span.data.method}]`
+        : operationName(span.op);
 
     const spanTime = useMemo(
       () => relativeTimeInMs(span.startTimestamp * 1000, startTimestampMs),
@@ -110,9 +116,6 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       style,
     } as CellProps;
 
-    // `data.responseBodySize` is from SDK version 7.44-7.45
-    const size = span.data.size ?? span.data.response?.size ?? span.data.responseBodySize;
-
     const renderFns = [
       () => (
         <Cell {...columnProps}>
@@ -133,8 +136,8 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       ),
       () => (
         <Cell {...columnProps}>
-          <Tooltip title={operationName(span.op)} isHoverable showOnlyOnOverflow>
-            <Text>{operationName(span.op)}</Text>
+          <Tooltip title={typeLabel} isHoverable showOnlyOnOverflow>
+            <Text>{typeLabel}</Text>
           </Tooltip>
         </Cell>
       ),


### PR DESCRIPTION
In the spirit of https://github.com/getsentry/sentry/pull/46445

Instead of trying a new column, what we if just added the `method` into the existing column?

![SCR-20230502-nzlg](https://user-images.githubusercontent.com/187460/235802489-79a8d8ff-3dbd-4746-9abf-1fd53321cdd5.png)

Relates to https://github.com/getsentry/team-replay/issues/35
