### PR TITLE
hc(feat): Remove actor_id from notification utils

### DIFF
--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -81,18 +81,18 @@ def get_events_by_participant(
 def get_personalized_digests(
     digest: Digest,
     participants_by_provider_by_event: Mapping[Event, Mapping[ExternalProviders, set[RpcActor]]],
-) -> Mapping[int, Digest]:
+) -> Mapping[RpcActor, Digest]:
     events_by_participant = get_events_by_participant(participants_by_provider_by_event)
 
-    actor_id_to_digest = {}
+    actor_to_digest = {}
 
     for participant, events in events_by_participant.items():
-        if participant.actor_id is not None:
+        if participant is not None:
             custom_digest = build_custom_digest(digest, events, participant)
             if custom_digest:
-                actor_id_to_digest[participant.actor_id] = custom_digest
+                actor_to_digest[participant] = custom_digest
 
-    return actor_id_to_digest
+    return actor_to_digest
 
 
 def get_event_from_groups_in_digest(digest: Digest) -> Iterable[Event]:

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -39,12 +39,10 @@ def _get_attachments(
     notification: BaseNotification,
     recipient: RpcActor,
     shared_context: Mapping[str, Any],
-    extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None,
+    extra_context_by_actor: Mapping[RpcActor, Mapping[str, Any]] | None,
 ) -> List[SlackAttachment]:
     extra_context = (
-        extra_context_by_actor_id[recipient.actor_id]
-        if extra_context_by_actor_id and recipient.actor_id
-        else {}
+        extra_context_by_actor[recipient] if extra_context_by_actor and recipient else {}
     )
     context = get_context(notification, recipient, shared_context, extra_context)
     cls = get_message_builder(notification.message_builder)
@@ -104,7 +102,7 @@ def send_notification_as_slack(
     notification: BaseNotification,
     recipients: Iterable[RpcActor | Team | User],
     shared_context: Mapping[str, Any],
-    extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None,
+    extra_context_by_actor: Mapping[RpcActor, Mapping[str, Any]] | None,
 ) -> None:
     """Send an "activity" or "alert rule" notification to a Slack user or team."""
     with sentry_sdk.start_span(
@@ -121,7 +119,7 @@ def send_notification_as_slack(
                     notification,
                     recipient,
                     shared_context,
-                    extra_context_by_actor_id,
+                    extra_context_by_actor,
                 )
 
             for channel, integration in integrations_by_channel.items():

--- a/src/sentry/mail/analytics.py
+++ b/src/sentry/mail/analytics.py
@@ -9,9 +9,11 @@ class EmailNotificationSent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id", required=False),
         analytics.Attribute("category"),
-        analytics.Attribute("actor_id"),
+        analytics.Attribute("actor_id", required=False),
         analytics.Attribute("user_id", required=False),
         analytics.Attribute("group_id", required=False),
+        analytics.Attribute("id"),
+        analytics.Attribute("actor_type"),
         # Remove after IssueAlertFallbackExperiment
         analytics.Attribute("fallback_experiment", required=False),
     )

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -114,7 +114,7 @@ def send_notification_as_email(
     notification: BaseNotification,
     recipients: Iterable[RpcActor | Team | RpcUser],
     shared_context: Mapping[str, Any],
-    extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None,
+    extra_context_by_actor: Mapping[RpcActor, Mapping[str, Any]] | None,
 ) -> None:
     for recipient in recipients:
         recipient_actor = RpcActor.from_object(recipient)
