### PR TITLE
chore(hybridcloud) Shift more reads off of user.actor_id

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -14,8 +14,8 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
     Incident,
 )
-from sentry.models import ACTOR_TYPES, Rule, actor_type_to_string
-from sentry.models.actor import Actor
+from sentry.models.actor import ACTOR_TYPES, Actor, actor_type_to_string
+from sentry.models.rule import Rule
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -14,13 +14,8 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
     Incident,
 )
-from sentry.models import (
-    ACTOR_TYPES,
-    Rule,
-    actor_type_to_class,
-    actor_type_to_string,
-    fetch_actors_by_actor_ids,
-)
+from sentry.models import ACTOR_TYPES, Rule, actor_type_to_string
+from sentry.models.actor import Actor
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -98,12 +93,11 @@ class AlertRuleSerializer(Serializer):
 
         resolved_actors = {}
         for k, v in ACTOR_TYPES.items():
-            # TODO(actorid) This relies on ducktyping between user and team.
-            # This will need to handle user + team separately.
-            resolved_actors[k] = {
-                a.actor_id: a.id
-                for a in fetch_actors_by_actor_ids(actor_type_to_class(v), owners_by_type[k])
-            }
+            actors = Actor.objects.filter(type=v, id__in=owners_by_type[k])
+            if k == "team":
+                resolved_actors[k] = {actor.id: actor.team_id for actor in actors}
+            if k == "user":
+                resolved_actors[k] = {actor.id: actor.user_id for actor in actors}
 
         for alert_rule in alert_rules.values():
             if alert_rule.owner_id:

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -4,8 +4,9 @@ from typing import Any, List, Mapping, MutableMapping, Optional
 from typing_extensions import TypedDict
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import ACTOR_TYPES, ExternalActor, User, actor_type_to_string
-from sentry.models.actor import Actor
+from sentry.models.actor import ACTOR_TYPES, Actor, actor_type_to_string
+from sentry.models.integrations.external_actor import ExternalActor
+from sentry.models.user import User
 from sentry.types.integrations import get_provider_string
 
 

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -4,14 +4,8 @@ from typing import Any, List, Mapping, MutableMapping, Optional
 from typing_extensions import TypedDict
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import (
-    ACTOR_TYPES,
-    ExternalActor,
-    User,
-    actor_type_to_class,
-    actor_type_to_string,
-    fetch_actors_by_actor_ids,
-)
+from sentry.models import ACTOR_TYPES, ExternalActor, User, actor_type_to_string
+from sentry.models.actor import Actor
 from sentry.types.integrations import get_provider_string
 
 
@@ -38,22 +32,26 @@ class ExternalActorSerializer(Serializer):  # type: ignore
             external_actor.actor_id: external_actor for external_actor in item_list
         }
 
-        # iterating over each actor id and split it up by type.
+        # Group actors by type (team/user)
         actor_ids_by_type = defaultdict(list)
         for actor_id, external_actor in external_actors_by_actor_id.items():
             if actor_id is not None:
                 type_str = actor_type_to_string(external_actor.actor.type)
                 actor_ids_by_type[type_str].append(actor_id)
 
-        # each actor id maps to an object
+        # Resolve actors to the team/user id.
+        # These attributes are indexed by the actor type so that we can select
+        # the right value in serialize()
         resolved_actors: MutableMapping[int, Any] = {}
         for type_str, type_id in ACTOR_TYPES.items():
-            cls = actor_type_to_class(type_id)
-            actor_ids = actor_ids_by_type[type_str]
-
-            # TODO(actorid) This relies on ducktyping. Need to handle user + team separately
-            for model in fetch_actors_by_actor_ids(cls, actor_ids):
-                resolved_actors[model.actor_id] = {type_str: model}
+            if type_str == "user":
+                actors = Actor.objects.filter(type=type_id, id__in=actor_ids_by_type[type_str])
+                for actor in actors:
+                    resolved_actors[actor.id] = {type_str: actor.user_id}
+            if type_str == "team":
+                actors = Actor.objects.filter(type=type_id, id__in=actor_ids_by_type[type_str])
+                for actor in actors:
+                    resolved_actors[actor.id] = {type_str: actor.user_id}
 
         # create a mapping of external actor to a set of attributes. Those attributes are either {"user": User} or {"team": Team}.
         return {
@@ -81,8 +79,8 @@ class ExternalActorSerializer(Serializer):  # type: ignore
 
         # Extra context `key` tells the API how to resolve actor_id.
         if key == "user":
-            data["userId"] = str(attrs[key].id)
+            data["userId"] = str(attrs[key])
         elif key == "team":
-            data["teamId"] = str(attrs[key].id)
+            data["teamId"] = str(attrs[key])
 
         return data

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -52,7 +52,7 @@ class ExternalActorSerializer(Serializer):  # type: ignore
             if type_str == "team":
                 actors = Actor.objects.filter(type=type_id, id__in=actor_ids_by_type[type_str])
                 for actor in actors:
-                    resolved_actors[actor.id] = {type_str: actor.user_id}
+                    resolved_actors[actor.id] = {type_str: actor.team_id}
 
         # create a mapping of external actor to a set of attributes. Those attributes are either {"user": User} or {"team": Team}.
         return {

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -11,10 +11,9 @@ from sentry.models import (
     RuleActivity,
     RuleActivityType,
     RuleFireHistory,
-    actor_type_to_class,
     actor_type_to_string,
-    fetch_actors_by_actor_ids,
 )
+from sentry.models.actor import Actor
 from sentry.services.hybrid_cloud.user.service import user_service
 
 
@@ -100,11 +99,11 @@ class RuleSerializer(Serializer):
                 owners_by_type[actor_type_to_string(item.owner.type)].append(item.owner_id)
 
         for k, v in ACTOR_TYPES.items():
-            # TODO(actorid) This relies on ducktyping. This needs to handle user + team separately.
-            resolved_actors[k] = {
-                a.actor_id: a.id
-                for a in fetch_actors_by_actor_ids(actor_type_to_class(v), owners_by_type[k])
-            }
+            actors = Actor.objects.filter(type=v, id__in=owners_by_type[k])
+            if k == "team":
+                resolved_actors[k] = {actor.id: actor.team_id for actor in actors}
+            if k == "user":
+                resolved_actors[k] = {actor.id: actor.user_id for actor in actors}
 
         for rule in rules.values():
             if rule.owner_id:


### PR DESCRIPTION
Remove a handful of reads from `User.actor_id` and `Team.actor_id`

Part of the work to remove `User.actor_id`

* Create columns, dual write ✅
* Backfill new columns ✅
* Change source of truth (read paths) **we are here**
* Drop user.actor_id column, solidifying actors as a region silo model
