### PR TITLE
feat(ui): Stop reporting `Unable to load all required endpoints` errors

### DIFF
--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -436,7 +436,7 @@ class AsyncComponent<
     return this.shouldRenderLoading
       ? this.renderLoading()
       : this.state.error
-      ? this.renderError(new Error('Unable to load all required endpoints'))
+      ? this.renderError()
       : this.renderBody();
   }
 

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -314,9 +314,7 @@ export default class AbstractExternalIssueForm<
   };
 
   renderComponent() {
-    return this.state.error
-      ? this.renderError(new Error('Unable to load all required endpoints'))
-      : this.renderBody();
+    return this.state.error ? this.renderError() : this.renderBody();
   }
 
   renderForm = (

--- a/static/app/utils/useApiRequests.tsx
+++ b/static/app/utils/useApiRequests.tsx
@@ -396,11 +396,7 @@ function useApiRequests<T extends Record<string, any>>({
 
   const renderComponent = useCallback(
     (children: React.ReactElement) =>
-      shouldRenderLoading
-        ? renderLoading()
-        : state.hasError
-        ? renderError(new Error('Unable to load all required endpoints'))
-        : children,
+      shouldRenderLoading ? renderLoading() : state.hasError ? renderError() : children,
     [shouldRenderLoading, state.hasError, renderError]
   );
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -599,7 +599,7 @@ class ReleasesList extends AsyncView<Props, State> {
                 !!releases?.length && <ReleaseArchivedNotice multi />}
 
               {error
-                ? super.renderError(new Error('Unable to load all required endpoints'))
+                ? super.renderError()
                 : this.renderInnerBody(activeDisplay, showReleaseAdoptionStages)}
             </Layout.Main>
           </Layout.Body>


### PR DESCRIPTION
We don't usually look at these errors as many of them are flakes. The errors are also kinda vague. Was it a 404? etc

examples https://sentry.sentry.io/issues/?project=11276&query=is%3Aunresolved+Unable+to+load&referrer=issue-list&statsPeriod=90d

fixes #49144