### PR TITLE
fix(replays): issues tab unstable sort

### DIFF
--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -70,8 +70,17 @@ function IssueList({projectId, replayId}: Props) {
         }
       >
         {issues
-          // prioritize the replay issues first
-          .sort(a => (a.project.id === projectId ? -1 : 1))
+          // prioritize the replay issues for the project first, followed by first_seen
+          .sort((a, b) => {
+            if (a.project.id === projectId) {
+              if (a.project.id === b.project.id) {
+                return new Date(a.firstSeen).getTime() - new Date(b.firstSeen).getTime();
+              }
+
+              return -1;
+            }
+            return 1;
+          })
           .map(issue => (
             <TableRow
               key={issue.id}


### PR DESCRIPTION
## Summary
Fixes an unstable sort in the issues tab. Re-renders would sometimes cause rows to jump to different indices

**Before**
https://github.com/getsentry/sentry/assets/7349258/e02c9eec-949d-4212-a1d3-f6cab8ef4e9b

**After**

https://github.com/getsentry/sentry/assets/7349258/0bd755bd-1981-4611-a1ff-92adff6898bb

