### PR TITLE
fix(crons): Correctly handle monitors with 0 margins

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -38,6 +38,15 @@ def check_monitors(current_datetime=None):
     if current_datetime is None:
         current_datetime = timezone.now()
 
+    # [!!]: We want our reference time to be clamped to the very start of the
+    # minute, otherwise we may mark checkins as missed if they didn't happen
+    # immediately before this task was run (usually a few seconds into the minute)
+    #
+    # Because we query `next_checkin__lt=current_datetime` clamping to the
+    # minute will ignore monitors that haven't had their checkin yet within
+    # this minute.
+    current_datetime = current_datetime.replace(second=0, microsecond=0)
+
     qs = (
         MonitorEnvironment.objects.filter(
             monitor__type__in=[MonitorType.CRON_JOB], next_checkin__lt=current_datetime

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -18,107 +18,114 @@ from sentry.testutils import TestCase
 
 
 class CheckMonitorsTest(TestCase):
+    def make_ref_time(self):
+        """
+        To accurately reflect the real usage of this task, we want the ref time
+        to be truncated down to a minute for our tests.
+        """
+        ts = timezone.now()
+
+        # Typically the task will not run exactly on the minute, but it will
+        # run very close, let's say for our test that it runs 12 seconds after
+        # the minute.
+        #
+        # This is testing that the task correctly clamps it's reference time
+        # down to the minute.
+        task_run_ts = ts.replace(second=12, microsecond=0)
+
+        # We truncate down to the minute when we mark the next_checkin, do the
+        # same here.
+        next_checkin_ts = ts.replace(second=0, microsecond=0)
+
+        return (task_run_ts, next_checkin_ts)
+
     def test_missing_checkin(self):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
+        task_run_ts, next_checkin_ts = self.make_ref_time()
+
         monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "* * * * *"},
         )
+        # Exepcted checkin was a full minute ago.
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=timezone.now() - timedelta(minutes=1),
+            last_checkin=next_checkin_ts - timedelta(minutes=2),
+            next_checkin=next_checkin_ts - timedelta(minutes=1),
             status=MonitorStatus.OK,
         )
 
-        check_monitors()
+        check_monitors(task_run_ts)
 
         assert MonitorEnvironment.objects.filter(
             id=monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
         ).exists()
+
+        # Because our checkin was a minute ago we'll have produced a missed checkin
         assert MonitorCheckIn.objects.filter(
             monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
         ).exists()
 
-    def test_missing_checkin_but_disabled(self):
+    def assert_state_does_not_change_for_state(self, state):
         org = self.create_organization()
         project = self.create_project(organization=org)
+
+        task_run_ts, next_checkin_ts = self.make_ref_time()
 
         monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "* * * * *"},
-            status=ObjectStatus.DISABLED,
+            status=state,
         )
+        # Exepcted checkin was a full minute ago, if this monitor wasn't in the
+        # `state` the monitor would usually end up marked as timed out
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            status=monitor.status,
+            next_checkin=next_checkin_ts - timedelta(minutes=1),
+            status=MonitorStatus.ACTIVE,
         )
 
-        check_monitors()
+        check_monitors(task_run_ts)
 
+        # The monitor does not get set to a timeout state
         assert MonitorEnvironment.objects.filter(
-            id=monitor_environment.id, status=MonitorStatus.DISABLED
+            id=monitor_environment.id, status=MonitorStatus.ACTIVE
         ).exists()
+
+        # No missed monitor is created
+        assert not MonitorCheckIn.objects.filter(
+            monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
+        ).exists()
+
+    def test_missing_checkin_but_disabled(self):
+        self.assert_state_does_not_change_for_state(ObjectStatus.DISABLED)
 
     def test_missing_checkin_but_pending_deletion(self):
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-
-        monitor = Monitor.objects.create(
-            organization_id=org.id,
-            project_id=project.id,
-            type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
-            status=ObjectStatus.PENDING_DELETION,
-        )
-        monitor_environment = MonitorEnvironment.objects.create(
-            monitor=monitor,
-            environment=self.environment,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            status=monitor.status,
-        )
-
-        check_monitors()
-
-        assert MonitorEnvironment.objects.filter(
-            id=monitor_environment.id, status=MonitorStatus.PENDING_DELETION
-        ).exists()
+        self.assert_state_does_not_change_for_state(ObjectStatus.PENDING_DELETION)
 
     def test_missing_checkin_but_deletion_in_progress(self):
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-
-        monitor = Monitor.objects.create(
-            organization_id=org.id,
-            project_id=project.id,
-            type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
-            status=ObjectStatus.DELETION_IN_PROGRESS,
-        )
-        monitor_environment = MonitorEnvironment.objects.create(
-            monitor=monitor,
-            environment=self.environment,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            status=monitor.status,
-        )
-
-        check_monitors()
-
-        assert MonitorEnvironment.objects.filter(
-            id=monitor_environment.id, status=MonitorStatus.DELETION_IN_PROGRESS
-        ).exists()
+        self.assert_state_does_not_change_for_state(ObjectStatus.DELETION_IN_PROGRESS)
 
     def test_not_missing_checkin(self):
