### PR TITLE
ref(audit-log): Clarify rule and alert rule in audit log

### DIFF
--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -176,10 +176,30 @@ function AuditLogList({
   const hasEntries = entries && entries.length > 0;
   const ipv4Length = 15;
 
-  const eventOptions = eventTypes?.map(type => ({
-    label: type,
-    value: type,
-  }));
+  const eventOptions = eventTypes
+    ?.map(type => {
+      // Having both rule.x and alertrule.x may be confusing, so we'll replace their labels to be more descriptive.
+      // We need to maintain the values here so we still fetch the correct audit log events from the backend should we want
+      // to filter.
+      // See https://github.com/getsentry/sentry/issues/46997
+      if (type.startsWith('rule.')) {
+        return {
+          label: type.replace('rule.', 'issue-alert.'),
+          value: type,
+        };
+      }
+      if (type.startsWith('alertrule.')) {
+        return {
+          label: type.replace('alertrule.', 'metric-alert.'),
+          value: type,
+        };
+      }
+      return {
+        label: type,
+        value: type,
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   const action = (
     <EventSelector

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -55,6 +55,32 @@ const addUsernameDisplay = (logEntryUser: User | undefined) => {
   return null;
 };
 
+const getEventOptions = (eventTypes: string[] | null) =>
+  eventTypes
+    ?.map(type => {
+      // Having both rule.x and alertrule.x may be confusing, so we'll replace their labels to be more descriptive.
+      // We need to maintain the values here so we still fetch the correct audit log events from the backend should we want
+      // to filter.
+      // See https://github.com/getsentry/sentry/issues/46997
+      if (type.startsWith('rule.')) {
+        return {
+          label: type.replace('rule.', 'issue-alert.'),
+          value: type,
+        };
+      }
+      if (type.startsWith('alertrule.')) {
+        return {
+          label: type.replace('alertrule.', 'metric-alert.'),
+          value: type,
+        };
+      }
+      return {
+        label: type,
+        value: type,
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+
 function AuditNote({
   entry,
   orgSlug,
@@ -176,31 +202,6 @@ function AuditLogList({
   const hasEntries = entries && entries.length > 0;
   const ipv4Length = 15;
 
-  const eventOptions = eventTypes
-    ?.map(type => {
-      // Having both rule.x and alertrule.x may be confusing, so we'll replace their labels to be more descriptive.
-      // We need to maintain the values here so we still fetch the correct audit log events from the backend should we want
-      // to filter.
-      // See https://github.com/getsentry/sentry/issues/46997
-      if (type.startsWith('rule.')) {
-        return {
-          label: type.replace('rule.', 'issue-alert.'),
-          value: type,
-        };
-      }
-      if (type.startsWith('alertrule.')) {
-        return {
-          label: type.replace('alertrule.', 'metric-alert.'),
-          value: type,
-        };
-      }
-      return {
-        label: type,
-        value: type,
-      };
-    })
-    .sort((a, b) => a.label.localeCompare(b.label));
-
   const action = (
     <EventSelector
       clearable
@@ -208,7 +209,7 @@ function AuditLogList({
       name="eventFilter"
       value={eventType}
       placeholder={t('Select Action: ')}
-      options={eventOptions}
+      options={getEventOptions(eventTypes)}
       onChange={options => {
         onEventSelect(options?.value);
       }}

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -55,6 +55,16 @@ const addUsernameDisplay = (logEntryUser: User | undefined) => {
   return null;
 };
 
+const getTypeDisplay = (event: string) => {
+  if (event.startsWith('rule.')) {
+    return event.replace('rule.', 'issue-alert.');
+  }
+  if (event.startsWith('alertrule.')) {
+    return event.replace('alertrule.', 'metric-alert.');
+  }
+  return event;
+};
+
 const getEventOptions = (eventTypes: string[] | null) =>
   eventTypes
     ?.map(type => {
@@ -90,6 +100,10 @@ function AuditNote({
 }) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === String(entry.data.id));
+
+  if (entry.event.startsWith('rule.')) {
+    return <Note>{entry.note.replace('rule', 'issue alert rule')}</Note>;
+  }
 
   if (!project) {
     return <Note>{entry.note}</Note>;
@@ -239,7 +253,7 @@ function AuditLogList({
                 </NameContainer>
               </UserInfo>
               <FlexCenter>
-                <MonoDetail>{entry.event}</MonoDetail>
+                <MonoDetail>{getTypeDisplay(entry.event)}</MonoDetail>
               </FlexCenter>
               <FlexCenter>
                 {entry.ipAddress && (

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -87,7 +87,7 @@ describe('OrganizationAuditLog', function () {
     expect(screen.getByText('member.add')).toBeInTheDocument();
   });
 
-  it('Replaces text in rule and alertrule entries', async function () {
+  it('replaces text in rule and alertrule entries', async function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/audit-logs/`,

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 
@@ -59,5 +59,26 @@ describe('OrganizationAuditLog', function () {
 
     expect(await screen.findByText('Sentry Staff')).toBeInTheDocument();
     expect(screen.getAllByText('Foo Bar')).toHaveLength(2);
+  });
+
+  it('replaces rule and alertrule audit types in dropdown', async function () {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: ENDPOINT,
+      body: {
+        rows: TestStubs.AuditLogs(),
+        options: ['rule.edit', 'alertrule.edit', 'member.add'],
+      },
+    });
+
+    render(<OrganizationAuditLog location={router.location} />, {
+      context: routerContext,
+    });
+
+    await userEvent.click(screen.getByText('Select Action:'));
+
+    expect(screen.getByText('issue-alert.edit')).toBeInTheDocument();
+    expect(screen.getByText('metric-alert.edit')).toBeInTheDocument();
+    expect(screen.getByText('member.add')).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -156,62 +156,5 @@ describe('OrganizationAuditLog', function () {
         `/settings/${organization.slug}/projects/${project.slug}/performance/`
       );
     }
-  });
-
-  it('Replaces text in rule and alertrule entries', async function () {
-    const {routerContext, router, projects} = initializeOrg({
-      ...initializeOrg(),
-      router: {
-        params: {orgId: 'org-slug'},
-      },
-    });
-
-    ProjectsStore.loadInitialData(projects);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/audit-logs/`,
-      method: 'GET',
-      body: {
-        rows: [
-          {
-            actor: TestStubs.User(),
-            event: 'rule.edit',
-            ipAddress: '127.0.0.1',
-            id: '214',
-            note: 'edited rule "New issue"',
-            targetObject: 123,
-            targetUser: null,
-            data: {},
-          },
-          {
-            actor: TestStubs.User(),
-            event: 'alertrule.edit',
-            ipAddress: '127.0.0.1',
-            id: '215',
-            note: 'edited metric alert rule "Failure rate too high"',
-            targetObject: 456,
-            targetUser: null,
-            data: {},
-          },
-        ],
-        options: TestStubs.AuditLogsApiEventNames(),
-      },
-    });
-
-    render(<OrganizationAuditLog location={router.location} />, {
-      context: routerContext,
-    });
-
-    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
-
-    // rule.edit -> issue-alert.edit
-    expect(screen.getByText('issue-alert.edit')).toBeInTheDocument();
-    expect(screen.getByText('edited issue alert rule "New issue"')).toBeInTheDocument();
-
-    // alertrule.edit -> metric-alert.edit
-    expect(screen.getByText('metric-alert.edit')).toBeInTheDocument();
-    expect(
-      screen.getByText('edited metric alert rule "Failure rate too high"')
-    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -158,7 +158,7 @@ describe('OrganizationAuditLog', function () {
     }
   });
 
-  it('Replaces text in rule and auditrule entries', async function () {
+  it('Replaces text in rule and alertrule entries', async function () {
     const {routerContext, router, projects} = initializeOrg({
       ...initializeOrg(),
       router: {

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -69,10 +69,27 @@ function OrganizationAuditLog({location}: Props) {
           query: payload,
         }
       );
+      // Having both rule.x and alertrule.x may be confusing. We'll replace them with issue-alert and metric-alert.
+      // See https://github.com/getsentry/sentry/issues/46997
+      const entryList = data.rows.map((row: AuditLog) => {
+        let event = row.event;
+        let note = row.note;
+        if (event.startsWith('rule.')) {
+          event = event.replace('rule.', 'issue-alert.');
+          note = note.replace('rule', 'issue alert rule');
+        } else if (event.startsWith('alertrule.')) {
+          event = event.replace('alertrule.', 'metric-alert.');
+        }
+        return {
+          ...row,
+          event,
+          note,
+        };
+      });
       setState(prevState => ({
         ...prevState,
-        entryList: data.rows,
-        eventTypes: data.options.sort(),
+        entryList,
+        eventTypes: data.options,
         isLoading: false,
         entryListPageLinks: response?.getResponseHeader('Link') ?? null,
       }));

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -69,26 +69,9 @@ function OrganizationAuditLog({location}: Props) {
           query: payload,
         }
       );
-      // Having both rule.x and alertrule.x may be confusing. We'll replace them with issue-alert and metric-alert.
-      // See https://github.com/getsentry/sentry/issues/46997
-      const entryList = data.rows.map((row: AuditLog) => {
-        let event = row.event;
-        let note = row.note;
-        if (event.startsWith('rule.')) {
-          event = event.replace('rule.', 'issue-alert.');
-          note = note.replace('rule', 'issue alert rule');
-        } else if (event.startsWith('alertrule.')) {
-          event = event.replace('alertrule.', 'metric-alert.');
-        }
-        return {
-          ...row,
-          event,
-          note,
-        };
-      });
       setState(prevState => ({
         ...prevState,
-        entryList,
+        entryList: data.rows,
         eventTypes: data.options,
         isLoading: false,
         entryListPageLinks: response?.getResponseHeader('Link') ?? null,


### PR DESCRIPTION
Replace name of event type `rule` with `issue-alert` and `alertrule` with `metric-alert`. 
Additionally, change the note of `issue-alert` events to use "issue alert rule" instead of just 
"rule".

Fixes #46997