### PR TITLE
chore(hybrid-cloud): RpcOrganizationMappingUpdate.from_orm

### DIFF
--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -104,7 +104,7 @@ def process_organization_updates(object_identifier: int, **kwds: Any):
         organization_mapping_service.delete(organization_id=object_identifier)
         return
 
-    rpc_org_update = RpcOrganizationMappingUpdate.from_orm(organization=org)
+    rpc_org_update = RpcOrganizationMappingUpdate.from_orm(org)
     organization_mapping_service.update(organization_id=org.id, update=rpc_org_update)
 
 

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -24,8 +24,8 @@ from sentry.services.hybrid_cloud.identity import identity_service
 from sentry.services.hybrid_cloud.log import AuditLogEvent, UserIpEvent
 from sentry.services.hybrid_cloud.log.impl import DatabaseBackedLogService
 from sentry.services.hybrid_cloud.organization_mapping import (
+    RpcOrganizationMappingUpdate,
     organization_mapping_service,
-    update_organization_mapping_from_instance,
 )
 from sentry.services.hybrid_cloud.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
@@ -104,8 +104,8 @@ def process_organization_updates(object_identifier: int, **kwds: Any):
         organization_mapping_service.delete(organization_id=object_identifier)
         return
 
-    update = update_organization_mapping_from_instance(org)
-    organization_mapping_service.update(organization_id=org.id, update=update)
+    rpc_org_update = RpcOrganizationMappingUpdate.from_orm(organization=org)
+    organization_mapping_service.update(organization_id=org.id, update=rpc_org_update)
 
 
 @receiver(process_region_outbox, sender=OutboxCategory.PROJECT_UPDATE)

--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -113,6 +113,9 @@ _hack_pydantic_type_validation()
 class RpcModel(pydantic.BaseModel):
     """A serializable object that may be part of an RPC schema."""
 
+    class Config:
+        orm_mode = True
+
     @classmethod
     def get_field_names(cls) -> Iterable[str]:
         return iter(cls.__fields__.keys())

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -9,7 +9,6 @@ from typing import Optional, cast
 
 from django.utils import timezone
 from pydantic.fields import Field
-from typing_extensions import TypedDict
 
 from sentry.models import Organization
 from sentry.services.hybrid_cloud import RpcModel
@@ -27,7 +26,7 @@ class RpcOrganizationMapping(RpcModel):
     customer_id: Optional[str] = None
 
 
-class RpcOrganizationMappingUpdate(TypedDict):
+class RpcOrganizationMappingUpdate(RpcModel):
     """A set of values to be updated on an OrganizationMapping.
 
     An absent key indicates that the attribute should not be updated. (Compare to a
@@ -38,15 +37,13 @@ class RpcOrganizationMappingUpdate(TypedDict):
     name: str
     customer_id: Optional[str]
 
-
-def update_organization_mapping_from_instance(
-    organization: Organization,
-) -> RpcOrganizationMappingUpdate:
-    attributes = {
-        attr_name: getattr(organization, attr_name)
-        for attr_name in RpcOrganizationMappingUpdate.__annotations__.keys()
-    }
-    return RpcOrganizationMappingUpdate(**attributes)  # type: ignore
+    @classmethod
+    def from_orm(cls, organization: Organization) -> "RpcOrganizationMappingUpdate":
+        attributes = {
+            attr_name: getattr(organization, attr_name)
+            for attr_name in RpcOrganizationMappingUpdate.__annotations__.keys()
+        }
+        return RpcOrganizationMappingUpdate(**attributes)
 
 
 class OrganizationMappingService(RpcService):

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -10,7 +10,6 @@ from typing import Optional, cast
 from django.utils import timezone
 from pydantic.fields import Field
 
-from sentry.models import Organization
 from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.silo import SiloMode
@@ -36,14 +35,6 @@ class RpcOrganizationMappingUpdate(RpcModel):
 
     name: str
     customer_id: Optional[str]
-
-    @classmethod
-    def from_orm(cls, organization: Organization) -> "RpcOrganizationMappingUpdate":
-        attributes = {
-            attr_name: getattr(organization, attr_name)
-            for attr_name in RpcOrganizationMappingUpdate.__annotations__.keys()
-        }
-        return RpcOrganizationMappingUpdate(**attributes)
 
 
 class OrganizationMappingService(RpcService):

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -56,11 +56,9 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
 
     def update(self, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
         with transaction.atomic():
-            (
-                OrganizationMapping.objects.filter(organization_id=organization_id)
-                .select_for_update()
-                .update(**update)
-            )
+            OrganizationMapping.objects.filter(
+                organization_id=organization_id
+            ).select_for_update().update(**update.dict())
 
     def verify_mappings(self, organization_id: int, slug: str) -> None:
         try:

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -90,21 +90,15 @@ class OrganizationMappingTest(TransactionTestCase):
 
         organization_mapping_service.update(
             organization_id=self.organization.id,
-            update=RpcOrganizationMappingUpdate(customer_id="test"),
+            update=RpcOrganizationMappingUpdate(name=fields["name"], customer_id="test"),
         )
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         assert org_mapping.customer_id == "test"
 
         organization_mapping_service.update(
             organization_id=self.organization.id,
-            update=RpcOrganizationMappingUpdate(name="new name!"),
+            update=RpcOrganizationMappingUpdate(name="new name!", customer_id="test"),
         )
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         assert org_mapping.customer_id == "test"
-        assert org_mapping.name == "new name!"
-
-        organization_mapping_service.update(
-            organization_id=self.organization.id, update=RpcOrganizationMappingUpdate()
-        )
-        # Does not overwrite with empty value.
         assert org_mapping.name == "new name!"

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -78,7 +78,12 @@ class OrganizationMappingTest(TransactionTestCase):
             )
 
     def test_update(self):
-        self.organization = Factories.create_organization(no_mapping=True)
+        with exempt_from_silo_limits():
+            self.organization = Factories.create_organization(
+                no_mapping=True,
+                name="test name",
+            )
+            self.organization.customer_id = "test"
         fields = {
             "name": "test name",
             "organization_id": self.organization.id,
@@ -97,11 +102,12 @@ class OrganizationMappingTest(TransactionTestCase):
 
         with exempt_from_silo_limits():
             self.organization.update(name="new name!")
+            self.organization.customer_id = "customer id"
 
         organization_mapping_service.update(
             organization_id=self.organization.id,
             update=RpcOrganizationMappingUpdate.from_orm(self.organization),
         )
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
-        assert org_mapping.customer_id == "test"
+        assert org_mapping.customer_id == "customer id"
         assert org_mapping.name == "new name!"


### PR DESCRIPTION
Minor clean up since we're deviating towards the `from_orm()` idiom.