### PR TITLE
feat(issue-states) add search filter aliases for ignored substatuses

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -31,7 +31,7 @@ from sentry.search.utils import (
     parse_substatus_value,
     parse_user_value,
 )
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
+from sentry.types.group import SUBSTATUS_ALIASES, SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
 is_filter_translation = {
     "assigned": ("unassigned", False),
@@ -39,12 +39,20 @@ is_filter_translation = {
     "for_review": ("for_review", True),
     "linked": ("linked", True),
     "unlinked": ("linked", False),
+    **{
+        status_key: ("status", status_value)
+        for status_key, status_value in STATUS_QUERY_CHOICES.items()
+    },
+    **{
+        substatus_key: ("substatus", substatus_value)
+        for substatus_key, substatus_value in SUBSTATUS_UPDATE_CHOICES.items()
+    },
+    **{
+        substatus_alias_key: ("substatus", substatus_value)
+        for substatus_alias_key, substatus_value in SUBSTATUS_ALIASES.items()
+    },
 }
-for status_key, status_value in STATUS_QUERY_CHOICES.items():
-    is_filter_translation[status_key] = ("status", status_value)
 
-for substatus_key, substatus_value in SUBSTATUS_UPDATE_CHOICES.items():
-    is_filter_translation[substatus_key] = ("substatus", substatus_value)
 
 issue_search_config = SearchConfig.create_from(
     default_config,

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -35,7 +35,7 @@ from sentry.models import (
 )
 from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.search.base import ANY
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES
+from sentry.types.group import SUBSTATUS_ALIASES, SUBSTATUS_UPDATE_CHOICES
 from sentry.utils.auth import find_users
 
 
@@ -66,6 +66,8 @@ def parse_status_value(status: Union[str, int]) -> int:
 
 
 def parse_substatus_value(substatus: Union[str, int]) -> int:
+    if substatus in SUBSTATUS_ALIASES:
+        return int(SUBSTATUS_ALIASES[substatus])
     if substatus in SUBSTATUS_UPDATE_CHOICES:
         return int(SUBSTATUS_UPDATE_CHOICES[substatus])
     if substatus in SUBSTATUS_UPDATE_CHOICES.values():

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -41,6 +41,12 @@ SUBSTATUS_UPDATE_CHOICES: Mapping[str, int] = {
     "new": GroupSubStatus.NEW,
 }
 
+SUBSTATUS_ALIASES: Mapping[str, int] = {
+    "archived_until_escalating": GroupSubStatus.UNTIL_ESCALATING,
+    "archived_forever": GroupSubStatus.FOREVER,
+    "archived_until_condition_met": GroupSubStatus.UNTIL_CONDITION_MET,
+}
+
 SUBSTATUS_TO_STR: Mapping[int, str] = {
     GroupSubStatus.UNTIL_ESCALATING: "archived_until_escalating",
     GroupSubStatus.UNTIL_CONDITION_MET: "archived_until_condition_met",

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -27,7 +27,7 @@ from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOI
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import region_silo_test
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
+from sentry.types.group import SUBSTATUS_ALIASES, SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
 
 class ParseSearchQueryTest(unittest.TestCase):
@@ -230,6 +230,15 @@ class ConvertSubStatusValueTest(TestCase):
             assert result[1].value.raw_value == [GROUP_SUBSTATUS_TO_STATUS_MAP.get(substatus_val)]
 
             filters = [SearchFilter(SearchKey("substatus"), "=", SearchValue([substatus_val]))]
+            result = convert_query_values(filters, [self.project], self.user, None)
+            assert result[0].value.raw_value == [substatus_val]
+            assert result[1].value.raw_value == [GROUP_SUBSTATUS_TO_STATUS_MAP.get(substatus_val)]
+
+    def test_alises(self):
+        for substatus_alias_string, substatus_val in SUBSTATUS_ALIASES.items():
+            filters = [
+                SearchFilter(SearchKey("substatus"), "=", SearchValue([substatus_alias_string]))
+            ]
             result = convert_query_values(filters, [self.project], self.user, None)
             assert result[0].value.raw_value == [substatus_val]
             assert result[1].value.raw_value == [GROUP_SUBSTATUS_TO_STATUS_MAP.get(substatus_val)]


### PR DESCRIPTION
`is:archived_forever` -> `is:forever`
`is:archived_until_escalating` -> `is:until_escalating`
`is:archived_until_condition_met` -> `is:until_condition_met`

Not totally sure how I feel about the actual aliase values. They're clear, but quite verbose. 

Resolves https://github.com/getsentry/sentry/issues/48754