### PR TITLE
feat(sourcemaps): Update release meta UI redirect

### DIFF
--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -120,10 +120,10 @@ export type ReleaseProject = {
 };
 
 export type ReleaseMeta = {
-  bundleId: string | null;
   commitCount: number;
   commitFilesChanged: number;
   deployCount: number;
+  isArtifactBundle: boolean;
   projects: ReleaseProject[];
   releaseFileCount: number;
   released: string;

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -59,7 +59,7 @@ function ProjectReleaseDetails({release, releaseMeta, orgSlug, projectSlug}: Pro
                   isArtifactBundle
                     ? `/settings/${orgSlug}/projects/${projectSlug}/source-maps/artifact-bundles/?query=${encodeURIComponent(
                         version
-                      )}/`
+                      )}`
                     : `/settings/${orgSlug}/projects/${projectSlug}/source-maps/release-bundles/${encodeURIComponent(
                         version
                       )}/`

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 function ProjectReleaseDetails({release, releaseMeta, orgSlug, projectSlug}: Props) {
   const {version, versionInfo, dateCreated, firstEvent, lastEvent} = release;
-  const {releaseFileCount, bundleId} = releaseMeta;
+  const {releaseFileCount, isArtifactBundle} = releaseMeta;
 
   return (
     <SidebarSection.Wrap>
@@ -56,9 +56,9 @@ function ProjectReleaseDetails({release, releaseMeta, orgSlug, projectSlug}: Pro
             value={
               <Link
                 to={
-                  bundleId
-                    ? `/settings/${orgSlug}/projects/${projectSlug}/source-maps/artifact-bundles/${encodeURIComponent(
-                        bundleId
+                  isArtifactBundle
+                    ? `/settings/${orgSlug}/projects/${projectSlug}/source-maps/artifact-bundles/?query=${encodeURIComponent(
+                        version
                       )}/`
                     : `/settings/${orgSlug}/projects/${projectSlug}/source-maps/release-bundles/${encodeURIComponent(
                         version


### PR DESCRIPTION
This PR adds support for the `isArtifactBundle` returned from the release meta endpoint.