### PR TITLE
feat: Stop auto creating topics

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2899,7 +2899,7 @@ KAFKA_TOPICS = {
 
 
 # If True, consumers will create the topics if they don't exist
-KAFKA_CONSUMER_AUTO_CREATE_TOPICS = True
+KAFKA_CONSUMER_AUTO_CREATE_TOPICS = False
 
 # For Jira, only approved apps can use the access_email_addresses scope
 # This scope allows Sentry to use the email endpoint (https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-user-email-get)


### PR DESCRIPTION
We should remove this setting entirely as consumers should never auto create topics anymore. For now, just flip the default. This is already being done when the devserver starts.
