### PR TITLE
fix(crons): Added TIMEOUT status to monitor sorting

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitors.py
+++ b/src/sentry/monitors/endpoints/organization_monitors.py
@@ -52,6 +52,7 @@ from rest_framework.response import Response
 DEFAULT_ORDERING = [
     MonitorStatus.ERROR,
     MonitorStatus.MISSED_CHECKIN,
+    MonitorStatus.TIMEOUT,
     MonitorStatus.OK,
     MonitorStatus.ACTIVE,
     MonitorStatus.DISABLED,

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -71,6 +71,7 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         monitor_error_older_checkin = add_status_monitor("ERROR", last_checkin_older)
         monitor_error = add_status_monitor("ERROR")
         monitor_missed_checkin = add_status_monitor("MISSED_CHECKIN")
+        monitor_timed_out = add_status_monitor("TIMEOUT")
 
         response = self.get_success_response(
             self.organization.slug, params={"environment": "jungle"}
@@ -81,6 +82,7 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
                 monitor_error,
                 monitor_error_older_checkin,
                 monitor_missed_checkin,
+                monitor_timed_out,
                 monitor_ok,
                 monitor_active,
                 monitor_disabled,


### PR DESCRIPTION
Needed to add `TIMEOUT` to monitor status sort