### PR TITLE
fix(issue-details): Return correct data when event ID query fails

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -351,7 +351,7 @@ class SnubaEventStorage(EventStorage):
         except (snuba.QueryOutsideRetentionError, snuba.QueryOutsideGroupActivityError):
             # This can happen when the date conditions for paging
             # and the current event generate impossible conditions.
-            return None
+            return [None for _ in filters]
 
         return [self.__get_event_id_from_result(result) for result in results]
 


### PR DESCRIPTION
Fixes SENTRY-111C