### PR TITLE
feat(starfish): update top charts in db module to be transaction based

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
@@ -11,12 +11,17 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {
+  useGetTransactionsForTables,
   useQueryDbOperations,
   useQueryDbTables,
   useQueryTopDbOperationsChart,
   useQueryTopTablesChart,
 } from 'sentry/views/starfish/modules/databaseModule/queries';
-import {datetimeToClickhouseFilterTimestamps} from 'sentry/views/starfish/utils/dates';
+import {queryToSeries} from 'sentry/views/starfish/modules/databaseModule/utils';
+import {
+  datetimeToClickhouseFilterTimestamps,
+  getDateFilters,
+} from 'sentry/views/starfish/utils/dates';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
 const INTERVAL = 12;
@@ -49,6 +54,7 @@ function parseOptions(options, label) {
 
 export default function APIModuleView({action, table, onChange}: Props) {
   const pageFilter = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilter);
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(
     pageFilter.selection.datetime
   );
@@ -87,6 +93,26 @@ export default function APIModuleView({action, table, onChange}: Props) {
       });
     });
   }
+
+  const tableNames = [...new Set(tableGraphData.map(d => d.domain))];
+  const {isLoading: isTopTransactionDataLoading, data: topTransactionsData} =
+    useGetTransactionsForTables(tableNames, INTERVAL);
+
+  const tpmTransactionSeries = queryToSeries(
+    topTransactionsData,
+    'transaction',
+    'count',
+    startTime,
+    endTime
+  );
+
+  const p75TransactionSeries = queryToSeries(
+    topTransactionsData,
+    'transaction',
+    'p75',
+    startTime,
+    endTime
+  );
 
   const topDomains = Object.values(seriesByDomain).map(series =>
     zeroFillSeries(
@@ -132,35 +158,18 @@ export default function APIModuleView({action, table, onChange}: Props) {
     });
   }
 
-  const tpmData = Object.values(tpmByQuery).map(series =>
-    zeroFillSeries(
-      series,
-      moment.duration(INTERVAL, 'hours'),
-      moment(start_timestamp),
-      moment(end_timestamp)
-    )
-  );
-  const topData = Object.values(seriesByQuery).map(series =>
-    zeroFillSeries(
-      series,
-      moment.duration(INTERVAL, 'hours'),
-      moment(start_timestamp),
-      moment(end_timestamp)
-    )
-  );
-
   return (
     <Fragment>
       <ChartsContainer>
         <ChartsContainerItem>
-          <ChartPanel title={t('Slowest Operations P75')}>
+          <ChartPanel title={t('Top Transactions P75')}>
             <Chart
               statsPeriod="24h"
               height={180}
-              data={topData}
+              data={p75TransactionSeries}
               start=""
               end=""
-              loading={isTopGraphLoading}
+              loading={isTopTransactionDataLoading}
               utc={false}
               grid={{
                 left: '0',
@@ -175,14 +184,14 @@ export default function APIModuleView({action, table, onChange}: Props) {
           </ChartPanel>
         </ChartsContainerItem>
         <ChartsContainerItem>
-          <ChartPanel title={t('Operation Throughput')}>
+          <ChartPanel title={t('Top Transactions Throughput')}>
             <Chart
               statsPeriod="24h"
               height={180}
-              data={tpmData}
+              data={tpmTransactionSeries}
               start=""
               end=""
-              loading={isTopGraphLoading}
+              loading={isTopTransactionDataLoading}
               utc={false}
               grid={{
                 left: '0',

--- a/static/app/views/starfish/modules/databaseModule/panel/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel/index.tsx
@@ -24,6 +24,7 @@ import {
   useQueryPanelTable,
   useQueryTransactionByTPMAndP75,
 } from 'sentry/views/starfish/modules/databaseModule/queries';
+import {queryToSeries} from 'sentry/views/starfish/modules/databaseModule/utils';
 import {getDateFilters} from 'sentry/views/starfish/utils/dates';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
@@ -358,30 +359,6 @@ const throughputQueryToChartData = (
     zeroFillSeries(countSeries, moment.duration(INTERVAL, 'hours'), startTime, endTime),
     zeroFillSeries(p75Series, moment.duration(INTERVAL, 'hours'), startTime, endTime),
   ];
-};
-
-const queryToSeries = (
-  data: (Record<string, any> & {interval: string})[],
-  groupByProperty: string,
-  seriesValueProperty: string,
-  startTime: moment.Moment,
-  endTime: moment.Moment
-): Series[] => {
-  const seriesMap: Record<string, Series> = {};
-
-  data.forEach(row => {
-    const dataEntry = {value: row[seriesValueProperty], name: row.interval};
-    if (!seriesMap[row[groupByProperty]]) {
-      seriesMap[row[groupByProperty]] = {
-        seriesName: row[groupByProperty],
-        data: [],
-      };
-    }
-    seriesMap[row[groupByProperty]].data.push(dataEntry);
-  });
-  return Object.values(seriesMap).map(series =>
-    zeroFillSeries(series, moment.duration(INTERVAL, 'hours'), startTime, endTime)
-  );
 };
 
 const SubHeader = styled('h3')`

--- a/static/app/views/starfish/modules/databaseModule/utils.ts
+++ b/static/app/views/starfish/modules/databaseModule/utils.ts
@@ -1,0 +1,30 @@
+import moment from 'moment';
+
+import {Series} from 'sentry/types/echarts';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
+
+const INTERVAL = 12;
+
+export const queryToSeries = (
+  data: (Record<string, any> & {interval: string})[],
+  groupByProperty: string,
+  seriesValueProperty: string,
+  startTime: moment.Moment,
+  endTime: moment.Moment
+): Series[] => {
+  const seriesMap: Record<string, Series> = {};
+
+  data.forEach(row => {
+    const dataEntry = {value: row[seriesValueProperty], name: row.interval};
+    if (!seriesMap[row[groupByProperty]]) {
+      seriesMap[row[groupByProperty]] = {
+        seriesName: row[groupByProperty],
+        data: [],
+      };
+    }
+    seriesMap[row[groupByProperty]].data.push(dataEntry);
+  });
+  return Object.values(seriesMap).map(series =>
+    zeroFillSeries(series, moment.duration(INTERVAL, 'hours'), startTime, endTime)
+  );
+};


### PR DESCRIPTION
This PR updates the top charts to be
![image](https://user-images.githubusercontent.com/44422760/236333932-257b15b0-1a4d-4570-94bb-6b59d40f54f5.png)

1. Top right - Top transactions by p75
2. Top left - Top transactions by throughput

The purpose of this change is to allow the user to easily correlate a db query throughput change or a table throughput change to just a overall throughput change

If someone could double check my queries, that would be great!