### PR TITLE
feat(dynamic-sampling):Add admin modifiable flag for setting prioritise transaction intensity

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -708,10 +708,11 @@ register("dynamic-sampling.prioritise_transactions.num_explicit_small_transactio
 # there will still be some rebalancing between the explicit and implicit transactions ( so setting rebalancing
 # to 0.0 is not the same as no rebalancing. To effectively disable rebalancing set the number of explicit
 # transactions to be rebalance (both small and large) to 0
-register("dynamic-sampling.prioritise_transactions.rebalance_intensity", 0.8)
+register(
+    "dynamic-sampling.prioritise_transactions.rebalance_intensity",
+    default=0.8,
+    flags=FLAG_MODIFIABLE_RATE,
+)
 register("hybrid_cloud.outbox_rate", default=0.0)
 # controls whether we allow people to upload artifact bundles instead of release bundles
 register("sourcemaps.enable-artifact-bundles", default=0.0)
-
-# TODO raduw (remove it when done) testing modifiable rate flag
-register("dynamic-sampling.test.modifiable", 0.8, flags=FLAG_MODIFIABLE_RATE)


### PR DESCRIPTION
This PR adds the ability to set the prioritise transaction bias intensity in the admin UI.