### PR TITLE
ref(format-sql): Only make one flagr call

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -388,9 +388,7 @@ class SqlFormatEventSerializer(EventSerializer):
                 None,
             )
 
-            if not breadcrumbs or not features.has(
-                "organizations:sql-format", event.project.organization, actor=user
-            ):
+            if not breadcrumbs:
                 return event_data
 
             for breadcrumb_item in breadcrumbs["data"]["values"]:
@@ -411,9 +409,7 @@ class SqlFormatEventSerializer(EventSerializer):
                 None,
             )
 
-            if not spans or not features.has(
-                "organizations:sql-format", event.project.organization, actor=user
-            ):
+            if not spans:
                 return event_data
 
             for span in spans["data"]:
@@ -427,9 +423,12 @@ class SqlFormatEventSerializer(EventSerializer):
 
     def serialize(self, obj, attrs, user):
         result = super().serialize(obj, attrs, user)
-        with sentry_sdk.start_span(op="event_serializer.format_sql"):
-            result = self._format_breadcrumb_messages(result, obj, user)
-            result = self._format_db_spans(result, obj, user)
+
+        if features.has("organizations:sql-format", obj.project.organization, actor=user):
+            with sentry_sdk.start_span(op="serialize", description="Format SQL"):
+                result = self._format_breadcrumb_messages(result, obj, user)
+                result = self._format_db_spans(result, obj, user)
+
         return result
 
 


### PR DESCRIPTION
- Was making two flagr checks, moved up to only make one
- Moved `start_span` under the flagr check so that it doesn't have any children and give it a description. This makes the aggregate times more easy to observe with Sentry since we can use self time and not duration which is not logged in metrics.