### PR TITLE
ref(api): Capture undefined `responseText` as separate event

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -538,13 +538,18 @@ export class Client {
               errorReason,
             });
 
-            // Make sure all of these errors group, so we don't produce a bunch of noise
-            scope.setFingerprint(['200 as error']);
+            const responseTextUndefined = responseText === undefined;
+            const fingerprint = responseTextUndefined
+              ? '200 with undefined responseText'
+              : '200 as error';
+            const message = responseTextUndefined
+              ? '200 API response with undefined responseText'
+              : '200 treated as error';
 
-            Sentry.captureException(
-              new Error(`200 treated as error: ${method} ${path}`),
-              scope
-            );
+            // Make sure all of these errors group, so we don't produce a bunch of noise
+            scope.setFingerprint([fingerprint]);
+
+            Sentry.captureException(new Error(`${message}: ${method} ${path}`), scope);
           }
 
           const shouldSkipErrorHandler =


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/49060, which made it so that we capture an event whenever a 200 response to a request made by our frontend API client counts as an error. 

Now that some of those events have come in, it's clear that at least one of the problems is that we're ending up with responses where `response.text()` returns `undefined`. This separates such cases out into their own issue, so that it can remain open (with a much more explanatory error message) while we debug the cause and the existing issue can be resolved. That way, if the existing issue regresses, we'll know that there's a second reason why 200s are counting as errors.

Part of https://github.com/getsentry/sentry/issues/49142