### PR TITLE
fix(hybrid-cloud): Fix Slack webhook response parser bug

### DIFF
--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -71,7 +71,7 @@ class SlackRequestParser(BaseRequestParser):
             successful_responses = [
                 result for result in response_map.values() if result.response is not None
             ]
-            if len(successful_responses < 1):
+            if len(successful_responses) == 0:
                 error_map = {region: result.error for region, result in response_map.items()}
                 logger.error(
                     "all_regions_error",
@@ -121,7 +121,7 @@ class SlackRequestParser(BaseRequestParser):
         successful_responses = [
             result for result in response_map.values() if result.response is not None
         ]
-        if len(successful_responses < 1):
+        if len(successful_responses) == 0:
             error_map = {region: result.error for region, result in response_map.items()}
             logger.error(
                 "all_regions_error",


### PR DESCRIPTION
Fix regression from https://github.com/getsentry/sentry/pull/46820/.

`successful_responses`, which is an iterable list, cannot be compared to a number.