### PR TITLE
feat(perf): Add http.method to all events for backend

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -248,4 +248,43 @@ describe('Performance Transaction Events Content', function () {
       .map(elem => elem.textContent);
     expect(columnTitles).toStrictEqual(expect.arrayContaining([t('measurements.lcp')]));
   });
+
+  it('rendering with http.method', function () {
+    const _eventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        version: 2,
+        name: 'transactionName',
+        fields,
+        query,
+        projects: [1],
+        orderby: '-timestamp',
+      },
+      initialData.router.location
+    );
+    render(
+      <OrganizationContext.Provider value={initialData.organization}>
+        <EventsPageContent
+          eventView={_eventView}
+          organization={initialData.organization}
+          location={initialData.router.location}
+          transactionName={transactionName}
+          spanOperationBreakdownFilter={SpanOperationBreakdownFilter.None}
+          onChangeSpanOperationBreakdownFilter={() => {}}
+          eventsDisplayFilterName={EventsDisplayFilterName.p100}
+          onChangeEventsDisplayFilter={() => {}}
+          webVital={WebVital.LCP}
+          setError={() => {}}
+          projectId="1"
+          projects={[TestStubs.Project({id: 1, platform: 'python'})]}
+        />
+      </OrganizationContext.Provider>,
+      {context: initialData.routerContext}
+    );
+
+    const columnTitles = screen
+      .getAllByRole('columnheader')
+      .map(elem => elem.textContent);
+    expect(columnTitles).toStrictEqual(expect.arrayContaining([t('http.method')]));
+  });
 });

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -20,6 +20,10 @@ import {WebVital} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import {useRoutes} from 'sentry/utils/useRoutes';
+import {
+  platformToPerformanceType,
+  PROJECT_PERFORMANCE_TYPE,
+} from 'sentry/views/performance/utils';
 
 import Filter, {filterToSearchConditions, SpanOperationBreakdownFilter} from '../filter';
 import {SetStateAction} from '../types';
@@ -83,6 +87,15 @@ function EventsContent(props: Props) {
   if (spanOperationBreakdownConditions) {
     eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
     transactionsListTitles.splice(2, 1, t('%s duration', spanOperationBreakdownFilter));
+  }
+
+  const platform = platformToPerformanceType(projects, eventView.project);
+  if (platform === PROJECT_PERFORMANCE_TYPE.BACKEND) {
+    const userIndex = transactionsListTitles.indexOf('user');
+    if (userIndex > 0) {
+      transactionsListTitles.splice(userIndex + 1, 0, 'http.method');
+      fields.splice(userIndex + 1, 0, {field: 'http.method'});
+    }
   }
 
   if (


### PR DESCRIPTION
### Summary
Just like how we optionally add columns for the frontend such as 'replay', this adds http.method when the platform is detected to be one of our backend projects.

### Screenshot
![Screenshot 2023-05-08 at 2 17 38 PM](https://user-images.githubusercontent.com/6111995/236901192-a6088986-4c0e-4612-b717-6fb103fb1789.png)



Fixes #48711
