### PR TITLE
fix(hc): Clean up imports on RPC interface definitions

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -5,8 +5,6 @@ from django.db.models import Max, prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.rule import RuleSerializer
-from sentry.incidents.endpoints.utils import translate_threshold
-from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.models import (
     AlertRule,
     AlertRuleActivity,
@@ -137,6 +135,9 @@ class AlertRuleSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
+        from sentry.incidents.endpoints.utils import translate_threshold
+        from sentry.incidents.logic import translate_aggregate_field
+
         env = obj.snuba_query.environment
         # Temporary: Translate aggregate back here from `tags[sentry:user]` to `user` for the frontend.
         aggregate = translate_aggregate_field(obj.snuba_query.aggregate, reverse=True)

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -5,7 +5,17 @@ import logging
 import sys
 from collections import namedtuple
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Mapping, MutableMapping, Optional, Sequence, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    FrozenSet,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Type,
+)
 from urllib.request import Request
 
 from sentry import audit_log
@@ -14,7 +24,6 @@ from sentry.exceptions import InvalidIdentity
 from sentry.models import ExternalActor, Identity, Integration, Organization, Team
 from sentry.pipeline import PipelineProvider
 from sentry.pipeline.views.base import PipelineView
-from sentry.services.hybrid_cloud.integration import RpcOrganizationIntegration, integration_service
 from sentry.shared_integrations.constants import (
     ERR_INTERNAL,
     ERR_UNAUTHORIZED,
@@ -29,6 +38,9 @@ from sentry.shared_integrations.exceptions import (
     UnsupportedResponseType,
 )
 from sentry.utils.audit import create_audit_entry
+
+if TYPE_CHECKING:
+    from sentry.services.hybrid_cloud.integration import RpcOrganizationIntegration
 
 FeatureDescription = namedtuple(
     "FeatureDescription",
@@ -270,6 +282,8 @@ class IntegrationInstallation:
 
     @property
     def org_integration(self) -> RpcOrganizationIntegration | None:
+        from sentry.services.hybrid_cloud.integration import integration_service
+
         if not hasattr(self, "_org_integration"):
             self._org_integration = integration_service.get_organization_integration(
                 integration_id=self.model.id,
@@ -295,6 +309,8 @@ class IntegrationInstallation:
         """
         Update the configuration field for an organization integration.
         """
+        from sentry.services.hybrid_cloud.integration import integration_service
+
         if not self.org_integration:
             return
 

--- a/src/sentry/models/integrations/organization_integrity_backfill_mixin.py
+++ b/src/sentry/models/integrations/organization_integrity_backfill_mixin.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from sentry.services.hybrid_cloud.integration import integration_service
-
 
 class OrganizationIntegrityBackfillMixin:
     organization_integration_id: Any
@@ -14,6 +12,8 @@ class OrganizationIntegrityBackfillMixin:
     integration_id: Any
 
     def save(self, *args, **kwds) -> None:
+        from sentry.services.hybrid_cloud.integration import integration_service
+
         if self.organization_id is None or self.integration_id is None:
             # Find the original org integration instance, backfill in the identifiers.
             org_integrations = integration_service.get_organization_integrations(

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -28,18 +28,17 @@ from rest_framework.request import Request
 
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry.services.hybrid_cloud import RpcModel
+from sentry.services.hybrid_cloud.organization import (
+    RpcOrganization,
+    RpcOrganizationMember,
+    RpcOrganizationMemberSummary,
+)
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser
-
-    from sentry.services.hybrid_cloud.organization import (
-        RpcOrganization,
-        RpcOrganizationMember,
-        RpcOrganizationMemberSummary,
-    )
 
 
 class RpcAuthenticatorType(IntEnum):
@@ -341,7 +340,7 @@ class AuthService(RpcService):
         user_id: int,
         is_superuser: bool,
         organization_id: Optional[int],
-        org_member: Optional["RpcOrganizationMemberSummary"],
+        org_member: Optional[RpcOrganizationMemberSummary],
     ) -> RpcAuthState:
         pass
 
@@ -371,10 +370,10 @@ class AuthService(RpcService):
         self,
         *,
         request: Request,
-        organization: "RpcOrganization",
+        organization: RpcOrganization,
         auth_identity: RpcAuthIdentity,
         auth_provider: RpcAuthProvider,
-    ) -> Tuple[RpcUser, "RpcOrganizationMember"]:
+    ) -> Tuple[RpcUser, RpcOrganizationMember]:
         pass
 
     @rpc_method

--- a/src/sentry/services/hybrid_cloud/integration/__init__.py
+++ b/src/sentry/services/hybrid_cloud/integration/__init__.py
@@ -5,22 +5,20 @@
 
 from abc import abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union, cast
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.base import (
+    IntegrationFeatures,
+    IntegrationInstallation,
+    IntegrationProvider,
+)
 from sentry.models.integrations import Integration, OrganizationIntegration
 from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs, RpcPaginationResult
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.silo import SiloMode
-
-if TYPE_CHECKING:
-    from sentry.integrations.base import (
-        IntegrationFeatures,
-        IntegrationInstallation,
-        IntegrationProvider,
-    )
 
 
 class RpcIntegration(RpcModel):
@@ -34,7 +32,7 @@ class RpcIntegration(RpcModel):
     def __hash__(self) -> int:
         return hash(self.id)
 
-    def get_provider(self) -> "IntegrationProvider":
+    def get_provider(self) -> IntegrationProvider:
         from sentry import integrations
 
         return integrations.get(self.provider)  # type: ignore
@@ -305,7 +303,7 @@ class IntegrationService(RpcService):
         *,
         integration: Union[RpcIntegration, Integration],
         organization_id: int,
-    ) -> "IntegrationInstallation":
+    ) -> IntegrationInstallation:
         """
         Returns the IntegrationInstallation class for a given integration.
         Intended to replace calls of `integration.get_installation`.
@@ -314,14 +312,14 @@ class IntegrationService(RpcService):
         from sentry import integrations
 
         provider = integrations.get(integration.provider)
-        installation: "IntegrationInstallation" = provider.get_installation(
+        installation: IntegrationInstallation = provider.get_installation(
             model=integration,
             organization_id=organization_id,
         )
         return installation
 
     @rpc_method
-    def has_feature(self, *, provider: str, feature: "IntegrationFeatures") -> bool:
+    def has_feature(self, *, provider: str, feature: IntegrationFeatures) -> bool:
         """
         Returns True if the IntegrationProvider subclass contains a given feature
         Intended to replace calls of `integration.has_feature`.
