### PR TITLE
chore: Try to capture bad setting record saves

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from django.conf import settings
 from django.db import models
 
@@ -126,6 +127,11 @@ class NotificationSetting(Model):
         "type_str",
         "value_str",
     )
+
+    def save(self, *args, **kwargs):
+        if self.user_id is None and self.team_id is None:
+            sentry_sdk.capture_exception(AssertionError("Notification setting missing user & team"))
+        super().save(*args, **kwargs)
 
 
 # REQUIRED for migrations to run


### PR DESCRIPTION
We have some notificationsetting records that are missing `user_id` and `team_id`. This *shouldn't* be happening, however the notificationsetting table doesn't have any timestamps so we aren't able to tell if the bad records are old or new. My hope is that by capturing exceptions when records matching this profile are created we can find and fix the relevant code paths if they exist, as they don't run during tests.
