### PR TITLE
fix(crons): Add MISSED to terminal check-in states

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -93,7 +93,7 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
 
         if "duration" in result:
             params["duration"] = result["duration"]
-        # if a duration is not defined and we're at a finish state, calculate one
+        # if a duration is not defined and we're at a finished state, calculate one
         elif params.get("status", checkin.status) in CheckInStatus.FINISHED_VALUES:
             duration = int((current_datetime - checkin.date_added).total_seconds() * 1000)
             params["duration"] = duration

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -147,8 +147,8 @@ class CheckInStatus:
     TIMEOUT = 5
     """Checkin was left in-progress past max_runtime"""
 
-    FINISHED_VALUES = (OK, ERROR, TIMEOUT)
-    """Sentient values used to indicate a monitor is finished running"""
+    FINISHED_VALUES = (OK, ERROR, MISSED, TIMEOUT)
+    """Terminal values used to indicate a monitor is finished running"""
 
     @classmethod
     def as_choices(cls):

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -189,6 +189,23 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             assert monitor_environment.status == MonitorStatus.ERROR
             assert monitor_environment.last_checkin > checkin.date_added
 
+    def test_finished_values(self):
+        monitor = self._create_monitor()
+        monitor_environment = self._create_monitor_environment(monitor, name="dev")
+        for status in CheckInStatus.FINISHED_VALUES:
+            for path_func in self._get_path_functions():
+                checkin = MonitorCheckIn.objects.create(
+                    monitor=monitor,
+                    monitor_environment=monitor_environment,
+                    project_id=self.project.id,
+                    date_added=monitor.date_added,
+                    status=status,
+                )
+
+                path = path_func(monitor.guid, checkin.guid)
+                resp = self.client.put(path, data={"status": "ok"}, **self.token_auth_headers)
+                assert resp.status_code == 400
+
     def test_invalid_duration(self):
         monitor = self._create_monitor()
         monitor_environment = self._create_monitor_environment(monitor, name="dev")


### PR DESCRIPTION
Adds `CheckInStatus.MISSED` as a terminal state + tests. Will fix generation of `duration` over maximums as well.

Fixes SENTRY-107X