### PR TITLE
CSP: add `'report-sample'` keyword for more visibility

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -419,6 +419,7 @@ CSP_DEFAULT_SRC = [
 CSP_SCRIPT_SRC = [
     "'self'",
     "'unsafe-inline'",
+    "'report-sample'",
 ]
 CSP_FONT_SRC = [
     "'self'",


### PR DESCRIPTION
`'report-sample'` asks the browser to send first 40 characters of the offending script/style in the CSP violation report.
https://www.w3.org/TR/CSP3/#grammardef-report-sample