### PR TITLE
fix(issue-details): Stop overfetching issue details

### DIFF
--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -88,7 +88,7 @@ export default function GroupSidebar({
     } catch {
       /* empty */
     }
-  }, [api, group]);
+  }, [api, group.id]);
 
   const fetchCurrentRelease = useCallback(async () => {
     try {
@@ -99,7 +99,7 @@ export default function GroupSidebar({
     } catch {
       /* empty */
     }
-  }, [api, group]);
+  }, [api, group.id]);
 
   const renderPluginIssue = () => {
     const issues: React.ReactNode[] = [];


### PR DESCRIPTION
Fixes JAVASCRIPT-2KZC

`group` is a new object each time the event changes  which causes multiple refetches each time we scroll through events.