### PR TITLE
feat(group-details): Add collapse param for tags for group details endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -186,12 +186,18 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     }
                 )
 
-            tags = tagstore.get_group_tag_keys(
-                group,
-                environment_ids,
-                limit=100,
-                tenant_ids={"organization_id": group.project.organization_id},
-            )
+            if "tags" not in collapse:
+                tags = tagstore.get_group_tag_keys(
+                    group,
+                    environment_ids,
+                    limit=100,
+                    tenant_ids={"organization_id": group.project.organization_id},
+                )
+                data.update(
+                    {
+                        "tags": sorted(serialize(tags, request.user), key=lambda x: x["name"]),
+                    }
+                )
 
             user_reports = (
                 UserReport.objects.filter(group_id=group.id)
@@ -243,7 +249,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     "pluginIssues": self._get_available_issue_plugins(request, group),
                     "pluginContexts": self._get_context_plugins(request, group),
                     "userReportCount": user_reports.count(),
-                    "tags": sorted(serialize(tags, request.user), key=lambda x: x["name"]),
                     "stats": {"24h": hourly_stats, "30d": daily_stats},
                 }
             )

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -251,6 +251,20 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
 
+    def test_collapse_tags(self):
+        self.login_as(user=self.user)
+        group = self.create_group()
+        url = f"/api/0/issues/{group.id}/"
+
+        # Without collapse param, tags should be present
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data["tags"] == []
+
+        # With collapse param, tags should not be present
+        response = self.client.get(url, {"collapse": ["tags"]})
+        assert "tags" not in response.data
+
 
 @region_silo_test(stable=True)
 class GroupUpdateTest(APITestCase):


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/48783

We can use this param to avoid making the tagstore call which isn't necessary for the frontend.