### PR TITLE
chore(login): update the login banners

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -78,9 +78,9 @@
   <div class="alert-banner">
     <div class="alert-message">
       {% if banner_choice == 0 %}
-      Need a quick refresh on frontend error monitoring? Join the upcoming 20 minute livestream on frontend error monitoring. &nbsp<a target="_blank" href="https://sentry.io/resources/livestream-ama-frontend-error-monitoring-101/?utm_medium=banner&utm_source=sentry-app&utm_campaign=frontend-error-webinar-may&utm_content=login-banner&utm_term=">Register</a>.
+      Need a quick refresher on frontend error monitoring? Join us May 30th at 10am PT for a 20 minute session on frontend error monitoring. &nbsp<a target="_blank" href="https://sentry.io/resources/livestream-ama-frontend-error-monitoring-101/?utm_medium=banner&utm_source=sentry-app&utm_campaign=frontend-error-webinar-may&utm_content=login-banner&utm_term=">Register</a>.
       {% elif banner_choice == 1 %}
-      Join the livestream AMA on Session Replay to learn about new and upcoming features that help you debug faster. &nbsp<a target="_blank" href="https://sentry.io/resources/session-replay-troubleshooting/?utm_medium=banner&utm_source=sentry-app&utm_campaign=session-replay-webinar-may&utm_content=login-banner&utm_term=">Register</a>.
+      Join us on May 25th at 10am PT to learn how to use Session Replay to investigate errors and performance issues. &nbsp<a target="_blank" href="https://sentry.io/resources/session-replay-troubleshooting/?utm_medium=banner&utm_source=sentry-app&utm_campaign=session-replay-webinar-may&utm_content=login-banner&utm_term=">Register</a>.
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Copy updates to the login banner. Promoting the same content, but added dates for the webinars and removed the term "livestream".