### PR TITLE
fix(Snuba): Pass Org ID to Snuba for Organization Group Index endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -291,6 +291,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             expand=expand,
             collapse=collapse,
             project_ids=project_ids,
+            organization_id=organization.id,
         )
 
         # we ignore date range for both short id and event ids


### PR DESCRIPTION
### Overview
- Snuba will now start [rejecting](https://github.com/getsentry/snuba/pull/4176) queries for events/transactions without Org IDs
- Fixed an endpoint that was sending `None` to Snuba for its Org ID