### PR TITLE
feat(starfish): Add slow samples table to endpoint details page

### DIFF
--- a/static/app/views/starfish/components/sampleEvents.tsx
+++ b/static/app/views/starfish/components/sampleEvents.tsx
@@ -1,0 +1,100 @@
+import Duration from 'sentry/components/duration';
+import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
+import EventView from 'sentry/utils/discover/eventView';
+import {
+  DiscoverQueryProps,
+  useGenericDiscoverQuery,
+} from 'sentry/utils/discover/genericDiscoverQuery';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {TextAlignLeft} from 'sentry/views/starfish/modules/APIModule/endpointTable';
+
+type Props = {
+  eventView: EventView;
+};
+
+type DataRow = {
+  id: string;
+  'transaction.duration': number;
+};
+
+const COLUMN_ORDER = [
+  {
+    key: 'id',
+    name: 'Event ID',
+    width: 300,
+  },
+  {
+    key: 'transaction.duration',
+    name: 'Duration',
+    width: -1,
+  },
+];
+
+export function SampleEvents({eventView}: Props) {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  const sampleEventsEventView = eventView
+    .clone()
+    .withColumns([
+      {
+        field: 'transaction.duration',
+        kind: 'field',
+      },
+    ])
+    .withSorts([
+      {
+        field: 'transaction.duration',
+        kind: 'desc',
+      },
+    ]);
+
+  function renderBodyCell(column: GridColumnHeader, row: DataRow): React.ReactNode {
+    if (column.key === 'id') {
+      return (
+        <Link to={`/performance/${row['project.name']}:${row.id}`}>
+          {row.id.slice(0, 8)}
+        </Link>
+      );
+    }
+
+    if (column.key === 'transaction.duration') {
+      return (
+        <Duration
+          seconds={row['transaction.duration'] / 1000}
+          fixedDigits={2}
+          abbreviation
+        />
+      );
+    }
+
+    return <TextAlignLeft>{row[column.key]}</TextAlignLeft>;
+  }
+
+  const {isLoading, data} = useGenericDiscoverQuery<any, DiscoverQueryProps>({
+    route: 'events',
+    eventView,
+    referrer: 'starfish-transaction-summary-sample-events',
+    limit: 5,
+    location,
+    orgSlug: organization.slug,
+    getRequestPayload: () => ({
+      ...sampleEventsEventView.getEventsAPIPayload(location),
+    }),
+  });
+
+  return (
+    <GridEditable
+      isLoading={isLoading}
+      data={data?.data}
+      columnOrder={COLUMN_ORDER}
+      columnSortBy={[]}
+      location={location}
+      grid={{
+        renderBodyCell,
+      }}
+    />
+  );
+}

--- a/static/app/views/starfish/components/sampleEvents.tsx
+++ b/static/app/views/starfish/components/sampleEvents.tsx
@@ -77,7 +77,7 @@ export function SampleEvents({eventView}: Props) {
 
   const {isLoading, data} = useGenericDiscoverQuery<any, DiscoverQueryProps>({
     route: 'events',
-    eventView,
+    eventView: sampleEventsEventView,
     referrer: 'starfish-transaction-summary-sample-events',
     limit: 5,
     location,

--- a/static/app/views/starfish/components/sampleEvents.tsx
+++ b/static/app/views/starfish/components/sampleEvents.tsx
@@ -19,7 +19,9 @@ type DataRow = {
   'transaction.duration': number;
 };
 
-const COLUMN_ORDER = [
+type Keys = 'id' | 'transaction.duration';
+type TableColumnHeader = GridColumnHeader<Keys>;
+const COLUMN_ORDER: TableColumnHeader[] = [
   {
     key: 'id',
     name: 'Event ID',
@@ -51,7 +53,7 @@ export function SampleEvents({eventView}: Props) {
       },
     ]);
 
-  function renderBodyCell(column: GridColumnHeader, row: DataRow): React.ReactNode {
+  function renderBodyCell(column: TableColumnHeader, row: DataRow): React.ReactNode {
     if (column.key === 'id') {
       return (
         <Link to={`/performance/${row['project.name']}:${row.id}`}>

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -23,6 +23,7 @@ import withApi from 'sentry/utils/withApi';
 import FacetBreakdownBar from 'sentry/views/starfish/components/breakdownBar';
 import Chart from 'sentry/views/starfish/components/chart';
 import {FacetInsights} from 'sentry/views/starfish/components/facetInsights';
+import {SampleEvents} from 'sentry/views/starfish/components/sampleEvents';
 import EndpointTable from 'sentry/views/starfish/modules/APIModule/endpointTable';
 import DatabaseTableView, {
   DataRow,
@@ -262,6 +263,8 @@ export default function EndpointOverview() {
             title={t('Where is time spent in this endpoint?')}
             transaction={transaction as string}
           />
+          <SubHeader>{t('Sample Events')}</SubHeader>
+          <SampleEvents eventView={eventView} />
           <SubHeader>{t('Correlations')}</SubHeader>
           <FacetInsights eventView={eventView} />
           <SubHeader>{t('HTTP Spans')}</SubHeader>

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -161,7 +161,7 @@ export default function EndpointOverview() {
     id: undefined,
     name: t('Endpoint Overview'),
     query: query.formatString(),
-    projects: [],
+    projects: [1],
     fields: [],
     version: 2,
   };


### PR DESCRIPTION
**e.g.,**
![Screenshot 2023-05-16 at 1 37 09 PM](https://github.com/getsentry/sentry/assets/989898/67625404-f68a-471d-ad36-95c3139be19c)
