### PR TITLE
Add metrics around JS symbolication

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -9,6 +9,7 @@ from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models import EventError
 from sentry.stacktraces.processing import find_stacktraces_in_data
+from sentry.utils import metrics
 from sentry.utils.http import get_origins
 from sentry.utils.safe import get_path
 
@@ -183,7 +184,10 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         for sinfo in stacktrace_infos
     ]
 
+    metrics.incr("sourcemaps.symbolicator.events")
+
     if not any(stacktrace["frames"] for stacktrace in stacktraces):
+        metrics.incr("sourcemaps.symbolicator.events.skipped")
         return
 
     response = symbolicator.process_js(


### PR DESCRIPTION
There is currently a big discrepancy between events going through the symbolicate_js task, and ones that end up being sent to symbolicator. To clear that up, this adds some more explicit metrics for events that will be sent to symbolicator from JS, and those that are being skipped because they contain no actionable stack traces.

Otherwise cleans up some A/B test comments, and filtering of python frames, as the symbolicator stacktraces should also contain filtered out frames.