### PR TITLE
fix(discover): Link unparameterized transaction banner to correct docs page

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -537,7 +537,7 @@ export class Results extends Component<Props, State> {
             'These are unparameterized transactions. To better organize your transactions, [link:set transaction names manually].',
             {
               link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/#parameterized-transaction-names" />
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/performance/instrumentation/automatic-instrumentation/#beforenavigate" />
               ),
             }
           )}


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-docs/issues/6923