### PR TITLE
feat(integrations): add optional integration_id argument

### DIFF
--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -39,6 +39,10 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
         """
         queryset = Repository.objects.filter(organization_id=organization.id)
 
+        integration_id = request.GET.get("integration_id", None)
+        if integration_id:
+            queryset = queryset.filter(integration_id=integration_id)
+
         status = request.GET.get("status", "active")
         query = request.GET.get("query")
         if query:

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
@@ -58,13 +58,12 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const orgId = this.props.organization.slug;
-    return [
-      [
-        'itemList',
-        `/organizations/${orgId}/repos/`,
-        {query: {status: '', integration_id: this.props.integration.id}},
-      ],
-    ];
+    return [['itemList', `/organizations/${orgId}/repos/`, {query: {status: ''}}]];
+  }
+
+  getIntegrationRepos() {
+    const integrationId = this.props.integration.id;
+    return this.state.itemList.filter(repo => repo.integrationId === integrationId);
   }
 
   // Called by row to signal repository change.
@@ -200,7 +199,7 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
   renderBody() {
     const {itemListPageLinks, integrationReposErrorStatus} = this.state;
     const orgId = this.props.organization.slug;
-    const itemList = this.state.itemList || [];
+    const itemList = this.getIntegrationRepos() || [];
     return (
       <Fragment>
         {integrationReposErrorStatus === 400 && (

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
@@ -58,12 +58,13 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const orgId = this.props.organization.slug;
-    return [['itemList', `/organizations/${orgId}/repos/`, {query: {status: ''}}]];
-  }
-
-  getIntegrationRepos() {
-    const integrationId = this.props.integration.id;
-    return this.state.itemList.filter(repo => repo.integrationId === integrationId);
+    return [
+      [
+        'itemList',
+        `/organizations/${orgId}/repos/`,
+        {query: {status: '', integration_id: this.props.integration.id}},
+      ],
+    ];
   }
 
   // Called by row to signal repository change.
@@ -199,7 +200,7 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
   renderBody() {
     const {itemListPageLinks, integrationReposErrorStatus} = this.state;
     const orgId = this.props.organization.slug;
-    const itemList = this.getIntegrationRepos() || [];
+    const itemList = this.state.itemList || [];
     return (
       <Fragment>
         {integrationReposErrorStatus === 400 && (

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -155,6 +155,30 @@ class OrganizationRepositoriesListTest(APITestCase):
             # Shouldn't even make the request to get repos
             assert not f.called
 
+    def test_passing_integration_id(self):
+        integration = self.create_integration(
+            organization=self.org,
+            provider="github",
+            external_id="github:1",
+        )
+        repo = Repository.objects.create(
+            name="example", organization_id=self.org.id, integration_id=integration.id
+        )
+        integration2 = self.create_integration(
+            organization=self.org,
+            provider="github",
+            external_id="github:2",
+        )
+        repo = Repository.objects.create(
+            name="example2", organization_id=self.org.id, integration_id=integration2.id
+        )
+        response = self.client.get(f"{self.url}?integration_id={integration.id}", format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(repo.id)
+        assert response.data[0]["externalSlug"] is None
+
 
 @region_silo_test(stable=True)
 class OrganizationRepositoriesCreateTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -169,7 +169,7 @@ class OrganizationRepositoriesListTest(APITestCase):
             provider="github",
             external_id="github:2",
         )
-        repo = Repository.objects.create(
+        Repository.objects.create(
             name="example2", organization_id=self.org.id, integration_id=integration2.id
         )
         response = self.client.get(f"{self.url}?integration_id={integration.id}", format="json")


### PR DESCRIPTION
We do some filtering in the UI for the integration ID which is a bad practice. We should pass the `integration_id` as part of the query