### PR TITLE
ref(crons): Use ObjectStatus for monitorStatus in the monitor row

### DIFF
--- a/static/app/views/monitors/components/row.tsx
+++ b/static/app/views/monitors/components/row.tsx
@@ -99,7 +99,7 @@ function MonitorRow({monitor, monitorEnv, organization, onDelete}: MonitorRowPro
       </MonitorName>
       <MonitorColumn>
         <TextOverflow>
-          {monitorStatus === MonitorStatus.DISABLED
+          {monitorStatus === 'disabled'
             ? t('Paused')
             : monitorStatus === MonitorStatus.ACTIVE || !lastCheckin
             ? t('Waiting for first check-in')


### PR DESCRIPTION
This more accurately reflects what it is in the backend