### PR TITLE
fix: Move ObjectStatus import to local

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -2,7 +2,6 @@
 
 import time
 
-from sentry.constants import ObjectStatus
 from sentry.runner import configure
 from sentry.types.activity import ActivityType
 
@@ -336,6 +335,8 @@ def main(
     load_performance_issues=False,
     slow=False,
 ):
+    from sentry.constants import ObjectStatus
+
     try:
         user = User.objects.filter(is_superuser=True)[0]
     except IndexError:


### PR DESCRIPTION
Avoids a chain of imports to sentry.utils.geo that can cause an error by accessing Django settings before they are initialized.