### PR TITLE
ref(subscriptions): Increase batch size

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -465,7 +465,7 @@ def post_process_forwarder(**options):
     "query-subscription-consumer",
     include_batching_options=True,
     allow_force_cluster=False,
-    default_max_batch_size=20,
+    default_max_batch_size=1000,
 )
 @click.option(
     "--processes",


### PR DESCRIPTION
Increase the max batch size for the query subscription consumer from 20 to 1000. 