### PR TITLE
ref(py): Replace ProjectStatus with ObjectStatus

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -18,8 +18,8 @@ from sentry.api.utils import (
     is_member_disabled_from_limit,
 )
 from sentry.auth.superuser import is_active_superuser
-from sentry.constants import ALL_ACCESS_PROJECTS, ALL_ACCESS_PROJECTS_SLUG
-from sentry.models import ApiKey, Organization, Project, ProjectStatus, ReleaseProject
+from sentry.constants import ALL_ACCESS_PROJECTS, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
+from sentry.models import ApiKey, Organization, Project, ReleaseProject
 from sentry.models.environment import Environment
 from sentry.models.release import Release
 from sentry.services.hybrid_cloud.organization import RpcOrganization, RpcUserOrganizationContext
@@ -240,7 +240,7 @@ class OrganizationEndpoint(Endpoint):  # type: ignore[misc]
         force_global_perms: bool = False,
         include_all_accessible: bool = False,
     ) -> list[Project]:
-        qs = Project.objects.filter(organization=organization, status=ProjectStatus.VISIBLE)
+        qs = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
         user = getattr(request, "user", None)
         # A project_id of -1 means 'all projects I have access to'
         # While no project_ids means 'all projects I am a member of'.

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -10,7 +10,8 @@ from sentry.api.base import Endpoint
 from sentry.api.exceptions import ProjectMoved, ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
 from sentry.api.utils import InvalidParams, get_date_range_from_params
-from sentry.models import Project, ProjectRedirect, ProjectStatus
+from sentry.constants import ObjectStatus
+from sentry.models import Project, ProjectRedirect
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 from .organization import OrganizationPermission
@@ -137,7 +138,7 @@ class ProjectEndpoint(Endpoint):
             except ProjectRedirect.DoesNotExist:
                 raise ResourceDoesNotExist
 
-        if project.status != ProjectStatus.VISIBLE:
+        if project.status != ObjectStatus.ACTIVE:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, project)

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -5,7 +5,8 @@ from rest_framework.response import Response
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Project, ProjectStatus
+from sentry.constants import ObjectStatus
+from sentry.models import Project
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,
@@ -51,7 +52,7 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
             return Response({"error": "You need to specify at least one project"}, status=400)
 
         project_ids = Project.objects.filter(
-            organization=organization, status=ProjectStatus.VISIBLE, slug__in=projects
+            organization=organization, status=ObjectStatus.ACTIVE, slug__in=projects
         ).values_list("id", flat=True)
         if len(project_ids) != len(projects):
             return Response({"error": "One or more projects are invalid"}, status=400)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -6,7 +6,8 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.event import SqlFormatEventSerializer
-from sentry.models.project import Project, ProjectStatus
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
 
 
 @region_silo_endpoint
