### PR TITLE
ref: Extract a CopyToClipboardButton component

### DIFF
--- a/static/app/components/copyToClipboardButton.tsx
+++ b/static/app/components/copyToClipboardButton.tsx
@@ -18,7 +18,13 @@ type Props = {
   >
 >;
 
-export function CopyToClipboardButton({onCopy, onError, text, ...props}: Props) {
+export function CopyToClipboardButton({
+  iconSize,
+  onCopy,
+  onError,
+  text,
+  ...props
+}: Props) {
   const {onClick, label} = useCopyToClipboard({
     text,
     onCopy,
@@ -35,7 +41,7 @@ export function CopyToClipboardButton({onCopy, onError, text, ...props}: Props) 
       onClick={onClick}
       {...props}
     >
-      <IconCopy size="xs" />
+      <IconCopy size={iconSize} />
     </CopyButton>
   );
 }

--- a/static/app/components/copyToClipboardButton.tsx
+++ b/static/app/components/copyToClipboardButton.tsx
@@ -1,5 +1,4 @@
 import {ComponentProps, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Button, ButtonProps} from 'sentry/components/button';
 import Clipboard from 'sentry/components/clipboard';
@@ -46,7 +45,7 @@ export function CopyToClipboardButton({
       }}
       value={text}
     >
-      <CopyButton
+      <Button
         aria-label={t('Copy')}
         size={props.size || 'xs'}
         title={tooltipTitle}
@@ -58,12 +57,8 @@ export function CopyToClipboardButton({
           setTooltipState('copy');
           onMouseLeave?.(e);
         }}
-        icon={<IconCopy size={iconSize || props.size || 'xs'} />}
+        icon={<IconCopy size={iconSize || props.size || 'xs'} color="subText" />}
       />
     </Clipboard>
   );
 }
-
-const CopyButton = styled(Button)`
-  color: ${p => p.theme.subText};
-`;

--- a/static/app/components/copyToClipboardButton.tsx
+++ b/static/app/components/copyToClipboardButton.tsx
@@ -1,0 +1,69 @@
+import {ComponentProps, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button, ButtonProps} from 'sentry/components/button';
+import Clipboard from 'sentry/components/clipboard';
+import {IconCopy} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+
+type Props = {
+  text: string;
+  iconSize?: ComponentProps<typeof IconCopy>['size'];
+} & Overwrite<
+  ButtonProps,
+  Partial<
+    Pick<ButtonProps, 'aria-label'> & {onCopy: undefined | ((copiedText: string) => void)}
+  >
+>;
+
+export function CopyToClipboardButton({
+  iconSize = 'xs',
+  onCopy,
+  onMouseLeave,
+  text,
+  ...props
+}: Props) {
+  const [tooltipState, setTooltipState] = useState<'copy' | 'copied' | 'error'>('copy');
+
+  const tooltipTitle =
+    tooltipState === 'copy'
+      ? t('Copy')
+      : tooltipState === 'copied'
+      ? t('Copied')
+      : t('Unable to copy');
+
+  return (
+    <Clipboard
+      hideUnsupported
+      onSuccess={() => {
+        setTooltipState('copied');
+        onCopy?.(text);
+      }}
+      onError={() => {
+        setTooltipState('error');
+      }}
+      value={text}
+    >
+      <CopyButton
+        aria-label={t('Copy')}
+        size={props.size || 'xs'}
+        title={tooltipTitle}
+        tooltipProps={{delay: 0, isHoverable: false, position: 'left'}}
+        translucentBorder
+        type="button"
+        {...props}
+        onMouseLeave={e => {
+          setTooltipState('copy');
+          onMouseLeave?.(e);
+        }}
+        icon={<IconCopy size={iconSize || props.size || 'xs'} />}
+      />
+    </Clipboard>
+  );
+}
+
+const CopyButton = styled(Button)`
+  color: ${p => p.theme.subText};
+`;

--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -1,4 +1,4 @@
-import {ComponentProps, MouseEvent, useMemo, useState} from 'react';
+import {ComponentProps, MouseEvent, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {
@@ -7,10 +7,7 @@ import {
   ObjectInspector as OrigObjectInspector,
 } from '@sentry-internal/react-inspector';
 
-import {Button} from 'sentry/components/button';
-import Clipboard from 'sentry/components/clipboard';
-import {IconCopy} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
@@ -45,15 +42,6 @@ function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props)
     [isDark, theme, emotionTheme.red400, emotionTheme.text]
   );
 
-  const [tooltipState, setTooltipState] = useState<'copy' | 'copied' | 'error'>('copy');
-
-  const tooltipTitle =
-    tooltipState === 'copy'
-      ? t('Copy')
-      : tooltipState === 'copied'
-      ? t('Copied')
-      : t('Unable to copy');
-
   const inspector = (
     <OrigObjectInspector
       data={data}
@@ -65,30 +53,11 @@ function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props)
   if (showCopyButton) {
     return (
       <Wrapper>
-        <Clipboard
-          hideUnsupported
-          onSuccess={() => {
-            setTooltipState('copied');
-            onCopy?.(data);
-          }}
-          onError={() => {
-            setTooltipState('error');
-          }}
-          value={JSON.stringify(data, null, '\t')}
-        >
-          <CopyButton
-            aria-label={t('Copy')}
-            type="button"
-            size="xs"
-            translucentBorder
-            borderless
-            title={tooltipTitle}
-            tooltipProps={{delay: 0, isHoverable: false, position: 'left'}}
-            onMouseLeave={() => setTooltipState('copy')}
-          >
-            <IconCopy size="xs" />
-          </CopyButton>
-        </Clipboard>
+        <StyledCopyButton
+          borderless
+          onCopy={onCopy}
+          text={JSON.stringify(data, null, '\t')}
+        />
         {inspector}
       </Wrapper>
     );
@@ -99,14 +68,18 @@ function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props)
 
 const Wrapper = styled('div')`
   position: relative;
+
+  /*
+  We need some minimum vertical height so the copy button has room.
+  But don't try to use min-height because then whitespace would be inconsistent.
+  */
+  padding-bottom: ${space(1.5)};
 `;
 
-const CopyButton = styled(Button)`
+const StyledCopyButton = styled(CopyToClipboardButton)`
   position: absolute;
   top: 0;
   right: ${space(0.5)};
-
-  color: ${p => p.theme.subText};
 `;
 
 export type OnExpandCallback = (

--- a/static/app/components/objectInspector.tsx
+++ b/static/app/components/objectInspector.tsx
@@ -55,7 +55,9 @@ function ObjectInspector({data, onCopy, showCopyButton, theme, ...props}: Props)
       <Wrapper>
         <StyledCopyButton
           borderless
+          iconSize="xs"
           onCopy={onCopy}
+          size="xs"
           text={JSON.stringify(data, null, '\t')}
         />
         {inspector}

--- a/static/app/components/textCopyInput.tsx
+++ b/static/app/components/textCopyInput.tsx
@@ -2,10 +2,8 @@ import {useCallback, useRef} from 'react';
 import {findDOMNode} from 'react-dom';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
-import Clipboard from 'sentry/components/clipboard';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {InputGroup, InputProps} from 'sentry/components/inputGroup';
-import {IconCopy} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {selectText} from 'sentry/utils/selectText';
 
@@ -16,7 +14,7 @@ interface Props extends Omit<InputProps, 'onCopy'> {
   children: string;
   className?: string;
   disabled?: boolean;
-  onCopy?: (value: string, event: React.MouseEvent) => void;
+  onCopy?: (value: string) => void;
   /**
    * Always show the ending of a long overflowing text in input
    */
@@ -57,24 +55,6 @@ function TextCopyInput({
   }, [rtl]);
 
   /**
-   * Select text when copy button is clicked
-   */
-  const handleCopyClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (!textRef.current) {
-        return;
-      }
-
-      handleSelectText();
-
-      onCopy?.(children, e);
-
-      e.stopPropagation();
-    },
-    [handleSelectText, children, onCopy]
-  );
-
-  /**
    * We are using direction: rtl; to always show the ending of a long overflowing text in input.
    *
    * This however means that the trailing characters with BiDi class O.N. ('Other Neutrals') goes to the other side.
@@ -98,11 +78,12 @@ function TextCopyInput({
         {...inputProps}
       />
       <InputGroup.TrailingItems>
-        <Clipboard hideUnsupported value={children}>
-          <StyledCopyButton borderless disabled={disabled} onClick={handleCopyClick}>
-            <IconCopy size={size === 'xs' ? 'xs' : 'sm'} />
-          </StyledCopyButton>
-        </Clipboard>
+        <StyledCopyButton
+          borderless
+          iconSize={size === 'xs' ? 'xs' : 'sm'}
+          onCopy={onCopy}
+          text={children}
+        />
       </InputGroup.TrailingItems>
     </InputGroup>
   );
@@ -114,8 +95,7 @@ const StyledInput = styled(InputGroup.Input)<{rtl?: boolean}>`
   direction: ${p => (p.rtl ? 'rtl' : 'ltr')};
 `;
 
-const StyledCopyButton = styled(Button)`
-  color: ${p => p.theme.subText};
+const StyledCopyButton = styled(CopyToClipboardButton)`
   padding: ${space(0.5)};
   min-height: 0;
   height: auto;

--- a/static/app/utils/useCopyToClipboard.tsx
+++ b/static/app/utils/useCopyToClipboard.tsx
@@ -1,0 +1,62 @@
+import {useCallback, useRef, useState} from 'react';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+
+type Opts = {
+  text: string;
+  errorMessage?: string;
+  hideMessages?: boolean;
+  onCopy?: undefined | ((copiedText: string) => void);
+  onError?: undefined | ((error: Error) => void);
+  successMessage?: string;
+};
+
+export default function useCopyToClipboard({
+  errorMessage = t('Error copying to clipboard'),
+  hideMessages,
+  onCopy,
+  onError,
+  successMessage = t('Copied to clipboard'),
+  text,
+}: Opts) {
+  const timeoutRef = useRef<undefined | ReturnType<typeof setTimeout>>();
+  const [state, setState] = useState<'ready' | 'copied' | 'error'>('ready');
+
+  const handleOnClick = useCallback(() => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setState('copied');
+        if (!hideMessages) {
+          addSuccessMessage(successMessage);
+        }
+        onCopy?.(text);
+      })
+      .catch(error => {
+        setState('error');
+        if (!hideMessages) {
+          addErrorMessage(errorMessage);
+        }
+        onError?.(error);
+      })
+      .finally(() => {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(() => setState('ready'), 1000);
+      });
+  }, [errorMessage, hideMessages, onCopy, onError, successMessage, text]);
+
+  const label =
+    state === 'ready'
+      ? t('Copy')
+      : state === 'copied'
+      ? t('Copied')
+      : t('Unable to copy');
+
+  return {
+    onClick: handleOnClick,
+    label,
+  };
+}

--- a/static/app/utils/useCopyToClipboard.tsx
+++ b/static/app/utils/useCopyToClipboard.tsx
@@ -55,7 +55,6 @@ export default function useCopyToClipboard({
   const timeoutRef = useRef<undefined | ReturnType<typeof setTimeout>>();
   const [state, setState] = useState<'ready' | 'copied' | 'error'>('ready');
 
-  ClipboardItem;
   const handleOnClick = useCallback(() => {
     navigator.clipboard
       .writeText(text)

--- a/static/app/utils/useCopyToClipboard.tsx
+++ b/static/app/utils/useCopyToClipboard.tsx
@@ -4,12 +4,44 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {t} from 'sentry/locale';
 
 type Opts = {
+  /**
+   * The text that you want to copy.
+   *
+   * Use `JSON.stringify()` if you have an object to share.
+   *
+   * If/When `new ClipboardItem()` accepts a mime type of application/json then
+   * it could accept other types, but for now string is the most common case.
+   */
   text: string;
-  errorMessage?: string;
+
+  /**
+   * The toast message that will appear if an error happens when copying.
+   *
+   * Disable toast messages by setting the `hideMessages` prop.
+   */
+  errorMessage?: React.ReactNode;
+
+  /**
+   * Disable creating toast messages when copying has succeeded/errored.
+   */
   hideMessages?: boolean;
+
+  /**
+   * Callback after copying is complete.
+   */
   onCopy?: undefined | ((copiedText: string) => void);
+
+  /**
+   * Callback if an error happened while copying.
+   */
   onError?: undefined | ((error: Error) => void);
-  successMessage?: string;
+
+  /**
+   * The toast messaage that will appear after the copy operation is done.
+   *
+   * Disable toast messages by setting the `hideMessages` prop.
+   */
+  successMessage?: React.ReactNode;
 };
 
 export default function useCopyToClipboard({
@@ -23,6 +55,7 @@ export default function useCopyToClipboard({
   const timeoutRef = useRef<undefined | ReturnType<typeof setTimeout>>();
   const [state, setState] = useState<'ready' | 'copied' | 'error'>('ready');
 
+  ClipboardItem;
   const handleOnClick = useCallback(() => {
     navigator.clipboard
       .writeText(text)

--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -16,7 +16,7 @@ describe('ApiTokenRow', () => {
     const cb = jest.fn();
     render(<ApiTokenRow onRemove={cb} token={TestStubs.ApiToken()} />);
 
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByLabelText('Remove'));
     expect(cb).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This new component will simplify most of the places where we use `<Clipboard>` in the app.

I'm going through them all right now, but it's tedious to check css styles & alignment in each case, so I thought it best to put the basics up first

The two components i've updated so far are look, visually, the same now as they do in prod. The differences are: consistent labels, tooltips, toasts, and browser checks, etc.

| Component | Updated |
| --- | --- |
| TextCopyInput | <img width="160" alt="SCR-20230505-nhdv" src="https://user-images.githubusercontent.com/187460/236575758-3fb815b8-ee39-4f90-bf94-54131f13555d.png"> |
| ObjectInspector | <img width="340" alt="SCR-20230505-nhjr" src="https://user-images.githubusercontent.com/187460/236575780-48fe658b-2fa5-48fa-8055-427a273810fc.png"> |


Once there are fewer places that use `<Clipboard>` I'd like to replace that component with a hook. Then anywhere that uses `navigator.clipboard` directly could hopefully switch to the hook too.