### PR TITLE
feat(starfish): Update db module tables

### DIFF
--- a/static/app/views/starfish/components/sparkline.tsx
+++ b/static/app/views/starfish/components/sparkline.tsx
@@ -8,10 +8,11 @@ import {Series} from 'sentry/types/echarts';
 type SparklineProps = {
   series: Series;
   color?: string | string[];
+  markLine?: Series;
   width?: number;
 };
 
-export default function Sparkline({series, width, color}: SparklineProps) {
+export default function Sparkline({series, width, color, markLine}: SparklineProps) {
   echarts.use([LineChart, SVGRenderer]);
 
   if (!series.data) {
@@ -30,7 +31,7 @@ export default function Sparkline({series, width, color}: SparklineProps) {
       echarts={echarts}
       option={{
         color,
-        series: [valueSeries],
+        series: [valueSeries, markLine],
         xAxis: {
           show: false,
           data: series.data.map(datum => datum.name),

--- a/static/app/views/starfish/modules/databaseModule/panel/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel/index.tsx
@@ -57,6 +57,7 @@ type DbQueryDetailProps = {
 
 export type TransactionListDataRow = {
   count: number;
+  example: string;
   frequency: number;
   group_id: string;
   p75: number;

--- a/static/app/views/starfish/modules/databaseModule/panel/index.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel/index.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react';
-import {Theme, useTheme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import keyBy from 'lodash/keyBy';
 import moment from 'moment';
@@ -7,14 +7,13 @@ import moment from 'moment';
 import Badge from 'sentry/components/badge';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import MarkLine from 'sentry/components/charts/components/markLine';
 import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import VersionHoverCard from 'sentry/components/versionHoverCard';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import {Series} from 'sentry/types/echarts';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart from 'sentry/views/starfish/components/chart';
@@ -34,7 +33,10 @@ import {
   useQueryPanelTable,
   useQueryTransactionByTPMAndP75,
 } from 'sentry/views/starfish/modules/databaseModule/queries';
-import {queryToSeries} from 'sentry/views/starfish/modules/databaseModule/utils';
+import {
+  generateMarkLine,
+  queryToSeries,
+} from 'sentry/views/starfish/modules/databaseModule/utils';
 import {getDateFilters} from 'sentry/views/starfish/utils/dates';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
@@ -214,6 +216,7 @@ function QueryDetailBody({
     endTime,
     SPARKLINE_INTERVAL
   );
+
   const markLine =
     spmTransactionSeries?.[0]?.data && (isNew || isOld)
       ? generateMarkLine(
@@ -246,7 +249,7 @@ function QueryDetailBody({
             {t('First Seen')}
             {row.newish === 1 && <Badge type="new" text="new" />}
           </SubHeader>
-          {Math.abs(moment(row.firstSeen).diff(startTime, 'minutes')) < 360 ? (
+          {Math.abs(moment(row.firstSeen).diff(startTime, 'minutes')) < 720 ? (
             <SubSubHeader>
               More than <TimeSince date={row.firstSeen} />{' '}
             </SubSubHeader>
@@ -299,7 +302,7 @@ function QueryDetailBody({
       <FormattedCode>{highlightSql(row.formatted_desc, row)}</FormattedCode>
       <FlexRowContainer>
         <FlexRowItem>
-          <SubHeader>{t('Throughput')}</SubHeader>
+          <SubHeader>{t('Throughput (Spans Per Minute)')}</SubHeader>
           <SubSubHeader>{row.epm.toFixed(3)}</SubSubHeader>
           <Chart
             statsPeriod="24h"
@@ -423,47 +426,12 @@ export const highlightSql = (description: string, queryDetail: DataRow) => {
   });
 };
 
-function generateMarkLine(
-  title: string,
-  position: string,
-  data: SeriesDataUnit[],
-  theme: Theme
-) {
-  const index = data.findIndex(item => {
-    return (
-      Math.abs(moment.duration(moment(item.name).diff(moment(position))).asSeconds()) <
-      86400
-    );
-  });
-  return {
-    seriesName: title,
-    type: 'line',
-    color: theme.blue300,
-    data: [],
-    xAxisIndex: 0,
-    yAxisIndex: 0,
-    markLine: MarkLine({
-      silent: true,
-      animation: false,
-      lineStyle: {color: theme.blue300, type: 'dotted'},
-      data: [
-        {
-          xAxis: index,
-        },
-      ],
-      label: {
-        show: false,
-      },
-    }),
-  };
-}
-
 const throughputQueryToChartData = (
   data: any,
   startTime: moment.Moment,
   endTime: moment.Moment
 ): Series[] => {
-  const countSeries: Series = {seriesName: 'count()', data: [] as any[]};
+  const countSeries: Series = {seriesName: 'spm()', data: [] as any[]};
   const p50Series: Series = {seriesName: 'p50()', data: [] as any[]};
   const p95Series: Series = {seriesName: 'p95()', data: [] as any[]};
   data.forEach(({count, p50, p95, interval}) => {

--- a/static/app/views/starfish/modules/databaseModule/panel/queryTransactionTable.tsx
+++ b/static/app/views/starfish/modules/databaseModule/panel/queryTransactionTable.tsx
@@ -30,7 +30,7 @@ type Props = {
   markLine?: Series;
 };
 
-type Keys = 'transaction' | 'spm' | 'p50' | 'frequency' | 'uniqueEvents';
+type Keys = 'transaction' | 'spm' | 'p50' | 'frequency' | 'uniqueEvents' | 'example';
 
 type TableColumnHeader = GridColumnHeader<Keys>;
 
@@ -146,6 +146,7 @@ function QueryTransactionTable(props: Props) {
             Span appears {dataRow.frequency?.toFixed(2)}x per txn ({dataRow.uniqueEvents}{' '}
             total txns)
           </span>
+          <Link to={`/performance/sentry:${dataRow.example}/`}>sample</Link>
         </Fragment>
       );
     }

--- a/static/app/views/starfish/modules/databaseModule/queries.ts
+++ b/static/app/views/starfish/modules/databaseModule/queries.ts
@@ -32,6 +32,9 @@ export const DEFAULT_WHERE = `
   action != ''
 `;
 
+const SPM =
+  'if(duration > 0, divide(count(), (max(start_timestamp) - min(start_timestamp) as duration)/60), 0)';
+
 const ORDERBY = `
   -power(10, floor(log10(count()))), -quantile(0.75)(exclusive_time)
 `;
@@ -265,7 +268,7 @@ export const useQueryTopTablesChart = (
   select
     floor(quantile(0.75)(exclusive_time), 5) as p75,
     domain,
-    count() as count,
+    divide(count(), multiply(${interval}, 60)) as count,
     toStartOfInterval(start_timestamp, INTERVAL ${interval} hour) as interval
   from default.spans_experimental_starfish
   where
@@ -288,7 +291,7 @@ export const useQueryTopTablesChart = (
   const query2 = `
   select
   floor(quantile(0.75)(exclusive_time), 5) as p75,
-  count() as count,
+  divide(count(), multiply(${interval}, 60)) as count,
   toStartOfInterval(start_timestamp, INTERVAL ${interval} hour) as interval
   from default.spans_experimental_starfish
   where
@@ -329,7 +332,8 @@ export const useQueryPanelTable = (
     SELECT
       transaction,
       count() AS count,
-      quantile(0.75)(exclusive_time) as p75
+      quantile(0.75)(exclusive_time) as p75,
+      any(transaction_id) as example
     FROM spans_experimental_starfish
     WHERE
       ${DEFAULT_WHERE}
@@ -397,7 +401,7 @@ export const useQueryPanelSparklines = (
       transaction,
       toStartOfInterval(start_timestamp, INTERVAL ${interval} hour) as interval,
       quantile(0.50)(exclusive_time) AS p50,
-      divide(count(), ${(endTime.unix() - startTime.unix()) / 60}) AS spm
+      divide(count(), multiply(${interval}, 60)) as spm
     FROM spans_experimental_starfish
     WHERE
       transaction in (
@@ -442,7 +446,7 @@ export const useQueryPanelGraph = (row: DataRow, interval: number) => {
       toStartOfInterval(start_timestamp, INTERVAL ${interval} HOUR) as interval,
       quantile(0.95)(exclusive_time) as p95,
       quantile(0.50)(exclusive_time) as p50,
-      count() as count
+      divide(count(), multiply(${interval}, 60)) as count
     FROM spans_experimental_starfish
     WHERE
       ${DEFAULT_WHERE}
@@ -527,7 +531,7 @@ export const useQueryMainTable = (options: {
   select
     description,
     group_id, count() as count,
-    (divide(count, ${(endTime.unix() - startTime.unix()) / 60}) AS epm),
+    ${SPM} as epm,
     quantile(0.75)(exclusive_time) as p75,
     quantile(0.50)(exclusive_time) as p50,
     quantile(0.95)(exclusive_time) as p95,
@@ -555,7 +559,7 @@ export const useQueryMainTable = (options: {
   ${havingFilters.length > 0 ? 'having' : ''}
     ${havingFilters.join(' and ')}
   order by ${orderBy}
-  limit ${limit ?? 100}
+  limit ${limit ?? 50}
 `;
 
   return useQuery<DataRow[]>({
@@ -701,8 +705,9 @@ export const getDbAggregatesQuery = ({datetime, transaction}) => {
     SELECT
     description,
     toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
-    count() AS count,
-    quantile(0.75)(exclusive_time) as p75
+    divide(count(), multiply(12, 60)) as count,
+    quantile(0.50)(exclusive_time) as p50,
+    quantile(0.95)(exclusive_time) as p95
     FROM spans_experimental_starfish
     WHERE module = 'db'
     ${transaction ? `AND transaction = '${transaction}'` : ''}

--- a/static/app/views/starfish/modules/databaseModule/utils.ts
+++ b/static/app/views/starfish/modules/databaseModule/utils.ts
@@ -1,6 +1,8 @@
+import {Theme} from '@emotion/react';
 import moment from 'moment';
 
-import {Series} from 'sentry/types/echarts';
+import MarkLine from 'sentry/components/charts/components/markLine';
+import {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 
 export const queryToSeries = (
@@ -36,3 +38,64 @@ export const queryToSeries = (
     )
   );
 };
+
+export function generateMarkLine(
+  title: string,
+  position: string,
+  data: SeriesDataUnit[],
+  theme: Theme
+) {
+  const index = data.findIndex(item => {
+    return (
+      Math.abs(moment.duration(moment(item.name).diff(moment(position))).asSeconds()) <
+      86400
+    );
+  });
+  return {
+    seriesName: title,
+    type: 'line',
+    color: theme.blue300,
+    data: [],
+    xAxisIndex: 0,
+    yAxisIndex: 0,
+    markLine: MarkLine({
+      silent: true,
+      animation: false,
+      lineStyle: {color: theme.blue300, type: 'dotted'},
+      data: [
+        {
+          xAxis: index,
+        },
+      ],
+      label: {
+        show: false,
+      },
+    }),
+  };
+}
+
+export function generateHorizontalLine(title: string, position: number, theme: Theme) {
+  return {
+    seriesName: title,
+    type: 'line',
+    color: theme.blue300,
+    data: [],
+    xAxisIndex: 0,
+    yAxisIndex: 0,
+    markLine: MarkLine({
+      silent: true,
+      animation: false,
+      lineStyle: {color: theme.blue300, type: 'dotted'},
+      data: [
+        {
+          yAxis: position,
+        },
+      ],
+      label: {
+        show: true,
+        position: 'insideStart',
+        formatter: title,
+      },
+    }),
+  };
+}

--- a/static/app/views/starfish/utils/combineTableDataWithSparklineData.tsx
+++ b/static/app/views/starfish/utils/combineTableDataWithSparklineData.tsx
@@ -1,4 +1,4 @@
-import {Duration} from 'moment';
+import {Duration, Moment} from 'moment';
 
 import {Series} from 'sentry/types/echarts';
 import {DataRow} from 'sentry/views/starfish/modules/APIModule/endpointTable';
@@ -7,14 +7,16 @@ import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 export default function combineTableDataWithSparklineData(
   tableData: DataRow[],
   aggregateData,
-  momentInterval: Duration
+  momentInterval: Duration,
+  startTime?: Moment,
+  endTime?: Moment
 ): DataRow[] {
   const aggregatesGroupedByQuery = {};
-  aggregateData.forEach(({description, interval, count, p75}) => {
+  aggregateData.forEach(({description, interval, count, p50, p95}) => {
     if (description in aggregatesGroupedByQuery) {
-      aggregatesGroupedByQuery[description].push({name: interval, count, p75});
+      aggregatesGroupedByQuery[description].push({name: interval, count, p50, p95});
     } else {
-      aggregatesGroupedByQuery[description] = [{name: interval, count, p75}];
+      aggregatesGroupedByQuery[description] = [{name: interval, count, p50, p95}];
     }
   });
 
@@ -29,17 +31,36 @@ export default function combineTableDataWithSparklineData(
       })),
     };
 
-    const p75Series: Series = {
-      seriesName: 'p75 Trend',
-      data: aggregatesGroupedByQuery[query]?.map(({name, p75}) => ({
+    const p50Series: Series = {
+      seriesName: 'p50 Trend',
+      data: aggregatesGroupedByQuery[query]?.map(({name, p50}) => ({
         name,
-        value: p75,
+        value: p50,
       })),
     };
 
-    const zeroFilledThroughput = zeroFillSeries(throughputSeries, momentInterval);
-    const zeroFilledP75 = zeroFillSeries(p75Series, momentInterval);
-    return {...data, throughput: zeroFilledThroughput, p75_trend: zeroFilledP75};
+    const p95Series: Series = {
+      seriesName: 'p95 Trend',
+      data: aggregatesGroupedByQuery[query]?.map(({name, p95}) => ({
+        name,
+        value: p95,
+      })),
+    };
+
+    const zeroFilledThroughput = zeroFillSeries(
+      throughputSeries,
+      momentInterval,
+      startTime,
+      endTime
+    );
+    const zeroFilledP50 = zeroFillSeries(p50Series, momentInterval, startTime, endTime);
+    const zeroFilledP95 = zeroFillSeries(p95Series, momentInterval, startTime, endTime);
+    return {
+      ...data,
+      throughput: zeroFilledThroughput,
+      p50_trend: zeroFilledP50,
+      p95_trend: zeroFilledP95,
+    };
   });
 
   return combinedData;


### PR DESCRIPTION
- This updates the db module tables, removing the numbers for sparklines instead so we can fit both p50 and p95
- This removes the txn graphs from the top of the page -- may replace the table graphs with a table of tables with sparklines instead
- Remove the hovercard from the table -- it was far too noisy most of the time, and hard to read
- Adds a sample button to the sidepanel
- Fixed a bug where the sparklines weren't zerofilled