### PR TITLE
ref(api): Rename `handleXhrErrorResponse` to `getXhrErrorResponseHandler`

### DIFF
--- a/static/app/actionCreators/project.tsx
+++ b/static/app/actionCreators/project.tsx
@@ -3,7 +3,7 @@ import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {Project} from 'sentry/types';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 
 /**
  * Fetches a project's details
@@ -21,7 +21,7 @@ export function fetchProjectDetails({
 
   promise.then(ProjectsStore.onUpdateSuccess).catch(error => {
     const message = t('Unable to fetch project details');
-    handleXhrErrorResponse(message)(error);
+    getXhrErrorResponseHandler(message)(error);
     addErrorMessage(message);
   });
 

--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -1,7 +1,7 @@
 import {Client} from 'sentry/api';
 import {MAX_AUTOCOMPLETE_RECENT_SEARCHES} from 'sentry/constants';
 import {RecentSearch, SavedSearch, SavedSearchType} from 'sentry/types';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 
 const getRecentSearchUrl = (orgSlug: string): string =>
   `/organizations/${orgSlug}/recent-searches/`;
@@ -29,7 +29,7 @@ export function saveRecentSearch(
     },
   });
 
-  promise.catch(handleXhrErrorResponse('Unable to save a recent search'));
+  promise.catch(getXhrErrorResponseHandler('Unable to save a recent search'));
 
   return promise;
 }
@@ -61,7 +61,7 @@ export function fetchRecentSearches(
 
   promise.catch(resp => {
     if (resp.status !== 401 && resp.status !== 403) {
-      handleXhrErrorResponse('Unable to fetch recent searches')(resp);
+      getXhrErrorResponseHandler('Unable to fetch recent searches')(resp);
     }
   });
 

--- a/static/app/components/forms/controls/selectAsyncControl.tsx
+++ b/static/app/components/forms/controls/selectAsyncControl.tsx
@@ -5,7 +5,7 @@ import debounce from 'lodash/debounce';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 
 import SelectControl, {ControlProps, GeneralSelectValue} from './selectControl';
 
@@ -93,7 +93,7 @@ class SelectAsyncControl extends Component<SelectAsyncControlProps> {
       },
       err => {
         addErrorMessage(t('There was a problem with the request.'));
-        handleXhrErrorResponse('SelectAsync failed')(err);
+        getXhrErrorResponseHandler('SelectAsync failed')(err);
         // eslint-disable-next-line no-console
         console.error(err);
       }

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -17,7 +17,7 @@ import SelectControl from 'sentry/components/forms/controls/selectControl';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DateString, Organization, PageFilters, SelectValue} from 'sentry/types';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import useApi from 'sentry/utils/useApi';
@@ -172,7 +172,7 @@ function AddToDashboardModal({
       addSuccessMessage(t('Successfully added widget to dashboard'));
     } catch (e) {
       const errorMessage = t('Unable to add widget to dashboard');
-      handleXhrErrorResponse(errorMessage)(e);
+      getXhrErrorResponseHandler(errorMessage)(e);
       addErrorMessage(errorMessage);
     }
   }

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -8,7 +8,7 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {t} from 'sentry/locale';
 import {Organization, PageFilters} from 'sentry/types';
 import {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
 
 import {
@@ -91,7 +91,7 @@ export function CustomMeasurementsProvider({
           const errorResponse =
             e?.responseJSON ?? t('Unable to fetch custom performance metrics');
           addErrorMessage(errorResponse);
-          handleXhrErrorResponse(errorResponse)(e);
+          getXhrErrorResponseHandler(errorResponse)(e);
         });
     }
 

--- a/static/app/utils/handleXhrErrorResponse.spec.jsx
+++ b/static/app/utils/handleXhrErrorResponse.spec.jsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 
 describe('handleXhrErrorResponse', function () {
   const stringError = {responseJSON: {detail: 'Error'}, status: 400};
@@ -13,23 +13,23 @@ describe('handleXhrErrorResponse', function () {
   });
 
   it('does nothing if we have invalid response', function () {
-    handleXhrErrorResponse('')(null);
+    getXhrErrorResponseHandler('')(null);
     expect(Sentry.captureException).not.toHaveBeenCalled();
-    handleXhrErrorResponse('')({});
+    getXhrErrorResponseHandler('')({});
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('captures an exception to sdk when `resp.detail` is a string', function () {
-    handleXhrErrorResponse('String error')(stringError);
+    getXhrErrorResponseHandler('String error')(stringError);
     expect(Sentry.captureException).toHaveBeenCalledWith(new Error('String error'));
   });
 
   it('captures an exception to sdk when `resp.detail` is an object', function () {
-    handleXhrErrorResponse('Object error')(objError);
+    getXhrErrorResponseHandler('Object error')(objError);
     expect(Sentry.captureException).toHaveBeenCalledWith(new Error('Object error'));
   });
   it('ignores `sudo-required` errors', function () {
-    handleXhrErrorResponse('Sudo required error')({
+    getXhrErrorResponseHandler('Sudo required error')({
       status: 401,
       responseJSON: {
         detail: {

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 
 import {ResponseMeta} from 'sentry/api';
 
-export default function handleXhrErrorResponse(message: string) {
+export default function getXhrErrorResponseHandler(message: string) {
   return (resp: ResponseMeta) => {
     if (!resp) {
       return;

--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -5,7 +5,7 @@ import {Client} from 'sentry/api';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Release} from 'sentry/types';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 
 import useApi from '../useApi';
 
@@ -78,7 +78,7 @@ function ReleasesProvider({
         const errorResponse = e?.responseJSON ?? t('Unable to fetch releases');
         addErrorMessage(errorResponse);
         setLoading(false);
-        handleXhrErrorResponse(errorResponse)(e);
+        getXhrErrorResponseHandler(errorResponse)(e);
       });
     return () => {
       shouldCancelRequest = true;

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -20,7 +20,7 @@ import {space} from 'sentry/styles/space';
 import {OnboardingSelectedSDK} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 import Redirect from 'sentry/utils/redirect';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
@@ -248,7 +248,7 @@ function Onboarding(props: Props) {
         project_id: recentCreatedProject.id,
       });
     } catch (error) {
-      handleXhrErrorResponse(t('Unable to delete project in onboarding'))(error);
+      getXhrErrorResponseHandler(t('Unable to delete project in onboarding'))(error);
       // we don't give the user any feedback regarding this error as this shall be silent
     }
   }, [api, organization, recentCreatedProject, onboardingContext]);

--- a/static/app/views/onboarding/setupDocsLoader.tsx
+++ b/static/app/views/onboarding/setupDocsLoader.tsx
@@ -15,7 +15,7 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization, Project, ProjectKey} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 import {decodeList} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {DynamicSDKLoaderOption} from 'sentry/views/settings/project/projectKeys/details/loaderSettings';
@@ -103,7 +103,7 @@ export function SetupDocsLoader({
       setProjectKeyUpdateError(false);
     } catch (error) {
       const message = t('Unable to updated dynamic SDK loader configuration');
-      handleXhrErrorResponse(message)(error);
+      getXhrErrorResponseHandler(message)(error);
       setProjectKeyUpdateError(true);
     }
   }, [api, location.query.product, organization.slug, project.slug, projectKey?.id]);

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -14,7 +14,7 @@ import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
 import {ProjectKey} from 'sentry/views/settings/project/projectKeys/types';
 
@@ -99,7 +99,7 @@ export function LoaderSettings({keyId, orgSlug, project, projectKey}: Props) {
         addSuccessMessage(t('Successfully updated dynamic SDK loader configuration'));
       } catch (error) {
         const message = t('Unable to updated dynamic SDK loader configuration');
-        handleXhrErrorResponse(message)(error);
+        getXhrErrorResponseHandler(message)(error);
         addErrorMessage(message);
       }
     },
@@ -146,7 +146,7 @@ export function LoaderSettings({keyId, orgSlug, project, projectKey}: Props) {
         addSuccessMessage(t('Successfully updated SDK version'));
       } catch (error) {
         const message = t('Unable to updated SDK version');
-        handleXhrErrorResponse(message)(error);
+        getXhrErrorResponseHandler(message)(error);
         addErrorMessage(message);
       }
     },

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
@@ -21,7 +21,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {Organization, Project} from 'sentry/types';
 import {CustomRepo, CustomRepoType} from 'sentry/types/debugFiles';
 import {defined} from 'sentry/utils';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 
 import Repository from './repository';
 import {dropDownItems, expandKeys, getRequestMessages} from './utils';
@@ -190,7 +190,7 @@ function CustomRepositories({
         'Rate limit for refreshing repository exceeded. Try again in a few minutes.'
       );
       addErrorMessage(errorMessage);
-      handleXhrErrorResponse(errorMessage)(error);
+      getXhrErrorResponseHandler(errorMessage)(error);
     }
   }
 

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -23,7 +23,7 @@ import {fields} from 'sentry/data/forms/projectGeneralSettings';
 import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {Organization, Project} from 'sentry/types';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import routeTitleGen from 'sentry/utils/routeTitle';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -91,7 +91,7 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
       .then(() => {
         // Need to hard reload because lots of components do not listen to Projects Store
         window.location.assign('/');
-      }, handleXhrErrorResponse('Unable to remove project'));
+      }, getXhrErrorResponseHandler('Unable to remove project'));
   };
 
   handleTransferProject = async () => {
@@ -110,7 +110,7 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
       window.location.assign('/');
     } catch (err) {
       if (err.status >= 500) {
-        handleXhrErrorResponse('Unable to transfer project')(err);
+        getXhrErrorResponseHandler('Unable to transfer project')(err);
       }
     }
   };

--- a/static/app/views/settings/projectIssueGrouping/upgradeGrouping.tsx
+++ b/static/app/views/settings/projectIssueGrouping/upgradeGrouping.tsx
@@ -11,7 +11,7 @@ import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {EventGroupingConfig, Organization, Project} from 'sentry/types';
-import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 import marked from 'sentry/utils/marked';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
@@ -89,7 +89,7 @@ function UpgradeGrouping({
       ProjectsStore.onUpdateSuccess(response);
       onUpgrade();
     } catch {
-      handleXhrErrorResponse(t('Unable to upgrade config'));
+      getXhrErrorResponseHandler(t('Unable to upgrade config'));
     }
   }
 


### PR DESCRIPTION
This renames `handleXhrErrorResponse` a) so that its name better reflects what it does, and b) as a preliminary step in changing how such responses are handled in a way that's backwards-compatible with `getsentry`. (Since it's a default export, changing the name in the file where it's defined doesn't affect `getsentry`, but it does make it so that when a similar change is made in `getsentry`, all of the names match.)