### PR TITLE
feat(replays): Add a button to copy bodies/payloads from the Replay>Network>Details panel

### DIFF
--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -66,7 +66,7 @@ function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props)
     return (
       <Wrapper>
         <Clipboard
-          value={JSON.stringify(data, null, '\t')}
+          hideUnsupported
           onSuccess={() => {
             setTooltipState('copied');
             onCopy?.(data);
@@ -74,8 +74,10 @@ function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props)
           onError={() => {
             setTooltipState('error');
           }}
+          value={JSON.stringify(data, null, '\t')}
         >
           <CopyButton
+            aria-label={t('Copy')}
             type="button"
             size="xs"
             translucentBorder

--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -1,19 +1,26 @@
-import {ComponentProps, MouseEvent, useMemo} from 'react';
+import {ComponentProps, MouseEvent, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 import {
   chromeDark,
   chromeLight,
   ObjectInspector as OrigObjectInspector,
 } from '@sentry-internal/react-inspector';
 
+import {Button} from 'sentry/components/button';
+import Clipboard from 'sentry/components/clipboard';
+import {IconCopy} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 
 type Props = Omit<ComponentProps<typeof OrigObjectInspector>, 'theme'> & {
+  onCopy?: (copiedCode: string) => void;
+  showCopyButton?: boolean;
   theme?: Record<string, any>;
 };
 
-function ObjectInspector({data, theme, ...props}: Props) {
+function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props) {
   const config = useLegacyStore(ConfigStore);
   const emotionTheme = useTheme();
   const isDark = config.theme === 'dark';
@@ -37,7 +44,16 @@ function ObjectInspector({data, theme, ...props}: Props) {
     [isDark, theme, emotionTheme.red400, emotionTheme.text]
   );
 
-  return (
+  const [tooltipState, setTooltipState] = useState<'copy' | 'copied' | 'error'>('copy');
+
+  const tooltipTitle =
+    tooltipState === 'copy'
+      ? t('Copy')
+      : tooltipState === 'copied'
+      ? t('Copied')
+      : t('Unable to copy');
+
+  const inspector = (
     <OrigObjectInspector
       data={data}
       // @ts-expect-error
@@ -45,9 +61,52 @@ function ObjectInspector({data, theme, ...props}: Props) {
       {...props}
     />
   );
+  if (showCopyButton) {
+    return (
+      <Wrapper>
+        <Clipboard
+          value={JSON.stringify(data, null, '\t')}
+          onSuccess={() => {
+            setTooltipState('copied');
+            onCopy?.(data);
+          }}
+          onError={() => {
+            setTooltipState('error');
+          }}
+        >
+          <CopyButton
+            type="button"
+            size="xs"
+            translucentBorder
+            borderless
+            title={tooltipTitle}
+            tooltipProps={{delay: 0, isHoverable: false, position: 'left'}}
+            onMouseLeave={() => setTooltipState('copy')}
+          >
+            <IconCopy size="xs" />
+          </CopyButton>
+        </Clipboard>
+        {inspector}
+      </Wrapper>
+    );
+  }
+
+  return inspector;
 }
 
-export type OnExpand = (
+const Wrapper = styled('div')`
+  position: relative;
+`;
+
+const CopyButton = styled(Button)`
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  color: ${p => p.theme.subText};
+`;
+
+export type OnExpandCallback = (
   path: string,
   expandedState: Record<string, boolean>,
   event: MouseEvent<HTMLDivElement>

--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -13,6 +13,7 @@ import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {space} from 'sentry/styles/space';
 
 type Props = Omit<ComponentProps<typeof OrigObjectInspector>, 'theme'> & {
   onCopy?: (copiedCode: string) => void;
@@ -101,7 +102,7 @@ const Wrapper = styled('div')`
 const CopyButton = styled(Button)`
   position: absolute;
   top: 0;
-  right: 0;
+  right: ${space(0.5)};
 
   color: ${p => p.theme.subText};
 `;

--- a/static/app/views/replays/detail/console/format.tsx
+++ b/static/app/views/replays/detail/console/format.tsx
@@ -22,7 +22,7 @@
 import {Fragment} from 'react';
 import isObject from 'lodash/isObject';
 
-import ObjectInspector, {OnExpand} from 'sentry/components/objectInspector';
+import ObjectInspector, {OnExpandCallback} from 'sentry/components/objectInspector';
 
 const formatRegExp = /%[sdj%]/g;
 
@@ -32,7 +32,7 @@ function isNull(arg: unknown) {
 interface FormatProps {
   args: any[];
   expandPaths?: string[];
-  onExpand?: OnExpand;
+  onExpand?: OnExpandCallback;
 }
 
 /**

--- a/static/app/views/replays/detail/console/messageFormatter.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.tsx
@@ -3,7 +3,7 @@ import isObject from 'lodash/isObject';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {getMeta} from 'sentry/components/events/meta/metaProxy';
-import {OnExpand} from 'sentry/components/objectInspector';
+import {OnExpandCallback} from 'sentry/components/objectInspector';
 import {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
 import {objectIsEmpty} from 'sentry/utils';
 
@@ -12,7 +12,7 @@ import Format from './format';
 interface Props {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
   expandPaths?: string[];
-  onExpand?: OnExpand;
+  onExpand?: OnExpandCallback;
 }
 
 /**

--- a/static/app/views/replays/detail/network/details/sections.tsx
+++ b/static/app/views/replays/detail/network/details/sections.tsx
@@ -94,7 +94,7 @@ export function QueryParamsSection({item}: SectionProps) {
   return (
     <SectionItem title={t('Query String Parameters')}>
       <Indent>
-        <ObjectInspector data={queryParams} expandLevel={3} />
+        <ObjectInspector data={queryParams} expandLevel={3} showCopyButton />
       </Indent>
     </SectionItem>
   );
@@ -114,7 +114,7 @@ export function RequestPayloadSection({item}: SectionProps) {
       <Indent>
         <Warning warnings={item.data?.request?._meta?.warnings} />
         {hasRequest ? (
-          <ObjectInspector data={item.data.request.body} expandLevel={2} />
+          <ObjectInspector data={item.data.request.body} expandLevel={2} showCopyButton />
         ) : (
           tct('Request body not found.', item.data)
         )}
@@ -138,7 +138,11 @@ export function ResponsePayloadSection({item}: SectionProps) {
       <Indent>
         <Warning warnings={item.data?.response?._meta?.warnings} />
         {hasResponse ? (
-          <ObjectInspector data={item.data.response.body} expandLevel={2} />
+          <ObjectInspector
+            data={item.data.response.body}
+            expandLevel={2}
+            showCopyButton
+          />
         ) : (
           tct('Response body not found.', item.data)
         )}

--- a/static/app/views/replays/detail/useVirtualizedInspector.tsx
+++ b/static/app/views/replays/detail/useVirtualizedInspector.tsx
@@ -1,7 +1,7 @@
 import {MouseEvent, RefObject, useCallback} from 'react';
 import {CellMeasurerCache, List} from 'react-virtualized';
 
-import {OnExpand} from 'sentry/components/objectInspector';
+import {OnExpandCallback} from 'sentry/components/objectInspector';
 
 type Opts = {
   cache: CellMeasurerCache;
@@ -38,7 +38,7 @@ function useVirtualizedInspector({cache, listRef, expandPathsRef}: Opts) {
   };
 }
 
-export type OnDimensionChange = OnExpand extends (...a: infer U) => infer R
+export type OnDimensionChange = OnExpandCallback extends (...a: infer U) => infer R
   ? (index: number, ...a: U) => R
   : never;
 export default useVirtualizedInspector;


### PR DESCRIPTION
You get tooltips before/after clicking
And on success or error, there's little toasts that pop up too

![SCR-20230504-mony](https://user-images.githubusercontent.com/187460/236330527-c1570959-4086-4f57-980f-697f8354dfc4.png)
![SCR-20230504-mpll](https://user-images.githubusercontent.com/187460/236330638-7a58fa88-52be-470b-a078-b86518de8183.png)


Edit: updated spacing on the right of the button ^


Fixes https://github.com/getsentry/sentry/issues/48549