### PR TITLE
fix(ui): Ignore events coming from urls starting with `file://`

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -87,6 +87,7 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
      */
     release: SENTRY_RELEASE_VERSION ?? sentryConfig?.release,
     allowUrls: SPA_DSN ? SPA_MODE_ALLOW_URLS : sentryConfig?.whitelistUrls,
+    denyUrls: [/^file:\/\//],
     integrations: getSentryIntegrations(sentryConfig, routes),
     tracesSampleRate,
     // @ts-ignore not part of browser SDK types yet


### PR DESCRIPTION
Our allow urls appear to be
```js
"whitelistUrls":["sentry.io","s1.sentry-cdn.com","\u003canonymous\u003e"]
```

see #49136 for more

fixes #49136