### PR TITLE
Remove Replay-related Team and Component labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -162,12 +162,6 @@
 - name: 'Component: Releases'
   color: '584774'
   description: ''
-- name: 'Component: Replay Details'
-  color: '584774'
-  description: Session Replays → Details
-- name: 'Component: Replay Index'
-  color: '584774'
-  description: Session Replays → Index page
 - name: 'Component: Rules'
   color: '584774'
   description: ''
@@ -313,9 +307,6 @@
 - name: 'Team: Performance'
   color: '8D5494'
   description: 'team-performance'
-- name: 'Team: Replay'
-  color: '8D5494'
-  description: team-replay
 - name: 'Team: Revenue'
   color: '8D5494'
   description: ''


### PR DESCRIPTION
We're using "Product Area: Replays" now.

See https://github.com/getsentry/team-ospo/issues/126.