### PR TITLE
feat(issue-states): Add the ongoing label to issues

### DIFF
--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -144,10 +144,20 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
             }),
         };
       case GroupInboxReason.NEW:
-      default:
         return {
           tagType: 'warning',
           reasonBadgeText: t('New Issue'),
+          tooltipText:
+            dateAdded &&
+            t('Created %(relative)s', {
+              relative: relativeDateAdded,
+            }),
+        };
+      case GroupInboxReason.ONGOING:
+      default:
+        return {
+          tagType: 'info',
+          reasonBadgeText: t('Ongoing'),
           tooltipText:
             dateAdded &&
             t('Created %(relative)s', {

--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -92,6 +92,7 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
     tooltipText?: string;
   } {
     const hasEscalatingIssues = organization.features.includes('escalating-issues-ui');
+    const hasIssueStates = organization.features.includes('issue-states');
     switch (reason) {
       case GroupInboxReason.UNIGNORED:
         return {
@@ -154,10 +155,30 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
             }),
         };
       case GroupInboxReason.ONGOING:
-      default:
         return {
           tagType: 'info',
           reasonBadgeText: t('Ongoing'),
+          tooltipText:
+            dateAdded &&
+            t('Created %(relative)s', {
+              relative: relativeDateAdded,
+            }),
+        };
+      default:
+        if (hasIssueStates) {
+          return {
+            tagType: 'info',
+            reasonBadgeText: t('Ongoing'),
+            tooltipText:
+              dateAdded &&
+              t('Created %(relative)s', {
+                relative: relativeDateAdded,
+              }),
+          };
+        }
+        return {
+          tagType: 'warning',
+          reasonBadgeText: t('New Issue'),
           tooltipText:
             dateAdded &&
             t('Created %(relative)s', {

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -198,6 +198,7 @@ export const enum GroupInboxReason {
   MANUAL = 3,
   REPROCESSED = 4,
   ESCALATING = 5,
+  ONGOING = 6,
 }
 
 export type InboxDetails = {

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -35,6 +35,7 @@ import {space} from 'sentry/styles/space';
 import {
   Group,
   GroupStatusResolution,
+  GroupSubstatus,
   IssueCategory,
   Organization,
   Project,
@@ -61,7 +62,8 @@ type UpdateData =
   | {isBookmarked: boolean}
   | {isSubscribed: boolean}
   | {inbox: boolean}
-  | GroupStatusResolution;
+  | GroupStatusResolution
+  | {substatus: GroupSubstatus};
 
 const isResolutionStatus = (data: UpdateData): data is GroupStatusResolution => {
   return (data as GroupStatusResolution).status !== undefined;
@@ -512,7 +514,11 @@ export function Actions(props: Props) {
           }
           disabled={disabled || isAutoResolved}
           onClick={() =>
-            onUpdate({status: ResolutionStatus.UNRESOLVED, statusDetails: {}})
+            onUpdate({
+              status: ResolutionStatus.UNRESOLVED,
+              statusDetails: {},
+              substatus: GroupSubstatus.ONGOING,
+            })
           }
         >
           {isIgnored

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -35,7 +35,6 @@ import {space} from 'sentry/styles/space';
 import {
   Group,
   GroupStatusResolution,
-  GroupSubstatus,
   IssueCategory,
   Organization,
   Project,
@@ -62,8 +61,7 @@ type UpdateData =
   | {isBookmarked: boolean}
   | {isSubscribed: boolean}
   | {inbox: boolean}
-  | GroupStatusResolution
-  | {substatus: GroupSubstatus};
+  | GroupStatusResolution;
 
 const isResolutionStatus = (data: UpdateData): data is GroupStatusResolution => {
   return (data as GroupStatusResolution).status !== undefined;
@@ -517,7 +515,6 @@ export function Actions(props: Props) {
             onUpdate({
               status: ResolutionStatus.UNRESOLVED,
               statusDetails: {},
-              substatus: GroupSubstatus.ONGOING,
             })
           }
         >


### PR DESCRIPTION
Add the `ongoing` label to issues per the group inbox reason. Also change the default behavior to only tag NEW issues if it matches the group inbox reaosn.

WOR-3015