### PR TITLE
fix(group): fire post_save signal to update cached Group

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1791,6 +1791,11 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
             substatus=GroupSubStatus.REGRESSED,
         )
     )
+    group.active_at = date
+    group.status = GroupStatus.UNRESOLVED
+    group.substatus = GroupSubStatus.REGRESSED
+    # groups may have been updated already from a separate event that groups to the same group
+    # only fire these signals the first time the row was actually updated
     if is_regression:
         issue_unresolved.send_robust(
             project=group.project,
@@ -1799,10 +1804,6 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
             transition_type="automatic",
             sender="handle_regression",
         )
-        group.active_at = date
-        group.status = GroupStatus.UNRESOLVED
-        group.substatus = GroupSubStatus.REGRESSED
-        # intentionally fire the signal to update the cached Group
         post_save.send(
             sender=Group,
             instance=group,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1791,23 +1791,24 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
             substatus=GroupSubStatus.REGRESSED,
         )
     )
-    issue_unresolved.send_robust(
-        project=group.project,
-        user=None,
-        group=group,
-        transition_type="automatic",
-        sender="handle_regression",
-    )
-    group.active_at = date
-    group.status = GroupStatus.UNRESOLVED
-    group.substatus = GroupSubStatus.REGRESSED
-    # intentionally fire the signal to update the cached Group
-    post_save.send(
-        sender=Group,
-        instance=group,
-        created=False,
-        update_fields=["last_seen", "active_at", "status", "substatus"],
-    )
+    if is_regression:
+        issue_unresolved.send_robust(
+            project=group.project,
+            user=None,
+            group=group,
+            transition_type="automatic",
+            sender="handle_regression",
+        )
+        group.active_at = date
+        group.status = GroupStatus.UNRESOLVED
+        group.substatus = GroupSubStatus.REGRESSED
+        # intentionally fire the signal to update the cached Group
+        post_save.send(
+            sender=Group,
+            instance=group,
+            created=False,
+            update_fields=["last_seen", "active_at", "status", "substatus"],
+        )
 
     if is_regression and release:
         resolution = None

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1805,7 +1805,7 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
     post_save.send(
         sender=Group,
         instance=group,
-        create=False,
+        created=False,
         update_fields=["last_seen", "active_at", "status", "substatus"],
     )
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1801,6 +1801,9 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
     group.active_at = date
     group.status = GroupStatus.UNRESOLVED
     group.substatus = GroupSubStatus.REGRESSED
+    # we already update these fields in the DB on .update() call, but we need to .save()
+    # to ensure the cache is updated properly since post_process_group retrieves the cached group
+    group.save(update_fields=["active_at", "status", "substatus"])
 
     if is_regression and release:
         resolution = None


### PR DESCRIPTION
We're seeing weird Group.substatus state transitions in `post_process_group` for regressed issues. 

I suspect an stale Group model row is being cached and being used in `post_process_group` here https://github.com/getsentry/sentry/blob/54aa3e3596facd7531acbfb24f5af0a0553bb3b6/src/sentry/tasks/post_process.py#L608 causing these errors to trigger.

This shouldn't cause too much of an issue besides an extra DB update.

Resolves SENTRY-10W7