### PR TITLE
ref(crons): Consistently use ObjectStatus for monitor.status

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -2,6 +2,7 @@
 
 import time
 
+from sentry.constants import ObjectStatus
 from sentry.runner import configure
 from sentry.types.activity import ActivityType
 
@@ -424,7 +425,7 @@ def main(
                     organization_id=org.id,
                     type=MonitorType.CRON_JOB,
                     defaults={
-                        "status": MonitorStatus.DISABLED,
+                        "status": ObjectStatus.DISABLED,
                         "config": {"schedule": next(MONITOR_SCHEDULES)},
                         "next_checkin": timezone.now() + timedelta(minutes=60),
                         "last_checkin": timezone.now(),

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -20,7 +20,6 @@ from sentry.monitors.models import (
     MonitorEnvironment,
     MonitorEnvironmentLimitsExceeded,
     MonitorLimitsExceeded,
-    MonitorStatus,
     MonitorType,
 )
 from sentry.monitors.utils import signal_first_checkin, signal_first_monitor_created
@@ -188,7 +187,7 @@ def _process_message(wrapper: Dict) -> None:
 
                 signal_first_checkin(project, monitor)
 
-            if check_in.status == CheckInStatus.ERROR and monitor.status != MonitorStatus.DISABLED:
+            if check_in.status == CheckInStatus.ERROR and monitor.status != ObjectStatus.DISABLED:
                 monitor_environment.mark_failed(start_time)
             else:
                 monitor_environment.mark_ok(check_in, start_time)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -17,6 +17,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import GLOBAL_PARAMS, MONITOR_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import ObjectStatus
 from sentry.models import Project, ProjectKey
 from sentry.monitors.models import (
     CheckInStatus,
@@ -25,7 +26,6 @@ from sentry.monitors.models import (
     MonitorEnvironment,
     MonitorEnvironmentLimitsExceeded,
     MonitorLimitsExceeded,
-    MonitorStatus,
 )
 from sentry.monitors.serializers import MonitorCheckInSerializerResponse
 from sentry.monitors.utils import signal_first_checkin, signal_first_monitor_created
@@ -99,8 +99,8 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
         Note: If a DSN is utilized for authentication, the response will be limited in details.
         """
         if monitor and monitor.status in [
-            MonitorStatus.PENDING_DELETION,
-            MonitorStatus.DELETION_IN_PROGRESS,
+            ObjectStatus.PENDING_DELETION,
+            ObjectStatus.DELETION_IN_PROGRESS,
         ]:
             return self.respond(status=404)
 
@@ -195,7 +195,7 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
 
             signal_first_checkin(project, monitor)
 
-            if checkin.status == CheckInStatus.ERROR and monitor.status != MonitorStatus.DISABLED:
+            if checkin.status == CheckInStatus.ERROR and monitor.status != ObjectStatus.DISABLED:
                 monitor_failed = monitor_environment.mark_failed(last_checkin=checkin.date_added)
                 if not monitor_failed:
                     if isinstance(request.auth, ProjectKey):

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -147,8 +147,8 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
                     )
                     .exclude(
                         monitor__status__in=[
-                            MonitorStatus.PENDING_DELETION,
-                            MonitorStatus.DELETION_IN_PROGRESS,
+                            ObjectStatus.PENDING_DELETION,
+                            ObjectStatus.DELETION_IN_PROGRESS,
                         ]
                     )
                     .exclude(

--- a/src/sentry/monitors/endpoints/organization_monitors.py
+++ b/src/sentry/monitors/endpoints/organization_monitors.py
@@ -18,6 +18,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.parameters import GLOBAL_PARAMS
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import ObjectStatus
 from sentry.db.models.query import in_iexact
 from sentry.mediators import project_rules
 from sentry.models import Environment, Organization, RuleActivity, RuleActivityType, RuleSource
@@ -93,7 +94,7 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
 
         queryset = Monitor.objects.filter(
             organization_id=organization.id, project_id__in=filter_params["project_id"]
-        ).exclude(status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS])
+        ).exclude(status__in=[ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS])
         query = request.GET.get("query")
 
         environments = None

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -442,7 +442,7 @@ class MonitorEnvironment(Model):
             "last_checkin": ts,
             "next_checkin": self.monitor.get_next_scheduled_checkin(ts),
         }
-        if checkin.status == CheckInStatus.OK and self.monitor.status != MonitorStatus.DISABLED:
+        if checkin.status == CheckInStatus.OK and self.monitor.status != ObjectStatus.DISABLED:
             params["status"] = MonitorStatus.OK
 
         MonitorEnvironment.objects.filter(id=self.id).exclude(last_checkin__gt=ts).update(**params)

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry.constants import ObjectStatus
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 
@@ -60,9 +61,9 @@ def check_monitors(current_datetime=None):
         )
         .exclude(
             monitor__status__in=[
-                MonitorStatus.DISABLED,
-                MonitorStatus.PENDING_DELETION,
-                MonitorStatus.DELETION_IN_PROGRESS,
+                ObjectStatus.DISABLED,
+                ObjectStatus.PENDING_DELETION,
+                ObjectStatus.DELETION_IN_PROGRESS,
             ]
         )[:MONITOR_LIMIT]
     )

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -9,13 +9,14 @@ from rest_framework import serializers
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.api.serializers.rest_framework.project import ProjectField
-from sentry.monitors.models import CheckInStatus, Monitor, MonitorStatus, MonitorType, ScheduleType
+from sentry.constants import ObjectStatus
+from sentry.monitors.models import CheckInStatus, Monitor, MonitorType, ScheduleType
 
 MONITOR_TYPES = {"cron_job": MonitorType.CRON_JOB}
 
 MONITOR_STATUSES = {
-    "active": MonitorStatus.ACTIVE,
-    "disabled": MonitorStatus.DISABLED,
+    "active": ObjectStatus.ACTIVE,
+    "disabled": ObjectStatus.DISABLED,
 }
 
 SCHEDULE_TYPES = {

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -44,10 +44,10 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         last_checkin_older = datetime.now() - timedelta(minutes=5)
 
         def add_status_monitor(status_key: str, date: datetime | None = None):
-            status = getattr(MonitorStatus, status_key)
-            # TODO(rjo100): this is precursor to removing the MonitorStatus from Monitors
+            monitor_status = getattr(MonitorStatus, status_key)
+            # TODO(rjo100): this is precursor to removing the MonitorStatus values from Monitors
             monitor = self._create_monitor(
-                status=getattr(MonitorStatus, "ACTIVE"),
+                status=ObjectStatus.ACTIVE,
                 last_checkin=date or last_checkin,
                 name=status_key,
             )
@@ -55,13 +55,13 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
                 monitor,
                 name="jungle",
                 last_checkin=(date or last_checkin) - timedelta(seconds=30),
-                status=status,
+                status=monitor_status,
             )
             self._create_monitor_environment(
                 monitor,
                 name="volcano",
                 last_checkin=(date or last_checkin) - timedelta(seconds=15),
-                status=getattr(MonitorStatus, "DISABLED"),
+                status=MonitorStatus.DISABLED,
             )
             return monitor
 


### PR DESCRIPTION
We should give `MonitorStatus` a better name