### PR TITLE
fix(starfish): Use timestamp now its available on spans

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -104,7 +104,7 @@ SPAN_COLUMN_MAP = {
     "span.self_time": "exclusive_time",
     "span.op": "op",
     "span.status": "span_status",
-    "timestamp": "end_timestamp",
+    "timestamp": "timestamp",
     "trace": "trace_id",
     "transaction": "segment_name",
     "transaction.id": "transaction_id",


### PR DESCRIPTION
- This uses the timestamp field now its available on the spans table
- Fixes SENTRY-10ZG