### PR TITLE
ref(dynamic-sampling): Add optional project

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -463,7 +463,7 @@ class Quota(Service):
         return (_limit_from_settings(options.get("system.rate-limit")), 60)
 
     def get_blended_sample_rate(
-        self, project: Optional["Project"], organization_id: Optional[int] = None
+        self, project: Optional["Project"] = None, organization_id: Optional[int] = None
     ) -> Optional[float]:
         """
         Returns the blended sample rate for an org based on the package that they are currently on. Returns ``None``


### PR DESCRIPTION
This PR adds the optional project to `get_blended_sample_rate`.