### PR TITLE
ref(crons): Hide monitor environments that are being deleted

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -8,7 +8,7 @@ from typing_extensions import TypedDict
 from sentry.api.serializers import ProjectSerializerResponse, Serializer, register, serialize
 from sentry.models import Project
 
-from .models import Monitor, MonitorCheckIn, MonitorEnvironment
+from .models import Monitor, MonitorCheckIn, MonitorEnvironment, MonitorStatus
 
 
 @register(MonitorEnvironment)
@@ -54,6 +54,9 @@ class MonitorSerializer(Serializer):
                 )
                 .select_related("environment")
                 .order_by("-last_checkin")
+                .exclude(
+                    status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS]
+                )
             ):
                 # individually serialize as related objects are prefetched
                 monitor_environments[monitor_environment.monitor_id].append(

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -130,6 +130,26 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         response = self.get_success_response(self.organization.slug, query="test-slug")
         self.check_valid_response(response, [monitor])
 
+    def test_ignore_pending_deletion_environments(self):
+        monitor = self._create_monitor()
+        self._create_monitor_environment(
+            monitor,
+            status=MonitorStatus.OK,
+            last_checkin=datetime.now() - timedelta(minutes=1),
+        )
+        self._create_monitor_environment(
+            monitor,
+            status=MonitorStatus.PENDING_DELETION,
+            name="deleted_environment",
+            last_checkin=datetime.now() - timedelta(minutes=1),
+        )
+
+        response = self.get_success_response(self.organization.slug)
+        self.check_valid_response(response, [monitor])
+        # Confirm we only see the one 'ok' environment
+        assert len(response.data[0]["environments"]) == 1
+        assert response.data[0]["environments"][0]["status"] == "ok"
+
 
 @region_silo_test(stable=True)
 class CreateOrganizationMonitorTest(MonitorTestCase):


### PR DESCRIPTION
PENDING_DELETION and DELETION_IN_PROGRESS shouldn't be shown on the frontend