### PR TITLE
feat(starfish): Surface facet changes in endpoint overview

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -58,7 +58,7 @@ type TagColumn = GridColumnOrder<ColumnKeys> & {
   field: string;
   canSort?: boolean;
 };
-const COLUMN_ORDER: TagColumn[] = [
+export const TAG_EXPLORER_COLUMN_ORDER: TagColumn[] = [
   {
     key: 'key',
     field: 'key',
@@ -142,7 +142,7 @@ const getColumnsWithReplacedDuration = (
   projects: Project[],
   eventView: EventView
 ) => {
-  const columns = COLUMN_ORDER.map(c => ({...c}));
+  const columns = TAG_EXPLORER_COLUMN_ORDER.map(c => ({...c}));
   const durationColumn = columns.find(c => c.key === 'aggregate');
 
   if (!durationColumn) {
@@ -403,7 +403,7 @@ export class TagExplorer extends Component<Props> {
     const cursor = decodeScalar(location.query?.[TAGS_CURSOR_NAME]);
 
     const tagEventView = eventView.clone();
-    tagEventView.fields = COLUMN_ORDER;
+    tagEventView.fields = TAG_EXPLORER_COLUMN_ORDER;
 
     const tagSorts = fromSorts(tagSort);
 

--- a/static/app/views/starfish/components/breakdownBar.tsx
+++ b/static/app/views/starfish/components/breakdownBar.tsx
@@ -241,30 +241,6 @@ function FacetBreakdownBar({title, transaction: maybeTransaction}: Props) {
     );
   }
 
-  // function renderChart(mod: string | undefined) {
-  //   switch (mod) {
-  //     case 'http':
-  //       return (
-  //         <HttpBreakdownChart
-  //           isHttpDurationDataLoading={isHttpDurationDataLoading}
-  //           isOtherHttpDurationDataLoading={isOtherHttpDurationDataLoading}
-  //           httpDurationData={httpDurationData}
-  //           otherHttpDurationData={otherHttpDurationData}
-  //           httpThroughputData={httpThroughputData}
-  //         />
-  //       );
-  //     case 'db':
-  //     default:
-  //       return (
-  //         <DatabaseDurationChart
-  //           isDbDurationLoading={isDbDurationLoading}
-  //           dbDurationData={dbDurationData}
-  //           dbThroughputData={dbThroughputData}
-  //         />
-  //       );
-  //   }
-  // }
-
   return (
     <Fragment>
       <TagSummary>

--- a/static/app/views/starfish/components/facetInsights.tsx
+++ b/static/app/views/starfish/components/facetInsights.tsx
@@ -1,0 +1,147 @@
+import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import Placeholder from 'sentry/components/placeholder';
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+import {Series} from 'sentry/types/echarts';
+import EventView from 'sentry/utils/discover/eventView';
+import {
+  DiscoverQueryProps,
+  useGenericDiscoverQuery,
+} from 'sentry/utils/discover/genericDiscoverQuery';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {TAG_EXPLORER_COLUMN_ORDER} from 'sentry/views/performance/transactionSummary/transactionOverview/tagExplorer';
+import Sparkline from 'sentry/views/starfish/components/sparkline';
+import {TextAlignLeft} from 'sentry/views/starfish/modules/APIModule/endpointTable';
+
+type Props = {
+  eventView: EventView;
+};
+
+type DataRow = {
+  count: number;
+  // p50: Series;
+  tagKey: string;
+  tagValue: string;
+  throughput: Series;
+  tpmCorrelation: string;
+};
+
+const COLUMN_ORDER = [
+  {
+    key: 'tagKey',
+    name: 'Key',
+    width: 300,
+  },
+  {
+    key: 'tagValue',
+    name: 'Value',
+    width: 300,
+  },
+  {
+    key: 'count',
+    name: 'count',
+    width: 200,
+  },
+  {
+    key: 'throughput',
+    name: 'tpm',
+    width: 200,
+  },
+  {
+    key: 'tpmCorrelation',
+    name: 'tpm correlation',
+    width: 200,
+  },
+];
+
+function transformSeries(name, data): Series {
+  return {
+    seriesName: name,
+    data: data.map(datum => {
+      return {name: datum[0], value: datum[1][0].count};
+    }),
+  };
+}
+
+export function FacetInsights({eventView}: Props) {
+  const location = useLocation();
+  const organization = useOrganization();
+  const facetStatsEventView = eventView.clone();
+  facetStatsEventView.fields = TAG_EXPLORER_COLUMN_ORDER;
+  const sortedFacetStatsEventView = facetStatsEventView.withSorts([
+    {
+      field: 'sumdelta',
+      kind: 'desc',
+    },
+  ]);
+
+  const {isLoading, data} = useGenericDiscoverQuery<any, DiscoverQueryProps>({
+    route: 'events-facets-stats',
+    eventView,
+    location,
+    orgSlug: organization.slug,
+    getRequestPayload: () => ({
+      ...sortedFacetStatsEventView.getEventsAPIPayload(location),
+      aggregateColumn: 'transaction.duration',
+    }),
+  });
+
+  if (isLoading) {
+    return <Placeholder height="400px" />;
+  }
+
+  const transformedData: DataRow[] = [];
+
+  const totals = data?.totals;
+  const keys = Object.keys(totals);
+  for (let index = 0; index < keys.length; index++) {
+    const element = keys[index];
+    transformedData.push({
+      tagKey: element.split(',')[0],
+      tagValue: element.split(',')[1],
+      count: totals[element].count,
+      throughput: transformSeries('throughput', data![element]['count()'].data),
+      tpmCorrelation: categorizeCorrelation(totals[element].sum_correlation),
+    });
+  }
+
+  return (
+    <GridEditable
+      isLoading={isLoading}
+      data={transformedData}
+      columnOrder={COLUMN_ORDER}
+      columnSortBy={[]}
+      location={location}
+      grid={{
+        renderBodyCell: (column: GridColumnHeader, row: DataRow) =>
+          renderBodyCell(column, row),
+      }}
+    />
+  );
+}
+
+function renderBodyCell(column: GridColumnHeader, row: DataRow): React.ReactNode {
+  if (column.key === 'throughput') {
+    return (
+      <Sparkline
+        color={CHART_PALETTE[3][0]}
+        series={row[column.key]}
+        width={column.width ? column.width - column.width / 5 : undefined}
+      />
+    );
+  }
+
+  return <TextAlignLeft>{row[column.key]}</TextAlignLeft>;
+}
+function categorizeCorrelation(correlation: number): string {
+  if (correlation >= 0.8) {
+    return 'very high correlation';
+  }
+  if (correlation >= 0.6) {
+    return 'high correlation';
+  }
+  if (correlation >= 0.4) {
+    return 'medium correlation';
+  }
+  return 'no/low correlation';
+}

--- a/static/app/views/starfish/components/facetInsights.tsx
+++ b/static/app/views/starfish/components/facetInsights.tsx
@@ -10,6 +10,7 @@ import {
   DiscoverQueryProps,
   useGenericDiscoverQuery,
 } from 'sentry/utils/discover/genericDiscoverQuery';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {TAG_EXPLORER_COLUMN_ORDER} from 'sentry/views/performance/transactionSummary/transactionOverview/tagExplorer';
@@ -92,12 +93,27 @@ export function FacetInsights({eventView}: Props) {
     }
 
     if (column.key === 'tagValue') {
+      const query = new MutableSearch(eventView.query);
+      let queryFilter = '';
+      query.tokens.forEach(value => {
+        if (value.key) {
+          queryFilter = queryFilter.concat(' ', `${value.key}:${value.value}`);
+        }
+      });
+      queryFilter = queryFilter.concat(' ', `${row.tagKey}:${row.tagValue}`);
       return (
         <OverflowEllipsisTextContainer>
           <Link
             to={`/discover/homepage/?${qs.stringify({
               ...eventView.generateQueryStringObject(),
-              field: ['title', 'transaction.duration', 'timestamp'],
+              query: queryFilter,
+              field: [
+                'title',
+                'p50(transaction.duration)',
+                'p75(transaction.duration)',
+                'p95(transaction.duration)',
+              ],
+              yAxis: 'count()',
             })}`}
           >
             {row[column.key]}

--- a/static/app/views/starfish/components/facetInsights.tsx
+++ b/static/app/views/starfish/components/facetInsights.tsx
@@ -18,8 +18,7 @@ type Props = {
 };
 
 type DataRow = {
-  count: number;
-  // p50: Series;
+  p50: Series;
   tagKey: string;
   tagValue: string;
   throughput: Series;
@@ -35,11 +34,11 @@ const COLUMN_ORDER = [
   {
     key: 'tagValue',
     name: 'Value',
-    width: 300,
+    width: 200,
   },
   {
-    key: 'count',
-    name: 'count',
+    key: 'p50',
+    name: 'p50(duration)',
     width: 200,
   },
   {
@@ -99,8 +98,8 @@ export function FacetInsights({eventView}: Props) {
     transformedData.push({
       tagKey: element.split(',')[0],
       tagValue: element.split(',')[1],
-      count: totals[element].count,
       throughput: transformSeries('throughput', data![element]['count()'].data),
+      p50: transformSeries('p50', data![element]['p75(transaction.duration)'].data),
       tpmCorrelation: categorizeCorrelation(totals[element].sum_correlation),
     });
   }
@@ -121,10 +120,10 @@ export function FacetInsights({eventView}: Props) {
 }
 
 function renderBodyCell(column: GridColumnHeader, row: DataRow): React.ReactNode {
-  if (column.key === 'throughput') {
+  if (column.key === 'throughput' || column.key === 'p50') {
     return (
       <Sparkline
-        color={CHART_PALETTE[3][0]}
+        color={column.key === 'throughput' ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1]}
         series={row[column.key]}
         width={column.width ? column.width - column.width / 5 : undefined}
       />

--- a/static/app/views/starfish/components/facetInsights.tsx
+++ b/static/app/views/starfish/components/facetInsights.tsx
@@ -156,13 +156,13 @@ export function FacetInsights({eventView}: Props) {
 
 function categorizeCorrelation(correlation: number): string {
   if (correlation >= 0.8) {
-    return 'very high correlation';
+    return 'very highly correlated';
   }
   if (correlation >= 0.6) {
-    return 'high correlation';
+    return 'highly correlated';
   }
   if (correlation >= 0.4) {
-    return 'medium correlation';
+    return 'correlated';
   }
   return 'no/low correlation';
 }

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -20,6 +20,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import withApi from 'sentry/utils/withApi';
 import FacetBreakdownBar from 'sentry/views/starfish/components/breakdownBar';
 import Chart from 'sentry/views/starfish/components/chart';
+import {FacetInsights} from 'sentry/views/starfish/components/facetInsights';
 import EndpointTable from 'sentry/views/starfish/modules/APIModule/endpointTable';
 import DatabaseTableView from 'sentry/views/starfish/modules/databaseModule/databaseTableView';
 import {useQueryMainTable} from 'sentry/views/starfish/modules/databaseModule/queries';
@@ -214,6 +215,8 @@ export default function EndpointOverview() {
             title={t('Where is time spent in this endpoint?')}
             transaction={transaction as string}
           />
+          <SubHeader>{t('Correlations')}</SubHeader>
+          <FacetInsights eventView={eventView} />
           <SubHeader>{t('HTTP Spans')}</SubHeader>
           <EndpointTable
             location={location}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -164,7 +164,7 @@ export default function EndpointOverview() {
                       <SubHeader>{t('Throughput')}</SubHeader>
                       <Chart
                         statsPeriod={(statsPeriod as string) ?? '24h'}
-                        height={140}
+                        height={150}
                         data={results?.[0] ? [results?.[0]] : []}
                         start=""
                         end=""
@@ -187,7 +187,7 @@ export default function EndpointOverview() {
                       <SubHeader>{t('p50(duration)')}</SubHeader>
                       <Chart
                         statsPeriod={(statsPeriod as string) ?? '24h'}
-                        height={140}
+                        height={150}
                         data={results?.[1] ? [results?.[1]] : []}
                         start=""
                         end=""

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -164,7 +164,7 @@ export default function EndpointOverview() {
                       <SubHeader>{t('Throughput')}</SubHeader>
                       <Chart
                         statsPeriod={(statsPeriod as string) ?? '24h'}
-                        height={110}
+                        height={140}
                         data={results?.[0] ? [results?.[0]] : []}
                         start=""
                         end=""
@@ -187,7 +187,7 @@ export default function EndpointOverview() {
                       <SubHeader>{t('p50(duration)')}</SubHeader>
                       <Chart
                         statsPeriod={(statsPeriod as string) ?? '24h'}
-                        height={110}
+                        height={140}
                         data={results?.[1] ? [results?.[1]] : []}
                         start=""
                         end=""

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -87,7 +87,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
               />
               <FailureRateChart
                 statsPeriod={eventView.statsPeriod}
-                height={120}
+                height={145}
                 data={transformedData}
                 start={eventView.start as string}
                 end={eventView.end as string}
@@ -155,7 +155,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
           return (
             <Chart
               statsPeriod="24h"
-              height={120}
+              height={145}
               data={transformedData}
               start=""
               end=""


### PR DESCRIPTION
Adds a 'correlation' table in the endpoint overview that
shows some facet correlation. Clicking on a facet takes
you to discover for sample events (for now)