### PR TITLE
feat(inbound-filters): Add the new 'health check' filter

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -216,6 +216,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:events-page': FeatureDisabledHook;
   'feature-disabled:events-sidebar-item': FeatureDisabledHook;
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
+  'feature-disabled:health-check-filter': FeatureDisabledHook;
   'feature-disabled:incidents-sidebar-item': FeatureDisabledHook;
   'feature-disabled:open-discover': FeatureDisabledHook;
   'feature-disabled:open-in-discover': FeatureDisabledHook;

--- a/static/app/views/settings/project/projectFilters/index.spec.jsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.jsx
@@ -22,7 +22,8 @@ describe('ProjectFilters', function () {
         location={{}}
         project={project}
         organization={org}
-      />
+      />,
+      {organization: org}
     );
   }
 
@@ -55,7 +56,7 @@ describe('ProjectFilters', function () {
     const filter = 'browser-extensions';
     const mock = createFilterMock(filter);
 
-    const control = screen.getByRole('checkbox', {
+    const control = await screen.findByRole('checkbox', {
       name: 'Filter out errors known to be caused by browser extensions',
     });
 
@@ -81,6 +82,8 @@ describe('ProjectFilters', function () {
       'web-crawlers': 'Filter out known web crawlers',
     };
 
+    await screen.findByText('Filters');
+
     for (const filter of Object.keys(FILTERS)) {
       const mock = createFilterMock(filter);
 
@@ -97,11 +100,11 @@ describe('ProjectFilters', function () {
     }
   });
 
-  it('has correct legacy browsers selected', function () {
+  it('has correct legacy browsers selected', async function () {
     renderComponent();
 
     expect(
-      screen.getByRole('checkbox', {name: 'Internet Explorer Version 8 and lower'})
+      await screen.findByRole('checkbox', {name: 'Internet Explorer Version 8 and lower'})
     ).toBeChecked();
 
     expect(
@@ -120,7 +123,7 @@ describe('ProjectFilters', function () {
     const mock = createFilterMock(filter);
 
     await userEvent.click(
-      screen.getByRole('checkbox', {name: 'Safari Version 5 and lower'})
+      await screen.findByRole('checkbox', {name: 'Safari Version 5 and lower'})
     );
     expect(mock.mock.calls[0][0]).toBe(getFilterEndpoint(filter));
     // Have to do this because no jest matcher for JS Set
@@ -163,7 +166,7 @@ describe('ProjectFilters', function () {
     const filter = 'legacy-browsers';
     const mock = createFilterMock(filter);
 
-    await userEvent.click(screen.getByRole('button', {name: 'All'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'All'}));
     expect(mock.mock.calls[0][0]).toBe(getFilterEndpoint(filter));
     expect(Array.from(mock.mock.calls[0][1].data.subfilters)).toEqual([
       'ie_pre_9',
@@ -189,7 +192,7 @@ describe('ProjectFilters', function () {
     });
 
     await userEvent.type(
-      screen.getByRole('textbox', {name: 'IP Addresses'}),
+      await screen.findByRole('textbox', {name: 'IP Addresses'}),
       'test\ntest2'
     );
     await userEvent.tab();
@@ -200,10 +203,10 @@ describe('ProjectFilters', function () {
     );
   });
 
-  it('filter by release/error message are not enabled', function () {
+  it('filter by release/error message are not enabled', async function () {
     renderComponent();
 
-    expect(screen.getByRole('textbox', {name: 'Releases'})).toBeDisabled();
+    expect(await screen.findByRole('textbox', {name: 'Releases'})).toBeDisabled();
     expect(screen.getByRole('textbox', {name: 'Error Message'})).toBeDisabled();
   });
 
@@ -220,7 +223,7 @@ describe('ProjectFilters', function () {
       />
     );
 
-    expect(screen.getByRole('textbox', {name: 'Releases'})).toBeEnabled();
+    expect(await screen.findByRole('textbox', {name: 'Releases'})).toBeEnabled();
     expect(screen.getByRole('textbox', {name: 'Error Message'})).toBeEnabled();
 
     const mock = MockApiClient.addMockResponse({
@@ -250,7 +253,7 @@ describe('ProjectFilters', function () {
     );
   });
 
-  it('disables configuration for non project:write users', function () {
+  it('disables configuration for non project:write users', async function () {
     render(
       <ProjectFilters
         organization={org}
@@ -261,12 +264,13 @@ describe('ProjectFilters', function () {
       {organization: TestStubs.Organization({access: []})}
     );
 
-    screen.getAllByRole('checkbox').forEach(checkbox => {
+    const checkboxes = await screen.findAllByRole('checkbox');
+    checkboxes.forEach(checkbox => {
       expect(checkbox).toBeDisabled();
     });
   });
 
-  it('shows disclaimer if error message filter is populated', function () {
+  it('shows disclaimer if error message filter is populated', async function () {
     render(
       <ProjectFilters
         organization={org}
@@ -282,7 +286,7 @@ describe('ProjectFilters', function () {
     );
 
     expect(
-      screen.getByText(
+      await screen.findByText(
         "Minidumps, errors in the minified production build of React, and Internet Explorer's i18n errors cannot be filtered by message."
       )
     ).toBeInTheDocument(0);

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -12,7 +12,7 @@ import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 import GroupTombstones from 'sentry/views/settings/project/projectFilters/groupTombstones';
 import ProjectFiltersChart from 'sentry/views/settings/project/projectFilters/projectFiltersChart';
-import ProjectFiltersSettings from 'sentry/views/settings/project/projectFilters/projectFiltersSettings';
+import {ProjectFiltersSettings} from 'sentry/views/settings/project/projectFilters/projectFiltersSettings';
 
 type Props = {
   organization: Organization;
@@ -65,12 +65,7 @@ function ProjectFilters(props: Props) {
             location={location}
           />
         ) : (
-          <ProjectFiltersSettings
-            organization={organization}
-            project={project}
-            params={params}
-            features={features}
-          />
+          <ProjectFiltersSettings project={project} params={params} features={features} />
         )}
       </div>
     </Fragment>

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Component, Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 import iconAndroid from 'sentry-logos/logo-android.svg';
 import iconIe from 'sentry-logos/logo-ie.svg';
@@ -8,13 +8,14 @@ import iconSafari from 'sentry-logos/logo-safari.svg';
 import Access from 'sentry/components/acl/access';
 import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
-import AsyncComponent from 'sentry/components/asyncComponent';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import FieldFromConfig from 'sentry/components/forms/fieldFromConfig';
 import Form, {FormProps} from 'sentry/components/forms/form';
 import FormField from 'sentry/components/forms/formField';
 import JsonForm from 'sentry/components/forms/jsonForm';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {
   Panel,
   PanelAlert,
@@ -28,10 +29,11 @@ import filterGroups, {
   getOptionsData,
 } from 'sentry/data/forms/inboundFilters';
 import {t} from 'sentry/locale';
-import HookStore from 'sentry/stores/hookStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {space} from 'sentry/styles/space';
-import {Organization, Project} from 'sentry/types';
+import {Project} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 
 const LEGACY_BROWSER_SUBFILTERS = {
   ie_pre_9: {
@@ -193,235 +195,235 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
   }
 }
 
+function CustomFilters({project, disabled}: {disabled: boolean; project: Project}) {
+  return (
+    <Feature
+      features={['projects:custom-inbound-filters']}
+      hookName="feature-disabled:custom-inbound-filters"
+      project={project}
+      renderDisabled={({children, ...props}) => {
+        if (typeof children === 'function') {
+          return children({
+            ...props,
+            renderDisabled: p => (
+              <FeatureDisabled
+                featureName={t('Custom Inbound Filters')}
+                features={p.features}
+                alert={PanelAlert}
+                message={t(
+                  'Release and Error Message filtering are not enabled on your Sentry installation'
+                )}
+              />
+            ),
+          });
+        }
+        return null;
+      }}
+    >
+      {({hasFeature, organization, renderDisabled, ...featureProps}) => (
+        <Fragment>
+          {!hasFeature &&
+            typeof renderDisabled === 'function' &&
+            // XXX: children is set to null as we're doing tricksy things
+            // in the renderDisabled prop a few lines higher.
+            renderDisabled({
+              organization,
+              hasFeature,
+              children: null,
+              ...featureProps,
+            })}
+
+          {customFilterFields.map(field => (
+            <FieldFromConfig
+              key={field.name}
+              field={field}
+              disabled={disabled || !hasFeature}
+            />
+          ))}
+
+          {hasFeature && project.options?.['filters:error_messages'] && (
+            <PanelAlert type="warning" data-test-id="error-message-disclaimer">
+              {t(
+                "Minidumps, errors in the minified production build of React, and Internet Explorer's i18n errors cannot be filtered by message."
+              )}
+            </PanelAlert>
+          )}
+        </Fragment>
+      )}
+    </Feature>
+  );
+}
+
 type Props = {
   features: Set<string>;
-  organization: Organization;
   params: {
     projectId: string;
   };
   project: Project;
 };
 
-type State = {
-  hooksDisabled: ReturnType<(typeof HookStore)['get']>;
-} & AsyncComponent['state'];
+type Filter = {
+  active: boolean;
+  description: string;
+  hello: string;
+  id: string;
+  name: string;
+};
 
-class ProjectFiltersSettings extends AsyncComponent<Props, State> {
-  getDefaultState() {
-    return {
-      ...super.getDefaultState(),
-      hooksDisabled: HookStore.get('feature-disabled:custom-inbound-filters'),
-    };
-  }
+export function ProjectFiltersSettings({project, params, features}: Props) {
+  const organization = useOrganization();
+  const {projectId} = params;
 
-  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization} = this.props;
-    const {projectId} = this.props.params;
-    return [['filterList', `/projects/${organization.slug}/${projectId}/filters/`]];
-  }
+  const projectEndpoint = `/projects/${organization.slug}/${projectId}/`;
+  const filtersEndpoint = `${projectEndpoint}filters/`;
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    if (prevProps.project.slug !== this.props.project.slug) {
-      this.reloadData();
-    }
-    super.componentDidUpdate(prevProps, prevState);
-  }
+  const {
+    data: filterList = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useApiQuery<Filter[]>([`/projects/${organization.slug}/${projectId}/filters/`], {
+    staleTime: Infinity,
+  });
 
-  handleLegacyChange = (
-    onChange: FormFieldProps['onChange'],
-    onBlur: FormFieldProps['onBlur'],
-    _filter,
-    subfilters: RowState['subfilters'],
-    e: React.MouseEvent
-  ) => {
-    onChange?.(subfilters, e);
-    onBlur?.(subfilters, e);
-  };
-
-  handleSubmit = (response: Project) => {
-    // This will update our project context
-    ProjectsStore.onUpdateSuccess(response);
-  };
-
-  renderDisabledCustomFilters = p => (
-    <FeatureDisabled
-      featureName={t('Custom Inbound Filters')}
-      features={p.features}
-      alert={PanelAlert}
-      message={t(
-        'Release and Error Message filtering are not enabled on your Sentry installation'
-      )}
-    />
+  const handleLegacyChange = useCallback(
+    ({
+      onChange,
+      onBlur,
+      event,
+      subfilters,
+    }: {
+      event: React.MouseEvent;
+      onBlur: FormFieldProps['onBlur'];
+      onChange: FormFieldProps['onChange'];
+      subfilters: RowState['subfilters'];
+    }) => {
+      onChange?.(subfilters, event);
+      onBlur?.(subfilters, event);
+    },
+    []
   );
 
-  // Need to maintain the this binding here
-  // eslint-disable-next-line react/function-component-definition
-  renderCustomFilters = (disabled: boolean) => () =>
-    (
-      <Feature
-        features={['projects:custom-inbound-filters']}
-        hookName="feature-disabled:custom-inbound-filters"
-        project={this.props.project}
-        renderDisabled={({children, ...props}) => {
-          if (typeof children === 'function') {
-            return children({
-              ...props,
-              renderDisabled: this.renderDisabledCustomFilters,
-            });
-          }
-          return null;
-        }}
-      >
-        {({hasFeature, organization, renderDisabled, ...featureProps}) => (
-          <Fragment>
-            {!hasFeature &&
-              typeof renderDisabled === 'function' &&
-              // XXX: children is set to null as we're doing tricksy things
-              // in the renderDisabled prop a few lines higher.
-              renderDisabled({
-                organization,
-                hasFeature,
-                children: null,
-                ...featureProps,
-              })}
-
-            {customFilterFields.map(field => (
-              <FieldFromConfig
-                key={field.name}
-                field={field}
-                disabled={disabled || !hasFeature}
-              />
-            ))}
-
-            {hasFeature && this.props.project.options?.['filters:error_messages'] && (
-              <PanelAlert type="warning" data-test-id="error-message-disclaimer">
-                {t(
-                  "Minidumps, errors in the minified production build of React, and Internet Explorer's i18n errors cannot be filtered by message."
-                )}
-              </PanelAlert>
-            )}
-          </Fragment>
-        )}
-      </Feature>
-    );
-
-  renderBody() {
-    const {features, organization, params, project} = this.props;
-    const {projectId} = params;
-
-    const projectEndpoint = `/projects/${organization.slug}/${projectId}/`;
-    const filtersEndpoint = `${projectEndpoint}filters/`;
-
-    return (
-      <Access access={['project:write']} project={project}>
-        {({hasAccess}) => (
-          <Fragment>
-            <Panel>
-              <PanelHeader>{t('Filters')}</PanelHeader>
-              <PanelBody>
-                {this.state.filterList.map(filter => {
-                  const fieldProps = {
-                    name: filter.id,
-                    label: filter.name,
-                    help: filter.description,
-                    disabled: !hasAccess,
-                  };
-
-                  // Note by default, forms generate data in the format of:
-                  // { [fieldName]: [value] }
-                  // Endpoints for these filters expect data to be:
-                  // { 'active': [value] }
-                  return (
-                    <PanelItem key={filter.id} noPadding>
-                      <NestedForm
-                        apiMethod="PUT"
-                        apiEndpoint={`${filtersEndpoint}${filter.id}/`}
-                        initialData={{[filter.id]: filter.active}}
-                        saveOnBlur
-                      >
-                        {filter.id !== 'legacy-browsers' ? (
-                          <FieldFromConfig
-                            key={filter.id}
-                            getData={data => ({active: data[filter.id]})}
-                            field={{
-                              type: 'boolean',
-                              ...fieldProps,
-                            }}
-                          />
-                        ) : (
-                          <FormField
-                            inline={false}
-                            {...fieldProps}
-                            getData={data => ({subfilters: [...data[filter.id]]})}
-                          >
-                            {({onChange, onBlur}) => (
-                              <LegacyBrowserFilterRow
-                                key={filter.id}
-                                data={filter}
-                                disabled={!hasAccess}
-                                onToggle={this.handleLegacyChange.bind(
-                                  this,
-                                  onChange,
-                                  onBlur
-                                )}
-                              />
-                            )}
-                          </FormField>
-                        )}
-                      </NestedForm>
-                    </PanelItem>
-                  );
-                })}
-                <PanelItem noPadding>
-                  <NestedForm
-                    apiMethod="PUT"
-                    apiEndpoint={projectEndpoint}
-                    initialData={{
-                      'filters:react-hydration-errors':
-                        project.options?.['filters:react-hydration-errors'],
-                    }}
-                    saveOnBlur
-                    onSubmitSuccess={this.handleSubmit}
-                  >
-                    <FieldFromConfig
-                      getData={getOptionsData}
-                      field={{
-                        type: 'boolean',
-                        name: 'filters:react-hydration-errors',
-                        label: t('Filter out hydration errors'),
-                        help: t(
-                          'React falls back to do a full re-render on a page and these errors are often not actionable.'
-                        ),
-                        disabled: !hasAccess,
-                      }}
-                    />
-                  </NestedForm>
-                </PanelItem>
-              </PanelBody>
-            </Panel>
-
-            <Form
-              apiMethod="PUT"
-              apiEndpoint={projectEndpoint}
-              initialData={project.options}
-              saveOnBlur
-              onSubmitSuccess={this.handleSubmit}
-            >
-              <JsonForm
-                features={features}
-                forms={filterGroups}
-                disabled={!hasAccess}
-                renderFooter={this.renderCustomFilters(!hasAccess)}
-              />
-            </Form>
-          </Fragment>
-        )}
-      </Access>
-    );
+  if (isLoading) {
+    return <LoadingIndicator />;
   }
-}
 
-export default ProjectFiltersSettings;
+  if (isError) {
+    return <LoadingError onRetry={refetch} />;
+  }
+
+  return (
+    <Access access={['project:write']} project={project}>
+      {({hasAccess}) => (
+        <Fragment>
+          <Panel>
+            <PanelHeader>{t('Filters')}</PanelHeader>
+            <PanelBody>
+              {filterList.map(filter => {
+                const fieldProps = {
+                  name: filter.id,
+                  label: filter.name,
+                  help: filter.description,
+                  disabled: !hasAccess,
+                };
+
+                // Note by default, forms generate data in the format of:
+                // { [fieldName]: [value] }
+                // Endpoints for these filters expect data to be:
+                // { 'active': [value] }
+                return (
+                  <PanelItem key={filter.id} noPadding>
+                    <NestedForm
+                      apiMethod="PUT"
+                      apiEndpoint={`${filtersEndpoint}${filter.id}/`}
+                      initialData={{[filter.id]: filter.active}}
+                      saveOnBlur
+                    >
+                      {filter.id !== 'legacy-browsers' ? (
+                        <FieldFromConfig
+                          key={filter.id}
+                          getData={data => ({active: data[filter.id]})}
+                          field={{
+                            type: 'boolean',
+                            ...fieldProps,
+                          }}
+                        />
+                      ) : (
+                        <FormField
+                          inline={false}
+                          {...fieldProps}
+                          getData={data => ({subfilters: [...data[filter.id]]})}
+                        >
+                          {({onChange, onBlur}) => (
+                            <LegacyBrowserFilterRow
+                              key={filter.id}
+                              data={filter}
+                              disabled={!hasAccess}
+                              onToggle={(_data, subfilters, event) =>
+                                handleLegacyChange({onChange, onBlur, event, subfilters})
+                              }
+                            />
+                          )}
+                        </FormField>
+                      )}
+                    </NestedForm>
+                  </PanelItem>
+                );
+              })}
+              <PanelItem noPadding>
+                <NestedForm
+                  apiMethod="PUT"
+                  apiEndpoint={projectEndpoint}
+                  initialData={{
+                    'filters:react-hydration-errors':
+                      project.options?.['filters:react-hydration-errors'],
+                  }}
+                  saveOnBlur
+                  onSubmitSuccess={(
+                    response // This will update our project context
+                  ) => ProjectsStore.onUpdateSuccess(response)}
+                >
+                  <FieldFromConfig
+                    getData={getOptionsData}
+                    field={{
+                      type: 'boolean',
+                      name: 'filters:react-hydration-errors',
+                      label: t('Filter out hydration errors'),
+                      help: t(
+                        'React falls back to do a full re-render on a page and these errors are often not actionable.'
+                      ),
+                      disabled: !hasAccess,
+                    }}
+                  />
+                </NestedForm>
+              </PanelItem>
+            </PanelBody>
+          </Panel>
+
+          <Form
+            apiMethod="PUT"
+            apiEndpoint={projectEndpoint}
+            initialData={project.options}
+            saveOnBlur
+            onSubmitSuccess={response =>
+              // This will update our project context
+              ProjectsStore.onUpdateSuccess(response)
+            }
+          >
+            <JsonForm
+              features={features}
+              forms={filterGroups}
+              disabled={!hasAccess}
+              renderFooter={() => (
+                <CustomFilters disabled={!hasAccess} project={project} />
+              )}
+            />
+          </Form>
+        </Fragment>
+      )}
+    </Access>
+  );
+}
 
 // TODO(ts): Understand why styled is not correctly inheriting props here
 const NestedForm = styled(Form)<FormProps>`

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -14,6 +14,7 @@ import FieldFromConfig from 'sentry/components/forms/fieldFromConfig';
 import Form, {FormProps} from 'sentry/components/forms/form';
 import FormField from 'sentry/components/forms/formField';
 import JsonForm from 'sentry/components/forms/jsonForm';
+import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {
@@ -28,7 +29,7 @@ import filterGroups, {
   customFilterFields,
   getOptionsData,
 } from 'sentry/data/forms/inboundFilters';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {space} from 'sentry/styles/space';
 import {Project} from 'sentry/types';
@@ -198,7 +199,7 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
 function CustomFilters({project, disabled}: {disabled: boolean; project: Project}) {
   return (
     <Feature
-      features={['projects:custom-inbound-filtersTESSSSTTT']}
+      features={['projects:custom-inbound-filters']}
       hookName="feature-disabled:custom-inbound-filters"
       project={project}
       renderDisabled={({children, ...props}) => {
@@ -393,8 +394,13 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                         type: 'boolean',
                         name: 'filters:health-check',
                         label: t('Filter out health check transactions'),
-                        help: t(
-                          'Filter transactions that match most common naming patterns for health checks'
+                        help: tct(
+                          'Filter transactions that match most common [link:naming patterns] for health checks',
+                          {
+                            link: (
+                              <ExternalLink href="https://docs.sentry.io/product/data-management-settings/filtering/#inbound-data-filters" />
+                            ),
+                          }
                         ),
                         disabled: !hasAccess,
                       }}

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -398,6 +398,7 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                           'Filter transactions that match most common [link:naming patterns] for health checks',
                           {
                             link: (
+                              // TODO(Priscila): Update the link once the Github Issue https://github.com/getsentry/sentry/issues/49089 is complete
                               <ExternalLink href="https://docs.sentry.io/product/data-management-settings/filtering/#inbound-data-filters" />
                             ),
                           }

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -198,7 +198,7 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
 function CustomFilters({project, disabled}: {disabled: boolean; project: Project}) {
   return (
     <Feature
-      features={['projects:custom-inbound-filters']}
+      features={['projects:custom-inbound-filtersTESSSSTTT']}
       hookName="feature-disabled:custom-inbound-filters"
       project={project}
       renderDisabled={({children, ...props}) => {
@@ -370,6 +370,38 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                   </PanelItem>
                 );
               })}
+              <PanelItem noPadding>
+                <Feature
+                  features={['organizations:inbound-filters-health-check']}
+                  hookName="feature-disabled:health-check-filter"
+                  organization={organization}
+                >
+                  <NestedForm
+                    apiMethod="PUT"
+                    apiEndpoint={projectEndpoint}
+                    initialData={{
+                      'filters:health-check': project.options?.['filters:health-check'],
+                    }}
+                    saveOnBlur
+                    onSubmitSuccess={(
+                      response // This will update our project context
+                    ) => ProjectsStore.onUpdateSuccess(response)}
+                  >
+                    <FieldFromConfig
+                      getData={getOptionsData}
+                      field={{
+                        type: 'boolean',
+                        name: 'filters:health-check',
+                        label: t('Filter out health check transactions'),
+                        help: t(
+                          'Filter transactions that match most common naming patterns for health checks'
+                        ),
+                        disabled: !hasAccess,
+                      }}
+                    />
+                  </NestedForm>
+                </Feature>
+              </PanelItem>
               <PanelItem noPadding>
                 <NestedForm
                   apiMethod="PUT"

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -373,7 +373,7 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
               })}
               <PanelItem noPadding>
                 <Feature
-                  features={['organizations:inbound-filters-health-check']}
+                  features={['organizations:health-check-filter']}
                   hookName="feature-disabled:health-check-filter"
                   organization={organization}
                 >


### PR DESCRIPTION
Add the new Inbound Filter 'Health Check' that is behind a plan feature flag called `organizations:inbound-filters-health-check`

**Preview:**

![image](https://github.com/getsentry/sentry/assets/29228205/d2ab6d50-9c30-48c0-9f6b-b12ada8d2d86)


closes https://github.com/getsentry/sentry/issues/49080

depends on https://github.com/getsentry/getsentry/pull/10558
