### PR TITLE
feat(issues): Add issue state tabs to the issues stream

### DIFF
--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -1,0 +1,15 @@
+import {getTabs} from './utils';
+
+describe('getTabs', () => {
+  it('should enable/disable tabs for escalating-issues-ui', () => {
+    expect(
+      getTabs(TestStubs.Organization({features: ['escalating-issues-ui']})).map(
+        tab => tab[1].name
+      )
+    ).toEqual(['Unresolved', 'New', 'Escalating', 'Ongoing', 'Archived']);
+
+    expect(
+      getTabs(TestStubs.Organization({features: []})).map(tab => tab[1].name)
+    ).toEqual(['All Unresolved', 'For Review', 'Ignored']);
+  });
+});

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -7,7 +7,10 @@ export enum Query {
   FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
+  NEW = 'is:new',
   ARCHIVED = 'is:archived',
+  ESCALATING = 'is:escalating',
+  ONGOING = 'is:ongoing',
   REPROCESSING = 'is:reprocessing',
 }
 
@@ -39,11 +42,12 @@ type OverviewTab = {
  * Get a list of currently active tabs
  */
 export function getTabs(organization: Organization) {
+  const hasEscalatingIssuesUi = organization.features.includes('escalating-issues-ui');
   const tabs: Array<[string, OverviewTab]> = [
     [
       Query.UNRESOLVED,
       {
-        name: t('All Unresolved'),
+        name: hasEscalatingIssuesUi ? t('Unresolved') : t('All Unresolved'),
         analyticsName: 'unresolved',
         count: true,
         enabled: true,
@@ -55,35 +59,61 @@ export function getTabs(organization: Organization) {
         name: t('For Review'),
         analyticsName: 'needs_review',
         count: true,
-        enabled: true,
+        enabled: !hasEscalatingIssuesUi,
         tooltipTitle:
           t(`Issues are marked for review when they are created, unresolved, or unignored.
           Mark an issue reviewed to move it out of this list.
           Issues are automatically marked reviewed in 7 days.`),
       },
     ],
-    organization.features.includes('escalating-issues-ui')
-      ? [
-          Query.ARCHIVED,
-          {
-            name: t('Archived'),
-            analyticsName: 'archived',
-            count: true,
-            enabled: true,
-            tooltipTitle: t(`Archived issues don’t trigger alerts.`),
-          },
-        ]
-      : [
-          Query.IGNORED,
-          {
-            name: t('Ignored'),
-            analyticsName: 'ignored',
-            count: true,
-            enabled: true,
-            tooltipTitle: t(`Ignored issues don’t trigger alerts. When their ignore
+    [
+      Query.NEW,
+      {
+        name: t('New'),
+        analyticsName: 'new',
+        count: true,
+        enabled: hasEscalatingIssuesUi,
+      },
+    ],
+    [
+      Query.ESCALATING,
+      {
+        name: t('Escalating'),
+        analyticsName: 'escalating',
+        count: true,
+        enabled: hasEscalatingIssuesUi,
+      },
+    ],
+    [
+      Query.ONGOING,
+      {
+        name: t('Ongoing'),
+        analyticsName: 'ongoing',
+        count: true,
+        enabled: hasEscalatingIssuesUi,
+      },
+    ],
+    [
+      Query.ARCHIVED,
+      {
+        name: t('Archived'),
+        analyticsName: 'archived',
+        count: true,
+        enabled: hasEscalatingIssuesUi,
+        tooltipTitle: t(`Archived issues don’t trigger alerts.`),
+      },
+    ],
+    [
+      Query.IGNORED,
+      {
+        name: t('Ignored'),
+        analyticsName: 'ignored',
+        count: true,
+        enabled: !hasEscalatingIssuesUi,
+        tooltipTitle: t(`Ignored issues don’t trigger alerts. When their ignore
         conditions are met they become Unresolved and are flagged for review.`),
-          },
-        ],
+      },
+    ],
     [
       Query.REPROCESSING,
       {

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -100,7 +100,6 @@ export function getTabs(organization: Organization) {
         analyticsName: 'archived',
         count: true,
         enabled: hasEscalatingIssuesUi,
-        tooltipTitle: t(`Archived issues don’t trigger alerts.`),
       },
     ],
     [


### PR DESCRIPTION
Adds tabs for new, ongoing, escalating to the issues stream

<img width="865" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/cf5e34f4-4c50-4567-8d04-86d08b26451d">

fixes #48304
