### PR TITLE
ref(indexer): Add metric name tag to sentry error when filtering metrics

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -161,6 +161,9 @@ class IndexerBatch:
             sentry_sdk.set_tag(
                 "sentry_metrics.organization_id", self.parsed_payloads_by_offset[offset]["org_id"]
             )
+            sentry_sdk.set_tag(
+                "sentry_metrics.metric_name", self.parsed_payloads_by_offset[offset]["name"]
+            )
             if _should_sample_debug_log():
                 logger.error(
                     "process_messages.dropped_message",


### PR DESCRIPTION
Sometimes, knowing what metric is filtered out is useful to reduce the scope of an investigation.