### PR TITLE
ref(issue-details): Use useApiQuery to fetch issue tags

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -6,6 +6,7 @@ import GroupStore from 'sentry/stores/groupStore';
 import {Actor, Group, Member, Note, User} from 'sentry/types';
 import {buildTeamId, buildUserId} from 'sentry/utils';
 import {uniqueId} from 'sentry/utils/guid';
+import {ApiQueryKey, useApiQuery, UseApiQueryOptions} from 'sentry/utils/queryClient';
 
 type AssignedBy = 'suggested_assignee' | 'assignee_selector';
 type AssignToUserParams = {
@@ -369,3 +370,46 @@ export function mergeGroups(
     options
   );
 }
+
+export type GroupTagResponseItem = {
+  key: string;
+  name: string;
+  topValues: Array<{
+    count: number;
+    firstSeen: string;
+    lastSeen: string;
+    name: string;
+    value: string;
+    readable?: boolean;
+  }>;
+  totalValues: number;
+};
+
+export type GroupTagsResponse = GroupTagResponseItem[];
+
+type FetchIssueTagsParameters = {
+  environment: string[];
+  groupId: string;
+  limit: number;
+  readable: boolean;
+};
+
+export const makeFetchIssueTagsQueryKey = ({
+  groupId,
+  environment,
+  readable,
+  limit,
+}: FetchIssueTagsParameters): ApiQueryKey => [
+  `/issues/${groupId}/tags/`,
+  {query: {environment, readable, limit}},
+];
+
+export const useFetchIssueTags = (
+  parameters: FetchIssueTagsParameters,
+  options: Partial<UseApiQueryOptions<GroupTagsResponse>> = {}
+) => {
+  return useApiQuery<GroupTagsResponse>(makeFetchIssueTagsQueryKey(parameters), {
+    staleTime: 30000,
+    ...options,
+  });
+};

