### PR TITLE
ref(onboarding): Update logic to display product selection for browser js

### DIFF
--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -237,7 +237,9 @@ function SetupDocs({route, router, location, selectedProjectSlug}: StepProps) {
   const [integrationUseManualSetup, setIntegrationUseManualSetup] = useState(false);
 
   const showIntegrationOnboarding = integrationSlug && !integrationUseManualSetup;
-  const showDocsWithProductSelection = currentPlatform.match('^javascript-([A-Za-z]+)$');
+  const showDocsWithProductSelection =
+    currentPlatform.match('^javascript-([A-Za-z]+)$') ??
+    (showLoaderOnboarding === false && currentPlatform === 'javascript');
 
   const hideLoaderOnboarding = useCallback(() => {
     setShowLoaderOnboarding(false);


### PR DESCRIPTION
if users prefer the installation via `yarn` or `npm`, the UI shall render the Browser JavaScript Docs with the product selection. This PR depends on https://github.com/getsentry/sentry-docs