### PR TITLE
feat(source-maps): adds logic to handle sdk out of date for source code debugging

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -101,7 +101,7 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
         if (
             sdk_info
             and sdk_info["version"] < JS_VERSION_FOR_DEBUG_ID
-            # need to ignore react native for now debug id is implemented there
+            # need to ignore react native for now until debug id is implemented there
             and sdk_info["name"] != "sentry.javascript.react-native"
         ):
             return self._create_response(

--- a/src/sentry/models/sourcemapprocessingissue.py
+++ b/src/sentry/models/sourcemapprocessingissue.py
@@ -14,6 +14,7 @@ class SourceMapProcessingIssue:
     PARTIAL_MATCH = "partial_match"
     DIST_MISMATCH = "dist_mismatch"
     SOURCEMAP_NOT_FOUND = "sourcemap_not_found"
+    SDK_OUT_OF_DATE = "sdk_out_of_date"
 
     _messages = {
         UNKNOWN_ERROR: "Unknown error",
@@ -25,6 +26,7 @@ class SourceMapProcessingIssue:
         PARTIAL_MATCH: "The absolute path url is a partial match",
         DIST_MISMATCH: "The dist values do not match",
         SOURCEMAP_NOT_FOUND: "The sourcemap could not be found",
+        SDK_OUT_OF_DATE: "The SDK is out of date",
     }
 
     @classmethod


### PR DESCRIPTION
This is a follow up to: https://github.com/getsentry/sentry/pull/49061 for adding the backend for source map debugging. Basically, if you don't have source map working and your SDK is older than 7.44 we tell you to upgrade.

Note that after this PR is merged, I need to add logic to handle cases where your SDK is up to date but source maps are not working.