### PR TITLE
feat(starfish): add profile to db query details

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/panel/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel/index.tsx
@@ -14,6 +14,7 @@ import {Series} from 'sentry/types/echarts';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart from 'sentry/views/starfish/components/chart';
 import Detail from 'sentry/views/starfish/components/detailPanel';
+import ProfileView from 'sentry/views/starfish/modules/databaseModule/panel/profileView';
 import QueryTransactionTable, {
   PanelSort,
 } from 'sentry/views/starfish/modules/databaseModule/panel/queryTransactionTable';
@@ -278,6 +279,15 @@ function QueryDetailBody({
         sort={sort}
         tableData={mergedTableData}
       />
+      <FlexRowContainer>
+        <FlexRowItem>
+          <SubHeader>{t('Example Profile')}</SubHeader>
+          <ProfileView
+            spanHash={row.group_id}
+            transactionNames={tableData.map(d => d.transaction)}
+          />
+        </FlexRowItem>
+      </FlexRowContainer>
       <FlexRowContainer>
         <FlexRowItem>
           <SubHeader>{t('Similar Queries')}</SubHeader>

--- a/static/app/views/starfish/modules/databaseModule/panel/profileView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel/profileView.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {SpanProfileDetails} from 'sentry/components/events/interfaces/spans/spanProfileDetails';
 import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -27,8 +29,6 @@ export function ProfileView(props: Props) {
     return <LoadingIndicator />;
   }
 
-  let profileView: React.ReactNode = 'No profile found';
-
   if (eventResult.data.id) {
     const event = eventResult.data;
     const spans = event.entries[0].data as RawSpanType[];
@@ -36,7 +36,7 @@ export function ProfileView(props: Props) {
     const currentSpan = spans.find(s => s.hash === spanHash);
     const profileId = event.contexts?.profile?.profile_id ?? undefined;
     if (currentSpan && profileId) {
-      profileView = (
+      return (
         <ProfilesProvider
           orgSlug={organization.slug}
           profileId={profileId}
@@ -58,7 +58,7 @@ export function ProfileView(props: Props) {
     }
   }
 
-  return profileView;
+  return <Fragment>'No profile found'</Fragment>;
 }
 
 export default ProfileView;

--- a/static/app/views/starfish/modules/databaseModule/panel/profileView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel/profileView.tsx
@@ -1,0 +1,64 @@
+import {SpanProfileDetails} from 'sentry/components/events/interfaces/spans/spanProfileDetails';
+import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import useOrganization from 'sentry/utils/useOrganization';
+import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
+import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesProvider';
+import {
+  useQueryGetEvent,
+  useQueryGetProfileIds,
+} from 'sentry/views/starfish/modules/databaseModule/queries';
+
+type Props = {
+  spanHash: string;
+  transactionNames: string[];
+};
+
+export function ProfileView(props: Props) {
+  const {spanHash, transactionNames} = props;
+  const organization = useOrganization();
+
+  const result = useQueryGetProfileIds(transactionNames, spanHash);
+  const eventResult = useQueryGetEvent(result.data[0]?.transaction_id);
+
+  const isLoading = result.isLoading || eventResult.isLoading;
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  let profileView: React.ReactNode = 'No profile found';
+
+  if (eventResult.data.id) {
+    const event = eventResult.data;
+    const spans = event.entries[0].data as RawSpanType[];
+
+    const currentSpan = spans.find(s => s.hash === spanHash);
+    const profileId = event.contexts?.profile?.profile_id ?? undefined;
+    if (currentSpan && profileId) {
+      profileView = (
+        <ProfilesProvider
+          orgSlug={organization.slug}
+          profileId={profileId}
+          projectSlug="sentry" // TODO - don't harcode this
+        >
+          <ProfileContext.Consumer>
+            {profiles => (
+              <ProfileGroupProvider
+                type="flamechart"
+                input={profiles?.type === 'resolved' ? profiles.data : null}
+                traceID={profileId || ''}
+              >
+                <SpanProfileDetails event={event} span={currentSpan} />
+              </ProfileGroupProvider>
+            )}
+          </ProfileContext.Consumer>
+        </ProfilesProvider>
+      );
+    }
+  }
+
+  return profileView;
+}
+
+export default ProfileView;

--- a/static/app/views/starfish/modules/databaseModule/queries.ts
+++ b/static/app/views/starfish/modules/databaseModule/queries.ts
@@ -1,6 +1,11 @@
 import {Moment, unix} from 'moment';
 
+import {EventTransaction} from 'sentry/types';
+import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
 import {DefinedUseQueryResult, useQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {DataRow} from 'sentry/views/starfish/modules/databaseModule/databaseTableView';
 import {TransactionListDataRow} from 'sentry/views/starfish/modules/databaseModule/panel';
@@ -511,6 +516,61 @@ export const useQueryTransactionByTPMAndP75 = (
     queryFn: () => fetch(`${HOST}/?query=${query}`).then(res => res.json()),
     retry: false,
     initialData: [],
+  });
+};
+
+export const useQueryGetProfileIds = (
+  transactionNames: string[],
+  spanHash: string
+): DefinedUseQueryResult<{transaction_id: string}[]> => {
+  const location = useLocation();
+  const {slug: orgSlug} = useOrganization();
+  const eventView = EventView.fromNewQueryWithLocation(
+    {
+      fields: ['transaction'],
+      name: 'Db module - profile',
+      query: `transaction:[${transactionNames.join(',')}] has:profile.id`,
+      projects: [1],
+      version: 1,
+    },
+    location
+  );
+  const discoverResult = useDiscoverQuery({eventView, location, orgSlug});
+
+  const transactionIds = discoverResult?.data?.data?.map(d => d.id);
+
+  const query = `
+    SELECT
+      transaction_id
+    FROM
+      default.spans_experimental_starfish
+    WHERE
+      group_id = '${spanHash}' AND
+      transaction_id IN ('${transactionIds?.join(`','`)}')
+  `;
+
+  return useQuery({
+    enabled: !!transactionIds?.length,
+    queryKey: ['transactionsWithProfiles', transactionIds?.join(',')],
+    queryFn: () => fetch(`${HOST}/?query=${query}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+};
+
+export const useQueryGetEvent = (
+  transactionEventId?: string
+): DefinedUseQueryResult<EventTransaction> => {
+  const path = `/api/0/projects/sentry/sentry/events/${transactionEventId?.replaceAll(
+    '-',
+    ''
+  )}/`;
+  return useQuery({
+    enabled: !!transactionEventId,
+    queryKey: ['event', transactionEventId],
+    queryFn: () => fetch(path).then(res => res.json()),
+    retry: false,
+    initialData: {},
   });
 };
 


### PR DESCRIPTION
Adds example profile (aka LOC), to the db query details page, with experimental data it isn't as reliable, but it should be better with the real thing!

Long term, we'll also need a better way to query for stacktraces associated to a query.