### PR TITLE
feat(consecutive-http): Exclude frontend events from detector

### DIFF
--- a/fixtures/events/performance_problems/consecutive-http/consecutive-http-basic.json
+++ b/fixtures/events/performance_problems/consecutive-http/consecutive-http-basic.json
@@ -1105,13 +1105,7 @@
   "level": "info",
   "location": "/",
   "logger": "",
-  "measurements": {
-    "connection.rtt": {"value": 2150.0, "unit": "millisecond"},
-    "fcp": {"value": 15997.49994277954, "unit": "millisecond"},
-    "fp": {"value": 15997.49994277954, "unit": "millisecond"},
-    "ttfb": {"value": 3169.8999404907227, "unit": "millisecond"},
-    "ttfb.requesttime": {"value": 3157.2999954223633, "unit": "millisecond"}
-  },
+  "measurements": {},
   "metadata": {"location": "/", "title": "/"},
   "nodestore_insert": 1677610408.724872,
   "received": 1677610406.707657,

--- a/fixtures/events/performance_problems/consecutive-http/consecutive-http-basic.json
+++ b/fixtures/events/performance_problems/consecutive-http/consecutive-http-basic.json
@@ -1108,7 +1108,6 @@
   "measurements": {
     "connection.rtt": {"value": 2150.0, "unit": "millisecond"},
     "fcp": {"value": 15997.49994277954, "unit": "millisecond"},
-    "lcp": {"value": 30000.49994277954, "unit": "millisecond"},
     "fp": {"value": 15997.49994277954, "unit": "millisecond"},
     "ttfb": {"value": 3169.8999404907227, "unit": "millisecond"},
     "ttfb.requesttime": {"value": 3157.2999954223633, "unit": "millisecond"}
@@ -1126,7 +1125,7 @@
     ]
   },
   "sdk": {
-    "name": "sentry.javascript.react",
+    "name": "sentry.javascript.node",
     "version": "7.39.0",
     "integrations": [
       "InboundFilters",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -671,7 +671,6 @@ register("performance.issues.render_blocking_assets.fcp_minimum_threshold", defa
 register("performance.issues.render_blocking_assets.fcp_maximum_threshold", default=10000.0)
 register("performance.issues.render_blocking_assets.fcp_ratio_threshold", default=0.33)
 register("performance.issues.render_blocking_assets.size_threshold", default=1000000)
-register("performance.issues.consecutive_http.lcp_ratio_threshold", default=0.33)
 register("performance.issues.consecutive_http.max_duration_between_spans", default=1000)
 register("performance.issues.consecutive_http.consecutive_count_threshold", default=3)
 register("performance.issues.consecutive_http.span_duration_threshold", default=1000)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -145,9 +145,6 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         "render_blocking_bytes_min": options.get(
             "performance.issues.render_blocking_assets.size_threshold"
         ),
-        "consecutive_http_spans_lcp_ratio_threshold": options.get(
-            "performance.issues.consecutive_http.lcp_ratio_threshold"
-        ),
         "consecutive_http_spans_max_duration_between_spans": options.get(
             "performance.issues.consecutive_http.max_duration_between_spans"
         ),
@@ -255,7 +252,6 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
                 "consecutive_http_spans_max_duration_between_spans"
             ],  # ms
             "detection_enabled": settings["consecutive_http_spans_detection_enabled"],
-            "lcp_ratio_threshold": settings["consecutive_http_spans_lcp_ratio_threshold"],
         },
         DetectorType.LARGE_HTTP_PAYLOAD: {"payload_size_threshold": 10000000},  # 10mb
     }

--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -47,7 +47,6 @@ const optionsAvailable = [
   'performance.issues.m_n_plus_one_db.la-rollout',
   'performance.issues.m_n_plus_one_db.ea-rollout',
   'performance.issues.m_n_plus_one_db.ga-rollout',
-  'performance.issues.consecutive_http.lcp_ratio_threshold',
   'performance.issues.consecutive_http.max_duration_between_spans',
   'performance.issues.consecutive_http.consecutive_count_threshold',
   'performance.issues.consecutive_http.span_duration_threshold',
@@ -193,7 +192,6 @@ export default class AdminSettings extends AsyncView<{}, State> {
               <PanelHeader>
                 Performance Issues - Consecutive HTTP Span Detector
               </PanelHeader>
-              {fields['performance.issues.consecutive_http.lcp_ratio_threshold']}
               {fields['performance.issues.consecutive_http.max_duration_between_spans']}
               {fields['performance.issues.consecutive_http.consecutive_count_threshold']}
               {fields['performance.issues.consecutive_http.span_duration_threshold']}

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -372,15 +372,6 @@ const performanceOptionDefinitions: Field[] = [
     ),
   },
   {
-    key: 'performance.issues.consecutive_http.lcp_ratio_threshold',
-    label: t('LCP Ratio Threshold'),
-    help: t(
-      'The sum of consecutive HTTP spans must be larger than this percentage of the LCP to be considered a problem.'
-    ),
-    ...HIGH_THROUGHPUT_RATE_OPTION,
-    defaultValue: () => '0.33',
-  },
-  {
     key: 'performance.issues.consecutive_http.max_duration_between_spans',
     label: t('Time Between Spans'),
     help: t(


### PR DESCRIPTION
We've decided to release this detector specifically for backend for now because frontend has other needs which could be better suited by rolling out another detector with different thresholds.

I put both frontend and backend changes in the same PR because the frontend changes are just UI for the options, which is internal and only changed by the performance team, they should be deployable together in this case.