### PR TITLE
fix(issue-platform): Make sure queries with `(un)handled` don't fail for performance issues

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -292,7 +292,7 @@ SEARCH_FILTER_UPDATERS: Mapping[int, GroupSearchFilterUpdater] = {
     GroupCategory.PERFORMANCE.value: lambda search_filters: [
         # need to remove this search filter, so we don't constrain the returned transactions
         sf
-        for sf in search_filters
+        for sf in _update_profiling_search_filters(search_filters)
         if sf.key.name != "message"
     ],
     GroupCategory.PROFILE.value: _update_profiling_search_filters,


### PR DESCRIPTION
This is a quick fix to solve a problem with perf issue on the issue platform. Previously we just filtered things out for profiling issues, but now that perf issues are on the issue platform we need to filter those search filters out from perf issues as well.

We should refactor this to work generally for any issue types on the issue platform.

