### PR TITLE
fix(crons): Validate check-in duration

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -10,6 +10,7 @@ from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.constants import ObjectStatus
+from sentry.db.models import BoundedPositiveIntegerField
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorType, ScheduleType
 
 MONITOR_TYPES = {"cron_job": MonitorType.CRON_JOB}
@@ -223,7 +224,12 @@ class MonitorCheckInValidator(serializers.Serializer):
             ("in_progress", CheckInStatus.IN_PROGRESS),
         )
     )
-    duration = EmptyIntegerField(required=False, allow_null=True)
+    duration = EmptyIntegerField(
+        required=False,
+        allow_null=True,
+        max_value=BoundedPositiveIntegerField.MAX_VALUE,
+        min_value=0,
+    )
     environment = serializers.CharField(required=False, allow_null=True)
     monitor_config = ConfigValidator(required=False)
 

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -11,6 +11,7 @@ from django.utils.http import urlquote
 from freezegun import freeze_time
 
 from sentry.constants import ObjectStatus
+from sentry.db.models import BoundedPositiveIntegerField
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -140,6 +141,27 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             resp = self.client.post(path, {"status": "error"}, **self.token_auth_headers)
             assert resp.status_code == 404
+
+    def test_invalid_duration(self):
+        monitor = self._create_monitor(slug="my-monitor")
+
+        path = reverse(self.endpoint_with_org, args=[self.organization.slug, monitor.slug])
+        resp = self.client.post(path, {"status": "ok", "duration": -1}, **self.token_auth_headers)
+
+        assert resp.status_code == 400, resp.content
+        assert resp.data["duration"][0] == "Ensure this value is greater than or equal to 0."
+
+        resp = self.client.post(
+            path,
+            {"status": "ok", "duration": BoundedPositiveIntegerField.MAX_VALUE + 1},
+            **self.token_auth_headers,
+        )
+
+        assert resp.status_code == 400, resp.content
+        assert (
+            resp.data["duration"][0]
+            == f"Ensure this value is less than or equal to {BoundedPositiveIntegerField.MAX_VALUE}."
+        )
 
     def test_deletion_in_progress(self):
         monitor = self._create_monitor(status=ObjectStatus.DELETION_IN_PROGRESS)

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -12,6 +12,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
+from sentry.db.models import BoundedPositiveIntegerField
 from sentry.monitors.consumers.monitor_consumer import (
     StoreMonitorCheckInStrategyFactory,
     _process_message,
@@ -248,6 +249,39 @@ class MonitorConsumerTest(TestCase):
 
             checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
             assert len(checkins) == 2
+
+    def test_invalid_duration(self):
+        monitor = self._create_monitor(slug="my-monitor")
+
+        # Try to ingest two the second will be rate limited
+        message = self.get_message("my-monitor", status="in_progress")
+        check_in_id = message.get("check_in_id")
+        _process_message(message)
+
+        # Invalid check-in updates
+        _process_message(
+            self.get_message("my-monitor", check_in_id=check_in_id, duration=-(1.0 / 1000))
+        )
+        _process_message(
+            self.get_message(
+                "my-monitor",
+                check_in_id=check_in_id,
+                duration=((BoundedPositiveIntegerField.MAX_VALUE + 1.0) / 1000),
+            )
+        )
+
+        # Invalid check-in creations
+        _process_message(self.get_message("my-monitor", duration=-(1.0 / 1000)))
+        _process_message(
+            self.get_message(
+                "my-monitor", duration=(BoundedPositiveIntegerField.MAX_VALUE + 1.0) / 1000
+            )
+        )
+
+        # Only one check-in should be processed and it should still be IN_PROGRESS
+        checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
+        assert len(checkins) == 1
+        assert checkins[0].status == CheckInStatus.IN_PROGRESS
 
     @pytest.mark.django_db
     def test_monitor_upsert(self):


### PR DESCRIPTION
Validates + logs invalid check-in durations

Closes SENTRY-114M
Closes SENTRY-114T
Closes SENTRY-114P
Closes SENTRY-114S
Closes SENTRY-11AV
Closes SENTRY-114W
Closes SENTRY-107X
Closes SENTRY-11A3
Closes SENTRY-11A0
Closes SENTRY-119R
Closes SENTRY-118X
Closes SENTRY-1193
Closes SENTRY-118E
Closes SENTRY-118D
Closes SENTRY-114Z
Closes SENTRY-114K
Closes SENTRY-10WM
Closes SENTRY-114J
Closes SENTRY-107G
Closes SENTRY-114D
Closes SENTRY-114C
Closes SENTRY-114A
Closes SENTRY-1144
Closes SENTRY-10J8
Closes SENTRY-112M
Closes SENTRY-112H
Closes SENTRY-111X
Closes SENTRY-111W
Closes SENTRY-111V