### PR TITLE
fix: Fix query subscription consumer settings in dev

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -62,7 +62,7 @@ _DEFAULT_DAEMONS = {
         "sentry",
         "run",
         "query-subscription-consumer",
-        "--force-offset-reset",
+        "--no-strict-offset-reset",
         "latest",
     ],
     "metrics-rh": [


### PR DESCRIPTION
All Arroyo consumers should pass --no-strict-offset-reset in dev. --force-offset-reset option no longer does anything.