### PR TITLE
feat(replays): allow replay requests to query across projects

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -122,7 +122,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 has_global_views = features.has(
                     "organizations:global-views", organization, actor=request.user
                 )
-                if not has_global_views and len(params.projects) > 1:
+                fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
+
+                if not has_global_views and len(params.projects) > 1 and not fetching_replay_data:
                     raise ParseError(detail="You cannot view events from multiple projects.")
 
             # Return both for now
@@ -150,7 +152,13 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 has_global_views = features.has(
                     "organizations:global-views", organization, actor=request.user
                 )
-                if not has_global_views and len(params.get("project_id", [])) > 1:
+                fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
+
+                if (
+                    not has_global_views
+                    and len(params.get("project_id", [])) > 1
+                    and not fetching_replay_data
+                ):
                     raise ParseError(detail="You cannot view events from multiple projects.")
 
             return params

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -248,8 +248,11 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         if not projects:
             return Response([])
 
-        if len(projects) > 1 and not features.has(
-            "organizations:global-views", organization, actor=request.user
+        is_fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
+        if (
+            len(projects) > 1
+            and not features.has("organizations:global-views", organization, actor=request.user)
+            and not is_fetching_replay_data
         ):
             return Response(
                 {"detail": "You do not have the multi project stream feature enabled"}, status=400
@@ -428,8 +431,12 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :auth: required
         """
         projects = self.get_projects(request, organization)
-        if len(projects) > 1 and not features.has(
-            "organizations:global-views", organization, actor=request.user
+        is_fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
+
+        if (
+            len(projects) > 1
+            and not features.has("organizations:global-views", organization, actor=request.user)
+            and not is_fetching_replay_data
         ):
             return Response(
                 {"detail": "You do not have the multi project stream feature enabled"}, status=400
@@ -469,8 +476,13 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :auth: required
         """
         projects = self.get_projects(request, organization)
-        if len(projects) > 1 and not features.has(
-            "organizations:global-views", organization, actor=request.user
+
+        is_fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
+
+        if (
+            len(projects) > 1
+            and not features.has("organizations:global-views", organization, actor=request.user)
+            and not is_fetching_replay_data
         ):
             return Response(
                 {"detail": "You do not have the multi project stream feature enabled"}, status=400

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -72,8 +72,12 @@ class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
         if not projects:
             return Response([])
 
-        if len(projects) > 1 and not features.has(
-            "organizations:global-views", organization, actor=request.user
+        is_fetching_replay_data = request.headers.get("X-Sentry-Replay-Request") == "1"
+
+        if (
+            len(projects) > 1
+            and not features.has("organizations:global-views", organization, actor=request.user)
+            and not is_fetching_replay_data
         ):
             return Response(
                 {"detail": "You do not have the multi project stream feature enabled"}, status=400

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -331,6 +331,12 @@ class GroupListTest(APITestCase, SnubaTestCase):
             response = self.get_response()
             assert response.status_code == 200
 
+    def test_replay_feature_gate(self):
+        # allow replays to query for backend
+        self.create_project(organization=self.project.organization)
+        self.login_as(user=self.user)
+        self.get_success_response(extra_headers={"HTTP_X-Sentry-Replay-Request": "1"})
+
     def test_with_all_projects(self):
         # ensure there are two or more projects
         self.create_project(organization=self.project.organization)


### PR DESCRIPTION
- On the Replay Details page, since replays can be associated with backend errors and traces, we need to be able to query across projects to get the associated data associated with the replay for issues and events.
- We'll do so by adding a header to those specific requests that the backend will then look for, and allow those queries to get multi project results. 
