### PR TITLE
fix(crons): Properly use validator for PUT

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -69,14 +69,15 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
         if checkin.status in CheckInStatus.FINISHED_VALUES:
             return self.respond(status=400)
 
+        # Discard monitor config so as it is not used
+        request.data.pop("monitor_config", None)
+
         serializer = MonitorCheckInValidator(
             data=request.data,
             partial=True,
             context={
                 "project": project,
                 "request": request,
-                "monitor_slug": monitor.slug,
-                "monitor": monitor,
             },
         )
         if not serializer.is_valid():

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -70,7 +70,14 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
             return self.respond(status=400)
 
         serializer = MonitorCheckInValidator(
-            data=request.data, partial=True, context={"project": project, "request": request}
+            data=request.data,
+            partial=True,
+            context={
+                "project": project,
+                "request": request,
+                "monitor": monitor,
+                "monitor_slug": monitor.slug,
+            },
         )
         if not serializer.is_valid():
             return self.respond(serializer.errors, status=400)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -75,8 +75,8 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
             context={
                 "project": project,
                 "request": request,
-                "monitor": monitor,
                 "monitor_slug": monitor.slug,
+                "monitor": monitor,
             },
         )
         if not serializer.is_valid():

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -69,7 +69,7 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
         if checkin.status in CheckInStatus.FINISHED_VALUES:
             return self.respond(status=400)
 
-        # Discard monitor config so as it is not used
+        # Discard monitor config as it is not used
         request.data.pop("monitor_config", None)
 
         serializer = MonitorCheckInValidator(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2358,7 +2358,7 @@ class MonitorIngestTestCase(MonitorTestCase):
         # Token based auth
         sentry_app = self.create_sentry_app(
             organization=self.organization,
-            scopes=["project:write"],
+            scopes=["project:read", "project:write"],
         )
         app = self.create_sentry_app_installation(
             slug=sentry_app.slug, organization=self.organization

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2358,7 +2358,7 @@ class MonitorIngestTestCase(MonitorTestCase):
         # Token based auth
         sentry_app = self.create_sentry_app(
             organization=self.organization,
-            scopes=["project:read", "project:write"],
+            scopes=["project:write"],
         )
         app = self.create_sentry_app_installation(
             slug=sentry_app.slug, organization=self.organization

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -178,7 +178,14 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             )
 
             path = path_func(monitor.guid, self.latest.guid)
-            resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
+            resp = self.client.put(
+                path,
+                data={
+                    "status": "ok",
+                    "monitor_config": {"schedule_type": "crontab", "schedule": "* * * * *"},
+                },
+                **self.token_auth_headers,
+            )
             assert resp.status_code == 200, resp.content
 
             checkin = MonitorCheckIn.objects.get(id=checkin.id)

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -95,7 +95,15 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             )
 
             path = path_func(monitor.guid, checkin.guid)
-            resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
+            # include monitor_config to test check-in validation no error thrown, no-op on server side
+            resp = self.client.put(
+                path,
+                data={
+                    "status": "ok",
+                    "monitor_config": {"schedule_type": "crontab", "schedule": "* * * * *"},
+                },
+                **self.token_auth_headers,
+            )
             assert resp.status_code == 200, resp.content
 
             checkin = MonitorCheckIn.objects.get(id=checkin.id)
@@ -178,6 +186,7 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             )
 
             path = path_func(monitor.guid, self.latest.guid)
+            # include monitor_config to test check-in validation no error thrown, no-op on server side
             resp = self.client.put(
                 path,
                 data={


### PR DESCRIPTION
Send monitor object to check-in validator for PUT on `latest` endpoint. Fixes a bug that caused the validator to fail when config was sent.

Fixes SENTRY-10DM