### PR TITLE
fix(team-members): team member dropdown should not close after selection

### DIFF
--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -65,10 +65,35 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(createMock).toHaveBeenCalled();
+  });
+
+  it('can add multiple members with one click on dropdown', async function () {
+    const org = TestStubs.Organization({access: [], openMembership: true});
+    render(
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />
+    );
+
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
+
+    await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
+    expect(createMock).toHaveBeenCalled();
+    expect(screen.getAllByTestId('add-member-menu')[0]).toBeVisible();
   });
 
   it('can add member to team with team:admin permission', async function () {
@@ -81,7 +106,11 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(createMock).toHaveBeenCalled();
@@ -97,7 +126,11 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(createMock).toHaveBeenCalled();
@@ -113,7 +146,11 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(openTeamAccessRequestModal).toHaveBeenCalled();
@@ -135,7 +172,11 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -157,7 +198,11 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -176,7 +221,11 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -195,7 +244,11 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -214,7 +267,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await screen.getAllByTestId('add-member');
+    await screen.findAllByRole('button', {name: 'Add Member'});
 
     expect(deleteMock).not.toHaveBeenCalled();
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
@@ -247,7 +300,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await screen.getAllByTestId('add-member');
+    await screen.findAllByRole('button', {name: 'Add Member'});
 
     expect(deleteMock).not.toHaveBeenCalled();
 
@@ -329,7 +382,11 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
+    await userEvent.click(
+      (
+        await screen.findAllByRole('button', {name: 'Add Member'})
+      )[0]
+    );
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     const admin = screen.queryByText('Team Admin');
@@ -378,7 +435,7 @@ describe('TeamMembers', function () {
     );
 
     waitFor(() => {
-      expect(screen.getByTestId('add-member')).toBeDisabled();
+      expect(screen.findByRole('button', {name: 'Add Member'})).toBeDisabled();
       expect(screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
     });
   });
@@ -418,7 +475,7 @@ describe('TeamMembers', function () {
     );
 
     waitFor(() => {
-      expect(screen.getByTestId('add-member')).toBeDisabled();
+      expect(screen.findByRole('button', {name: 'Add Member'})).toBeDisabled();
       expect(screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
       expect(screen.findByRole('button', {name: 'Leave'})).toBeDisabled();
     });

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -65,11 +65,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(createMock).toHaveBeenCalled();
@@ -85,11 +81,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(createMock).toHaveBeenCalled();
@@ -105,11 +97,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(createMock).toHaveBeenCalled();
@@ -125,11 +113,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     expect(openTeamAccessRequestModal).toHaveBeenCalled();
@@ -151,11 +135,7 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -177,11 +157,7 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -200,11 +176,7 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -223,11 +195,7 @@ describe('TeamMembers', function () {
       {context: routerContext}
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getByTestId('invite-member'));
 
     expect(openInviteMembersModal).toHaveBeenCalled();
@@ -246,7 +214,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await screen.findAllByRole('button', {name: 'Add Member'});
+    await screen.getAllByTestId('add-member');
 
     expect(deleteMock).not.toHaveBeenCalled();
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
@@ -279,7 +247,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await screen.findAllByRole('button', {name: 'Add Member'});
+    await screen.getAllByTestId('add-member');
 
     expect(deleteMock).not.toHaveBeenCalled();
 
@@ -361,11 +329,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    await userEvent.click(
-      (
-        await screen.findAllByRole('button', {name: 'Add Member'})
-      )[0]
-    );
+    await userEvent.click((await screen.getAllByTestId('add-member'))[0]);
     await userEvent.click(screen.getAllByTestId('letter_avatar-avatar')[0]);
 
     const admin = screen.queryByText('Team Admin');
@@ -414,7 +378,7 @@ describe('TeamMembers', function () {
     );
 
     waitFor(() => {
-      expect(screen.findByRole('button', {name: 'Add Member'})).toBeDisabled();
+      expect(screen.getByTestId('add-member')).toBeDisabled();
       expect(screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
     });
   });
@@ -454,7 +418,7 @@ describe('TeamMembers', function () {
     );
 
     waitFor(() => {
-      expect(screen.findByRole('button', {name: 'Add Member'})).toBeDisabled();
+      expect(screen.getByTestId('add-member')).toBeDisabled();
       expect(screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
       expect(screen.findByRole('button', {name: 'Leave'})).toBeDisabled();
     });

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -48,6 +48,7 @@ type Props = {
 
 type State = {
   dropdownBusy: boolean;
+  dropdownOpen: boolean;
   error: boolean;
   loading: boolean;
   orgMembers: Member[];
@@ -61,6 +62,7 @@ class TeamMembers extends AsyncView<Props, State> {
       loading: true,
       error: false,
       dropdownBusy: false,
+      dropdownOpen: false,
       teamMembers: [],
       orgMembers: [],
     };
@@ -119,7 +121,7 @@ class TeamMembers extends AsyncView<Props, State> {
     const {organization, params} = this.props;
     const {orgMembers, teamMembers} = this.state;
 
-    this.setState({loading: true});
+    this.setState({loading: true, dropdownOpen: true});
 
     // Reset members list after adding member to team
     this.debouncedFetchMembersRequest('');
@@ -145,7 +147,7 @@ class TeamMembers extends AsyncView<Props, State> {
           addSuccessMessage(t('Successfully added member to team.'));
         },
         error: () => {
-          this.setState({loading: false});
+          this.setState({loading: false, dropdownOpen: false});
           addErrorMessage(t('Unable to add team member.'));
         },
       }
@@ -253,6 +255,8 @@ class TeamMembers extends AsyncView<Props, State> {
 
     return (
       <DropdownAutoComplete
+        isOpen={this.state.dropdownOpen}
+        closeOnSelect={false}
         items={items}
         alignMenu="right"
         onSelect={
@@ -269,12 +273,16 @@ class TeamMembers extends AsyncView<Props, State> {
         emptyMessage={t('No members')}
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
-        onClose={() => this.debouncedFetchMembersRequest('')}
+        onClose={() => {
+          this.setState({dropdownOpen: false});
+          this.debouncedFetchMembersRequest('');
+        }}
         disabled={isDropdownDisabled}
       >
         {({isOpen}) => (
           <DropdownButton
             isOpen={isOpen}
+            onClick={() => this.setState({dropdownOpen: true})}
             size="xs"
             data-test-id="add-member"
             disabled={isDropdownDisabled}

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -18,7 +18,6 @@ import DropdownButton from 'sentry/components/dropdownButton';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import Link from 'sentry/components/links/link';
 import LoadingError from 'sentry/components/loadingError';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {IconUser} from 'sentry/icons';
@@ -50,7 +49,6 @@ type State = {
   dropdownBusy: boolean;
   dropdownOpen: boolean;
   error: boolean;
-  loading: boolean;
   orgMembers: Member[];
   teamMembers: TeamMember[];
 } & AsyncView['state'];
@@ -59,7 +57,6 @@ class TeamMembers extends AsyncView<Props, State> {
   getDefaultState() {
     return {
       ...super.getDefaultState(),
-      loading: true,
       error: false,
       dropdownBusy: false,
       dropdownOpen: false,
@@ -121,7 +118,7 @@ class TeamMembers extends AsyncView<Props, State> {
     const {organization, params} = this.props;
     const {orgMembers, teamMembers} = this.state;
 
-    this.setState({loading: true, dropdownOpen: true});
+    this.setState({dropdownOpen: true});
 
     // Reset members list after adding member to team
     this.debouncedFetchMembersRequest('');
@@ -140,14 +137,13 @@ class TeamMembers extends AsyncView<Props, State> {
             return;
           }
           this.setState({
-            loading: false,
             error: false,
             teamMembers: teamMembers.concat([orgMember as TeamMember]),
           });
           addSuccessMessage(t('Successfully added member to team.'));
         },
         error: () => {
-          this.setState({loading: false, dropdownOpen: false});
+          this.setState({dropdownOpen: false});
           addErrorMessage(t('Unable to add team member.'));
         },
       }
@@ -313,10 +309,6 @@ class TeamMembers extends AsyncView<Props, State> {
   }
 
   render() {
-    if (this.state.loading) {
-      return <LoadingIndicator />;
-    }
-
     if (this.state.error) {
       return <LoadingError onRetry={this.fetchData} />;
     }

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -47,7 +47,6 @@ type Props = {
 
 type State = {
   dropdownBusy: boolean;
-  dropdownOpen: boolean;
   error: boolean;
   orgMembers: Member[];
   teamMembers: TeamMember[];
@@ -59,7 +58,6 @@ class TeamMembers extends AsyncView<Props, State> {
       ...super.getDefaultState(),
       error: false,
       dropdownBusy: false,
-      dropdownOpen: false,
       teamMembers: [],
       orgMembers: [],
     };
@@ -118,8 +116,6 @@ class TeamMembers extends AsyncView<Props, State> {
     const {organization, params} = this.props;
     const {orgMembers, teamMembers} = this.state;
 
-    this.setState({dropdownOpen: true});
-
     // Reset members list after adding member to team
     this.debouncedFetchMembersRequest('');
 
@@ -143,7 +139,6 @@ class TeamMembers extends AsyncView<Props, State> {
           addSuccessMessage(t('Successfully added member to team.'));
         },
         error: () => {
-          this.setState({dropdownOpen: false});
           addErrorMessage(t('Unable to add team member.'));
         },
       }
@@ -251,7 +246,6 @@ class TeamMembers extends AsyncView<Props, State> {
 
     return (
       <DropdownAutoComplete
-        isOpen={this.state.dropdownOpen}
         closeOnSelect={false}
         items={items}
         alignMenu="right"
@@ -269,16 +263,13 @@ class TeamMembers extends AsyncView<Props, State> {
         emptyMessage={t('No members')}
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
-        onClose={() => {
-          this.setState({dropdownOpen: false});
-          this.debouncedFetchMembersRequest('');
-        }}
+        onClose={() => this.debouncedFetchMembersRequest('')}
         disabled={isDropdownDisabled}
+        data-test-id="add-member-menu"
       >
         {({isOpen}) => (
           <DropdownButton
             isOpen={isOpen}
-            onClick={() => this.setState({dropdownOpen: true})}
             size="xs"
             data-test-id="add-member"
             disabled={isDropdownDisabled}


### PR DESCRIPTION
When adding new team member from organization settings the drop down closes every time. Expected behavior is that it stays open because usually people add multiple team members in one attempt. This fixes the issue by keeping the dropdown open and only close on click.



https://github.com/getsentry/sentry/assets/132939361/89735f54-2c93-4525-918c-05599afda23f

Fixes: ER-1212



