### PR TITLE
bug(replays): Fix arrow direction of toggle buttons inside Replay>Network>Details panel

### DIFF
--- a/static/app/views/replays/detail/network/details/components.tsx
+++ b/static/app/views/replays/detail/network/details/components.tsx
@@ -109,7 +109,7 @@ export function SectionItem({
     <Fragment>
       <SectionTitle>
         <ToggleButton aria-label={t('toggle section')} onClick={() => setIsOpen(!isOpen)}>
-          <IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />
+          <IconChevron direction={isOpen ? 'down' : 'right'} size="xs" />
           {title}
           {titleExtra ? <SectionTitleExtra>{titleExtra}</SectionTitleExtra> : null}
         </ToggleButton>


### PR DESCRIPTION
New arrows look like:

![SCR-20230504-lvxf](https://user-images.githubusercontent.com/187460/236319007-6314e9e7-c99b-4664-9f1b-41eadd59bdd0.png)
![SCR-20230504-lvwv](https://user-images.githubusercontent.com/187460/236319010-c04827d1-05cc-4bd8-815f-bc0ce540f489.png)
![SCR-20230504-lvwe](https://user-images.githubusercontent.com/187460/236319011-922290c3-150d-4c53-a607-82c30e9b9db7.png)


Fixes https://github.com/getsentry/sentry/issues/48552
