### PR TITLE
Error trying to use `SystemToken` from non-internal IP

### DIFF
--- a/src/sentry/auth/system.py
+++ b/src/sentry/auth/system.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import logging
 from typing import Any
 from uuid import uuid4
 
@@ -15,6 +16,8 @@ from sentry.utils.cache import memoize
 INTERNAL_NETWORKS = [
     ipaddress.ip_network(str(net), strict=False) for net in settings.INTERNAL_SYSTEM_IPS
 ]
+
+logger = logging.getLogger(__name__)
 
 
 def is_internal_ip(request: HttpRequest) -> bool:
@@ -48,8 +51,17 @@ class SystemToken:
     def from_request(cls, request: HttpRequest, token: str) -> SystemToken | None:
         """Returns a system token if this is a valid system request."""
         system_token = get_system_token()
-        if constant_time_compare(system_token, token) and is_internal_ip(request):
-            return cls()
+        if constant_time_compare(system_token, token):
+            if is_internal_ip(request):
+                return cls()
+            # else:
+            # We have a valid system token, but the remote is not an internal IP
+            # This can happen because:
+            # - the system token was leaked (unlikely)
+            # - an internal service (eg symbolicator) is trying to use the system token,
+            #   but is not covered by the internal IP ranges (more likely)
+            logger.error("Trying to use `SystemToken` from non-internal IP")
+
         return None
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
We want to raise an error here, as it may indicate a token leak (unlikely), or misconfigured infrastructure (more likely, and what happened prompting this change).