### PR TITLE
ref(ui): Fix alignment of compactSelect loading indicator

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -561,9 +561,9 @@ const MenuTitle = styled('span')`
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   && {
-    margin: ${space(0.5)} ${space(0.5)} ${space(0.5)} ${space(1)};
-    height: ${space(1)};
-    width: ${space(1)};
+    margin: 0 ${space(0.5)} 0 ${space(1)};
+    height: 12px;
+    width: 12px;
   }
 `;
 


### PR DESCRIPTION
Before

![clipboard.png](https://i.imgur.com/ICVkzFi.png)

After

![clipboard.png](https://i.imgur.com/puHhq66.png)

The size was 12px but we were setting the container width to 8px. I'm
avoiding using space here since the size is not set using space