### PR TITLE
ref(py): Avoid redefining ProjectStatus

### DIFF
--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -8,15 +8,13 @@ from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
     Model,
+    ProjectStatus,
     region_silo_only_model,
     sane_repr,
 )
 
 if TYPE_CHECKING:
     from sentry.models import Team
-
-# TODO(dcramer): pull in enum library
-ProjectStatus = ObjectStatus
 
 
 class ProjectTeamManager(BaseManager):


### PR DESCRIPTION
This was already defined here https://github.com/getsentry/sentry/blob/master/src/sentry/models/project.py#L46