### PR TITLE
WIP(generic-metric): Pass metric key path through constructor instead of inferring from input

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -31,7 +31,9 @@ _INGEST_CODEC: sentry_kafka_schemas.codecs.Codec[Any] = sentry_kafka_schemas.get
 
 class MessageProcessor:
     def __init__(self, config: MetricsIngestConfiguration):
-        self._indexer = STORAGE_TO_INDEXER[config.db_backend](**config.db_backend_options)
+        self._indexer = STORAGE_TO_INDEXER[config.db_backend](
+            metric_key_path=config.use_case_id, **config.db_backend_options
+        )
         self._config = config
 
     # The following two methods are required to work such that the parallel

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from operator import or_
 from time import sleep
-from typing import Any, Mapping, Optional, Sequence, Set
+from typing import Any, Collection, Mapping, Optional, Sequence, Set
 
 import sentry_sdk
 from django.conf import settings
@@ -12,17 +12,22 @@ from psycopg2.errorcodes import DEADLOCK_DETECTED
 from sentry.sentry_metrics.configuration import IndexerStorage, UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.indexer.base import (
     FetchType,
-    KeyCollection,
-    KeyResult,
     KeyResults,
+    OrgId,
     StringIndexer,
     UseCaseKeyCollection,
+    UseCaseKeyResult,
+    UseCaseKeyResults,
 )
 from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCache
 from sentry.sentry_metrics.indexer.limiters.writes import writes_limiter_factory
 from sentry.sentry_metrics.indexer.postgres.models import TABLE_MAPPING, BaseIndexer, IndexerTable
 from sentry.sentry_metrics.indexer.strings import StaticStringIndexer
-from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPING
+from sentry.sentry_metrics.use_case_id_registry import (
+    METRIC_PATH_MAPPING,
+    REVERSE_METRIC_PATH_MAPPING,
+    UseCaseID,
+)
 from sentry.utils import metrics
 
 __all__ = ["PostgresIndexer"]
