### PR TITLE
fix(large-http-detector): Use array for offender_span_ids

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -38,7 +38,9 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
 
     def _store_performance_problem(self, span) -> None:
         fingerprint = self._fingerprint(span)
-        offender_span_ids = span.get("span_id", None)
+        offender_span_ids = []
+        if offender_span_id := span.get("span_id", None):
+            offender_span_ids.append(offender_span_id)
         desc: str = span.get("description", None)
 
         self.stored_problems[fingerprint] = PerformanceProblem(

--- a/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
@@ -56,7 +56,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 evidence_data={
                     "parent_span_ids": [],
                     "cause_span_ids": [],
-                    "offender_span_ids": "bbbbbbbbbbbbbbbb",
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
                     "op": "http",
                 },
                 evidence_display=[],

--- a/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
@@ -52,7 +52,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 type=PerformanceLargeHTTPPayloadGroupType,
                 parent_span_ids=None,
                 cause_span_ids=[],
-                offender_span_ids="bbbbbbbbbbbbbbbb",
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
                 evidence_data={
                     "parent_span_ids": [],
                     "cause_span_ids": [],


### PR DESCRIPTION
This field is supposed to be an array. Found this bug when creating an example locally, parsing the perfEvidenceData would break.