### PR TITLE
fix(ui): zIndex can be undefined?

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -447,7 +447,7 @@ export function Control({
           </DropdownButton>
         )}
         <StyledPositionWrapper
-          zIndex={theme.zIndex.tooltip}
+          zIndex={theme.zIndex?.tooltip}
           visible={overlayIsOpen}
           {...overlayProps}
         >


### PR DESCRIPTION
Not totally sure what's going on here. It looks like it crashes the page or something else has crashed the page and this error is a side effect.

fixes JAVASCRIPT-2KKX
fixes JAVASCRIPT-2KKW
fixes JAVASCRIPT-2KKV
fixes JAVASCRIPT-2HHH
