### PR TITLE
ref(issue-details): Remove `tags` from group response in frontend

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -4,7 +4,7 @@ import isNil from 'lodash/isNil';
 import {Client, RequestCallbacks, RequestOptions} from 'sentry/api';
 import GroupStore from 'sentry/stores/groupStore';
 import {Actor, Group, Member, Note, User} from 'sentry/types';
-import {buildTeamId, buildUserId} from 'sentry/utils';
+import {buildTeamId, buildUserId, defined} from 'sentry/utils';
 import {uniqueId} from 'sentry/utils/guid';
 import {ApiQueryKey, useApiQuery, UseApiQueryOptions} from 'sentry/utils/queryClient';
 
@@ -389,9 +389,9 @@ export type GroupTagsResponse = GroupTagResponseItem[];
 
 type FetchIssueTagsParameters = {
   environment: string[];
-  groupId: string;
   limit: number;
   readable: boolean;
+  groupId?: string;
 };
 
 export const makeFetchIssueTagsQueryKey = ({
@@ -406,10 +406,11 @@ export const makeFetchIssueTagsQueryKey = ({
 
 export const useFetchIssueTags = (
   parameters: FetchIssueTagsParameters,
-  options: Partial<UseApiQueryOptions<GroupTagsResponse>> = {}
+  {enabled = true, ...options}: Partial<UseApiQueryOptions<GroupTagsResponse>> = {}
 ) => {
   return useApiQuery<GroupTagsResponse>(makeFetchIssueTagsQueryKey(parameters), {
     staleTime: 30000,
+    enabled: defined(parameters.groupId) && enabled,
     ...options,
   });
 };

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -94,7 +94,7 @@ export default function TagFacets({
 
   const {isLoading, isError, data, refetch} = useFetchIssueTagsForDetailsPage({
     groupId,
-    environments,
+    environment: environments.map(({name}) => name),
   });
 
   const tagsData = useMemo(() => {

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -550,7 +550,6 @@ export interface BaseGroup extends GroupRelease {
   shortId: string;
   status: string;
   subscriptionDetails: {disabled?: boolean; reason?: string} | null;
-  tags: Pick<Tag, 'key' | 'name' | 'totalValues'>[];
   title: string;
   type: EventOrGroupType;
   userReportCount: number;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -324,7 +324,6 @@ export function getAnalyticsDataForEvent(event?: Event | null): BaseEventAnalyti
 export type CommonGroupAnalyticsData = {
   days_since_last_seen: number;
   error_count: number;
-  group_has_replay: boolean;
   group_id: number;
   group_num_user_feedback: number;
   has_external_issue: boolean;
@@ -360,7 +359,6 @@ export function getAnalyticsDataForGroup(group?: Group | null): CommonGroupAnaly
     issue_level: group?.level,
     is_assigned: !!group?.assignedTo,
     error_count: Number(group?.count || -1),
-    group_has_replay: Boolean(group?.tags?.find(({key}) => key === 'replayId')),
     num_comments: group ? group.numComments : -1,
     has_external_issue: group?.annotations ? group?.annotations.length > 0 : false,
     has_owner: group?.owners ? group?.owners.length > 0 : false,

--- a/static/app/views/issueDetails/groupDetails.spec.jsx
+++ b/static/app/views/issueDetails/groupDetails.spec.jsx
@@ -123,6 +123,10 @@ describe('groupDetails', () => {
       url: `/organizations/${organization.slug}/environments/`,
       body: TestStubs.Environments(),
     });
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/tags/`,
+      body: [],
+    });
   });
 
   afterEach(() => {
@@ -253,8 +257,8 @@ describe('groupDetails', () => {
     const sampleGroup = TestStubs.Group({issueCategory: IssueCategory.ERROR});
     sampleGroup.tags.push({key: 'sample_event'});
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/`,
-      body: {...sampleGroup},
+      url: `/issues/${group.id}/tags/`,
+      body: [{key: 'sample_event'}],
     });
 
     createWrapper();

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -30,6 +30,7 @@ import {Event, Group, IssueType, Organization, Project} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getMessage} from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -87,6 +88,10 @@ function GroupHeaderTabs({
       organization,
     });
   }, [hasReplaySupport, replaysCount, project, organization]);
+
+  useRouteAnalyticsParams({
+    group_has_replay: (replaysCount ?? 0) > 0,
+  });
 
   return (
     <StyledTabList hideBorder>

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -3,7 +3,7 @@ import orderBy from 'lodash/orderBy';
 import {bulkUpdate, useFetchIssueTags} from 'sentry/actionCreators/group';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import {Environment, Group, GroupActivity} from 'sentry/types';
+import {Group, GroupActivity} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 
 export function markEventSeen(
@@ -134,17 +134,23 @@ export function getGroupReprocessingStatus(
   }
 }
 
-export const useFetchIssueTagsForDetailsPage = ({
-  groupId,
-  environments,
-}: {
-  environments: Environment[];
-  groupId: string;
-}) => {
-  return useFetchIssueTags({
+export const useFetchIssueTagsForDetailsPage = (
+  {
     groupId,
-    environment: environments.map(({name}) => name),
-    readable: true,
-    limit: 4,
-  });
+    environment = [],
+  }: {
+    environment: string[];
+    groupId?: string;
+  },
+  {enabled = true}: {enabled?: boolean} = {}
+) => {
+  return useFetchIssueTags(
+    {
+      groupId,
+      environment,
+      readable: true,
+      limit: 4,
+    },
+    {enabled}
+  );
 };


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/48783

This removes the type reference and the two existing usages of `group.tags`:

1. Route analytics. This now uses the `useReplaysCount` hook.
2. `isSampleEvent`. This now uses the full tags response. Behavior will be _slightly_ different, the sample event header will pop up shortly after the issue renders. But I don't think this is a deal-breaker (and not worth adding a bunch of time to every request)