### PR TITLE
fix(source-maps): Add check for if event has exception

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -76,6 +76,8 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
             raise NotFound(detail="Event not found")
 
         try:
+            if "exception" not in event.interfaces:
+                raise ParseError(detail="Event does not contain an exception")
             exception = event.interfaces["exception"].values[exception_idx]
         except IndexError:
             raise ParseError(detail="Query parameter 'exception_idx' is out of bounds")

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -86,6 +86,21 @@ class SourceMapDebugEndpointTestCase(APITestCase):
         )
         assert resp.data["detail"] == "Query parameter 'frame_idx' is out of bounds"
 
+    def test_no_exception(self):
+        event_data = self.base_data.copy()
+        del event_data["exception"]
+        event = self.store_event(data=event_data, project_id=self.project.id)
+
+        resp = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            event.event_id,
+            frame_idx=0,
+            exception_idx=0,
+        )
+
+        assert resp.data["detail"] == "Event does not contain an exception"
+
     def test_exception_out_of_bounds(self):
         event = self.store_event(
             data=self.base_data,


### PR DESCRIPTION
this pr adds a check to the sourcemap debug endpoint to see if an event has an exception. 

Fixes SENTRY-114Y