### PR TITLE
fix(crons): Minimally updates monitor config during upsert

### DIFF
--- a/src/sentry/monitors/consumers/check_in.py
+++ b/src/sentry/monitors/consumers/check_in.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from copy import deepcopy
 from typing import Dict, Mapping, Optional
 
 import msgpack
@@ -77,7 +78,11 @@ def _ensure_monitor_with_config(
 
     # Update existing monitor
     if monitor and not created and monitor.config != validated_config:
-        monitor.update(config=validated_config)
+        monitor_config = deepcopy(monitor.config)
+        # Only update keys that were specified in the payload
+        for key in config.keys():
+            monitor_config[key] = validated_config[key]
+        monitor.update(config=monitor_config)
 
     return monitor
 

--- a/src/sentry/monitors/consumers/check_in.py
+++ b/src/sentry/monitors/consumers/check_in.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-from copy import deepcopy
 from typing import Dict, Mapping, Optional
 
 import msgpack
@@ -78,11 +77,7 @@ def _ensure_monitor_with_config(
 
     # Update existing monitor
     if monitor and not created and monitor.config != validated_config:
-        monitor_config = deepcopy(monitor.config)
-        # Only update keys that were specified in the payload
-        for key in config.keys():
-            monitor_config[key] = validated_config[key]
-        monitor.update(config=monitor_config)
+        monitor.update_config(config, validated_config)
 
     return monitor
 

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
-
 from django.db import transaction
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import Throttled
@@ -176,12 +174,9 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
 
             # Update monitor configuration during checkin if config is changed
             if update_monitor and monitor_data["config"] != monitor.config:
-                validated_config = monitor_data["config"]
-                monitor_config = deepcopy(monitor.config)
-                # Only update keys that were specified in the payload
-                for key in request.data.get("monitor_config", {}).keys():
-                    monitor_config[key] = validated_config[key]
-                monitor.update(config=monitor_config)
+                monitor.update_config(
+                    request.data.get("monitor_config", {}), monitor_data["config"]
+                )
 
             try:
                 monitor_environment = MonitorEnvironment.objects.ensure_environment(

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -258,7 +258,8 @@ class Monitor(Model):
         monitor_config = self.config
         # Only update keys that were specified in the payload
         for key in config_payload.keys():
-            monitor_config[key] = validated_config[key]
+            if key in validated_config:
+                monitor_config[key] = validated_config[key]
         self.save()
 
 

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -254,6 +254,13 @@ class Monitor(Model):
         )
         return next_checkin + timedelta(minutes=int(self.config.get("checkin_margin") or 0))
 
+    def update_config(self, config_payload, validated_config):
+        monitor_config = self.config
+        # Only update keys that were specified in the payload
+        for key in config_payload.keys():
+            monitor_config[key] = validated_config[key]
+        self.save()
+
 
 @receiver(pre_save, sender=Monitor)
 def check_organization_monitor_limits(sender, instance, **kwargs):

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -187,6 +187,7 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             monitor = Monitor.objects.get(guid=monitor.guid)
             assert monitor.config["schedule"] == "10 * * * *"
+            # The monitor config is merged, so checkin_margin is not overwritten
             assert monitor.config["checkin_margin"] == 5
 
             checkins = MonitorCheckIn.objects.filter(monitor=monitor)

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -159,13 +159,18 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
                 path,
                 {
                     "status": "ok",
-                    "monitor_config": {"schedule_type": "crontab", "schedule": "5 * * * *"},
+                    "monitor_config": {
+                        "schedule_type": "crontab",
+                        "schedule": "5 * * * *",
+                        "checkin_margin": 5,
+                    },
                 },
                 **self.dsn_auth_headers,
             )
             assert resp.status_code == 201, resp.content
             monitor = Monitor.objects.get(slug=slug)
             assert monitor.config["schedule"] == "5 * * * *"
+            assert monitor.config["checkin_margin"] == 5
 
             checkins = MonitorCheckIn.objects.filter(monitor=monitor)
             assert len(checkins) == 1
@@ -182,6 +187,7 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             monitor = Monitor.objects.get(guid=monitor.guid)
             assert monitor.config["schedule"] == "10 * * * *"
+            assert monitor.config["checkin_margin"] == 5
 
             checkins = MonitorCheckIn.objects.filter(monitor=monitor)
             assert len(checkins) == 2

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -53,7 +53,11 @@ class MonitorConsumerTest(TestCase):
             project_id=self.project.id,
             next_checkin=timezone.now() + timedelta(minutes=1),
             type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
+            config={
+                "schedule": "* * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "checkin_margin": 5,
+            },
             **kwargs,
         )
 
@@ -214,6 +218,7 @@ class MonitorConsumerTest(TestCase):
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["schedule"] == "13 * * * *"
+        assert monitor.config["checkin_margin"] == 5
 
         monitor_environment = MonitorEnvironment.objects.get(id=checkin.monitor_environment.id)
         assert monitor_environment.status == MonitorStatus.OK

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -218,6 +218,7 @@ class MonitorConsumerTest(TestCase):
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.config["schedule"] == "13 * * * *"
+        # The monitor config is merged, so checkin_margin is not overwritten
         assert monitor.config["checkin_margin"] == 5
 
         monitor_environment = MonitorEnvironment.objects.get(id=checkin.monitor_environment.id)


### PR DESCRIPTION
Minimally update monitor config during upsert so as not to overwrite upcoming `alert_rule_id` or existing variables like `checkin_margin` `max_runtime` or `timezone`

Fixes [49216](https://github.com/getsentry/sentry/issues/49216)