### PR TITLE
fix(txnames): Revert high threshold for running the clusterer

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -63,7 +63,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 span.set_data("project_id", project.id)
                 tx_names = list(redis.get_transaction_names(project))
                 new_rules = []
-                if len(tx_names) >= redis.MAX_SET_SIZE:
+                if len(tx_names) >= MERGE_THRESHOLD:
                     clusterer = TreeClusterer(merge_threshold=MERGE_THRESHOLD)
                     clusterer.add_input(tx_names)
                     new_rules = clusterer.get_rules()

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -71,7 +71,10 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 # The Redis store may have more up-to-date last_seen values,
                 # so we must update the stores to bring these values to
                 # project options, even if there aren't any new rules.
-                rules.update_rules(project, new_rules)
+                num_rules_added = rules.update_rules(project, new_rules)
+
+                # Track a global counter of new rules:
+                metrics.incr("txcluster.new_rules_discovered", num_rules_added)
 
                 # Clear transaction names to prevent the set from picking up
                 # noise over a long time range.

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -204,7 +204,7 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
     project2 = Project(id=223, name="project2", organization_id=default_organization.id)
     for project in (project1, project2):
         project.save()
-        _add_mock_data(project, 10)
+        _add_mock_data(project, 4)
 
     spawn_clusterers()
 

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -176,12 +176,12 @@ def test_save_rules(default_project):
     assert project_rules == {}
 
     with freeze_time("2012-01-14 12:00:01"):
-        update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
+        assert 2 == update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
     project_rules = get_rules(project)
     assert project_rules == {"foo": 1326542401, "bar": 1326542401}
 
     with freeze_time("2012-01-14 12:00:02"):
-        update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
+        assert 1 == update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
     project_rules = get_rules(project)
     assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
 
@@ -352,7 +352,7 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
         assert get_rules(project1) == {"/user/*/**": 1}
         # Update rules to update the project option storage.
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 3):
-            update_rules(project1, [])
+            assert 0 == update_rules(project1, [])
         # After project options are updated, the last_seen should also be updated.
         assert get_redis_rules(project1) == {"/user/*/**": 2}
         assert get_rules(project1) == {"/user/*/**": 2}


### PR DESCRIPTION
As part of https://github.com/getsentry/team-ingest/issues/93, we merged https://github.com/getsentry/sentry/pull/46503, to ensure we would not run the clusterer for fresh projects until they collect a high amount of unique transaction names. This was based on a suspicion that we would otherwise declare all URL transactions as sanitized prematurely.

However, we did not have any data to back up this decision, and there is no reason to impose this threshold from the algorithm's point of view: There is already the (lower) `MERGE_THRESHOLD` which should prevent low-quality replacement rules.

What we _do_ know is that we've seen a decline in the number of transactions changed by clustering rules (see metric `event.transaction_name_changes`), which might be because we are now too strict about when we run the clusterer.