### PR TITLE
feat(replays): make error_has_replay use event.contexts

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -20,6 +20,7 @@ import {defined} from 'sentry/utils';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 import {getDaysSinceDatePrecise} from 'sentry/utils/getDaysSinceDate';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 
 function isTombstone(maybe: BaseGroup | Event | GroupTombstone): maybe is GroupTombstone {
   return !maybe.hasOwnProperty('type');
@@ -311,7 +312,7 @@ export function getAnalyticsDataForEvent(event?: Event | null): BaseEventAnalyti
     sdk_name: event?.sdk?.name,
     sdk_version: event?.sdk?.version,
     release_user_agent: event?.release?.userAgent,
-    error_has_replay: Boolean(event?.tags?.find(({key}) => key === 'replayId')),
+    error_has_replay: Boolean(getReplayIdFromEvent(event)),
     error_has_user_feedback: defined(event?.userReport),
     has_otel: event?.contexts?.otel !== undefined,
   };

--- a/static/app/utils/replays/getReplayIdFromEvent.tsx
+++ b/static/app/utils/replays/getReplayIdFromEvent.tsx
@@ -1,6 +1,6 @@
 import {Event} from 'sentry/types';
 
-export function getReplayIdFromEvent(event?: Event) {
+export function getReplayIdFromEvent(event: Event | null | undefined) {
   const replayTagId = event?.tags?.find(({key}) => key === 'replayId')?.value;
   const replayContextId = event?.contexts?.replay?.replay_id;
 


### PR DESCRIPTION
## Summary
A replayId appears also in `event.contexts` so the `error_has_replay` attribute needs to be updated.