### PR TITLE
chore(issue-platform): Remove project level option for creating issues via platform

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -629,14 +629,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings["sentry:performance_issue_send_to_issues_platform"] = result[
                     "performanceIssueSendToPlatform"
                 ]
-        if "performanceIssueCreationThroughPlatform" in result:
-            if project.update_option(
-                "sentry:performance_issue_create_issue_through_platform",
-                result["performanceIssueCreationThroughPlatform"],
-            ):
-                changed_proj_settings[
-                    "sentry:performance_issue_create_issue_through_platform"
-                ] = result["performanceIssueCreationThroughPlatform"]
         # TODO(dcramer): rewrite options to use standard API config
         if has_project_write:
             options = request.data.get("options", {})

--- a/src/sentry/issues/utils.py
+++ b/src/sentry/issues/utils.py
@@ -31,8 +31,6 @@ def issue_category_can_create_group(category: GroupCategory, project: Project) -
             category == GroupCategory.PERFORMANCE
             # system-wide option
             and options.get("performance.issues.create_issues_through_platform", False)
-            # more-granular per-project option
-            and project.get_option("sentry:performance_issue_create_issue_through_platform", True)
         )
     )
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -105,10 +105,6 @@ register(key="sentry:performance_issue_creation_rate", default=1.0)
 # Can be used to turn off writing occurrences for users if there is a project-specific issue.
 register(key="sentry:performance_issue_send_to_issues_platform", default=True)
 
-# Rate at which performance issues are created through issues platform per project. Defaults to False, system flags and options will determine if an organization creates issues through platform.
-# Can be used to turn off issue creation for users if there is a project-specific issue.
-register(key="sentry:performance_issue_create_issue_through_platform", default=False)
-
 DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "n_plus_one_db_detection_rate": 1.0,
     "n_plus_one_api_calls_detection_rate": 1.0,

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -192,9 +192,7 @@ def make_performance_event(project, sample_name: str):
     timestamp = datetime(2017, 9, 6, 0, 0)
     start_timestamp = timestamp - timedelta(seconds=3)
 
-    if options.get(
-        "performance.issues.create_issues_through_platform", True
-    ) and project.get_option("sentry:performance_issue_create_issue_through_platform", True):
+    if options.get("performance.issues.create_issues_through_platform", True):
         event_id = "44f1419e73884cd2b45c79918f4b6dc4"
         occurrence_data = SAMPLE_TO_OCCURRENCE_MAP[sample_name].to_dict()
         occurrence_data["event_id"] = event_id

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -414,7 +414,6 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         )
         perf_event_manager = EventManager(event_data)
         perf_event_manager.normalize()
-        self.project.update_option("sentry:performance_issue_create_issue_through_platform", True)
 
         with override_options(
             {

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -92,10 +92,8 @@ class PerfIssuePlatformEventMixin(PerfIssueTransactionTestMixin):
             return event.for_group(event.groups[0])
 
     def assertPasses(self, rule, event=None, **kwargs):
-        self.project.update_option("sentry:performance_issue_create_issue_through_platform", True)
         with self.options({"performance.issues.create_issues_through_platform": True}):
             super().assertPasses(rule, event=event, **kwargs)
-        self.project.update_option("sentry:performance_issue_create_issue_through_platform", False)
 
 
 class StandardIntervalMixin:

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2612,7 +2612,6 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
     def test_generic_query_perf(self):
         event_id = uuid.uuid4().hex
         group_type = PerformanceNPlusOneGroupType
-        self.project.update_option("sentry:performance_issue_create_issue_through_platform", True)
 
         with self.options(
             {"performance.issues.create_issues_through_platform": True}


### PR DESCRIPTION
This removes the project level option for creating issues via the issue platform. We've defaulted this to true and no longer need to keep it in place.
