### PR TITLE
fix(notifications) Pass user_id into more notification writes

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -129,8 +129,12 @@ class NotificationSetting(Model):
     )
 
     def save(self, *args, **kwargs):
-        if self.user_id is None and self.team_id is None:
-            sentry_sdk.capture_exception(AssertionError("Notification setting missing user & team"))
+        try:
+            assert (
+                self.user_id is not None and self.team_id is not None
+            ), "Notification setting missing user & team"
+        except AssertionError as err:
+            sentry_sdk.capture_exception(err)
         super().save(*args, **kwargs)
 
 

--- a/tests/sentry/integrations/slack/test_uninstall.py
+++ b/tests/sentry/integrations/slack/test_uninstall.py
@@ -100,6 +100,18 @@ class SlackUninstallTest(APITestCase):
         self.assert_settings(ExternalProviders.EMAIL, NotificationSettingOptionValues.NEVER)
         self.assert_settings(ExternalProviders.SLACK, NotificationSettingOptionValues.NEVER)
 
+    def test_uninstall_generates_settings_with_userid(self):
+        self.uninstall()
+
+        self.assert_settings(ExternalProviders.SLACK, NotificationSettingOptionValues.NEVER)
+        # Ensure uninstall sets user_id.
+        settings = NotificationSetting.objects.find_settings(
+            provider=ExternalProviders.SLACK,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+        )
+        assert settings[0].user_id == self.user.id
+
     def test_uninstall_with_multiple_organizations(self):
         organization = self.create_organization(owner=self.user)
         integration = self.create_slack_integration(organization, "TXXXXXXX2")


### PR DESCRIPTION
We missed some notification writes, and we're getting notification settings without user_id or team_id. This closes off one of those paths.

Refs SENTRY-10ZK