### PR TITLE
feat(txnames): Expose more data in debugging endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -8,6 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.utils import get_date_range_from_stats_period
 from sentry.ingest.transaction_clusterer.datasource import redis, snuba
+from sentry.ingest.transaction_clusterer.rules import get_redis_rules, get_rules
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 
 
@@ -51,7 +52,9 @@ class ProjectTransactionNamesCluster(ProjectEndpoint):
                 "meta": {
                     "unique_transaction_names": transaction_names
                     if return_all_names
-                    else len(transaction_names)
+                    else len(transaction_names),
+                    "rules_redis": get_redis_rules(project),
+                    "rules_projectoption": get_rules(project),
                 },
             }
         )

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -148,11 +148,13 @@ def _now() -> int:
     return int(datetime.now(timezone.utc).timestamp())
 
 
-def _get_rules(project: Project) -> RuleSet:
+def get_rules(project: Project) -> RuleSet:
+    """Get rules from project option"""
     return ProjectOptionRuleStore().read(project)
 
 
 def get_redis_rules(project: Project) -> RuleSet:
+    """Get rules from redis"""
     return RedisRuleStore().read(project)
 
 

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -149,12 +149,12 @@ def _now() -> int:
 
 
 def get_rules(project: Project) -> RuleSet:
-    """Get rules from project option"""
+    """Get rules from project options."""
     return ProjectOptionRuleStore().read(project)
 
 
 def get_redis_rules(project: Project) -> RuleSet:
-    """Get rules from redis"""
+    """Get rules from Redis."""
     return RedisRuleStore().read(project)
 
 

--- a/tests/sentry/api/endpoints/test_project_transaction_names.py
+++ b/tests/sentry/api/endpoints/test_project_transaction_names.py
@@ -56,7 +56,9 @@ class ProjectTransactionNamesClusterTest(APITestCase):
         assert data == {
             "rules": ["/a/*/**"],
             "meta": {
-                "unique_transaction_names": ["/a/b/c/", "/a/foo", "/a/whathever/c/d/", "/not_a/"]
+                "rules_projectoption": {},
+                "rules_redis": {},
+                "unique_transaction_names": ["/a/b/c/", "/a/foo", "/a/whathever/c/d/", "/not_a/"],
             },
         }
 


### PR DESCRIPTION
Expose redis and project option rules in the endpoint used for debugging transaction clustering.

We were already able to get the project option rules in the overall project API endpoint, but the redis data with the most recent "last used" updates was hidden.

ref: https://github.com/getsentry/team-ingest/issues/124