### PR TITLE
fix(onboarding): Add missing `useEffect` dependency

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -135,6 +135,7 @@ function Onboarding(props: Props) {
     onboardingContext,
     onboardingSteps,
     organization.slug,
+    props.location.pathname,
   ]);
 
   const heartbeatFooter = !!organization?.features.includes(


### PR DESCRIPTION
This adds a missing dependency to the `useEffect` hook used in the `Onboarding` component, to keep the linter from complaining and blocking pre-commit hooks when unrelated changes are made to the file.