### PR TITLE
ref(py): Consistently use `ACTIVE` for status's (TagKeyStatus)

### DIFF
--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -23,7 +23,7 @@ INTERNAL_TAG_KEYS = frozenset(("release", "dist", "user", "filename", "function"
 
 # TODO(dcramer): pull in enum library
 class TagKeyStatus:
-    VISIBLE = 0
+    ACTIVE = 0
     PENDING_DELETION = 1
     DELETION_IN_PROGRESS = 2
 
@@ -123,7 +123,7 @@ class TagStorage(Service):
 
     @raises([TagKeyNotFound])
     def get_tag_key(
-        self, project_id, environment_id, key, status=TagKeyStatus.VISIBLE, tenant_ids=None
+        self, project_id, environment_id, key, status=TagKeyStatus.ACTIVE, tenant_ids=None
     ):
         """
         >>> get_tag_key(1, 2, "key1")
@@ -134,7 +134,7 @@ class TagStorage(Service):
         self,
         project_id,
         environment_id,
-        status=TagKeyStatus.VISIBLE,
+        status=TagKeyStatus.ACTIVE,
         include_values_seen=False,
         tenant_ids=None,
     ):
@@ -144,7 +144,7 @@ class TagStorage(Service):
         raise NotImplementedError
 
     def get_tag_keys_for_projects(
-        self, projects, environments, start, end, status=TagKeyStatus.VISIBLE, tenant_ids=None
+        self, projects, environments, start, end, status=TagKeyStatus.ACTIVE, tenant_ids=None
     ):
         """
         >>> get_tag_key([1], [2])

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -399,11 +399,11 @@ class SnubaTagStorage(TagStorage):
         project_id,
         environment_id,
         key,
-        status=TagKeyStatus.VISIBLE,
+        status=TagKeyStatus.ACTIVE,
         tenant_ids=None,
         **kwargs,
     ):
-        assert status is TagKeyStatus.VISIBLE
+        assert status is TagKeyStatus.ACTIVE
         return self.__get_tag_key_and_top_values(
             project_id, None, environment_id, key, tenant_ids=tenant_ids, **kwargs
         )
@@ -412,12 +412,12 @@ class SnubaTagStorage(TagStorage):
         self,
         project_id,
         environment_id,
-        status=TagKeyStatus.VISIBLE,
+        status=TagKeyStatus.ACTIVE,
         include_values_seen=False,
         denylist=None,
         tenant_ids=None,
     ):
-        assert status is TagKeyStatus.VISIBLE
+        assert status is TagKeyStatus.ACTIVE
         return self.__get_tag_keys(
             project_id,
             None,
@@ -432,7 +432,7 @@ class SnubaTagStorage(TagStorage):
         environments,
         start,
         end,
-        status=TagKeyStatus.VISIBLE,
+        status=TagKeyStatus.ACTIVE,
         use_cache=False,
         include_transactions=False,
         tenant_ids=None,

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -39,7 +39,7 @@ class TagKey(TagType):
     _sort_key = "values_seen"
 
     def __init__(
-        self, key, values_seen=None, status=TagKeyStatus.VISIBLE, count=None, top_values=None
+        self, key, values_seen=None, status=TagKeyStatus.ACTIVE, count=None, top_values=None
     ):
         self.key = key
         self.values_seen = values_seen

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -101,7 +101,7 @@ class ProjectTagKeyDeleteTest(APITestCase):
 
         assert (
             tagstore.get_tag_key(
-                project.id, None, "environment", status=TagKeyStatus.VISIBLE  # environment_id
+                project.id, None, "environment", status=TagKeyStatus.ACTIVE  # environment_id
             ).status
-            == TagKeyStatus.VISIBLE
+            == TagKeyStatus.ACTIVE
         )


### PR DESCRIPTION
This is the only other enum-like thing that wasn't using ACTIVE in a
consistent manor to everything else.