### PR TITLE
feat(rules): Only show RuleSource.ISSUE rules

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -23,6 +23,7 @@ from sentry.constants import ObjectStatus
 from sentry.incidents.models import AlertRule, Incident
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.models import OrganizationMemberTeam, Project, Rule, RuleStatus, Team
+from sentry.models.rule import RuleSource
 from sentry.snuba.dataset import Dataset
 from sentry.utils.cursors import Cursor, StringCursor
 
@@ -73,7 +74,9 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             # Filter to only error alert rules
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
         issue_rules = Rule.objects.filter(
-            status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE], project__in=projects
+            status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE],
+            source__in=[RuleSource.ISSUE],
+            project__in=projects,
         )
         name = request.GET.get("name", None)
         if name:


### PR DESCRIPTION
We don't want to list the cron alert rules at the moment.

We may want to wait on https://github.com/getsentry/sentry/pull/48568

That said, I'm actually not sure if this index will work in this case, since we're querying on the `project` and `status` already, I don't think the index will be applied.

cc @wedamija 