### PR TITLE
feat(trends): Get processed event timeseries

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trendsv2.py
+++ b/src/sentry/api/endpoints/organization_events_trendsv2.py
@@ -94,14 +94,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             )
             return f" transaction:[{top_transaction_as_str}]"
 
-        def get_event_stats_metrics(
-            query_columns,
-            user_query,
-            params,
-            rollup,
-            zerofill_results,
-            comparison_delta,
-        ):
+        def get_event_stats_metrics(_, user_query, params, rollup, zerofill_results, __):
             # Get top events
             top_events = get_top_events(
                 selected_columns,
@@ -109,7 +102,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 params=params,
                 orderby=["-count()"],
                 limit=100,
-                referrer=Referrer.API_TRENDS_GET_EVENT_STATS_NEW.value,
+                referrer=Referrer.API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS.value,
             )
 
             if top_events.get("data", None) is None:
@@ -123,9 +116,9 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 params,
                 rollup=rollup,
                 zerofill_results=zerofill_results,
-                referrer=Referrer.API_TRENDS_GET_EVENT_STATS_NEW.value,
+                referrer=Referrer.API_TRENDS_GET_EVENT_STATS_V2_TIMESERIES.value,
                 groupby=Column("transaction"),
-                raw_result=True,
+                apply_formatting=False,
             )
 
             translated_groupby = ["transaction"]
@@ -139,7 +132,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 if result_key in results:
                     results[result_key]["data"].append(row)
                 else:
-                    # TODO come up with a better name
+                    # TODO filter out entries that don't have transaction or trend_function
                     logger.warning(
                         "trends.top-events.timeseries.key-mismatch",
                         extra={"result_key": result_key, "top_event_keys": list(results.keys())},

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -271,7 +271,6 @@ from .endpoints.organization_events_meta import (
     OrganizationEventsMetaEndpoint,
     OrganizationEventsRelatedIssuesEndpoint,
 )
-from .endpoints.organization_events_new_trends import OrganizationEventsNewTrendsStatsEndpoint
 from .endpoints.organization_events_span_ops import OrganizationEventsSpanOpsEndpoint
 from .endpoints.organization_events_spans_histogram import OrganizationEventsSpansHistogramEndpoint
 from .endpoints.organization_events_spans_performance import (
@@ -289,6 +288,7 @@ from .endpoints.organization_events_trends import (
     OrganizationEventsTrendsEndpoint,
     OrganizationEventsTrendsStatsEndpoint,
 )
+from .endpoints.organization_events_trendsv2 import OrganizationEventsNewTrendsStatsEndpoint
 from .endpoints.organization_events_vitals import OrganizationEventsVitalsEndpoint
 from .endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from .endpoints.organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
@@ -1246,9 +1246,9 @@ ORGANIZATION_URLS = [
     # This endpoint is for experimentation only
     # Once this feature is developed, the endpoint will replace /events-trends-stats
     url(
-        r"^(?P<organization_slug>[^\/]+)/new-events-trends-stats/$",
+        r"^(?P<organization_slug>[^\/]+)/events-trends-statsv2/$",
         OrganizationEventsNewTrendsStatsEndpoint.as_view(),
-        name="sentry-api-0-organization-events-new-trends-stats",
+        name="sentry-api-0-organization-events-trends-statsv2",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/events-trace-light/(?P<trace_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -895,6 +895,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         functions_acl: Optional[List[str]] = None,
         limit: Optional[int] = 10000,
         use_metrics_layer: Optional[bool] = False,
+        groupby: Optional[Column] = None,
     ):
         super().__init__(
             params=params,
@@ -915,8 +916,12 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         self.time_column = self.resolve_time_column(interval)
         self.limit = None if limit is None else Limit(limit)
 
-        # This is a timeseries, the groupby will always be time
+        # This is a timeseries, the implied groupby will always be time
         self.groupby = [self.time_column]
+
+        # If additional groupby is provided it will be used first before time
+        if groupby is not None:
+            self.groupby.insert(0, groupby)
 
     def resolve_time_column(self, interval: int) -> Function:
         """Need to round the timestamp to the interval requested

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from typing import Dict, List, Optional, Sequence
 
 import sentry_sdk
+from snuba_sdk import Column
 
 from sentry.discover.arithmetic import categorize_columns
 from sentry.search.events.builder import (
@@ -75,6 +76,8 @@ def timeseries_query(
     functions_acl: Optional[List[str]] = None,
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
+    groupby: Optional[Column] = None,
+    raw_result: Optional[bool] = False,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -96,6 +99,7 @@ def timeseries_query(
                 functions_acl=functions_acl,
                 allow_metric_aggregates=allow_metric_aggregates,
                 use_metrics_layer=use_metrics_layer,
+                groupby=groupby,
             )
             metrics_referrer = referrer + ".metrics-enhanced"
             result = metrics_query.run_query(metrics_referrer)
@@ -114,6 +118,10 @@ def timeseries_query(
             )
             sentry_sdk.set_tag("performance.dataset", "metrics")
             result["meta"]["isMetricsData"] = True
+
+            if raw_result:
+                return result
+
             return SnubaTSResult(
                 {
                     "data": result["data"],

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -77,7 +77,7 @@ def timeseries_query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     groupby: Optional[Column] = None,
-    raw_result: Optional[bool] = False,
+    apply_formatting: Optional[bool] = True,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -119,7 +119,8 @@ def timeseries_query(
             sentry_sdk.set_tag("performance.dataset", "metrics")
             result["meta"]["isMetricsData"] = True
 
-            if raw_result:
+            # Sometimes additional formatting needs to be done downstream
+            if not apply_formatting:
                 return result
 
             return SnubaTSResult(

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -335,7 +335,14 @@ class ReferrerBase(Enum):
     API_TRACE_VIEW_HOVER_CARD = "api.trace-view.hover-card"
     API_TRACE_VIEW_SPAN_DETAIL = "api.trace-view.span-detail"
     API_TRENDS_GET_EVENT_STATS = "api.trends.get-event-stats"
-    API_TRENDS_GET_EVENT_STATS_NEW = "api.trends.get-event-stats-new"
+    API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS = "api.trends.get-event-statsv2.top-events"
+    API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS_METRICS_ENHANCED = (
+        "api.trends.get-event-statsv2.top-events.metrics-enhanced"
+    )
+    API_TRENDS_GET_EVENT_STATS_V2_TIMESERIES = "api.trends.get-event-statsv2.timeseries"
+    API_TRENDS_GET_EVENT_STATS_V2_TIMESERIES_METRICS_ENHANCED = (
+        "api.trends.get-event-statsv2.timeseries.metrics-enhanced"
+    )
     API_TRENDS_GET_PERCENTAGE_CHANGE = "api.trends.get-percentage-change"
     API_VROOM = "api.vroom"
     BACKFILL_PERF_ISSUE_EVENTS = "migration.backfill_perf_issue_events_issue_platform"


### PR DESCRIPTION
This PR sends processed event timeseries to the microservice instead of indexed events one. The fetching is done in two steps: 1. fetch top N transaction name with the highest count 2. fetch `trendFunction` metric and `count` for those transaction names. Also I'm renaming the endpoint from `new-events-trends-stats` to `events-trends-statsv2`. Top N query doesn't work for processed events so this PR makes direct queries bypassing TopNQueryBuilder