### PR TITLE
fix(hybridcloud) Fix invalid notification setting assertion

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -130,8 +130,8 @@ class NotificationSetting(Model):
 
     def save(self, *args, **kwargs):
         try:
-            assert (
-                self.user_id is not None and self.team_id is not None
+            assert not (
+                self.user_id is None and self.team_id is None
             ), "Notification setting missing user & team"
         except AssertionError as err:
             sentry_sdk.capture_exception(err)

--- a/tests/sentry/api/endpoints/test_user_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings.py
@@ -215,7 +215,7 @@ class UserNotificationSettingsGetTestV2(UserNotificationSettingsTestBase):
 
 
 @control_silo_test
-class UserNotificationSettingsTest(UserNotificationSettingsTestBase):
+class UserNotificationSettingsUpdateTest(UserNotificationSettingsTestBase):
     method = "put"
 
     def test_simple(self):


### PR DESCRIPTION
I accidentally flipped the logic, and we're capturing valid operations instead of invalid ones.

