### PR TITLE
feat(repos): use integration_id in query

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationRepos.spec.jsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.spec.jsx
@@ -156,7 +156,7 @@ describe('IntegrationRepos', function () {
       const updateRepo = MockApiClient.addMockResponse({
         method: 'PUT',
         url: `/organizations/${org.slug}/repos/4/`,
-        body: {},
+        body: {id: 244},
       });
       render(<IntegrationRepos integration={integration} />);
 
@@ -176,7 +176,7 @@ describe('IntegrationRepos', function () {
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         method: 'GET',
-        body: [TestStubs.Repository({name: 'repo-name', externalSlug: 9876})],
+        body: [TestStubs.Repository({name: 'repo-name-other', externalSlug: 9876})],
       });
       const getItems = MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/integrations/${integration.id}/repos/`,
@@ -188,7 +188,7 @@ describe('IntegrationRepos', function () {
       const updateRepo = MockApiClient.addMockResponse({
         method: 'PUT',
         url: `/organizations/${org.slug}/repos/4/`,
-        body: {},
+        body: {id: 4320},
       });
       render(<IntegrationRepos integration={integration} />);
 

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.tsx
@@ -58,12 +58,13 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const orgId = this.props.organization.slug;
-    return [['itemList', `/organizations/${orgId}/repos/`, {query: {status: ''}}]];
-  }
-
-  getIntegrationRepos() {
-    const integrationId = this.props.integration.id;
-    return this.state.itemList.filter(repo => repo.integrationId === integrationId);
+    return [
+      [
+        'itemList',
+        `/organizations/${orgId}/repos/`,
+        {query: {status: 'active', integration_id: this.props.integration.id}},
+      ],
+    ];
   }
 
   // Called by row to signal repository change.
@@ -197,9 +198,8 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {itemListPageLinks, integrationReposErrorStatus} = this.state;
+    const {itemListPageLinks, integrationReposErrorStatus, itemList} = this.state;
     const orgId = this.props.organization.slug;
-    const itemList = this.getIntegrationRepos() || [];
     return (
       <Fragment>
         {integrationReposErrorStatus === 400 && (


### PR DESCRIPTION
Now that the backend can accept the `integration_id` in the query, we should pass it down.