### PR TITLE
ref(js): Drop @emotion css-prop type import

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -30,6 +30,7 @@
     // Don't do anything to JSX. This doesn't really matter since we don't use
     // typescript to compile files, but left here for documentation purposes.
     "jsx": "preserve",
+    "jsxImportSource": "@emotion/react",
 
     // Type checking specific options
     "alwaysStrict": false,

--- a/static/app/components/gridEditable/sortLink.tsx
+++ b/static/app/components/gridEditable/sortLink.tsx
@@ -1,7 +1,6 @@
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {LocationDescriptorObject} from 'history';
-import omit from 'lodash/omit';
 
 import Link from 'sentry/components/links/link';
 import {IconArrow} from 'sentry/icons';
@@ -57,7 +56,10 @@ type LinkProps = React.ComponentPropsWithoutRef<typeof Link>;
 type StyledLinkProps = LinkProps & {align: Alignments};
 
 const StyledLink = styled((props: StyledLinkProps) => {
-  const forwardProps = omit(props, ['align', 'css']);
+  // @ts-ignore It doesn't look like the `css` property is a part of the props,
+  // but prior to this style of destructure-omitting it, it was being omitted
+  // with lodash.omit. I mean keeping it omitted here just in case.
+  const {align: _align, css: _css, ...forwardProps} = props;
   return <Link {...forwardProps} />;
 })`
   display: block;

--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import {useCallback} from 'react';
 import {Location} from 'history';
 
 import Count from 'sentry/components/count';

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -7,9 +7,6 @@
  * When importing types prefer importing from `sentry/types` when possible for ergonomic and ease of updating and
  * re-organizing types in the future.
  */
-// XXX(epurkhiser): When we switch to the new React JSX runtime we will no
-// longer need this import and can drop babel-preset-css-prop for babel-preset.
-/// <reference types="@emotion/react/types/css-prop" />
 
 export * from './auth';
 export * from './core';

--- a/static/app/utils/useApiRequests.spec.tsx
+++ b/static/app/utils/useApiRequests.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import trimStart from 'lodash/trimStart';
 import uniqBy from 'lodash/uniqBy';

--- a/static/app/views/issueList/issueCategoryFilter.tsx
+++ b/static/app/views/issueList/issueCategoryFilter.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';

--- a/static/app/views/starfish/views/spans/index.tsx
+++ b/static/app/views/starfish/views/spans/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import {Location} from 'history';
 


### PR DESCRIPTION
we've been on the new jsx transform for a while, but we never correctly set `"jsxImportSource": "@emotion/react"` like we were supposed to.