### PR TITLE
ref(perf): Adjust tag key length in span details

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -571,6 +571,10 @@ export const SpanDetailContainer = styled('div')`
 
 export const SpanDetails = styled('div')`
   padding: ${space(2)};
+
+  table.table.key-value td.key {
+    max-width: 280px;
+  }
 `;
 
 const ValueTd = styled('td')`


### PR DESCRIPTION
### Summary
Span details needs some more max-width now that we have long data keys. In the long term we probably need to re-do this layout considering how much horizontal space it takes up.


### Screenshot
![Screenshot 2023-05-16 at 2 57 47 PM](https://github.com/getsentry/sentry/assets/6111995/6b4d9e36-6f5c-4058-850e-08bb4bd93c9a)

