### PR TITLE
fix(crons): Returns all envs if none are specified for a monitor

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -45,35 +45,35 @@ class MonitorSerializer(Serializer):
             )
         }
 
-        environment_data = {}
+        serialized_monitor_environments = defaultdict(list)
+        monitor_environments = (
+            MonitorEnvironment.objects.filter(monitor__in=item_list)
+            .select_related("environment")
+            .order_by("-last_checkin")
+            .exclude(
+                status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS]
+            )
+        )
         if self.environments:
-            monitor_environments = defaultdict(list)
-            for monitor_environment in (
-                MonitorEnvironment.objects.filter(
-                    monitor__in=item_list, environment__in=self.environments
-                )
-                .select_related("environment")
-                .order_by("-last_checkin")
-                .exclude(
-                    status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS]
-                )
-            ):
-                # individually serialize as related objects are prefetched
-                monitor_environments[monitor_environment.monitor_id].append(
-                    serialize(
-                        monitor_environment,
-                        user,
-                    )
-                )
+            monitor_environments.filter(environment__in=self.environments)
 
-            environment_data = {
-                str(item.id): monitor_environments.get(item.id, []) for item in item_list
-            }
+        for monitor_environment in monitor_environments:
+            # individually serialize as related objects are prefetched
+            serialized_monitor_environments[monitor_environment.monitor_id].append(
+                serialize(
+                    monitor_environment,
+                    user,
+                )
+            )
+
+        environment_data = {
+            str(item.id): serialized_monitor_environments.get(item.id, []) for item in item_list
+        }
 
         return {
             item: {
                 "project": projects[str(item.project_id)] if item.project_id else None,
-                "environments": environment_data[str(item.id)] if self.environments else [],
+                "environments": environment_data[str(item.id)],
             }
             for item in item_list
         }

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -55,7 +55,7 @@ class MonitorSerializer(Serializer):
             )
         )
         if self.environments:
-            monitor_environments.filter(environment__in=self.environments)
+            monitor_environments = monitor_environments.filter(environment__in=self.environments)
 
         for monitor_environment in monitor_environments:
             # individually serialize as related objects are prefetched

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -32,6 +32,19 @@ class OrganizationMonitorDetailsTest(MonitorTestCase):
             self.organization.slug, monitor.slug, environment="jungle", status_code=404
         )
 
+    def test_filtering_monitor_environment(self):
+        monitor = self._create_monitor()
+        self._create_monitor_environment(monitor, name="production")
+        self._create_monitor_environment(monitor, name="jungle")
+
+        response = self.get_success_response(self.organization.slug, monitor.slug)
+        assert len(response.data["environments"]) == 2
+
+        response = self.get_success_response(
+            self.organization.slug, monitor.slug, environment="production"
+        )
+        assert len(response.data["environments"]) == 1
+
 
 @region_silo_test(stable=True)
 class UpdateMonitorTest(MonitorTestCase):


### PR DESCRIPTION
Fixes `MonitorSerializer` to return data for all environments if none are specified