### PR TITLE
fix(alerts): Open help links in a new tab

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -399,6 +399,7 @@ function RuleNode({
           trailingItems={
             <Button
               href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"
+              external
               size="xs"
             >
               {t('Learn More')}

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -152,6 +152,7 @@ class ActionsPanel extends PureComponent<Props> {
         trailingItems={
           <Button
             href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error"
+            external
             size="xs"
           >
             {t('Learn More')}


### PR DESCRIPTION
The "learn more" buttons should open in a new tab so users don't lose their progress when clicking.

![image](https://github.com/getsentry/sentry/assets/10888943/2433d68a-8b58-4baa-9be4-9610dfab20bc)
