### PR TITLE
feat(api): Reimplement team creation endpoint changes w/ fixes

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -212,6 +212,13 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                     raise PermissionDenied(
                         detail="You must be a member of the organization to join a new team as a Team Admin"
                     )
+            # catch generic exception to ensure the team gets deleted if we can't add the user as
+            # a Team Admin
+            except Exception as e:
+                if set_team_admin:
+                    team.delete()
+                raise ValidationError({"detail": str(e)})
+
         self.create_audit_entry(
             request=request,
             organization=organization,

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -195,7 +195,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
             )
 
         if self.should_add_creator_to_team(request):
-            cleanup_needed = False
+            cleanup_needed = True
             try:
                 with transaction.atomic():
                     member = OrganizationMember.objects.get(
@@ -206,21 +206,15 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                         organizationmember=member,
                         role="admin" if set_team_admin else None,
                     )
+                cleanup_needed = False
             except OrganizationMember.DoesNotExist:
                 if set_team_admin:
                     # delete team if we can't add the user as a team admin
-                    cleanup_needed = True
                     raise PermissionDenied(
                         detail="You must be a member of the organization to join a new team as a Team Admin"
                     )
-            # catch generic exception to ensure the team gets deleted if we can't add the user as
-            # a Team Admin
-            except Exception as err:
-                if set_team_admin:
-                    cleanup_needed = True
-                raise err
             finally:
-                if cleanup_needed:
+                if set_team_admin and cleanup_needed:
                     team.delete()
 
         self.create_audit_entry(

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -209,7 +209,6 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                 cleanup_needed = False
             except OrganizationMember.DoesNotExist:
                 if set_team_admin:
-                    # delete team if we can't add the user as a team admin
                     raise PermissionDenied(
                         detail="You must be a member of the organization to join a new team as a Team Admin"
                     )

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -26,11 +26,10 @@ CONFLICTING_SLUG_ERROR = "A team with this slug already exists."
 
 # OrganizationPermission + team:write
 class OrganizationTeamsPermission(OrganizationPermission):
+    # PUT and DELETE are irrelevant because they are handled by TeamDetailsEndpoint
     scope_map = {
-        "GET": ["org:read", "org:write", "org:admin"],
+        "GET": ["org:read", "org:write"],
         "POST": ["org:write", "team:write"],
-        "PUT": ["org:write", "org:admin", "team:write"],
-        "DELETE": ["org:admin", "team:write"],
     }
 
 
@@ -48,8 +47,8 @@ class TeamPostSerializer(serializers.Serializer):
             )
         },
     )
-    set_admin = serializers.BooleanField(required=False, default=False)
     idp_provisioned = serializers.BooleanField(required=False, default=False)
+    set_admin = serializers.BooleanField(required=False, default=False)
 
     def validate(self, attrs):
         if not (attrs.get("name") or attrs.get("slug")):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1489,6 +1489,8 @@ SENTRY_FEATURES = {
     "organizations:team-insights": True,
     # Enable u2f verification on superuser form
     "organizations:u2f-superuser-form": False,
+    # Enable project creation for all
+    "organizations:team-project-creation-all": False,
     # Enable setting team-level roles and receiving permissions from them
     "organizations:team-roles": False,
     # Enable team member role provisioning through scim

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -183,6 +183,7 @@ default_manager.add("organizations:slack-overage-notifications", OrganizationFea
 default_manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:streamline-targeting-context", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add('organizations:team-project-creation-all', OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:team-roles", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -274,7 +274,7 @@ class OrganizationTeamsCreateTest(APITestCase):
             status_code=400,
         )
         assert response.data == {
-            "detail": "Unable to set user as Team Admin because organization:team-roles flag is not enabled"
+            "detail": "You do not have permission to join a new team as a team admin"
         }
 
     @with_feature("organizations:team-roles")
@@ -287,7 +287,7 @@ class OrganizationTeamsCreateTest(APITestCase):
             status_code=400,
         )
         assert response.data == {
-            "detail": "Unable to set user as Team Admin because organization:team-project-creation-all flag is not enabled"
+            "detail": "You do not have permission to join a new team as a team admin"
         }
 
     @with_feature(["organizations:team-roles", "organizations:team-project-creation-all"])
