### PR TITLE
feat(source-maps): adds new case for source map debugging

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -54,6 +54,12 @@ function getErrorMessage(
     }
     return `${baseSourceMapDocsLink}troubleshooting_js/` + (section ? `#${section}` : '');
   }
+  function getMigrationGuide() {
+    if (docPlatform === 'react-native') {
+      return 'https://docs.sentry.io/platforms/react-native/migration/';
+    }
+    return 'https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#upgrading-from-6x-to-7x';
+  }
 
   const defaultDocsLink = `${baseSourceMapDocsLink}#uploading-source-maps-to-sentry`;
 
@@ -158,14 +164,16 @@ function getErrorMessage(
           ),
         },
       ];
-    case SourceMapProcessingIssueType.SOURCEMAP_NOT_FOUND:
+    case SourceMapProcessingIssueType.SDK_OUT_OF_DATE:
       return [
         {
-          title: t("Source Map File doesn't exist"),
+          title: t('SDK Out of Date'),
           desc: t(
-            "Sentry couldn't fetch the source map file for this event. Read our docs for troubleshooting help."
+            "We're not able to un-minify your application's source code, because your SDK %s is out of date with version %s. Please update it to the latest version.",
+            error.data.sdkName,
+            error.data.sdkVersion
           ),
-          docsLink: getTroubleshootingLink(),
+          docsLink: error.data.showMigrationGuide ? getMigrationGuide() : undefined,
         },
       ];
     case SourceMapProcessingIssueType.UNKNOWN_ERROR:
@@ -301,12 +309,14 @@ export function SourceMapDebug({debugFrames, event}: SourcemapDebugProps) {
                 key={idx}
                 title={message.title}
                 docsLink={
-                  <DocsExternalLink
-                    href={message.docsLink}
-                    onClick={() => handleDocsClick(message.type)}
-                  >
-                    {t('Read Guide')}
-                  </DocsExternalLink>
+                  message.docsLink ? (
+                    <DocsExternalLink
+                      href={message.docsLink}
+                      onClick={() => handleDocsClick(message.type)}
+                    >
+                      {t('Read Guide')}
+                    </DocsExternalLink>
+                  ) : null
                 }
                 onExpandClick={() => handleExpandClick(message.type)}
               >

--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.tsx
@@ -164,6 +164,16 @@ function getErrorMessage(
           ),
         },
       ];
+    case SourceMapProcessingIssueType.SOURCEMAP_NOT_FOUND:
+      return [
+        {
+          title: t("Source Map File doesn't exist"),
+          desc: t(
+            "Sentry couldn't fetch the source map file for this event. Read our docs for troubleshooting help."
+          ),
+          docsLink: getTroubleshootingLink(),
+        },
+      ];
     case SourceMapProcessingIssueType.SDK_OUT_OF_DATE:
       return [
         {

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
@@ -50,6 +50,11 @@ interface NoURLMatchDebugError extends BaseSourceMapDebugError {
   type: SourceMapProcessingIssueType.NO_URL_MATCH;
 }
 
+interface SDKOutOfDate extends BaseSourceMapDebugError {
+  data: {sdkName: string; sdkVersion: string; showMigrationGuide: boolean};
+  type: SourceMapProcessingIssueType.SDK_OUT_OF_DATE;
+}
+
 export type SourceMapDebugError =
   | UnknownErrorDebugError
   | MissingReleaseDebugError
@@ -59,7 +64,8 @@ export type SourceMapDebugError =
   | PartialMatchDebugError
   | DistMismatchDebugError
   | SourcemapNotFoundDebugError
-  | NoURLMatchDebugError;
+  | NoURLMatchDebugError
+  | SDKOutOfDate;
 
 export interface SourceMapDebugResponse {
   errors: SourceMapDebugError[];
@@ -75,6 +81,7 @@ export enum SourceMapProcessingIssueType {
   PARTIAL_MATCH = 'partial_match',
   DIST_MISMATCH = 'dist_mismatch',
   SOURCEMAP_NOT_FOUND = 'sourcemap_not_found',
+  SDK_OUT_OF_DATE = 'sdk_out_of_date',
 }
 
 const sourceMapDebugQuery = ({


### PR DESCRIPTION
This PR adds a new source map debugging strategy for an outdated SDK:

![Screen Shot 2023-05-12 at 3 53 39 PM](https://github.com/getsentry/sentry/assets/8533851/6a664d2c-1ce7-44b0-bb6e-b4007744c0db)

We ask them to upgrade and if they are a major revision out of date, we expose the migration guide. A backend PR will be added later to generate this response.