### PR TITLE
ref(ui): Allow useApiRequests to take in arrays as query params

### DIFF
--- a/static/app/utils/useApiRequests.tsx
+++ b/static/app/utils/useApiRequests.tsx
@@ -90,7 +90,7 @@ type EndpointRequestOptions = {
 export type EndpointDefinition<T extends Record<string, any>> = [
   key: keyof T,
   url: string,
-  urlOptions?: {query?: Record<string, string>},
+  urlOptions?: {query?: Record<string, string | string[]>},
   requestOptions?: EndpointRequestOptions
 ];
 


### PR DESCRIPTION
If an array is passed it simply splits it out into separate entries in the request anyways so we should allow it in the types.

`environment: [x, y, z]` => `?environment=x&environment=y&environment=z`