### PR TITLE
feat(replays): support replay count for all projects in issues stream

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -15,7 +15,6 @@ import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Group, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
@@ -49,8 +48,7 @@ function EventOrGroupExtraDetails({
 
   const issuesPath = `/organizations/${organization.slug}/issues/`;
 
-  const showReplayCount =
-    organization.features.includes('session-replay') && projectSupportsReplay(project);
+  const showReplayCount = organization.features.includes('session-replay');
 
   return (
     <GroupExtra>

--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -31,6 +31,7 @@ function IssueReplayCount({groupId}: Props) {
     'This issue has %s replays available to view',
     count
   );
+
   return (
     <Tooltip title={count > 50 ? titleOver50 : title50OrLess}>
       <ReplayCountLink

--- a/static/app/components/replays/issuesReplayCountProvider.tsx
+++ b/static/app/components/replays/issuesReplayCountProvider.tsx
@@ -5,7 +5,6 @@ import useReplaysCount from 'sentry/components/replays/useReplaysCount';
 import GroupStore from 'sentry/stores/groupStore';
 import type {Group, Organization} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
 
 type Props = {
   children: ReactNode;
@@ -42,30 +41,12 @@ function Provider({
   groupIds,
   organization,
 }: Props & {organization: Organization}) {
-  const {projects} = useProjects();
-
-  const projectsById = useMemo(
-    () => projects.reduce((map, p) => map.set(p.id, p), new Map()),
-    [projects]
-  );
-
-  // Only ask for the groupIds where the project have sent one or more replays.
-  // For projects that don't support replay the count will always be zero.
   const [groups, projectIds] = useMemo(() => {
     const pIds = new Set<number>();
-    const gIds = groupIds
-      .map(id => GroupStore.get(id) as Group)
-      .filter(Boolean)
-      .filter(group => {
-        const proj = projectsById.get(group.project.id);
-        if (proj?.hasReplays) {
-          pIds.add(Number(group.project.id));
-          return true;
-        }
-        return false;
-      });
+    const gIds = groupIds.map(id => GroupStore.get(id) as Group).filter(Boolean);
+
     return [gIds, Array.from(pIds)];
-  }, [projectsById, groupIds]);
+  }, [groupIds]);
 
   const replayGroupIds = useMemo(() => groups.map(group => group.id), [groups]);
 


### PR DESCRIPTION
## Summary
This removes gating logic around project support and replay count for group ids. We will now fetch replay counts for all projects within an issue stream.

Closes: https://github.com/orgs/getsentry/projects/23/views/24?pane=issue&itemId=27747777

In issues stream:
![image](https://github.com/getsentry/sentry/assets/7349258/b54b5827-6484-439a-81f4-9d2f7dd42247)

In replay details issues tab:
![image](https://github.com/getsentry/sentry/assets/7349258/06500017-71a4-497d-b713-61ac5a4e5537)

