### PR TITLE
instr(txnames): Count number of discovered rules

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -193,7 +193,7 @@ def get_sorted_rules(project: Project) -> List[Tuple[ReplacementRule, int]]:
 def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> int:
     """Write newly discovered rules to projection option and redis, and update last_used.
 
-    Returns the number of _new_ rules (that were not already present in project option).
+    Return the number of _new_ rules (that were not already present in project option).
     """
     # Run the updates even if there aren't any new rules, to get all the stores
     # up-to-date.

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -71,7 +71,10 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 # The Redis store may have more up-to-date last_seen values,
                 # so we must update the stores to bring these values to
                 # project options, even if there aren't any new rules.
-                rules.update_rules(project, new_rules)
+                num_rules_added = rules.update_rules(project, new_rules)
+
+                # Track a global counter of new rules:
+                metrics.incr("txcluster.new_rules_discovered", num_rules_added)
 
                 # Clear transaction names to prevent the set from picking up
                 # noise over a long time range.

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -176,12 +176,12 @@ def test_save_rules(default_project):
     assert project_rules == {}
 
     with freeze_time("2012-01-14 12:00:01"):
-        update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
+        assert 2 == update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
     project_rules = get_rules(project)
     assert project_rules == {"foo": 1326542401, "bar": 1326542401}
 
     with freeze_time("2012-01-14 12:00:02"):
-        update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
+        assert 1 == update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
     project_rules = get_rules(project)
     assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
 
@@ -352,7 +352,7 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
         assert get_rules(project1) == {"/user/*/**": 1}
         # Update rules to update the project option storage.
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 3):
-            update_rules(project1, [])
+            assert 0 == update_rules(project1, [])
         # After project options are updated, the last_seen should also be updated.
         assert get_redis_rules(project1) == {"/user/*/**": 2}
         assert get_rules(project1) == {"/user/*/**": 2}


### PR DESCRIPTION
In order to detect regressions in our transaction clusterer, keep track of the number of _new_ rules discovered across projects.

ref: https://github.com/getsentry/team-ingest/issues/124