### PR TITLE
Increase number of bundles returned by Lookup API

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("sentry.api")
 # The marker for "release" bundles
 RELEASE_BUNDLE_TYPE = "release.bundle"
 # The number of bundles ("artifact" or "release") that we query
-MAX_BUNDLES_QUERY = 4
+MAX_BUNDLES_QUERY = 5
 # The number of files returned by the `get_releasefiles` query
 MAX_RELEASEFILES_QUERY = 10
 

--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("sentry.api")
 # The marker for "release" bundles
 RELEASE_BUNDLE_TYPE = "release.bundle"
 # The number of bundles ("artifact" or "release") that we query
-MAX_BUNDLES_QUERY = 2
+MAX_BUNDLES_QUERY = 4
 # The number of files returned by the `get_releasefiles` query
 MAX_RELEASEFILES_QUERY = 10
 


### PR DESCRIPTION
Through A/B testing, we see a couple of events that fail symbolication, presumably because a project is splitting / uploading multiple bundles per release, and some files we are looking for are not available in the bundles that we do return from the API. To increase that chance, we increase the number of bundles we query/return. However this number does have performance implications down the line.

Ideally, projects would just have a single bundle per release, but we have to put some kind of limit on this.