### PR TITLE
fix(issue-states): filtering issues by substatus

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -508,6 +508,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
     ) -> Mapping[str, Condition]:
         queryset_conditions: Dict[str, Condition] = {
             "status": QCallbackCondition(lambda statuses: Q(status__in=statuses)),
+            "substatus": QCallbackCondition(lambda substatuses: Q(substatus__in=substatuses)),
             "bookmarked_by": QCallbackCondition(
                 lambda users: Q(
                     bookmark_set__project__in=projects,

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -23,11 +23,11 @@ from sentry.api.issue_search import (
 )
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
-from sentry.models.group import STATUS_QUERY_CHOICES
+from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import region_silo_test
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES
+from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
 
 class ParseSearchQueryTest(unittest.TestCase):
@@ -227,15 +227,32 @@ class ConvertSubStatusValueTest(TestCase):
             filters = [SearchFilter(SearchKey("substatus"), "=", SearchValue([substatus_string]))]
             result = convert_query_values(filters, [self.project], self.user, None)
             assert result[0].value.raw_value == [substatus_val]
+            assert result[1].value.raw_value == [GROUP_SUBSTATUS_TO_STATUS_MAP.get(substatus_val)]
 
             filters = [SearchFilter(SearchKey("substatus"), "=", SearchValue([substatus_val]))]
             result = convert_query_values(filters, [self.project], self.user, None)
             assert result[0].value.raw_value == [substatus_val]
+            assert result[1].value.raw_value == [GROUP_SUBSTATUS_TO_STATUS_MAP.get(substatus_val)]
 
     def test_invalid(self):
         filters = [SearchFilter(SearchKey("substatus"), "=", SearchValue("wrong"))]
         with pytest.raises(InvalidSearchQuery, match="invalid substatus value"):
             convert_query_values(filters, [self.project], self.user, None)
+
+    def test_mixed_with_status(self):
+        filters = [
+            SearchFilter(SearchKey("substatus"), "=", SearchValue(["ongoing"])),
+            SearchFilter(SearchKey("status"), "=", SearchValue(["unresolved"])),
+            SearchFilter(SearchKey("substatus"), "=", SearchValue(["until_escalating"])),
+        ]
+        result = convert_query_values(filters, [self.project], self.user, None)
+        assert [sf.value.raw_value for sf in result] == [
+            [GroupSubStatus.ONGOING],
+            [GroupStatus.UNRESOLVED],
+            [GroupSubStatus.UNTIL_ESCALATING],
+            [GroupStatus.UNRESOLVED],
+            [GroupStatus.IGNORED],
+        ]
 
 
 @region_silo_test(stable=True)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1,3 +1,4 @@
+import functools
 from datetime import timedelta
 from unittest.mock import Mock, patch
 from uuid import uuid4
@@ -51,9 +52,10 @@ from sentry.search.events.constants import (
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.features import Feature, with_feature
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 from sentry.utils import json
 
 
@@ -1919,6 +1921,114 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert len(response.data) == 1
         assert int(response.data[0]["id"]) == event.group.id
+
+    def test_query_status_and_substatus_overlapping(self):
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        )
+        event.group.update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
+        self.login_as(user=self.user)
+
+        get_query_response = functools.partial(
+            self.get_response, sort_by="date", limit=10, expand="inbox", collapse="stats"
+        )
+
+        response0 = get_query_response(
+            query="is:unresolved",
+        )
+
+        with Feature("organizations:issue-states"):
+            response1 = get_query_response(
+                query="is:ongoing"
+            )  # (status=unresolved, substatus=(ongoing))
+            response2 = get_query_response(
+                query="is:unresolved"
+            )  # (status=unresolved, substatus=*)
+            response3 = get_query_response(
+                query="is:unresolved is:ongoing !is:regressed"
+            )  # (status=unresolved, substatus=(ongoing, !regressed))
+            response4 = get_query_response(
+                query="is:unresolved is:ongoing !is:ignored"
+            )  # (status=unresolved, substatus=(ongoing, !ignored))
+            response5 = get_query_response(
+                query="!is:regressed is:unresolved"
+            )  # (status=unresolved, substatus=(!regressed))
+            response6 = get_query_response(
+                query="!is:until_escalating"
+            )  # (status=(!unresolved), substatus=(!until_escalating))
+
+        assert (
+            response0.status_code
+            == response1.status_code
+            == response2.status_code
+            == response3.status_code
+            == response4.status_code
+            == response5.status_code
+            == response6.status_code
+            == 200
+        )
+        assert (
+            [int(r["id"]) for r in response0.data]
+            == [int(r["id"]) for r in response1.data]
+            == [int(r["id"]) for r in response2.data]
+            == [int(r["id"]) for r in response3.data]
+            == [int(r["id"]) for r in response4.data]
+            == [int(r["id"]) for r in response5.data]
+            == [int(r["id"]) for r in response6.data]
+            == [event.group.id]
+        )
+
+    def test_query_status_and_substatus_nonoverlapping(self):
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        )
+        event.group.update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
+        self.login_as(user=self.user)
+
+        get_query_response = functools.partial(
+            self.get_response, sort_by="date", limit=10, expand="inbox", collapse="stats"
+        )
+
+        with Feature("organizations:issue-states"):
+            response1 = get_query_response(query="is:escalating")
+            response2 = get_query_response(query="is:new")
+            response3 = get_query_response(query="is:regressed")
+            response4 = get_query_response(query="is:forever")
+            response5 = get_query_response(query="is:until_condition_met")
+            response6 = get_query_response(query="is:until_escalating")
+            response7 = get_query_response(query="is:resolved")
+            response8 = get_query_response(query="is:ignored")
+            response9 = get_query_response(query="is:muted")
+            response10 = get_query_response(query="!is:unresolved")
+
+        assert (
+            response1.status_code
+            == response2.status_code
+            == response3.status_code
+            == response4.status_code
+            == response5.status_code
+            == response6.status_code
+            == response7.status_code
+            == response8.status_code
+            == response9.status_code
+            == response10.status_code
+            == 200
+        )
+        assert (
+            [int(r["id"]) for r in response1.data]
+            == [int(r["id"]) for r in response2.data]
+            == [int(r["id"]) for r in response3.data]
+            == [int(r["id"]) for r in response4.data]
+            == [int(r["id"]) for r in response5.data]
+            == [int(r["id"]) for r in response6.data]
+            == [int(r["id"]) for r in response7.data]
+            == [int(r["id"]) for r in response8.data]
+            == [int(r["id"]) for r in response9.data]
+            == [int(r["id"]) for r in response10.data]
+            == []
+        )
 
 
 @region_silo_test


### PR DESCRIPTION
Fixes a bug when searching by an issue's substatus(e.g. `is:ongoing`), included all issues in the mapped status category (`is:unresolved`). 

Normally, filtering on substatus by itself also implies filtering on the status value as well since substatus is more specific than status. Further down in the future, it might make sense to add two extra multi-column indexes:
```
("project", "substatus", "last_seen", "id"),
("project", "substatus", "type", "last_seen", "id"),
```
to the Group table to support performant and frequently used queries on in-place of the indexes that make use of status:
```
("project", "status", "last_seen", "id"),
("project", "status", "type", "last_seen", "id"),
```

Status and substatus filtering combinations:
* filter on status - `is:unresolved`
* filter on substatus - `is:ongoing`
* filter on negated status - `!is:unresolved`
* filter on negated substatus - `!is:ongoing`
* filter on status + substatus - `is:unresolved is:ongoing` _equivalent to `is:ongoing`_
* filter on status + negated substatus overlapping - `is:unresolved !is:forever` 
* filter on negated status + substatus non-overlapping - `!is:unresolved is:ongoing` _bad query_
* filter on negated status + substatus overlapping - `!is:unresolved is:forever`
* filter on negated status + negated substatus overlapping - `!is:unresolved !is:ongoing` _equivalent to `!is:unresolved`_


Resolves https://github.com/getsentry/sentry/issues/48760