### PR TITLE
chore(perf-issues): Add is_early_adopter as detection tag

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -288,7 +288,7 @@ def _detect_performance_problems(
         run_detector_on_data(detector, data)
 
     # Metrics reporting only for detection, not created issues.
-    report_metrics_for_detectors(data, event_id, detectors, sdk_span)
+    report_metrics_for_detectors(data, event_id, detectors, sdk_span, project.organization)
 
     organization = cast(Organization, project.organization)
     if project is None or organization is None:
@@ -339,7 +339,11 @@ def run_detector_on_data(detector, data):
 
 # Reports metrics and creates spans for detection
 def report_metrics_for_detectors(
-    event: Event, event_id: Optional[str], detectors: Sequence[PerformanceDetector], sdk_span: Any
+    event: Event,
+    event_id: Optional[str],
+    detectors: Sequence[PerformanceDetector],
+    sdk_span: Any,
+    organization: Organization,
 ):
     all_detected_problems = [i for d in detectors for i in d.stored_problems]
     has_detected_problems = bool(all_detected_problems)
@@ -385,7 +389,10 @@ def report_metrics_for_detectors(
         # Reduce cardinality in case there are custom browser name tags.
         allowed_browser_name = browser_name
 
-    detected_tags = {"sdk_name": sdk_name}
+    detected_tags = {
+        "sdk_name": sdk_name,
+        "is_early_adopter": organization.flags.early_adopter.is_set,
+    }
     event_integrations = event.get("sdk", {}).get("integrations", []) or []
 
     for integration_name in INTEGRATIONS_OF_INTEREST:

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -405,6 +405,7 @@ class PerformanceDetectionTest(TestCase):
                     "m_n_plus_one_db": False,
                     "uncompressed_assets": True,
                     "browser_name": "Chrome",
+                    "is_early_adopter": False,
                 },
             )
             in incr_mock.mock_calls


### PR DESCRIPTION
Add an is_early_adopter tag in the detection tags because it would be useful to estimate the EA and GA impact. If we have X new issues with Y detections in EA, then we could get a very rough estimate of potential GA impact by looking at the proportion of EA:GA detection