### PR TITLE
fix(hc): Enforce uniqueness on IntegrationService.get_integration

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -147,8 +147,11 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if not integration_kwargs:
             return None
 
-        integration = Integration.objects.filter(**integration_kwargs).first()
-        return self._serialize_integration(integration) if integration else None
+        try:
+            integration = Integration.objects.get(**integration_kwargs)
+        except Integration.DoesNotExist:
+            return None
+        return self._serialize_integration(integration)
 
     def get_organization_integrations(
         self,

--- a/tests/sentry/hybrid_cloud/test_integration.py
+++ b/tests/sentry/hybrid_cloud/test_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import List
 
+import pytest
 from freezegun import freeze_time
 
 from sentry.constants import ObjectStatus
@@ -143,6 +144,10 @@ class IntegrationServiceTest(BaseIntegrationServiceTest):
         assert result is None
         result = integration_service.get_integration()
         assert result is None
+
+        # non-unique result
+        with pytest.raises(Integration.MultipleObjectsReturned):
+            integration_service.get_integration(organization_id=self.organization.id)
 
     def test_update_integrations(self):
         new_metadata = {"new": "data"}

--- a/tests/sentry/models/test_external_actor.py
+++ b/tests/sentry/models/test_external_actor.py
@@ -1,0 +1,32 @@
+from sentry.models import ACTOR_TYPES, Actor, ExternalActor
+from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class ExternalActorTest(TestCase):
+    def setUp(self) -> None:
+        actor = Actor.objects.create(type=ACTOR_TYPES["team"])
+        org = self.create_organization()
+        self.create_team(organization=org, actor=actor)
+
+        integrations = [
+            self.create_integration(
+                organization=org, external_id=f"integration-{i}", provider="jira"
+            )
+            for i in range(10)
+        ]
+        target_integration = integrations[len(integrations) // 2]
+
+        self.external_actor = ExternalActor.objects.create(
+            actor=actor,
+            organization=org,
+            integration_id=target_integration.id,
+            provider=0,
+            external_name="testname",
+        )
+
+    def test_delete(self):
+        obj_id = self.external_actor.id
+        self.external_actor.delete()
+        assert list(ExternalActor.objects.filter(id=obj_id)) == []


### PR DESCRIPTION
Raise an exception if the filter arguments are not sufficient to resolve to a single unique integration.

Add a unit test that exposed a related bug in a parallel dev branch.