### PR TITLE
Skip "native" JS frames in symbolication.

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -149,7 +149,7 @@ def _handles_frame(frame):
     if (abs_path := frame.get("abs_path")) is None:
         return False
     # skip "native" frames without a line
-    if abs_path == "native" and frame.get("lineno", 0) == 0:
+    if abs_path in ("native", "[native code]") and frame.get("lineno", 0) == 0:
         return False
     return True
 

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -145,7 +145,13 @@ def _handles_frame(frame):
     if not frame:
         return False
 
-    return frame.get("abs_path") is not None
+    # skip frames without an `abs_path`
+    if (abs_path := frame.get("abs_path")) is None:
+        return False
+    # skip "native" frames without a line
+    if abs_path == "native" and frame.get("lineno", 0) == 0:
+        return False
+    return True
 
 
 def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:


### PR DESCRIPTION
Primarily the react-native SDK will emit "native" frames in the stack trace which are not symbolicate-able. We will skip them entirely to avoid raising processing errors for them.