### PR TITLE
feat(replay): details issue tab support backend errors

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -220,7 +220,7 @@ export type RequestOptions = RequestCallbacks & {
   /**
    * Headers add to the request.
    */
-  headers?: Record<string, any>;
+  headers?: Record<string, string>;
   /**
    * The HTTP method to use when making the API request
    */

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -218,6 +218,10 @@ export type RequestOptions = RequestCallbacks & {
    */
   data?: any;
   /**
+   * Headers add to the request.
+   */
+  headers?: Record<string, any>;
+  /**
    * The HTTP method to use when making the API request
    */
   method?: APIRequestMethod;
@@ -430,6 +434,7 @@ export class Client {
     const headers = new Headers({
       Accept: 'application/json; charset=utf-8',
       'Content-Type': 'application/json',
+      ...options.headers,
     });
 
     // Do not set the X-CSRFToken header when making a request outside of the

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -54,7 +54,7 @@ function IssueList({projectId, replayId}: Props) {
             query: `replayId:${replayId}`,
           },
           headers: {
-            'x-sentry-replay-request': 1,
+            'x-sentry-replay-request': '1',
           },
         }
       );

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -53,6 +53,9 @@ function IssueList({projectId, replayId}: Props) {
           query: {
             query: `replayId:${replayId}`,
           },
+          headers: {
+            'x-sentry-replay-request': 1,
+          },
         }
       );
       setState({


### PR DESCRIPTION
## Summary 
Adds backend error support in replay details issue tab.

Requires: https://github.com/getsentry/sentry/pull/48493
Relates to: https://github.com/getsentry/sentry/issues/48249
Closes: https://github.com/getsentry/sentry/issues/48478

![image](https://user-images.githubusercontent.com/7349258/236051551-6cf59139-0341-4da0-a461-4df610bb33af.png)
