### PR TITLE
Do not stringify/escape Span `data` that is already a string

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -515,20 +515,18 @@ function SpanDetail(props: Props) {
                 <Row title={key} key={key}>
                   <Fragment>
                     <FileSize bytes={value} />
-                    {value >= 1024 && (
-                      <span>{` (${JSON.stringify(value, null, 4) || ''} B)`}</span>
-                    )}
+                    {value >= 1024 && <span>{` (${maybeStringify(value)} B)`}</span>}
                   </Fragment>
                 </Row>
               ))}
               {map(nonSizeKeys, (value, key) => (
                 <Row title={key} key={key}>
-                  {JSON.stringify(value, null, 4) || ''}
+                  {maybeStringify(value)}
                 </Row>
               ))}
               {unknownKeys.map(key => (
                 <Row title={key} key={key}>
-                  {JSON.stringify(span[key], null, 4) || ''}
+                  {maybeStringify(span[key])}
                 </Row>
               ))}
             </tbody>
@@ -549,6 +547,13 @@ function SpanDetail(props: Props) {
       {renderSpanDetails()}
     </SpanDetailContainer>
   );
+}
+
+function maybeStringify(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value, null, 4);
 }
 
 const StyledDiscoverButton = styled(DiscoverButton)`


### PR DESCRIPTION
This avoids some annoying escaping that can happen if attaching strings to the span data.

Before:
![Bildschirmfoto 2023-05-04 um 11 43 18](https://user-images.githubusercontent.com/580492/236170209-b8b50ae9-ea7b-42c5-ad91-f98d2ce02b17.png)
After:
![Bildschirmfoto 2023-05-04 um 11 43 50](https://user-images.githubusercontent.com/580492/236170247-c37b366a-9f56-45a1-97bd-d783a11c161a.png)
