### PR TITLE
fix(issue-states): increase time limits for auto transitioning to ongoing issues

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1013,13 +1013,13 @@ CELERYBEAT_SCHEDULE = {
         "task": "sentry.tasks.schedule_auto_transition_new",
         # Run job once a day at 00:30
         "schedule": crontab(minute=30, hour="0"),
-        "options": {"expires": 3600},
+        "options": {"expires": 10 * 60},
     },
     "schedule_auto_transition_regressed": {
         "task": "sentry.tasks.schedule_auto_transition_regressed",
         # Run job once a day at 02:30
         "schedule": crontab(minute=30, hour="2"),
-        "options": {"expires": 3600},
+        "options": {"expires": 10 * 60},
     },
 }
 

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -13,8 +13,6 @@ from sentry.tasks.base import instrumented_task
 @instrumented_task(
     name="sentry.tasks.schedule_auto_transition_new",
     queue="auto_transition_issue_states",
-    time_limit=75,
-    soft_time_limit=60,
 )  # type: ignore
 @monitor(monitor_slug="schedule_auto_transition_new")
 def schedule_auto_transition_new() -> None:
@@ -44,8 +42,8 @@ def schedule_auto_transition_new() -> None:
 @instrumented_task(
     name="sentry.tasks.auto_transition_issues_new_to_ongoing",
     queue="auto_transition_issue_states",
-    time_limit=75,
-    soft_time_limit=60,
+    time_limit=1.25 * 5 * 60,
+    soft_time_limit=5 * 60,
 )  # type: ignore
 def auto_transition_issues_new_to_ongoing(
     project_id: int,
@@ -82,8 +80,6 @@ def auto_transition_issues_new_to_ongoing(
 @instrumented_task(
     name="sentry.tasks.schedule_auto_transition_regressed",
     queue="auto_transition_issue_states",
-    time_limit=75,
-    soft_time_limit=60,
 )  # type: ignore
 @monitor(monitor_slug="schedule_auto_transition_regressed")
 def schedule_auto_transition_regressed() -> None:
@@ -113,8 +109,8 @@ def schedule_auto_transition_regressed() -> None:
 @instrumented_task(
     name="sentry.tasks.auto_transition_issues_regressed_to_ongoing",
     queue="auto_transition_issue_states",
-    time_limit=75,
-    soft_time_limit=60,
+    time_limit=1.25 * 5 * 60,
+    soft_time_limit=5 * 60,
 )  # type: ignore
 def auto_transition_issues_regressed_to_ongoing(
     project_id: int,


### PR DESCRIPTION
I suspect we're timing out when the tasks run. 