### PR TITLE
chore(frontend): Delete un-used DATA_CATEGORY_NAMES constant

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -2,7 +2,6 @@
 
 import {t} from 'sentry/locale';
 import {
-  DataCategory,
   DataCategoryExact,
   DataCategoryInfo,
   OrgRole,

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -229,14 +229,6 @@ export const DEFAULT_RELATIVE_PERIODS_PAGE_FILTER = {
   '30d': t('30D'),
 };
 
-export const DATA_CATEGORY_NAMES = {
-  [DataCategory.ERRORS]: t('Errors'),
-  [DataCategory.TRANSACTIONS]: t('Transactions'),
-  [DataCategory.ATTACHMENTS]: t('Attachments'),
-  [DataCategory.PROFILES]: t('Profiles'),
-  [DataCategory.REPLAYS]: t('Session Replays'),
-};
-
 // https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
 export const DATA_CATEGORY_INFO: Record<DataCategoryExact, DataCategoryInfo> = {
   [DataCategoryExact.ERROR]: {


### PR DESCRIPTION
Not used in either `sentry` nor `getsentry`.