### PR TITLE
feat(consecutive-http): Convert remaining parameters into options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -673,6 +673,8 @@ register("performance.issues.render_blocking_assets.fcp_ratio_threshold", defaul
 register("performance.issues.render_blocking_assets.size_threshold", default=1000000)
 register("performance.issues.consecutive_http.lcp_ratio_threshold", default=0.33)
 register("performance.issues.consecutive_http.max_duration_between_spans", default=1000)
+register("performance.issues.consecutive_http.consecutive_count_threshold", default=3)
+register("performance.issues.consecutive_http.span_duration_threshold", default=1000)
 
 # System-wide option for sending occurrences to the issues platform
 register("performance.issues.send_to_issues_platform", default=False, flags=FLAG_MODIFIABLE_BOOL)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -151,6 +151,12 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         "consecutive_http_spans_max_duration_between_spans": options.get(
             "performance.issues.consecutive_http.max_duration_between_spans"
         ),
+        "consecutive_http_spans_count_threshold": options.get(
+            "performance.issues.consecutive_http.consecutive_count_threshold"
+        ),
+        "consecutive_http_spans_span_duration_threshold": options.get(
+            "performance.issues.consecutive_http.span_duration_threshold"
+        ),
     }
 
     default_project_settings = (
@@ -241,11 +247,13 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             "detection_enabled": settings["uncompressed_assets_detection_enabled"],
         },
         DetectorType.CONSECUTIVE_HTTP_OP: {
-            "span_duration_threshold": 1000,  # ms
-            "consecutive_count_threshold": 3,
+            "span_duration_threshold": settings[
+                "consecutive_http_spans_span_duration_threshold"
+            ],  # ms
+            "consecutive_count_threshold": settings["consecutive_http_spans_count_threshold"],
             "max_duration_between_spans": settings[
                 "consecutive_http_spans_max_duration_between_spans"
-            ],
+            ],  # ms
             "detection_enabled": settings["consecutive_http_spans_detection_enabled"],
             "lcp_ratio_threshold": settings["consecutive_http_spans_lcp_ratio_threshold"],
         },


### PR DESCRIPTION
We'd like to modify `span_duration_threshold` and
`consecutive_count_threshold` to see what impact they have on detection
