### PR TITLE
feat(metrics_) Add `http.status_code` and `geo.country_code` to shared indexed strings

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -136,6 +136,8 @@ SHARED_TAG_STRINGS = {
     "span.status_code": PREFIX + 247,
     "span.domain": PREFIX + 248,
     "span.description": PREFIX + 249,
+    "http.status_code": PREFIX + 250,
+    "geo.country_code": PREFIX + 251,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
All transaction metrics will get the following new tags `browser.name`, `os.name`, `geo.country_code` and `http.status_code` (https://github.com/getsentry/team-ingest/issues/123).

`browser.name` and `os.name` are already shared indexed strings.

This PR adds `http.status_code` and `geo.country_code` to the list of shared/cross org indexed strings.
