### PR TITLE
ref(js): Update MemberListStore to support pagination

### DIFF
--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -63,7 +63,7 @@ function NoteInput({
 }: Props) {
   const theme = useTheme();
 
-  const members = useLegacyStore(MemberListStore).map(member => ({
+  const members = useLegacyStore(MemberListStore).members.map(member => ({
     id: `user:${member.id}`,
     display: member.name,
     email: member.email,

--- a/static/app/components/assigneeSelector.spec.jsx
+++ b/static/app/components/assigneeSelector.spec.jsx
@@ -106,8 +106,7 @@ describe('AssigneeSelector', () => {
       },
     });
 
-    MemberListStore.state = [];
-    MemberListStore.loaded = false;
+    MemberListStore.reset();
   });
 
   // Doesn't need to always be async, but it was easier to prevent flakes this way

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -80,7 +80,10 @@ export class AssigneeSelectorDropdown extends Component<
 
   getInitialState() {
     const group = GroupStore.get(this.props.id);
-    const memberList = MemberListStore.loaded ? MemberListStore.getAll() : undefined;
+    const memberList = MemberListStore.state.loading
+      ? undefined
+      : MemberListStore.getAll();
+
     const loading = GroupStore.hasStatus(this.props.id, 'assignTo');
     const suggestedOwners = group?.owners;
 
@@ -137,8 +140,8 @@ export class AssigneeSelectorDropdown extends Component<
 
   unlisteners = [
     GroupStore.listen(itemIds => this.onGroupChange(itemIds), undefined),
-    MemberListStore.listen((users: User[]) => {
-      this.handleMemberListUpdate(users);
+    MemberListStore.listen(({members}: typeof MemberListStore.state) => {
+      this.handleMemberListUpdate(members);
     }, undefined),
   ];
 

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -73,8 +73,7 @@ describe('Group > AssignedTo', () => {
     MockApiClient.clearMockResponses();
     GroupStore.reset();
     TeamStore.reset();
-    MemberListStore.state = [];
-    MemberListStore.loaded = false;
+    MemberListStore.reset();
   });
 
   const openMenu = async () => {

--- a/static/app/components/selectMembers/index.tsx
+++ b/static/app/components/selectMembers/index.tsx
@@ -60,7 +60,7 @@ class SelectMembers extends Component<Props, State> {
     loading: false,
     inputValue: '',
     options: null,
-    memberListLoading: !MemberListStore.isLoaded(),
+    memberListLoading: MemberListStore.state.loading,
   };
 
   componentWillUnmount() {
@@ -68,11 +68,10 @@ class SelectMembers extends Component<Props, State> {
   }
 
   unlisteners = [
-    MemberListStore.listen(() => {
-      this.setState({
-        memberListLoading: !MemberListStore.isLoaded(),
-      });
-    }, undefined),
+    MemberListStore.listen(
+      () => this.setState({memberListLoading: MemberListStore.state.loading}),
+      undefined
+    ),
   ];
 
   renderUserBadge = (user: User) => (

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1936,7 +1936,7 @@ class SmartSearchBarContainer extends Component<Props, ContainerState> {
   }
 
   unsubscribe = MemberListStore.listen(
-    (members: ContainerState['members']) => this.setState({members}),
+    ({members}: typeof MemberListStore.state) => this.setState({members}),
     undefined
   );
 

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -2,46 +2,67 @@ import {createStore, StoreDefinition} from 'reflux';
 
 import {User} from 'sentry/types';
 
+type State = {
+  cursor: string | null;
+  hasMore: boolean | null;
+  loading: boolean;
+  members: User[];
+};
+
+// XXX(epurkhiser): Either this store is completely wrong, or it is misnamed, a
+// `Member` has one `User`, this stores users not members.
+
 interface MemberListStoreDefinition extends StoreDefinition {
   getAll(): User[];
   getById(memberId: string): User | undefined;
-  getState(): User[];
+  getState(): State;
   init(): void;
-  isLoaded(): boolean;
-  loadInitialData(items: User[]): void;
-  loaded: boolean;
-  state: User[];
+  loadInitialData(items: User[], hasMore?: boolean | null, cursor?: string | null): void;
+  reset(): void;
+  state: State;
 }
 
 const storeConfig: MemberListStoreDefinition = {
-  loaded: false,
-  state: [],
+  state: {
+    members: [],
+    loading: true,
+    hasMore: null,
+    cursor: null,
+  },
 
   init() {
     // XXX: Do not use `this.listenTo` in this store. We avoid usage of reflux
     // listeners due to their leaky nature in tests.
 
-    this.state = [];
-    this.loaded = false;
+    this.reset();
   },
 
-  // TODO(dcramer): this should actually come from an action of some sorts
-  loadInitialData(items: User[]) {
-    this.state = items;
-    this.loaded = true;
+  reset() {
+    this.state = {
+      members: [],
+      loading: true,
+      hasMore: null,
+      cursor: null,
+    };
+  },
+
+  loadInitialData(items: User[], hasMore, cursor) {
+    this.state = {
+      members: items,
+      loading: false,
+      hasMore: hasMore ?? this.state.hasMore,
+      cursor: cursor ?? this.state.cursor,
+    };
+
     this.trigger(this.state, 'initial');
   },
 
-  isLoaded() {
-    return this.loaded;
-  },
-
   getById(memberId) {
-    return this.state.find(({id}) => memberId === id);
+    return this.state.members.find(({id}) => memberId === id);
   },
 
   getAll() {
-    return this.state;
+    return this.state.members;
   },
 
   getState() {

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -103,9 +103,12 @@ function withIssueTags<Props extends WithIssueTagsProps>(
 
     // Listen to member store updates and cleanup listener on unmount
     useEffect(() => {
-      const unsubscribeMembers = MemberListStore.listen((users: User[]) => {
-        setAssigned({users});
-      }, undefined);
+      const unsubscribeMembers = MemberListStore.listen(
+        ({members}: typeof MemberListStore.state) => {
+          setAssigned({users: members});
+        },
+        undefined
+      );
 
       return () => unsubscribeMembers();
     }, [setAssigned]);

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -39,9 +39,9 @@ function IssueWidgetQueries({
   const [memberListStoreLoaded, setMemberListStoreLoaded] = useState(false);
 
   useEffect(() => {
-    setMemberListStoreLoaded(MemberListStore.isLoaded());
+    setMemberListStoreLoaded(!MemberListStore.state.loading);
     const unlistener = MemberListStore.listen(() => {
-      setMemberListStoreLoaded(MemberListStore.isLoaded());
+      setMemberListStoreLoaded(!MemberListStore.state.loading);
     }, undefined);
     return () => unlistener();
   }, []);

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -129,7 +129,7 @@ class ProjectContext extends Component<Props, State> {
   );
 
   unsubscribeMembers = MemberListStore.listen(
-    (memberList: (typeof MemberListStore)['state']) => this.setState({memberList}),
+    ({members}: typeof MemberListStore.state) => this.setState({memberList: members}),
     undefined
   );
 


### PR DESCRIPTION
Right now we don't store the cursor or if there are more members to load
in the member store, we need this to properly handle loading more
members via pagination (via something like a useMembers)