### PR TITLE
Avoid applying source context when symbolicating profiles

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -146,11 +146,11 @@ class Symbolicator:
         )
         return process_response(res)
 
-    def process_payload(self, stacktraces, modules, signal=None):
+    def process_payload(self, stacktraces, modules, signal=None, apply_source_context=True):
         (sources, process_response) = sources_for_symbolication(self.project)
         json = {
             "sources": sources,
-            "options": {"dif_candidates": True},
+            "options": {"dif_candidates": True, "apply_source_context": apply_source_context},
             "stacktraces": stacktraces,
             "modules": modules,
         }

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -279,7 +279,9 @@ def _symbolicate(
     while True:
         try:
             with sentry_sdk.start_span(op="task.profiling.symbolicate.process_payload"):
-                response = symbolicator.process_payload(stacktraces=stacktraces, modules=modules)
+                response = symbolicator.process_payload(
+                    stacktraces=stacktraces, modules=modules, apply_source_context=False
+                )
                 return (
                     response.get("modules", modules),
                     response.get("stacktraces", stacktraces),


### PR DESCRIPTION
This should avoid some work on the symbolicator side that will not be used in profiles, as the source context is being discarded right away.