### PR TITLE
ref(js): Get module and in_app from symbolicator

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -52,6 +52,10 @@ def _merge_frame(new_frame, symbolicated):
     if data_sourcemap := get_path(symbolicated, "data", "sourcemap"):
         frame_meta = new_frame.setdefault("data", {})
         frame_meta["sourcemap"] = data_sourcemap
+    if symbolicated.get("module"):
+        new_frame["module"] = symbolicated["module"]
+    if symbolicated.get("in_app"):
+        new_frame["in_app"] = symbolicated["in_app"]
     # if symbolicated.get("status"):
     # NOTE: We don't need this currently, and it's not clear whether we'll use it at all.
     # frame_meta["symbolicator_status"] = symbolicated["status"]

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -2164,6 +2164,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 "function",
                 "context_line",
                 "module",
+                "in_app",
             }
 
             def filtered_frame(frame: dict) -> dict:


### PR DESCRIPTION
Symbolicator should now set the `module` and `in_app` fields on js frames correctly. Therefore we read these fields from Symbolicator's reponse and add `in_app` to our A/B tests as well.