### PR TITLE
chore(capman): make wait_for_event_count use a special referrer

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1018,7 +1018,7 @@ class SnubaTestCase(BaseTestCase):
         last_events_seen = 0
 
         while attempt < attempts:
-            events = eventstore.get_events(snuba_filter)
+            events = eventstore.get_events(snuba_filter, referrer="test.wait_for_event_count")
             last_events_seen = len(events)
             if len(events) >= total:
                 break


### PR DESCRIPTION
This test util is used by acceptance tests. A special case has been made for it [in snuba](https://github.com/getsentry/snuba/pull/4154/files). 