### PR TITLE
ref(pageFilters): Don't show desync message when using chart zoom

### DIFF
--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -50,6 +50,10 @@ type Options = {
    * Persist changes to the page filter selection into local storage
    */
   save?: boolean;
+  /**
+   * Skip checking desync state after updating the page filter value.
+   */
+  skipDesyncUpdate?: boolean;
 };
 
 /**
@@ -294,7 +298,7 @@ export function updateProjects(
   if (options?.environments) {
     persistPageFilters('environments', options);
   }
-  updateDesyncedUrlState(router);
+  !options?.skipDesyncUpdate && updateDesyncedUrlState(router);
 }
 
 /**
@@ -313,7 +317,7 @@ export function updateEnvironments(
   PageFiltersStore.updateEnvironments(environment);
   updateParams({environment}, router, options);
   persistPageFilters('environments', options);
-  updateDesyncedUrlState(router);
+  !options?.skipDesyncUpdate && updateDesyncedUrlState(router);
 }
 
 /**
@@ -333,7 +337,7 @@ export function updateDateTime(
   PageFiltersStore.updateDateTime({...selection.datetime, ...datetime});
   updateParams(datetime, router, options);
   persistPageFilters('datetime', options);
-  updateDesyncedUrlState(router);
+  !options?.skipDesyncUpdate && updateDesyncedUrlState(router);
 }
 
 /**

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -172,7 +172,8 @@ class ChartZoom extends Component<Props> {
               : startFormatted,
             end: endFormatted ? getUtcToLocalDateObject(endFormatted) : endFormatted,
           },
-          router
+          router,
+          {skipDesyncUpdate: true}
         );
       }
 


### PR DESCRIPTION
**Before ——** when the user zooms into a certain date range, triggering an update to the date page filter, a desync message appears. This is unexpected and potentially confusing, as the filter update was intentional and was not triggered by clicking on a shared link.

https://user-images.githubusercontent.com/44172267/236958077-c7f15af6-6e62-485c-90b4-b30c0ae9a696.mov

**After ——** when using chart zoom, the date page filter is updated but is not marked as desynced

https://user-images.githubusercontent.com/44172267/236957947-8ce34fcc-6d16-45b3-8fe0-d0fad5ce85a2.mov

