### PR TITLE
ref: Update QuickContext HoverHeader to use CopyToClipboardButton

### DIFF
--- a/static/app/views/discover/table/quickContext/quickContextWrapper.spec.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.spec.tsx
@@ -137,7 +137,7 @@ describe('Quick Context', function () {
       expect(await screen.findByText(/Issue/i)).toBeInTheDocument();
       expect(screen.getByText(/SENTRY-VVY/i)).toBeInTheDocument();
       expect(
-        screen.getByTestId('quick-context-hover-header-copy-icon')
+        screen.getByTestId('quick-context-hover-header-copy-button')
       ).toBeInTheDocument();
     });
 
@@ -167,7 +167,7 @@ describe('Quick Context', function () {
       expect(screen.getByText(/22.10.0/i)).toBeInTheDocument();
       expect(screen.getByText(/(aaf33944f93d)/i)).toBeInTheDocument();
       expect(
-        screen.getByTestId('quick-context-hover-header-copy-icon')
+        screen.getByTestId('quick-context-hover-header-copy-button')
       ).toBeInTheDocument();
     });
 
@@ -185,7 +185,7 @@ describe('Quick Context', function () {
       expect(await screen.findByText(/Event ID/i)).toBeInTheDocument();
       expect(screen.getByText(/6b43e285/i)).toBeInTheDocument();
       expect(
-        screen.getByTestId('quick-context-hover-header-copy-icon')
+        screen.getByTestId('quick-context-hover-header-copy-button')
       ).toBeInTheDocument();
     });
   });

--- a/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
@@ -131,9 +131,8 @@ function HoverHeader({
 
         {!hideCopy && copyContent && (
           <CopyToClipboardButton
+            borderless
             data-test-id="quick-context-hover-header-copy-button"
-            text={copyContent}
-            size="zero"
             iconSize="xs"
             onCopy={() => {
               trackAnalytics('discover_v2.quick_context_header_copy', {
@@ -141,6 +140,8 @@ function HoverHeader({
                 clipBoardTitle: title,
               });
             }}
+            size="zero"
+            text={copyContent}
           />
         )}
       </HoverHeaderContent>

--- a/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import Clipboard from 'sentry/components/clipboard';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Body, Hovercard} from 'sentry/components/hovercard';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Version from 'sentry/components/version';
-import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
@@ -131,19 +130,18 @@ function HoverHeader({
         {copyLabel}
 
         {!hideCopy && copyContent && (
-          <Clipboard value={copyContent}>
-            <IconCopy
-              cursor="pointer"
-              data-test-id="quick-context-hover-header-copy-icon"
-              size="xs"
-              onClick={() => {
-                trackAnalytics('discover_v2.quick_context_header_copy', {
-                  organization,
-                  clipBoardTitle: title,
-                });
-              }}
-            />
-          </Clipboard>
+          <CopyToClipboardButton
+            data-test-id="quick-context-hover-header-copy-button"
+            text={copyContent}
+            size="zero"
+            iconSize="xs"
+            onCopy={() => {
+              trackAnalytics('discover_v2.quick_context_header_copy', {
+                organization,
+                clipBoardTitle: title,
+              });
+            }}
+          />
         )}
       </HoverHeaderContent>
     </HoverHeaderWrapper>


### PR DESCRIPTION
The change seems straight forward, but i have not been able to bring up this modal in to see it working. 

Relates to https://github.com/getsentry/sentry/issues/48581