### PR TITLE
instr(txnames): Track number of rules per project

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -5,6 +5,7 @@ import sentry_sdk
 
 from sentry.ingest.transaction_clusterer.datasource.redis import get_redis_client
 from sentry.models import Project
+from sentry.utils import metrics
 
 from .base import ReplacementRule
 
@@ -79,6 +80,10 @@ class ProjectOptionRuleStore:
         """Writes the rules to project options, sorted by depth."""
         # we make sure the database stores lists such that they are json round trippable
         converted_rules = [list(tup) for tup in self._sort(rules)]
+
+        # Track the number of rules per project.
+        metrics.timing("txcluster.rules_per_project", len(converted_rules))
+
         project.update_option(self._option_name, converted_rules)
 
 


### PR DESCRIPTION
Track the distribution of rule set size written by the transaction clustering job. A decrease in the number of rules could indicate a regression in transaction clustering, or a bug in the rule expiry logic.

ref: https://github.com/getsentry/team-ingest/issues/124