@@ -44,15 +49,23 @@ class PGStringIndexerV2(StringIndexer):
     and the corresponding reverse lookup.
     """
 
-    def _get_db_records(self, use_case_id: UseCaseKey, db_keys: KeyCollection) -> Any:
-        conditions = []
-        for pair in db_keys.as_tuples():
-            organization_id, string = pair
-            conditions.append(Q(organization_id=int(organization_id), string=string))
+    def _get_db_records(self, db_use_case_keys: UseCaseKeyCollection) -> Any:
+        """
+        We are not querying for the use case ID because the order of
+        operations for our changes needs to be:
+        >>> 1. Change write path
+            2. do DB backfill
+            3. Change Read path (this code)
+        We are currently at step 1
+        """
+        conditions = [
+            Q(organization_id=int(organization_id), string=string)
+            for _, organization_id, string in db_use_case_keys.as_tuples()
+        ]
 
-        query_statement = reduce(or_, conditions)
-
-        return self._table(use_case_id).objects.filter(query_statement)
+        return self._get_table_from_use_case_ids(db_use_case_keys.mapping.keys()).objects.filter(
+            reduce(or_, conditions)
+        )
 
     def _bulk_create_with_retry(
         self, table: IndexerTable, new_records: Sequence[BaseIndexer]
@@ -95,17 +108,37 @@ class PGStringIndexerV2(StringIndexer):
     def bulk_record(
         self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
     ) -> KeyResults:
-        db_read_keys = KeyCollection(org_strings)
+        res = self._uca_bulk_record({REVERSE_METRIC_PATH_MAPPING[use_case_id]: org_strings})
+        return res.results[REVERSE_METRIC_PATH_MAPPING[use_case_id]]
 
-        db_read_key_results = KeyResults()
-        db_read_key_results.add_key_results(
+    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+        """Store a string and return the integer ID generated for it"""
+        result = self.bulk_record(use_case_id=use_case_id, org_strings={org_id: {string}})
+        return result[org_id][string]
+
+    def _uca_bulk_record(
+        self, strings: Mapping[UseCaseID, Mapping[OrgId, Set[str]]]
+    ) -> UseCaseKeyResults:
+        db_read_keys = UseCaseKeyCollection(strings)
+
+        db_read_key_results = UseCaseKeyResults()
+        db_read_key_results.add_use_case_key_results(
             [
-                KeyResult(org_id=db_obj.organization_id, string=db_obj.string, id=db_obj.id)
-                for db_obj in self._get_db_records(use_case_id, db_read_keys)
+                UseCaseKeyResult(
+                    use_case_id=(
+                        UseCaseID.TRANSACTIONS
+                        if self._get_metric_path_key(strings.keys()) is UseCaseKey.PERFORMANCE
+                        else UseCaseID.SESSIONS
+                    ),
+                    org_id=db_obj.organization_id,
+                    string=db_obj.string,
+                    id=db_obj.id,
+                )
+                for db_obj in self._get_db_records(db_read_keys)
             ],
             FetchType.DB_READ,
         )
-        db_write_keys = db_read_key_results.get_unmapped_keys(db_read_keys)
+        db_write_keys = db_read_key_results.get_unmapped_use_case_keys(db_read_keys)
 
         metrics.incr(
             _INDEXER_DB_METRIC,
@@ -121,26 +154,48 @@ class PGStringIndexerV2(StringIndexer):
         if db_write_keys.size == 0:
             return db_read_key_results
 
-        config = get_ingest_config(use_case_id, IndexerStorage.POSTGRES)
+        config = get_ingest_config(
+            self._get_metric_path_key(strings.keys()), IndexerStorage.POSTGRES
+        )
         writes_limiter = writes_limiter_factory.get_ratelimiter(config)
 
-        new_use_case_id = REVERSE_METRIC_PATH_MAPPING[use_case_id]
-        with writes_limiter.check_write_limits(
-            UseCaseKeyCollection({new_use_case_id: db_write_keys})
-        ) as writes_limiter_state:
+        """
+        Changes to writes_limiter will happen in a separate PR.
+        For now, we are going to operate on the assumption that no custom use case ID
+        will enter this part of the code path. Therethere strings can only be one of the
+        follow 2 types:
+        {
+            "sessions" : {
+                org_id_1: ... ,
+                org_id_n: ... ,
+            }
+        }
+        {
+            "transactions" : {
+                org_id_1: ... ,
+                org_id_n: ... ,
+            }
+        }
+        """
+        use_case_id = next(iter(strings.keys()))
+        use_case_path_key = self._get_metric_path_key(strings.keys())
+        with writes_limiter.check_write_limits(db_write_keys) as writes_limiter_state:
             # After the DB has successfully committed writes, we exit this
             # context manager and consume quotas. If the DB crashes we
             # shouldn't consume quota.
             use_case_collection = writes_limiter_state.accepted_keys
             # TODO: later we will use the whole use case collection instead
             # of pulling out the key collection
-            filtered_db_write_keys = use_case_collection.mapping[new_use_case_id]
+            filtered_db_write_keys = use_case_collection.mapping[use_case_id]
             del db_write_keys
 
-            rate_limited_key_results = KeyResults()
+            rate_limited_key_results = UseCaseKeyResults()
             for dropped_string in writes_limiter_state.dropped_strings:
-                rate_limited_key_results.add_key_result(
-                    dropped_string.key_result,
+                key_result = dropped_string.key_result
+                rate_limited_key_results.add_use_case_key_result(
+                    UseCaseKeyResult(
+                        use_case_id, key_result.org_id, key_result.string, key_result.id
+                    ),
                     fetch_type=dropped_string.fetch_type,
                     fetch_type_ext=dropped_string.fetch_type_ext,
                 )
@@ -148,31 +203,50 @@ class PGStringIndexerV2(StringIndexer):
             if filtered_db_write_keys.size == 0:
                 return db_read_key_results.merge(rate_limited_key_results)
 
-            new_records = []
-            for write_pair in filtered_db_write_keys.as_tuples():
-                organization_id, string = write_pair
-                new_records.append(
-                    self._table(use_case_id)(organization_id=int(organization_id), string=string)
-                )
+            if use_case_path_key is UseCaseKey.PERFORMANCE:
+                new_records = [
+                    self._get_table_from_use_case_ids(strings.keys())(
+                        organization_id=int(organization_id),
+                        string=string,
+                        use_case_id=use_case_id.value,
+                    )
+                    for organization_id, string in filtered_db_write_keys.as_tuples()
+                ]
+            else:
+                new_records = [
+                    self._get_table_from_use_case_ids(strings.keys())(
+                        organization_id=int(organization_id),
+                        string=string,
+                    )
+                    for organization_id, string in filtered_db_write_keys.as_tuples()
+                ]
 
             with metrics.timer("sentry_metrics.indexer.pg_bulk_create"):
-                self._bulk_create_with_retry(self._table(use_case_id), new_records)
+                self._bulk_create_with_retry(
+                    self._get_table_from_use_case_ids(strings.keys()), new_records
+                )
 
-        db_write_key_results = KeyResults()
-        db_write_key_results.add_key_results(
+        db_write_key_results = UseCaseKeyResults()
+        db_write_key_results.add_use_case_key_results(
             [
-                KeyResult(org_id=db_obj.organization_id, string=db_obj.string, id=db_obj.id)
-                for db_obj in self._get_db_records(use_case_id, filtered_db_write_keys)
+                UseCaseKeyResult(
+                    use_case_id,
+                    org_id=db_obj.organization_id,
+                    string=db_obj.string,
+                    id=db_obj.id,
+                )
+                for db_obj in self._get_db_records(
+                    UseCaseKeyCollection({use_case_id: filtered_db_write_keys})
+                )
             ],
             fetch_type=FetchType.FIRST_SEEN,
         )
 
         return db_read_key_results.merge(db_write_key_results).merge(rate_limited_key_results)
 
-    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
-        """Store a string and return the integer ID generated for it"""
-        result = self.bulk_record(use_case_id=use_case_id, org_strings={org_id: {string}})
-        return result[org_id][string]
+    def _uca_record(self, use_case_id: UseCaseID, org_id: int, string: str) -> Optional[int]:
+        result = self._uca_bulk_record(strings={use_case_id: {org_id: {string}}})
+        return result[use_case_id][org_id][string]
 
     def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
         """Lookup the integer ID for a string.
