### PR TITLE
ref(strings): Add `span.description` tag

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -133,6 +133,7 @@ SHARED_TAG_STRINGS = {
     "span.status": PREFIX + 246,
     "span.status_code": PREFIX + 247,
     "span.domain": PREFIX + 248,
+    "span.description": PREFIX + 249,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
Ref: https://github.com/getsentry/relay/pull/2095

Adds the new tag `span.description` to the indexer.