+        """
+        Our monitor task runs once per minute, we want to test that when it
+        runs within the minute we correctly do not mark missed checkins that
+        may happen within that minute, only at the start of the next minute do
+        we mark those checkins as missed.
+        """
         org = self.create_organization()
         project = self.create_project(organization=org)
+
+        task_run_ts, next_checkin_ts = self.make_ref_time()
+        last_checkin_ts = next_checkin_ts - timedelta(minutes=1)
 
         monitor = Monitor.objects.create(
             organization_id=org.id,
@@ -126,69 +133,95 @@ class CheckMonitorsTest(TestCase):
             type=MonitorType.CRON_JOB,
             config={"schedule": "* * * * *"},
         )
+        # Expected checkin is this minute
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=timezone.now() + timedelta(minutes=1),
+            last_checkin=last_checkin_ts,
+            next_checkin=next_checkin_ts,
             status=MonitorStatus.OK,
         )
+        # Last checkin was a minute ago
         MonitorCheckIn.objects.create(
-            monitor=monitor, project_id=project.id, status=CheckInStatus.OK
+            monitor=monitor,
+            project_id=project.id,
+            status=CheckInStatus.OK,
+            date_added=last_checkin_ts,
         )
 
-        check_monitors()
+        # Running the task will not mark the monitor as missed, since the next
+        # checkin time will be exactly the same as the reference time for the
+        # monitor.
+        check_monitors(task_run_ts)
 
+        # Monitor stays in OK state
         assert MonitorEnvironment.objects.filter(
             id=monitor_environment.id, status=MonitorStatus.OK
+        ).exists()
+
+        # No missed monitor is created
+        assert not MonitorCheckIn.objects.filter(
+            monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
         ).exists()
 
     def test_timeout_with_no_future_complete_checkin(self):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        current_datetime = timezone.now() - timedelta(hours=24)
+        task_run_ts, next_checkin_ts = self.make_ref_time()
+        check_in_24hr_ago = next_checkin_ts - timedelta(hours=24)
 
+        # Schedule is once a day
         monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "0 0 * * *"},
-            date_added=current_datetime,
         )
+        # Next checkin should should have been 24 hours ago
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=current_datetime + timedelta(hours=12, minutes=1),
-            last_checkin=current_datetime + timedelta(hours=12),
+            last_checkin=check_in_24hr_ago - timedelta(hours=24),
+            next_checkin=check_in_24hr_ago,
             status=MonitorStatus.OK,
         )
-        checkin = MonitorCheckIn.objects.create(
+        # In progress started 24hr ago
+        checkin1 = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,
             status=CheckInStatus.IN_PROGRESS,
-            date_added=current_datetime,
-            date_updated=current_datetime,
+            date_added=check_in_24hr_ago,
+            date_updated=check_in_24hr_ago,
         )
+        # We started another checkin right now
         checkin2 = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,
             status=CheckInStatus.IN_PROGRESS,
-            date_added=monitor_environment.last_checkin,
-            date_updated=monitor_environment.last_checkin,
+            date_added=next_checkin_ts,
+            date_updated=next_checkin_ts,
         )
 
-        assert checkin.date_added == checkin.date_updated == current_datetime
+        assert checkin1.date_added == checkin1.date_updated == check_in_24hr_ago
 
-        check_monitors(current_datetime=current_datetime + timedelta(hours=12, minutes=1))
+        # Running check monitor will mark the first checkin as timed out, but
+        # the second checkin is not yet timed out.
+        check_monitors(task_run_ts)
 
-        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
+        # First checkin is marked as timed out
+        assert MonitorCheckIn.objects.filter(id=checkin1.id, status=CheckInStatus.TIMEOUT).exists()
 
+        # Second checkin is marked as timed out
         assert MonitorCheckIn.objects.filter(
             id=checkin2.id, status=CheckInStatus.IN_PROGRESS
         ).exists()
 
+        # XXX(epurkhiser): At the moment we mark the monitor with the MOST
+        # RECENT updated checkins status. In this scenario we actually already
+        # have checkin2 in progress, but because we just marked
         assert MonitorEnvironment.objects.filter(
             id=monitor_environment.id, status=MonitorStatus.TIMEOUT
         ).exists()
@@ -197,69 +230,76 @@ class CheckMonitorsTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        current_datetime = timezone.now() - timedelta(hours=24)
+        task_run_ts, next_checkin_ts = self.make_ref_time()
+        check_in_24hr_ago = next_checkin_ts - timedelta(hours=24)
 
