### PR TITLE
feat(crons): Add UI for alert rule config in new monitors

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -1,0 +1,98 @@
+import {useEffect} from 'react';
+
+import Avatar from 'sentry/components/avatar';
+import {t} from 'sentry/locale';
+import {Project} from 'sentry/types';
+import {useMembers} from 'sentry/utils/useMembers';
+import {useTeams} from 'sentry/utils/useTeams';
+
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
+import SelectField from './selectField';
+
+// projects can be passed as a direct prop as well
+export interface RenderFieldProps extends InputFieldProps {
+  avatarSize?: number;
+  projects?: Project[];
+  /**
+   * Use the slug as the select field value. Without setting this the numeric id
+   * of the project will be used.
+   */
+  valueIsSlug?: boolean;
+}
+
+function SentryMemberTeamSelectorField({
+  avatarSize = 20,
+  placeholder = t('Choose Teams and Members'),
+  ...props
+}: RenderFieldProps) {
+  const {
+    members,
+    fetching: fetchingMembers,
+    onSearch: onMemberSearch,
+    loadMore: loadMoreMembers,
+  } = useMembers();
+
+  // XXX(epurkhiser): It would be nice to use an object as the value, but
+  // frustratingly that is difficult likely because we're recreating this
+  // object on every re-render.
+  const memberOptions = members?.map(member => ({
+    value: `member:${member.id}`,
+    label: member.name,
+    leadingItems: <Avatar user={member} size={avatarSize} />,
+  }));
+
+  const {
+    teams,
+    fetching: fetchingTeams,
+    onSearch: onTeamSearch,
+    loadMore: loadMoreTeams,
+  } = useTeams({provideUserTeams: true});
+
+  const teamOptions = teams?.map(team => ({
+    value: `team:${team.id}`,
+    label: team.name,
+    leadingItems: <Avatar team={team} size={avatarSize} />,
+  }));
+
+  // TODO(epurkhiser): This is an unfortunate hack right now since we don't
+  // actually load members anywhere and the useMembers and useTeams hook don't
+  // handle initial loading of data.
+  //
+  // In the future when these things use react query we should be able to clean
+  // this up.
+  useEffect(
+    () => {
+      loadMoreMembers();
+      loadMoreTeams();
+    },
+    // Only ensure things are loaded at mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return (
+    <SelectField
+      placeholder={placeholder}
+      allowClear
+      onInputChange={value => {
+        onMemberSearch(value);
+        onTeamSearch(value);
+      }}
+      isLoading={fetchingMembers || fetchingTeams}
+      options={[
+        {
+          label: t('Members'),
+          options: memberOptions,
+        },
+        {
+          label: t('Teams'),
+          options: teamOptions,
+        },
+      ]}
+      {...props}
+    />
+  );
+}
+
+export default SentryMemberTeamSelectorField;

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -1,12 +1,14 @@
-import {useRef, useState} from 'react';
+import {Fragment, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
 
 import Alert from 'sentry/components/alert';
+import AlertLink from 'sentry/components/alertLink';
 import {RadioOption} from 'sentry/components/forms/controls/radioGroup';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import RadioField from 'sentry/components/forms/fields/radioField';
 import SelectField from 'sentry/components/forms/fields/selectField';
+import SentryMemberTeamSelectorField from 'sentry/components/forms/fields/sentryMemberTeamSelectorField';
 import SentryProjectSelectorField from 'sentry/components/forms/fields/sentryProjectSelectorField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form, {FormProps} from 'sentry/components/forms/form';
@@ -24,6 +26,7 @@ import slugify from 'sentry/utils/slugify';
 import commonTheme from 'sentry/utils/theme';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {crontabAsText} from 'sentry/views/monitors/utils';
 
 import {
@@ -70,6 +73,22 @@ type TransformedData = {
  */
 function transformData(_data: Record<string, any>, model: FormModel) {
   return model.fields.toJSON().reduce<TransformedData>((data, [k, v]) => {
+    if (k === 'alertRule') {
+      const alertTargets = (v as string[] | undefined)?.map(item => {
+        // See SentryMemberTeamSelectorField to understand why these are strings
+        const [type, id] = item.split(':');
+
+        // XXX(epurkhiser): For whateve reason the rules API wants the team and
+        // mebmer to be capitalized.
+        const targetType = {team: 'Team', member: 'Member'}[type];
+
+        return {targetType, targetIdentifier: id};
+      });
+
+      data[k] = {targets: alertTargets};
+      return data;
+    }
+
     // We're only concerned with transforming the config
     if (!k.startsWith('config.')) {
       data[k] = v;
@@ -343,6 +362,35 @@ function MonitorForm({
             inline={false}
           />
         </InputGroup>
+        {(monitor === undefined || monitor.config.alert_rule_id) && (
+          <Fragment>
+            <StyledListItem>{t('Notify members')}</StyledListItem>
+            <ListItemSubText>
+              {t(
+                'Tell us who to notify when a check-in reaches the thresholds above or has an error. You can send notifications to members or teams.'
+              )}
+            </ListItemSubText>
+            <InputGroup>
+              {monitor === undefined ? (
+                <StyledSentryMemberTeamSelectorField
+                  name="alertRule"
+                  multiple
+                  stacked
+                  inline={false}
+                />
+              ) : (
+                <AlertLink
+                  priority="muted"
+                  to={normalizeUrl(
+                    `/alerts/rules/${monitor.project.slug}/${monitor.config.alert_rule_id}/`
+                  )}
+                >
+                  {t('Customize this monitors notification configuration in Alerts')}
+                </AlertLink>
+              )}
+            </InputGroup>
+          </Fragment>
+        )}
       </StyledList>
     </Form>
   );
@@ -367,6 +415,10 @@ const StyledTextField = styled(TextField)`
 `;
 
 const StyledSentryProjectSelectorField = styled(SentryProjectSelectorField)`
+  padding: 0;
+`;
+
+const StyledSentryMemberTeamSelectorField = styled(SentryMemberTeamSelectorField)`
   padding: 0;
 `;
 

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -39,6 +39,7 @@ interface BaseConfig {
   checkin_margin: number;
   max_runtime: number;
   timezone: string;
+  alert_rule_id?: number;
 }
 
 /**


### PR DESCRIPTION
In the creation form

![clipboard.png](https://i.imgur.com/OKwU9cm.png)

After creation when editing a monitor

![clipboard.png](https://i.imgur.com/tP4RkYE.png)