### PR TITLE
fix(escalating): Update issue archived reason with new substatus

### DIFF
--- a/static/app/components/archivedBox.spec.tsx
+++ b/static/app/components/archivedBox.spec.tsx
@@ -47,18 +47,20 @@ describe('ArchivedBox', function () {
     expect(screen.getByText(/This issue has been archived/)).toBeInTheDocument();
     expect(container).toSnapshot();
   });
-  it('swaps archived for archived', function () {
+  it('handles archived forever', function () {
     render(<ArchivedBox statusDetails={{}} />, {
       organization: TestStubs.Organization({features: ['escalating-issues-ui']}),
     });
-    expect(screen.getByText(/This issue has been archived/)).toBeInTheDocument();
+    expect(screen.getByText(/This issue has been archived forever/)).toBeInTheDocument();
   });
   it('handes archived until escalating', function () {
-    render(<ArchivedBox statusDetails={{untilEscalating: true}} />, {
+    render(<ArchivedBox statusDetails={{ignoreUntilEscalating: true}} />, {
       organization: TestStubs.Organization({features: ['escalating-issues-ui']}),
     });
     expect(
-      screen.getByText(/This issue has been archived until it escalates/)
+      screen.getByText(
+        /This issue has been archived\. It'll return to your inbox if it escalates/
+      )
     ).toBeInTheDocument();
   });
 });

--- a/static/app/components/archivedBox.spec.tsx
+++ b/static/app/components/archivedBox.spec.tsx
@@ -4,53 +4,35 @@ import ArchivedBox from './archivedBox';
 
 describe('ArchivedBox', function () {
   it('handles ignoreUntil', function () {
-    const {container} = render(
-      <ArchivedBox statusDetails={{ignoreUntil: '2017-06-21T19:45:10Z'}} />
-    );
+    render(<ArchivedBox statusDetails={{ignoreUntil: '2017-06-21T19:45:10Z'}} />);
     expect(screen.getByText(/This issue has been archived until/)).toBeInTheDocument();
-    expect(container).toSnapshot();
   });
   it('handles ignoreCount', function () {
-    const {container} = render(<ArchivedBox statusDetails={{ignoreUserCount: 100}} />);
+    render(<ArchivedBox statusDetails={{ignoreUserCount: 100}} />);
     expect(
       screen.getByText(/This issue has been archived until it affects/)
     ).toBeInTheDocument();
-    expect(container).toSnapshot();
   });
   it('handles ignoreCount with ignoreWindow', function () {
-    const {container} = render(
-      <ArchivedBox statusDetails={{ignoreCount: 100, ignoreWindow: 1}} />
-    );
+    render(<ArchivedBox statusDetails={{ignoreCount: 100, ignoreWindow: 1}} />);
     expect(
       screen.getByText(/This issue has been archived until it occurs/)
     ).toBeInTheDocument();
-    expect(container).toSnapshot();
   });
   it('handles ignoreUserCount', function () {
-    const {container} = render(<ArchivedBox statusDetails={{ignoreUserCount: 100}} />);
+    render(<ArchivedBox statusDetails={{ignoreUserCount: 100}} />);
     expect(
       screen.getByText(/This issue has been archived until it affects/)
     ).toBeInTheDocument();
-    expect(container).toSnapshot();
   });
   it('handles ignoreUserCount with ignoreUserWindow', function () {
-    const {container} = render(
-      <ArchivedBox statusDetails={{ignoreUserCount: 100, ignoreUserWindow: 1}} />
-    );
+    render(<ArchivedBox statusDetails={{ignoreUserCount: 100, ignoreUserWindow: 1}} />);
     expect(
       screen.getByText(/This issue has been archived until it affects/)
     ).toBeInTheDocument();
-    expect(container).toSnapshot();
-  });
-  it('handles default', function () {
-    const {container} = render(<ArchivedBox statusDetails={{}} />);
-    expect(screen.getByText(/This issue has been archived/)).toBeInTheDocument();
-    expect(container).toSnapshot();
   });
   it('handles archived forever', function () {
-    render(<ArchivedBox statusDetails={{}} />, {
-      organization: TestStubs.Organization({features: ['escalating-issues-ui']}),
-    });
+    render(<ArchivedBox statusDetails={{}} />);
     expect(screen.getByText(/This issue has been archived forever/)).toBeInTheDocument();
   });
   it('handes archived until escalating', function () {

--- a/static/app/components/archivedBox.tsx
+++ b/static/app/components/archivedBox.tsx
@@ -17,11 +17,16 @@ function ArchivedBox({statusDetails}: Props) {
       ignoreWindow,
       ignoreUserCount,
       ignoreUserWindow,
-      untilEscalating,
+      ignoreUntilEscalating,
     } = statusDetails;
 
-    if (untilEscalating) {
-      return t('This issue has been archived until it escalates.');
+    if (ignoreUntilEscalating) {
+      return t(
+        "This issue has been archived. It'll return to your inbox if it escalates. To learn more, %s",
+        <ExternalLink href="https://docs.sentry.io/product/issues/states-triage/">
+          {t('read the docs')}
+        </ExternalLink>
+      );
     }
     if (ignoreUntil) {
       return t(
@@ -62,20 +67,13 @@ function ArchivedBox({statusDetails}: Props) {
       );
     }
 
-    return t('This issue has been archived.');
+    return t('This issue has been archived forever.');
   }
 
   return (
     <BannerContainer priority="default">
       <BannerSummary>
-        <span>
-          {renderReason()}{' '}
-          {t(
-            "It'll return to your inbox if it escalates. To learn more, %s",
-            // TODO(workflow): Need escalating-issues-ui docs link
-            <ExternalLink href="#">{t('read the docs')}</ExternalLink>
-          )}
-        </span>
+        <span>{renderReason()}</span>
       </BannerSummary>
     </BannerContainer>
   );

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -491,6 +491,7 @@ export type ResolutionStatusDetails = {
   // Sent in requests. ignoreUntil is used in responses.
   ignoreDuration?: number;
   ignoreUntil?: string;
+  ignoreUntilEscalating?: boolean;
   ignoreUserCount?: number;
   ignoreUserWindow?: number;
   ignoreWindow?: number;
@@ -503,7 +504,6 @@ export type ResolutionStatusDetails = {
   inNextRelease?: boolean;
   inRelease?: string;
   repository?: string;
-  untilEscalating?: boolean;
 };
 
 export type GroupStatusResolution = {


### PR DESCRIPTION
Correctly handles archived forever and looks at the correct issue state variable for until escalating

![image](https://user-images.githubusercontent.com/1400464/236072863-b4497210-2cef-4aab-940e-cfd9a514b89e.png)
