### PR TITLE
feat(escalating-issues): Allow slack messages to archive until escalating

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -55,7 +55,9 @@ def build_assigned_text(identity: RpcIdentity, assignee: str) -> str | None:
     return f"*Issue assigned to {assignee_text} by <@{identity.external_id}>*"
 
 
-def build_action_text(identity: RpcIdentity, action: MessageAction) -> str | None:
+def build_action_text(
+    identity: RpcIdentity, action: MessageAction, has_escalating: bool = False
+) -> str | None:
     if action.name == "assign":
         selected_options = action.selected_options or []
         if not len(selected_options):
@@ -65,7 +67,7 @@ def build_action_text(identity: RpcIdentity, action: MessageAction) -> str | Non
 
     # Resolve actions have additional 'parameters' after ':'
     status = STATUSES.get((action.value or "").split(":", 1)[0])
-
+    status = "archived" if status == "ignored" and has_escalating else status
     # Action has no valid action text, ignore
     if not status:
         return None
@@ -123,9 +125,7 @@ def has_releases(project: Project) -> bool:
 
 
 def get_action_text(
-    text: str,
-    actions: Sequence[Any],
-    identity: RpcIdentity,
+    text: str, actions: Sequence[Any], identity: RpcIdentity, has_escalating=False
 ) -> str:
     return (
         text
@@ -133,7 +133,9 @@ def get_action_text(
         + "\n".join(
             [
                 action_text
-                for action_text in [build_action_text(identity, action) for action in actions]
+                for action_text in [
+                    build_action_text(identity, action, has_escalating) for action in actions
+                ]
                 if action_text
             ]
         )
@@ -149,14 +151,16 @@ def build_actions(
     identity: RpcIdentity | None = None,
 ) -> tuple[Sequence[MessageAction], str, str]:
     """Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign."""
+    has_escalating = features.has("organizations:escalating-issues", project.organization)
+
     if actions and identity:
-        text = get_action_text(text, actions, identity)
+        text = get_action_text(text, actions, identity, has_escalating)
         return [], text, "_actioned_issue"
 
     ignore_button = MessageAction(
         name="status",
-        label="Ignore",
-        value="ignored",
+        label="Archive" if has_escalating else "Ignore",
+        value="ignored:until_escalating" if has_escalating else "ignored:forever",
     )
 
     resolve_button = MessageAction(
@@ -178,14 +182,14 @@ def build_actions(
         resolve_button = MessageAction(
             name="status",
             label="Unresolve",
-            value="unresolved",
+            value="unresolved:ongoing",
         )
 
     if status == GroupStatus.IGNORED:
         ignore_button = MessageAction(
             name="status",
-            label="Stop Ignoring",
-            value="unresolved",
+            label="Stop Archive" if has_escalating else "Stop Ignoring",
+            value="unresolved:ongoing",
         )
 
     assignee = group.get_assignee()

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -125,7 +125,7 @@ def has_releases(project: Project) -> bool:
 
 
 def get_action_text(
-    text: str, actions: Sequence[Any], identity: RpcIdentity, has_escalating=False
+    text: str, actions: Sequence[Any], identity: RpcIdentity, has_escalating: bool = False
 ) -> str:
     return (
         text

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -188,7 +188,7 @@ def build_actions(
     if status == GroupStatus.IGNORED:
         ignore_button = MessageAction(
             name="status",
-            label="Stop Archive" if has_escalating else "Stop Ignoring",
+            label="Mark as Ongoing" if has_escalating else "Stop Ignoring",
             value="unresolved:ongoing",
         )
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -222,7 +222,12 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
         if not len(status_data):
             return
 
-        status: MutableMapping[str, Any] = {"status": status_data[0]}
+        status: MutableMapping[str, Any] = {
+            "status": status_data[0],
+        }
+
+        if len(status_data) > 1:
+            status["substatus"] = status_data[1]
 
         resolve_type = status_data[-1]
 

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -14,6 +14,7 @@ from sentry.models import (
     Group,
     GroupAssignee,
     GroupStatus,
+    GroupSubStatus,
     Identity,
     InviteStatus,
     OrganizationMember,
@@ -58,7 +59,7 @@ class StatusActionTest(BaseEventTest):
             },
             project_id=self.project.id,
         )
-        status_action = {"name": "status", "value": "ignored", "type": "button"}
+        status_action = {"name": "status", "value": "ignored:forever", "type": "button"}
         original_message = {
             "type": "message",
             "attachments": [
@@ -84,6 +85,55 @@ class StatusActionTest(BaseEventTest):
 
         assert resp.status_code == 200, resp.content
         assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.FOREVER
+
+        expect_status = f"Identity not found.\n*Issue ignored by <@{self.external_id}>*"
+        assert resp.data["attachments"][0]["text"] == expect_status
+
+    def test_archive_issue(self):
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "IntegrationError",
+                "fingerprint": ["group-1"],
+                "exception": {
+                    "values": [
+                        {
+                            "type": "IntegrationError",
+                            "value": "Identity not found.",
+                        }
+                    ]
+                },
+            },
+            project_id=self.project.id,
+        )
+        status_action = {"name": "status", "value": "ignored:until_escalating", "type": "button"}
+        original_message = {
+            "type": "message",
+            "attachments": [
+                {
+                    "id": 1,
+                    "ts": 1681409875,
+                    "color": "E03E2F",
+                    "fallback": "[node] IntegrationError: Identity not found.",
+                    "text": "Identity not found.",
+                    "title": "IntegrationError",
+                    "footer": "NODE-F via <http://localhost:8000/organizations/sentry/alerts/rules/node/3/details/|New Issue in #critical channel>",
+                    "mrkdwn_in": ["text"],
+                }
+            ],
+        }
+        resp = self.post_webhook(
+            action_data=[status_action],
+            original_message=original_message,
+            type="interactive_message",
+            callback_id=json.dumps({"issue": event.group.id}),
+        )
+        self.group = Group.objects.get(id=event.group.id)
+
+        assert resp.status_code == 200, resp.content
+        assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
         expect_status = f"Identity not found.\n*Issue ignored by <@{self.external_id}>*"
         assert resp.data["attachments"][0]["text"] == expect_status
@@ -98,13 +148,14 @@ class StatusActionTest(BaseEventTest):
             )
             AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)
 
-        status_action = {"name": "status", "value": "ignored", "type": "button"}
+        status_action = {"name": "status", "value": "ignored:forever", "type": "button"}
 
         resp = self.post_webhook(action_data=[status_action])
         self.group = Group.objects.get(id=self.group.id)
 
         assert resp.status_code == 200, resp.content
         assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.FOREVER
 
         expect_status = f"*Issue ignored by <@{self.external_id}>*"
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
@@ -195,13 +246,15 @@ class StatusActionTest(BaseEventTest):
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
     def test_response_differs_on_bot_message(self):
-        status_action = {"name": "status", "value": "ignored", "type": "button"}
+        status_action = {"name": "status", "value": "ignored:forever", "type": "button"}
 
         original_message = {"type": "message"}
 
         resp = self.post_webhook(action_data=[status_action], original_message=original_message)
         self.group = Group.objects.get(id=self.group.id)
 
+        assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.FOREVER
         assert resp.status_code == 200, resp.content
         assert "attachments" in resp.data
         assert resp.data["attachments"][0]["title"] == self.group.title
@@ -298,7 +351,7 @@ class StatusActionTest(BaseEventTest):
             user=user2,
         )
 
-        status_action = {"name": "status", "value": "ignored", "type": "button"}
+        status_action = {"name": "status", "value": "ignored:forever", "type": "button"}
 
         resp = self.post_webhook(
             action_data=[status_action], slack_user={"id": user2_identity.external_id}


### PR DESCRIPTION
## Objective

<img width="1185" alt="Screenshot 2023-05-12 at 11 30 43 AM" src="https://github.com/getsentry/sentry/assets/10491193/111c72b4-ce9e-4c3b-9ef8-05343f098c64">
<img width="1185" alt="Screenshot 2023-05-12 at 11 31 07 AM" src="https://github.com/getsentry/sentry/assets/10491193/aa7d77e3-72e9-48db-8f8a-8690f24b09eb">

This PR allows users to archive issues from Slack. I also updated the logic to support the Group substatus even for orgs that do not have the escalating feature flag.