### PR TITLE
feat(consecutive-http): Add tag to separate frontend events

### DIFF
--- a/src/sentry/utils/event.py
+++ b/src/sentry/utils/event.py
@@ -11,3 +11,23 @@ def has_event_minified_stack_trace(event):
                 return True
 
     return False
+
+
+def is_event_from_browser_javascript_sdk(event):
+    sdk_name = get_path(event, "sdk", "name")
+    if sdk_name is None:
+        return False
+
+    return sdk_name.lower() in [
+        "sentry.javascript.browser",
+        "sentry.javascript.react",
+        "sentry.javascript.gatsby",
+        "sentry.javascript.ember",
+        "sentry.javascript.vue",
+        "sentry.javascript.angular",
+        "sentry.javascript.angular-ivy",
+        "sentry.javascript.nextjs",
+        "sentry.javascript.electron",
+        "sentry.javascript.remix",
+        "sentry.javascript.svelte",
+    ]

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -400,7 +400,7 @@ def report_metrics_for_detectors(
             detected_tags["browser_name"] = allowed_browser_name
 
         if detector.type in [DetectorType.CONSECUTIVE_HTTP_OP]:
-            detected_tags["frontend"] = is_event_from_browser_javascript_sdk(event)
+            detected_tags["is_frontend"] = is_event_from_browser_javascript_sdk(event)
 
         first_problem = detected_problems[detected_problem_keys[0]]
         if first_problem.fingerprint:

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -12,6 +12,7 @@ from sentry.eventstore.models import Event
 from sentry.models import Organization, Project, ProjectOption
 from sentry.projectoptions.defaults import DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
 from sentry.utils import metrics
+from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.safe import get_path
 
@@ -397,6 +398,9 @@ def report_metrics_for_detectors(
 
         if detector.type in [DetectorType.UNCOMPRESSED_ASSETS]:
             detected_tags["browser_name"] = allowed_browser_name
+
+        if detector.type in [DetectorType.CONSECUTIVE_HTTP_OP]:
+            detected_tags["frontend"] = is_event_from_browser_javascript_sdk(event)
 
         first_problem = detected_problems[detected_problem_keys[0]]
         if first_problem.fingerprint:


### PR DESCRIPTION
Adds a tag to distinguish between frontend/backend detection for consecutive http issues