### PR TITLE
feat(starfish): Add p75 and throughput sparklines for db queries table

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
@@ -11,6 +11,8 @@ import {Sort} from 'sentry/views/starfish/modules/databaseModule';
 import {SortableHeader} from 'sentry/views/starfish/modules/databaseModule/panel/queryTransactionTable';
 
 import {highlightSql} from './panel';
+import Sparkline from 'sentry/views/starfish/components/sparkline';
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 
 type Props = {
   isDataLoading: boolean;
@@ -41,7 +43,15 @@ export type DataRow = {
   transactions: number;
 };
 
-type Keys = 'description' | 'domain' | 'epm' | 'p75' | 'transactions' | 'total_time';
+type Keys =
+  | 'description'
+  | 'domain'
+  | 'throughput'
+  | 'p75_trend'
+  | 'epm'
+  | 'p75'
+  | 'transactions'
+  | 'total_time';
 export type TableColumnHeader = GridColumnHeader<Keys>;
 export type MainTableSort = Sort<TableColumnHeader>;
 
@@ -54,6 +64,16 @@ const COLUMN_ORDER: TableColumnHeader[] = [
   {
     key: 'domain',
     name: 'Table',
+    width: 200,
+  },
+  {
+    key: 'throughput',
+    name: 'Throughput',
+    width: 200,
+  },
+  {
+    key: 'p75_trend',
+    name: 'P75 Trend',
     width: 200,
   },
   {
@@ -179,10 +199,9 @@ export default function DatabaseTableView({
     const rowStyle: CSSProperties | undefined = isSelectedRow
       ? {fontWeight: 'bold'}
       : undefined;
+    const value = row[key];
 
     if (key === 'description') {
-      const value = row[key];
-
       let headerExtra = '';
       if (row.newish === 1) {
         headerExtra = `Query (First seen ${row.firstSeen})`;
@@ -200,11 +219,34 @@ export default function DatabaseTableView({
         </Hovercard>
       );
     }
+
     if (key === 'p75' || key === 'total_time') {
-      const value = row[key];
       return <span style={rowStyle}>{value.toFixed(2)}ms</span>;
     }
-    return <span style={rowStyle}>{row[key]}</span>;
+
+    if (key === 'throughput') {
+      console.dir(row[key]);
+      return (
+        <Sparkline
+          color={CHART_PALETTE[3][0]}
+          series={value}
+          width={column.width ? column.width - column.width / 5 : undefined}
+        />
+      );
+    }
+
+    if (key === 'p75_trend') {
+      console.dir(row[key]);
+      return (
+        <Sparkline
+          color={CHART_PALETTE[3][3]}
+          series={value}
+          width={column.width ? column.width - column.width / 5 : undefined}
+        />
+      );
+    }
+
+    return <span style={rowStyle}>{value}</span>;
   }
 
   return (

--- a/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
@@ -225,7 +225,6 @@ export default function DatabaseTableView({
     }
 
     if (key === 'throughput') {
-      console.dir(row[key]);
       return (
         <Sparkline
           color={CHART_PALETTE[3][0]}
@@ -236,7 +235,6 @@ export default function DatabaseTableView({
     }
 
     if (key === 'p75_trend') {
-      console.dir(row[key]);
       return (
         <Sparkline
           color={CHART_PALETTE[3][3]}

--- a/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseTableView.tsx
@@ -6,13 +6,13 @@ import Badge from 'sentry/components/badge';
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import {Hovercard} from 'sentry/components/hovercard';
 import Link from 'sentry/components/links/link';
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {space} from 'sentry/styles/space';
+import Sparkline from 'sentry/views/starfish/components/sparkline';
 import {Sort} from 'sentry/views/starfish/modules/databaseModule';
 import {SortableHeader} from 'sentry/views/starfish/modules/databaseModule/panel/queryTransactionTable';
 
 import {highlightSql} from './panel';
-import Sparkline from 'sentry/views/starfish/components/sparkline';
-import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 
 type Props = {
   isDataLoading: boolean;

--- a/static/app/views/starfish/modules/databaseModule/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/index.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import moment from 'moment';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -7,15 +8,23 @@ import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import Switch from 'sentry/components/switchButton';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Series} from 'sentry/types/echarts';
 import EventView from 'sentry/utils/discover/eventView';
 import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import {useQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useQueryMainTable} from 'sentry/views/starfish/modules/databaseModule/queries';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  getDbAggregatesQuery,
+  useQueryMainTable,
+} from 'sentry/views/starfish/modules/databaseModule/queries';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
 import DatabaseChartView from './databaseChartView';
 import DatabaseTableView, {DataRow, MainTableSort} from './databaseTableView';
@@ -54,6 +63,57 @@ function DatabaseModule() {
     filterOld,
     sortKey: sort.sortHeader?.key,
     sortDirection: sort.direction,
+  });
+
+  const pageFilters = usePageFilters();
+
+  const {data: dbAggregateData} = useQuery({
+    queryKey: ['dbAggregates', transaction, filterNew, filterOld],
+    queryFn: () =>
+      fetch(
+        `${HOST}/?query=${getDbAggregatesQuery({
+          datetime: pageFilters.selection.datetime,
+          transaction,
+        })}`
+      ).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+
+  const aggregatesGroupedByQuery = {};
+  dbAggregateData.forEach(({description, interval, count, p75}) => {
+    if (description in aggregatesGroupedByQuery) {
+      aggregatesGroupedByQuery[description].push({name: interval, count, p75});
+    } else {
+      aggregatesGroupedByQuery[description] = [{name: interval, count, p75}];
+    }
+  });
+
+  const combinedDbData = tableData.map(data => {
+    const query = data.description;
+
+    const throughputSeries: Series = {
+      seriesName: 'throughput',
+      data: aggregatesGroupedByQuery[query]?.map(({name, count}) => ({
+        name,
+        value: count,
+      })),
+    };
+
+    const p75Series: Series = {
+      seriesName: 'p75 Trend',
+      data: aggregatesGroupedByQuery[query]?.map(({name, p75}) => ({
+        name,
+        value: p75,
+      })),
+    };
+
+    const zeroFilledThroughput = zeroFillSeries(
+      throughputSeries,
+      moment.duration(12, 'hours')
+    );
+    const zeroFilledP75 = zeroFillSeries(p75Series, moment.duration(12, 'hours'));
+    return {...data, throughput: zeroFilledThroughput, p75_trend: zeroFilledP75};
   });
 
   useEffect(() => {
@@ -160,7 +220,7 @@ function DatabaseModule() {
             </SearchFilterContainer>
             <DatabaseTableView
               location={location}
-              data={tableData}
+              data={combinedDbData}
               isDataLoading={isTableDataLoading || isTableRefetching}
               onSelect={setSelectedRow}
               onSortChange={setSort}

--- a/static/app/views/starfish/modules/databaseModule/queries.ts
+++ b/static/app/views/starfish/modules/databaseModule/queries.ts
@@ -558,3 +558,21 @@ export const getDateQueryFilter = (startTime: Moment, endTime: Moment) => {
   ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
   `;
 };
+
+export const getDbAggregatesQuery = ({datetime, transaction}) => {
+  const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
+  return `
+    SELECT
+    description,
+    toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
+    count() AS count,
+    quantile(0.75)(exclusive_time) as p75
+    FROM spans_experimental_starfish
+    WHERE module = 'db'
+    ${transaction ? `AND transaction = '${transaction}'` : ''}
+    ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
+    ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
+    GROUP BY description, interval
+    ORDER BY interval asc
+  `;
+};

--- a/static/app/views/starfish/utils/combineTableDataWithSparklineData.tsx
+++ b/static/app/views/starfish/utils/combineTableDataWithSparklineData.tsx
@@ -1,0 +1,46 @@
+import {Duration} from 'moment';
+
+import {Series} from 'sentry/types/echarts';
+import {DataRow} from 'sentry/views/starfish/modules/APIModule/endpointTable';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
+
+export default function combineTableDataWithSparklineData(
+  tableData: DataRow[],
+  aggregateData,
+  momentInterval: Duration
+): DataRow[] {
+  const aggregatesGroupedByQuery = {};
+  aggregateData.forEach(({description, interval, count, p75}) => {
+    if (description in aggregatesGroupedByQuery) {
+      aggregatesGroupedByQuery[description].push({name: interval, count, p75});
+    } else {
+      aggregatesGroupedByQuery[description] = [{name: interval, count, p75}];
+    }
+  });
+
+  const combinedData = tableData.map(data => {
+    const query = data.description;
+
+    const throughputSeries: Series = {
+      seriesName: 'throughput',
+      data: aggregatesGroupedByQuery[query]?.map(({name, count}) => ({
+        name,
+        value: count,
+      })),
+    };
+
+    const p75Series: Series = {
+      seriesName: 'p75 Trend',
+      data: aggregatesGroupedByQuery[query]?.map(({name, p75}) => ({
+        name,
+        value: p75,
+      })),
+    };
+
+    const zeroFilledThroughput = zeroFillSeries(throughputSeries, momentInterval);
+    const zeroFilledP75 = zeroFillSeries(p75Series, momentInterval);
+    return {...data, throughput: zeroFilledThroughput, p75_trend: zeroFilledP75};
+  });
+
+  return combinedData;
+}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -31,7 +31,6 @@ import {
 } from 'sentry/views/starfish/modules/databaseModule/queries';
 import {HOST} from 'sentry/views/starfish/utils/constants';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
-import {getDbThroughput} from 'sentry/views/starfish/views/webServiceView/queries';
 
 const EventsRequest = withApi(_EventsRequest);
 
@@ -121,7 +120,7 @@ export default function EndpointOverview() {
     isRefetching: isTableRefetching,
   } = useQueryMainTable({});
 
-  const {isLoading, data: throughputData} = useQuery({
+  const {data: dbAggregateData} = useQuery({
     queryKey: ['dbAggregates'],
     queryFn: () =>
       fetch(
@@ -135,7 +134,7 @@ export default function EndpointOverview() {
   });
 
   const aggregatesGroupedByQuery = {};
-  throughputData.forEach(({description, interval, count, p75}) => {
+  dbAggregateData.forEach(({description, interval, count, p75}) => {
     if (description in aggregatesGroupedByQuery) {
       aggregatesGroupedByQuery[description].push({name: interval, count, p75});
     } else {
@@ -169,8 +168,6 @@ export default function EndpointOverview() {
     const zeroFilledP75 = zeroFillSeries(p75Series, moment.duration(12, 'hours'));
     return {...data, throughput: zeroFilledThroughput, p75_trend: zeroFilledP75};
   });
-
-  console.dir(combinedDbData);
 
   const query = new MutableSearch([
     'has:http.method',

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import moment from 'moment';
 import * as qs from 'query-string';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
@@ -12,7 +13,9 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {NewQuery} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
 import EventView from 'sentry/utils/discover/eventView';
+import {useQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -26,12 +29,9 @@ import {
   getDbAggregatesQuery,
   useQueryMainTable,
 } from 'sentry/views/starfish/modules/databaseModule/queries';
-import {getDbThroughput} from 'sentry/views/starfish/views/webServiceView/queries';
-import {useQuery} from 'sentry/utils/queryClient';
 import {HOST} from 'sentry/views/starfish/utils/constants';
-import {Series} from 'sentry/types/echarts';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
-import moment from 'moment';
+import {getDbThroughput} from 'sentry/views/starfish/views/webServiceView/queries';
 
 const EventsRequest = withApi(_EventsRequest);
 

--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -127,7 +127,7 @@ export const getDatabaseTimeSpent = ({transaction}) => {
   `;
 };
 
-export const getDbThroughput = ({transaction}) => {
+export const getDbThroughput = transaction => {
   return `SELECT
   count() as count,
   toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval

--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -127,7 +127,7 @@ export const getDatabaseTimeSpent = ({transaction}) => {
   `;
 };
 
-export const getDbThroughput = transaction => {
+export const getDbThroughput = ({transaction}) => {
   return `SELECT
   count() as count,
   toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval


### PR DESCRIPTION
Adds sparklines for p75 and throughput for the DB query table

Span data is quite sparse for now, so I expect these sparklines to be more visually interesting once we've got real data

### DB Module View
![image](https://github.com/getsentry/sentry/assets/16740047/ce795fed-80f5-45bb-a4f0-15f1503888d4)


### Endpoint Overview
![image](https://github.com/getsentry/sentry/assets/16740047/b6f153ab-1f0a-40f3-bb1c-fd000e83da01)