--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -17,13 +17,12 @@ const {router, organization, routerContext} = initializeOrg({
   },
 });
 describe('Tag Facets', function () {
-  let tagsMock;
   const project = TestStubs.Project();
   project.platform = 'android';
   const tags = ['os', 'device', 'release'];
 
   beforeEach(function () {
-    tagsMock = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/issues/1/tags/',
       body: {
         release: {
@@ -99,7 +98,7 @@ describe('Tag Facets', function () {
 
   describe('Tag Distributions', function () {
     it('does not display anything if no tag values recieved', async function () {
-      tagsMock = MockApiClient.addMockResponse({
+      MockApiClient.addMockResponse({
         url: '/issues/1/tags/',
         body: {},
       });
@@ -116,7 +115,7 @@ describe('Tag Facets', function () {
         }
       );
       await waitFor(() => {
-        expect(tagsMock).toHaveBeenCalled();
+        expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
       });
       expect(screen.queryByText('os')).not.toBeInTheDocument();
       expect(screen.queryByText('device')).not.toBeInTheDocument();
@@ -137,11 +136,10 @@ describe('Tag Facets', function () {
         }
       );
       await waitFor(() => {
-        expect(tagsMock).toHaveBeenCalled();
+        expect(screen.getByRole('listitem', {name: 'os'})).toBeInTheDocument();
+        expect(screen.getByRole('listitem', {name: 'device'})).toBeInTheDocument();
+        expect(screen.getByRole('listitem', {name: 'release'})).toBeInTheDocument();
       });
-      expect(screen.getByRole('listitem', {name: 'os'})).toBeInTheDocument();
-      expect(screen.getByRole('listitem', {name: 'device'})).toBeInTheDocument();
-      expect(screen.getByRole('listitem', {name: 'release'})).toBeInTheDocument();
     });
 
     it('expands first tag distribution by default', async function () {
@@ -157,11 +155,8 @@ describe('Tag Facets', function () {
           organization,
         }
       );
-      await waitFor(() => {
-        expect(tagsMock).toHaveBeenCalled();
-      });
       expect(
-        screen.getByRole('button', {name: 'Collapse os tag distribution'})
+        await screen.findByRole('button', {name: 'Collapse os tag distribution'})
       ).toBeInTheDocument();
     });
 
@@ -179,10 +174,10 @@ describe('Tag Facets', function () {
         }
       );
       await waitFor(() => {
-        expect(tagsMock).toHaveBeenCalled();
+        expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
       });
       expect(
-        screen.getByRole('button', {name: 'Collapse os tag distribution'})
+        await screen.findByRole('button', {name: 'Collapse os tag distribution'})
       ).toBeInTheDocument();
       await userEvent.click(
         screen.getByRole('button', {name: 'Collapse os tag distribution'})
@@ -208,7 +203,7 @@ describe('Tag Facets', function () {
         }
       );
       await waitFor(() => {
-        expect(tagsMock).toHaveBeenCalled();
+        expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
       });
       await userEvent.click(
         screen.getByRole('button', {name: 'Expand device tag distribution'})
@@ -239,7 +234,7 @@ describe('Tag Facets', function () {
         }
       );
       await waitFor(() => {
-        expect(tagsMock).toHaveBeenCalled();
+        expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
       });
       await userEvent.click(
         screen.getByRole('button', {name: 'Expand device tag distribution'})

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -179,7 +179,7 @@ export default function TagFacets({
 function WrapperWithTitle({children}: {children: ReactNode}) {
   return (
     <SidebarSection.Wrap>
-      <div>
+      <SidebarSection.Title>
         {t('All Tags')}
         <TooltipWrapper>
           <Tooltip
@@ -189,7 +189,7 @@ function WrapperWithTitle({children}: {children: ReactNode}) {
             <IconQuestion size="sm" color="gray200" />
           </Tooltip>
         </TooltipWrapper>
-      </div>
+      </SidebarSection.Title>
       {children}
     </SidebarSection.Wrap>
   );

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -18,9 +18,7 @@ import TagFacets, {
 } from 'sentry/components/group/tagFacets';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import * as SidebarSection from 'sentry/components/sidebarSection';
-import {Tooltip} from 'sentry/components/tooltip';
 import {backend, frontend} from 'sentry/data/platformCategories';
-import {IconQuestion} from 'sentry/icons/iconQuestion';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
@@ -228,19 +226,6 @@ export default function GroupSidebar({
             ? BACKEND_TAGS
             : DEFAULT_TAGS
         }
-        title={
-          <div>
-            {t('All Tags')}
-            <TooltipWrapper>
-              <Tooltip
-                title={t('The tags associated with all events in this issue')}
-                disableForVisualTest
-              >
-                <IconQuestion size="sm" color="gray200" />
-              </Tooltip>
-            </TooltipWrapper>
-          </div>
-        }
         event={event}
         tagFormatter={TAGS_FORMATTER}
         project={project}
@@ -268,9 +253,4 @@ const StyledAvatarList = styled(AvatarList)`
 
 const StyledSidebarSectionTitle = styled(SidebarSection.Title)`
   gap: ${space(1)};
-`;
-
-const TooltipWrapper = styled('span')`
-  vertical-align: middle;
-  padding-left: ${space(0.5)};
 `;

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -1,9 +1,9 @@
 import orderBy from 'lodash/orderBy';
 
-import {bulkUpdate} from 'sentry/actionCreators/group';
+import {bulkUpdate, useFetchIssueTags} from 'sentry/actionCreators/group';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import {Group, GroupActivity} from 'sentry/types';
+import {Environment, Group, GroupActivity} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 
 /**
@@ -159,3 +159,18 @@ export function getGroupReprocessingStatus(
       return ReprocessingStatus.NO_STATUS;
   }
 }
+
+export const useFetchIssueTagsForDetailsPage = ({
+  groupId,
+  environments,
+}: {
+  environments: Environment[];
+  groupId: string;
+}) => {
+  return useFetchIssueTags({
+    groupId,
+    environment: environments.map(({name}) => name),
+    readable: true,
+    limit: 4,
+  });
+};


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/48783

This converts the "All Tags" section to use useApiQuery. I'm doing this so that we can use the response elsewhere in the issue details page, which is needed to remove `tags` from the initial group response and help us speed up the page.

And of course, it's always nice to have more useApiQuery in here