### PR TITLE
ref(hybrid-cloud): Change imports to avoid sentry.models during startup

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -6,7 +6,6 @@
 from abc import abstractmethod
 from typing import Iterable, List, Optional, cast
 
-from sentry.models.organizationmember import InviteStatus
 from sentry.services.hybrid_cloud.organization import (
     RpcOrganizationMember,
     RpcOrganizationMemberFlags,
@@ -138,7 +137,7 @@ class OrganizationService(RpcService):
         flags: Optional[RpcOrganizationMemberFlags] = None,
         role: Optional[str] = None,
         inviter_id: Optional[int] = None,
-        invite_status: Optional[int] = InviteStatus.APPROVED.value,
+        invite_status: Optional[int] = 0,  # InviteStatus.APPROVED.value,
     ) -> RpcOrganizationMember:
         pass
 

--- a/src/sentry/services/hybrid_cloud/region.py
+++ b/src/sentry/services/hybrid_cloud/region.py
@@ -4,12 +4,12 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from sentry.db.models import BaseManager
 from sentry.services.hybrid_cloud import ArgumentDict
 from sentry.services.hybrid_cloud.rpc import RpcServiceUnimplementedException
 from sentry.types.region import Region, get_region_by_name
 
 if TYPE_CHECKING:
+    from sentry.db.models import BaseManager
     from sentry.models import OrganizationMapping
 
 


### PR DESCRIPTION
This PR is my attempt at refactoring the imports to allow standing up the region silo.

Test with: `SENTRY_SILO_MODE=REGION SENTRY_REGION=region sentry devserver` which should fail on master currently.