### PR TITLE
feat(sourcemaps): Return sum of artifacts for artifacts connected to the same release

### DIFF
--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -75,7 +75,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
 
         # We want to first check if there are any bundles that are weakly associated with this release, if so we want
         # to count the artifacts of the newest "ArtifactBundle".
-        last_bundle = release.last_weakly_associated_artifact_bundle()
+        weakly_associated_count = release.count_weakly_associated_artifact_bundles()
         return Response(
             {
                 "version": release.version,
@@ -88,9 +88,9 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "commitFilesChanged": commit_files_changed,
                 # In case there is not artifact bundle that is weakly associated with this release, we check if there is
                 # the old "ReleaseFile". In case the old "ReleaseFile" is not present, we will return 0.
-                "releaseFileCount": release.count_artifacts()
-                if last_bundle is None
-                else last_bundle.artifact_count,
-                "bundleId": None if last_bundle is None else str(last_bundle.bundle_id),
+                "releaseFileCount": weakly_associated_count[1]
+                if weakly_associated_count is not None
+                else release.count_artifacts(),
+                "isArtifactBundle": weakly_associated_count is not None,
             }
         )

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -74,8 +74,8 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
         ]
 
         # We want to first check if there are any bundles that are weakly associated with this release, if so we want
-        # to count the artifacts of the newest "ArtifactBundle".
-        weakly_associated_count = release.count_weakly_associated_artifact_bundles()
+        # to count the sum of their artifacts.
+        weakly_associated_count = release.count_artifacts_in_artifact_bundles()
         return Response(
             {
                 "version": release.version,
@@ -86,7 +86,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "commitCount": release.commit_count,
                 "released": release.date_released or release.date_added,
                 "commitFilesChanged": commit_files_changed,
-                # In case there is not artifact bundle that is weakly associated with this release, we check if there is
+                # In case there is no artifact bundle that is weakly associated with this release, we check if there is
                 # the old "ReleaseFile". In case the old "ReleaseFile" is not present, we will return 0.
                 "releaseFileCount": weakly_associated_count[1]
                 if weakly_associated_count is not None

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1203,10 +1203,8 @@ class Release(Model):
         counts = get_artifact_counts([self.id])
         return counts.get(self.id, 0)
 
-    def count_weakly_associated_artifact_bundles(self):
-        """Counts the number of artifacts in the most recent "ArtifactBundle" that is weakly associated
-        with this release.
-        """
+    def count_artifacts_in_artifact_bundles(self):
+        """Counts the number of artifacts in the artifact bundles associated with this release."""
         qs = (
             ArtifactBundle.objects.filter(
                 organization_id=self.organization.id,

--- a/tests/sentry/api/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_release_meta.py
@@ -116,9 +116,9 @@ class ReleaseMetaTest(APITestCase):
 
         data = json.loads(response.content)
         assert data["releaseFileCount"] == 2
-        assert data["bundleId"] is None
+        assert not data["isArtifactBundle"]
 
-    def test_artifact_count_with_weak_existing_association(self):
+    def test_artifact_count_with_single_weak_association(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.organization
         org.flags.allow_joinleave = False
@@ -151,4 +151,43 @@ class ReleaseMetaTest(APITestCase):
 
         data = json.loads(response.content)
         assert data["releaseFileCount"] == 10
-        assert data["bundleId"] == str(bundle.bundle_id)
+        assert data["isArtifactBundle"]
+
+    def test_artifact_count_with_multiple_weak_association(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        project = self.create_project(teams=[team1], organization=org)
+
+        release = Release.objects.create(organization_id=org.id, version="abcabcabc")
+        release.add_project(project)
+
+        self.create_release_archive(release=release.version)
+
+        self.create_member(teams=[team1], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        bundle_1 = self.create_artifact_bundle(org=org, artifact_count=10)
+        ReleaseArtifactBundle.objects.create(
+            organization_id=org.id, release_name=release.version, artifact_bundle=bundle_1
+        )
+        bundle_2 = self.create_artifact_bundle(org=org, artifact_count=30)
+        ReleaseArtifactBundle.objects.create(
+            organization_id=org.id, release_name=release.version, artifact_bundle=bundle_2
+        )
+
+        url = reverse(
+            "sentry-api-0-organization-release-meta",
+            kwargs={"organization_slug": org.slug, "version": release.version},
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+
+        data = json.loads(response.content)
+        assert data["releaseFileCount"] == 40
+        assert data["isArtifactBundle"]


### PR DESCRIPTION
This PR fixes a problem in which we were returning only the last artifact bundle's count connected to a specific release. Now we return the sum of all artifacts across bundles connected to the same release.

A change introduced with this PR is that we don't return anymore the `bundleId` but we return `isArtifactBundle` to signal that when the user clicks we will prompt them with the page to search artifact bundles by the release.

Closes https://github.com/getsentry/sentry/issues/48154