### PR TITLE
fix(metrics): add sentry_received_timestamp

### DIFF
--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1162,6 +1162,7 @@ class GetProjectReleasesCountTest(TestCase, SnubaTestCase):
                     "type": "s",
                     "value": [1, 2, 3],
                     "retention_days": 90,
+                    "sentry_received_timestamp": time.time(),
                 }
             ],
             entity=EntityKey.MetricsSets.value,


### PR DESCRIPTION
Missed one smol test in https://github.com/getsentry/sentry/pull/48843 :(