### PR TITLE
fix: Broken global tags in arroyo and cardinality limiter

### DIFF
--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -2,11 +2,19 @@ __all__ = ["MetricsBackend"]
 
 from random import random
 from threading import local
-from typing import Any, Mapping, Optional, Union
+from typing import Mapping, MutableMapping, Optional, Union
 
 from django.conf import settings
 
-Tags = Mapping[str, Any]
+# Note: One can pass a lot without TypeErrors, but some values such as None
+# don't actually get serialized as tags properly all the way to statsd (they
+# just get lost)
+# We still loosely type here because we have too many places where we send None
+# for a tag value, and sometimes even keys. It doesn't cause real bugs, your
+# monitoring is just slightly broken.
+TagValue = Union[str, int, float, None]
+Tags = Mapping[str, TagValue]
+MutableTags = MutableMapping[str, TagValue]
 
 
 class MetricsBackend(local):

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -1,0 +1,158 @@
+from contextlib import contextmanager
+from threading import local
+from typing import Generator, List, Optional, Union
+
+from django.conf import settings
+
+from sentry.metrics.base import MetricsBackend, MutableTags, Tags, TagValue
+
+_BAD_TAGS = frozenset(["event", "project", "group"])
+_METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(
+    [
+        # snuba related tags
+        "process_message",
+        "commit_log_msg_latency",
+        "commit_log_latency",
+        "process_message.normalized",
+        "batching_consumer.batch.size",
+        "batching_consumer.batch.flush",
+        "batching_consumer.batch.flush.normalized",
+    ]
+)
+
+
+class BadMetricTags(RuntimeError):
+    pass
+
+
+def _filter_tags(key: str, tags: MutableTags) -> MutableTags:
+    """Removes unwanted tags from the tag mapping and returns a filtered one."""
+    if key in _METRICS_THAT_CAN_HAVE_BAD_TAGS:
+        return tags
+
+    discarded = frozenset(key for key in tags if key.endswith("_id") or key in _BAD_TAGS)
+    if not discarded:
+        return tags
+
+    if settings.SENTRY_METRICS_DISALLOW_BAD_TAGS:
+        raise BadMetricTags(
+            f"discarded illegal metric tags: {sorted(discarded)} for metric {key!r}"
+        )
+    return {k: v for k, v in tags.items() if k not in discarded}
+
+
+_THREAD_LOCAL_TAGS = local()
+_GLOBAL_TAGS: List[Tags] = []
+
+
+def _add_global_tags(_all_threads: bool = False, **tags: TagValue) -> List[Tags]:
+    if _all_threads:
+        stack = _GLOBAL_TAGS
+    else:
+        if not hasattr(_THREAD_LOCAL_TAGS, "stack"):
+            stack = _THREAD_LOCAL_TAGS.stack = []
+        else:
+            stack = _THREAD_LOCAL_TAGS.stack
+
+    stack.append(tags)
+    return stack
+
+
+def add_global_tags(_all_threads: bool = False, **tags: TagValue) -> None:
+    """
+    Set multiple metric tags onto the global or thread-local stack which then
+    apply to all metrics.
+
+    When used in combination with the `global_tags` context manager,
+    `add_global_tags` is reverted in any wrapping invocaation of `global_tags`.
+    For example::
+
+        with global_tags(tag_a=123):
+            add_global_tags(tag_b=123)
+
+        # tag_b is no longer visible
+    """
+    _add_global_tags(_all_threads=_all_threads, **tags)
+
+
+@contextmanager
+def global_tags(_all_threads: bool = False, **tags: TagValue) -> Generator[None, None, None]:
+    """
+    The context manager version of `add_global_tags` that reverts all tag
+    changes upon exit.
+
+    See docstring of `add_global_tags` for how those two methods interact.
+    """
+    stack = _add_global_tags(_all_threads=_all_threads, **tags)
+    old_len = len(stack) - 1
+
+    try:
+        yield
+    finally:
+        del stack[old_len:]
+
+
+def _get_current_global_tags() -> MutableTags:
+    rv: MutableTags = {}
+
+    for tags in _GLOBAL_TAGS:
+        rv.update(tags)
+
+    for tags in getattr(_THREAD_LOCAL_TAGS, "stack", None) or ():
+        rv.update(tags)
+
+    return rv
+
+
+class MiddlewareWrapper(MetricsBackend):
+    """
+    A wrapper around any metrics backend implementing tags denylisting and global tag context.
+    """
+
+    def __init__(self, inner: MetricsBackend) -> None:
+        self.inner = inner
+
+    def incr(
+        self,
+        key: str,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        amount: Union[float, int] = 1,
+        sample_rate: float = 1,
+    ) -> None:
+        current_tags = _get_current_global_tags()
+        if tags is not None:
+            current_tags.update(tags)
+        current_tags = _filter_tags(key, current_tags)
+
+        return self.inner.incr(key, instance, current_tags, amount, sample_rate)
+
+    def timing(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+    ) -> None:
+        current_tags = _get_current_global_tags()
+        if tags is not None:
+            current_tags.update(tags)
+        current_tags = _filter_tags(key, current_tags)
+
+        return self.inner.timing(key, value, instance, current_tags, sample_rate)
+
+    def gauge(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+    ) -> None:
+        current_tags = _get_current_global_tags()
+        if tags is not None:
+            current_tags.update(tags)
+        current_tags = _filter_tags(key, current_tags)
+
+        return self.inner.gauge(key, value, instance, current_tags, sample_rate)

