### PR TITLE
feat(generic-metrics): Use case awareness for the indexer's read path

### DIFF
--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -118,7 +118,7 @@ class PGStringIndexerV2(StringIndexer):
             [
                 UseCaseKeyResult(
                     use_case_id=(
-                        db_obj.use_case_id
+                        UseCaseID(db_obj.use_case_id)
                         if self._get_metric_path_key(strings.keys()) is UseCaseKey.PERFORMANCE
                         else UseCaseID.SESSIONS
                     ),

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -61,7 +61,11 @@ class PGStringIndexerV2(StringIndexer):
         for use_case_id, organization_id, string in db_use_case_keys.as_tuples():
             if metric_path_key is UseCaseKey.PERFORMANCE:
                 conditions.append(
-                    Q(use_case_id=use_case_id, organization_id=int(organization_id), string=string)
+                    Q(
+                        use_case_id=use_case_id.value,
+                        organization_id=int(organization_id),
+                        string=string,
+                    )
                 )
             else:
                 conditions.append(Q(organization_id=int(organization_id), string=string))

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -52,7 +52,7 @@ class PGStringIndexerV2(StringIndexer):
         >>> 3. Change Read path (this code)
         We are currently at step 3.
         Only the performance-path Postgres table has a `use_case_id` column
-        at the moment, but this will change.
+        at the moment, but this will change in the future.
         """
         use_case_ids = db_use_case_keys.mapping.keys()
         metric_path_key = self._get_metric_path_key(use_case_ids)

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -110,7 +110,7 @@ class PGStringIndexerV2(StringIndexer):
             [
                 UseCaseKeyResult(
                     use_case_id=(
-                        UseCaseID.TRANSACTIONS
+                        db_obj.use_case_id
                         if self._get_metric_path_key(strings.keys()) is UseCaseKey.PERFORMANCE
                         else UseCaseID.SESSIONS
                     ),

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -300,6 +300,26 @@ def test_already_cached_plus_read_results(
     )
 
 
+def test_read_when_bulk_record(indexer, use_case_id):
+    strings = {
+        use_case_id: {
+            1: {"a"},
+            2: {"b", "c"},
+            3: {"d", "e", "f"},
+            4: {"g", "h", "i", "j"},
+            5: {"k", "l", "m", "n", "o"},
+        }
+    }
+    indexer.bulk_record(strings)
+    results = indexer.bulk_record(strings)
+    assert all(
+        str_meta_data.fetch_type is FetchType.DB_READ
+        for key_result in results.results.values()
+        for metadata in key_result.meta.values()
+        for str_meta_data in metadata.values()
+    )
+
+
 def test_rate_limited(indexer, use_case_id, writes_limiter_option_name):
     """
     Assert that rate limits per-org and globally are applied at all.


### PR DESCRIPTION
Now that the indexer is writing `use_case_id` to the `performance` metric path key pipeline's Postgres instance, we can also read from it and query against it with `use_case_id`. This PR does that.

As a reminder, the steps we were following:
1. Indexer write path **[DONE]**
2. Backfill Postgres and drop defaults **[IN PROGRESS]** -- https://github.com/getsentry/sentry/pull/47940 needs to be merged and completed first
3. Indexer read path 