### PR TITLE
feat(nav): Add billing nav to search links

### DIFF
--- a/static/app/components/search/sources/routeSource.spec.jsx
+++ b/static/app/components/search/sources/routeSource.spec.jsx
@@ -28,7 +28,7 @@ describe('RouteSource', function () {
     });
   });
 
-  it('can find a billing related route', async function () {
+  it('can load links via hooks', async function () {
     const mock = jest.fn().mockReturnValue(null);
     const {organization, project} = initializeOrg();
     HookStore.add('settings:organization-navigation-config', () => {

--- a/static/app/components/search/sources/routeSource.spec.jsx
+++ b/static/app/components/search/sources/routeSource.spec.jsx
@@ -2,6 +2,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {RouteSource} from 'sentry/components/search/sources/routeSource';
+import HookStore from 'sentry/stores/hookStore';
 
 describe('RouteSource', function () {
   it('can find a route', async function () {
@@ -23,6 +24,39 @@ describe('RouteSource', function () {
         sourceType: 'route',
         title: 'Security',
         to: '/settings/account/security/',
+      });
+    });
+  });
+
+  it('can find a billing related route', async function () {
+    const mock = jest.fn().mockReturnValue(null);
+    const {organization, project} = initializeOrg();
+    HookStore.add('settings:organization-navigation-config', () => {
+      return {
+        name: 'Usage & Billing',
+        items: [
+          {
+            path: '/settings/spike-protection',
+            title: 'Spike Protection',
+          },
+        ],
+      };
+    });
+
+    render(
+      <RouteSource query="Spike" {...{organization, project}}>
+        {mock}
+      </RouteSource>
+    );
+
+    await waitFor(() => {
+      const calls = mock.mock.calls;
+      expect(calls[calls.length - 1][0].results[0].item).toEqual({
+        path: '/settings/spike-protection',
+        resultType: 'route',
+        sourceType: 'route',
+        title: 'Spike Protection',
+        to: '/settings/spike-protection',
       });
     });
   });

--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import flattenDepth from 'lodash/flattenDepth';
 
+import HookStore from 'sentry/stores/hookStore';
 import {Organization, Project} from 'sentry/types';
 import {createFuzzySearch, Fuse} from 'sentry/utils/fuzzySearch';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
@@ -96,6 +97,16 @@ class RouteSource extends Component<Props, State> {
     this.createSearch();
   }
 
+  getHookConfigs(): Config {
+    const {organization} = this.props;
+
+    return organization
+      ? HookStore.get('settings:organization-navigation-config').map(cb =>
+          cb(organization)
+        )
+      : [];
+  }
+
   async createSearch() {
     const {project, organization} = this.props;
 
@@ -111,6 +122,7 @@ class RouteSource extends Component<Props, State> {
         mapFunc(accountSettingsNavigation, context),
         mapFunc(projectSettingsNavigation, context),
         mapFunc(organizationSettingsNavigation, context),
+        mapFunc(this.getHookConfigs(), context),
       ],
       2
     );


### PR DESCRIPTION


Currently search is not pulling from Billing and Usage nav items which I'm adding here. 

Test:
Menu items are listed as links in search if you have access to and not if you don't. Automated test to come. Opening pull request to discuss some questions.



https://github.com/getsentry/sentry/assets/132939361/d93b4d9a-11fd-4489-8199-90aa31970582


Fixes ER-1543