### PR TITLE
chore(py): Remove unused TeamStatus.VISIBLE

### DIFF
--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -127,9 +127,6 @@ class TeamStatus:
     PENDING_DELETION = 1
     DELETION_IN_PROGRESS = 2
 
-    # Deprecated. Do not use
-    VISIBLE = 0
-
 
 @region_silo_only_model
 class Team(Model, SnowflakeIdMixin):


### PR DESCRIPTION
There are no usages of this after 1ab1775fd5 and 4366e06176