@@ -180,7 +254,7 @@ class PGStringIndexerV2(StringIndexer):
         Returns None if the entry cannot be found.
 
         """
-        table = self._table(use_case_id)
+        table = self._get_table_from_metric_path_key(use_case_id)
         try:
             id: int = table.objects.using_replica().get(organization_id=org_id, string=string).id
         except table.DoesNotExist:
@@ -193,7 +267,7 @@ class PGStringIndexerV2(StringIndexer):
 
         Returns None if the entry cannot be found.
         """
-        table = self._table(use_case_id)
+        table = self._get_table_from_metric_path_key(use_case_id)
         try:
             obj = table.objects.get_from_cache(id=id, use_replica=True)
         except table.DoesNotExist:
@@ -203,8 +277,19 @@ class PGStringIndexerV2(StringIndexer):
         string: str = obj.string
         return string
 
-    def _table(self, use_case_id: UseCaseKey) -> IndexerTable:
-        return TABLE_MAPPING[use_case_id]
+    def _get_metric_path_key(self, use_case_ids: Collection[UseCaseID]) -> UseCaseKey:
+        metrics_paths = {METRIC_PATH_MAPPING[use_case_id] for use_case_id in use_case_ids}
+        if len(metrics_paths) > 1:
+            raise ValueError(
+                f"The set of use_case_ids: {use_case_ids} maps to multiple metric path keys"
+            )
+        return next(iter(metrics_paths))
+
+    def _get_table_from_use_case_ids(self, use_case_ids: Collection[UseCaseID]) -> IndexerTable:
+        return TABLE_MAPPING[self._get_metric_path_key(use_case_ids)]
+
+    def _get_table_from_metric_path_key(self, metric_path_key: UseCaseKey) -> IndexerTable:
+        return TABLE_MAPPING[metric_path_key]
 
     def resolve_shared_org(self, string: str) -> Optional[int]:
         raise NotImplementedError(

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -20,20 +20,11 @@ from sentry.sentry_metrics.use_case_id_registry import REVERSE_METRIC_PATH_MAPPI
 from sentry.testutils.helpers.options import override_options
 
 BACKENDS = [
-    # TODO: add cloud spanner here
     RawSimpleIndexer,
     pytest.param(PGStringIndexerV2, marks=pytest.mark.django_db),
 ]
 
-
-@pytest.fixture(params=BACKENDS)
-def indexer_cls(request):
-    return request.param
-
-
-@pytest.fixture
-def indexer(indexer_cls):
-    return indexer_cls()
+USE_CASE_KEYS = [UseCaseKey.PERFORMANCE, UseCaseKey.RELEASE_HEALTH]
 
 
 @pytest.fixture
@@ -48,7 +39,26 @@ def indexer_cache():
     indexer_cache.cache.clear()
 
 
-use_case_id = UseCaseKey("release-health")
+@pytest.fixture(params=BACKENDS)
+def indexer_cls(request):
+    return request.param
+
+
+@pytest.fixture(params=USE_CASE_KEYS)
+def use_case_id(request):
+    return request.param
+
+
+@pytest.fixture
+def writes_limiter_option_name(use_case_id):
+    if use_case_id is UseCaseKey.RELEASE_HEALTH:
+        return "sentry-metrics.writes-limiter.limits.releasehealth"
+    return "sentry-metrics.writes-limiter.limits.performance"
+
+
+@pytest.fixture
+def indexer(indexer_cls):
+    return indexer_cls()
 
 
 def assert_fetch_type_for_tag_string_set(
@@ -57,7 +67,7 @@ def assert_fetch_type_for_tag_string_set(
     assert all([meta[string].fetch_type == fetch_type for string in str_set])
 
 
-def test_static_and_non_static_strings(indexer):
+def test_static_and_non_static_strings(indexer, use_case_id):
     static_indexer = StaticStringIndexer(indexer)
     org_strings = {
         2: {"release", "1.0.0"},
@@ -85,7 +95,7 @@ def test_static_and_non_static_strings(indexer):
     assert_fetch_type_for_tag_string_set(meta[3], FetchType.FIRST_SEEN, {"2.0.0"})
 
 
-def test_indexer(indexer, indexer_cache):
+def test_indexer(indexer, indexer_cache, use_case_id):
     org1_id = 1
     org2_id = 2
     strings = {"hello", "hey", "hi"}
@@ -142,7 +152,7 @@ def test_indexer(indexer, indexer_cache):
     assert not results.get(999)
 
 
-def test_resolve_and_reverse_resolve(indexer, indexer_cache):
+def test_resolve_and_reverse_resolve(indexer, indexer_cache, use_case_id):
     """
     Test `resolve` and `reverse_resolve` methods
     """
@@ -169,7 +179,7 @@ def test_resolve_and_reverse_resolve(indexer, indexer_cache):
     assert indexer.reverse_resolve(use_case_id=use_case_id, org_id=org1_id, id=1234) is None
 
 
-def test_already_created_plus_written_results(indexer, indexer_cache) -> None:
+def test_already_created_plus_written_results(indexer, indexer_cache, use_case_id) -> None:
     """
     Test that we correctly combine db read results with db write results
     for the same organization.
@@ -212,7 +222,7 @@ def test_already_created_plus_written_results(indexer, indexer_cache) -> None:
     assert_fetch_type_for_tag_string_set(fetch_meta[org_id], FetchType.FIRST_SEEN, {"v1.2.3"})
 
 
-def test_already_cached_plus_read_results(indexer, indexer_cache) -> None:
+def test_already_cached_plus_read_results(indexer, indexer_cache, use_case_id) -> None:
     """
     Test that we correctly combine cached results with read results
     for the same organization.
@@ -249,7 +259,7 @@ def test_already_cached_plus_read_results(indexer, indexer_cache) -> None:
     assert_fetch_type_for_tag_string_set(fetch_meta[org_id], FetchType.DB_READ, {"bam"})
 
 
-def test_rate_limited(indexer):
+def test_rate_limited(indexer, use_case_id, writes_limiter_option_name):
     """
     Assert that rate limits per-org and globally are applied at all.
 
@@ -264,7 +274,7 @@ def test_rate_limited(indexer):
 
     with override_options(
         {
-            "sentry-metrics.writes-limiter.limits.releasehealth.per-org": [
+            f"{writes_limiter_option_name}.per-org": [
                 {"window_seconds": 10, "granularity_seconds": 10, "limit": 1}
             ],
         }
@@ -298,7 +308,7 @@ def test_rate_limited(indexer):
     # attempt to index even more strings, and assert that we can't get any indexed
     with override_options(
         {
-            "sentry-metrics.writes-limiter.limits.releasehealth.per-org": [
+            f"{writes_limiter_option_name}.per-org": [
                 {"window_seconds": 10, "granularity_seconds": 10, "limit": 1}
             ],
         }
@@ -318,7 +328,7 @@ def test_rate_limited(indexer):
     # assert that if we reconfigure limits, the quota resets
     with override_options(
         {
-            "sentry-metrics.writes-limiter.limits.releasehealth.global": [
+            f"{writes_limiter_option_name}.global": [
                 {"window_seconds": 10, "granularity_seconds": 10, "limit": 2}
             ],
         }

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -57,8 +57,10 @@ def writes_limiter_option_name(use_case_id):
 
 
 @pytest.fixture
-def indexer(indexer_cls):
-    return indexer_cls()
+def indexer(indexer_cls, use_case_id):
+    if indexer_cls is RawSimpleIndexer:
+        return indexer_cls()
+    return indexer_cls(metric_key_path=use_case_id)
 
 
 def assert_fetch_type_for_tag_string_set(

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -24,7 +24,7 @@ def assert_fetch_type_for_tag_string_set(
 class PostgresIndexerV2Test(TestCase):
     def setUp(self) -> None:
         self.strings = {"hello", "hey", "hi"}
-        self.indexer = CachingIndexer(indexer_cache, PGStringIndexerV2())
+        self.indexer = CachingIndexer(indexer_cache, PGStringIndexerV2(UseCaseKey.PERFORMANCE))
         self.org2 = self.create_organization()
         self.use_case_id = UseCaseID.SESSIONS
         self.use_case_key = UseCaseKey.RELEASE_HEALTH

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -1,10 +1,16 @@
 from typing import Mapping, Set
 
 from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.sentry_metrics.indexer.base import FetchType, KeyCollection, Metadata
+from sentry.sentry_metrics.indexer.base import (
+    FetchType,
+    KeyCollection,
+    Metadata,
+    UseCaseKeyCollection,
+)
 from sentry.sentry_metrics.indexer.cache import CachingIndexer
 from sentry.sentry_metrics.indexer.postgres.models import StringIndexer
 from sentry.sentry_metrics.indexer.postgres.postgres_v2 import PGStringIndexerV2, indexer_cache
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.testutils.cases import TestCase
 from sentry.utils.cache import cache
 
@@ -20,7 +26,8 @@ class PostgresIndexerV2Test(TestCase):
         self.strings = {"hello", "hey", "hi"}
         self.indexer = CachingIndexer(indexer_cache, PGStringIndexerV2())
         self.org2 = self.create_organization()
-        self.use_case_id = UseCaseKey("release-health")
+        self.use_case_id = UseCaseID.SESSIONS
+        self.use_case_key = UseCaseKey.RELEASE_HEALTH
         self.cache_namespace = self.use_case_id.value
 
     def tearDown(self) -> None:
@@ -37,7 +44,7 @@ class PostgresIndexerV2Test(TestCase):
         assert indexer_cache.get(key, self.cache_namespace) is None
         assert indexer_cache.get(string.id, self.cache_namespace) is None
 
-        self.indexer.indexer._get_db_records(self.use_case_id, collection)
+        self.indexer.indexer._get_db_records(UseCaseKeyCollection({self.use_case_id: collection}))
 
         assert indexer_cache.get(string.id, self.cache_namespace) is None
         assert indexer_cache.get(key, self.cache_namespace) is None


### PR DESCRIPTION
### TODO
1. Wait for all indexer changes to be merged
2. Determine if we should obtain config in __init__ as well
3. Determine if we want to remove passing `config.db_backend_options` to the indexer