### PR TITLE
feat(perf): Introduce trendsv2 in UI

### DIFF
--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -24,10 +24,17 @@ export type SearchBarProps = {
   onSearch: (query: string) => void;
   organization: Organization;
   query: string;
+  className?: string;
 };
 
 function SearchBar(props: SearchBarProps) {
-  const {organization, eventView: _eventView, onSearch, query: searchQuery} = props;
+  const {
+    organization,
+    eventView: _eventView,
+    onSearch,
+    query: searchQuery,
+    className,
+  } = props;
 
   const [searchResults, setSearchResults] = useState<SearchGroup[]>([]);
   const transactionCount = searchResults[0]?.children?.length || 0;
@@ -217,7 +224,11 @@ function SearchBar(props: SearchBarProps) {
   };
 
   return (
-    <Container data-test-id="transaction-search-bar" ref={containerRef}>
+    <Container
+      className={className || ''}
+      data-test-id="transaction-search-bar"
+      ref={containerRef}
+    >
       <BaseSearchBar
         placeholder={t('Search Transactions')}
         onChange={handleSearchChange}

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -72,9 +72,11 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
   ];
   const rest = {...props, eventView};
   eventView.additionalConditions.addFilterValues('tpm()', ['>0.01']);
-  eventView.additionalConditions.addFilterValues('count_percentage()', ['>0.25', '<4']);
-  eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);
-  eventView.additionalConditions.addFilterValues('confidence()', ['>6']);
+  if (!organization.features.includes('performance-new-trends')) {
+    eventView.additionalConditions.addFilterValues('count_percentage()', ['>0.25', '<4']);
+    eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);
+    eventView.additionalConditions.addFilterValues('confidence()', ['>6']);
+  }
 
   const chart = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
@@ -89,6 +91,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
           limit={3}
           cursor="0:0:1"
           noPagination
+          withBreakpoint={organization.features.includes('performance-new-trends')}
         />
       ),
       transform: transformTrendsDiscover,

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -298,7 +298,7 @@ function ChangedTransactions(props: Props) {
           <TransactionsListContainer data-test-id="changed-transactions">
             <TrendsTransactionPanel>
               <StyledHeaderTitleLegend>
-                {chartTitle} {withBreakpoint && '- With Breakpoints'}
+                {chartTitle}
                 <QuestionTooltip size="sm" position="top" title={titleTooltipContent} />
               </StyledHeaderTitleLegend>
               {isLoading ? (

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -12,6 +12,7 @@ import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -34,6 +35,7 @@ import {
   getCurrentTrendFunction,
   getCurrentTrendParameter,
   getSelectedQueryKey,
+  modifyTransactionNameTrendsQuery,
   modifyTrendsViewDefaultPeriod,
   resetCursors,
   TRENDS_FUNCTIONS,
@@ -147,6 +149,20 @@ class TrendsContent extends Component<Props, State> {
     });
   };
 
+  getFreeTextFromQuery(query: string) {
+    const conditions = new MutableSearch(query);
+    const transactionValues = conditions.getFilterValues('transaction');
+    if (transactionValues.length) {
+      return transactionValues[0];
+    }
+    if (conditions.freeText.length > 0) {
+      // raw text query will be wrapped in wildcards in generatePerformanceEventView
+      // so no need to wrap it here
+      return conditions.freeText.join(' ');
+    }
+    return '';
+  }
+
   getPerformanceLink() {
     const {location} = this.props;
 
@@ -173,6 +189,10 @@ class TrendsContent extends Component<Props, State> {
 
     const trendView = eventView.clone() as TrendView;
     modifyTrendsViewDefaultPeriod(trendView, location);
+
+    if (organization.features.includes('performance-new-trends')) {
+      modifyTransactionNameTrendsQuery(trendView);
+    }
 
     const fields = generateAggregateFields(
       organization,
@@ -237,15 +257,24 @@ class TrendsContent extends Component<Props, State> {
                   <EnvironmentPageFilter />
                   <DatePageFilter alignDropdown="left" />
                 </PageFilterBar>
-                <StyledSearchBar
-                  searchSource="trends"
-                  organization={organization}
-                  projectIds={trendView.project}
-                  query={query}
-                  fields={fields}
-                  onSearch={this.handleSearch}
-                  maxQueryLength={MAX_QUERY_LENGTH}
-                />
+                {organization.features.includes('performance-new-trends') ? (
+                  <StyledTransactionNameSearchBar
+                    organization={organization}
+                    eventView={trendView}
+                    onSearch={this.handleSearch}
+                    query={this.getFreeTextFromQuery(query)}
+                  />
+                ) : (
+                  <StyledSearchBar
+                    searchSource="trends"
+                    organization={organization}
+                    projectIds={trendView.project}
+                    query={query}
+                    fields={fields}
+                    onSearch={this.handleSearch}
+                    maxQueryLength={MAX_QUERY_LENGTH}
+                  />
+                )}
                 <CompactSelect
                   triggerProps={{prefix: t('Percentile')}}
                   value={currentTrendFunction.field}
@@ -354,6 +383,18 @@ const FilterActions = styled('div')`
 `;
 
 const StyledSearchBar = styled(SearchBar)`
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    order: 1;
+    grid-column: 1/5;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    order: initial;
+    grid-column: auto;
+  }
+`;
+
+const StyledTransactionNameSearchBar = styled(TransactionNameSearchBar)`
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     order: 1;
     grid-column: 1/5;

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -3,7 +3,6 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/alert';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -273,6 +272,9 @@ class TrendsContent extends Component<Props, State> {
                   trendView={trendView}
                   location={location}
                   setError={this.setError}
+                  withBreakpoint={organization.features.includes(
+                    'performance-new-trends'
+                  )}
                 />
                 <ChangedTransactions
                   trendChangeType={TrendChangeType.REGRESSION}
@@ -280,28 +282,11 @@ class TrendsContent extends Component<Props, State> {
                   trendView={trendView}
                   location={location}
                   setError={this.setError}
+                  withBreakpoint={organization.features.includes(
+                    'performance-new-trends'
+                  )}
                 />
               </ListContainer>
-              <Feature features={['organizations:performance-new-trends']}>
-                <ListContainer>
-                  <ChangedTransactions
-                    trendChangeType={TrendChangeType.IMPROVED}
-                    previousTrendFunction={previousTrendFunction}
-                    trendView={trendView}
-                    location={location}
-                    setError={this.setError}
-                    withBreakpoint
-                  />
-                  <ChangedTransactions
-                    trendChangeType={TrendChangeType.REGRESSION}
-                    previousTrendFunction={previousTrendFunction}
-                    trendView={trendView}
-                    location={location}
-                    setError={this.setError}
-                    withBreakpoint
-                  />
-                </ListContainer>
-              </Feature>
             </DefaultTrends>
           </Layout.Main>
         </Layout.Body>

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -430,3 +430,9 @@ export function transformEventStatsSmoothed(data?: Series[], seriesName?: string
     smoothedResults,
   };
 }
+
+export function modifyTransactionNameTrendsQuery(trendView: TrendView) {
+  const query = new MutableSearch(trendView.query);
+  query.setFilterValues('tpm()', ['>0.01']);
+  trendView.query = query.formatString();
+}


### PR DESCRIPTION
- use new trends on the landing page 
- remove indexed trends from the trends page (I'll add another dev only flag later to render both indexed and metrics trends for internal debugging)
- use transaction name search in trends since most of the filters won't work for processed events