### PR TITLE
fix(replays): Fix padding around the TimestampButton in Replay>Network table

### DIFF
--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -152,7 +152,7 @@ const NetworkTableCell = forwardRef<HTMLDivElement, Props>(
       ),
       () => (
         <Cell {...columnProps} numeric>
-          <TimestampButton
+          <StyledTimestampButton
             format="mm:ss.SSS"
             onClick={(event: MouseEvent) => {
               event.stopPropagation();
@@ -217,6 +217,10 @@ const Text = styled('div')`
   white-space: nowrap;
   overflow: hidden;
   padding: ${space(0.75)} ${space(1.5)};
+`;
+
+const StyledTimestampButton = styled(TimestampButton)`
+  padding-inline: ${space(1.5)};
 `;
 
 export default NetworkTableCell;


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/187460/235803554-914e2838-846f-4139-bb10-739317ff0bd6.png) | ![after](https://user-images.githubusercontent.com/187460/235803555-118ec77e-b800-49d4-a6ea-744422ad20c5.png) |
