### PR TITLE
chore(hybrid-cloud): Simplify usage of RpcOrganizationMemberMappingUpdate

### DIFF
--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -80,9 +80,7 @@ def process_organization_member_updates(
         )
         return
 
-    rpc_org_member_update = RpcOrganizationMemberMappingUpdate.from_orm(
-        organization_member=org_member
-    )
+    rpc_org_member_update = RpcOrganizationMemberMappingUpdate.from_orm(org_member)
 
     organizationmember_mapping_service.update_with_organization_member(
         organizationmember_id=org_member.id,

--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -113,6 +113,9 @@ _hack_pydantic_type_validation()
 class RpcModel(pydantic.BaseModel):
     """A serializable object that may be part of an RPC schema."""
 
+    class Config:
+        orm_mode = True
+
     @classmethod
     def get_field_names(cls) -> Iterable[str]:
         return iter(cls.__fields__.keys())

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/__init__.py
@@ -43,16 +43,6 @@ class RpcOrganizationMemberMappingUpdate(RpcModel):
     inviter_id: Optional[int]
     invite_status: Optional[int]
 
-    @classmethod
-    def from_orm(
-        cls, organization_member: OrganizationMember
-    ) -> "RpcOrganizationMemberMappingUpdate":
-        attributes = {
-            attr_name: getattr(organization_member, attr_name)
-            for attr_name in RpcOrganizationMemberMappingUpdate.__annotations__.keys()
-        }
-        return RpcOrganizationMemberMappingUpdate(**attributes)
-
 
 class OrganizationMemberMappingService(RpcService):
     key = "organizationmember_mapping"

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
@@ -69,11 +69,7 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
             organization_id=organization_id,
             organizationmember_id=organizationmember_id,
         )
-        update_dict = {
-            attr_name: getattr(rpc_update_org_member, attr_name)
-            for attr_name in RpcOrganizationMemberMappingUpdate.__annotations__.keys()
-        }
-        org_member_map.update(**update_dict)
+        org_member_map.update(**rpc_update_org_member.dict())
         return self._serialize_rpc(org_member_map)
 
     def delete_with_organization_member(


### PR DESCRIPTION
Leverage [`dict()`](https://docs.pydantic.dev/latest/usage/exporting_models/#modeldict) and `from_orm()` model methods that are provided by the pydantic library.

See https://docs.pydantic.dev/latest/usage/models/#model-properties