### PR TITLE
fix(integrations): Add org info to scope for all jira webhook events

### DIFF
--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -14,6 +14,7 @@ from sentry_sdk import Scope
 
 from sentry.api.base import Endpoint
 from sentry.integrations.utils import AtlassianConnectValidationError
+from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,17 @@ class JiraWebhookBase(Endpoint, abc.ABC):
     def convert_args(self, request: Request, *args, **kwargs):
         token = self.get_token(request)
         kwargs["token"] = token
+
+        if self.lookup_integration_from_token:
+            integration = get_integration_from_jwt(
+                token=token,
+                path=request.path,
+                provider=self.provider,
+                query_params=request.GET,
+                method=request.method,
+            )
+            kwargs["integration"] = integration
+
         return super().convert_args(request, *args, **kwargs)
 
     def handle_exception(

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -15,6 +15,7 @@ from sentry_sdk import Scope
 from sentry.api.base import Endpoint
 from sentry.integrations.utils import AtlassianConnectValidationError
 from sentry.integrations.utils.atlassian_connect import get_integration_from_jwt
+from sentry.integrations.utils.scope import bind_org_context_from_integration
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ class JiraWebhookBase(Endpoint, abc.ABC):
                 method=request.method,
             )
             kwargs["integration"] = integration
+            bind_org_context_from_integration(integration.id)
 
         return super().convert_args(request, *args, **kwargs)
 

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -31,6 +31,7 @@ class JiraWebhookBase(Endpoint, abc.ABC):
     authentication_classes = ()
     permission_classes = ()
     provider = "jira"
+    lookup_integration_from_token = True
 
     @csrf_exempt
     def dispatch(self, request: Request, *args, **kwargs) -> Response:

--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -36,6 +36,11 @@ class JiraWebhookBase(Endpoint, abc.ABC):
     def dispatch(self, request: Request, *args, **kwargs) -> Response:
         return super().dispatch(request, *args, **kwargs)
 
