### PR TITLE
fix(consecutive-http): Don't record problem if lcp is None

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -69,9 +69,11 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         )
 
         exceeds_min_lcp_threshold = (
-            self._sum_span_duration(self.consecutive_http_spans) / self.lcp
+            self.lcp is not None
+            and self.lcp > 0
+            and self._sum_span_duration(self.consecutive_http_spans) / self.lcp
             >= self.settings.get("lcp_ratio_threshold")
-            if self.lcp and is_event_from_browser_javascript_sdk(self.event())
+            if is_event_from_browser_javascript_sdk(self.event())
             else True
         )
 


### PR DESCRIPTION
There was a bug where if self.lcp is None, then the exceeds_min_lcp_threshold boolean would be True and may lead to creating an issue. This is incorrect because the default True was meant to only trigger for backend events. If the event is frontend and there is no LCP, this should be False and we shouldn't record the issue

Also adds a check to protect against lcp = 0 and dividing by 0.