### PR TITLE
fix(issue-details): update loading state for issue tracking

### DIFF
--- a/static/app/components/group/externalIssuesList.tsx
+++ b/static/app/components/group/externalIssuesList.tsx
@@ -248,7 +248,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
   renderLoading() {
     return (
       <SidebarSection.Wrap data-test-id="linked-issues">
-        <SidebarSection.Title>{t('Linked Issues')}</SidebarSection.Title>
+        <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
         <SidebarSection.Content>
           <Placeholder height="120px" />
         </SidebarSection.Content>


### PR DESCRIPTION
this pr updates the loading state for the issue tracking section on the sidebar. right now, it says Linked Issues, even though when rendered it will say Issue Tracking leading to a very brief (but noticeable) flash of Linked Issues before saying Issue Tracking