### PR TITLE
fix(hybrid-cloud): Add a self parameter to provider() stub

### DIFF
--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -28,7 +28,7 @@ class BaseRequestParser(abc.ABC):
     """Base Class for Integration Request Parsers"""
 
     @property
-    def provider() -> str:
+    def provider(self) -> str:
         raise NotImplementedError("'provider' property is required by IntegrationControlMiddleware")
 
     def __init__(self, request: HttpRequest, response_handler: Callable):


### PR DESCRIPTION
From https://github.com/getsentry/sentry/pull/46820.