### PR TITLE
chore: Remove feature flag for release health + dashboards

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1329,8 +1329,6 @@ SENTRY_FEATURES = {
     "organizations:dashboards-edit": True,
     # Enable metrics enhanced performance in dashboards
     "organizations:dashboards-mep": False,
-    # Enable release health widget in dashboards
-    "organizations:dashboards-rh-widget": False,
     # Enable the dynamic sampling "Transaction Name" priority in the UI
     "organizations:dynamic-sampling-transaction-name-priority": False,
     # Enable minimap in the widget viewer modal in dashboards

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -73,7 +73,6 @@ default_manager.add("organizations:mute-alerts", OrganizationFeature, FeatureHan
 default_manager.add("organizations:custom-event-title", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:customer-domains", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:dashboards-rh-widget", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-template", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:discover-events-rate-limit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -45,7 +45,7 @@ import {
   Position,
 } from './layoutUtils';
 import SortableWidget from './sortableWidget';
-import {DashboardDetails, DashboardWidgetSource, Widget, WidgetType} from './types';
+import {DashboardDetails, DashboardWidgetSource, Widget} from './types';
 import {getDashboardFiltersFromURL} from './utils';
 
 export const DRAG_HANDLE_CLASS = 'widget-drag';
@@ -459,18 +459,10 @@ class Dashboard extends Component<Props, State> {
 
   render() {
     const {layouts, isMobile} = this.state;
-    const {isEditing, dashboard, widgetLimitReached, organization} = this.props;
-    let {widgets} = dashboard;
-    // Filter out any issue/release widgets if the user does not have the feature flag
-    widgets = widgets.filter(({widgetType}) => {
-      if (widgetType === WidgetType.RELEASE) {
-        return organization.features.includes('dashboards-rh-widget');
-      }
-      return true;
-    });
+    const {isEditing, dashboard, widgetLimitReached} = this.props;
 
     const columnDepths = calculateColumnDepths(layouts[DESKTOP]);
-    const widgetsWithLayout = assignDefaultLayout(widgets, columnDepths);
+    const widgetsWithLayout = assignDefaultLayout(dashboard.widgets, columnDepths);
 
     const canModifyLayout = !isMobile && isEditing;
 

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -13,21 +13,16 @@ import {BuildStep} from './buildStep';
 const DATASET_CHOICES: [DataSet, string][] = [
   [DataSet.EVENTS, t('Errors and Transactions')],
   [DataSet.ISSUES, t('Issues (States, Assignment, Time, etc.)')],
+  [DataSet.RELEASES, t('Releases (Sessions, Crash rates)')],
 ];
 
 interface Props {
   dataSet: DataSet;
   displayType: DisplayType;
-  hasReleaseHealthFeature: boolean;
   onChange: (dataSet: DataSet) => void;
 }
 
-export function DataSetStep({
-  dataSet,
-  onChange,
-  hasReleaseHealthFeature,
-  displayType,
-}: Props) {
+export function DataSetStep({dataSet, onChange, displayType}: Props) {
   const disabledChoices: RadioGroupProps<string>['disabledChoices'] = [];
 
   if (displayType !== DisplayType.TABLE) {
@@ -61,14 +56,7 @@ export function DataSetStep({
       <DataSetChoices
         label="dataSet"
         value={dataSet}
-        choices={
-          hasReleaseHealthFeature
-            ? [
-                ...DATASET_CHOICES,
-                [DataSet.RELEASES, t('Releases (Sessions, Crash rates)')],
-              ]
-            : DATASET_CHOICES
-        }
+        choices={DATASET_CHOICES}
         disabledChoices={disabledChoices}
         onChange={newDataSet => {
           onChange(newDataSet as DataSet);

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -161,20 +161,11 @@ function WidgetBuilder({
     defaultTableColumns = [defaultTableColumns];
   }
 
-  const hasReleaseHealthFeature = organization.features.includes('dashboards-rh-widget');
-
-  const filteredDashboardWidgets = dashboard.widgets.filter(({widgetType}) => {
-    if (widgetType === WidgetType.RELEASE) {
-      return hasReleaseHealthFeature;
-    }
-    return true;
-  });
-
   const isEditing = defined(widgetIndex);
   const widgetIndexNum = Number(widgetIndex);
   const isValidWidgetIndex =
     widgetIndexNum >= 0 &&
-    widgetIndexNum < filteredDashboardWidgets.length &&
+    widgetIndexNum < dashboard.widgets.length &&
     Number.isInteger(widgetIndexNum);
   const orgSlug = organization.slug;
 
@@ -269,7 +260,7 @@ function WidgetBuilder({
     }
 
     if (isEditing && isValidWidgetIndex) {
-      const widgetFromDashboard = filteredDashboardWidgets[widgetIndexNum];
+      const widgetFromDashboard = dashboard.widgets[widgetIndexNum];
 
       let queries;
       let newDisplayType = widgetFromDashboard.displayType;
@@ -1008,7 +999,6 @@ function WidgetBuilder({
                                 dataSet={state.dataSet}
                                 displayType={state.displayType}
                                 onChange={handleDataSetChange}
-                                hasReleaseHealthFeature={hasReleaseHealthFeature}
                               />
                               {isTabularChart && (
                                 <DashboardsMEPConsumer>

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -25,7 +25,6 @@ const defaultOrgFeatures = [
   'dashboards-edit',
   'global-views',
   'dashboards-mep',
-  'dashboards-rh-widget',
 ];
 
 // Mocking worldMapChart to avoid act warnings

--- a/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
@@ -7,7 +7,7 @@ import {OverwriteWidgetModalProps} from 'sentry/components/modals/widgetBuilder/
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType} from 'sentry/views/dashboards/types';
 import {
   getTopNConvertedDefaultWidgets,
   WidgetTemplate,
@@ -28,15 +28,9 @@ export function WidgetLibrary({
   bypassOverwriteModal,
   onWidgetSelect,
   selectedWidgetId,
-  organization,
 }: Props) {
   const theme = useTheme();
-  let defaultWidgets = getTopNConvertedDefaultWidgets();
-  if (!organization.features.includes('dashboards-rh-widget')) {
-    defaultWidgets = defaultWidgets.filter(
-      widget => !(widget.widgetType === WidgetType.RELEASE)
-    );
-  }
+  const defaultWidgets = getTopNConvertedDefaultWidgets();
 
   function getLibrarySelectionHandler(
     widget: OverwriteWidgetModalProps['widget'],


### PR DESCRIPTION
With release-health backend in single-tenant we can remove this feature flag check as release-health has been available in self-hosted and saas for quite a while now.

Are there other feature flags that could be enabled/removed now that all environments have release-health/metrics available?