### PR TITLE
fix: Ensure that ParsedMessage is aligned with IngestMetric

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -22,6 +22,7 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message
 from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec, ValidationError
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMetric
 from sentry_kafka_schemas.schema_types.snuba_metrics_v1 import Metric
 
@@ -75,7 +76,7 @@ def invalid_metric_tags(tags: Mapping[str, str]) -> Sequence[str]:
 
 
 # TODO: Move this to where we do use case registration
-def extract_use_case_id(mri: str) -> Optional[UseCaseID]:
+def extract_use_case_id(mri: str) -> UseCaseID:
     """
     Returns the use case ID given the MRI, returns None if MRI is invalid.
     """
@@ -110,7 +111,9 @@ class IndexerBatch:
             assert isinstance(msg.value, BrokerValue)
             partition_offset = PartitionIdxOffset(msg.value.partition.index, msg.value.offset)
             try:
-                parsed_payload = json.loads(msg.payload.value.decode("utf-8"), use_rapid_json=True)
+                parsed_payload: ParsedMessage = json.loads(
+                    msg.payload.value.decode("utf-8"), use_rapid_json=True
+                )
             except rapidjson.JSONDecodeError:
                 self.skipped_offsets.add(partition_offset)
                 logger.error(
@@ -133,6 +136,7 @@ class IndexerBatch:
                     extra={"payload_value": str(msg.payload.value)},
                     exc_info=True,
                 )
+
             try:
                 parsed_payload["use_case_id"] = extract_use_case_id(parsed_payload["name"])
             except ValidationError:
@@ -143,6 +147,13 @@ class IndexerBatch:
                     exc_info=True,
                 )
                 continue
+
+            # Ensure that the parsed_payload can be cast back to to
+            # IngestMetric. If there are any schema changes, this check would
+            # fail and ParsedMessage needs to be adjusted to be a superset of
+            # IngestMetric again.
+            _: IngestMetric = parsed_payload
+
             self.parsed_payloads_by_offset[partition_offset] = parsed_payload
 
     @metrics.wraps("process_messages.filter_messages")


### PR DESCRIPTION
We do json schema validation against the input mesage, then cast the
output to a hand-maintained ParsedMessage because we mutate the payload
to have additional fields.

Mutating dictionaries generally does not play well with static typing. A
better solution would be to define a struct like `{"use_case_id": ...,
"inner": kafka_payload}` where kafka_payload is the message decoded from
the topic.

In absence of such a solution, we can ensure that ParsedMessage is a
superset of KafkaPayload by assigning it to a differently-typed
variable.
