### PR TITLE
ref(replay): cta link to docs instead of github

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -182,7 +182,7 @@ function NetworkList({
             {tct('Start collecting the body of requests and responses. [link]', {
               link: (
                 <ExternalLink
-                  href="https://github.com/getsentry/sentry-javascript/issues/7103"
+                  href="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details"
                   onClick={dismiss}
                 >
                   {t('Learn More')}


### PR DESCRIPTION
We have docs merged in! Lets point to it.

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
