### PR TITLE
ref(utils): Make `handleXhrErrorResponse` actually handle error responses

### DIFF
--- a/static/app/actionCreators/project.tsx
+++ b/static/app/actionCreators/project.tsx
@@ -21,7 +21,7 @@ export function fetchProjectDetails({
 
   promise.then(ProjectsStore.onUpdateSuccess).catch(error => {
     const message = t('Unable to fetch project details');
-    handleXhrErrorResponse(message)(error);
+    handleXhrErrorResponse(message, error);
     addErrorMessage(message);
   });
 

--- a/static/app/actionCreators/project.tsx
+++ b/static/app/actionCreators/project.tsx
@@ -1,5 +1,5 @@
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {Project} from 'sentry/types';
@@ -19,7 +19,7 @@ export function fetchProjectDetails({
 }): Promise<Project> {
   const promise = api.requestPromise(`/projects/${orgSlug}/${projSlug}/`);
 
-  promise.then(ProjectsStore.onUpdateSuccess).catch(error => {
+  promise.then(ProjectsStore.onUpdateSuccess).catch((error: ResponseMeta) => {
     const message = t('Unable to fetch project details');
     handleXhrErrorResponse(message, error);
     addErrorMessage(message);

--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -61,7 +61,7 @@ export function fetchRecentSearches(
 
   promise.catch(resp => {
     if (resp.status !== 401 && resp.status !== 403) {
-      handleXhrErrorResponse('Unable to fetch recent searches')(resp);
+      handleXhrErrorResponse('Unable to fetch recent searches', resp);
     }
   });
 

--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -61,7 +61,7 @@ export function fetchRecentSearches(
     },
   });
 
-  promise.catch(resp => {
+  promise.catch((resp: ResponseMeta) => {
     if (resp.status !== 401 && resp.status !== 403) {
       handleXhrErrorResponse('Unable to fetch recent searches', resp);
     }

--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -1,4 +1,4 @@
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {MAX_AUTOCOMPLETE_RECENT_SEARCHES} from 'sentry/constants';
 import {RecentSearch, SavedSearch, SavedSearchType} from 'sentry/types';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
@@ -29,7 +29,9 @@ export function saveRecentSearch(
     },
   });
 
-  promise.catch(handleXhrErrorResponse('Unable to save a recent search'));
+  promise.catch((resp: ResponseMeta) =>
+    handleXhrErrorResponse('Unable to save a recent search', resp)
+  );
 
   return promise;
 }

--- a/static/app/components/forms/controls/selectAsyncControl.tsx
+++ b/static/app/components/forms/controls/selectAsyncControl.tsx
@@ -3,7 +3,7 @@ import ReactSelect from 'react-select';
 import debounce from 'lodash/debounce';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {t} from 'sentry/locale';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 
@@ -91,7 +91,7 @@ class SelectAsyncControl extends Component<SelectAsyncControlProps> {
         const {onResults} = this.props;
         return typeof onResults === 'function' ? onResults(resp) : resp;
       },
-      err => {
+      (err: ResponseMeta) => {
         addErrorMessage(t('There was a problem with the request.'));
         handleXhrErrorResponse('SelectAsync failed', err);
         // eslint-disable-next-line no-console

--- a/static/app/components/forms/controls/selectAsyncControl.tsx
+++ b/static/app/components/forms/controls/selectAsyncControl.tsx
@@ -93,7 +93,7 @@ class SelectAsyncControl extends Component<SelectAsyncControlProps> {
       },
       err => {
         addErrorMessage(t('There was a problem with the request.'));
-        handleXhrErrorResponse('SelectAsync failed')(err);
+        handleXhrErrorResponse('SelectAsync failed', err);
         // eslint-disable-next-line no-console
         console.error(err);
       }

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -171,6 +171,10 @@ function AddToDashboardModal({
       closeModal();
       addSuccessMessage(t('Successfully added widget to dashboard'));
     } catch (e) {
+      // TODO: Seems like we won't ever get here, since `updateDashboard`
+      // already includes a `.catch()` on the promise it returns. Does this even
+      // need to be in a try-catch? The existing `.catch()` calls
+      // `addErrorMessage`, but should it also call `handleXhrErrorResponse`?
       const errorMessage = t('Unable to add widget to dashboard');
       handleXhrErrorResponse(errorMessage, e);
       addErrorMessage(errorMessage);

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -172,7 +172,7 @@ function AddToDashboardModal({
       addSuccessMessage(t('Successfully added widget to dashboard'));
     } catch (e) {
       const errorMessage = t('Unable to add widget to dashboard');
-      handleXhrErrorResponse(errorMessage)(e);
+      handleXhrErrorResponse(errorMessage, e);
       addErrorMessage(errorMessage);
     }
   }

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -91,7 +91,7 @@ export function CustomMeasurementsProvider({
           const errorResponse =
             e?.responseJSON ?? t('Unable to fetch custom performance metrics');
           addErrorMessage(errorResponse);
-          handleXhrErrorResponse(errorResponse)(e);
+          handleXhrErrorResponse(errorResponse, e);
         });
     }
 

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {Query} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {getFieldTypeFromUnit} from 'sentry/components/events/eventCustomPerformanceMetrics';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
@@ -83,7 +83,7 @@ export function CustomMeasurementsProvider({
 
           setState({customMeasurements: newCustomMeasurements});
         })
-        .catch(e => {
+        .catch((e: ResponseMeta) => {
           if (shouldCancelRequest) {
             return;
           }

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -88,8 +88,7 @@ export function CustomMeasurementsProvider({
             return;
           }
 
-          const errorResponse =
-            e?.responseJSON ?? t('Unable to fetch custom performance metrics');
+          const errorResponse = t('Unable to fetch custom performance metrics');
           addErrorMessage(errorResponse);
           handleXhrErrorResponse(errorResponse, e);
         });

--- a/static/app/utils/handleXhrErrorResponse.spec.jsx
+++ b/static/app/utils/handleXhrErrorResponse.spec.jsx
@@ -13,23 +13,24 @@ describe('handleXhrErrorResponse', function () {
   });
 
   it('does nothing if we have invalid response', function () {
-    handleXhrErrorResponse('')(null);
+    handleXhrErrorResponse('', null);
     expect(Sentry.captureException).not.toHaveBeenCalled();
-    handleXhrErrorResponse('')({});
+    handleXhrErrorResponse('', {});
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('captures an exception to sdk when `resp.detail` is a string', function () {
-    handleXhrErrorResponse('String error')(stringError);
+    handleXhrErrorResponse('String error', stringError);
     expect(Sentry.captureException).toHaveBeenCalledWith(new Error('String error'));
   });
 
   it('captures an exception to sdk when `resp.detail` is an object', function () {
-    handleXhrErrorResponse('Object error')(objError);
+    handleXhrErrorResponse('Object error', objError);
     expect(Sentry.captureException).toHaveBeenCalledWith(new Error('Object error'));
   });
+
   it('ignores `sudo-required` errors', function () {
-    handleXhrErrorResponse('Sudo required error')({
+    handleXhrErrorResponse('Sudo required error', {
       status: 401,
       responseJSON: {
         detail: {

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -2,40 +2,38 @@ import * as Sentry from '@sentry/react';
 
 import {ResponseMeta} from 'sentry/api';
 
-export default function handleXhrErrorResponse(message: string) {
-  return (resp: ResponseMeta) => {
-    if (!resp) {
-      return;
-    }
-    if (!resp.responseJSON) {
-      return;
-    }
+export default function handleXhrErrorResponse(message: string, resp: ResponseMeta) {
+  if (!resp) {
+    return;
+  }
+  if (!resp.responseJSON) {
+    return;
+  }
 
-    const {responseJSON} = resp;
+  const {responseJSON} = resp;
 
-    // If this is a string then just capture it as error
-    if (typeof responseJSON.detail === 'string') {
-      Sentry.withScope(scope => {
-        scope.setExtra('status', resp.status);
-        scope.setExtra('detail', responseJSON.detail);
-        Sentry.captureException(new Error(message));
-      });
-      return;
-    }
+  // If this is a string then just capture it as error
+  if (typeof responseJSON.detail === 'string') {
+    Sentry.withScope(scope => {
+      scope.setExtra('status', resp.status);
+      scope.setExtra('detail', responseJSON.detail);
+      Sentry.captureException(new Error(message));
+    });
+    return;
+  }
 
-    // Ignore sudo-required errors
-    if (responseJSON.detail && responseJSON.detail.code === 'sudo-required') {
-      return;
-    }
+  // Ignore sudo-required errors
+  if (responseJSON.detail && responseJSON.detail.code === 'sudo-required') {
+    return;
+  }
 
-    if (responseJSON.detail && typeof responseJSON.detail.message === 'string') {
-      Sentry.withScope(scope => {
-        scope.setExtra('status', resp.status);
-        scope.setExtra('detail', responseJSON.detail);
-        scope.setExtra('code', responseJSON.detail.code);
-        Sentry.captureException(new Error(message));
-      });
-      return;
-    }
-  };
+  if (responseJSON.detail && typeof responseJSON.detail.message === 'string') {
+    Sentry.withScope(scope => {
+      scope.setExtra('status', resp.status);
+      scope.setExtra('detail', responseJSON.detail);
+      scope.setExtra('code', responseJSON.detail.code);
+      Sentry.captureException(new Error(message));
+    });
+    return;
+  }
 }

--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -75,7 +75,7 @@ function ReleasesProvider({
           return;
         }
 
-        const errorResponse = e?.responseJSON ?? t('Unable to fetch releases');
+        const errorResponse = t('Unable to fetch releases');
         addErrorMessage(errorResponse);
         setLoading(false);
         handleXhrErrorResponse(errorResponse, e);

--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -78,7 +78,7 @@ function ReleasesProvider({
         const errorResponse = e?.responseJSON ?? t('Unable to fetch releases');
         addErrorMessage(errorResponse);
         setLoading(false);
-        handleXhrErrorResponse(errorResponse)(e);
+        handleXhrErrorResponse(errorResponse, e);
       });
     return () => {
       shouldCancelRequest = true;

--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -1,7 +1,7 @@
 import {createContext, useContext, useEffect, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Release} from 'sentry/types';
@@ -69,7 +69,7 @@ function ReleasesProvider({
         setLoading(false);
         setReleases(response);
       })
-      .catch(e => {
+      .catch((e: ResponseMeta) => {
         if (shouldCancelRequest) {
           setLoading(false);
           return;

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -248,7 +248,7 @@ function Onboarding(props: Props) {
         project_id: recentCreatedProject.id,
       });
     } catch (error) {
-      handleXhrErrorResponse(t('Unable to delete project in onboarding'))(error);
+      handleXhrErrorResponse(t('Unable to delete project in onboarding'), error);
       // we don't give the user any feedback regarding this error as this shall be silent
     }
   }, [api, organization, recentCreatedProject, onboardingContext]);

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -103,7 +103,7 @@ export function SetupDocsLoader({
       setProjectKeyUpdateError(false);
     } catch (error) {
       const message = t('Unable to updated dynamic SDK loader configuration');
-      handleXhrErrorResponse(message)(error);
+      handleXhrErrorResponse(message, error);
       setProjectKeyUpdateError(true);
     }
   }, [api, location.query.product, organization.slug, project.slug, projectKey?.id]);

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -99,7 +99,7 @@ export function LoaderSettings({keyId, orgSlug, project, projectKey}: Props) {
         addSuccessMessage(t('Successfully updated dynamic SDK loader configuration'));
       } catch (error) {
         const message = t('Unable to updated dynamic SDK loader configuration');
-        handleXhrErrorResponse(message)(error);
+        handleXhrErrorResponse(message, error);
         addErrorMessage(message);
       }
     },
@@ -146,7 +146,7 @@ export function LoaderSettings({keyId, orgSlug, project, projectKey}: Props) {
         addSuccessMessage(t('Successfully updated SDK version'));
       } catch (error) {
         const message = t('Unable to updated SDK version');
-        handleXhrErrorResponse(message)(error);
+        handleXhrErrorResponse(message, error);
         addErrorMessage(message);
       }
     },

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
@@ -190,7 +190,7 @@ function CustomRepositories({
         'Rate limit for refreshing repository exceeded. Try again in a few minutes.'
       );
       addErrorMessage(errorMessage);
-      handleXhrErrorResponse(errorMessage)(error);
+      handleXhrErrorResponse(errorMessage, error);
     }
   }
 

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -110,7 +110,7 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
       window.location.assign('/');
     } catch (err) {
       if (err.status >= 500) {
-        handleXhrErrorResponse('Unable to transfer project')(err);
+        handleXhrErrorResponse('Unable to transfer project', err);
       }
     }
   };

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -7,6 +7,7 @@ import {
   removeProject,
   transferProject,
 } from 'sentry/actionCreators/projects';
+import {ResponseMeta} from 'sentry/api';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
@@ -88,10 +89,13 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
           throw err;
         }
       )
-      .then(() => {
-        // Need to hard reload because lots of components do not listen to Projects Store
-        window.location.assign('/');
-      }, handleXhrErrorResponse('Unable to remove project'));
+      .then(
+        () => {
+          // Need to hard reload because lots of components do not listen to Projects Store
+          window.location.assign('/');
+        },
+        (err: ResponseMeta) => handleXhrErrorResponse('Unable to remove project', err)
+      );
   };
 
   handleTransferProject = async () => {

--- a/static/app/views/settings/projectIssueGrouping/upgradeGrouping.tsx
+++ b/static/app/views/settings/projectIssueGrouping/upgradeGrouping.tsx
@@ -88,8 +88,8 @@ function UpgradeGrouping({
       clearIndicators();
       ProjectsStore.onUpdateSuccess(response);
       onUpgrade();
-    } catch {
-      handleXhrErrorResponse(t('Unable to upgrade config'));
+    } catch (err) {
+      handleXhrErrorResponse(t('Unable to upgrade config'), err);
     }
   }
 


### PR DESCRIPTION
_Part of https://github.com/getsentry/sentry/issues/48981, which aims to improve the way we handle errors in our frontend API client._

Currently, our `handleXhrErrorResponse` helper function does not, as the name might imply, handle error responses arising from XHR requests. Instead, it returns a callback, and that callback does the error handling. That handler almost always gets immediately gets invoked, though, with the result that the majority of the calls to `handleXhrErrorResponse` look like `handleXhrErrorResponse('some error message')(responseMetadata)`. 

This is - at best - unnecessarily complicated and - at worst - misleading and likely to cause bugs. For example, this misnaming makes us prone to doing things like `handleXhrErrorResponse(responseMetadata)`, which then leads to events in Sentry titled `Error: [object Object]`. (You'd think TS would save us from ourselves here, but it doesn't ([and can't](https://github.com/microsoft/TypeScript/issues/7588#issuecomment-261851083)) type thrown errors or promise rejections, and so it's no use.)

![image](https://github.com/getsentry/sentry/assets/14812505/75355f24-539d-4e41-8586-7f2864751472)

To fix this problem, this PR refactors `handleXhrErrorResponse` to do the error handling itself. In places where the callback it currently returns is being immediately invoked, this allows us to have a single call, of the form `handleXhrErrorResponse('some error message', responseMetadata)`, which then _will_ get flagged by TS if you do `handleXhrErrorResponse(responseMetadata)`, because there's a whole argument missing. In the few places where it wasn't being immediately invoked, wrapping the `handleXhrErrorResponse` call in a function converts it back to being a callback.

This also fixes the places where we've been passing an object in place of the error message, and therefore should eliminate all new instances of `Error: [object Object]`.