### PR TITLE
feat(auth): bump sso expiry to 7 days

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -30,7 +30,7 @@ MFA_SESSION_KEY = "mfa"
 
 def _sso_expiry_from_env(seconds: str | None) -> timedelta:
     if seconds is None:
-        return timedelta(hours=20)
+        return timedelta(days=7)
     return timedelta(seconds=int(seconds))
 
 

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -151,7 +151,7 @@ class LoginTest(TestCase):
 def test_sso_expiry_default():
     value = sentry.utils.auth._sso_expiry_from_env(None)
     # make sure no accidental changes affect sso timeout
-    assert value == timedelta(hours=20)
+    assert value == timedelta(days=7)
 
 
 def test_sso_expiry_from_env():


### PR DESCRIPTION
- allow an identity to be valid for 7 days