### PR TITLE
fix(issue-platform): Update grouping for platform performance issues

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -123,6 +123,7 @@ function EventEntries({
           showGroupingConfig={
             orgFeatures.includes('set-grouping-config') && 'groupingConfig' in event
           }
+          group={group}
         />
       )}
       {!isShare && (

--- a/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
@@ -23,6 +23,18 @@ describe('Grouping Variant', () => {
       },
     ],
   };
+  const occurrenceEvent = {
+    ...event,
+    occurrence: {
+      fingerprint: ['test-fingerprint'],
+      evidenceData: {
+        op: 'db',
+        offenderSpanIds: ['2'],
+        causeSpanIds: ['1'],
+        parentSpanIds: [],
+      },
+    },
+  };
   const performanceIssueVariant = {
     type: EventGroupVariantType.PERFORMANCE_PROBLEM,
     description: 'performance issue',
@@ -44,6 +56,32 @@ describe('Grouping Variant', () => {
         showGroupingConfig={false}
         variant={performanceIssueVariant}
         event={event}
+      />
+    );
+
+    expect(
+      within(screen.getByText('Parent Span Hashes').closest('tr') as HTMLElement)
+        .getByText('[')
+        .closest('td')
+    ).toHaveTextContent('[]');
+    expect(
+      within(
+        screen.getByText('Source Span Hashes').closest('tr') as HTMLElement
+      ).getByText('hash1')
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByText('Offender Span Hashes').closest('tr') as HTMLElement
+      ).getByText('hash2')
+    ).toBeInTheDocument();
+  });
+
+  it('renders grouping details for occurrence-backed performance issues', () => {
+    render(
+      <GroupingVariant
+        showGroupingConfig={false}
+        variant={performanceIssueVariant}
+        event={occurrenceEvent}
       />
     );
 

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -34,7 +34,11 @@ class GroupingInfo extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {organization, event, projectSlug, group} = this.props;
 
-    if (event.occurrence && group?.issueCategory === IssueCategory.PERFORMANCE) {
+    if (
+      event.occurrence &&
+      group?.issueCategory === IssueCategory.PERFORMANCE &&
+      event.type === 'transaction'
+    ) {
       return [];
     }
 

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -73,7 +73,7 @@ class GroupingInfo extends AsyncComponent<Props, State> {
     const variant = group
       ? {
           [group.issueType]: {
-            description: 'performance problem',
+            description: t('performance problem'),
             hash: occurrence?.fingerprint[0] || '',
             hasMismatch: false,
             key: group.issueType,
@@ -107,11 +107,11 @@ class GroupingInfo extends AsyncComponent<Props, State> {
           .map(variant => variant.description)
           .sort((a, b) => a!.toLowerCase().localeCompare(b!.toLowerCase()))
           .join(', ')
-      : 'nothing';
+      : t('nothing');
 
     return (
       <p data-test-id="loaded-grouping-info">
-        <strong>{t('Grouped by:')}</strong> {groupedBy || t('nothing')}
+        <strong>{t('Grouped by:')}</strong> {groupedBy}
       </p>
     );
   }

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -96,7 +96,9 @@ class GroupingInfo extends AsyncComponent<Props, State> {
     const {group, event} = this.props;
 
     const groupInfo =
-      group?.issueCategory === IssueCategory.PERFORMANCE && event.occurrence
+      group?.issueCategory === IssueCategory.PERFORMANCE &&
+      event.occurrence &&
+      event.type === 'transaction'
         ? // performance issue grouping details are generated clint-side
           this.generatePerformanceGroupInfo()
         : _groupInfo;
@@ -140,7 +142,9 @@ class GroupingInfo extends AsyncComponent<Props, State> {
     const {event, showGroupingConfig, group} = this.props;
 
     const groupInfo =
-      group?.issueCategory === IssueCategory.PERFORMANCE && event.occurrence
+      group?.issueCategory === IssueCategory.PERFORMANCE &&
+      event.occurrence &&
+      event.type === 'transaction'
         ? this.generatePerformanceGroupInfo()
         : _groupInfo;
 

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -8,8 +8,8 @@ import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EventGroupInfo, Organization} from 'sentry/types';
-import {Event} from 'sentry/types/event';
+import {EventGroupInfo, Group, IssueCategory, Organization} from 'sentry/types';
+import {Event, EventOccurrence} from 'sentry/types/event';
 import withOrganization from 'sentry/utils/withOrganization';
 import {groupingFeedbackTypes} from 'sentry/views/issueDetails/grouping/grouping';
 
@@ -21,6 +21,7 @@ type Props = AsyncComponent['props'] & {
   organization: Organization;
   projectSlug: string;
   showGroupingConfig: boolean;
+  group?: Group;
 };
 
 type State = AsyncComponent['state'] & {
@@ -31,7 +32,11 @@ type State = AsyncComponent['state'] & {
 
 class GroupingInfo extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization, event, projectSlug} = this.props;
+    const {organization, event, projectSlug, group} = this.props;
+
+    if (event.occurrence && group?.issueCategory === IssueCategory.PERFORMANCE) {
+      return [];
+    }
 
     let path = `/projects/${organization.slug}/${projectSlug}/events/${event.id}/grouping-info/`;
     if (this.state?.configOverride) {
@@ -60,18 +65,49 @@ class GroupingInfo extends AsyncComponent<Props, State> {
     this.setState({configOverride: selection.value}, () => this.reloadData());
   };
 
+  generatePerformanceGroupInfo() {
+    const {group, event} = this.props;
+    const {occurrence} = event;
+    const {evidenceData} = occurrence as EventOccurrence;
+
+    const variant = group
+      ? {
+          [group.issueType]: {
+            description: 'performance problem',
+            hash: occurrence?.fingerprint[0] || '',
+            hasMismatch: false,
+            key: group.issueType,
+            type: 'performance-problem',
+            evidence: {
+              op: evidenceData?.op,
+              parent_span_ids: evidenceData?.parentSpanIds,
+              cause_span_ids: evidenceData?.causeSpanIds,
+              offender_span_ids: evidenceData?.offenderSpanIds,
+            },
+          },
+        }
+      : null;
+
+    return variant;
+  }
+
   renderGroupInfoSummary() {
-    const {groupInfo} = this.state;
+    const {groupInfo: _groupInfo} = this.state;
+    const {group, event} = this.props;
 
-    if (!groupInfo) {
-      return null;
-    }
+    const groupInfo =
+      group?.issueCategory === IssueCategory.PERFORMANCE && event.occurrence
+        ? // performance issue grouping details are generated clint-side
+          this.generatePerformanceGroupInfo()
+        : _groupInfo;
 
-    const groupedBy = Object.values(groupInfo)
-      .filter(variant => variant.hash !== null && variant.description !== null)
-      .map(variant => variant.description)
-      .sort((a, b) => a!.toLowerCase().localeCompare(b!.toLowerCase()))
-      .join(', ');
+    const groupedBy = groupInfo
+      ? Object.values(groupInfo)
+          .filter(variant => variant.hash !== null && variant.description !== null)
+          .map(variant => variant.description)
+          .sort((a, b) => a!.toLowerCase().localeCompare(b!.toLowerCase()))
+          .join(', ')
+      : 'nothing';
 
     return (
       <p data-test-id="loaded-grouping-info">
@@ -100,8 +136,13 @@ class GroupingInfo extends AsyncComponent<Props, State> {
   }
 
   renderGroupInfo() {
-    const {groupInfo, loading} = this.state;
-    const {event, showGroupingConfig} = this.props;
+    const {groupInfo: _groupInfo, loading} = this.state;
+    const {event, showGroupingConfig, group} = this.props;
+
+    const groupInfo =
+      group?.issueCategory === IssueCategory.PERFORMANCE && event.occurrence
+        ? this.generatePerformanceGroupInfo()
+        : _groupInfo;
 
     const variants = groupInfo
       ? Object.values(groupInfo).sort((a, b) =>

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -649,7 +649,7 @@ type EventEvidenceDisplay = {
   value: string;
 };
 
-type EventOccurrence = {
+export type EventOccurrence = {
   detectionTime: string;
   eventId: string;
   /**

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -148,6 +148,7 @@ function GroupEventDetailsContent({
             organization.features.includes('set-grouping-config') &&
             'groupingConfig' in event
           }
+          group={group}
         />
       )}
 


### PR DESCRIPTION
Occurrence-backed performance issues won't use `/grouping-info` endpoint since its grouping information can be pulled from the event.evidence_data dict.