### PR TITLE
perf(sql-format): Add a span to track format time

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -427,8 +427,9 @@ class SqlFormatEventSerializer(EventSerializer):
 
     def serialize(self, obj, attrs, user):
         result = super().serialize(obj, attrs, user)
-        result = self._format_breadcrumb_messages(result, obj, user)
-        result = self._format_db_spans(result, obj, user)
+        with sentry_sdk.start_span(op="event_serializer.format_sql"):
+            result = self._format_breadcrumb_messages(result, obj, user)
+            result = self._format_db_spans(result, obj, user)
         return result
 
 


### PR DESCRIPTION
We already collect spans for serializers, but this will allow us to separate the total serialization time from the time spent formatting SQL.