### PR TITLE
fix(roles): Failing tests from `team-roles` feature flag

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -120,7 +120,7 @@ class SentryPermission(ScopedPermission):
         if org_context is None:
             assert False, "Failed to fetch organization in determine_access"
 
-        if request.user and request.user.is_authenticated and request.auth:
+        if request.auth and request.user and request.user.is_authenticated:
             request.access = access.from_request_org_and_scopes(
                 request=request,
                 rpc_user_org_context=org_context,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2094,14 +2094,14 @@ SENTRY_TEAM_ROLES = (
         "scopes": {
             "event:read",
             "event:write",
-            "event:admin",
+            # "event:admin",  # Scope granted/withdrawn by "sentry:events_member_admin" to org-level role
             "project:releases",
             "project:read",
             "org:read",
             "member:read",
             "team:read",
             "alerts:read",
-            "alerts:write",
+            # "alerts:write",  # Scope granted/withdrawn by "sentry:alerts_member_write" to org-level role
         },
     },
     {

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -108,14 +108,14 @@ class OrganizationInviteRequestUpdateTest(InviteRequestBase):
 
     def test_owner_can_update_role(self):
         self.login_as(user=self.user)
-        resp = self.get_response(self.org.slug, self.invite_request.id, role="admin")
+        resp = self.get_response(self.org.slug, self.invite_request.id, role="manager")
 
         assert resp.status_code == 200
-        assert resp.data["role"] == "admin"
-        assert resp.data["orgRole"] == "admin"
+        assert resp.data["role"] == "manager"
+        assert resp.data["orgRole"] == "manager"
         assert resp.data["inviteStatus"] == "requested_to_be_invited"
 
-        assert OrganizationMember.objects.filter(id=self.invite_request.id, role="admin").exists()
+        assert OrganizationMember.objects.filter(id=self.invite_request.id, role="manager").exists()
 
     def test_owner_can_update_teams(self):
         self.login_as(user=self.user)
@@ -163,7 +163,7 @@ class OrganizationInviteRequestUpdateTest(InviteRequestBase):
 
     def test_member_cannot_update_invite_request(self):
         self.login_as(user=self.member.user)
-        resp = self.get_response(self.org.slug, self.request_to_join.id, role="admin")
+        resp = self.get_response(self.org.slug, self.request_to_join.id, role="manager")
         assert resp.status_code == 403
 
 
@@ -255,16 +255,20 @@ class OrganizationInviteRequestApproveTest(InviteRequestBase):
     def test_owner_can_update_and_approve(self, mock_invite_email):
         self.login_as(user=self.user)
         resp = self.get_response(
-            self.org.slug, self.request_to_join.id, approve=1, role="admin", teams=[self.team.slug]
+            self.org.slug,
+            self.request_to_join.id,
+            approve=1,
+            role="manager",
+            teams=[self.team.slug],
         )
 
         assert resp.status_code == 200
-        assert resp.data["role"] == "admin"
-        assert resp.data["orgRole"] == "admin"
+        assert resp.data["role"] == "manager"
+        assert resp.data["orgRole"] == "manager"
         assert resp.data["inviteStatus"] == "approved"
 
         assert OrganizationMember.objects.filter(
-            id=self.request_to_join.id, role="admin", invite_status=InviteStatus.APPROVED.value
+            id=self.request_to_join.id, role="manager", invite_status=InviteStatus.APPROVED.value
         ).exists()
 
         assert OrganizationMemberTeam.objects.filter(

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -433,6 +433,7 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase):
         member_om = OrganizationMember.objects.get(organization=self.organization, user=member)
         assert member_om.role == "member"
 
+    @with_feature({"organizations:team-roles": False})
     def test_can_update_from_retired_role_without_flag(self):
         member = self.create_user("baz@example.com")
         member_om = self.create_member(
@@ -456,6 +457,7 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase):
         member_om = OrganizationMember.objects.get(organization=self.organization, user=member)
         assert member_om.role == "member"
 
+    @with_feature({"organizations:team-roles": False})
     def test_can_update_to_retired_role_without_flag(self):
         member = self.create_user("baz@example.com")
         member_om = self.create_member(

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -86,7 +86,7 @@ class TeamUpdateTest(TeamDetailsTestBase):
         team = self.create_team()
         member = self.create_member(user=user, organization=self.organization, role="member")
 
-        self.create_team_membership(team, member, role="member")
+        self.create_team_membership(team, member)
         self.login_as(user)
 
         self.get_error_response(team.organization.slug, team.slug, slug="foobar", status_code=403)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -81,6 +81,7 @@ class OrganizationSerializerTest(TestCase):
             "sso-saml2",
             "symbol-sources",
             "team-insights",
+            "team-roles",
             "performance-issues-search",
             "transaction-name-normalize",
             "transaction-name-mark-scrubbed-as-sanitized",

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -81,7 +81,6 @@ class OrganizationSerializerTest(TestCase):
             "sso-saml2",
             "symbol-sources",
             "team-insights",
-            "team-roles",
             "performance-issues-search",
             "transaction-name-normalize",
             "transaction-name-mark-scrubbed-as-sanitized",


### PR DESCRIPTION
Some tests fails when the `team-roles` feature flag defaults to True (see https://github.com/getsentry/sentry/pull/48415) due to the retired admin role.