@@ -127,7 +127,7 @@ def send_notification_as_email(
             with sentry_sdk.start_span(op="notification.send_email", description="build_message"):
                 msg = MessageBuilder(
                     **get_builder_args(
-                        notification, recipient_actor, shared_context, extra_context_by_actor_id
+                        notification, recipient_actor, shared_context, extra_context_by_actor
                     )
                 )
 
@@ -145,13 +145,11 @@ def get_builder_args(
     notification: BaseNotification,
     recipient: RpcActor,
     shared_context: Mapping[str, Any] | None = None,
-    extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None = None,
+    extra_context_by_actor: Mapping[RpcActor, Mapping[str, Any]] | None = None,
 ) -> Mapping[str, Any]:
     # TODO: move context logic to single notification class method
     extra_context = (
-        extra_context_by_actor_id[recipient.actor_id]
-        if extra_context_by_actor_id and recipient.actor_id
-        else {}
+        extra_context_by_actor[recipient] if extra_context_by_actor and recipient else {}
     )
     context = get_context(notification, recipient, shared_context or {}, extra_context)
     return get_builder_args_from_context(notification, context)

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -116,6 +116,8 @@ class BaseNotification(abc.ABC):
         params = {
             "organization_id": self.organization.id,
             "actor_id": recipient.actor_id,
+            "id": recipient.id,
+            "actor_type": recipient.actor_type,
             "group_id": group.id if group else None,
         }
         if recipient.actor_type == ActorType.USER:

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -15,7 +15,7 @@ Notifiable = Callable[
         BaseNotification,
         Iterable[Union[RpcActor, Team, User, RpcUser]],
         Mapping[str, Any],
-        Optional[Mapping[int, Mapping[str, Any]]],
+        Optional[Mapping[RpcActor, Mapping[str, Any]]],
     ],
     None,
 ]
@@ -49,7 +49,7 @@ def notify(
     notification: Any,
     recipients: Iterable[RpcActor | Team | RpcUser],
     shared_context: Mapping[str, Any],
-    extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None = None,
+    extra_context_by_actor: Mapping[RpcActor, Mapping[str, Any]] | None = None,
 ) -> None:
     """Send notifications to these users or team."""
 
@@ -81,4 +81,4 @@ def notify(
             new_recipients += list(Team.objects.filter(id__in=team_ids))
         recipients = new_recipients
     """ ###################### End Hack ###################### """
-    registry[provider](notification, recipients, shared_context, extra_context_by_actor_id)
+    registry[provider](notification, recipients, shared_context, extra_context_by_actor)

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -103,9 +103,9 @@ class ParticipantMap:
     ) -> Iterable[Tuple[ExternalProviders, Iterable[RpcActor], Mapping[int, Mapping[str, Any]]]]:
         for provider, participants_with_reasons in self._dict.items():
             extra_context = {
-                participant.actor_id: {"reason": reason}
+                participant: {"reason": reason}
                 for participant, reason in participants_with_reasons.items()
-                if participant.actor_id is not None
+                if participant is not None
             }
             yield provider, participants_with_reasons.keys(), extra_context
 

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -100,7 +100,9 @@ class ParticipantMap:
 
     def split_participants_and_context(
         self,
-    ) -> Iterable[Tuple[ExternalProviders, Iterable[RpcActor], Mapping[int, Mapping[str, Any]]]]:
+    ) -> Iterable[
+        Tuple[ExternalProviders, Iterable[RpcActor], Mapping[RpcActor, Mapping[str, Any]]]
+    ]:
         for provider, participants_with_reasons in self._dict.items():
             extra_context = {
                 participant: {"reason": reason}

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -104,7 +104,7 @@ class RpcActor(RpcModel):
     def from_rpc_team(cls, team: RpcTeam) -> "RpcActor":
         return cls(id=team.id, actor_id=team.actor_id, actor_type=ActorType.TEAM, slug=team.slug)
 
-    def __eq__(self, other: Any):
+    def __eq__(self, other: Any) -> bool:
         try:
             return self.id == other.id and self.actor_type == other.actor_type
         except AttributeError:

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from sentry.models.actor import get_actor_id_for_user
 from sentry.services.hybrid_cloud import RpcModel
@@ -104,7 +104,7 @@ class RpcActor(RpcModel):
     def from_rpc_team(cls, team: RpcTeam) -> "RpcActor":
         return cls(id=team.id, actor_id=team.actor_id, actor_type=ActorType.TEAM, slug=team.slug)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any):
         try:
             return self.id == other.id and self.actor_type == other.actor_type
         except AttributeError:

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -105,7 +105,8 @@ class RpcActor(RpcModel):
         return cls(id=team.id, actor_id=team.actor_id, actor_type=ActorType.TEAM, slug=team.slug)
 
     def __eq__(self, other: Any) -> bool:
