### PR TITLE
ref(onboarding): Replace push with replace

### DIFF
--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -71,7 +71,7 @@ describe('Onboarding Product Selection', function () {
     // Uncheck performance monitoring
     await userEvent.click(performanceMonitoring);
     await waitFor(() =>
-      expect(router.push).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         pathname: undefined,
         query: {product: ['session-replay']},
       })
@@ -86,7 +86,7 @@ describe('Onboarding Product Selection', function () {
     // Uncheck sesseion replay
     await userEvent.click(sessionReplay);
     await waitFor(() =>
-      expect(router.push).toHaveBeenCalledWith({
+      expect(router.replace).toHaveBeenCalledWith({
         pathname: undefined,
         query: {product: ['performance-monitoring']},
       })

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -37,7 +37,7 @@ export function ProductSelection({
     if (!defaultSelectedProducts) {
       return;
     }
-    router.push({
+    router.replace({
       pathname: router.location.pathname,
       query: {
         ...router.location.query,
@@ -50,7 +50,7 @@ export function ProductSelection({
 
   const handleClickProduct = useCallback(
     (product: PRODUCT) => {
-      router.push({
+      router.replace({
         pathname: router.location.pathname,
         query: {
           ...router.location.query,

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -249,7 +249,7 @@ function Onboarding(props: Props) {
       if (onboardingSteps[stepIndex].id === 'select-platform') {
         onboardingContext.setData({...onboardingContext.data, selectedSDK: undefined});
 
-        props.router.push(
+        props.router.replace(
           normalizeUrl(`/onboarding/${organization.slug}/${previousStep.id}/`)
         );
         return;
@@ -265,7 +265,7 @@ function Onboarding(props: Props) {
         deleteRecentCreatedProject();
       }
 
-      props.router.push(
+      props.router.replace(
         normalizeUrl(`/onboarding/${organization.slug}/${previousStep.id}/`)
       );
     },

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -249,7 +249,7 @@ function Onboarding(props: Props) {
       if (onboardingSteps[stepIndex].id === 'select-platform') {
         onboardingContext.setData({...onboardingContext.data, selectedSDK: undefined});
 
-        props.router.replace(
+        props.router.push(
           normalizeUrl(`/onboarding/${organization.slug}/${previousStep.id}/`)
         );
         return;
@@ -265,7 +265,7 @@ function Onboarding(props: Props) {
         deleteRecentCreatedProject();
       }
 
-      props.router.replace(
+      props.router.push(
         normalizeUrl(`/onboarding/${organization.slug}/${previousStep.id}/`)
       );
     },


### PR DESCRIPTION
Replacing `push` with `replace` in the onboarding product selection so users are able to navigate back using their browsers only 