+        # Schedule is once a day
         monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "0 0 * * *"},
-            date_added=current_datetime,
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=current_datetime + timedelta(hours=12, minutes=1),
-            last_checkin=current_datetime + timedelta(hours=12),
+            # Next checkin is in the future, we just completed our last checkin
+            last_checkin=next_checkin_ts,
+            next_checkin=next_checkin_ts + timedelta(hours=24),
             status=MonitorStatus.OK,
         )
-        checkin = MonitorCheckIn.objects.create(
+        # Checkin 24hr ago
+        checkin1 = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,
             status=CheckInStatus.IN_PROGRESS,
-            date_added=current_datetime,
-            date_updated=current_datetime,
+            date_added=check_in_24hr_ago,
+            date_updated=check_in_24hr_ago,
         )
         checkin2 = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,
             status=CheckInStatus.OK,
-            date_added=monitor_environment.last_checkin,
-            date_updated=monitor_environment.last_checkin,
+            date_added=next_checkin_ts,
+            date_updated=next_checkin_ts,
         )
 
-        assert checkin.date_added == checkin.date_updated == current_datetime
+        assert checkin1.date_added == checkin1.date_updated == check_in_24hr_ago
 
-        check_monitors(current_datetime=current_datetime + timedelta(hours=12, minutes=1))
+        # Running check monitor will mark the first checkin as timed out. The
+        # second checkin was already marked as OK.
+        check_monitors(task_run_ts)
 
-        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
-
+        # The first checkin is marked as timed out
+        assert MonitorCheckIn.objects.filter(id=checkin1.id, status=CheckInStatus.TIMEOUT).exists()
+        # The second checkin has not changed status
         assert MonitorCheckIn.objects.filter(id=checkin2.id, status=CheckInStatus.OK).exists()
 
+        # Monitor does not change from OK to TIMED OUT since it was already OK.
         assert MonitorEnvironment.objects.filter(
             id=monitor_environment.id, status=MonitorStatus.OK
         ).exists()
 
-    def test_timeout_with_via_configuration(self):
+    def test_timeout_via_max_runtime_configuration(self):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        current_datetime = timezone.now() - timedelta(hours=24)
+        task_run_ts, next_checkin_ts = self.make_ref_time()
+        check_in_24hr_ago = next_checkin_ts - timedelta(hours=24)
 
         monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "0 0 * * *", "max_runtime": 60},
-            date_added=current_datetime,
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=current_datetime + timedelta(hours=1, minutes=1),
-            last_checkin=current_datetime + timedelta(hours=1),
+            last_checkin=check_in_24hr_ago,
+            next_checkin=next_checkin_ts,
             status=MonitorStatus.OK,
         )
         checkin = MonitorCheckIn.objects.create(
@@ -267,14 +307,20 @@ class CheckMonitorsTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=project.id,
             status=CheckInStatus.IN_PROGRESS,
-            date_added=current_datetime,
-            date_updated=current_datetime,
+            date_added=next_checkin_ts,
+            date_updated=next_checkin_ts,
         )
 
-        assert checkin.date_added == checkin.date_updated == current_datetime
+        assert checkin.date_added == checkin.date_updated == next_checkin_ts
 
-        check_monitors(current_datetime=current_datetime + timedelta(hours=1, minutes=1))
+        # Running the check_monitors at 35 minutes does not mark the timeout as missed, it's still allowed to be running
+        check_monitors(task_run_ts + timedelta(minutes=35))
+        assert MonitorCheckIn.objects.filter(
+            id=checkin.id, status=CheckInStatus.IN_PROGRESS
+        ).exists()
 
+        # After 60 minutes the checkin will be marked as missed
+        check_monitors(task_run_ts + timedelta(minutes=60))
         assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
 
         assert MonitorEnvironment.objects.filter(
@@ -286,16 +332,23 @@ class CheckMonitorsTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
+        task_run_ts, next_checkin_ts = self.make_ref_time()
+
         exception_monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule_type": ScheduleType.INTERVAL, "schedule": [-2, "minute"]},
+            config={
+                "schedule_type": ScheduleType.INTERVAL,
+                # XXX: Note the invalid schedule will cause an exception,
+                # typically the validator protects us against this
+                "schedule": [-2, "minute"],
+            },
         )
         MonitorEnvironment.objects.create(
             monitor=exception_monitor,
             environment=self.environment,
-            next_checkin=timezone.now() - timedelta(minutes=1),
+            next_checkin=next_checkin_ts - timedelta(minutes=1),
             status=MonitorStatus.OK,
         )
 
@@ -308,14 +361,16 @@ class CheckMonitorsTest(TestCase):
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=timezone.now() - timedelta(minutes=1),
+            next_checkin=next_checkin_ts - timedelta(minutes=1),
             status=MonitorStatus.OK,
         )
 
