### PR TITLE
feat(dynamic-sampling): Return whether an org has dynamic sampling

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -436,6 +436,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     onboardingTasks: OnboardingTasksSerializerResponse
     codecovAccess: bool
     aiSuggestedSolution: bool
+    isDynamicallySampled: bool
 
 
 class DetailedOrganizationSerializer(OrganizationSerializer):
@@ -555,6 +556,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             team__organization=obj
         ).count()
         context["onboardingTasks"] = serialize(tasks_to_serialize, user)
+        context["isDynamicallySampled"] = quotas.get_blended_sample_rate(None, obj.id) is not None
+
         return context
 
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -556,7 +556,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             team__organization=obj
         ).count()
         context["onboardingTasks"] = serialize(tasks_to_serialize, user)
-        context["isDynamicallySampled"] = quotas.get_blended_sample_rate(None, obj.id) is not None
+        sample_rate = quotas.get_blended_sample_rate(None, obj.id)
+        context["isDynamicallySampled"] = sample_rate is not None and sample_rate < 1.0
 
         return context
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -244,6 +244,29 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         response = self.get_success_response(self.organization.slug)
         assert response.data["hasAuthProvider"] is True
 
+    def test_is_dynamically_sampled(self):
+        self.user = self.create_user("super@example.org", is_superuser=True)
+        org = self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+
+        with patch(
+            "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate", return_value=0.5
+        ):
+            response = self.get_success_response(org.slug)
+            assert response.data["isDynamicallySampled"]
+
+        with patch(
+            "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate", return_value=1.0
+        ):
+            response = self.get_success_response(org.slug)
+            assert not response.data["isDynamicallySampled"]
+
+        with patch(
+            "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate", return_value=None
+        ):
+            response = self.get_success_response(org.slug)
+            assert not response.data["isDynamicallySampled"]
+
 
 @region_silo_test
 class OrganizationUpdateTest(OrganizationDetailsTestBase):


### PR DESCRIPTION
This PR adds a new flag for the organization details endpoint which is true when an organization is using dynamic sampling with a sample rate < 100%.