### PR TITLE
fix: Remove duplicate metric.

### DIFF
--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -205,10 +205,9 @@ class PGStringIndexerV2(StringIndexer):
                     for organization_id, string in filtered_db_write_keys.as_tuples()
                 ]
 
-            with metrics.timer("sentry_metrics.indexer.pg_bulk_create"):
-                self._bulk_create_with_retry(
-                    self._get_table_from_use_case_ids(strings.keys()), new_records
-                )
+            self._bulk_create_with_retry(
+                self._get_table_from_use_case_ids(strings.keys()), new_records
+            )
 
         db_write_key_results = UseCaseKeyResults()
         db_write_key_results.add_use_case_key_results(


### PR DESCRIPTION
This metric is already recorded within _bulk_create_with_retry. We do
not need to record it twice.