--- a/tests/sentry/metrics/test_middleware.py
+++ b/tests/sentry/metrics/test_middleware.py
@@ -1,0 +1,40 @@
+import pytest
+from django.test import override_settings
+
+from sentry.metrics.middleware import (
+    BadMetricTags,
+    _filter_tags,
+    _get_current_global_tags,
+    add_global_tags,
+    global_tags,
+)
+
+
+def test_filter_tags_dev():
+    with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=True):
+        _filter_tags("x", {"foo": "bar"})
+        with pytest.raises(
+            BadMetricTags,
+            match=r"discarded illegal metric tags: \['event', 'foo_id', 'project'\] for metric 'x'",
+        ):
+            _filter_tags("x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22})
+
+
+def test_filter_tags_prod():
+    with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=False):
+        assert _filter_tags("x", {"foo": "bar"}) == {"foo": "bar"}
+        assert _filter_tags("x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22}) == {
+            "foo": "bar"
+        }
+
+
+def test_global():
+    assert _get_current_global_tags() == {}
+
+    with global_tags(tag_a=123):
+        assert _get_current_global_tags() == {"tag_a": 123}
+        add_global_tags(tag_b=123)
+
+        assert _get_current_global_tags() == {"tag_a": 123, "tag_b": 123}
+
+    assert _get_current_global_tags() == {}

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from django.test import override_settings
 
 from sentry.utils import metrics
 
@@ -45,33 +44,3 @@ def test_wraps():
         args, kwargs = timing.call_args
         assert args[0] == "key"
         assert args[3] == {"foo": True, "result": "success"}
-
-
-def test_global():
-    assert metrics._get_current_global_tags() == {}
-
-    with metrics.global_tags(tag_a=123):
-        assert metrics._get_current_global_tags() == {"tag_a": 123}
-        metrics.add_global_tags(tag_b=123)
-
-        assert metrics._get_current_global_tags() == {"tag_a": 123, "tag_b": 123}
-
-    assert metrics._get_current_global_tags() == {}
-
-
-def test_filter_tags_dev():
-    with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=True):
-        metrics._filter_tags("x", {"foo": "bar"})
-        with pytest.raises(
-            metrics.BadMetricTags,
-            match=r"discarded illegal metric tags: \['event', 'foo_id', 'project'\] for metric 'x'",
-        ):
-            metrics._filter_tags("x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22})
-
-
-def test_filter_tags_prod():
-    with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=False):
-        assert metrics._filter_tags("x", {"foo": "bar"}) == {"foo": "bar"}
-        assert metrics._filter_tags(
-            "x", {"foo": "bar", "foo_id": 42, "project": 42, "event": 22}
-        ) == {"foo": "bar"}


### PR DESCRIPTION
Both arroyo and sentry-redis-tools grab `sentry.utils.metrics.backend`
to send their metrics to. Unfortunately that backend class is not the
"correct" entrypoint to use from the application, because over time,
more and more "pre-processing" logic has accumulated in the module
`sentry.utils.metrics` that runs way before any metrics backend.

That means it's not possible to acquire an instance of MetricsBackend
that actually behaves the same as the functions in
`sentry.utils.metrics`, meaning metrics emitted from arroyo neither go
through the "bad tags" filter nor do they get global tags applied.

In order to close the gap, move (almost) all pre-processing logic from
global functions into a "wrapper" backend.

The alternative would be to write a backend singleton class that
delegates to the global functions. That would be a less invasive change,
but also a less unit-testable design.