@@ -329,7 +327,7 @@ class IntegrationService(RpcService):
         """
         from sentry import integrations
 
-        int_provider: "IntegrationProvider" = integrations.get(provider)
+        int_provider: IntegrationProvider = integrations.get(provider)
         return feature in int_provider.features
 
     @rpc_method

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -77,7 +77,11 @@ class RpcMethodSignature:
 
         def create_field(param: inspect.Parameter) -> Tuple[Any, Any]:
             if param.annotation is param.empty:
-                raise RpcServiceSetupException("Type hints are required on RPC methods")
+                raise RpcServiceSetupException("Type annotations are required on RPC methods")
+            if isinstance(param.annotation, str):
+                raise RpcServiceSetupException(
+                    "Type annotations on RPC methods must be actual type tokens, not strings"
+                )
 
             default_value = ... if param.default is param.empty else param.default
             return param.annotation, default_value

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -19,7 +19,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
-from sentry.api.serializers import serialize
 from sentry.api.utils import generate_organization_url, is_member_disabled_from_limit
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
@@ -607,6 +606,8 @@ class ProjectView(RegionSiloOrganizationView):
     """
 
     def get_context_data(self, request: Request, organization: Organization, project: Project, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
+        from sentry.api.serializers import serialize
+
         context = super().get_context_data(request, organization)
         context["project"] = project
         context["processing_issues"] = serialize(project).get("processingIssues", 0)


### PR DESCRIPTION
Make type annotations visible to Pydantic. Resolve circular import problems that previously prevented this.