### PR TITLE
fix(txnames): Atomic update of redis rules for lifetime bump

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,7 +68,7 @@
   },
 
   "python.linting.pylintEnabled": false,
-  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Enabled": false,
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,
@@ -82,5 +82,8 @@
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
   "python.formatting.blackPath": "${workspaceFolder}/.venv/bin/black",
   "python.formatting.provider": "black",
-  "python.testing.pytestArgs": ["tests"]
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.linting.mypyEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,7 +68,7 @@
   },
 
   "python.linting.pylintEnabled": false,
-  "python.linting.flake8Enabled": false,
+  "python.linting.flake8Enabled": true,
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,
@@ -82,8 +82,5 @@
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
   "python.formatting.blackPath": "${workspaceFolder}/.venv/bin/black",
   "python.formatting.provider": "black",
-  "python.testing.pytestArgs": [
-    "tests"
-  ],
-  "python.linting.mypyEnabled": true
+  "python.testing.pytestArgs": ["tests"]
 }

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -124,8 +124,6 @@ def _bump_rule_lifetime(project: Project, event_data: Mapping[str, Any]) -> None
     if not applied_rules:
         return
 
-    stored_rules = clusterer_rules.get_redis_rules(project)
-
     for applied_rule in applied_rules:
         # There are two types of rules:
         # Transaction clustering rules  -- ["<pattern>", "<action>"]
@@ -134,7 +132,6 @@ def _bump_rule_lifetime(project: Project, event_data: Mapping[str, Any]) -> None
         # for the length of the array should be enough.
         if len(applied_rule) == 2:
             pattern = applied_rule[0]
-            if pattern in stored_rules:
-                # Only one clustering rule is applied per project
-                clusterer_rules.update_redis_rules(project, [pattern])
-                return
+            # Only one clustering rule is applied per project
+            clusterer_rules.bump_last_used(project, pattern)
+            return

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -61,7 +61,7 @@ class RedisRuleStore:
                 p.hmset(key, rules)
             p.execute()
 
-    def update_rule(self, project: Project, rule: str, last_used: int):
+    def update_rule(self, project: Project, rule: str, last_used: int) -> None:
         """Overwrite a rule's last_used timestamp.
 
         This function does not create the rule if it does not exist.
@@ -206,7 +206,7 @@ def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> None
     rule_store.merge(project)
 
 
-def bump_last_used(project: Project, pattern: str):
+def bump_last_used(project: Project, pattern: str) -> None:
     """If an entry for `pattern` exists, bump its last_used timestamp in redis
 
     The updated last_used timestamps are transferred from redis to project options

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -207,7 +207,7 @@ def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> None
 
 
 def bump_last_used(project: Project, pattern: str) -> None:
-    """If an entry for `pattern` exists, bump its last_used timestamp in redis
+    """If an entry for `pattern` exists, bump its last_used timestamp in redis.
 
     The updated last_used timestamps are transferred from redis to project options
     in the `cluster_projects` task.

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -13,6 +13,8 @@ from sentry.ingest.transaction_clusterer.datasource.redis import (
 )
 from sentry.ingest.transaction_clusterer.rules import (
     ProjectOptionRuleStore,
+    RedisRuleStore,
+    bump_last_used,
     get_redis_rules,
     get_rules,
     get_sorted_rules,
@@ -412,3 +414,13 @@ def test_stale_rules_arent_saved(default_project):
     with freeze_time("2001-01-01 01:00:00"):
         update_rules(default_project, [ReplacementRule("baz/baz")])
     assert get_sorted_rules(default_project) == [("baz/baz", 978310800)]
+
+
+def test_bump_last_used():
+    """Redis update works and does not delete other keys in the set"""
+    project1 = Project(id=123, name="project1")
+    RedisRuleStore().write(project1, {"foo": 1, "bar": 2})
+    assert get_redis_rules(project1) == {"foo": 1, "bar": 2}
+    with freeze_time("2000-01-01 01:00:00"):
+        bump_last_used(project1, "bar")
+    assert get_redis_rules(project1) == {"foo": 1, "bar": 946688400}

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -417,7 +417,7 @@ def test_stale_rules_arent_saved(default_project):
 
 
 def test_bump_last_used():
-    """Redis update works and does not delete other keys in the set"""
+    """Redis update works and does not delete other keys in the set."""
     project1 = Project(id=123, name="project1")
     RedisRuleStore().write(project1, {"foo": 1, "bar": 2})
     assert get_redis_rules(project1) == {"foo": 1, "bar": 2}


### PR DESCRIPTION
For updating the `last_used` timestamp in the redis rule store, we currently use the `merge()` function from `CompositeRuleStore`, which is non-atomic. This means there is a chance that a lifetime bump accidentally deletes a newly discovered rule:

```mermaid
sequenceDiagram
    Ingestion->>+Redis: get rules
    Redis-->>+Ingestion: {"foo": 1}
    Clusterer->>+Redis: write {"foo": 1, "bar": 2} 
    Ingestion->>+Redis: write {"foo": 3}
```

This PR fixes the problem by using [`HSET`](https://redis.io/commands/hset/) (which only amends the hash) instead of overwriting the entire hash.

ref: https://github.com/getsentry/team-ingest/issues/124