### PR TITLE
fix(dynamic-sampling): Improve project rebalancing with 0 count projects

### DIFF
--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -215,8 +215,14 @@ def adjust_sample_rates(
     projects_with_counts = {
         project_id: count_per_root for project_id, count_per_root, _, _ in projects_with_tx_count
     }
-    all_projects_ids = Project.objects.filter(organization=organization).values_list(
-        "id", flat=True
+    # Since we don't mind about strong consistency, we query a replica of the main database with the possibility of
+    # having out of date information. This is a trade-off we accept, since we work under the assumption that eventually
+    # the projects of an org will be replicated consistently across replicas, because no org should continue to create
+    # new projects.
+    all_projects_ids = (
+        Project.objects.using_replica()
+        .filter(organization=organization)
+        .values_list("id", flat=True)
     )
     for project_id in all_projects_ids:
         # In case a specific project has not been considered in the count query, it means that no metrics were extracted

--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -212,6 +212,12 @@ def adjust_sample_rates(
     if sample_rate is None:
         return
 
+    all_projects_ids = Project.objects.filter(organization=organization).values_list(
+        "id", flat=True
+    )
+    for project_id in all_projects_ids:
+        pass
+
     projects = []
     for project_id, count_per_root, count_keep, count_drop in projects_with_tx_count:
         projects.append(

--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -212,14 +212,20 @@ def adjust_sample_rates(
     if sample_rate is None:
         return
 
+    projects_with_counts = {
+        project_id: count_per_root for project_id, count_per_root, _, _ in projects_with_tx_count
+    }
     all_projects_ids = Project.objects.filter(organization=organization).values_list(
         "id", flat=True
     )
     for project_id in all_projects_ids:
-        pass
+        # In case a specific project has not been considered in the count query, it means that no metrics were extracted
+        # for it, thus we consider it as having 0 transactions for the query's time window.
+        if project_id not in projects_with_counts:
+            projects_with_counts[project_id] = 0
 
     projects = []
-    for project_id, count_per_root, count_keep, count_drop in projects_with_tx_count:
+    for project_id, count_per_root in projects_with_counts.items():
         projects.append(
             DSElement(
                 id=project_id,


### PR DESCRIPTION
This PR fixes an edge case that was occurring in the prioritize by project bias. The problem was that the query was returning all `(org, project)` pairs that had metrics, thus if a project didn't have a count it wasn't considered at all.

This fix intersects all projects with the return projects and puts to `count = 0` the projects that weren't returned by the queries.

Closes https://github.com/getsentry/sentry/issues/48623