### PR TITLE
fix(form): Correctly remove field and fieldState

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -256,6 +256,8 @@ class FormModel {
    * Remove a field from the descriptor map and errors.
    */
   removeField(id: string) {
+    this.fields.delete(id);
+    this.fieldState.delete(id);
     this.fieldDescriptor.delete(id);
     this.errors.delete(id);
   }


### PR DESCRIPTION
When removing a form field it would persist the value of the field, so
when the form saved even though the field isn't there it was still
sending it's previous value.