### PR TITLE
chore(hybrid-cloud): Update org member inviter reference to inviter_id

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -103,6 +103,11 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
     def serialize(
         self, obj: OrganizationMember, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> OrganizationMemberResponse:
+        inviter_name = None
+        if obj.inviter_id:
+            inviter = user_service.get_user(user_id=obj.inviter_id)
+            if inviter:
+                inviter_name = inviter.get_display_name()
         d: OrganizationMemberResponse = {
             "id": str(obj.id),
             "email": obj.get_email(),
@@ -122,7 +127,7 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             },
             "dateCreated": obj.date_added,
             "inviteStatus": obj.get_invite_status_name(),
-            "inviterName": obj.inviter.get_display_name() if obj.inviter else None,
+            "inviterName": inviter_name,
             "orgRolesFromTeams": attrs.get("orgRolesFromTeams", []),
         }
 

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -269,7 +269,7 @@ class User(BaseModel, AbstractBaseUser):
     def get_full_name(self):
         return self.name
 
-    def get_salutation_name(self):
+    def get_salutation_name(self) -> str:
         name = self.name or self.username.split("@", 1)[0].split(".", 1)[0]
         first_name = name.split(" ", 1)[0]
         return first_name.capitalize()

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -88,6 +88,11 @@ class RpcUser(RpcModel):
     def get_full_name(self) -> str:
         return self.name
 
+    def get_salutation_name(self):
+        name = self.name or self.username.split("@", 1)[0].split(".", 1)[0]
+        first_name = name.split(" ", 1)[0]
+        return first_name.capitalize()
+
     def get_avatar_type(self) -> str:
         if self.avatar is not None:
             return self.avatar.avatar_type

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -88,7 +88,7 @@ class RpcUser(RpcModel):
     def get_full_name(self) -> str:
         return self.name
 
-    def get_salutation_name(self):
+    def get_salutation_name(self) -> str:
         name = self.name or self.username.split("@", 1)[0].split(".", 1)[0]
         first_name = name.split(" ", 1)[0]
         return first_name.capitalize()

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -125,8 +125,8 @@ class HybridCloudTestMixin:
         )
 
         assert org_member_mapping.role == org_member.role
-        if org_member.inviter:
-            assert org_member_mapping.inviter_id == org_member.inviter.id
+        if org_member.inviter_id:
+            assert org_member_mapping.inviter_id == org_member.inviter_id
         else:
             assert org_member_mapping.inviter_id is None
         assert org_member_mapping.invite_status == org_member.invite_status

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -192,7 +192,7 @@ class OrganizationInviteRequestApproveTest(InviteRequestBase):
         assert audit_log_entry.data == member.get_audit_log_data()
 
     def test_member_cannot_approve_invite_request(self):
-        self.invite_request.inviter = self.member.user
+        self.invite_request.inviter_id = self.member.user.id
         self.invite_request.save()
 
         self.login_as(user=self.member.user)

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -111,9 +111,9 @@ class OrganizationInviteRequestCreateTest(
         member = OrganizationMember.objects.get(
             organization=self.organization, email=response.data["email"]
         )
-        assert member.user is None
+        assert member.user_id is None
         assert member.role == "member"
-        assert member.inviter == self.user
+        assert member.inviter_id == self.user.id
         assert member.invite_status == InviteStatus.REQUESTED_TO_BE_INVITED.value
 
         teams = OrganizationMemberTeam.objects.filter(organizationmember=member)
@@ -180,7 +180,7 @@ class OrganizationInviteRequestCreateTest(
 
         members = OrganizationMember.objects.filter(organization=self.organization)
         join_request = members.get(email=resp.data["email"])
-        assert join_request.user is None
+        assert join_request.user_id is None
         assert join_request.role == "member"
         assert not join_request.invite_approved
 

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -565,7 +565,7 @@ class OrganizationMemberListPostTest(OrganizationMemberListTestBase):
         assert om.email == "jane@gmail.com"
         assert om.role == "member"
         assert list(om.teams.all()) == [self.team]
-        assert om.inviter == self.user
+        assert om.inviter_id == self.user.id
 
         mock_send_invite_email.assert_called_once_with()
 
@@ -578,7 +578,7 @@ class OrganizationMemberListPostTest(OrganizationMemberListTestBase):
         assert om.email == "jane@gmail.com"
         assert om.role == "member"
         assert list(om.teams.all()) == []
-        assert om.inviter == self.user
+        assert om.inviter_id == self.user.id
 
     @patch.object(OrganizationMember, "send_invite_email")
     def test_no_email(self, mock_send_invite_email):
@@ -594,7 +594,7 @@ class OrganizationMemberListPostTest(OrganizationMemberListTestBase):
         assert om.email == "jane@gmail.com"
         assert om.role == "member"
         assert list(om.teams.all()) == [self.team]
-        assert om.inviter == self.user
+        assert om.inviter_id == self.user.id
 
         assert not mock_send_invite_email.mock_calls
 


### PR DESCRIPTION
This pull request updates references to `org_member.inviter` to be  `org_member.inviter_id`.

This is part of the foreign key breakage on org members.