-        try:
-            return self.id == other.id and self.actor_type == other.actor_type
-        except AttributeError:
-            return False
+        return (
+            isinstance(other, self.__class__)
+            and self.id == other.id
+            and self.actor_type == other.actor_type
+        )

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -66,7 +66,13 @@ class RpcActor(RpcModel):
 
     @classmethod
     def from_orm_user(cls, user: "User", fetch_actor: bool = True) -> "RpcActor":
-        actor_id = get_actor_id_for_user(user) if fetch_actor else user.actor_id
+        actor_id = (
+            get_actor_id_for_user(user)
+            if fetch_actor
+            else user.actor_id
+            if hasattr(user, "actor_id")
+            else None
+        )
         return cls(
             id=user.id,
             actor_id=actor_id,
@@ -76,7 +82,13 @@ class RpcActor(RpcModel):
 
     @classmethod
     def from_rpc_user(cls, user: RpcUser, fetch_actor: bool = True) -> "RpcActor":
-        actor_id = get_actor_id_for_user(user) if fetch_actor else user.actor_id
+        actor_id = (
+            get_actor_id_for_user(user)
+            if fetch_actor
+            else user.actor_id
+            if hasattr(user, "actor_id")
+            else None
+        )
         return cls(
             id=user.id,
             actor_id=actor_id,

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from sentry.models import Team, User
 
 
-class ActorType(Enum):
+class ActorType(str, Enum):
     USER = "User"
     TEAM = "Team"
 
@@ -44,25 +44,29 @@ class RpcActor(RpcModel):
 
     @classmethod
     def from_object(
-        cls, obj: Union["RpcActor", "User", "Team", "RpcUser", "RpcTeam"]
+        cls, obj: Union["RpcActor", "User", "Team", "RpcUser", "RpcTeam"], fetch_actor: bool = True
     ) -> "RpcActor":
+        """
+        fetch_actor: whether to make an extra query or call to fetch the actor id
+                     Without the actor_id the RpcActor acts as a tuple of id and type.
+        """
         from sentry.models import Team, User
 
         if isinstance(obj, cls):
             return obj
         if isinstance(obj, User):
-            return cls.from_orm_user(obj)
+            return cls.from_orm_user(obj, fetch_actor=fetch_actor)
         if isinstance(obj, Team):
             return cls.from_orm_team(obj)
         if isinstance(obj, RpcUser):
-            return cls.from_rpc_user(obj)
+            return cls.from_rpc_user(obj, fetch_actor=fetch_actor)
         if isinstance(obj, RpcTeam):
             return cls.from_rpc_team(obj)
         raise TypeError(f"Cannot build RpcActor from {type(obj)}")
 
     @classmethod
-    def from_orm_user(cls, user: "User") -> "RpcActor":
-        actor_id = get_actor_id_for_user(user)
+    def from_orm_user(cls, user: "User", fetch_actor: bool = True) -> "RpcActor":
+        actor_id = get_actor_id_for_user(user) if fetch_actor else user.actor_id
         return cls(
             id=user.id,
             actor_id=actor_id,
@@ -71,8 +75,8 @@ class RpcActor(RpcModel):
         )
 
     @classmethod
-    def from_rpc_user(cls, user: RpcUser) -> "RpcActor":
-        actor_id = get_actor_id_for_user(user)
+    def from_rpc_user(cls, user: RpcUser, fetch_actor: bool = True) -> "RpcActor":
+        actor_id = get_actor_id_for_user(user) if fetch_actor else user.actor_id
         return cls(
             id=user.id,
             actor_id=actor_id,
@@ -87,3 +91,9 @@ class RpcActor(RpcModel):
     @classmethod
     def from_rpc_team(cls, team: RpcTeam) -> "RpcActor":
         return cls(id=team.id, actor_id=team.actor_id, actor_type=ActorType.TEAM, slug=team.slug)
+
+    def __eq__(self, other):
+        try:
+            return self.id == other.id and self.actor_type == other.actor_type
+        except AttributeError:
+            return False


### PR DESCRIPTION
This enables usage of `RpcActor` without an actor_id, i.e. as a structure to contain id and type (`TEAM` or `USER`).
First step towards removing references of actor id in the control silo and setting `stable=True` on tests.