@@ -301,7 +301,7 @@ class OrganizationTeamsCreateTest(APITestCase):
             status_code=401,
         )
         assert response.data == {
-            "detail": "Unable to set user as Team Admin because user is not authenticated"
+            "detail": "You must be authenticated to join a new team as a Team Admin"
         }
         mock_creator_check.assert_called_once()
 
@@ -328,7 +328,7 @@ class OrganizationTeamsCreateTest(APITestCase):
                 status_code=400,
             )
             assert response.data == {
-                "detail": "Unable to set user as team admin because user is not a member of the organization",
+                "detail": "You must be a member of the organization to join a new team as a Team Admin",
             }
         # assert that the created team was deleted because adding the user a team admin failed
         assert Team.objects.count() == team_count

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -246,6 +246,8 @@ class OrganizationTeamsCreateTest(APITestCase):
         )
 
     def test_org_member_does_not_exist_passes(self):
+        prior_team_count = Team.objects.count()
+
         # Multiple calls are made to OrganizationMember.objects.get, so in order to only raise
         # OrganizationMember.DoesNotExist for the correct call, we set a reference to the actual
         # function then call the reference unless the organization matches the test case
@@ -271,6 +273,7 @@ class OrganizationTeamsCreateTest(APITestCase):
         assert not OrganizationMemberTeam.objects.filter(
             organizationmember=member, team=team, is_active=True
         ).exists()
+        assert Team.objects.count() == prior_team_count + 1
 
     @with_feature(["organizations:team-roles", "organizations:team-project-creation-all"])
     def test_valid_team_admin(self):
@@ -361,4 +364,19 @@ class OrganizationTeamsCreateTest(APITestCase):
             assert response.data == {
                 "detail": "You must be a member of the organization to join a new team as a Team Admin",
             }
+        assert Team.objects.count() == prior_team_count
+
+    @with_feature(["organizations:team-roles", "organizations:team-project-creation-all"])
+    @patch.object(OrganizationMemberTeam.objects, "create", side_effect=Exception("test"))
+    def test_team_admin_org_member_team_create_generically_fails(self, mock_create):
+        prior_team_count = Team.objects.count()
+        response = self.get_error_response(
+            self.organization.slug,
+            name="hello world",
+            slug="foobar",
+            set_team_admin=True,
+            status_code=400,
+        )
+        mock_create.assert_called_once()
+        assert response.data == {"detail": "test"}
         assert Team.objects.count() == prior_team_count

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -243,12 +243,12 @@ class OrganizationTeamsCreateTest(APITestCase):
 
     @with_feature(["organizations:team-roles", "organizations:team-project-creation-all"])
     def test_valid_team_admin(self):
-        team_count = Team.objects.count()
+        prior_team_count = Team.objects.count()
         resp = self.get_success_response(
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            set_admin=True,
+            setTeamAdmin=True,
             status_code=201,
         )
 
@@ -263,14 +263,14 @@ class OrganizationTeamsCreateTest(APITestCase):
         assert OrganizationMemberTeam.objects.filter(
             organizationmember=member, team=team, is_active=True, role="admin"
         ).exists()
