### PR TITLE
chore(starfish): Add a new endpoint so we can test regressions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -227,6 +227,7 @@ yarn.lock                                                @getsentry/owners-js-de
 
 ## Starfish
 /src/sentry/api/endpoints/organization_events_facets_stats_performance.py           @getsentry/team-starfish
+/src/sentry/api/endpoints/organization_events_starfish.py                           @getsentry/team-starfish
 /tests/snuba/api/endpoints/test_organization_events_facets_stats_performance.py     @getsentry/team-starfish
 
 /static/app/views/starfish/                                                         @getsentry/team-starfish

--- a/src/sentry/api/endpoints/organization_events_starfish.py
+++ b/src/sentry/api/endpoints/organization_events_starfish.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,13 +11,16 @@ from sentry.models.dashboard import Dashboard
 from sentry.snuba import metrics_enhanced_performance
 from sentry.snuba.referrer import Referrer
 
-TAG_ALIASES = {"release": "sentry:release", "dist": "sentry:dist", "user": "sentry:user"}
-SIX_HOURS = int(timedelta(hours=6).total_seconds())
 FEATURE = "organizations:starfish-test-endpoint"
 
 
 @region_silo_endpoint
 class OrganizationEventsStarfishEndpoint(OrganizationEventsV2EndpointBase):
+    """
+    This is a test endpoint that's meant to only be used for starfish testing
+    purposes.
+    """
+
     def get(self, request: Request, organization) -> Response:
         if not features.has(FEATURE, organization, actor=request.user):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_events_starfish.py
+++ b/src/sentry/api/endpoints/organization_events_starfish.py
@@ -1,0 +1,59 @@
+from datetime import timedelta
+
+import sentry_sdk
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import NoProjects
+from sentry.api.bases.organization_events import OrganizationEventsV2EndpointBase
+from sentry.api.serializers import serialize
+from sentry.models.dashboard import Dashboard
+from sentry.snuba import metrics_enhanced_performance
+from sentry.snuba.referrer import Referrer
+
+TAG_ALIASES = {"release": "sentry:release", "dist": "sentry:dist", "user": "sentry:user"}
+SIX_HOURS = int(timedelta(hours=6).total_seconds())
+FEATURE = "organizations:starfish-test-endpoint"
+
+
+@region_silo_endpoint
+class OrganizationEventsStarfishEndpoint(OrganizationEventsV2EndpointBase):
+    def get(self, request: Request, organization) -> Response:
+        if not features.has(FEATURE, organization, actor=request.user):
+            return Response(status=404)
+
+        try:
+            # db requests
+            dashboard = Dashboard.objects.filter(organization_id=organization.id).last()
+            serialize(dashboard, request.user)
+
+            try:
+                snuba_params, params = self.get_snuba_dataclass(request, organization)
+            except NoProjects:
+                return Response([])
+
+            with sentry_sdk.start_span(op="starfish.endpoint", description="starfish_test_query"):
+                referrer = Referrer.API_DISCOVER_QUERY_TABLE.value
+                metrics_enhanced_performance.query(
+                    selected_columns=["title", "count()"],
+                    query="event.type:transaction",
+                    params=params,
+                    snuba_params=snuba_params,
+                    limit=10000,
+                    referrer=referrer,
+                )
+
+                metrics_enhanced_performance.query(
+                    selected_columns=["title", "count_if(mechanism,equals,ANR)"],
+                    query="event.type:transaction",
+                    params=params,
+                    snuba_params=snuba_params,
+                    limit=10000,
+                    referrer=referrer,
+                )
+        except Exception:
+            return Response(status=200)
+
+        return Response(status=200)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -5,6 +5,7 @@ from sentry.api.endpoints.internal.integration_proxy import InternalIntegrationP
 from sentry.api.endpoints.organization_events_facets_stats_performance import (
     OrganizationEventsFacetsStatsPerformanceEndpoint,
 )
+from sentry.api.endpoints.organization_events_starfish import OrganizationEventsStarfishEndpoint
 from sentry.api.utils import method_dispatch
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
@@ -1166,6 +1167,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/events-facets-stats/$",
         OrganizationEventsFacetsStatsPerformanceEndpoint.as_view(),
         name="sentry-api-0-organization-events-facets-stats-performance",
+    ),
+    url(
+        r"^(?P<organization_slug>[^\/]+)/events-starfish/$",
+        OrganizationEventsStarfishEndpoint.as_view(),
+        name="sentry-api-0-organization-events-starfish",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/events-facets-performance/$",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1426,6 +1426,8 @@ SENTRY_FEATURES = {
     "organizations:streamline-targeting-context": False,
     # Enable the new experimental starfish view
     "organizations:starfish-view": False,
+    # Enable starfish endpoint that's used for regressing testing purposes
+    "organizations:starfish-test-endpoint": False,
     # Enable Session Stats down to a minute resolution
     "organizations:minute-resolution-sessions": True,
     # Notify all project members when fallthrough is disabled, instead of just the auto-assignee

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -177,6 +177,7 @@ default_manager.add("organizations:set-grouping-config", OrganizationFeature, Fe
 default_manager.add("organizations:slack-escape-messages", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:starfish-test-endpoint", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:streamline-targeting-context", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:team-roles", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
Adding an endpoint with some db and snuba queries
so we can introduce regressions to test out starfish
workflows. 

Will add a follow up to call it in the frontend somewhere
(probably discover, dashboards and starfish homepages) 
feature flagged to just the sentry org.