### PR TITLE
disable caching on integration details endpoint

### DIFF
--- a/src/sentry/api/endpoints/integrations/organization_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/details.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from django.db import transaction
 from django.http import Http404
+from django.views.decorators.cache import never_cache
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -25,6 +26,7 @@ class IntegrationSerializer(serializers.Serializer):
 
 @control_silo_endpoint
 class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint):
+    @never_cache
     def get(self, request: Request, organization, integration_id) -> Response:
         org_integration = self.get_organization_integration(organization.id, integration_id)
 
@@ -35,6 +37,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         )
 
     @requires_feature("organizations:integrations-custom-scm")
+    @never_cache
     def put(self, request: Request, organization, integration_id) -> Response:
         integration = self.get_integration(organization.id, integration_id)
 
@@ -66,6 +69,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
             )
         return self.respond(serializer.errors, status=400)
 
+    @never_cache
     def delete(self, request: Request, organization, integration_id) -> Response:
         # Removing the integration removes the organization
         # integrations and all linked issues.
@@ -99,6 +103,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
 
         return self.respond(status=204)
 
+    @never_cache
     def post(self, request: Request, organization, integration_id) -> Response:
         integration = self.get_integration(organization.id, integration_id)
         installation = integration_service.get_installation(


### PR DESCRIPTION
The details and configuration pages of integrations can potentially contain sensitive data. This instructs the client browser to not cache the responses. 

This is a best effort at preventing this data from being cached. Browsers will generally honor this, but proxy devices between the client and server are free to ignore the cache header and cache the responses (as they often do). 

### Ticket: [INFO-161](https://getsentry.atlassian.net/browse/INFO-161)

[INFO-161]: https://getsentry.atlassian.net/browse/INFO-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