-        assert Team.objects.count() == team_count + 1
+        assert Team.objects.count() == prior_team_count + 1
 
     def test_team_admin_missing_team_roles_flag(self):
         response = self.get_error_response(
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            set_admin=True,
+            setTeamAdmin=True,
             status_code=400,
         )
         assert response.data == {
@@ -283,7 +283,7 @@ class OrganizationTeamsCreateTest(APITestCase):
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            set_admin=True,
+            setTeamAdmin=True,
             status_code=400,
         )
         assert response.data == {
@@ -297,7 +297,7 @@ class OrganizationTeamsCreateTest(APITestCase):
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            set_admin=True,
+            setTeamAdmin=True,
             status_code=401,
         )
         assert response.data == {
@@ -324,7 +324,7 @@ class OrganizationTeamsCreateTest(APITestCase):
                 self.organization.slug,
                 name="hello world",
                 slug="foobar",
-                set_admin=True,
+                setTeamAdmin=True,
                 status_code=400,
             )
             assert response.data == {

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -307,7 +307,7 @@ class OrganizationTeamsCreateTest(APITestCase):
 
     @with_feature(["organizations:team-roles", "organizations:team-project-creation-all"])
     def test_team_admin_member_does_not_exist(self):
-        team_count = Team.objects.count()
+        prior_team_count = Team.objects.count()
 
         # Multiple calls are made to OrganizationMember.objects.get, so in order to only raise
         # OrganizationMember.DoesNotExist for the correct call, we set a reference to the actual
@@ -330,5 +330,4 @@ class OrganizationTeamsCreateTest(APITestCase):
             assert response.data == {
                 "detail": "You must be a member of the organization to join a new team as a Team Admin",
             }
-        # assert that the created team was deleted because adding the user a team admin failed
-        assert Team.objects.count() == team_count
+        assert Team.objects.count() == prior_team_count

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -325,7 +325,7 @@ class OrganizationTeamsCreateTest(APITestCase):
                 name="hello world",
                 slug="foobar",
                 set_team_admin=True,
-                status_code=400,
+                status_code=403,
             )
             assert response.data == {
                 "detail": "You must be a member of the organization to join a new team as a Team Admin",

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -248,7 +248,7 @@ class OrganizationTeamsCreateTest(APITestCase):
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            setTeamAdmin=True,
+            set_team_admin=True,
             status_code=201,
         )
 
@@ -270,8 +270,8 @@ class OrganizationTeamsCreateTest(APITestCase):
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            setTeamAdmin=True,
-            status_code=400,
+            set_team_admin=True,
+            status_code=404,
         )
         assert response.data == {
             "detail": "You do not have permission to join a new team as a team admin"
@@ -283,8 +283,8 @@ class OrganizationTeamsCreateTest(APITestCase):
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            setTeamAdmin=True,
-            status_code=400,
+            set_team_admin=True,
+            status_code=404,
         )
         assert response.data == {
             "detail": "You do not have permission to join a new team as a team admin"
@@ -297,11 +297,11 @@ class OrganizationTeamsCreateTest(APITestCase):
             self.organization.slug,
             name="hello world",
             slug="foobar",
-            setTeamAdmin=True,
-            status_code=401,
+            set_team_admin=True,
+            status_code=400,
         )
         assert response.data == {
-            "detail": "You must be authenticated to join a new team as a Team Admin"
+            "detail": "You do not have permission to join a new team as a Team Admin"
         }
         mock_creator_check.assert_called_once()
 
@@ -324,7 +324,7 @@ class OrganizationTeamsCreateTest(APITestCase):
                 self.organization.slug,
                 name="hello world",
                 slug="foobar",
-                setTeamAdmin=True,
+                set_team_admin=True,
                 status_code=400,
             )
             assert response.data == {

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from unittest.mock import patch
 
+import pytest
 from django.urls import reverse
 
 from sentry.api.endpoints.organization_teams import OrganizationTeamsEndpoint
@@ -370,13 +371,13 @@ class OrganizationTeamsCreateTest(APITestCase):
     @patch.object(OrganizationMemberTeam.objects, "create", side_effect=Exception("test"))
     def test_team_admin_org_member_team_create_generically_fails(self, mock_create):
         prior_team_count = Team.objects.count()
-        response = self.get_error_response(
-            self.organization.slug,
-            name="hello world",
-            slug="foobar",
-            set_team_admin=True,
-            status_code=400,
-        )
+        with pytest.raises(Exception):
+            self.get_error_response(
+                self.organization.slug,
+                name="hello world",
+                slug="foobar",
+                set_team_admin=True,
+                status_code=400,
+            )
         mock_create.assert_called_once()
-        assert response.data == {"detail": "test"}
         assert Team.objects.count() == prior_team_count


### PR DESCRIPTION
Reimplement https://github.com/getsentry/sentry/pull/48279 with fixes. The original PR errored if the user was not being set as `Team Admin` but was not part of the organization. 

1. Create a test that checks that if user is not being added as `Team Admin` and the user is not part of the organization, the team is still created without erroring
2. Break team creation and adding member to team into 2 separate try-excepts
3. Delete created team if second try-except fails w/ `OrganizationMember.DoesNotExist` or any generic error and the request wants to add the user as a `Team Admin`

See [Github Gist](https://gist.github.com/schew2381/1a727d6647fd2fbd0dd16296c41186a9) to see the original vs new POST