### PR TITLE
fix(threads): Use remapped thread state in thread tags

### DIFF
--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -900,7 +900,7 @@ describe('Threads', function () {
 
         expect(screen.getByText('Threads')).toBeInTheDocument();
         expect(screen.getByText('Thread State')).toBeInTheDocument();
-        expect(screen.getByText('Blocked')).toBeInTheDocument();
+        expect(screen.getAllByText('Blocked')).toHaveLength(2);
         expect(screen.getAllByText('waiting on tid=1')).toHaveLength(2);
         expect(screen.getByText('Thread Tags')).toBeInTheDocument();
 
@@ -988,7 +988,7 @@ describe('Threads', function () {
           id: 0,
           current: false,
           crashed: true,
-          name: null,
+          name: 'main',
           stacktrace: {
             frames: [
               {
@@ -1039,8 +1039,9 @@ describe('Threads', function () {
 
         expect(screen.getByText('Threads')).toBeInTheDocument();
         expect(screen.getByText('Thread State')).toBeInTheDocument();
-        // WaitingPerformingGc maps to Waiting
-        expect(screen.getByText('Waiting')).toBeInTheDocument();
+        // WaitingPerformingGc maps to Waiting for both Thread tag and Thread State
+        expect(screen.getByText('Thread Tags')).toBeInTheDocument();
+        expect(screen.getAllByText('Waiting')).toHaveLength(2);
       });
 
       it('toggle full stack trace button', async function () {

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -157,6 +157,8 @@ export function Threads({
       return null;
     }
 
+    const threadStateDisplay = getMappedThreadState(threadState);
+
     return (
       <Pills>
         {!isNil(id) && <Pill name={t('id')} value={String(id)} />}
@@ -167,7 +169,9 @@ export function Threads({
             {crashed ? t('yes') : t('no')}
           </Pill>
         )}
-        {!isNil(threadState) && <Pill name={t('state')} value={threadState} />}
+        {!isNil(threadStateDisplay) && (
+          <Pill name={t('state')} value={threadStateDisplay} />
+        )}
         {!isNil(lockReason) && <Pill name={t('lock reason')} value={lockReason} />}
       </Pills>
     );


### PR DESCRIPTION
The thread state wasn't aligned between Thread Tags and Thread State widgets.

### Before
![image](https://user-images.githubusercontent.com/4999776/236563583-74394068-fd02-4165-9708-2fc90ae160b2.png)

### After
![image](https://user-images.githubusercontent.com/4999776/236564302-0d0dc378-0373-45ff-89db-b19539a184b4.png)
