### PR TITLE
feat(platforms): Add SvelteKit as a platform (frontend)

### DIFF
--- a/fixtures/integration-docs/_platforms.json
+++ b/fixtures/integration-docs/_platforms.json
@@ -193,6 +193,12 @@
           "type": "framework",
           "id": "javascript-svelte",
           "name": "Svelte"
+        },
+        {
+          "link": "https://docs.sentry.io/platforms/javascript/guides/sveltekit/",
+          "type": "framework",
+          "id": "javascript-sveltekit",
+          "name": "SvelteKit"
         }
       ],
       "id": "javascript",

--- a/fixtures/integration-docs/javascript-sveltekit.json
+++ b/fixtures/integration-docs/javascript-sveltekit.json
@@ -1,0 +1,6 @@
+{
+  "html": "<div class=\"section\" id=\"installation\"></div>\n",
+  "link": "https://docs.sentry.io/platforms/javascript/guides/sveltekit/",
+  "id": "javascript-sveltekit",
+  "name": "SvelteKit"
+}

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
-    "platformicons": "^5.4.0",
+    "platformicons": "^5.6.0",
     "po-catalog-loader": "2.0.0",
     "prettier": "2.8.8",
     "prismjs": "^1.29.0",

--- a/static/app/components/events/interfaces/crashContent/exception/utils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/utils.tsx
@@ -33,5 +33,6 @@ export const sourceMapSdkDocsMap: Record<string, string> = {
   'sentry.javascript.nextjs': 'nextjs',
   'sentry.javascript.remix': 'remix',
   'sentry.javascript.svelte': 'svelte',
+  'sentry.javascript.sveltekit': 'sveltekit',
   'sentry.javascript.react-native': 'react-native',
 };

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -501,6 +501,7 @@ export function isEventFromBrowserJavaScriptSDK(event: EventTransaction): boolea
     'sentry.javascript.electron',
     'sentry.javascript.remix',
     'sentry.javascript.svelte',
+    'sentry.javascript.sveltekit',
   ].includes(sdkName.toLowerCase());
 }
 

--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -47,6 +47,12 @@ export const supportedPlatformExpectedDocKeys: Record<
     '2-configure-performance',
     '3-configure-profiling',
   ],
+  'javascript-sveltekit': [
+    '0-alert',
+    '1-install',
+    '2-configure-performance',
+    '3-configure-profiling',
+  ],
 };
 
 function makeDocKey(platformId: PlatformKey, key: string) {
@@ -55,6 +61,9 @@ function makeDocKey(platformId: PlatformKey, key: string) {
   }
   if (platformId === 'javascript-remix') {
     return `node-javascript-remix-profiling-onboarding-${key}`;
+  }
+  if (platformId === 'javascript-sveltekit') {
+    return `node-javascript-sveltekit-profiling-onboarding-${key}`;
   }
   return `${platformId}-profiling-onboarding-${key}`;
 }

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -55,6 +55,7 @@ export const frontend = [
   'javascript-nextjs',
   'javascript-remix',
   'javascript-svelte',
+  'javascript-sveltekit',
   'unity',
 ] as const;
 
@@ -226,6 +227,7 @@ export const profiling: PlatformKey[] = [
   'node-connect',
   'javascript-nextjs',
   'javascript-remix',
+  'javascript-sveltekit',
   // python
   'python',
   'python-django',
@@ -264,6 +266,7 @@ export const releaseHealth: PlatformKey[] = [
   'javascript-nextjs',
   'javascript-remix',
   'javascript-svelte',
+  'javascript-sveltekit',
   // mobile
   'android',
   'apple-ios',
@@ -310,6 +313,7 @@ export const replayPlatforms: readonly PlatformKey[] = [
   'javascript-react',
   'javascript-remix',
   'javascript-svelte',
+  'javascript-sveltekit',
   'javascript-vue',
   'javascript',
 ];
@@ -330,6 +334,7 @@ export const replayOnboardingPlatforms: readonly PlatformKey[] = [
   'javascript-react',
   'javascript-remix',
   'javascript-svelte',
+  'javascript-sveltekit',
   'javascript-vue',
   'javascript',
 ];

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -25,7 +25,7 @@ const platformIntegrations: PlatformIntegration[] = [
 ]
   .map(platform => {
     const integrations = platform.integrations.reduce((acc, value) => {
-      // filter out any javascript-[angular|angularjs|ember|gatsby|nextjs|react|remix|svelte|vue]-* platforms; as they're not meant to be used as a platform in the PlatformPicker component
+      // filter out any javascript-[angular|angularjs|ember|gatsby|nextjs|react|remix|svelte|sveltekit|vue]-* platforms; as they're not meant to be used as a platform in the PlatformPicker component
       if (value.id.match('^javascript-([A-Za-z]+)-([a-zA-Z0-9]+.*)$')) {
         return acc;
       }

--- a/static/app/utils/profiling/platforms.tsx
+++ b/static/app/utils/profiling/platforms.tsx
@@ -15,6 +15,7 @@ export const supportedProfilingPlatformSDKs = [
   'ruby',
   'javascript-nextjs',
   'javascript-remix',
+  'javascript-sveltekit',
 ] as const;
 export type SupportedProfilingPlatform = (typeof supportedProfilingPlatforms)[number];
 export type SupportedProfilingPlatformSDK =
@@ -44,6 +45,9 @@ export function getDocsPlatformSDKForPlatform(
   }
   if (platform === 'javascript-remix') {
     return 'javascript-remix';
+  }
+  if (platform === 'javascript-sveltekit') {
+    return 'javascript-sveltekit';
   }
 
   // Python

--- a/static/app/views/setupWizard/index.tsx
+++ b/static/app/views/setupWizard/index.tsx
@@ -18,6 +18,8 @@ type Props = {
 const platformDocsMapping = {
   'javascript-nextjs':
     'https://docs.sentry.io/platforms/javascript/guides/nextjs/#verify',
+  'javascript-sveltekit':
+    'https://docs.sentry.io/platforms/javascript/guides/sveltekit/#verify',
   'react-native': 'https://docs.sentry.io/platforms/react-native/#verify',
   cordova: 'https://docs.sentry.io/platforms/javascript/guides/cordova/#verify',
   'javascript-electron':

--- a/yarn.lock
+++ b/yarn.lock
@@ -8690,10 +8690,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.4.0.tgz#27ee813e4e1ce9e1bcf01a6e52c237520f4cc4e3"
-  integrity sha512-IzSW9Rn0lAqb6voHuaOtqNKaFHVO00Cm2cfLXOugye/em7xiFfAEL7mzeyYYZ1eTqiGSA+YO9ak+Psv+B6xAlg==
+platformicons@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.6.0.tgz#3d6e9088e4d2cfc80097fd772508eed8445e638e"
+  integrity sha512-OG1TF4Ls5wp2HBLTXIaGc8UJoZae+7ICzkYX/QaBWnfoyXEt+d2oHHZBF9ffucACBazSMQicEcchrltwNSybhQ==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
This PR adds SvelteKit as a platform to the Sentry frontend since the SvelteKit SDK is nearing GA. 

Going to merge this only after https://github.com/getsentry/sentry-docs/issues/6843 is done.