### PR TITLE
chore(issue-platform): Remove `organizations:issue-platform-search-perf-issues` flag and usages

### DIFF
--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import eventstore, features
+from sentry import eventstore
 from sentry.api.serializers import serialize
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import GroupCategory
@@ -54,11 +54,7 @@ def get_query_builder_for_group(
     query: str, snuba_params: Mapping[str, Any], group: Group, limit: int, offset: int
 ) -> QueryBuilder:
     dataset = Dataset.IssuePlatform
-    if group.issue_category == GroupCategory.PERFORMANCE and not features.has(
-        "organizations:issue-platform-search-perf-issues", group.project.organization
-    ):
-        dataset = Dataset.Transactions
-    elif group.issue_category == GroupCategory.ERROR:
+    if group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events
     return QueryBuilder(
         dataset=dataset,

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -483,9 +483,7 @@ class GroupSerializerBase(Serializer, ABC):
         # partition the item_list by type
         error_issues = [group for group in item_list if GroupCategory.ERROR == group.issue_category]
         generic_issues = [
-            group
-            for group in item_list
-            if group.issue_category and group.issue_category != GroupCategory.ERROR
+            group for group in item_list if group.issue_category != GroupCategory.ERROR
         ]
 
         # bulk query for the seen_stats by type

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -91,7 +91,6 @@ default_manager.add("organizations:issue-details-tag-improvements", Organization
 default_manager.add("organizations:issue-list-removal-action", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-platform", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:issue-platform-search-perf-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-secondary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -246,22 +246,15 @@ def _query_params_for_generic(
     return None
 
 
-def get_search_strategies(
-    organization: Organization, actor: Optional[Any]
-) -> Mapping[int, GroupSearchStrategy]:
+def get_search_strategies() -> Mapping[int, GroupSearchStrategy]:
     strategies = {}
     for group_category in GroupCategory:
         if group_category == GroupCategory.ERROR:
             strategy = _query_params_for_error
         elif group_category == GroupCategory.PERFORMANCE:
-            if not features.has(
-                "organizations:issue-platform-search-perf-issues", organization, actor=actor
-            ):
-                strategy = _query_params_for_perf
-            else:
-                strategy = functools.partial(
-                    _query_params_for_generic, categories=[GroupCategory.PERFORMANCE]
-                )
+            strategy = functools.partial(
+                _query_params_for_generic, categories=[GroupCategory.PERFORMANCE]
+            )
         else:
             strategy = functools.partial(
                 _query_params_for_generic, categories=[GroupCategory.PROFILE]

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import eventstore, eventtypes, features, tagstore
+from sentry import eventstore, eventtypes, tagstore
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
     BaseManager,
@@ -34,7 +34,6 @@ from sentry.db.models import (
 )
 from sentry.eventstore.models import GroupEvent
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_type_by_type_id
-from sentry.issues.query import apply_performance_conditions
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.snuba.dataset import Dataset
 from sentry.types.activity import ActivityType
@@ -208,24 +207,14 @@ def get_oldest_or_latest_event_for_environments(
     if len(environments) > 0:
         conditions.append(["environment", "IN", environments])
 
-    if group.issue_category == GroupCategory.PERFORMANCE and not features.has(
-        "organizations:issue-platform-search-perf-issues", group.project.organization
-    ):
-        apply_performance_conditions(conditions, group)
-        _filter = eventstore.Filter(
-            conditions=conditions,
-            project_ids=[group.project_id],
-        )
-        dataset = Dataset.Transactions
+    if group.issue_category == GroupCategory.ERROR:
+        dataset = Dataset.Events
     else:
-        if group.issue_category == GroupCategory.ERROR:
-            dataset = Dataset.Events
-        else:
-            dataset = Dataset.IssuePlatform
+        dataset = Dataset.IssuePlatform
 
-        _filter = eventstore.Filter(
-            conditions=conditions, project_ids=[group.project_id], group_ids=[group.id]
-        )
+    _filter = eventstore.Filter(
+        conditions=conditions, project_ids=[group.project_id], group_ids=[group.id]
+    )
 
     events = eventstore.get_events(
         filter=_filter,

--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Sequence
 
-from sentry import features
 from sentry.issues.grouptype import GroupCategory
 from sentry.models import Organization
 from sentry.snuba.dataset import Dataset
@@ -20,10 +19,6 @@ To add support for a new issue category/dataset:
 def get_dataset_from_category(category: int, organization: Organization) -> Dataset:
     if category == GroupCategory.ERROR.value:
         return Dataset.Events
-    elif category == GroupCategory.PERFORMANCE.value and not features.has(
-        "organizations:issue-platform-search-perf-issues", organization
-    ):
-        return Dataset.Transactions
     return Dataset.IssuePlatform
 
 

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1603,8 +1603,6 @@ class DiscoverDatasetConfig(DatasetConfig):
         group_short_ids = [v for v in value if v and v != "unknown"]
         general_group_filter_values = ["" for v in value if not v or v == "unknown"]
 
-        group_ids = []
-
         if group_short_ids and self.builder.params.organization is not None:
             try:
                 groups = Group.objects.by_qualified_short_id_bulk(
@@ -1614,10 +1612,7 @@ class DiscoverDatasetConfig(DatasetConfig):
             except Exception:
                 raise InvalidSearchQuery(f"Invalid value '{group_short_ids}' for 'issue:' filter")
             else:
-                for group in groups:
-                    group_ids.append(group.id)
-                group_ids = sorted(group_ids)
-                general_group_filter_values.extend(group_ids)
+                general_group_filter_values.extend(sorted([group.id for group in groups]))
 
         if general_group_filter_values:
             return self.builder.convert_search_filter_to_condition(

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -276,7 +276,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             ),
         )
 
-        strategy = get_search_strategies(organization, actor)[group_category]
+        strategy = get_search_strategies()[group_category]
         snuba_query_params = strategy(
             pinned_query_partial,
             selected_columns,
@@ -358,7 +358,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         if not group_categories:
             group_categories = {
                 gc
-                for gc in get_search_strategies(organization, actor).keys()
+                for gc in get_search_strategies().keys()
                 if gc != GroupCategory.PROFILE.value
                 or features.has("organizations:issue-platform", organization, actor=actor)
             }

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -11,10 +11,8 @@ from pytz import UTC
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query, Request
 
-from sentry import features
 from sentry.api.utils import default_start_end_dates
 from sentry.issues.grouptype import GroupCategory
-from sentry.issues.query import apply_performance_conditions
 from sentry.models import (
     Group,
     Project,
@@ -693,15 +691,9 @@ class SnubaTagStorage(TagStorage):
     def apply_group_filters_conditions(self, group: Group, conditions, filters):
         dataset = Dataset.Events
         if group:
-            if group.issue_category == GroupCategory.PERFORMANCE and not features.has(
-                "organizations:issue-platform-search-perf-issues", group.organization
-            ):
-                dataset = Dataset.Transactions
-                apply_performance_conditions(conditions, group)
-            else:
-                filters["group_id"] = [group.id]
-                if not group.issue_category == GroupCategory.ERROR:
-                    dataset = Dataset.IssuePlatform
+            filters["group_id"] = [group.id]
+            if not group.issue_category == GroupCategory.ERROR:
+                dataset = Dataset.IssuePlatform
         return dataset, conditions, filters
 
     def get_group_tag_value_count(self, group, environment_id, key, tenant_ids=None):

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -692,7 +692,7 @@ class SnubaTagStorage(TagStorage):
         dataset = Dataset.Events
         if group:
             filters["group_id"] = [group.id]
-            if not group.issue_category == GroupCategory.ERROR:
+            if group.issue_category != GroupCategory.ERROR:
                 dataset = Dataset.IssuePlatform
         return dataset, conditions, filters
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -519,7 +519,9 @@ class PerformanceIssueTestCase(BaseTestCase):
             ]
         ):
             event = perf_event_manager.save(self.project.id)
-            return event.for_group(mock_eventstream.call_args[0][2].group)
+            group_event = event.for_group(mock_eventstream.call_args[0][2].group)
+            group_event.occurrence = mock_eventstream.call_args[0][1]
+            return group_event
 
 
 class APITestCase(BaseTestCase, BaseAPITestCase):

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -94,6 +94,27 @@ TEST_ISSUE_OCCURRENCE = IssueOccurrence(
     "info",
     "/api/123/",
 )
+TEST_PERF_ISSUE_OCCURRENCE = IssueOccurrence(
+    uuid.uuid4().hex,
+    1,
+    uuid.uuid4().hex,
+    ["some-fingerprint"],
+    "N+1 Query",
+    "it was bad",
+    "1234",
+    {"Test": 123},
+    [
+        IssueEvidence(
+            "db",
+            "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+            True,
+        ),
+    ],
+    PerformanceNPlusOneGroupType,
+    ensure_aware(datetime.now()),
+    "info",
+    "/api/123/",
+)
 
 SAMPLE_TO_OCCURRENCE_MAP = {
     "transaction-n-plus-one-api-call": IssueOccurrence(

--- a/tests/acceptance/test_performance_issues.py
+++ b/tests/acceptance/test_performance_issues.py
@@ -1,11 +1,19 @@
 import random
 import string
+from datetime import timedelta
+from unittest import mock
 from unittest.mock import patch
 
 import pytz
 
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from sentry import options
+from sentry.issues.grouptype import (
+    NoiseConfig,
+    PerformanceNPlusOneAPICallsGroupType,
+    PerformanceNPlusOneGroupType,
+)
+from sentry.issues.ingest import send_issue_occurrence_to_eventstream
 from sentry.models import Group
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -65,11 +73,26 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase):
             "n-plus-one-in-django-new-view", mock_now.return_value.timestamp()
         )
 
-        with self.feature(FEATURES):
-            event = self.store_event(data=event_data, project_id=self.project.id)
+        with self.feature(FEATURES), mock.patch(
+            "sentry.issues.ingest.send_issue_occurrence_to_eventstream",
+            side_effect=send_issue_occurrence_to_eventstream,
+        ) as mock_eventstream, mock.patch.object(
+            PerformanceNPlusOneGroupType,
+            "noise_config",
+            new=NoiseConfig(0, timedelta(minutes=1)),
+        ), self.options(
+            {
+                "performance.issues.send_to_issues_platform": True,
+                "performance.issues.create_issues_through_platform": True,
+            }
+        ), self.feature(
+            "organizations:issue-platform"
+        ):
+            self.store_event(data=event_data, project_id=self.project.id)
+            group = mock_eventstream.call_args[0][2].group
 
-            self.page.visit_issue(self.org.slug, event.groups[0].id)
-            self.browser.snapshot("performance issue details", desktop_only=True)
+        self.page.visit_issue(self.org.slug, group.id)
+        self.browser.snapshot("performance issue details", desktop_only=True)
 
     @patch("django.utils.timezone.now")
     def test_multiple_events_with_one_cause_are_grouped(self, mock_now):
@@ -93,11 +116,25 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase):
 
         event_data["contexts"]["trace"]["op"] = "navigation"
 
-        with self.feature(FEATURES):
-            event = self.store_event(data=event_data, project_id=self.project.id)
-
-            self.page.visit_issue(self.org.slug, event.groups[0].id)
-            self.browser.snapshot("N+1 API Call issue details", desktop_only=True)
+        with self.feature(FEATURES), mock.patch(
+            "sentry.issues.ingest.send_issue_occurrence_to_eventstream",
+            side_effect=send_issue_occurrence_to_eventstream,
+        ) as mock_eventstream, mock.patch.object(
+            PerformanceNPlusOneAPICallsGroupType,
+            "noise_config",
+            new=NoiseConfig(0, timedelta(minutes=1)),
+        ), self.options(
+            {
+                "performance.issues.send_to_issues_platform": True,
+                "performance.issues.create_issues_through_platform": True,
+            }
+        ), self.feature(
+            "organizations:issue-platform"
+        ):
+            self.store_event(data=event_data, project_id=self.project.id)
+            group = mock_eventstream.call_args[0][2].group
+        self.page.visit_issue(self.org.slug, group.id)
+        self.browser.snapshot("N+1 API Call issue details", desktop_only=True)
 
     @patch("django.utils.timezone.now")
     def test_multiple_events_with_multiple_causes_are_not_grouped(self, mock_now):

--- a/tests/sentry/api/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/api/endpoints/test_event_grouping_info.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import reverse
 
 from sentry.testutils import APITestCase
@@ -58,6 +59,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
         assert response.status_code == 200
         assert content == {}
 
+    @pytest.mark.skip("We no longer return perf issue info from the grouping info endpoint")
     def test_transaction_event_with_problem(self):
         event = self.create_performance_issue()
         url = reverse(

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -379,9 +379,3 @@ class GroupSerializerTest(TestCase):
         assert serialized["count"] == "1"
         assert serialized["issueCategory"] == "performance"
         assert serialized["issueType"] == "performance_n_plus_one_db_queries"
-
-        with self.feature("organizations:issue-platform-search-perf-issues"):
-            serialized = serialize(perf_group)
-            assert serialized["count"] == "1"
-            assert serialized["issueCategory"] == "performance"
-            assert serialized["issueType"] == "performance_n_plus_one_db_queries"

--- a/tests/sentry/api/serializers/test_group_stream.py
+++ b/tests/sentry/api/serializers/test_group_stream.py
@@ -82,13 +82,6 @@ class StreamGroupSerializerTestCase(TestCase, SnubaTestCase, SearchIssueTestMixi
         assert serialized["issueType"] == "performance_n_plus_one_db_queries"
         assert [stat[1] for stat in serialized["stats"]["24h"][:-1]] == [0] * 23
         assert serialized["stats"]["24h"][-1][1] == 1
-        with self.feature("organizations:issue-platform-search-perf-issues"):
-            serialized = serialize(group, serializer=StreamGroupSerializerSnuba(stats_period="24h"))
-            assert serialized["count"] == "1"
-            assert serialized["issueCategory"] == "performance"
-            assert serialized["issueType"] == "performance_n_plus_one_db_queries"
-            assert [stat[1] for stat in serialized["stats"]["24h"][:-1]] == [0] * 23
-            assert serialized["stats"]["24h"][-1][1] == 1
 
     @freeze_time(before_now(days=1).replace(hour=13, minute=30, second=0, microsecond=0))
     def test_profiling_issue(self):

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -106,10 +106,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase):
         description = GitHubIssueBasic().get_group_description(event.group, event)
         assert "db - SELECT `books_author`.`id`, `books_author" in description
         title = GitHubIssueBasic().get_group_title(event.group, event)
-        assert (
-            title
-            == 'N+1 Query: SELECT "books_author"."id", "books_author"."name" FROM "books_author" WHERE "books_author"."id" = %s LIMIT 21'
-        )
+        assert title == "N+1 Query"
 
     def test_generic_issues_content(self):
         """Test that a GitHub issue created from a generic issue has the expected title and description"""

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -7,6 +7,7 @@ from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.types.rules import RuleFuture
 from sentry.utils import json
+from sentry.utils.http import absolute_uri
 
 
 class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
@@ -104,14 +105,22 @@ class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
         data = self.create_issue_base(event)
 
         # Make assertions about what would be POSTed to api/2/issue.
-        assert (
-            data["fields"]["summary"]
-            == 'N+1 Query: SELECT "books_author"."id", "books_author"."name" FROM "books_author" WHERE "books_author"."id" = %s LIMIT 21'
+        assert data["fields"]["summary"] == "N+1 Query"
+        # TODO: Uncomment this and remove the other check on `description` once we fix the contents
+        # to include the query
+        # assert (
+        #     "*Transaction Name* | db - SELECT `books_author`.`id`, `books_author`"
+        #     in data["fields"]["description"]
+        # )
+        short_id = event.group.qualified_short_id
+        group_url = absolute_uri(
+            event.group.get_absolute_url(params={"referrer": "jira_integration"})
         )
-        assert (
-            "*Transaction Name* | db - SELECT `books_author`.`id`, `books_author`"
-            in data["fields"]["description"]
+        rule_url = absolute_uri(
+            f"/organizations/{self.project.organization.slug}/alerts/rules/{self.project.slug}/{self.jira_rule.id}/"
         )
+        description = f"Sentry Issue: [{short_id}|{group_url}]\nThis ticket was automatically created by Sentry via [{self.jira_rule.rule.label}|{rule_url}]"
+        assert description == data["fields"]["description"]
         assert data["fields"]["issuetype"]["id"] == "1"
 
         external_issue = ExternalIssue.objects.get(key="APP-123")

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -7,7 +7,7 @@ import responses
 from sentry.integrations.msteams import MsTeamsNotifyServiceAction
 from sentry.models import Integration
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
-from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.utils import json
 
 
@@ -108,7 +108,12 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         assert description["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
 
     @responses.activate
-    def test_applies_correctly_performance_issue(self):
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_PERF_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    def test_applies_correctly_performance_issue(self, occurrence):
         event = self.create_performance_issue()
 
         rule = self.get_rule(

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -91,7 +91,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         results[0].callback(event, futures=[])
         data = json.loads(responses.calls[0].request.body)
 
-        perf_issue_title = 'N+1 Query: SELECT "books_author"."id", "books_author"."name" FROM "books_author" WHERE "books_author"."id" = %s LIMIT 21'
+        perf_issue_title = "N+1 Query"
 
         assert data["event_action"] == "trigger"
         assert data["payload"]["summary"] == perf_issue_title

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -6,7 +6,7 @@ import responses
 from sentry.models import Activity, Identity, IdentityProvider, IdentityStatus, Integration
 from sentry.notifications.notifications.activity import AssignedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
@@ -156,8 +156,13 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_PERF_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_assignment_performance_issue(self, mock_func):
+    def test_assignment_performance_issue(self, mock_func, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is assigned
         """

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -30,7 +30,7 @@ from sentry.ownership.grammar import dump_schema
 from sentry.plugins.base import Notification
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import ExternalProviders
@@ -80,8 +80,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_PERF_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_performance_issue_alert_user(self, mock_func):
+    def test_performance_issue_alert_user(self, mock_func, occurrence):
         """Test that performance issue alerts are sent to a Slack user."""
 
         event = self.create_performance_issue()

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -5,7 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import RegressionActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -41,8 +41,13 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_PERF_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_regression_performance_issue(self, mock_func):
+    def test_regression_performance_issue(self, mock_func, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue regresses
         """

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -5,7 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -42,8 +42,13 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_PERF_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_resolved_performance_issue(self, mock_func):
+    def test_resolved_performance_issue(self, mock_func, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is resolved
         """

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -5,7 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedInReleaseActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -43,8 +43,13 @@ class SlackResolvedInReleaseNotificationTest(
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_PERF_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_resolved_in_release_performance_issue(self, mock_func):
+    def test_resolved_in_release_performance_issue(self, mock_func, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
         """

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -5,7 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import UnassignedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -40,8 +40,13 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_PERF_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_unassignment_performance_issue(self, mock_func):
+    def test_unassignment_performance_issue(self, mock_func, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is unassigned
         """

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -208,10 +208,12 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         with self.feature("organizations:performance-issues"):
             attachments = SlackIssuesMessageBuilder(event.group, event).build()
         assert attachments["title"] == "N+1 Query"
-        assert (
-            attachments["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
+        # TODO: Uncomment this once we fix the `evidence_display` for occurrences
+        # assert (
+        #     attachments["text"]
+        #     == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        # )
+        assert attachments["text"] == ""
         assert attachments["fallback"] == f"[{self.project.slug}] N+1 Query"
         assert attachments["color"] == "#2788CE"  # blue for info level
 

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -270,6 +270,9 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase):
                         "is_new_group_environment": False,
                     }
                 ],
+                occurrence_id=event.occurrence_id,
+                project_id=event.group.project_id,
+                group_id=event.group_id,
             )
 
         assert len(mail.outbox) == 1

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -680,13 +680,12 @@ class FrequencyConditionTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
             },
         ]
 
-        with self.feature("organizations:issue-platform-search-perf-issues"):
-            result = preview(self.project, conditions, [], *MATCH_ARGS)
-            assert group.id in result
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
+        assert group.id in result
 
-            conditions[1]["value"] = 1
-            result = preview(self.project, conditions, [], *MATCH_ARGS)
-            assert group.id not in result
+        conditions[1]["value"] = 1
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
+        assert group.id not in result
 
     def test_no_activity_event_filter(self):
         conditions = [

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -445,8 +445,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         self.login_as(user=self.user)
 
         url = f"/api/0/issues/{event_1.group.id}/events/"
-        with self.feature("organizations:issue-platform-search-perf-issues"):
-            response = self.do_request(url)
+        response = self.do_request(url)
 
         assert response.status_code == 200, response.content
         assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -638,10 +638,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
             "query": f"project:{self.project.slug} issue:{event.groups[0].qualified_short_id}",
             "dataset": "issuePlatform",
         }
-        with self.feature(
-            ["organizations:issue-platform-search-perf-issues", "organizations:profiling"]
-        ):
-            response = self.do_request(query)
+        response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["count()"] == 1
 

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -21,6 +21,7 @@ from sentry.models.transaction_threshold import (
 )
 from sentry.search.events import constants
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -34,7 +35,9 @@ MAX_QUERYABLE_TRANSACTION_THRESHOLDS = 1
 
 
 @region_silo_test
-class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
+class OrganizationEventsEndpointTest(
+    APITestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceIssueTestCase
+):
     viewname = "sentry-api-0-organization-events"
     referrer = "api.organization-events"
 
@@ -602,43 +605,17 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
             {"project.name": self.project.slug, "id": "a" * 32, "count()": 1}
         ]
 
-    def test_performance_issue_ids_filter(self):
-        data = load_data(
-            platform="transaction",
-            timestamp=self.ten_mins_ago,
-            start_timestamp=self.eleven_mins_ago,
-            fingerprint=[f"{PerformanceNPlusOneGroupType.type_id}-group1"],
-        )
-        event = self.store_event(data=data, project_id=self.project.id)
+    def test_performance_issue_id_filter(self):
+        event = self.create_performance_issue()
 
         query = {
             "field": ["count()"],
             "statsPeriod": "2h",
-            "query": f"project:{self.project.slug} performance.issue_ids:{event.groups[0].id}",
-        }
-        response = self.do_request(query)
-        assert response.status_code == 200, response.content
-        assert response.data["data"][0]["count()"] == 1
-
-    def test_performance_issue_issue_platform_issue_ids_filter(self):
-        # Just a duplicate of `test_generic_issue_ids_filter` to verify that perf issues read from
-        # the issue platform correctly here. Remove once we kill the related flags.
-        data = load_data(
-            platform="transaction",
-            timestamp=self.ten_mins_ago,
-            start_timestamp=self.eleven_mins_ago,
-            fingerprint=[f"{PerformanceNPlusOneGroupType.type_id}-group1"],
-        )
-        with self.options({"performance.issues.send_to_issues_platform": True}):
-            event = self.store_event(data=data, project_id=self.project.id)
-
-        query = {
-            "field": ["count()"],
-            "statsPeriod": "2h",
-            "query": f"project:{self.project.slug} issue:{event.groups[0].qualified_short_id}",
+            "query": f"issue.id:{event.group.id}",
             "dataset": "issuePlatform",
         }
-        response = self.do_request(query)
+        with self.options({"performance.issues.create_issues_through_platform": True}):
+            response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["count()"] == 1
 
@@ -742,42 +719,30 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase, SearchIssueTest
         assert response.status_code == 400, response.content
 
     def test_performance_short_group_id(self):
-        project = self.create_project(name="foo bar")
-        data = load_data(
-            "transaction",
-            fingerprint=[f"{PerformanceNPlusOneGroupType.type_id}-group1"],
-        )
-        event = self.store_event(data=data, project_id=project.id)
-
+        event = self.create_performance_issue()
         query = {
             "field": ["count()"],
             "statsPeriod": "1h",
-            "query": f"project:{project.slug} issue:{event.groups[0].qualified_short_id}",
+            "query": f"project:{event.group.project.slug} issue:{event.group.qualified_short_id}",
+            "dataset": "issuePlatform",
         }
-        response = self.do_request(query)
+        with self.options({"performance.issues.create_issues_through_platform": True}):
+            response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["count()"] == 1
 
     def test_multiple_performance_short_group_ids_filter(self):
-        project = self.create_project(name="foo bar")
-        data1 = load_data(
-            "transaction",
-            fingerprint=[f"{PerformanceNPlusOneGroupType.type_id}-group1"],
-        )
-        event1 = self.store_event(data=data1, project_id=project.id)
-
-        data2 = load_data(
-            "transaction",
-            fingerprint=[f"{PerformanceNPlusOneGroupType.type_id}-group2"],
-        )
-        event2 = self.store_event(data=data2, project_id=project.id)
+        event1 = self.create_performance_issue()
+        event2 = self.create_performance_issue()
 
         query = {
             "field": ["count()"],
             "statsPeriod": "1h",
-            "query": f"project:{project.slug} issue:[{event1.groups[0].qualified_short_id},{event2.groups[0].qualified_short_id}]",
+            "query": f"project:{event1.group.project.slug} issue:[{event1.group.qualified_short_id},{event2.group.qualified_short_id}]",
+            "dataset": "issuePlatform",
         }
-        response = self.do_request(query)
+        with self.options({"performance.issues.create_issues_through_platform": True}):
+            response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["count()"] == 2
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -521,21 +521,6 @@ class PerformanceGroupSerializerSnubaTest(
         assert iso_format(result["firstSeen"]) == iso_format(timestamp + timedelta(minutes=1))
         assert result["count"] == str(times + 1)
 
-        with self.feature("organizations:issue-platform-search-perf-issues"):
-            result = serialize(
-                first_group,
-                serializer=GroupSerializerSnuba(
-                    environment_ids=[environment.id],
-                    start=timestamp - timedelta(hours=1),
-                    end=timestamp + timedelta(hours=1),
-                ),
-            )
-
-            assert result["userCount"] == 2
-            assert iso_format(result["lastSeen"]) == iso_format(timestamp + timedelta(minutes=2))
-            assert iso_format(result["firstSeen"]) == iso_format(timestamp + timedelta(minutes=1))
-            assert result["count"] == str(times + 1)
-
 
 @region_silo_test
 class ProfilingGroupSerializerSnubaTest(

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -101,6 +101,5 @@ class GroupTestSnuba(TestCase, SnubaTestCase):
             )
         perf_group = self.transaction_event_1.groups[0]
 
-        with self.feature("organizations:issue-platform-search-perf-issues"):
-            assert perf_group.get_latest_event_for_environments().event_id == "d" * 32
-            assert perf_group.get_oldest_event_for_environments().event_id == "f" * 32
+        assert perf_group.get_latest_event_for_environments().event_id == "d" * 32
+        assert perf_group.get_oldest_event_for_environments().event_id == "f" * 32

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -63,10 +63,17 @@ class GroupTestSnuba(TestCase, SnubaTestCase):
         event_data_3["start_timestamp"] = iso_format(before_now(seconds=31))
         event_data_3["event_id"] = "f" * 32
 
-        self.transaction_event_1 = self.store_event(data=event_data_1, project_id=self.project.id)
-        self.transaction_event_2 = self.store_event(data=event_data_2, project_id=self.project.id)
-        self.transaction_event_3 = self.store_event(data=event_data_3, project_id=self.project.id)
-        perf_group = self.transaction_event_1.groups[0]
+        with self.options({"performance.issues.send_to_issues_platform": True}):
+            self.transaction_event_1 = self.store_event(
+                data=event_data_1, project_id=self.project.id
+            )
+            self.transaction_event_2 = self.store_event(
+                data=event_data_2, project_id=self.project.id
+            )
+            self.transaction_event_3 = self.store_event(
+                data=event_data_3, project_id=self.project.id
+            )
+            perf_group = self.transaction_event_1.groups[0]
 
         assert perf_group.get_latest_event_for_environments().event_id == "d" * 32
         assert perf_group.get_oldest_event_for_environments().event_id == "f" * 32

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -16,6 +16,7 @@ from sentry.issues.grouptype import (
     PerformanceRenderBlockingAssetSpanGroupType,
     ProfileFileIOGroupType,
 )
+from sentry.issues.ingest import send_issue_occurrence_to_eventstream
 from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models import (
     Environment,
@@ -2136,10 +2137,22 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
             "culprit": "app/components/events/eventEntries in map",
             "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
         }
-        with self.options({"performance.issues.send_to_issues_platform": True}), self.feature(
+        with mock.patch(
+            "sentry.issues.ingest.send_issue_occurrence_to_eventstream",
+            side_effect=send_issue_occurrence_to_eventstream,
+        ) as mock_eventstream, mock.patch.object(
+            PerformanceRenderBlockingAssetSpanGroupType,
+            "noise_config",
+            new=NoiseConfig(0, timedelta(minutes=1)),
+        ), self.options(
+            {
+                "performance.issues.send_to_issues_platform": True,
+                "performance.issues.create_issues_through_platform": True,
+            }
+        ), self.feature(
             "organizations:issue-platform"
         ):
-            transaction_event_1 = self.store_event(
+            self.store_event(
                 data={
                     **transaction_event_data,
                     "event_id": "a" * 32,
@@ -2152,9 +2165,9 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
                 },
                 project_id=self.project.id,
             )
-            self.perf_group_1 = transaction_event_1.groups[0]
+            self.perf_group_1 = mock_eventstream.call_args[0][2].group
 
-            transaction_event_2 = self.store_event(
+            self.store_event(
                 data={
                     **transaction_event_data,
                     "event_id": "a" * 32,
@@ -2167,8 +2180,7 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
                 },
                 project_id=self.project.id,
             )
-            self.perf_group_2 = transaction_event_2.groups[0]
-
+            self.perf_group_2 = mock_eventstream.call_args[0][2].group
         error_event_data = {
             "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
             "message": "bar",
@@ -2204,21 +2216,30 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
         self.error_group_2 = error_event_2.group
 
     def test_performance_query(self):
-        results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
-        assert list(results) == [self.perf_group_1, self.perf_group_2]
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                self.perf_group_1.issue_type.build_visible_feature_name(),
+            ]
+        ):
+            results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
+            assert list(results) == [self.perf_group_1, self.perf_group_2]
 
-        results = self.make_query(
-            search_filter_query="issue.type:[performance_n_plus_one_db_queries, performance_render_blocking_asset_span] my_tag:1"
-        )
-        assert list(results) == [self.perf_group_1, self.perf_group_2]
+            results = self.make_query(
+                search_filter_query="issue.type:[performance_n_plus_one_db_queries, performance_render_blocking_asset_span] my_tag:1"
+            )
+            assert list(results) == [self.perf_group_1, self.perf_group_2]
 
     def test_performance_query_no_duplicates(self):
         # Regression test to catch an issue we had with performance issues showing duplicated in the
         # issue stream. This was  caused by us dual writing perf issues to transactions and to the
         # issue platform. We'd end up reading the same issue twice and duplicate it in the response.
-        with self.feature("organizations:issue-platform"), self.options(
-            {"performance.issues.send_to_issues_platform": True}
-        ):
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                self.perf_group_1.issue_type.build_visible_feature_name(),
+            ]
+        ), self.options({"performance.issues.send_to_issues_platform": True}):
             results = self.make_query(search_filter_query="!issue.category:error my_tag:1")
             assert list(results) == [self.perf_group_1, self.perf_group_2]
 
@@ -2226,71 +2247,88 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
         with Feature({"organizations:performance-issues-search": False}):
             results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
             assert list(results) == []
-        with Feature({"organizations:performance-issues-search": True}):
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                self.perf_group_1.issue_type.build_visible_feature_name(),
+            ]
+        ):
             results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
             assert list(results) == [self.perf_group_1, self.perf_group_2]
 
     def test_error_performance_query(self):
-        results = self.make_query(search_filter_query="my_tag:1")
-        assert list(results) == [
-            self.perf_group_1,
-            self.perf_group_2,
-            self.error_group_2,
-            self.error_group_1,
-        ]
-        results = self.make_query(
-            search_filter_query="issue.category:[performance, error] my_tag:1"
-        )
-        assert list(results) == [
-            self.perf_group_1,
-            self.perf_group_2,
-            self.error_group_2,
-            self.error_group_1,
-        ]
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                self.perf_group_1.issue_type.build_visible_feature_name(),
+            ]
+        ):
+            results = self.make_query(search_filter_query="my_tag:1")
+            assert list(results) == [
+                self.perf_group_1,
+                self.perf_group_2,
+                self.error_group_2,
+                self.error_group_1,
+            ]
+            results = self.make_query(
+                search_filter_query="issue.category:[performance, error] my_tag:1"
+            )
+            assert list(results) == [
+                self.perf_group_1,
+                self.perf_group_2,
+                self.error_group_2,
+                self.error_group_1,
+            ]
 
-        results = self.make_query(
-            search_filter_query="issue.type:[performance_render_blocking_asset_span, error] my_tag:1"
-        )
-        assert list(results) == [
-            self.perf_group_1,
-            self.perf_group_2,
-            self.error_group_2,
-            self.error_group_1,
-        ]
+            results = self.make_query(
+                search_filter_query="issue.type:[performance_render_blocking_asset_span, error] my_tag:1"
+            )
+            assert list(results) == [
+                self.perf_group_1,
+                self.perf_group_2,
+                self.error_group_2,
+                self.error_group_1,
+            ]
 
     def test_cursor_performance_issues(self):
-        results = self.make_query(
-            projects=[self.project],
-            search_filter_query="issue.category:performance my_tag:1",
-            sort_by="date",
-            limit=1,
-            count_hits=True,
-        )
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                self.perf_group_1.issue_type.build_visible_feature_name(),
+            ]
+        ):
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:performance my_tag:1",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
 
-        assert list(results) == [self.perf_group_1]
-        assert results.hits == 2
+            assert list(results) == [self.perf_group_1]
+            assert results.hits == 2
 
-        results = self.make_query(
-            projects=[self.project],
-            search_filter_query="issue.category:performance my_tag:1",
-            sort_by="date",
-            limit=1,
-            cursor=results.next,
-            count_hits=True,
-        )
-        assert list(results) == [self.perf_group_2]
-        assert results.hits == 2
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:performance my_tag:1",
+                sort_by="date",
+                limit=1,
+                cursor=results.next,
+                count_hits=True,
+            )
+            assert list(results) == [self.perf_group_2]
+            assert results.hits == 2
 
-        results = self.make_query(
-            projects=[self.project],
-            search_filter_query="issue.category:performance my_tag:1",
-            sort_by="date",
-            limit=1,
-            cursor=results.next,
-            count_hits=True,
-        )
-        assert list(results) == []
-        assert results.hits == 2
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:performance my_tag:1",
+                sort_by="date",
+                limit=1,
+                cursor=results.next,
+                count_hits=True,
+            )
+            assert list(results) == []
+            assert results.hits == 2
 
     def test_perf_issue_search_message_term_queries_postgres(self):
         from django.db.models import Q
@@ -2299,66 +2337,107 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
 
         transaction_name = "im a little tea pot"
 
-        tx = self.store_event(
-            data={
-                "level": "info",
-                "culprit": "app/components/events/eventEntries in map",
-                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                "fingerprint": [f"{PerformanceRenderBlockingAssetSpanGroupType.type_id}-group12"],
-                "event_id": "e" * 32,
-                "timestamp": iso_format(self.base_datetime),
-                "start_timestamp": iso_format(self.base_datetime),
-                "type": "transaction",
-                "transaction": transaction_name,
-            },
-            project_id=self.project.id,
-        )
-        assert "tea" in tx.search_message
-        created_group = tx.groups[0]
+        with mock.patch(
+            "sentry.issues.ingest.send_issue_occurrence_to_eventstream",
+            side_effect=send_issue_occurrence_to_eventstream,
+        ) as mock_eventstream, mock.patch.object(
+            PerformanceRenderBlockingAssetSpanGroupType,
+            "noise_config",
+            new=NoiseConfig(0, timedelta(minutes=1)),
+        ), self.options(
+            {
+                "performance.issues.send_to_issues_platform": True,
+                "performance.issues.create_issues_through_platform": True,
+            }
+        ), self.feature(
+            "organizations:issue-platform"
+        ):
+            tx = self.store_event(
+                data={
+                    "level": "info",
+                    "culprit": "app/components/events/eventEntries in map",
+                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                    "fingerprint": [
+                        f"{PerformanceRenderBlockingAssetSpanGroupType.type_id}-group12"
+                    ],
+                    "event_id": "e" * 32,
+                    "timestamp": iso_format(self.base_datetime),
+                    "start_timestamp": iso_format(self.base_datetime),
+                    "type": "transaction",
+                    "transaction": transaction_name,
+                },
+                project_id=self.project.id,
+            )
+            assert "tea" in tx.search_message
+            created_group = mock_eventstream.call_args[0][2].group
 
         find_group = Group.objects.filter(
             Q(type=PerformanceRenderBlockingAssetSpanGroupType.type_id, message__icontains="tea")
         ).first()
 
         assert created_group == find_group
-        result = snuba.raw_query(
-            dataset=snuba.Dataset.Transactions,
-            start=self.base_datetime - timedelta(hours=1),
-            end=self.base_datetime + timedelta(hours=1),
-            selected_columns=[
-                "event_id",
-                "group_ids",
-                "transaction_name",
-            ],
-            groupby=None,
-            filter_keys={"project_id": [self.project.id], "event_id": [tx.event_id]},
-            referrer="_insert_transaction.verify_transaction",
-        )
-        assert result["data"][0]["transaction_name"] == transaction_name
-        assert result["data"][0]["group_ids"] == [created_group.id]
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                created_group.issue_type.build_visible_feature_name(),
+            ]
+        ):
+            result = snuba.raw_query(
+                dataset=snuba.Dataset.IssuePlatform,
+                start=self.base_datetime - timedelta(hours=1),
+                end=self.base_datetime + timedelta(hours=1),
+                selected_columns=[
+                    "event_id",
+                    "group_id",
+                    "transaction_name",
+                ],
+                groupby=None,
+                filter_keys={"project_id": [self.project.id], "event_id": [tx.event_id]},
+                referrer="_insert_transaction.verify_transaction",
+            )
+            assert result["data"][0]["transaction_name"] == transaction_name
+            assert result["data"][0]["group_id"] == created_group.id
 
-        results = self.make_query(search_filter_query="issue.category:performance tea")
-        assert set(results) == {created_group}
+            results = self.make_query(search_filter_query="issue.category:performance tea")
+            assert set(results) == {created_group}
 
-        results2 = self.make_query(search_filter_query="tea")
-        assert set(results2) == {created_group}
+            results2 = self.make_query(search_filter_query="tea")
+            assert set(results2) == {created_group}
 
     def test_search_message_error_and_perf_issues(self):
-        tx = self.store_event(
-            data={
-                "level": "info",
-                "culprit": "app/components/events/eventEntries in map",
-                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                "fingerprint": [f"{PerformanceRenderBlockingAssetSpanGroupType.type_id}-group12"],
-                "event_id": "e" * 32,
-                "timestamp": iso_format(self.base_datetime),
-                "start_timestamp": iso_format(self.base_datetime),
-                "type": "transaction",
-                "transaction": "/api/0/events",
-            },
-            project_id=self.project.id,
-        )
-        perf_issue = tx.groups[0]
+        with mock.patch(
+            "sentry.issues.ingest.send_issue_occurrence_to_eventstream",
+            side_effect=send_issue_occurrence_to_eventstream,
+        ) as mock_eventstream, mock.patch.object(
+            PerformanceRenderBlockingAssetSpanGroupType,
+            "noise_config",
+            new=NoiseConfig(0, timedelta(minutes=1)),
+        ), self.options(
+            {
+                "performance.issues.send_to_issues_platform": True,
+                "performance.issues.create_issues_through_platform": True,
+            }
+        ), self.feature(
+            "organizations:issue-platform"
+        ):
+            self.store_event(
+                data={
+                    "level": "info",
+                    "culprit": "app/components/events/eventEntries in map",
+                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                    "fingerprint": [
+                        f"{PerformanceRenderBlockingAssetSpanGroupType.type_id}-group12"
+                    ],
+                    "event_id": "e" * 32,
+                    "timestamp": iso_format(self.base_datetime),
+                    "start_timestamp": iso_format(self.base_datetime),
+                    "type": "transaction",
+                    "transaction": "/api/0/events",
+                },
+                project_id=self.project.id,
+            )
+            perf_issue = mock_eventstream.call_args[0][2].group
+
         assert perf_issue
 
         error = self.store_event(
@@ -2378,15 +2457,21 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
 
         assert error_issue != perf_issue
 
-        assert set(self.make_query(search_filter_query="is:unresolved /api/0/events")) == {
-            perf_issue,
-            error_issue,
-        }
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                perf_issue.issue_type.build_visible_feature_name(),
+            ]
+        ):
+            assert set(self.make_query(search_filter_query="is:unresolved /api/0/events")) == {
+                perf_issue,
+                error_issue,
+            }
 
-        assert set(self.make_query(search_filter_query="/api/0/events")) == {
-            error_issue,
-            perf_issue,
-        }
+            assert set(self.make_query(search_filter_query="/api/0/events")) == {
+                error_issue,
+                perf_issue,
+            }
 
     def test_compound_message_negation(self):
         self.store_event(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2529,7 +2529,7 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         group_type = PerformanceNPlusOneGroupType
         self.project.update_option("sentry:performance_issue_create_issue_through_platform", True)
 
-        with self.feature("organizations:issue-platform-search-perf-issues"), self.options(
+        with self.options(
             {"performance.issues.create_issues_through_platform": True}
         ), mock.patch.object(
             PerformanceNPlusOneGroupType, "noise_config", new=NoiseConfig(0, timedelta(minutes=1))


### PR DESCRIPTION
We no longer need this flag since perf issues have been migrated over to the issue platform. Perf issue haven't been released anywhere other than saas, so we don't need to worry about keeping this around.

Most of this pr is just test fixes. The small amount of other code changed is just removing dead branches that this flag used to gate. Pr looks huge, but a lot of it is just adding in cruft to make sure that perf issue tests run on the issue platform now