### PR TITLE
ref(project-deletion): Update audit log logic

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -828,7 +828,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 self.create_audit_entry(
                     **common_audit_data,
                     event=audit_log.get_event_id("PROJECT_REMOVE"),
-                    data={project.get_audit_log_data()},
+                    data={**project.get_audit_log_data()},
                 )
 
             project.rename_on_pending_deletion()

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -70,6 +70,14 @@ default_manager.add(
         event_id=32,
         name="PROJECT_REMOVE",
         api_name="project.remove",
+        template="removed project {slug}",
+    )
+)
+default_manager.add(
+    AuditLogEvent(
+        event_id=33,
+        name="PROJECT_REMOVE_WITH_ORIGIN",
+        api_name="project.remove-with-origin",
         template="removed project {slug} in {origin}",
     )
 )

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -66,7 +66,9 @@ def create_audit_entry_from_user(
     if entry.event == audit_log.get_event_id("ORG_REMOVE"):
         _create_org_delete_log(entry)
 
-    elif entry.event == audit_log.get_event_id("PROJECT_REMOVE"):
+    elif entry.event == audit_log.get_event_id(
+        "PROJECT_REMOVE"
+    ) or entry.event == audit_log.get_event_id("PROJECT_REMOVE_WITH_ORIGIN"):
         _create_project_delete_log(entry)
 
     elif entry.event == audit_log.get_event_id("TEAM_REMOVE"):

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -25,6 +25,7 @@ class AuditLogEventRegisterTest(TestCase):
             "project.create",
             "project.edit",
             "project.remove",
+            "project.remove-with-origin",
             "project.request-transfer",
             "project.accept-transfer",
             "project.enable",

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -155,10 +155,34 @@ class CreateAuditEntryTest(TestCase):
             event=audit_log.get_event_id("PROJECT_REMOVE"),
             data=self.project.get_audit_log_data(),
         )
+        audit_log_event = audit_log.get(entry.event)
 
         assert entry.actor == self.user
         assert entry.target_object == self.project.id
         assert entry.event == audit_log.get_event_id("PROJECT_REMOVE")
+        assert audit_log_event.render(entry) == "removed project" + " " + self.project.slug
+
+        deleted_project = DeletedProject.objects.get(slug=self.project.slug)
+        self.assert_valid_deleted_log(deleted_project, self.project)
+        assert deleted_project.platform == self.project.platform
+
+    def test_audit_entry_project_delete_with_origin_log(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=audit_log.get_event_id("PROJECT_REMOVE_WITH_ORIGIN"),
+            data={**self.project.get_audit_log_data(), "origin": "settings"},
+        )
+        audit_log_event = audit_log.get(entry.event)
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == audit_log.get_event_id("PROJECT_REMOVE_WITH_ORIGIN")
+        assert (
+            audit_log_event.render(entry)
+            == "removed project" + " " + self.project.slug + " in settings"
+        )
 
         deleted_project = DeletedProject.objects.get(slug=self.project.slug)
         self.assert_valid_deleted_log(deleted_project, self.project)


### PR DESCRIPTION
Since it is not very straightforward to implement the suggestion that was given in the PR https://github.com/getsentry/sentry/pull/48419/files#r1183484096, a not ideal but simple solution was to create a register for the case when an origin is provided, otherwise, I would have to mess around the [template format](https://github.com/getsentry/sentry/blob/a1c9f0beb3b1f358cf0dff26ec3213cbf0d2d953/src/sentry/audit_log/manager.py#L76) and I didn't want to get that far with this implementation.