-        check_monitors()
+        check_monitors(task_run_ts)
 
+        # Logged the exception
         assert logger.exception.call_count == 1
 
+        # We still amrked a monitor as missed
         assert MonitorEnvironment.objects.filter(
             id=monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
         ).exists()
@@ -328,67 +383,77 @@ class CheckMonitorsTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        current_datetime = timezone.now() - timedelta(hours=24)
+        task_run_ts, next_checkin_ts = self.make_ref_time()
+        check_in_24hr_ago = next_checkin_ts - timedelta(hours=24)
 
+        # This monitor will cause failure
         exception_monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
-            config={"schedule_type": ScheduleType.INTERVAL, "schedule": [-2, "minute"]},
+            config={
+                "schedule_type": ScheduleType.INTERVAL,
+                # XXX: Note the invalid schedule will cause an exception,
+                # typically the validator protects us against this
+                "schedule": [-2, "minute"],
+            },
         )
         exception_monitor_environment = MonitorEnvironment.objects.create(
             monitor=exception_monitor,
             environment=self.environment,
-            next_checkin=timezone.now() - timedelta(minutes=1),
+            last_checkin=next_checkin_ts,
+            next_checkin=next_checkin_ts + timedelta(hours=24),
             status=MonitorStatus.OK,
         )
-        checkin = MonitorCheckIn.objects.create(
+        MonitorCheckIn.objects.create(
             monitor=exception_monitor,
             monitor_environment=exception_monitor_environment,
             project_id=project.id,
             status=CheckInStatus.IN_PROGRESS,
-            date_added=current_datetime,
-            date_updated=current_datetime,
+            date_added=check_in_24hr_ago,
+            date_updated=check_in_24hr_ago,
         )
 
+        # This monitor will be fine
         monitor = Monitor.objects.create(
             organization_id=org.id,
             project_id=project.id,
             type=MonitorType.CRON_JOB,
             config={"schedule": "0 0 * * *"},
-            date_added=current_datetime,
+            date_added=check_in_24hr_ago,
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            next_checkin=current_datetime + timedelta(hours=12, minutes=1),
-            last_checkin=current_datetime + timedelta(hours=12),
+            last_checkin=next_checkin_ts,
+            next_checkin=next_checkin_ts + timedelta(hours=24),
             status=MonitorStatus.OK,
         )
-        checkin = MonitorCheckIn.objects.create(
+        checkin1 = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,
             status=CheckInStatus.IN_PROGRESS,
-            date_added=current_datetime,
-            date_updated=current_datetime,
+            date_added=check_in_24hr_ago,
+            date_updated=check_in_24hr_ago,
         )
         checkin2 = MonitorCheckIn.objects.create(
             monitor=monitor,
             monitor_environment=monitor_environment,
             project_id=project.id,
             status=CheckInStatus.IN_PROGRESS,
-            date_added=monitor_environment.last_checkin,
-            date_updated=monitor_environment.last_checkin,
+            date_added=next_checkin_ts,
+            date_updated=next_checkin_ts,
         )
 
-        assert checkin.date_added == checkin.date_updated == current_datetime
+        assert checkin1.date_added == checkin1.date_updated == check_in_24hr_ago
 
-        check_monitors(current_datetime=current_datetime + timedelta(hours=12, minutes=1))
+        check_monitors(task_run_ts)
 
+        # Logged the exception
         assert logger.exception.call_count == 1
 
-        assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
+        assert MonitorCheckIn.objects.filter(id=checkin1.id, status=CheckInStatus.TIMEOUT).exists()
 
         assert MonitorCheckIn.objects.filter(
             id=checkin2.id, status=CheckInStatus.IN_PROGRESS


### PR DESCRIPTION
When a monitor is configured with a margin of zero it means that we expect the monitor to checkin immediately at `**:**:00` (zero seconds). Typically this is not feasible due to network latency and other scheduling issues.

The problem is, we run our task which checks for missed monitors very close to on the minute.

So what this means is if we had a check-in that was expected to happen at 12:00:00, and we run our task at 12:00:08, then the query that we run to look for monitors to mark as missed finds our monitor that was set to run at 12:00:00 because the check-in hasn't happened yet (`next_checkin < 12:00:08`) (but likely will in the next few seconds). Then it will be marked as missed, and moments later a OK check-in will come in.

We can fix this by clamping the tasks reference time down to the minute (by removing the second and microsecond components), now when it runs it will look for monitors that have their `next_checkin < 12:00:00`. This will NOT include our monitor since it's next check-in is equal to that minute.

---

FYI The reason we began noticing this much more clearly was due to #47718, which put the task on a crontab instead of an interval, meaning it accurately ran on the minute, where as before it would sometimes run late into the minute.