### PR TITLE
feat(metrics): Span metrics in API

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -125,6 +125,10 @@ class TransactionMRI(Enum):
     USER_MISERY = "e:transactions/user_misery@ratio"
     TEAM_KEY_TRANSACTION = "e:transactions/team_key_transaction@none"
 
+    # Spans (might be moved to their own namespace soon)
+    SPAN_USER = "s:transactions/span.user@none"
+    SPAN_DURATION = "d:transactions/span.duration@millisecond"
+
 
 @dataclass
 class ParsedMRI:

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -96,6 +96,11 @@ class TransactionMetricKey(Enum):
     FAILURE_COUNT = "transaction.failure_count"
     TEAM_KEY_TRANSACTION = "transactions.team_key_transaction"
 
+    # Span metrics.
+    # NOTE: These might be moved to their own namespace soon.
+    SPAN_USER = "span.user"
+    SPAN_DURATION = "span.duration"
+
 
 # TODO: these tag keys and values below probably don't belong here, and should
 # be moved to another more private file.


### PR DESCRIPTION
This allows running queries on the metrics API like:

```
/api/0/organizations/{org}/metrics/data/?useCase=performance&field=avg(span.duration)&groupBy=environment
```

or

```
/api/0/organizations/{org}/metrics/data/?useCase=performance&field=count_unique(span.user)&groupBy=environment
```