### PR TITLE
fix(gha): Bump minimum version requirement when bumping package

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -49,6 +49,7 @@ jobs:
 
         re="$(sed 's/[_-]/[_-]/g' <<< "$PACKAGE")"
         sed -i "s/^$re==.*/$PACKAGE==$VERSION/g" -- requirements*.txt
+        sed -i "s/^$re>=.*/$PACKAGE>=$VERSION/g" -- requirements*.txt
 
         if git diff --exit-code; then
           exit 0


### PR DESCRIPTION
We noticed that bumping sentry-kafka-schemas actually only ever updates
requirements-frozen.txt. But when we bump that package, it is typically
because we have made a change that we need to be _sure_ is in all repos.
