### PR TITLE
feat(platforms): Add SvelteKit as a platform (backend)

### DIFF
--- a/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
@@ -70,6 +70,7 @@ LATEST_RELEASE_TTAS = {
     "javascript-remix": 11751,
     "javascript-replay-onboarding-1-install": 2609,
     "javascript-svelte": 4604,
+    "javascript-sveltekit": 5222,
     "javascript-vue": 10115,
     "java-spring-boot": 11731,
     "kotlin": 4520,

--- a/src/sentry/utils/event.py
+++ b/src/sentry/utils/event.py
@@ -30,4 +30,5 @@ def is_event_from_browser_javascript_sdk(event):
         "sentry.javascript.electron",
         "sentry.javascript.remix",
         "sentry.javascript.svelte",
+        "sentry.javascript.sveltekit",
     ]

--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -46,6 +46,7 @@ FRONTEND = [
     "javascript-nextjs",
     "javascript-remix",
     "javascript-svelte",
+    "javascript-sveltekit",
     "unity",
 ]
 
@@ -218,6 +219,7 @@ RELEASE_HEALTH = [
     "javascript-nextjs",
     "javascript-remix",
     "javascript-svelte",
+    "javascript-sveltekit",
     # mobile
     "android",
     "apple-ios",


### PR DESCRIPTION
This PR adds SvelteKit as a platform to the Sentry backend since the SvelteKit SDK is nearing GA. 

Going to merge this only after https://github.com/getsentry/sentry-docs/issues/6843 is done.