### PR TITLE
fix(API): Fix usage of `getXhrErrorResponseHandler`

### DIFF
--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -88,8 +88,7 @@ export function CustomMeasurementsProvider({
             return;
           }
 
-          const errorResponse =
-            e?.responseJSON ?? t('Unable to fetch custom performance metrics');
+          const errorResponse = t('Unable to fetch custom performance metrics');
           addErrorMessage(errorResponse);
           getXhrErrorResponseHandler(errorResponse)(e);
         });

--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -75,7 +75,7 @@ function ReleasesProvider({
           return;
         }
 
-        const errorResponse = e?.responseJSON ?? t('Unable to fetch releases');
+        const errorResponse = t('Unable to fetch releases');
         addErrorMessage(errorResponse);
         setLoading(false);
         getXhrErrorResponseHandler(errorResponse)(e);

--- a/static/app/views/settings/projectIssueGrouping/upgradeGrouping.tsx
+++ b/static/app/views/settings/projectIssueGrouping/upgradeGrouping.tsx
@@ -88,8 +88,8 @@ function UpgradeGrouping({
       clearIndicators();
       ProjectsStore.onUpdateSuccess(response);
       onUpgrade();
-    } catch {
-      getXhrErrorResponseHandler(t('Unable to upgrade config'));
+    } catch (err) {
+      getXhrErrorResponseHandler(t('Unable to upgrade config'))(err);
     }
   }
 


### PR DESCRIPTION
This fixes two places where we've been using `getXhrErrorResponseHandler` wrong, either passing it a JSON object rather than an error message (leading to `Error: [object Object]` events in Sentry) or failing the call the handler it returns.

![image](https://github.com/getsentry/sentry/assets/14812505/75355f24-539d-4e41-8586-7f2864751472)

(Split off of https://github.com/getsentry/sentry/pull/48982)
