### PR TITLE
fix(perf): Fix uncompressed asset file types

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -8,7 +8,7 @@ from ..base import DetectorType, PerformanceDetector, fingerprint_resource_span,
 from ..performance_problem import PerformanceProblem
 from ..types import Span
 
-FILE_EXTENSION_DENYLIST = ("woff", "woff2")
+FILE_EXTENSION_ALLOWLIST = ("css", "json", "js")
 
 
 class UncompressedAssetSpanDetector(PerformanceDetector):
@@ -68,7 +68,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
             return
 
         # Ignore assets with certain file extensions
-        if description.endswith(FILE_EXTENSION_DENYLIST):
+        if not description.endswith(FILE_EXTENSION_ALLOWLIST):
             return
 
         # Ignore assets under a certain duration threshold

--- a/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
+++ b/tests/sentry/utils/performance_issues/test_uncompressed_assets_detector.py
@@ -163,6 +163,61 @@ class UncompressedAssetsDetectorTest(TestCase):
             )
         ]
 
+    def test_does_not_detect_jpg_asset(self):
+        event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "tags": [["browser.name", "chrome"]],
+            "spans": [
+                create_asset_span(
+                    op="resource.link",
+                    desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.css",
+                    duration=1000.0,
+                    data={
+                        "http.transfer_size": 1_000_000,
+                        "http.response_content_length": 1_000_000,
+                        "http.decoded_response_content_length": 1_000_000,
+                    },
+                ),
+                create_compressed_asset_span(),
+            ],
+        }
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1012-7f5aaccd4a1347f512fc3d04068b9621baff2783",
+                op="resource.script",
+                desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.css",
+                type=PerformanceUncompressedAssetsGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "op": "resource.script",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                },
+                evidence_display=[],
+            )
+        ]
+
+        event["spans"] = [
+            create_asset_span(
+                op="resource.css",
+                desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/some.jpg",
+                duration=1000.0,
+                data={
+                    "http.transfer_size": 1_000_000,
+                    "http.response_content_length": 1_000_000,
+                    "http.decoded_response_content_length": 1_000_000,
+                },
+            ),
+            create_compressed_asset_span(),
+        ]
+
+        assert self.find_problems(event) == []
+
     def test_does_not_detect_woff_asset(self):
         event = {
             "event_id": "a" * 16,


### PR DESCRIPTION
### Summary
Switched to an allowlist since we're apparently getting png/jpg (and probably others) under the resource.css op

Fixes PERF-2046
