### PR TITLE
Fix double-sampling of `symbolicate_js` events

### DIFF
--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -139,15 +139,14 @@ def _do_symbolicate_event(
         )
 
     if data["platform"] in ("javascript", "node"):
-        from sentry.lang.javascript.processing import (
-            get_js_symbolication_function as get_symbolication_function,
-        )
-    else:
-        from sentry.lang.native.processing import (
-            get_native_symbolication_function as get_symbolication_function,
-        )
+        from sentry.lang.javascript.processing import process_js_stacktraces
 
-    symbolication_function = get_symbolication_function(data)
+        symbolication_function = process_js_stacktraces
+    else:
+        from sentry.lang.native.processing import get_native_symbolication_function
+
+        symbolication_function = get_native_symbolication_function(data)
+
     symbolication_function_name = getattr(symbolication_function, "__name__", "none")
 
     if killswitch_matches_context(


### PR DESCRIPTION
We applied a sampling rate to route events to the `symbolicate_event` queue / task, and then applied that sample rate again inside that task again, which was not correct.