### PR TITLE
fix(starfish): Flow improvements

### DIFF
--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -71,6 +71,7 @@ const COLUMN_ORDER = [
 
 type SpanTableRow = {
   exclusive_time: number;
+  'project.name': string;
   spanDuration: number;
   spanOp: string;
   span_id: string;
@@ -159,7 +160,7 @@ export default function SpanSummary({location, params}: Props) {
     data: {data: Transaction[]};
   }>(
     [
-      `/organizations/sentry/events/?field=id&field=timestamp&field=transaction.duration&query=id:[${spanSampleData
+      `/organizations/sentry/events/?field=id&field=timestamp&field=transaction.duration&field=project.name&query=id:[${spanSampleData
         .map(datum => datum.transaction_id.replaceAll('-', ''))
         .join(
           ','
@@ -185,6 +186,7 @@ export default function SpanSummary({location, params}: Props) {
 
     return {
       transaction_id: datum.transaction_id,
+      'project.name': transaction?.['project.name'],
       span_id: datum.span_id,
       timestamp: transaction?.timestamp,
       spanOp: datum.span_operation,
@@ -409,7 +411,7 @@ function renderBodyCell(
   if (column.key === 'transaction_id') {
     return (
       <Link
-        to={`/performance/sentry:${row.transaction_id}#span-${row.span_id
+        to={`/performance/${row['project.name']}:${row.transaction_id}#span-${row.span_id
           .slice(19)
           .replace('-', '')}`}
       >

--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -185,6 +185,7 @@ export default function SpanSummary({location, params}: Props) {
     const transaction = transactionDataById[datum.transaction_id.replaceAll('-', '')];
 
     return {
+      transaction: datum.transaction,
       transaction_id: datum.transaction_id,
       'project.name': transaction?.['project.name'],
       span_id: datum.span_id,

--- a/static/app/views/starfish/views/spans/queries.tsx
+++ b/static/app/views/starfish/views/spans/queries.tsx
@@ -25,11 +25,7 @@ export const getSpanListQuery = (
 
   return `SELECT
     group_id, span_operation, description,
-    count() as count,
-    count(DISTINCT transaction) as transaction_count,
-    count / transaction_count as count_per_transaction,
     sum(exclusive_time) as total_exclusive_time,
-    quantile(0.999)(exclusive_time) as p999,
     quantile(0.95)(exclusive_time) as p95,
     quantile(0.50)(exclusive_time) as p50
     FROM spans_experimental_starfish

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -7,6 +7,7 @@ import GridEditable, {
   GridColumnHeader,
 } from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
+import Link from 'sentry/components/links/link';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {Series} from 'sentry/types/echarts';
 import {TableColumnSort} from 'sentry/views/discover/table/types';
@@ -124,6 +125,14 @@ function renderBodyCell(column: GridColumnHeader, row: SpanDataRow): React.React
         series={row[column.key]}
         width={column.width ? column.width - column.width / 5 : undefined}
       />
+    );
+  }
+
+  if (column.key === 'description') {
+    return (
+      <Link to={`/starfish/span/${encodeURIComponent(row.group_id)}`}>
+        {row.description}
+      </Link>
     );
   }
 

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -150,11 +150,6 @@ const COLUMN_ORDER = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'action',
-    name: 'Action',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
     key: 'description',
     name: 'Description',
     width: COL_WIDTH_UNDEFINED,
@@ -162,11 +157,6 @@ const COLUMN_ORDER = [
   {
     key: 'total_exclusive_time',
     name: 'Exclusive Time',
-    width: 250,
-  },
-  {
-    key: 'p95_trend',
-    name: 'p95 Trend',
     width: 250,
   },
   {
@@ -180,23 +170,8 @@ const COLUMN_ORDER = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'p999',
-    name: 'p99.9',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'count',
-    name: 'Count',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'transaction_count',
-    name: 'Transactions',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'count_per_transaction',
-    name: 'Spans per Transaction',
-    width: COL_WIDTH_UNDEFINED,
+    key: 'p95_trend',
+    name: 'p95 Trend',
+    width: 250,
   },
 ];

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {useQueries, useQuery} from '@tanstack/react-query';
 import {Location} from 'history';
 import keyBy from 'lodash/keyBy';
+import _orderBy from 'lodash/orderBy';
 import sumBy from 'lodash/sumBy';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
@@ -118,16 +119,20 @@ export default function SpansView(props: Props) {
 
           const clusters = Object.keys(exclusiveTimeBySubCluster);
 
-          const segments = (clusters || []).map(clusterName => {
-            const subCluster = CLUSTERS[clusterName];
+          const segments = _orderBy(
+            (clusters || []).map(clusterName => {
+              const subCluster = CLUSTERS[clusterName];
 
-            return {
-              name: subCluster?.label || clusterName,
-              value: clusterName,
-              count: exclusiveTimeBySubCluster[clusterName]?.exclusive_time,
-              url: '',
-            };
-          });
+              return {
+                name: subCluster?.label || clusterName,
+                value: clusterName,
+                count: exclusiveTimeBySubCluster[clusterName]?.exclusive_time,
+                url: '',
+              };
+            }),
+            'count',
+            'desc'
+          );
 
           if (segments.length === 0) {
             return null;


### PR DESCRIPTION
A grab-bag of improvements

- Fix missing transaction names from span summary page
- Fix missing sidebar data on span summary when span op is unknown
- Fix incorrect aggregate data due to grouping on transaction
- Add link to span details page from span explorer
- Improve aggregate display to show relative value to overall
- Remove hard-coded Sentry project
