### PR TITLE
ref(dynamic-sampling): Refactor usage of get_blended_sample_rate

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -556,7 +556,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             team__organization=obj
         ).count()
         context["onboardingTasks"] = serialize(tasks_to_serialize, user)
-        sample_rate = quotas.get_blended_sample_rate(None, obj.id)
+        sample_rate = quotas.get_blended_sample_rate(organization_id=obj.id)
         context["isDynamicallySampled"] = sample_rate is not None and sample_rate < 1.0
 
         return context

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("sentry.dynamic_sampling")
 
 
 def get_guarded_blended_sample_rate(organization: Organization, project: Project) -> float:
-    sample_rate = quotas.get_blended_sample_rate(project)
+    sample_rate = quotas.get_blended_sample_rate(organization_id=organization.id)
 
     if sample_rate is None:
         raise Exception("get_blended_sample_rate returns none")

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -73,7 +73,7 @@ def test_generate_rules_capture_exception(get_blended_sample_rate, sentry_sdk):
     # if blended rate is None that means no dynamic sampling behavior should happen.
     # Therefore no rules should be set.
     assert generate_rules(fake_project) == []
-    get_blended_sample_rate.assert_called_with(fake_project)
+    get_blended_sample_rate.assert_called_with(organization_id=fake_project.organization.id)
     assert sentry_sdk.capture_exception.call_count == 1
     _validate_rules(fake_project)
 
@@ -93,7 +93,7 @@ def test_generate_rules_return_only_uniform_if_sample_rate_is_100_and_other_rule
             "type": "trace",
         },
     ]
-    get_blended_sample_rate.assert_called_with(default_project)
+    get_blended_sample_rate.assert_called_with(organization_id=default_project.organization.id)
     _validate_rules(default_project)
 
 
@@ -171,7 +171,7 @@ def test_generate_rules_return_uniform_rules_and_env_rule(get_blended_sample_rat
             "type": "trace",
         },
     ]
-    get_blended_sample_rate.assert_called_with(default_project)
+    get_blended_sample_rate.assert_called_with(organization_id=default_project.organization.id)
     _validate_rules(default_project)
 
 
@@ -451,7 +451,7 @@ def test_generate_rules_with_zero_base_sample_rate(get_blended_sample_rate, defa
             "type": "trace",
         },
     ]
-    get_blended_sample_rate.assert_called_with(default_project)
+    get_blended_sample_rate.assert_called_with(organization_id=default_project.organization.id)
     _validate_rules(default_project)
 
 
@@ -524,7 +524,7 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
             "type": "trace",
         },
     ]
-    get_blended_sample_rate.assert_called_with(default_project)
+    get_blended_sample_rate.assert_called_with(organization_id=default_project.organization.id)
     _validate_rules(default_project)
 
 

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -88,7 +88,7 @@ class QuotaTest(TestCase):
 
     def test_get_blended_sample_rate(self):
         org = self.create_organization()
-        assert self.backend.get_blended_sample_rate(org) is None
+        assert self.backend.get_blended_sample_rate(organization_id=org.id) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR updates the usages of `get_blended_sample_rate` to now use the `organization_id` instead of `project` object.

Closes https://github.com/getsentry/sentry/issues/48683