### PR TITLE
chore(hybrid-cloud): Use user_service to query for Sentry emails when fetching commits

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import sentry_sdk
@@ -16,7 +18,7 @@ from sentry.models import (
     User,
 )
 from sentry.plugins.base import bindings
-from sentry.services.hybrid_cloud.user import user_service
+from sentry.services.hybrid_cloud.user import RpcUser, user_service
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.email import MessageBuilder
@@ -70,7 +72,7 @@ def handle_invalid_identity(identity, commit_failure=False):
     max_retries=5,
 )
 @retry(exclude=(Release.DoesNotExist, User.DoesNotExist))
-def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
+def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **kwargs):
     # TODO(dcramer): this function could use some cleanup/refactoring as it's a bit unwieldy
     commit_list = []
 
@@ -245,14 +247,18 @@ def is_integration_provider(provider):
     return provider and provider.startswith("integrations:")
 
 
-def get_emails_for_user_or_org(user, orgId):
+def get_emails_for_user_or_org(user: RpcUser | None, orgId: int):
     emails = []
+    if not user:
+        return []
     if user.is_sentry_app:
         organization = Organization.objects.get(id=orgId)
-        members = organization.get_members_with_org_roles(roles=["owner"]).select_related("user")
+        members = organization.get_members_with_org_roles(roles=["owner"])
 
         for m in list(members):
-            emails.append(m.user.email)
+            user = user_service.get_user(user_id=m.user_id)
+            if user:
+                emails.append(user.email)
     else:
         emails = [user.email]
 

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -254,11 +254,9 @@ def get_emails_for_user_or_org(user: RpcUser | None, orgId: int):
     if user.is_sentry_app:
         organization = Organization.objects.get(id=orgId)
         members = organization.get_members_with_org_roles(roles=["owner"])
-
-        for m in list(members):
-            user = user_service.get_user(user_id=m.user_id)
-            if user:
-                emails.append(user.email)
+        user_ids = [m.user_id for m in members if m.user_id]
+        emails = {u.email for u in user_service.get_many(filter={"user_ids": user_ids}) if u.email}
+        emails = list(emails)
     else:
         emails = [user.email]
 


### PR DESCRIPTION
This avoids `select_related("user")` on org members.

This is a minor step into breaking foreign keys on org members.