### PR TITLE
ref(metrics-indexer): tests should have sentry_received_timestamp

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1275,6 +1275,9 @@ class BaseMetricsTestCase(SnubaTestCase):
             "value": value,
             "retention_days": 90,
             "use_case_id": use_case_id,
+            # making up a sentry_received_timestamp, but it should be sometime
+            # after the timestamp of the event
+            "sentry_received_timestamp": timestamp + 10,
         }
 
         msg["mapping_meta"] = {}


### PR DESCRIPTION
**context**
A little while back we added the `sentry_received_timestamp` in https://github.com/getsentry/sentry/pull/47577. 

However, the following snuba change https://github.com/getsentry/snuba/pull/4052 that was supposed to come after is blocked because tests are failing because we are not sending `sentry_received_timestamp` along in the snuba tests in sentry. This needs to be merged before we can merge the other PR. 

