### PR TITLE
chore(js): Add types to `catch` callbacks handling error responses

### DIFF
--- a/static/app/actionCreators/project.tsx
+++ b/static/app/actionCreators/project.tsx
@@ -1,5 +1,5 @@
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {Project} from 'sentry/types';
@@ -19,7 +19,7 @@ export function fetchProjectDetails({
 }): Promise<Project> {
   const promise = api.requestPromise(`/projects/${orgSlug}/${projSlug}/`);
 
-  promise.then(ProjectsStore.onUpdateSuccess).catch(error => {
+  promise.then(ProjectsStore.onUpdateSuccess).catch((error: ResponseMeta) => {
     const message = t('Unable to fetch project details');
     getXhrErrorResponseHandler(message)(error);
     addErrorMessage(message);

--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -1,4 +1,4 @@
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {MAX_AUTOCOMPLETE_RECENT_SEARCHES} from 'sentry/constants';
 import {RecentSearch, SavedSearch, SavedSearchType} from 'sentry/types';
 import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
@@ -59,7 +59,7 @@ export function fetchRecentSearches(
     },
   });
 
-  promise.catch(resp => {
+  promise.catch((resp: ResponseMeta) => {
     if (resp.status !== 401 && resp.status !== 403) {
       getXhrErrorResponseHandler('Unable to fetch recent searches')(resp);
     }

--- a/static/app/components/forms/controls/selectAsyncControl.tsx
+++ b/static/app/components/forms/controls/selectAsyncControl.tsx
@@ -3,7 +3,7 @@ import ReactSelect from 'react-select';
 import debounce from 'lodash/debounce';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {t} from 'sentry/locale';
 import getXhrErrorResponseHandler from 'sentry/utils/handleXhrErrorResponse';
 
@@ -91,7 +91,7 @@ class SelectAsyncControl extends Component<SelectAsyncControlProps> {
         const {onResults} = this.props;
         return typeof onResults === 'function' ? onResults(resp) : resp;
       },
-      err => {
+      (err: ResponseMeta) => {
         addErrorMessage(t('There was a problem with the request.'));
         getXhrErrorResponseHandler('SelectAsync failed')(err);
         // eslint-disable-next-line no-console

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {Query} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {getFieldTypeFromUnit} from 'sentry/components/events/eventCustomPerformanceMetrics';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
@@ -83,7 +83,7 @@ export function CustomMeasurementsProvider({
 
           setState({customMeasurements: newCustomMeasurements});
         })
-        .catch(e => {
+        .catch((e: ResponseMeta) => {
           if (shouldCancelRequest) {
             return;
           }

--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -1,7 +1,7 @@
 import {createContext, useContext, useEffect, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {Client} from 'sentry/api';
+import {Client, ResponseMeta} from 'sentry/api';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Release} from 'sentry/types';
@@ -69,7 +69,7 @@ function ReleasesProvider({
         setLoading(false);
         setReleases(response);
       })
-      .catch(e => {
+      .catch((e: ResponseMeta) => {
         if (shouldCancelRequest) {
           setLoading(false);
           return;


### PR DESCRIPTION
This adds types in various places where we handle error responses.

(This is what's left of https://github.com/getsentry/sentry/pull/48982 after I split the other changes there off into separate PRs.)