### PR TITLE
ref(trends): Impose strict top event limit

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trendsv2.py
+++ b/src/sentry/api/endpoints/organization_events_trendsv2.py
@@ -75,6 +75,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
         selected_columns.append(trend_function)
         selected_columns.append("count()")
         request.yAxis = selected_columns
+        top_events_limit = 10
 
         def get_top_events(selected_columns, user_query, params, orderby, limit, referrer):
             return query(
@@ -102,7 +103,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 user_query=user_query,
                 params=params,
                 orderby=["-count()"],
-                limit=100,
+                limit=top_events_limit,
                 referrer=Referrer.API_TRENDS_GET_EVENT_STATS_V2_TOP_EVENTS.value,
             )
 
@@ -167,7 +168,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 request,
                 organization,
                 get_event_stats_metrics,
-                top_events=50,
+                top_events=top_events_limit,
                 query_column=trend_function,
                 params=params,
                 query=_query,

--- a/src/sentry/api/endpoints/organization_events_trendsv2.py
+++ b/src/sentry/api/endpoints/organization_events_trendsv2.py
@@ -75,7 +75,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
         selected_columns.append(trend_function)
         selected_columns.append("count()")
         request.yAxis = selected_columns
-        top_events_limit = 10
+        top_events_limit = 8
 
         def get_top_events(selected_columns, user_query, params, orderby, limit, referrer):
             return query(


### PR DESCRIPTION
This is a temporary fix to select top 8 events. For each transaction name we're getting two timeseries (trend_function and count) of 1 hour bucket for 14 days (the default stats period) which amounts to 1*24*14*2=672 data points. I'm picking 8 events very conservatively here until I can either paginate the query or parallelize it.