### PR TITLE
feat(large-http): Convert threshold to system option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -674,6 +674,7 @@ register("performance.issues.render_blocking_assets.size_threshold", default=100
 register("performance.issues.consecutive_http.max_duration_between_spans", default=1000)
 register("performance.issues.consecutive_http.consecutive_count_threshold", default=3)
 register("performance.issues.consecutive_http.span_duration_threshold", default=1000)
+register("performance.issues.large_http_payload.size_threshold", default=1000000)  # 1MB
 
 # System-wide option for sending occurrences to the issues platform
 register("performance.issues.send_to_issues_platform", default=False, flags=FLAG_MODIFIABLE_BOOL)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -154,6 +154,9 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
         "consecutive_http_spans_span_duration_threshold": options.get(
             "performance.issues.consecutive_http.span_duration_threshold"
         ),
+        "large_http_payload_size_threshold": options.get(
+            "performance.issues.large_http_payload.size_threshold"
+        ),
     }
 
     default_project_settings = (
@@ -253,7 +256,9 @@ def get_detection_settings(project_id: Optional[int] = None) -> Dict[DetectorTyp
             ],  # ms
             "detection_enabled": settings["consecutive_http_spans_detection_enabled"],
         },
-        DetectorType.LARGE_HTTP_PAYLOAD: {"payload_size_threshold": 10000000},  # 10mb
+        DetectorType.LARGE_HTTP_PAYLOAD: {
+            "payload_size_threshold": settings["large_http_payload_size_threshold"]
+        },
     }
 
 

--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -50,6 +50,7 @@ const optionsAvailable = [
   'performance.issues.consecutive_http.max_duration_between_spans',
   'performance.issues.consecutive_http.consecutive_count_threshold',
   'performance.issues.consecutive_http.span_duration_threshold',
+  'performance.issues.large_http_payload.size_threshold',
   'profile.issues.blocked_main_thread-ingest.la-rollout',
   'profile.issues.blocked_main_thread-ingest.ea-rollout',
   'profile.issues.blocked_main_thread-ingest.ga-rollout',
@@ -195,6 +196,10 @@ export default class AdminSettings extends AsyncView<{}, State> {
               {fields['performance.issues.consecutive_http.max_duration_between_spans']}
               {fields['performance.issues.consecutive_http.consecutive_count_threshold']}
               {fields['performance.issues.consecutive_http.span_duration_threshold']}
+            </Panel>
+            <Panel>
+              <PanelHeader>Performance Issues - Large HTTP Payload Detector</PanelHeader>
+              {fields['performance.issues.large_http.size_threshold']}
             </Panel>
             <Panel>
               <PanelHeader>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -406,6 +406,18 @@ const performanceOptionDefinitions: Field[] = [
     step: 1,
   },
   {
+    key: 'performance.issues.large_http_payload.size_threshold',
+    label: t('Payload Size Threshold'),
+    help: t(
+      'The threshold at which the payload size of an HTTP span is considered to be too large, in bytes.'
+    ),
+    defaultValue: () => '1000000',
+    component: NumberField,
+    min: 0,
+    max: Number.MAX_SAFE_INTEGER,
+    step: 1,
+  },
+  {
     key: 'profile.issues.blocked_main_thread-ingest.la-rollout',
     label: t('Limited Availability Detection Rate'),
     help: t(


### PR DESCRIPTION
Converting to an option so we have the ability to change the threshold more easily. Also sets the default to 1MB instead of 10MB

Putting both frontend and backend together because it's only accessible by internal devs