### PR TITLE
Skip `OrganizationEventsFacetsPerformanceEndpointTest::test_basic_request` flaky test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import pytest
 from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -86,6 +87,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
         self._transaction_count += 1
         self.store_event(data=event, project_id=project_id)
 
+    @pytest.mark.skip("Flaky test failing because of Query timeout.")
     def test_basic_request(self):
         response = self.do_request()
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-import pytest
 from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -87,7 +86,6 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
         self._transaction_count += 1
         self.store_event(data=event, project_id=project_id)
 
-    @pytest.mark.skip("Flaky test failing because of Query timeout.")
     def test_basic_request(self):
         response = self.do_request()
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import pytest
 from django.urls import reverse
 
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -85,6 +86,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
         self._transaction_count += 1
         self.store_event(data=event, project_id=project_id)
 
+    @pytest.mark.skip("Flaky test failing because of Query timeout.")
     def test_basic_request(self):
         response = self.do_request(
             {


### PR DESCRIPTION
This PR skips `tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py::OrganizationEventsFacetsPerformanceEndpointTest::test_basic_request` due to `Query timeout`.