### PR TITLE
feat(exception-group): Auto-collapse child exception groups

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -166,25 +166,10 @@ describe('Exception Content', function () {
 
       const exceptions = screen.getAllByTestId('exception-value');
 
-      // There are 4 exceptions in the exception group fixture
-      expect(exceptions).toHaveLength(4);
-
       // First exception should be the parent ExceptionGroup
       expect(within(exceptions[0]).getByText('ExceptionGroup 1')).toBeInTheDocument();
       expect(
         within(exceptions[0]).getByRole('heading', {name: 'ExceptionGroup 1'})
-      ).toBeInTheDocument();
-    });
-
-    it('displays exception group tree in first frame when sorting by oldest', function () {
-      render(<Content {...defaultProps} newestFirst={false} />);
-
-      const exceptions = screen.getAllByTestId('exception-value');
-
-      // Last exception should be the parent ExceptionGroup
-      expect(within(exceptions[3]).getByText('ExceptionGroup 1')).toBeInTheDocument();
-      expect(
-        within(exceptions[3]).getByRole('heading', {name: 'ExceptionGroup 1'})
       ).toBeInTheDocument();
     });
 
@@ -197,6 +182,41 @@ describe('Exception Content', function () {
       expect(
         within(exceptionGroupWithNoContext).getByText('Related Exceptions')
       ).toBeInTheDocument();
+    });
+
+    it('collapses sub-groups by default', async function () {
+      render(<Content {...defaultProps} />);
+
+      // There are 4 values, but 1 should be hidden
+      expect(screen.getAllByTestId('exception-value').length).toBe(3);
+      expect(screen.queryByRole('heading', {name: 'ValueError'})).not.toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole('button', {name: /show 1 related exception/i})
+      );
+
+      // After expanding, ValueError should be visible
+      expect(screen.getAllByTestId('exception-value').length).toBe(4);
+      expect(screen.getByRole('heading', {name: 'ValueError'})).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole('button', {name: /hide 1 related exception/i})
+      );
+
+      // After collapsing, ValueError should be gone again
+      expect(screen.getAllByTestId('exception-value').length).toBe(3);
+      expect(screen.queryByRole('heading', {name: 'ValueError'})).not.toBeInTheDocument();
+    });
+
+    it('auto-opens sub-groups when clicking link in tree', async function () {
+      render(<Content {...defaultProps} />);
+
+      expect(screen.queryByRole('heading', {name: 'ValueError'})).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: /ValueError: test/i}));
+
+      // After expanding, ValueError should be visible
+      expect(screen.getByRole('heading', {name: 'ValueError'})).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -1,13 +1,14 @@
-import {useContext} from 'react';
+import {useContext, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {Tooltip} from 'sentry/components/tooltip';
-import {tct} from 'sentry/locale';
+import {tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {ExceptionType, Project} from 'sentry/types';
-import {Event} from 'sentry/types/event';
+import {Event, ExceptionValue} from 'sentry/types/event';
 import {STACK_TYPE} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {OrganizationContext} from 'sentry/views/organizationContext';
@@ -34,6 +35,88 @@ type Props = {
     'groupingCurrentLevel' | 'hasHierarchicalGrouping'
   >;
 
+type CollapsedExceptionMap = {[exceptionId: number]: boolean};
+
+const useCollapsedExceptions = (values?: ExceptionValue[]) => {
+  const [collapsedExceptions, setCollapsedSections] = useState<CollapsedExceptionMap>(
+    () => {
+      if (!values) {
+        return {};
+      }
+
+      return values
+        .filter(
+          ({mechanism}) => mechanism?.is_exception_group && defined(mechanism.parent_id)
+        )
+        .reduce(
+          (acc, next) => ({...acc, [next.mechanism?.exception_id ?? -1]: true}),
+          {}
+        );
+    }
+  );
+
+  const toggleException = (exceptionId: number) => {
+    setCollapsedSections(old => {
+      if (!defined(old[exceptionId])) {
+        return old;
+      }
+
+      return {...old, [exceptionId]: !old[exceptionId]};
+    });
+  };
+
+  const expandException = (exceptionId: number) => {
+    setCollapsedSections(old => {
+      const exceptionValue = values?.find(
+        value => value.mechanism?.exception_id === exceptionId
+      );
+      const exceptionGroupId = exceptionValue?.mechanism?.parent_id;
+
+      if (!exceptionGroupId || !defined(old[exceptionGroupId])) {
+        return old;
+      }
+
+      return {...old, [exceptionGroupId]: false};
+    });
+  };
+
+  return {toggleException, collapsedExceptions, expandException};
+};
+
+function ToggleExceptionButton({
+  values,
+  exception,
+  toggleException,
+  collapsedExceptions,
+}: {
+  collapsedExceptions: CollapsedExceptionMap;
+  exception: ExceptionValue;
+  toggleException: (exceptionId: number) => void;
+  values: ExceptionValue[];
+}) {
+  const exceptionId = exception.mechanism?.exception_id;
+
+  if (!exceptionId || !defined(collapsedExceptions[exceptionId])) {
+    return null;
+  }
+
+  const collapsed = collapsedExceptions[exceptionId];
+  const numChildren = values.filter(
+    ({mechanism}) => mechanism?.parent_id === exceptionId
+  ).length;
+
+  return (
+    <ShowRelatedExceptionsButton
+      priority="link"
+      onClick={() => toggleException(exceptionId)}
+    >
+      {collapsed
+        ? tn('Show %s related exceptions', 'Show %s related exceptions', numChildren)
+        : tn('Hide %s related exceptions', 'Hide %s related exceptions', numChildren)}
+    </ShowRelatedExceptionsButton>
+  );
+}
+
 export function Content({
   newestFirst,
   event,
@@ -46,6 +129,9 @@ export function Content({
   type,
   meta,
 }: Props) {
+  const {collapsedExceptions, toggleException, expandException} =
+    useCollapsedExceptions(values);
+
   // Organization context may be unavailable for the shared event view, so we
   // avoid using the `useOrganization` hook here and directly useContext
   // instead.
@@ -75,6 +161,11 @@ export function Content({
     const id = defined(exc.mechanism?.exception_id)
       ? `exception-${exc.mechanism?.exception_id}`
       : undefined;
+
+    if (exc.mechanism?.parent_id && collapsedExceptions[exc.mechanism.parent_id]) {
+      return null;
+    }
+
     return (
       <div key={excIdx} className="exception" data-test-id="exception-value">
         {defined(exc?.module) ? (
@@ -91,6 +182,9 @@ export function Content({
             exc.value
           )}
         </StyledPre>
+        <ToggleExceptionButton
+          {...{collapsedExceptions, toggleException, values, exception: exc}}
+        />
         {exc.mechanism && (
           <Mechanism data={exc.mechanism} meta={meta?.[excIdx]?.mechanism} />
         )}
@@ -98,6 +192,7 @@ export function Content({
           mechanism={exc.mechanism}
           allExceptions={values}
           newestFirst={newestFirst}
+          onExceptionClick={expandException}
         />
         <ErrorBoundary mini>
           {hasSourcemapDebug && (
@@ -143,4 +238,9 @@ const Title = styled('h5')`
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
+`;
+
+const ShowRelatedExceptionsButton = styled(Button)`
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/components/events/interfaces/crashContent/exception/relatedExceptions.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/relatedExceptions.spec.tsx
@@ -19,6 +19,7 @@ describe('ExceptionGroupContext', function () {
     allExceptions: entry.data.values ?? [],
     mechanism: exceptionGroup1Mechanism,
     newestFirst: true,
+    onExceptionClick: jest.fn(),
   };
 
   it('renders tree with exception group', function () {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/47828

To prevent the stack trace from becoming too long and unwieldy, this collapses child exception groups. This means that only the first level of the tree is visible at first, but the user may expand them by clicking "Show n related exceptions" or clicking the element in the exception tree.

Can test on this issue: https://sentry-sdks.dev.getsentry.net:7999/issues/4126628864/events/e303031f97ab4b25b0f275d41a35a323/?project=5428537


https://user-images.githubusercontent.com/10888943/236264285-819e2ba8-a89d-4466-beac-a6961c1cb4e3.mp4

