### PR TITLE
feat(replay): Show seconds in tooltip for timestamps

### DIFF
--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -23,7 +23,7 @@ function TimestampButton({
   timestampMs,
 }: Props) {
   return (
-    <Tooltip title={<DateTime date={timestampMs} />} skipWrapper>
+    <Tooltip title={<DateTime seconds date={timestampMs} />} skipWrapper>
       <StyledButton
         as={onClick ? 'button' : 'span'}
         onClick={onClick}


### PR DESCRIPTION
This makes it a lot easier for us to debug replays:

<img width="160" alt="image" src="https://user-images.githubusercontent.com/79684/235924511-c955aa7e-4779-4420-b91e-9ea4ca12fe77.png">


Closes https://github.com/getsentry/sentry/issues/37971