### PR TITLE
fix(crons): Clamp next_checkin to the minute

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -67,6 +67,10 @@ def get_next_schedule(last_checkin, schedule_type, schedule):
     else:
         raise NotImplementedError("unknown schedule_type")
 
+    # Ensure we clamp the expected time down to the minute, that is the level
+    # of granularity we're able to support
+    next_schedule = next_schedule.replace(second=0, microsecond=0)
+
     return next_schedule
 
 

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -28,6 +28,7 @@ class MonitorTestCase(TestCase):
         monitor = Monitor(config={"schedule": "* * * * *"})
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
 
+        # XXX: Seconds are removed as we clamp to the minute
         assert monitor_environment.monitor.get_next_scheduled_checkin(ts) == datetime(
             2019, 1, 1, 1, 11, tzinfo=timezone.utc
         )
@@ -44,6 +45,7 @@ class MonitorTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
 
+        # XXX: Seconds are removed as we clamp to the minute
         assert monitor_environment.monitor.get_next_scheduled_checkin(ts) == datetime(
             2019, 1, 1, 1, 11, tzinfo=timezone.utc
         )
@@ -64,6 +66,7 @@ class MonitorTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
 
+        # XXX: Seconds are removed as we clamp to the minute
         assert monitor_environment.monitor.get_next_scheduled_checkin(ts) == datetime(
             2019, 1, 1, 12, 00, tzinfo=timezone.utc
         )
@@ -82,8 +85,9 @@ class MonitorTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment(monitor=monitor, last_checkin=ts)
 
+        # XXX: Seconds are removed as we clamp to the minute.
         assert monitor_environment.monitor.get_next_scheduled_checkin(ts) == datetime(
-            2019, 2, 1, 1, 10, 20, tzinfo=timezone.utc
+            2019, 2, 1, 1, 10, 0, tzinfo=timezone.utc
         )
 
     def test_save_defaults_slug_to_name(self):


### PR DESCRIPTION
Before this change we would include the second component in our computed next_checkin for interval based schedules

We do not support second-granular checkin times, so for clarity we round to the second.

This does not introduce a behavior change as the existing implementation of marking checkins as missed would already correctly account for next_checkin's that were not on the minute boundary, this just makes it more clear.

(Before GH-48826, this WOULD have been an issue however, since the reference time was not on the minute boundary, it was possible the second portion of the next_checkin would have an effect on a monitor being incorrect marked as missed)