### PR TITLE
feat(issue-states): Add search validation to disallow mutually exclusive substatuses

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -303,7 +303,9 @@ def convert_query_values(
 
 
 def valid_substatus_search(filters: list[SearchFilter]) -> bool:
-    parsed = lambda substatus: substatus[0] if isinstance(substatus, list) else substatus
+    def parsed(substatus: str | list[str]) -> str:
+        return substatus[0] if isinstance(substatus, list) else substatus
+
     substatuses = [
         parsed(filter.value.raw_value) for filter in filters if filter.key.name == "substatus"
     ]

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -250,7 +250,7 @@ class ConvertSubStatusValueTest(TestCase):
             SearchFilter(SearchKey("substatus"), "=", SearchValue(["until_escalating"])),
         ]
         with pytest.raises(
-            InvalidSearchQuery, match="Mutually exclusive substatus filters are not supported"
+            InvalidSearchQuery, match="Mutually exclusive status filters are not supported"
         ):
             convert_query_values(filters, [self.project], self.user, None)
 

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -232,9 +232,26 @@ class ConvertSubStatusValueTest(TestCase):
             result = convert_query_values(filters, [self.project], self.user, None)
             assert result[0].value.raw_value == [substatus_val]
 
+            filters = [
+                SearchFilter(SearchKey("substatus"), "=", SearchValue(["forever"])),
+                SearchFilter(SearchKey("substatus"), "=", SearchValue(["until_escalating"])),
+            ]
+            result = convert_query_values(filters, [self.project], self.user, None)
+            assert result[0].value.raw_value == [5]
+            assert result[1].value.raw_value == [1]
+
     def test_invalid(self):
-        filters = [SearchFilter(SearchKey("substatus"), "=", SearchValue("wrong"))]
+        filters = [SearchFilter(SearchKey("substatus"), "=", SearchValue(["wrong"]))]
         with pytest.raises(InvalidSearchQuery, match="invalid substatus value"):
+            convert_query_values(filters, [self.project], self.user, None)
+
+        filters = [
+            SearchFilter(SearchKey("substatus"), "=", SearchValue(["escalating"])),
+            SearchFilter(SearchKey("substatus"), "=", SearchValue(["until_escalating"])),
+        ]
+        with pytest.raises(
+            InvalidSearchQuery, match="Mutually exclusive substatus filters are not supported"
+        ):
             convert_query_values(filters, [self.project], self.user, None)
 
 


### PR DESCRIPTION
Prevent searches like `is:escalating is:until_escalating` (mutually exclusive substatuses) and `is:resolved is:escalating` (mutually exclusive status/substatus pair)