### PR TITLE
fix(starfish): wrong label in span page

### DIFF
--- a/static/app/views/starfish/views/spanSummary/sidebar.tsx
+++ b/static/app/views/starfish/views/spanSummary/sidebar.tsx
@@ -147,7 +147,7 @@ export default function Sidebar({
         </SidebarItemValueContainer>
       </FlexItem>
       <FlexItem>
-        <SidebarItemHeader>{t('Total Events')}</SidebarItemHeader>
+        <SidebarItemHeader>{t('Total Spans')}</SidebarItemHeader>
         <SidebarItemValueContainer>{count}</SidebarItemValueContainer>
       </FlexItem>
       <FlexItem>


### PR DESCRIPTION
The `Total Events` label in the span page, is actually the total times the span has been seen.
This PR updates the label to be `Total Spans`.

`Total Events` would be available from `count_unique_transaction_id`