### PR TITLE
chore(hybrid-cloud): save outbox messages when creating them for org members

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -185,8 +185,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                         with transaction.atomic():
                             member.regenerate_token()
                             member.save()
-                            region_outbox = member.outbox_for_update()
-                            region_outbox.save()
+                            region_outbox = member.save_outbox_for_update()
                         if region_outbox:
                             region_outbox.drain_shard(max_updates_to_drain=10)
                     else:
@@ -297,8 +296,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
             ).update(role=None)
 
             member.update(role=role)
-            region_outbox = member.outbox_for_update()
-            region_outbox.save()
+            region_outbox = member.save_outbox_for_update()
         if region_outbox:
             region_outbox.drain_shard(max_updates_to_drain=10)
         if omt_update_count > 0:

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -283,8 +283,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             if settings.SENTRY_ENABLE_INVITES:
                 om.token = om.generate_token()
             om.save()
-            region_outbox = om.outbox_for_create()
-            region_outbox.save()
+            region_outbox = om.save_outbox_for_create()
         if region_outbox:
             region_outbox.drain_shard(max_updates_to_drain=10)
 

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -270,6 +270,11 @@ class OrganizationMember(Model):
             payload=dict(user_id=self.user_id),
         )
 
+    def save_outbox_for_create(self) -> RegionOutbox:
+        outbox = self.outbox_for_create()
+        outbox.save()
+        return outbox
+
     def outbox_for_update(self) -> RegionOutbox:
         return RegionOutbox(
             shard_scope=OutboxScope.ORGANIZATION_SCOPE,

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -284,6 +284,11 @@ class OrganizationMember(Model):
             payload=dict(user_id=self.user_id),
         )
 
+    def save_outbox_for_update(self) -> RegionOutbox:
+        outbox = self.outbox_for_update()
+        outbox.save()
+        return outbox
+
     def refresh_expires_at(self):
         now = timezone.now()
         self.token_expires_at = now + timedelta(days=INVITE_DAYS_VALID)

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -250,8 +250,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             )
             org_member.remove_user()
             org_member.save()
-            region_outbox = org_member.outbox_for_update()
-            region_outbox.save()
+            region_outbox = org_member.save_outbox_for_update()
         if region_outbox:
             region_outbox.drain_shard(max_updates_to_drain=10)
         return serialize_member(org_member)

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -183,8 +183,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 inviter_id=inviter_id,
                 invite_status=invite_status,
             )
-            region_outbox = org_member.outbox_for_create()
-            region_outbox.save()
+            region_outbox = org_member.save_outbox_for_create()
         if region_outbox:
             region_outbox.drain_shard(max_updates_to_drain=10)
         return serialize_member(org_member)

--- a/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
@@ -234,8 +234,7 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
 
         # Creation step of receiver
         org_member = OrganizationMember.objects.create(**fields)
-        region_outbox = org_member.outbox_for_create()
-        region_outbox.save()
+        region_outbox = org_member.save_outbox_for_create()
         region_outbox.drain_shard()
 
         with exempt_from_silo_limits():
@@ -268,8 +267,7 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
             "invite_status": InviteStatus.REQUESTED_TO_JOIN.value,
         }
         org_member = OrganizationMember.objects.create(**fields)
-        region_outbox = org_member.outbox_for_create()
-        region_outbox.save()
+        region_outbox = org_member.save_outbox_for_create()
         region_outbox.drain_shard()
 
         with exempt_from_silo_limits():

--- a/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmembermapping.py
@@ -247,8 +247,7 @@ class ReceiverTest(TransactionTestCase, HybridCloudTestMixin):
 
         # Update step of receiver
         org_member.update(role="owner")
-        region_outbox = org_member.outbox_for_update()
-        region_outbox.save()
+        region_outbox = org_member.save_outbox_for_update()
         region_outbox.drain_shard()
 
         with exempt_from_silo_limits():

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -164,7 +164,7 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
             assert qs.exists()
 
         with outbox_runner():
-            member.outbox_for_update().save()
+            member.save_outbox_for_update()
 
         # ensure that even if the outbox sends a general, non delete update, it doesn't cascade
         # the delete to auth identity objects.


### PR DESCRIPTION
This is a proposal to introduce `save_outbox_for_update()` and `save_outbox_for_create()` methods for org members.