@@ -18,7 +19,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         try:
             project = Project.objects.get(
-                slug=project_slug, organization_id=organization.id, status=ProjectStatus.VISIBLE
+                slug=project_slug, organization_id=organization.id, status=ObjectStatus.ACTIVE
             )
         except Project.DoesNotExist:
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -16,7 +16,8 @@ from sentry.api.serializers.models.project import (
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOTFOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import CURSOR_QUERY_PARAM, GLOBAL_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.models import Project, ProjectStatus, Team
+from sentry.constants import ObjectStatus
+from sentry.models import Project, Team
 from sentry.search.utils import tokenize_query
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
@@ -149,7 +150,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 else:
                     queryset = queryset.none()
 
-        queryset = queryset.filter(status=ProjectStatus.VISIBLE).distinct()
+        queryset = queryset.filter(status=ObjectStatus.ACTIVE).distinct()
 
         # TODO(davidenwang): remove this after frontend requires only paginated projects
         get_all_projects = request.GET.get("all_projects") == "1"

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -21,7 +21,7 @@ from sentry.api.serializers.models.project import DetailedProjectSerializer
 from sentry.api.serializers.rest_framework.list import EmptyListField, ListField
 from sentry.api.serializers.rest_framework.origin import OriginField
 from sentry.auth.superuser import is_active_superuser
-from sentry.constants import RESERVED_PROJECT_SLUGS
+from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.datascrubbing import validate_pii_config_update
 from sentry.dynamic_sampling import generate_rules, get_supported_biases_ids, get_user_biases
 from sentry.grouping.enhancer import Enhancements, InvalidEnhancerConfig
@@ -41,7 +41,6 @@ from sentry.models import (
     Project,
     ProjectBookmark,
     ProjectRedirect,
-    ProjectStatus,
     ScheduledDeletion,
 )
 from sentry.notifications.types import NotificationSettingTypes
@@ -805,8 +804,8 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        updated = Project.objects.filter(id=project.id, status=ProjectStatus.VISIBLE).update(
-            status=ProjectStatus.PENDING_DELETION
+        updated = Project.objects.filter(id=project.id, status=ObjectStatus.ACTIVE).update(
+            status=ObjectStatus.PENDING_DELETION
         )
         if updated:
             scheduled = ScheduledDeletion.schedule(project, days=0, actor=request.user)

--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -9,8 +9,9 @@ from sentry.api.bases.project import ProjectPermission
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import ProjectWithOrganizationSerializer, serialize
 from sentry.auth.superuser import is_active_superuser
+from sentry.constants import ObjectStatus
 from sentry.db.models.query import in_iexact
-from sentry.models import Project, ProjectPlatform, ProjectStatus
+from sentry.models import Project, ProjectPlatform
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.search.utils import tokenize_query
 
@@ -33,9 +34,9 @@ class ProjectIndexEndpoint(Endpoint):
 
         status = request.GET.get("status", "active")
         if status == "active":
-            queryset = queryset.filter(status=ProjectStatus.VISIBLE)
+            queryset = queryset.filter(status=ObjectStatus.ACTIVE)
         elif status == "deleted":
-            queryset = queryset.exclude(status=ProjectStatus.VISIBLE)
+            queryset = queryset.exclude(status=ObjectStatus.ACTIVE)
         elif status:
             queryset = queryset.none()
 

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -8,7 +8,8 @@ from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint, TeamPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import ProjectSummarySerializer, serialize
-from sentry.models import Project, ProjectStatus
+from sentry.constants import ObjectStatus
+from sentry.models import Project
 from sentry.signals import project_created
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
@@ -62,7 +63,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
         if request.auth and hasattr(request.auth, "project"):
             queryset = Project.objects.filter(id=request.auth.project.id)
         else:
-            queryset = Project.objects.filter(teams=team, status=ProjectStatus.VISIBLE)
+            queryset = Project.objects.filter(teams=team, status=ObjectStatus.ACTIVE)
 
         stats_period = request.GET.get("statsPeriod")
         if stats_period not in (None, "", "24h", "14d", "30d"):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -49,6 +49,7 @@ from sentry.constants import (
     SAFE_FIELDS_DEFAULT,
     SCRAPE_JAVASCRIPT_DEFAULT,
     SENSITIVE_FIELDS_DEFAULT,
+    ObjectStatus,
 )
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.utils import convert_crashreport_count
@@ -60,7 +61,6 @@ from sentry.models import (
     OrganizationOption,
     OrganizationStatus,
     Project,
-    ProjectStatus,
     Team,
     TeamStatus,
 )
@@ -577,9 +577,9 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
 
     def _project_list(self, organization: Organization, access: Access) -> list[Project]:
         project_list = list(
-            Project.objects.filter(
-                organization=organization, status=ProjectStatus.VISIBLE
-            ).order_by("slug")
+            Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE).order_by(
+                "slug"
+            )
         )
 
         for project in project_list:

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -19,7 +19,7 @@ from sentry.api.serializers.models.team import get_org_roles
 from sentry.app import env
 from sentry.auth.access import Access
 from sentry.auth.superuser import is_active_superuser
-from sentry.constants import StatsPeriod
+from sentry.constants import ObjectStatus, StatsPeriod
 from sentry.digests import backend as digests
 from sentry.eventstore.models import DEFAULT_SUBJECT_TEMPLATE
 from sentry.features.base import ProjectFeature
@@ -34,7 +34,6 @@ from sentry.models import (
     ProjectBookmark,
     ProjectOption,
     ProjectPlatform,
-    ProjectStatus,
     ProjectTeam,
     Release,
     Team,
@@ -54,10 +53,10 @@ from sentry.tasks.symbolication import should_demote_symbolication
 from sentry.utils import json
 
 STATUS_LABELS = {
-    ProjectStatus.VISIBLE: "active",
-    ProjectStatus.HIDDEN: "deleted",
-    ProjectStatus.PENDING_DELETION: "deleted",
-    ProjectStatus.DELETION_IN_PROGRESS: "deleted",
+    ObjectStatus.ACTIVE: "active",
+    ObjectStatus.HIDDEN: "deleted",
+    ObjectStatus.PENDING_DELETION: "deleted",
+    ObjectStatus.DELETION_IN_PROGRESS: "deleted",
 }
 
 STATS_PERIOD_CHOICES = {

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -4,7 +4,8 @@ from operator import or_
 
 from django.db.models import Q
 
-from sentry.models import EventUser, Project, ProjectStatus, Release
+from sentry.constants import ObjectStatus
+from sentry.models import EventUser, Project, Release
 from sentry.utils.dates import to_timestamp
 from sentry.utils.geo import geo_by_addr
 
@@ -83,7 +84,7 @@ def serialize_projects(organization, item_list, user):
     return {
         id: {"id": id, "slug": slug}
         for id, slug in Project.objects.filter(
-            id__in=item_list, organization=organization, status=ProjectStatus.VISIBLE
+            id__in=item_list, organization=organization, status=ObjectStatus.ACTIVE
         ).values_list("id", "slug")
     }
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -19,9 +19,10 @@ from sentry.api.paginator import (
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import CombinedRuleSerializer
 from sentry.api.utils import InvalidParams
+from sentry.constants import ObjectStatus
 from sentry.incidents.models import AlertRule, Incident
 from sentry.incidents.serializers import AlertRuleSerializer
-from sentry.models import OrganizationMemberTeam, Project, ProjectStatus, Rule, RuleStatus, Team
+from sentry.models import OrganizationMemberTeam, Project, Rule, RuleStatus, Team
 from sentry.snuba.dataset import Dataset
 from sentry.utils.cursors import Cursor, StringCursor
 
@@ -37,7 +38,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         project_ids = self.get_requested_project_ids_unchecked(request) or None
         if project_ids == {-1}:  # All projects for org:
             project_ids = Project.objects.filter(
-                organization=organization, status=ProjectStatus.VISIBLE
+                organization=organization, status=ObjectStatus.ACTIVE
             ).values_list("id", flat=True)
         elif project_ids is None:  # All projects for user
             org_team_list = Team.objects.filter(organization=organization).values_list(
@@ -47,7 +48,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
                 organizationmember__user=request.user, team__in=org_team_list
             ).values_list("team", flat=True)
             project_ids = Project.objects.filter(
-                teams__in=user_team_list, status=ProjectStatus.VISIBLE
+                teams__in=user_team_list, status=ObjectStatus.ACTIVE
             ).values_list("id", flat=True)
 
         # Materialize the project ids here. This helps us to not overwhelm the query planner with

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from sentry import analytics, options
 from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
 from sentry.integrations import (
     FeatureDescription,
     IntegrationFeatures,
@@ -16,7 +17,7 @@ from sentry.integrations import (
     IntegrationProvider,
 )
 from sentry.integrations.mixins import ServerlessMixin
-from sentry.models import OrganizationIntegration, Project, ProjectStatus
+from sentry.models import OrganizationIntegration, Project
 from sentry.pipeline import PipelineView
 from sentry.utils.sdk import capture_exception
 
@@ -240,7 +241,7 @@ class AwsLambdaProjectSelectPipelineView(PipelineView):
 
         organization = pipeline.organization
         projects = Project.objects.filter(
-            organization=organization, status=ProjectStatus.VISIBLE
+            organization=organization, status=ObjectStatus.ACTIVE
         ).order_by("slug")
 
         # if only one project, automatically use that

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -65,18 +65,16 @@ class ProjectManager(BaseManager):
 
     def get_for_user_ids(self, user_ids: Sequence[int]) -> QuerySet:
         """Returns the QuerySet of all projects that a set of Users have access to."""
-        from sentry.models import ProjectStatus
+        from sentry.models import ObjectStatus
 
         return self.filter(
-            status=ProjectStatus.VISIBLE,
+            status=ObjectStatus.ACTIVE,
             teams__organizationmember__user_id__in=user_ids,
         )
 
     def get_for_team_ids(self, team_ids: Sequence[int]) -> QuerySet:
         """Returns the QuerySet of all projects that a set of Teams have access to."""
-        from sentry.models import ProjectStatus
-
-        return self.filter(status=ProjectStatus.VISIBLE, teams__in=team_ids)
+        return self.filter(status=ObjectStatus.ACTIVE, teams__in=team_ids)
 
     # TODO(dcramer): we might want to cache this per user
     def get_for_user(self, team, user, scope=None, _skip_team_check=False):
@@ -96,7 +94,7 @@ class ProjectManager(BaseManager):
                 logging.info(f"User does not have access to team: {team.id}")
                 return []
 
-        base_qs = self.filter(teams=team, status=ProjectStatus.VISIBLE)
+        base_qs = self.filter(teams=team, status=ObjectStatus.ACTIVE)
 
         project_list = []
         for project in base_qs:

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -22,7 +22,7 @@ ProjectStatus = ObjectStatus
 class ProjectTeamManager(BaseManager):
     def get_for_teams_with_org_cache(self, teams: Sequence["Team"]) -> Sequence["ProjectTeam"]:
         project_teams = (
-            self.filter(team__in=teams, project__status=ProjectStatus.VISIBLE)
+            self.filter(team__in=teams, project__status=ObjectStatus.ACTIVE)
             .order_by("project__name", "project__slug")
             .select_related("project")
         )

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.app import env
+from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -41,13 +42,7 @@ class TeamManager(BaseManager):
         Returns a list of all teams a user has some level of access to.
         """
         from sentry.auth.superuser import is_active_superuser
-        from sentry.models import (
-            OrganizationMember,
-            OrganizationMemberTeam,
-            Project,
-            ProjectStatus,
-            ProjectTeam,
-        )
+        from sentry.models import OrganizationMember, OrganizationMemberTeam, Project, ProjectTeam
 
         if not user.is_authenticated:
             return []
@@ -80,7 +75,7 @@ class TeamManager(BaseManager):
 
         if with_projects:
             project_list = sorted(
-                Project.objects.filter(teams__in=team_list, status=ProjectStatus.VISIBLE),
+                Project.objects.filter(teams__in=team_list, status=ObjectStatus.ACTIVE),
                 key=lambda x: x.name.lower(),
             )
 

--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -9,7 +9,8 @@ from sentry.api.base import Endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases.project import ProjectPermission
 from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist
-from sentry.models import Organization, Project, ProjectKey, ProjectStatus
+from sentry.constants import ObjectStatus
+from sentry.models import Organization, Project, ProjectKey
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
@@ -63,7 +64,7 @@ class MonitorEndpoint(Endpoint):
             raise ResourceDoesNotExist
 
         project = Project.objects.get_from_cache(id=monitor.project_id)
-        if project.status != ProjectStatus.VISIBLE:
+        if project.status != ObjectStatus.ACTIVE:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, project)
@@ -187,7 +188,7 @@ class MonitorIngestEndpoint(Endpoint):
         else:
             project = Project.objects.get_from_cache(id=monitor.project_id)
 
-        if project.status != ProjectStatus.VISIBLE:
+        if project.status != ObjectStatus.ACTIVE:
             raise ResourceDoesNotExist
 
         # Validate that the authenticated project matches the monitor. This is

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, List, Mapping, Optional, cast
 
 from pydantic import Field
 
+from sentry.constants import ObjectStatus
 from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmember import InviteStatus
 from sentry.roles import team_roles
@@ -55,9 +56,7 @@ class RpcTeamMember(RpcModel):
 
 
 def project_status_visible() -> int:
-    from sentry.models import ProjectStatus
-
-    return int(ProjectStatus.VISIBLE)
+    return int(ObjectStatus.ACTIVE)
 
 
 class RpcProject(RpcModel):

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -6,6 +6,7 @@ from typing import Iterable, List, MutableMapping, Optional, Set, cast
 from django.db import transaction
 
 from sentry import roles
+from sentry.constants import ObjectStatus
 from sentry.db.postgres.roles import in_test_psql_role_override
 from sentry.models import (
     Organization,
@@ -13,7 +14,6 @@ from sentry.models import (
     OrganizationMemberTeam,
     OrganizationStatus,
     Project,
-    ProjectStatus,
     ProjectTeam,
     Team,
     TeamStatus,
@@ -78,7 +78,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         all_project_ids: Set[int] = set()
         project_ids_by_team_id: MutableMapping[int, List[int]] = defaultdict(list)
         for pt in ProjectTeam.objects.filter(
-            project__status=ProjectStatus.VISIBLE, team_id__in={omt.team_id for omt in omts}
+            project__status=ObjectStatus.ACTIVE, team_id__in={omt.team_id for omt in omts}
         ):
             all_project_ids.add(pt.project_id)
             project_ids_by_team_id[pt.team_id].append(pt.project_id)

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -23,7 +23,8 @@ from sentry.api.serializers import serialize
 from sentry.api.utils import generate_organization_url, is_member_disabled_from_limit
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
-from sentry.models import Organization, OrganizationStatus, Project, ProjectStatus, Team, TeamStatus
+from sentry.constants import ObjectStatus
+from sentry.models import Organization, OrganizationStatus, Project, Team, TeamStatus
 from sentry.models.avatars.base import AvatarBase
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.organization import (
@@ -198,7 +199,7 @@ class OrganizationMixin:
         except Project.DoesNotExist:
             return None
 
-        if project.status != ProjectStatus.VISIBLE:
+        if project.status != ObjectStatus.ACTIVE:
             return None
 
         return project

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -13,6 +13,7 @@ from sentry import roles
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY, SETUP_WIZARD_CACHE_TIMEOUT
 from sentry.api.serializers import serialize
 from sentry.cache import default_cache
+from sentry.constants import ObjectStatus
 from sentry.models import (
     ApiToken,
     Organization,
@@ -20,7 +21,6 @@ from sentry.models import (
     Project,
     ProjectKey,
     ProjectKeyStatus,
-    ProjectStatus,
 )
 from sentry.utils.http import absolute_uri
 from sentry.utils.urls import add_params_to_url
@@ -67,7 +67,7 @@ class SetupWizardView(BaseView):
 
         for org in orgs:
             projects = list(
-                Project.objects.filter(organization=org, status=ProjectStatus.VISIBLE).order_by(
+                Project.objects.filter(organization=org, status=ObjectStatus.ACTIVE).order_by(
                     "-date_added"
                 )[:50]
             )

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -5,7 +5,7 @@ from unittest import mock
 from django.urls import reverse
 
 from sentry import audit_log
-from sentry.constants import RESERVED_PROJECT_SLUGS
+from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.dynamic_sampling import DEFAULT_BIASES, RuleType
 from sentry.models import (
     ApiToken,
@@ -22,7 +22,6 @@ from sentry.models import (
     ProjectBookmark,
     ProjectOwnership,
     ProjectRedirect,
-    ProjectStatus,
     ProjectTeam,
     Rule,
     ScheduledDeletion,
@@ -1193,7 +1192,7 @@ class ProjectDeleteTest(APITestCase):
         assert ScheduledDeletion.objects.filter(model_name="Project", object_id=project.id).exists()
 
         deleted_project = Project.objects.get(id=project.id)
-        assert deleted_project.status == ProjectStatus.PENDING_DELETION
+        assert deleted_project.status == ObjectStatus.PENDING_DELETION
         assert deleted_project.slug == "abc123"
         assert OrganizationOption.objects.filter(
             organization_id=deleted_project.organization_id,

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -1,8 +1,9 @@
 from django.urls import reverse
 from rest_framework import status
 
+from sentry.constants import ObjectStatus
 from sentry.db.postgres.roles import in_test_psql_role_override
-from sentry.models import Project, ProjectKey, ProjectStatus, SentryAppInstallationToken
+from sentry.models import Project, ProjectKey, SentryAppInstallationToken
 from sentry.models.apitoken import ApiToken
 from sentry.testutils import APITestCase
 
@@ -67,7 +68,7 @@ class ProjectsListTest(APITestCase):
         org = self.create_organization()
         team = self.create_team(organization=org, members=[user])
         project1 = self.create_project(teams=[team])
-        project2 = self.create_project(teams=[team], status=ProjectStatus.PENDING_DELETION)
+        project2 = self.create_project(teams=[team], status=ObjectStatus.PENDING_DELETION)
 
         self.login_as(user=user)
 


### PR DESCRIPTION
This was already just an alias of ObjectStatus.

On top of that, it was defined in two paces (project and projectteam)
and had a bad circular import dependency making it difficult to not be
defined in multiple places

https://github.com/getsentry/sentry/blob/c1b2bff5be3bcf2b235c5d6efe04f5e1ee617edd/src/sentry/models/project.py#L45-L46

https://github.com/getsentry/sentry/blob/c1b2bff5be3bcf2b235c5d6efe04f5e1ee617edd/src/sentry/models/projectteam.py#L18-L19

This pattern of `SomeStatus = ObjectStatus` is not a pattern we follow
anywhere else