+    def convert_args(self, request: Request, *args, **kwargs):
+        token = self.get_token(request)
+        kwargs["token"] = token
+        return super().convert_args(request, *args, **kwargs)
+
     def handle_exception(
         self,
         request: Request,

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -19,7 +19,7 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
     """
 
     def post(self, request: Request, *args, **kwargs) -> Response:
-        token = self.get_token(request)
+        token = kwargs["token"]
 
         state = request.data
         if not state:

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -18,6 +18,10 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
     Webhook hit by Jira whenever someone installs the Sentry integration in their Jira instance.
     """
 
+    # Prevent the base `dispatch` method from trying to look up the integration based on the auth
+    # headers of the request, given that it doesn't exist yet at that point
+    lookup_integration_from_token = False
+
     def post(self, request: Request, *args, **kwargs) -> Response:
         token = kwargs["token"]
 

--- a/src/sentry/integrations/jira/webhooks/issue_updated.py
+++ b/src/sentry/integrations/jira/webhooks/issue_updated.py
@@ -9,7 +9,6 @@ from rest_framework.response import Response
 from sentry_sdk import Scope
 
 from sentry.api.base import control_silo_endpoint
-from sentry.integrations.utils import get_integration_from_jwt
 from sentry.shared_integrations.exceptions import ApiError
 
 from ..utils import handle_assignee_change, handle_jira_api_error, handle_status_change
@@ -39,14 +38,7 @@ class JiraIssueUpdatedWebhook(JiraWebhookBase):
         return super().handle_exception(request, exc, handler_context, scope)
 
     def post(self, request: Request, *args, **kwargs) -> Response:
-        token = self.get_token(request)
-        integration = get_integration_from_jwt(
-            token=token,
-            path=request.path,
-            provider=self.provider,
-            query_params=request.GET,
-            method="POST",
-        )
+        integration = kwargs["integration"]
 
         data = request.data
         if not data.get("changelog"):

--- a/src/sentry/integrations/jira/webhooks/uninstalled.py
+++ b/src/sentry/integrations/jira/webhooks/uninstalled.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint
 from sentry.constants import ObjectStatus
-from sentry.integrations.utils import get_integration_from_jwt
 
 from .base import JiraWebhookBase
 
@@ -15,14 +14,8 @@ class JiraSentryUninstalledWebhook(JiraWebhookBase):
     """
 
     def post(self, request: Request, *args, **kwargs) -> Response:
-        token = self.get_token(request)
-        integration = get_integration_from_jwt(
-            token=token,
-            path=request.path,
-            provider=self.provider,
-            query_params=request.GET,
-            method="POST",
-        )
+        integration = kwargs["integration"]
+
         integration.update(status=ObjectStatus.DISABLED)
 
         return self.respond()

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -8,7 +8,7 @@ from sentry_sdk import configure_scope
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.utils.sdk import bind_organization_context
+from sentry.utils.sdk import bind_ambiguous_org_context, bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -67,5 +67,4 @@ def bind_org_context_from_integration(integration_id: int) -> None:
     elif len(orgs) == 1:
         bind_organization_context(orgs[0])
     else:
-        # skip this case for now
-        pass
+        bind_ambiguous_org_context(orgs, f"integration (id={integration_id})")

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 import logging
+from typing import cast
 
 from sentry_sdk import configure_scope
+
+from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.integration import integration_service
 
 logger = logging.getLogger(__name__)
 
@@ -20,3 +26,23 @@ def clear_tags_and_context() -> None:
 
         if reset_values:
             logger.info("We've reset the context and tags.")
+
+
+def get_orgs_from_integration(integration_id: int) -> list[Organization]:
+    """
+    Given the id of an `Integration`, return a list of associated `Organization` objects.
+
+    Note: An `Integration` is an instance of given provider's integration, tied to a single entity
+    on the provider's end (for example, an instance of the GitHub integration tied to a particular
+    GitHub org, or an instance of the Slack integration tied to a particular Slack workspace), which
+    can be shared by multiple orgs.
+    """
+
+    _, org_integrations = integration_service.get_organization_contexts(
+        integration_id=integration_id
+    )
+    orgs = Organization.objects.get_many_from_cache(
+        [org_integration.organization_id for org_integration in org_integrations]
+    )
+
+    return cast("list[Organization]", orgs)

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -7,6 +7,8 @@ from sentry_sdk import configure_scope
 
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.utils.sdk import bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -46,3 +48,24 @@ def get_orgs_from_integration(integration_id: int) -> list[Organization]:
     )
 
     return cast("list[Organization]", orgs)
+
+
+def bind_org_context_from_integration(integration_id: int) -> None:
+    """
+    Given the id of an Integration, get the associated org(s) and bind that data to the scope.
+
+    Note: An `Integration` is an instance of given provider's integration, tied to a single entity
+    on the provider's end (for example, an instance of the GitHub integration tied to a particular
+    GitHub org, or an instance of the Slack integration tied to a particular Slack workspace), which
+    can be shared by multiple orgs.
+    """
+
+    orgs = get_orgs_from_integration(integration_id)
+
+    if len(orgs) == 0:
+        raise IntegrationError(f"No orgs are associated with integration id={integration_id}")
+    elif len(orgs) == 1:
+        bind_organization_context(orgs[0])
+    else:
+        # skip this case for now
+        pass

--- a/src/sentry/testutils/helpers/context_manager.py
+++ b/src/sentry/testutils/helpers/context_manager.py
@@ -1,4 +1,16 @@
+from contextlib import contextmanager
 from typing import Any, Callable
+from unittest.mock import patch
+
+from sentry_sdk import Scope
+
+
+@contextmanager
+def patch_configure_scope_with_scope(mocked_function_name: str, scope: Scope):
+    with patch(mocked_function_name) as mock_configure_scope:
+        mock_configure_scope.return_value.__enter__.return_value = scope
+
+        yield mock_configure_scope
 
 
 # TODO: This is kind of gross, but no other way seemed to work

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -552,7 +552,7 @@ def bind_organization_context(organization):
     helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
 
     # XXX(dcramer): this is duplicated in organizationContext.jsx on the frontend
-    with sentry_sdk.configure_scope() as scope, sentry_sdk.start_span(
+    with configure_scope() as scope, sentry_sdk.start_span(
         op="other", description="bind_organization_context"
     ):
         # This can be used to find errors that may have been mistagged

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -38,7 +38,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_simple_assign(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -58,7 +58,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
         )
 
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -77,7 +77,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
         )
 
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -90,7 +90,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_assign_missing_email(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
@@ -101,7 +101,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_simple_deassign(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_no_assignee_payload.json")
@@ -113,7 +113,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch("sentry.integrations.jira.utils.api.sync_group_assignee_inbound")
     def test_simple_deassign_assignee_missing(self, mock_sync_group_assignee_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_missing_payload.json")
@@ -125,7 +125,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
     @patch.object(IssueSyncMixin, "sync_status_inbound")
     def test_simple_status_sync_inbound(self, mock_sync_status_inbound):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ) as mock_get_integration_from_jwt:
             data = StubService.get_stub_data("jira", "edit_issue_status_payload.json")
@@ -158,7 +158,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
 
     def test_missing_changelog(self):
         with patch(
-            "sentry.integrations.jira.webhooks.issue_updated.get_integration_from_jwt",
+            "sentry.integrations.jira.webhooks.base.get_integration_from_jwt",
             return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "changelog_missing.json")

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -51,6 +51,22 @@ class BindOrgContextFromIntegrationTest(TestCase):
 
         mock_bind_org_context.assert_called_with(org)
 
+        @patch("sentry.integrations.utils.scope.bind_ambiguous_org_context")
+        def test_binds_org_context_with_multiple_orgs(
+            self, mock_bind_ambiguous_org_context: MagicMock
+        ):
+            maisey_org = self.create_organization(slug="themaiseymaiseydog")
+            charlie_org = self.create_organization(slug="charliebear")
+            integration = Integration.objects.create(name="squirrelChasers")
+            integration.add_organization(maisey_org)
+            integration.add_organization(charlie_org)
+
+            bind_org_context_from_integration(integration.id)
+
+            mock_bind_ambiguous_org_context.assert_called_with(
+                [maisey_org, charlie_org], f"integration (id={integration.id})"
+            )
+
     def test_raises_error_if_no_orgs_found(self):
         integration = Integration.objects.create(name="squirrelChasers")
 

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -1,5 +1,13 @@
-from sentry.integrations.utils.scope import get_orgs_from_integration
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sentry.integrations.utils.scope import (
+    bind_org_context_from_integration,
+    get_orgs_from_integration,
+)
 from sentry.models.integrations.integration import Integration
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import TestCase
 
 
@@ -30,3 +38,23 @@ class GetOrgsFromIntegrationTest(TestCase):
         found_orgs = get_orgs_from_integration(integration.id)
 
         assert found_orgs == []
+
+
+class BindOrgContextFromIntegrationTest(TestCase):
+    @patch("sentry.integrations.utils.scope.bind_organization_context")
+    def test_binds_org_context_with_single_org(self, mock_bind_org_context: MagicMock):
+        org = self.create_organization(slug="dogsaregreat")
+        integration = Integration.objects.create(name="squirrelChasers")
+        integration.add_organization(org)
+
+        bind_org_context_from_integration(integration.id)
+
+        mock_bind_org_context.assert_called_with(org)
+
+    def test_raises_error_if_no_orgs_found(self):
+        integration = Integration.objects.create(name="squirrelChasers")
+
+        with pytest.raises(
+            IntegrationError, match=f"No orgs are associated with integration id={integration.id}"
+        ):
+            bind_org_context_from_integration(integration.id)

--- a/tests/sentry/integrations/utils/test_scope.py
+++ b/tests/sentry/integrations/utils/test_scope.py
@@ -1,0 +1,32 @@
+from sentry.integrations.utils.scope import get_orgs_from_integration
+from sentry.models.integrations.integration import Integration
+from sentry.testutils import TestCase
+
+
+class GetOrgsFromIntegrationTest(TestCase):
+    def test_finds_single_org(self):
+        org = self.create_organization(slug="dogsaregreat")
+        integration = Integration.objects.create(name="squirrelChasers")
+        integration.add_organization(org)
+
+        found_orgs = get_orgs_from_integration(integration.id)
+
+        assert found_orgs == [org]
+
+    def test_finds_multiple_orgs(self):
+        maisey_org = self.create_organization(slug="themaiseymaiseydog")
+        charlie_org = self.create_organization(slug="charliebear")
+        integration = Integration.objects.create(name="squirrelChasers")
+        integration.add_organization(maisey_org)
+        integration.add_organization(charlie_org)
+
+        found_orgs = get_orgs_from_integration(integration.id)
+
+        assert found_orgs == [maisey_org, charlie_org]
+
+    def test_finds_no_orgs_without_erroring(self):
+        integration = Integration.objects.create(name="squirrelChasers")
+
+        found_orgs = get_orgs_from_integration(integration.id)
+
+        assert found_orgs == []

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 from sentry_sdk import Scope
 
 from sentry.testutils import TestCase
-from sentry.testutils.helpers import set_mock_context_manager_return_value
+from sentry.testutils.helpers import patch_configure_scope_with_scope
 from sentry.utils.sdk import (
     capture_exception_with_scope_check,
     check_current_scope_transaction,
@@ -50,8 +50,7 @@ class CheckTagTest(TestCase):
         mock_scope = Scope()
         mock_scope._tags = {}
 
-        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
-            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
             check_tag("org.slug", "squirrel_chasers")
 
         assert "possible_mistag" not in mock_scope._tags
@@ -63,8 +62,7 @@ class CheckTagTest(TestCase):
         mock_scope = Scope()
         mock_scope._tags = {"org.slug": "squirrel_chasers"}
 
-        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
-            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
             check_tag("org.slug", "squirrel_chasers")
 
         assert "possible_mistag" not in mock_scope._tags
@@ -76,8 +74,7 @@ class CheckTagTest(TestCase):
         mock_scope = Scope()
         mock_scope._tags = {"org.slug": "good_dogs"}
 
-        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
-            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
+        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
             check_tag("org.slug", "squirrel_chasers")
 
         extra = {
@@ -98,9 +95,7 @@ class CheckScopeTransactionTest(TestCase):
         mock_scope = Scope()
         mock_scope._transaction = "/dogs/{name}/"
 
-        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
-            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
-
+        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
             mismatch = check_current_scope_transaction(Request(HttpRequest()))
             assert mismatch is None
 
@@ -109,9 +104,7 @@ class CheckScopeTransactionTest(TestCase):
         mock_scope = Scope()
         mock_scope._transaction = "/tricks/{trick_name}/"
 
-        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
-            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
-
+        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
             mismatch = check_current_scope_transaction(Request(HttpRequest()))
             assert mismatch == {
                 "scope_transaction": "/tricks/{trick_name}/",
@@ -124,9 +117,7 @@ class CheckScopeTransactionTest(TestCase):
         mock_scope._transaction = "/tricks/{trick_name}/"
         mock_scope._transaction_info["source"] = "custom"
 
-        with patch("sentry.utils.sdk.configure_scope") as mock_configure_scope:
-            set_mock_context_manager_return_value(mock_configure_scope, as_value=mock_scope)
-
+        with patch_configure_scope_with_scope("sentry.utils.sdk.configure_scope", mock_scope):
             mismatch = check_current_scope_transaction(Request(HttpRequest()))
             # custom transaction names shouldn't be flagged even if they don't match
             assert mismatch is None


### PR DESCRIPTION
_Draft until a bunch of other PRs have gone through_

----------

This builds upon the work done in https://github.com/getsentry/sentry/pull/48365 and https://github.com/getsentry/sentry/pull/48316 (which added the helpers `bind_ambiguous_org_context` and `bind_org_context_from_integration`, respectively) to enable the adding of org context information to all events associated with Jira webhook requests. Key changes:

- Modify the base webhook class, `JiraWebhookBase`, to add a `convert_args` method which parses the incoming token, uses it to pull the associated `Integration` from the database, and adds both to the request's kwargs. Once it has the integration, it also calls `bind_org_context_from_integration` before returning. In the base `dispatch` method, `convert_args` is [called immediately before](https://github.com/getsentry/sentry/blob/5ba334b67c6304319c048689d58f028809f4f826/src/sentry/api/base.py#L319) the request is passed to the endpoint's method-specific handler.
- Add a class attribute, `lookup_integration_from_token`, to the same class, which controls whether or not to use the parsed token to get the `Integration` and bind org context. It is set to `True` in the base class, so that by default the integration will be retrieved, but subclasses can set it to `False` to prevent that behavior. In that case, `convert_args` will parse the token and add it to kwargs, but won't do anything else. (This exists primarily for the `installed` webhook, which can't have the integration looked up before its handler runs, because the handler is the one which creates the integration in the first place.)
- In the `installed` webhook, pull the token from kwargs rather than parsing it directly, and, for reasons previously discussed, set `lookup_integration_from_token` to `False`.
- In the `issue-updated` and `unintalled` webhooks, pull the integration from kwargs rather than parsing the token and using it to find the integration.
- Update the `issue-updated` webhook tests so that the correct `get_integration_from_jwt` method is mocked.
- Add tests to show both the default and `lookup_integration_from_token=False` behavior.