### PR TITLE
feat(replays): Auto-dismiss the Replay>Network `req resp bodies are available` after the user sets them up

### DIFF
--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -40,7 +40,7 @@ export function ReqRespBodiesAlert({
           xhr: <code>xhr</code>,
           link: (
             <ExternalLink
-              href="https://github.com/getsentry/sentry-javascript/issues/7103"
+              href="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details"
               onClick={dismiss}
             >
               {t('Learn More')}
@@ -51,7 +51,7 @@ export function ReqRespBodiesAlert({
     : tct('Start collecting the body of requests and responses. [link]', {
         link: (
           <ExternalLink
-            href="https://github.com/getsentry/sentry-javascript/issues/7103"
+            href="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details"
             onClick={dismiss}
           >
             {t('Learn More')}

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -1,15 +1,87 @@
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import ExternalLink from 'sentry/components/links/externalLink';
+import {IconClose, IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectSdkNeedsUpdate from 'sentry/utils/useProjectSdkNeedsUpdate';
 import {Output} from 'sentry/views/replays/detail/network/details/getOutputType';
 import type {TabKey} from 'sentry/views/replays/detail/network/details/tabs';
 import type {NetworkSpan} from 'sentry/views/replays/types';
+
+export const useDismissReqRespBodiesAlert = () => {
+  const organization = useOrganization();
+  return useDismissAlert({
+    key: `${organization.id}:replay-network-bodies-alert-dismissed`,
+  });
+};
+
+export function ReqRespBodiesAlert({
+  isNetworkDetailsSetup,
+}: {
+  isNetworkDetailsSetup: boolean;
+}) {
+  const {dismiss, isDismissed} = useDismissReqRespBodiesAlert();
+
+  if (isDismissed) {
+    return null;
+  }
+
+  const message = isNetworkDetailsSetup
+    ? tct(
+        'Click on a [fetch] or [xhr] request to see request and response payloads. [link]',
+        {
+          fetch: <code>fetch</code>,
+          xhr: <code>xhr</code>,
+          link: (
+            <ExternalLink
+              href="https://github.com/getsentry/sentry-javascript/issues/7103"
+              onClick={dismiss}
+            >
+              {t('Learn More')}
+            </ExternalLink>
+          ),
+        }
+      )
+    : tct('Start collecting the body of requests and responses. [link]', {
+        link: (
+          <ExternalLink
+            href="https://github.com/getsentry/sentry-javascript/issues/7103"
+            onClick={dismiss}
+          >
+            {t('Learn More')}
+          </ExternalLink>
+        ),
+      });
+  return (
+    <StyledAlert
+      icon={<IconInfo />}
+      opaque={false}
+      showIcon
+      type="info"
+      trailingItems={
+        <StyledButton priority="link" size="sm" onClick={dismiss}>
+          <IconClose color="gray500" size="sm" />
+        </StyledButton>
+      }
+    >
+      {message}
+    </StyledAlert>
+  );
+}
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(1)};
+`;
+
+const StyledButton = styled(Button)`
+  color: inherit;
+`;
 
 export function UnsupportedOp({type}: {type: 'headers' | 'bodies'}) {
   const title =

--- a/static/app/views/replays/detail/network/details/sections.tsx
+++ b/static/app/views/replays/detail/network/details/sections.tsx
@@ -102,14 +102,14 @@ export function QueryParamsSection({item}: SectionProps) {
 }
 
 export function RequestPayloadSection({item}: SectionProps) {
-  const {dismiss} = useDismissReqRespBodiesAlert();
+  const {dismiss, isDismissed} = useDismissReqRespBodiesAlert();
 
   const hasRequest = 'request' in item.data;
   useEffect(() => {
-    if (hasRequest) {
+    if (!isDismissed && hasRequest) {
       dismiss();
     }
-  }, [dismiss, hasRequest]);
+  }, [dismiss, hasRequest, isDismissed]);
 
   return (
     <SectionItem
@@ -133,14 +133,14 @@ export function RequestPayloadSection({item}: SectionProps) {
 }
 
 export function ResponsePayloadSection({item}: SectionProps) {
-  const {dismiss} = useDismissReqRespBodiesAlert();
+  const {dismiss, isDismissed} = useDismissReqRespBodiesAlert();
 
   const hasResponse = 'response' in item.data;
   useEffect(() => {
-    if (hasResponse) {
+    if (!isDismissed && hasResponse) {
       dismiss();
     }
-  }, [dismiss, hasResponse]);
+  }, [dismiss, hasResponse, isDismissed]);
 
   return (
     <SectionItem

--- a/static/app/views/replays/detail/network/details/sections.tsx
+++ b/static/app/views/replays/detail/network/details/sections.tsx
@@ -1,4 +1,4 @@
-import {Fragment, MouseEvent} from 'react';
+import {Fragment, MouseEvent, useEffect} from 'react';
 import queryString from 'query-string';
 
 import {Button} from 'sentry/components/button';
@@ -14,6 +14,7 @@ import {
   SizeTooltip,
   Warning,
 } from 'sentry/views/replays/detail/network/details/components';
+import {useDismissReqRespBodiesAlert} from 'sentry/views/replays/detail/network/details/onboarding';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 import type {NetworkSpan} from 'sentry/views/replays/types';
 
@@ -101,7 +102,15 @@ export function QueryParamsSection({item}: SectionProps) {
 }
 
 export function RequestPayloadSection({item}: SectionProps) {
+  const {dismiss} = useDismissReqRespBodiesAlert();
+
   const hasRequest = 'request' in item.data;
+  useEffect(() => {
+    if (hasRequest) {
+      dismiss();
+    }
+  }, [dismiss, hasRequest]);
+
   return (
     <SectionItem
       title={t('Request Payload')}
@@ -124,7 +133,14 @@ export function RequestPayloadSection({item}: SectionProps) {
 }
 
 export function ResponsePayloadSection({item}: SectionProps) {
+  const {dismiss} = useDismissReqRespBodiesAlert();
+
   const hasResponse = 'response' in item.data;
+  useEffect(() => {
+    if (hasResponse) {
+      dismiss();
+    }
+  }, [dismiss, hasResponse]);
 
   return (
     <SectionItem

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -3,21 +3,16 @@ import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualiz
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
-import {Alert} from 'sentry/components/alert';
-import {Button} from 'sentry/components/button';
-import ExternalLink from 'sentry/components/links/externalLink';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {IconClose, IconInfo} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
-import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import useUrlParams from 'sentry/utils/useUrlParams';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import NetworkDetails from 'sentry/views/replays/detail/network/details';
+import {ReqRespBodiesAlert} from 'sentry/views/replays/detail/network/details/onboarding';
 import NetworkFilters from 'sentry/views/replays/detail/network/networkFilters';
 import NetworkHeaderCell, {
   COLUMN_COUNT,
@@ -57,7 +52,6 @@ function NetworkList({
   const {currentTime, currentHoverTime} = useReplayContext();
 
   const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
-  const {dismiss, isDismissed} = useDismissAlert({key: 'replay-network-bodies'});
 
   const filterProps = useNetworkFilters({networkSpans: networkSpans || []});
   const {items: filteredItems, searchTerm, setSearchTerm} = filterProps;
@@ -167,30 +161,7 @@ function NetworkList({
         organization={organization}
         renderDisabled={false}
       >
-        {isDismissed ? null : (
-          <StyledAlert
-            icon={<IconInfo />}
-            opaque={false}
-            showIcon
-            type="info"
-            trailingItems={
-              <StyledButton priority="link" size="sm" onClick={dismiss}>
-                <IconClose color="gray500" size="sm" />
-              </StyledButton>
-            }
-          >
-            {tct('Start collecting the body of requests and responses. [link]', {
-              link: (
-                <ExternalLink
-                  href="https://github.com/getsentry/sentry-javascript/issues/7103"
-                  onClick={dismiss}
-                >
-                  {t('Learn More')}
-                </ExternalLink>
-              ),
-            })}
-          </StyledAlert>
-        )}
+        <ReqRespBodiesAlert isNetworkDetailsSetup={isNetworkDetailsSetup} />
       </Feature>
       <NetworkTable ref={containerRef}>
         <SplitPanel
@@ -314,14 +285,6 @@ const NetworkTable = styled(FluidHeight)`
     bottom: 0;
     width: 999999999%;
   }
-`;
-
-const StyledAlert = styled(Alert)`
-  margin-bottom: ${space(1)};
-`;
-
-const StyledButton = styled(Button)`
-  color: inherit;
 `;
 
 export default NetworkList;


### PR DESCRIPTION
**First** we show the promo message:
![SCR-20230504-ngxr](https://user-images.githubusercontent.com/187460/236338951-00ac2a63-afa8-40e2-a993-b079cc84b85e.png)

**After there is data** we show the how-to-use messagae:
![SCR-20230504-ngyx](https://user-images.githubusercontent.com/187460/236339024-5e9a3cf6-d5a5-4a9d-9d2e-dcca839d708b.png)

And once they click into the request or response tab (when the tab has data, not just for any row in the list) then we will dismiss the alert so it won't appear next time they load a page.

Auto-dismissing the alert will not cause a re-render! So the alert stays up after they did the correct click. 

Fixes https://github.com/getsentry/sentry/issues/48576