### PR TITLE
fix(starfish): Raise an error if referrer is missing

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1471,7 +1471,7 @@ class QueryBuilder(BaseQueryBuilder):
         return value
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
-        if referrer is None:
+        if referrer is None:  # type: ignore
             InvalidSearchQuery("Query missing referrer.")
         return raw_snql_query(self.get_snql_query(), referrer, use_cache)
 

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1471,6 +1471,8 @@ class QueryBuilder(BaseQueryBuilder):
         return value
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
+        if referrer is None:
+            InvalidSearchQuery("Query missing referrer.")
         return raw_snql_query(self.get_snql_query(), referrer, use_cache)
 
     def process_results(self, results: Any) -> EventsResponse:

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1471,7 +1471,7 @@ class QueryBuilder(BaseQueryBuilder):
         return value
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
-        if referrer is None:  # type: ignore
+        if not referrer:
             InvalidSearchQuery("Query missing referrer.")
         return raw_snql_query(self.get_snql_query(), referrer, use_cache)
 


### PR DESCRIPTION
A lot of code/tests need to be updated to make referrer
required in all the functions, so just went with @wmak's
suggestion of raising an error if it happens! This shouldn't
break anything in prod since the queries would fail
in the first place (because snuba will immediately reject
referrer-less queries)

This will prevent people from introducing new referrer-less
queries