### PR TITLE
bug(replays): Replay>Network>Details should hide setup code snippets if the url is Filtered

### DIFF
--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -210,8 +210,7 @@ function SetupInstructions({
           }
         )}
       </p>
-
-      {showSnippet === Output.URL_SKIPPED && (
+      {showSnippet === Output.URL_SKIPPED && url !== '[Filtered]' && (
         <Alert type="warning">
           {tct('Add [url] to your [field] list to start capturing data.', {
             url: <kbd>{url}</kbd>,
@@ -219,7 +218,6 @@ function SetupInstructions({
           })}
         </Alert>
       )}
-
       {showSnippet === Output.BODY_SKIPPED && (
         <Alert type="warning">
           {tct('Enable [field] to capture both Request and Response payloads.', {
@@ -227,7 +225,6 @@ function SetupInstructions({
           })}
         </Alert>
       )}
-
       <h1>{t('Prerequisites')}</h1>
       <ol>
         {sdkNeedsUpdate ? (
@@ -240,10 +237,12 @@ function SetupInstructions({
         <li>{t('Edit the Replay integration configuration to allow this URL.')}</li>
         <li>{t('That’s it!')}</li>
       </ol>
-
-      <CodeSnippet filename="JavaScript" language="javascript">
-        {code}
-      </CodeSnippet>
+      {url !== '[Filtered]' && (
+        <CodeSnippet filename="JavaScript" language="javascript">
+          {code}
+        </CodeSnippet>
+      )}
+      › has copy, print and download buttons
     </StyledInstructions>
   );
 }

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -242,7 +242,6 @@ function SetupInstructions({
           {code}
         </CodeSnippet>
       )}
-      › has copy, print and download buttons
     </StyledInstructions>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/48730
