### PR TITLE
chore(js): Combine `getXhrErrorResponseHandler` and `handleXhrErrorResponse`

### DIFF
--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -2,45 +2,38 @@ import * as Sentry from '@sentry/react';
 
 import {ResponseMeta} from 'sentry/api';
 
-export default function getXhrErrorResponseHandler(message: string) {
-  return (resp: ResponseMeta) => {
-    if (!resp) {
-      return;
-    }
-    if (!resp.responseJSON) {
-      return;
-    }
-
-    const {responseJSON} = resp;
-
-    // If this is a string then just capture it as error
-    if (typeof responseJSON.detail === 'string') {
-      Sentry.withScope(scope => {
-        scope.setExtra('status', resp.status);
-        scope.setExtra('detail', responseJSON.detail);
-        Sentry.captureException(new Error(message));
-      });
-      return;
-    }
-
-    // Ignore sudo-required errors
-    if (responseJSON.detail && responseJSON.detail.code === 'sudo-required') {
-      return;
-    }
-
-    if (responseJSON.detail && typeof responseJSON.detail.message === 'string') {
-      Sentry.withScope(scope => {
-        scope.setExtra('status', resp.status);
-        scope.setExtra('detail', responseJSON.detail);
-        scope.setExtra('code', responseJSON.detail.code);
-        Sentry.captureException(new Error(message));
-      });
-      return;
-    }
-  };
-}
-
 export function handleXhrErrorResponse(message: string, resp: ResponseMeta): void {
-  const handler = getXhrErrorResponseHandler(message);
-  return handler(resp);
+  if (!resp) {
+    return;
+  }
+  if (!resp.responseJSON) {
+    return;
+  }
+
+  const {responseJSON} = resp;
+
+  // If this is a string then just capture it as error
+  if (typeof responseJSON.detail === 'string') {
+    Sentry.withScope(scope => {
+      scope.setExtra('status', resp.status);
+      scope.setExtra('detail', responseJSON.detail);
+      Sentry.captureException(new Error(message));
+    });
+    return;
+  }
+
+  // Ignore sudo-required errors
+  if (responseJSON.detail && responseJSON.detail.code === 'sudo-required') {
+    return;
+  }
+
+  if (responseJSON.detail && typeof responseJSON.detail.message === 'string') {
+    Sentry.withScope(scope => {
+      scope.setExtra('status', resp.status);
+      scope.setExtra('detail', responseJSON.detail);
+      scope.setExtra('code', responseJSON.detail.code);
+      Sentry.captureException(new Error(message));
+    });
+    return;
+  }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/49154 and https://github.com/getsentry/getsentry/pull/10557, which switched all uses of the default export from `handleXhrErrorResponse.tsx` to be uses of its named export `handleXhrErrorResponse` instead (in `sentry` and `getsentry`, respectively). Now that that's been done, the default export is no longer needed and its logic can be rolled into `handleXhrErrorResponse`.

Note: This is the last PR in a long series of incremental PRs superseding https://github.com/getsentry/sentry/pull/48982, such that backwards compatibility be maintained between `sentry` and `getsentry`.