### PR TITLE
ref(performance): Make "All Transactions" the default view for Remix and SvelteKit

### DIFF
--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -89,7 +89,7 @@ export enum PROJECT_PERFORMANCE_TYPE {
 
 // The native SDK is equally used on clients and end-devices as on
 // backend, the default view should be "All Transactions".
-const FRONTEND_PLATFORMS: string[] = [...frontend].filter(
+const FRONTEND_PLATFORMS: string[] = frontend.filter(
   platform =>
     // Next, Remix and Sveltekit habe both, frontend and backend transactions.
     !['javascript-nextjs', 'javascript-remix', 'javascript-sveltekit'].includes(platform)

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -90,7 +90,9 @@ export enum PROJECT_PERFORMANCE_TYPE {
 // The native SDK is equally used on clients and end-devices as on
 // backend, the default view should be "All Transactions".
 const FRONTEND_PLATFORMS: string[] = [...frontend].filter(
-  platform => platform !== 'javascript-nextjs' // Next has both frontend and backend transactions.
+  platform =>
+    // Next, Remix and Sveltekit habe both, frontend and backend transactions.
+    !['javascript-nextjs', 'javascript-remix', 'javascript-sveltekit'].includes(platform)
 );
 const BACKEND_PLATFORMS: string[] = backend.filter(platform => platform !== 'native');
 const MOBILE_PLATFORMS: string[] = [...mobile];


### PR DESCRIPTION
While working on #48523 I noticed that the NextJS platform gets "All Transactions" as a default view in the performance landing page. I think we want to extend this to Remix and SvelteKit as well, as these platforms will also get frontend and backend transactions.