### PR TITLE
fix(issue-details): Fix crash when participants is undefined

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -365,7 +365,7 @@ export function getAnalyticsDataForGroup(group?: Group | null): CommonGroupAnaly
     has_external_issue: group?.annotations ? group?.annotations.length > 0 : false,
     has_owner: group?.owners ? group?.owners.length > 0 : false,
     integration_assignment_source: group ? getAssignmentIntegration(group) : '',
-    num_participants: group?.participants.length ?? 0,
+    num_participants: group?.participants?.length ?? 0,
     num_viewers: group?.seenBy.filter(user => user.id !== activeUser?.id).length ?? 0,
     group_num_user_feedback: group?.userReportCount ?? 0,
   };


### PR DESCRIPTION
Fixes JAVASCRIPT-2KQ4

https://sentry.sentry.io/issues/4157064303

I believe this situation can happen when GroupStore has a group loaded from the issue stream, but hasn't made the full group request that it expects on the group details page.