### PR TITLE
perf(group-event): Parallelize queries to get prev and next event IDs

### DIFF
--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from datetime import datetime
 from typing import Any, List
 
@@ -39,17 +38,10 @@ def wrap_event_response(request_user: Any, event: Event, project: Project, envir
         if environments:
             conditions.append(["environment", "IN", environments])
 
-        # Ignore any time params and search entire retention period
-        next_event_filter = deepcopy(_filter)
-        next_event_filter.end = datetime.utcnow()
-        next_event = eventstore.get_next_event_id(event, filter=next_event_filter)
+        prev_ids, next_ids = eventstore.get_prev_next_event_ids(event, filter=_filter)
 
-        prev_event_filter = deepcopy(_filter)
-        prev_event_filter.start = datetime.utcfromtimestamp(0)
-        prev_event = eventstore.get_prev_event_id(event, filter=prev_event_filter)
-
-        next_event_id = next_event[1] if next_event else None
-        prev_event_id = prev_event[1] if prev_event else None
+        next_event_id = next_ids[1] if next_ids else None
+        prev_event_id = prev_ids[1] if prev_ids else None
 
     event_data["nextEventID"] = next_event_id
     event_data["previousEventID"] = prev_event_id

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -38,7 +38,7 @@ def wrap_event_response(request_user: Any, event: Event, project: Project, envir
         if environments:
             conditions.append(["environment", "IN", environments])
 
-        prev_ids, next_ids = eventstore.get_prev_next_event_ids(event, filter=_filter)
+        prev_ids, next_ids = eventstore.get_adjacent_event_ids(event, filter=_filter)
 
         next_event_id = next_ids[1] if next_ids else None
         prev_event_id = prev_ids[1] if prev_ids else None

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -122,7 +122,7 @@ class EventStorage(Service):
         "get_event_by_id",
         "get_events",
         "get_unfetched_events",
-        "get_prev_next_event_ids",
+        "get_adjacent_event_ids",
         "bind_nodes",
         "get_unfetched_transactions",
     )
@@ -212,7 +212,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_prev_next_event_ids(self, event, snuba_filter):
+    def get_adjacent_event_ids(self, event, snuba_filter):
         """
         Gets the previous and next event IDs given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id) for (prev_ids, next_ids)

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -122,8 +122,7 @@ class EventStorage(Service):
         "get_event_by_id",
         "get_events",
         "get_unfetched_events",
-        "get_prev_event_id",
-        "get_next_event_id",
+        "get_prev_next_event_ids",
         "bind_nodes",
         "get_unfetched_transactions",
     )
@@ -213,21 +212,10 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_next_event_id(self, event, snuba_filter):
+    def get_prev_next_event_ids(self, event, snuba_filter):
         """
-        Gets the next event given a current event and some conditions/filters.
-        Returns a tuple of (project_id, event_id)
-
-        Arguments:
-        event (Event): Event object
-        snuba_filter (Filter): Filter
-        """
-        raise NotImplementedError
-
-    def get_prev_event_id(self, event, snuba_filter):
-        """
-        Gets the previous event given a current event and some conditions/filters.
-        Returns a tuple of (project_id, event_id)
+        Gets the previous and next event IDs given a current event and some conditions/filters.
+        Returns a tuple of (project_id, event_id) for (prev_ids, next_ids)
 
         Arguments:
         event (Event): Event object

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -278,7 +278,7 @@ class SnubaEventStorage(EventStorage):
         else:
             return snuba.Dataset.Discover
 
-    def get_prev_next_event_ids(self, event, filter):
+    def get_adjacent_event_ids(self, event, filter):
         """
         Returns (project_id, event_id) of a previous event given a current event
         and a filter. Returns None if no previous event is found.
@@ -286,7 +286,7 @@ class SnubaEventStorage(EventStorage):
         assert filter, "You must provide a filter"
 
         if not event:
-            return None
+            return (None, None)
 
         prev_filter = deepcopy(filter)
         prev_filter.conditions = prev_filter.conditions or []

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -1,7 +1,8 @@
 import logging
 import random
-from copy import deepcopy
+from copy import copy, deepcopy
 from datetime import datetime, timedelta
+from typing import Any, Mapping
 
 import sentry_sdk
 from django.utils import timezone
@@ -277,29 +278,7 @@ class SnubaEventStorage(EventStorage):
         else:
             return snuba.Dataset.Discover
 
-    def get_next_event_id(self, event, filter):
-        """
-        Returns (project_id, event_id) of a next event given a current event
-        and any filters/conditions. Returns None if no next event is found.
-        """
-        assert filter, "You must provide a filter"
-
-        if not event:
-            return None
-
-        filter = deepcopy(filter)
-        filter.conditions = filter.conditions or []
-        filter.conditions.extend(get_after_event_condition(event))
-        filter.start = event.datetime
-        dataset = self._get_dataset_for_event(event)
-        return self.__get_event_id_from_filter(
-            filter=filter,
-            orderby=ASC_ORDERING,
-            dataset=dataset,
-            tenant_ids={"organization_id": event.project.organization_id},
-        )
-
-    def get_prev_event_id(self, event, filter):
+    def get_prev_next_event_ids(self, event, filter):
         """
         Returns (project_id, event_id) of a previous event given a current event
         and a filter. Returns None if no previous event is found.
@@ -309,16 +288,25 @@ class SnubaEventStorage(EventStorage):
         if not event:
             return None
 
-        filter = deepcopy(filter)
-        filter.conditions = filter.conditions or []
-        filter.conditions.extend(get_before_event_condition(event))
+        prev_filter = deepcopy(filter)
+        prev_filter.conditions = prev_filter.conditions or []
+        prev_filter.conditions.extend(get_before_event_condition(event))
+        prev_filter.start = datetime.utcfromtimestamp(0)
         # the previous event can have the same timestamp, add 1 second
         # to the end condition since it uses a less than condition
-        filter.end = event.datetime + timedelta(seconds=1)
+        prev_filter.end = event.datetime + timedelta(seconds=1)
+        prev_filter.orderby = DESC_ORDERING
+
+        next_filter = deepcopy(filter)
+        next_filter.conditions = next_filter.conditions or []
+        next_filter.conditions.extend(get_after_event_condition(event))
+        next_filter.start = event.datetime
+        next_filter.end = datetime.utcnow()
+        next_filter.orderby = ASC_ORDERING
+
         dataset = self._get_dataset_for_event(event)
-        return self.__get_event_id_from_filter(
-            filter=filter,
-            orderby=DESC_ORDERING,
+        return self.__get_event_ids_from_filters(
+            filters=(prev_filter, next_filter),
             dataset=dataset,
             tenant_ids={"organization_id": event.project.organization_id},
         )
@@ -326,36 +314,46 @@ class SnubaEventStorage(EventStorage):
     def __get_columns(self, dataset: Dataset):
         return [col.value.event_name for col in EventStorage.minimal_columns[dataset]]
 
-    def __get_event_id_from_filter(
-        self, filter=None, orderby=None, dataset=snuba.Dataset.Discover, tenant_ids=None
+    def __get_event_ids_from_filters(
+        self, filters=(), dataset=snuba.Dataset.Discover, tenant_ids=None
     ):
         columns = [Columns.EVENT_ID.value.alias, Columns.PROJECT_ID.value.alias]
         try:
             # This query uses the discover dataset to enable
             # getting events across both errors and transactions, which is
             # required when doing pagination in discover
-            result = snuba.aliased_query(
-                selected_columns=columns,
-                conditions=filter.conditions,
-                filter_keys=filter.filter_keys,
-                start=filter.start,
-                end=filter.end,
-                limit=1,
+            results = snuba.bulk_raw_query(
+                [
+                    snuba.SnubaQueryParams(
+                        **snuba.aliased_query_params(
+                            selected_columns=copy(columns),
+                            conditions=filter.conditions,
+                            filter_keys=filter.filter_keys,
+                            start=filter.start,
+                            end=filter.end,
+                            orderby=filter.orderby,
+                            limit=1,
+                            referrer="eventstore.get_next_or_prev_event_id",
+                            dataset=dataset,
+                            tenant_ids=tenant_ids,
+                        )
+                    )
+                    for filter in filters
+                ],
                 referrer="eventstore.get_next_or_prev_event_id",
-                orderby=orderby,
-                dataset=dataset,
-                tenant_ids=tenant_ids,
             )
         except (snuba.QueryOutsideRetentionError, snuba.QueryOutsideGroupActivityError):
             # This can happen when the date conditions for paging
             # and the current event generate impossible conditions.
             return None
 
+        return [self.__get_event_id_from_result(result) for result in results]
+
+    def __get_event_id_from_result(self, result: Mapping[str, Any]):
         if "error" in result or len(result["data"]) == 0:
             return None
 
         row = result["data"][0]
-
         return (str(row["project_id"]), str(row["event_id"]))
 
     def __make_event(self, snuba_data):

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -211,12 +211,12 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
             event = self.eventstore.get_event_by_id(self.project2.id, "d" * 32)
             assert event is None
 
-    def test_get_prev_next_event_ids(self):
+    def test_get_adjacent_event_ids(self):
         event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
 
         _filter = Filter(project_ids=[self.project1.id, self.project2.id])
 
-        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_adjacent_event_ids(event, filter=_filter)
 
         assert prev_event == (str(self.project1.id), "a" * 32)
 
@@ -224,10 +224,13 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         assert next_event == (str(self.project2.id), "c" * 32)
 
         # Returns None if no event
-        assert self.eventstore.get_prev_event_id(None, filter=_filter) is None
-        assert self.eventstore.get_next_event_id(None, filter=_filter) is None
+        prev_event_none, next_event_none = self.eventstore.get_adjacent_event_ids(
+            None, filter=_filter
+        )
+        assert prev_event_none is None
+        assert next_event_none is None
 
-    def test_prev_next_event_ids_same_timestamp(self):
+    def test_adjacent_event_ids_same_timestamp(self):
         project = self.create_project()
 
         event1 = self.store_event(
@@ -264,14 +267,13 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
 
         event = self.eventstore.get_event_by_id(project.id, "a" * 32)
 
-        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_adjacent_event_ids(event, filter=_filter)
         assert prev_event is None
         assert next_event == (str(project.id), "b" * 32)
 
         event = self.eventstore.get_event_by_id(project.id, "b" * 32)
 
-        prev_event = self.eventstore.get_prev_event_id(event, filter=_filter)
-        next_event = self.eventstore.get_next_event_id(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_adjacent_event_ids(event, filter=_filter)
         assert prev_event == (str(project.id), "a" * 32)
         assert next_event is None
 
@@ -282,13 +284,13 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
             conditions=apply_performance_conditions([], group),
         )
         event = self.eventstore.get_event_by_id(self.project2.id, "f" * 32)
-        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_adjacent_event_ids(event, filter=_filter)
 
         assert prev_event == (str(self.project2.id), "e" * 32)
         assert next_event is None
 
         event = self.eventstore.get_event_by_id(self.project2.id, "e" * 32)
-        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_adjacent_event_ids(event, filter=_filter)
 
         assert prev_event is None
         assert next_event == (str(self.project2.id), "f" * 32)

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -211,14 +211,12 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
             event = self.eventstore.get_event_by_id(self.project2.id, "d" * 32)
             assert event is None
 
-    def test_get_next_prev_event_id(self):
+    def test_get_prev_next_event_ids(self):
         event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
 
         _filter = Filter(project_ids=[self.project1.id, self.project2.id])
 
-        prev_event = self.eventstore.get_prev_event_id(event, filter=_filter)
-
-        next_event = self.eventstore.get_next_event_id(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
 
         assert prev_event == (str(self.project1.id), "a" * 32)
 
@@ -229,7 +227,7 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         assert self.eventstore.get_prev_event_id(None, filter=_filter) is None
         assert self.eventstore.get_next_event_id(None, filter=_filter) is None
 
-    def test_next_prev_event_id_same_timestamp(self):
+    def test_prev_next_event_ids_same_timestamp(self):
         project = self.create_project()
 
         event1 = self.store_event(
@@ -266,8 +264,7 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
 
         event = self.eventstore.get_event_by_id(project.id, "a" * 32)
 
-        prev_event = self.eventstore.get_prev_event_id(event, filter=_filter)
-        next_event = self.eventstore.get_next_event_id(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
         assert prev_event is None
         assert next_event == (str(project.id), "b" * 32)
 
@@ -285,15 +282,13 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
             conditions=apply_performance_conditions([], group),
         )
         event = self.eventstore.get_event_by_id(self.project2.id, "f" * 32)
-        prev_event = self.eventstore.get_prev_event_id(event, filter=_filter)
-        next_event = self.eventstore.get_next_event_id(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
 
         assert prev_event == (str(self.project2.id), "e" * 32)
         assert next_event is None
 
         event = self.eventstore.get_event_by_id(self.project2.id, "e" * 32)
-        prev_event = self.eventstore.get_prev_event_id(event, filter=_filter)
-        next_event = self.eventstore.get_next_event_id(event, filter=_filter)
+        prev_event, next_event = self.eventstore.get_prev_next_event_ids(event, filter=_filter)
 
         assert prev_event is None
         assert next_event == (str(self.project2.id), "f" * 32)


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/48499

It looks like there was only this one use of get_<prev|next>_event_id so I replaced those two functions with `get_prev_next_event_ids` which should work exactly the same, just using `bulk_raw_query` instead.