### PR TITLE
ref(utils): Rename trusted relays helper functions and types

### DIFF
--- a/static/app/views/settings/organizationRelay/modals/createTrustedRelaysResponseError.tsx
+++ b/static/app/views/settings/organizationRelay/modals/createTrustedRelaysResponseError.tsx
@@ -1,6 +1,7 @@
 import {t} from 'sentry/locale';
+import RequestError from 'sentry/utils/requestError/requestError';
 
-type Error = {
+type TrustedRelaysResponseError = {
   message: string;
   type:
     | 'unknown'
@@ -12,13 +13,15 @@ type Error = {
     | 'duplicated-key';
 };
 
-type XhrError = {
+interface TrustedRelaysRequestError extends RequestError {
   responseJSON?: {
     trustedRelays: Array<string>;
   };
-};
+}
 
-function handleError(error: XhrError): Error {
+function createTrustedRelaysResponseError(
+  error: TrustedRelaysRequestError
+): TrustedRelaysResponseError {
   const errorMessage = error.responseJSON?.trustedRelays[0];
 
   if (!errorMessage) {
@@ -76,4 +79,4 @@ function handleError(error: XhrError): Error {
   };
 }
 
-export default handleError;
+export default createTrustedRelaysResponseError;

--- a/static/app/views/settings/organizationRelay/modals/modalManager.tsx
+++ b/static/app/views/settings/organizationRelay/modals/modalManager.tsx
@@ -98,7 +98,7 @@ class DialogManager<P extends Props = Props, S extends State = State> extends Co
     }));
   }
 
-  convertErrorXhrResponse(error: ReturnType<typeof handleXhrErrorResponse>) {
+  handleErrorResponse(error: ReturnType<typeof handleXhrErrorResponse>) {
     switch (error.type) {
       case 'invalid-key':
       case 'missing-key':
@@ -142,7 +142,7 @@ class DialogManager<P extends Props = Props, S extends State = State> extends Co
       onSubmitSuccess(response);
       closeModal();
     } catch (error) {
-      this.convertErrorXhrResponse(handleXhrErrorResponse(error));
+      this.handleErrorResponse(handleXhrErrorResponse(error));
     }
   };
 

--- a/static/app/views/settings/organizationRelay/modals/modalManager.tsx
+++ b/static/app/views/settings/organizationRelay/modals/modalManager.tsx
@@ -8,8 +8,8 @@ import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import {Organization, Relay} from 'sentry/types';
 
+import createTrustedRelaysResponseError from './createTrustedRelaysResponseError';
 import Form from './form';
-import handleXhrErrorResponse from './handleXhrErrorResponse';
 import Modal from './modal';
 
 type FormProps = React.ComponentProps<typeof Form>;
@@ -98,7 +98,7 @@ class DialogManager<P extends Props = Props, S extends State = State> extends Co
     }));
   }
 
-  handleErrorResponse(error: ReturnType<typeof handleXhrErrorResponse>) {
+  handleErrorResponse(error: ReturnType<typeof createTrustedRelaysResponseError>) {
     switch (error.type) {
       case 'invalid-key':
       case 'missing-key':
@@ -142,7 +142,7 @@ class DialogManager<P extends Props = Props, S extends State = State> extends Co
       onSubmitSuccess(response);
       closeModal();
     } catch (error) {
-      this.handleErrorResponse(handleXhrErrorResponse(error));
+      this.handleErrorResponse(createTrustedRelaysResponseError(error));
     }
   };
 


### PR DESCRIPTION
_Part of https://github.com/getsentry/sentry/issues/48981, which aims to improve the way we handle errors in our frontend API client._

We have a helper function, `handleXhrErrorResponse`, which is used all over the codebase. There is also a relay-specific function of the same name, which is used in just one place. This renames the latter (and another associated helper and the types it uses) both in order to differentiate it from the more widely-used one (making on-going work on that one easier) and to make the name(s) more reflective of what is actually being done.