### PR TITLE
fix(issue-stream): Fix pagination caption when realtime is enabled

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -727,10 +727,11 @@ class IssueListOverview extends Component<Props, State> {
     }
   };
 
-  onRealtimePoll = (data: any, _links: any) => {
+  onRealtimePoll = (data: any, {queryCount}: {queryCount: number}) => {
     // Note: We do not update state with cursors from polling,
     // `CursorPoller` updates itself with new cursors
     GroupStore.addToFront(data);
+    this.setState({queryCount});
   };
 
   listener = GroupStore.listen(() => this.onGroupChange(), undefined);
@@ -1151,7 +1152,7 @@ class IssueListOverview extends Component<Props, State> {
     // validate that it's correct at the first and last page
     if (!links?.next?.results || this.allResultsVisible()) {
       // On last available page
-      numPreviousIssues = queryCount - groupIds.length;
+      numPreviousIssues = Math.max(queryCount - groupIds.length, 0);
     } else if (!links?.previous?.results) {
       // On first available page
       numPreviousIssues = 0;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/48717

- Ensure that `numPreviousIssues` doesn't go negative so we don't get `-1-10 of 10`
- Update `queryCount` when poll updates come in so that we don't get `1-11 of 10`