### PR TITLE
fix(hybrid-cloud): Create org member mapping rows on update if it does not exist

### DIFF
--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
@@ -81,12 +81,19 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
         organization_id: int,
         rpc_update_org_member: RpcOrganizationMemberMappingUpdate,
     ) -> RpcOrganizationMemberMapping:
-        org_member_map = OrganizationMemberMapping.objects.get(
-            organization_id=organization_id,
-            organizationmember_id=organizationmember_id,
-        )
-        org_member_map.update(**rpc_update_org_member.dict())
-        return self._serialize_rpc(org_member_map)
+        try:
+            org_member_map = OrganizationMemberMapping.objects.get(
+                organization_id=organization_id,
+                organizationmember_id=organizationmember_id,
+            )
+            org_member_map.update(**rpc_update_org_member.dict())
+            return self._serialize_rpc(org_member_map)
+        except OrganizationMemberMapping.DoesNotExist:
+            return self.create_mapping(
+                organizationmember_id=organizationmember_id,
+                organization_id=organization_id,
+                **rpc_update_org_member.dict(),
+            )
 
     def delete_with_organization_member(
         self,


### PR DESCRIPTION
Fixes [SENTRY-10Y9](https://sentry.sentry.io/issues/4152927305/).

Depends on https://github.com/getsentry/sentry/pull/48531 to be able to repair values on creation.