### PR TITLE
chore(starfish): Remove the count if query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_starfish.py
+++ b/src/sentry/api/endpoints/organization_events_starfish.py
@@ -46,14 +46,14 @@ class OrganizationEventsStarfishEndpoint(OrganizationEventsV2EndpointBase):
                     referrer=referrer,
                 )
 
-                metrics_enhanced_performance.query(
-                    selected_columns=["title", "count_if(mechanism,equals,ANR)"],
-                    query="event.type:transaction",
-                    params=params,
-                    snuba_params=snuba_params,
-                    limit=10000,
-                    referrer=referrer,
-                )
+                # metrics_enhanced_performance.query(
+                #     selected_columns=["title", "count_if(mechanism,equals,ANR)"],
+                #     query="event.type:transaction",
+                #     params=params,
+                #     snuba_params=snuba_params,
+                #     limit=10000,
+                #     referrer=referrer,
+                # )
         except Exception:
             return Response(status=200)
 


### PR DESCRIPTION
Remove the count_if, it's much slower than I anticipated,
will add it back as a "regression" in a few hours