### PR TITLE
fix(discover-quick-content): Suspect commits section has unwanted border and shadow

### DIFF
--- a/static/app/components/events/eventCause.tsx
+++ b/static/app/components/events/eventCause.tsx
@@ -110,7 +110,7 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
   );
 }
 
-const StyledPanel = styled(Panel)`
+export const StyledPanel = styled(Panel)`
   margin: 0;
 `;
 

--- a/static/app/views/discover/table/quickContext/issueContext.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Count from 'sentry/components/count';
 import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
-import {EventCause} from 'sentry/components/events/eventCause';
+import {EventCause, StyledPanel} from 'sentry/components/events/eventCause';
 import {CauseHeader, DataSection} from 'sentry/components/events/styles';
 import {getAssignedToDisplayName} from 'sentry/components/group/assignedTo';
 import {Panel} from 'sentry/components/panels';
@@ -186,7 +186,7 @@ const SuspectCommitsContainer = styled(ContextContainer)`
     margin: 0;
   }
 
-  ${Panel} {
+  ${StyledPanel} {
     border: none;
     box-shadow: none;
   }


### PR DESCRIPTION
Noticed some unwanted styling with suspect commits under issue contexts in QCID:
<img width="336" alt="Screenshot 2023-05-08 at 5 26 20 PM" src="https://user-images.githubusercontent.com/60121741/236938874-0f666c23-c0d5-433f-85ef-9ca90d7494c7.png">

Wasn't targetting the correct nested styling.