### PR TITLE
feat(starfish): More dynamic Spans view

### DIFF
--- a/static/app/views/starfish/views/spans/clusters.tsx
+++ b/static/app/views/starfish/views/spans/clusters.tsx
@@ -1,7 +1,8 @@
-type Cluster = {
+export type Cluster = {
   condition: (value: any) => string;
   label: string;
   name: string;
+  description_label?: string;
   grouping_column?: string;
   grouping_condition?: (value: any) => () => string;
   isDynamic?: boolean;
@@ -17,6 +18,7 @@ export const CLUSTERS: Record<string, Cluster> = {
   'top.db': {
     name: 'top.db',
     label: 'DB',
+    description_label: 'Query',
     condition: () => "module == 'db'",
     grouping_column:
       "action IN ['SELECT', 'INSERT'] ? concat('db.',  lower(action)) : 'db.other'",
@@ -41,6 +43,7 @@ export const CLUSTERS: Record<string, Cluster> = {
   'top.http': {
     name: 'top.http',
     label: 'HTTP',
+    description_label: 'URL',
     condition: () => "module == 'http'",
     grouping_column: 'span_operation',
   },

--- a/static/app/views/starfish/views/spans/clusters.tsx
+++ b/static/app/views/starfish/views/spans/clusters.tsx
@@ -3,6 +3,7 @@ export type Cluster = {
   label: string;
   name: string;
   description_label?: string;
+  domain_label?: string;
   grouping_column?: string;
   grouping_condition?: (value: any) => () => string;
   isDynamic?: boolean;
@@ -19,6 +20,7 @@ export const CLUSTERS: Record<string, Cluster> = {
     name: 'top.db',
     label: 'DB',
     description_label: 'Query',
+    domain_label: 'Table',
     condition: () => "module == 'db'",
     grouping_column:
       "action IN ['SELECT', 'INSERT'] ? concat('db.',  lower(action)) : 'db.other'",
@@ -44,6 +46,7 @@ export const CLUSTERS: Record<string, Cluster> = {
     name: 'top.http',
     label: 'HTTP',
     description_label: 'URL',
+    domain_label: 'Host',
     condition: () => "module == 'http'",
     grouping_column: 'span_operation',
   },

--- a/static/app/views/starfish/views/spans/clusters.tsx
+++ b/static/app/views/starfish/views/spans/clusters.tsx
@@ -1,4 +1,13 @@
-export const CLUSTERS = {
+type Cluster = {
+  condition: (value: any) => string;
+  label: string;
+  name: string;
+  grouping_column?: string;
+  grouping_condition?: (value: any) => () => string;
+  isDynamic?: boolean;
+};
+
+export const CLUSTERS: Record<string, Cluster> = {
   top: {
     name: 'top',
     label: 'All',

--- a/static/app/views/starfish/views/spans/queries.tsx
+++ b/static/app/views/starfish/views/spans/queries.tsx
@@ -26,6 +26,7 @@ export const getSpanListQuery = (
   return `SELECT
     group_id, span_operation, domain, description,
     sum(exclusive_time) as total_exclusive_time,
+    uniq(transaction) as transactions,
     quantile(0.75)(exclusive_time) as p75
     FROM spans_experimental_starfish
     WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')

--- a/static/app/views/starfish/views/spans/queries.tsx
+++ b/static/app/views/starfish/views/spans/queries.tsx
@@ -24,7 +24,7 @@ export const getSpanListQuery = (
   const validConditions = conditions.filter(Boolean);
 
   return `SELECT
-    group_id, span_operation, description,
+    group_id, span_operation, domain, description,
     sum(exclusive_time) as total_exclusive_time,
     quantile(0.75)(exclusive_time) as p75
     FROM spans_experimental_starfish
@@ -32,7 +32,7 @@ export const getSpanListQuery = (
     ${validConditions.length > 0 ? 'AND' : ''}
     ${validConditions.join(' AND ')}
     ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
-    GROUP BY group_id, span_operation, description
+    GROUP BY group_id, span_operation, domain, description
     ORDER BY ${orderBy ?? 'count'} desc
     ${limit ? `LIMIT ${limit}` : ''}`;
 };

--- a/static/app/views/starfish/views/spans/queries.tsx
+++ b/static/app/views/starfish/views/spans/queries.tsx
@@ -27,6 +27,7 @@ export const getSpanListQuery = (
     group_id, span_operation, domain, description,
     sum(exclusive_time) as total_exclusive_time,
     uniq(transaction) as transactions,
+    quantile(0.50)(exclusive_time) as p50,
     quantile(0.75)(exclusive_time) as p75
     FROM spans_experimental_starfish
     WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')

--- a/static/app/views/starfish/views/spans/queries.tsx
+++ b/static/app/views/starfish/views/spans/queries.tsx
@@ -26,8 +26,7 @@ export const getSpanListQuery = (
   return `SELECT
     group_id, span_operation, description,
     sum(exclusive_time) as total_exclusive_time,
-    quantile(0.95)(exclusive_time) as p95,
-    quantile(0.50)(exclusive_time) as p50
+    quantile(0.75)(exclusive_time) as p75
     FROM spans_experimental_starfish
     WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
     ${validConditions.length > 0 ? 'AND' : ''}

--- a/static/app/views/starfish/views/spans/queries.tsx
+++ b/static/app/views/starfish/views/spans/queries.tsx
@@ -45,8 +45,8 @@ export const getSpansTrendsQuery = (datetime: DateTimeObject, groupIDs: string[]
   return `
     SELECT
     group_id, span_operation,
-    toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
-    quantile(0.95)(exclusive_time) as p95
+    toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval,
+    quantile(0.50)(exclusive_time) as percentile_value
     FROM spans_experimental_starfish
     WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
     ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -5,6 +5,7 @@ import Duration from 'sentry/components/duration';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnHeader,
+  GridColumnOrder,
 } from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
@@ -14,7 +15,10 @@ import {TableColumnSort} from 'sentry/views/discover/table/types';
 import Sparkline from 'sentry/views/starfish/components/sparkline';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
+import type {Cluster} from './clusters';
+
 type Props = {
+  clusters: Cluster[];
   isLoading: boolean;
   location: Location;
   onSetOrderBy: (orderBy: string) => void;
@@ -41,6 +45,7 @@ export default function SpansTable({
   spansData,
   orderBy,
   onSetOrderBy,
+  clusters,
   spansTrendsData,
   isLoading,
 }: Props) {
@@ -81,7 +86,7 @@ export default function SpansTable({
     <GridEditable
       isLoading={isLoading}
       data={combinedSpansData}
-      columnOrder={COLUMN_ORDER}
+      columnOrder={getColumns(clusters)}
       columnSortBy={
         orderBy ? [] : [{key: orderBy, order: 'desc'} as TableColumnSort<string>]
       }
@@ -143,35 +148,43 @@ function renderBodyCell(column: GridColumnHeader, row: SpanDataRow): React.React
   return row[column.key];
 }
 
-const COLUMN_ORDER = [
-  {
-    key: 'span_operation',
-    name: 'Operation',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'description',
-    name: 'Description',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'total_exclusive_time',
-    name: 'Exclusive Time',
-    width: 250,
-  },
-  {
-    key: 'p50',
-    name: 'p50',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'p95',
-    name: 'p95',
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'p95_trend',
-    name: 'p95 Trend',
-    width: 250,
-  },
-];
+function getColumns(clusters: Cluster[]): GridColumnOrder[] {
+  const description =
+    clusters.findLast(cluster => Boolean(cluster.description_label))?.description_label ||
+    'Description';
+
+  const order: Array<GridColumnOrder | false> = [
+    {
+      key: 'span_operation',
+      name: 'Operation',
+      width: COL_WIDTH_UNDEFINED,
+    },
+    {
+      key: 'description',
+      name: description,
+      width: COL_WIDTH_UNDEFINED,
+    },
+    {
+      key: 'total_exclusive_time',
+      name: 'Exclusive Time',
+      width: 250,
+    },
+    {
+      key: 'p50',
+      name: 'p50',
+      width: COL_WIDTH_UNDEFINED,
+    },
+    {
+      key: 'p95',
+      name: 'p95',
+      width: COL_WIDTH_UNDEFINED,
+    },
+    {
+      key: 'p95_trend',
+      name: 'p95 Trend',
+      width: 250,
+    },
+  ];
+
+  return order.filter((x): x is GridColumnOrder => Boolean(x));
+}

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -171,13 +171,8 @@ function getColumns(clusters: Cluster[]): GridColumnOrder[] {
       width: 250,
     },
     {
-      key: 'p50',
-      name: 'p50',
-      width: COL_WIDTH_UNDEFINED,
-    },
-    {
-      key: 'p95',
-      name: 'p95',
+      key: 'p75',
+      name: 'p75',
       width: COL_WIDTH_UNDEFINED,
     },
     {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import {Location} from 'history';
 import moment from 'moment';
 
@@ -135,9 +136,11 @@ function renderBodyCell(column: GridColumnHeader, row: SpanDataRow): React.React
 
   if (column.key === 'description') {
     return (
-      <Link to={`/starfish/span/${encodeURIComponent(row.group_id)}`}>
-        {row.description}
-      </Link>
+      <OverflowEllipsisTextContainer>
+        <Link to={`/starfish/span/${encodeURIComponent(row.group_id)}`}>
+          {row.description}
+        </Link>
+      </OverflowEllipsisTextContainer>
     );
   }
 
@@ -197,3 +200,9 @@ function getColumns(clusters: Cluster[]): GridColumnOrder[] {
 
   return order.filter((x): x is GridColumnOrder => Boolean(x));
 }
+
+export const OverflowEllipsisTextContainer = styled('span')`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`;

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -149,12 +149,13 @@ function renderBodyCell(column: GridColumnHeader, row: SpanDataRow): React.React
 }
 
 function getColumns(clusters: Cluster[]): GridColumnOrder[] {
+  const secondCluster = clusters.at(1);
   const description =
     clusters.findLast(cluster => Boolean(cluster.description_label))?.description_label ||
     'Description';
 
   const order: Array<GridColumnOrder | false> = [
-    {
+    !secondCluster && {
       key: 'span_operation',
       name: 'Operation',
       width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -175,7 +175,7 @@ function getColumns(clusters: Cluster[]): GridColumnOrder[] {
     },
     {
       key: 'total_exclusive_time',
-      name: 'Exclusive Time',
+      name: 'Total Time',
       width: 250,
     },
     {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -184,6 +184,11 @@ function getColumns(clusters: Cluster[]): GridColumnOrder[] {
       width: COL_WIDTH_UNDEFINED,
     },
     {
+      key: 'p50',
+      name: 'p50',
+      width: COL_WIDTH_UNDEFINED,
+    },
+    {
       key: 'p75',
       name: 'p75',
       width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -154,6 +154,9 @@ function getColumns(clusters: Cluster[]): GridColumnOrder[] {
     clusters.findLast(cluster => Boolean(cluster.description_label))?.description_label ||
     'Description';
 
+  const domain =
+    clusters.findLast(cluster => Boolean(cluster.domain_label))?.domain_label || 'Domain';
+
   const order: Array<GridColumnOrder | false> = [
     !secondCluster && {
       key: 'span_operation',
@@ -163,6 +166,11 @@ function getColumns(clusters: Cluster[]): GridColumnOrder[] {
     {
       key: 'description',
       name: description,
+      width: COL_WIDTH_UNDEFINED,
+    },
+    !!secondCluster && {
+      key: 'domain',
+      name: domain,
       width: COL_WIDTH_UNDEFINED,
     },
     {

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -37,7 +37,7 @@ export type SpanDataRow = {
 export type SpanTrendDataRow = {
   group_id: string;
   interval: string;
-  percentile: string;
+  percentile_value: string;
   span_operation: string;
 };
 

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -179,6 +179,11 @@ function getColumns(clusters: Cluster[]): GridColumnOrder[] {
       width: 250,
     },
     {
+      key: 'transactions',
+      name: 'Transactions',
+      width: COL_WIDTH_UNDEFINED,
+    },
+    {
       key: 'p75',
       name: 'p75',
       width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -40,11 +40,12 @@ export default function SpansView(props: Props) {
         name: clusterName,
       }
   );
+
   const currentCluster = currentClusters.at(-1);
-  if (currentCluster.isDynamic) {
-    currentCluster.condition = currentClusters
-      .at(-2)
-      .grouping_condition(currentCluster.name);
+  if (currentCluster?.isDynamic) {
+    const previousCluster = currentClusters.at(-2);
+    currentCluster.condition =
+      previousCluster?.grouping_condition?.(currentCluster.name) || (() => '');
   }
 
   const clusterBreakdowns = useQueries({
@@ -66,7 +67,7 @@ export default function SpansView(props: Props) {
   });
 
   const {isLoading: areSpansLoading, data: spansData} = useQuery<SpanDataRow[]>({
-    queryKey: ['spans', currentCluster.name, orderBy],
+    queryKey: ['spans', currentCluster?.name || 'none', orderBy],
     queryFn: () =>
       fetch(
         `${HOST}/?query=${getSpanListQuery(
@@ -85,7 +86,7 @@ export default function SpansView(props: Props) {
   const {isLoading: areSpansTrendsLoading, data: spansTrendsData} = useQuery<
     SpanTrendDataRow[]
   >({
-    queryKey: ['spansTrends', currentCluster.name],
+    queryKey: ['spansTrends', currentCluster?.name || 'none'],
     queryFn: () =>
       fetch(
         `${HOST}/?query=${getSpansTrendsQuery(pageFilter.selection.datetime, groupIDs)}`

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -159,6 +159,7 @@ export default function SpansView(props: Props) {
 
       <SpansTable
         location={props.location}
+        clusters={currentClusters}
         isLoading={areSpansLoading || areSpansTrendsLoading}
         spansData={spansData}
         orderBy={orderBy}

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -7,6 +7,7 @@ import _orderBy from 'lodash/orderBy';
 import sumBy from 'lodash/sumBy';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
+import SearchBar from 'sentry/components/searchBar';
 import TagDistributionMeter from 'sentry/components/tagDistributionMeter';
 import {space} from 'sentry/styles/space';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -30,6 +31,9 @@ type State = {
 export default function SpansView(props: Props) {
   const pageFilter = usePageFilters();
   const [state, setState] = useState<State>({orderBy: 'total_exclusive_time'});
+
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [didConfirmSearch, setDidConfirmSearch] = useState<boolean>(false);
   const {orderBy} = state;
 
   const [clusterPath, setClusterPath] = useState<string[]>(['top']);
@@ -41,6 +45,8 @@ export default function SpansView(props: Props) {
       }
   );
 
+  const descriptionFilter = didConfirmSearch && searchTerm ? `${searchTerm}` : undefined;
+
   const currentCluster = currentClusters.at(-1);
   if (currentCluster?.isDynamic) {
     const previousCluster = currentClusters.at(-2);
@@ -51,10 +57,11 @@ export default function SpansView(props: Props) {
   const clusterBreakdowns = useQueries({
     queries: currentClusters.map(cluster => {
       return {
-        queryKey: ['clusterBreakdown', cluster.name],
+        queryKey: ['clusterBreakdown', descriptionFilter, cluster.name],
         queryFn: () =>
           fetch(
             `${HOST}/?query=${getTimeSpentQuery(
+              descriptionFilter,
               cluster.grouping_column || '',
               currentClusters.map(c => c.condition(c.name))
             )}`
@@ -67,10 +74,11 @@ export default function SpansView(props: Props) {
   });
 
   const {isLoading: areSpansLoading, data: spansData} = useQuery<SpanDataRow[]>({
-    queryKey: ['spans', currentCluster?.name || 'none', orderBy],
+    queryKey: ['spans', currentCluster?.name || 'none', descriptionFilter, orderBy],
     queryFn: () =>
       fetch(
         `${HOST}/?query=${getSpanListQuery(
+          descriptionFilter,
           pageFilter.selection.datetime,
           currentClusters.map(c => c.condition(c.name)),
           orderBy,
@@ -86,10 +94,14 @@ export default function SpansView(props: Props) {
   const {isLoading: areSpansTrendsLoading, data: spansTrendsData} = useQuery<
     SpanTrendDataRow[]
   >({
-    queryKey: ['spansTrends', currentCluster?.name || 'none'],
+    queryKey: ['spansTrends', currentCluster?.name || 'none', descriptionFilter],
     queryFn: () =>
       fetch(
-        `${HOST}/?query=${getSpansTrendsQuery(pageFilter.selection.datetime, groupIDs)}`
+        `${HOST}/?query=${getSpansTrendsQuery(
+          descriptionFilter,
+          pageFilter.selection.datetime,
+          groupIDs
+        )}`
       ).then(res => res.json()),
     retry: false,
     initialData: [],
@@ -156,6 +168,18 @@ export default function SpansView(props: Props) {
       <div>
         <button onClick={() => setClusterPath(['top'])}>Reset</button>
       </div>
+
+      <SearchBar
+        onChange={value => {
+          setSearchTerm(value);
+          setDidConfirmSearch(false);
+        }}
+        placeholder="Search Spans"
+        query={searchTerm}
+        onSearch={() => {
+          setDidConfirmSearch(true);
+        }}
+      />
 
       <SpansTable
         location={props.location}


### PR DESCRIPTION
Makes a few initial changes, to test out a new direction. First of all, adds a span filter bar. Second of all, makes this view more aligned to how the Database and API modules look in terms of columns. Also adds some typing, and so on. Also, makes the columns a _little_ dynamic (e.g., the "Description" column becomes "Query").

- Add cluster typing
- Dynamic description based on current type
- Hide operation once cluster is selected
- Use p75 percentile instead
- Add dynamic domain column
- Add transactions column
- Add p50 column
- Switch to p50 trend
- Rename exclusive time to total time
- Add rudimentary span search filter
- Add description overflow
