### PR TITLE
feat(starfish): Span view charts

### DIFF
--- a/static/app/views/starfish/views/spans/clusters.tsx
+++ b/static/app/views/starfish/views/spans/clusters.tsx
@@ -4,6 +4,7 @@ export type Cluster = {
   name: string;
   description_label?: string;
   domain_label?: string;
+  explanation?: string;
   grouping_column?: string;
   grouping_condition?: (value: any) => () => string;
   isDynamic?: boolean;
@@ -13,12 +14,14 @@ export const CLUSTERS: Record<string, Cluster> = {
   top: {
     name: 'top',
     label: 'All',
+    explanation: 'Time Spent',
     condition: () => '',
     grouping_column: "module IN ['db', 'http'] ? concat('top.',  module) : 'top.other'",
   },
   'top.db': {
     name: 'top.db',
-    label: 'DB',
+    label: 'Database',
+    explanation: 'Database Operations',
     description_label: 'Query',
     domain_label: 'Table',
     condition: () => "module == 'db'",
@@ -45,6 +48,7 @@ export const CLUSTERS: Record<string, Cluster> = {
   'top.http': {
     name: 'top.http',
     label: 'HTTP',
+    explanation: 'HTTP Server vs. Client',
     description_label: 'URL',
     domain_label: 'Host',
     condition: () => "module == 'http'",
@@ -60,6 +64,7 @@ export const CLUSTERS: Record<string, Cluster> = {
   'http.client': {
     name: 'http.client',
     label: 'Client',
+    explanation: 'HTTP Methods',
     condition: () => "span_operation == 'http.client'",
     grouping_column:
       "action IN ['GET', 'POST'] ? concat('http.client.', lower(action)) : 'http.client.other'",
@@ -67,6 +72,7 @@ export const CLUSTERS: Record<string, Cluster> = {
   'http.client.get': {
     name: 'http.client.get',
     label: 'GET',
+    explanation: 'Domains',
     condition: () => "action == 'GET'",
     grouping_column: 'domain',
     grouping_condition: value => () => `domain = '${value}'`,

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -37,12 +37,12 @@ export function SpanTimeCharts({descriptionFilter, clusters}: Props) {
   const lastCluster = clusters.at(-1);
 
   const {isLoading, data} = useSpansQuery({
-    queryString: getSpanTotalTimeChartQuery(
+    queryString: `${getSpanTotalTimeChartQuery(
       pageFilter.selection.datetime,
       descriptionFilter,
       lastCluster?.grouping_column || '',
       clusters.map(c => c.condition(c.name))
-    ),
+    )}&referrer=span-time-charts`,
     initialData: [],
   });
 

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -192,7 +192,7 @@ export const getSpanTotalTimeChartQuery = (
   const validConditions = conditions.filter(Boolean);
 
   return `SELECT
-    ${groupingColumn} AS primary_group,
+    ${groupingColumn ? `${groupingColumn} AS primary_group,` : ''}
     count() AS throughput,
     sum(exclusive_time) AS total_time,
     quantile(0.50)(exclusive_time) AS p50,
@@ -203,7 +203,7 @@ export const getSpanTotalTimeChartQuery = (
     ${validConditions.length > 0 ? 'AND' : ''}
     ${validConditions.join(' AND ')}
     ${descriptionFilter ? `AND match(lower(description), '${descriptionFilter}')` : ''}
-    GROUP BY primary_group, interval
+    GROUP BY ${groupingColumn ? 'primary_group, ' : ''} interval
     ORDER BY interval ASC
   `;
 };

--- a/static/app/views/starfish/views/spans/spanTotalTimeChart.tsx
+++ b/static/app/views/starfish/views/spans/spanTotalTimeChart.tsx
@@ -1,0 +1,113 @@
+import {useTheme} from '@emotion/react';
+import groupBy from 'lodash/groupBy';
+import moment from 'moment';
+
+import {DateTimeObject} from 'sentry/components/charts/utils';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import Chart from 'sentry/views/starfish/components/chart';
+import {
+  datetimeToClickhouseFilterTimestamps,
+  PERIOD_REGEX,
+} from 'sentry/views/starfish/utils/dates';
+import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
+
+import type {Cluster} from './clusters';
+
+type Props = {
+  clusters: Cluster[];
+  descriptionFilter: string;
+};
+
+export function SpanTotalTimeChart({descriptionFilter, clusters}: Props) {
+  const themes = useTheme();
+
+  const pageFilter = usePageFilters();
+  const [_, num, unit] = pageFilter.selection.datetime.period?.match(PERIOD_REGEX) ?? [];
+  const startTime =
+    num && unit
+      ? moment().subtract(num, unit as 'h' | 'd')
+      : moment(pageFilter.selection.datetime.start);
+  const endTime = moment(pageFilter.selection.datetime.end ?? undefined);
+
+  const lastCluster = clusters.at(-1);
+
+  const {isLoading, data} = useSpansQuery({
+    queryString: getSpanTotalTimeChartQuery(
+      pageFilter.selection.datetime,
+      descriptionFilter,
+      lastCluster?.grouping_column || '',
+      clusters.map(c => c.condition(c.name))
+    ),
+    initialData: [],
+  });
+
+  if (!lastCluster) {
+    return null;
+  }
+
+  const dataByGroup = groupBy(data, 'primary_group');
+
+  const series = Object.keys(dataByGroup).map(groupName => {
+    const groupData = dataByGroup[groupName];
+
+    return zeroFillSeries(
+      {
+        seriesName: groupName,
+        data: groupData.map(datum => ({
+          value: datum.exclusive_time,
+          name: datum.interval,
+        })),
+      },
+      moment.duration(1, 'day'),
+      startTime,
+      endTime
+    );
+  });
+
+  return (
+    <Chart
+      statsPeriod="24h"
+      height={100}
+      data={series}
+      start=""
+      end=""
+      loading={isLoading}
+      utc={false}
+      grid={{
+        left: '0',
+        right: '0',
+        top: '8px',
+        bottom: '0',
+      }}
+      definedAxisTicks={4}
+      stacked
+      chartColors={themes.charts.getColorPalette(2)}
+      disableXAxis
+    />
+  );
+}
+
+export const getSpanTotalTimeChartQuery = (
+  datetime: DateTimeObject,
+  descriptionFilter: string | undefined,
+  groupingColumn: string,
+  conditions: string[] = []
+) => {
+  const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
+  const validConditions = conditions.filter(Boolean);
+
+  return `SELECT
+    ${groupingColumn} AS primary_group,
+    sum(exclusive_time) AS exclusive_time,
+    toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval
+    FROM spans_experimental_starfish
+    WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
+    ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
+    ${validConditions.length > 0 ? 'AND' : ''}
+    ${validConditions.join(' AND ')}
+    ${descriptionFilter ? `AND match(lower(description), '${descriptionFilter}')` : ''}
+    GROUP BY primary_group, interval
+    ORDER BY interval ASC
+  `;
+};

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -9,9 +9,12 @@ import sumBy from 'lodash/sumBy';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import SearchBar from 'sentry/components/searchBar';
 import TagDistributionMeter from 'sentry/components/tagDistributionMeter';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {HOST} from 'sentry/views/starfish/utils/constants';
+import {SpanTotalTimeChart} from 'sentry/views/starfish/views/spans/spanTotalTimeChart';
 
 import {CLUSTERS} from './clusters';
 import {getSpanListQuery, getSpansTrendsQuery, getTimeSpentQuery} from './queries';
@@ -181,6 +184,14 @@ export default function SpansView(props: Props) {
         }}
       />
 
+      <ChartsContainer>
+        <ChartsContainerItem>
+          <ChartPanel title={t('Total Time')}>
+            <SpanTotalTimeChart clusters={currentClusters} />
+          </ChartPanel>
+        </ChartsContainerItem>
+      </ChartsContainer>
+
       <SpansTable
         location={props.location}
         clusters={currentClusters}
@@ -199,4 +210,15 @@ const FilterOptionsContainer = styled('div')`
   flex-direction: row;
   gap: ${space(1)};
   margin-bottom: ${space(2)};
+`;
+
+const ChartsContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: ${space(2)};
+`;
+
+const ChartsContainerItem = styled('div')`
+  flex: 1;
 `;

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -182,7 +182,10 @@ export default function SpansView(props: Props) {
         }}
       />
 
-      <SpanTimeCharts clusters={currentClusters} />
+      <SpanTimeCharts
+        descriptionFilter={descriptionFilter || ''}
+        clusters={currentClusters}
+      />
 
       <SpansTable
         location={props.location}

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -154,7 +154,7 @@ export default function SpansView(props: Props) {
           return (
             <TagDistributionMeter
               key={cluster.name}
-              title={cluster.label}
+              title={cluster.explanation || cluster.label}
               onTagClick={(_name, value) => {
                 setClusterPath([...clusterPath.slice(0, depth + 1), value.value]);
               }}

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -9,12 +9,10 @@ import sumBy from 'lodash/sumBy';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import SearchBar from 'sentry/components/searchBar';
 import TagDistributionMeter from 'sentry/components/tagDistributionMeter';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {HOST} from 'sentry/views/starfish/utils/constants';
-import {SpanTotalTimeChart} from 'sentry/views/starfish/views/spans/spanTotalTimeChart';
+import {SpanTimeCharts} from 'sentry/views/starfish/views/spans/spanTimeCharts';
 
 import {CLUSTERS} from './clusters';
 import {getSpanListQuery, getSpansTrendsQuery, getTimeSpentQuery} from './queries';
@@ -184,13 +182,7 @@ export default function SpansView(props: Props) {
         }}
       />
 
-      <ChartsContainer>
-        <ChartsContainerItem>
-          <ChartPanel title={t('Total Time')}>
-            <SpanTotalTimeChart clusters={currentClusters} />
-          </ChartPanel>
-        </ChartsContainerItem>
-      </ChartsContainer>
+      <SpanTimeCharts clusters={currentClusters} />
 
       <SpansTable
         location={props.location}
@@ -210,15 +202,4 @@ const FilterOptionsContainer = styled('div')`
   flex-direction: row;
   gap: ${space(1)};
   margin-bottom: ${space(2)};
-`;
-
-const ChartsContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: ${space(2)};
-`;
-
-const ChartsContainerItem = styled('div')`
-  flex: 1;
 `;


### PR DESCRIPTION
Adds charts that match the information in the breakdown bars and the columns.

<img width="1294" alt="Screenshot 2023-05-10 at 10 36 02 PM" src="https://github.com/getsentry/sentry/assets/989898/fef8a637-458d-44e3-b7c6-0c98dcb718f4">

- Add breakdown explanations
- Add total duration graph
- Add p50 chart
- Add throughput
