### PR TITLE
fix(txnames): Actually update rules in redis

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -124,8 +124,6 @@ def _bump_rule_lifetime(project: Project, event_data: Mapping[str, Any]) -> None
     if not applied_rules:
         return
 
-    stored_rules = clusterer_rules.get_redis_rules(project)
-
     for applied_rule in applied_rules:
         # There are two types of rules:
         # Transaction clustering rules  -- ["<pattern>", "<action>"]
@@ -134,7 +132,6 @@ def _bump_rule_lifetime(project: Project, event_data: Mapping[str, Any]) -> None
         # for the length of the array should be enough.
         if len(applied_rule) == 2:
             pattern = applied_rule[0]
-            if pattern in stored_rules:
-                # Only one clustering rule is applied per project
-                clusterer_rules.update_redis_rules(project, [pattern])
-                return
+            # Only one clustering rule is applied per project
+            clusterer_rules.bump_last_used(project, pattern)
+            return

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -59,6 +59,7 @@ class RedisRuleStore:
             p.delete(key)
             if len(rules) > 0:
                 p.hmset(key, rules)
+            p.execute()
 
 
 class ProjectOptionRuleStore:

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -61,6 +61,18 @@ class RedisRuleStore:
                 p.hmset(key, rules)
             p.execute()
 
+    def update_rule(self, project: Project, rule: str, last_used: int) -> None:
+        """Overwrite a rule's last_used timestamp.
+
+        This function does not create the rule if it does not exist.
+        """
+        client = get_redis_client()
+        key = self._get_rules_key(project)
+        # There is no atomic "overwrite if exists" for hashes, so fetch keys first:
+        existing_rules = client.hkeys(key)
+        if rule in existing_rules:
+            client.hset(key, rule, last_used)
+
 
 class ProjectOptionRuleStore:
     _option_name = "sentry:transaction_name_cluster_rules"
@@ -194,16 +206,10 @@ def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> None
     rule_store.merge(project)
 
 
-def update_redis_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> None:
-    if not new_rules:
-        return
+def bump_last_used(project: Project, pattern: str) -> None:
+    """If an entry for `pattern` exists, bump its last_used timestamp in redis.
 
-    last_seen = _now()
-    new_rule_set = {rule: last_seen for rule in new_rules}
-    rule_store = CompositeRuleStore(
-        [
-            RedisRuleStore(),
-            LocalRuleStore(new_rule_set),
-        ]
-    )
-    rule_store.merge(project)
+    The updated last_used timestamps are transferred from redis to project options
+    in the `cluster_projects` task.
+    """
+    RedisRuleStore().update_rule(project, pattern, _now())

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -716,3 +716,5 @@ register(
 register("hybrid_cloud.outbox_rate", default=0.0)
 # controls whether we allow people to upload artifact bundles instead of release bundles
 register("sourcemaps.enable-artifact-bundles", default=0.0)
+# Decides whether an incoming transaction triggers an update of the clustering rule applied to it.
+register("txnames.bump-lifetime-sample-rate", default=0.1)


### PR DESCRIPTION
We never actually updated the redis rule store because the [redis pipeline](https://redis-py.readthedocs.io/en/stable/advanced_features.html#pipelines) used to delete and set the key was never executed.

The consequence is that rules that should not have expired expired anyway.

Tests did not catch this because they mocked the redis store.

Includes https://github.com/getsentry/sentry/pull/48988 which changes the way we update the rule life time.

ref: https://github.com/getsentry/team-ingest/issues/124