### PR TITLE
fix(roles): Allow Team Admins to modify Project Teams

### DIFF
--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -37,10 +37,8 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
             team = Team.objects.get(organization_id=project.organization_id, slug=team_slug)
         except Team.DoesNotExist:
             raise Http404
-        if not request.access.has_team_scope(team, "project:write"):
-            return Response(
-                {"detail": ["You do not have permission to perform this action."]}, status=403
-            )
+
+        # A user with project:write can grant access to this project to other user/teams
         project.add_team(team)
         return Response(serialize(project, request.user, ProjectWithTeamSerializer()), status=201)
 

--- a/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
@@ -41,6 +41,9 @@ function TeamSelect({
       return <EmptyMessage>{t('No Teams assigned')}</EmptyMessage>;
     }
 
+    // If the user is not a team-admin in any parent teams of this project, they will
+    // not be able to edit the configuration. Warn the user if this is their last team
+    // where they have team-admin role.
     const isUserLastTeamWrite =
       selectedTeams.reduce(
         (count, team) => (team.access.includes('team:write') ? count + 1 : count),

--- a/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
@@ -23,17 +23,11 @@ type Props = TeamSelectProps & {
    * Used when showing Teams for a Project
    */
   selectedTeams: Team[];
-  /**
-   * Message to display when the last team is removed
-   * if empty no confirm will be displayed.
-   */
-  confirmLastTeamRemoveMessage?: string;
 };
 
 function TeamSelect({
   disabled,
   canCreateTeam,
-  confirmLastTeamRemoveMessage,
   project,
   selectedTeams,
   organization,
@@ -47,17 +41,29 @@ function TeamSelect({
       return <EmptyMessage>{t('No Teams assigned')}</EmptyMessage>;
     }
 
-    const confirmMessage =
-      numTeams === 1 && confirmLastTeamRemoveMessage
-        ? confirmLastTeamRemoveMessage
-        : null;
+    const isUserLastTeamWrite =
+      selectedTeams.reduce(
+        (count, team) => (team.access.includes('team:write') ? count + 1 : count),
+        0
+      ) === 1;
+    const isOnlyTeam = numTeams === 1;
+
+    const confirmMessage = isUserLastTeamWrite
+      ? t(
+          "This is the last team that grants Team Admin access to you for this project. After removing this team, you will not be able to edit this project's configuration."
+        )
+      : isOnlyTeam
+      ? t(
+          'This is the last team with access to this project. After removing this team, only organization owners and managers will be able to access the project pages.'
+        )
+      : null;
 
     return (
       <React.Fragment>
         {selectedTeams.map(team => (
           <TeamRow
             key={team.slug}
-            disabled={disabled}
+            disabled={disabled || !team.access.includes('team:write')}
             confirmMessage={confirmMessage}
             organization={organization}
             team={team}

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -127,7 +127,6 @@ class ProjectTeams extends AsyncView<Props, State> {
 
     const canCreateTeam = this.canCreateTeam();
     const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
-    const isTeamAdmin = hasWriteAccess && !organization.access.includes('project:write');
 
     return (
       <div>
@@ -138,10 +137,9 @@ class ProjectTeams extends AsyncView<Props, State> {
           )}
         </TextBlock>
         <TextBlock>
-          {isTeamAdmin &&
-            t(
-              'Team Admins can grant other teams access to this project. However, they cannot revoke access unless they are admins for the other teams too.'
-            )}
+          {t(
+            'Team Admins can grant other teams access to this project. However, they cannot revoke access unless they are admins for the other teams too.'
+          )}
         </TextBlock>
         <PermissionAlert project={project} />
 

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -3,6 +3,7 @@ import {RouteComponentProps} from 'react-router';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openCreateTeamModal} from 'sentry/actionCreators/modal';
 import {addTeamToProject, removeTeamFromProject} from 'sentry/actionCreators/projects';
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {t, tct} from 'sentry/locale';
 import TeamStore from 'sentry/stores/teamStore';
 import {Organization, Project, Team} from 'sentry/types';
@@ -10,6 +11,7 @@ import routeTitleGen from 'sentry/utils/routeTitle';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TeamSelectForProject from 'sentry/views/settings/components/teamSelect/teamSelectForProject';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
 type Props = {
@@ -121,21 +123,30 @@ class ProjectTeams extends AsyncView<Props, State> {
 
   renderBody() {
     const {project, organization} = this.props;
+    const {projectTeams} = this.state;
 
     const canCreateTeam = this.canCreateTeam();
-    const hasAccess = organization.access.includes('project:write');
-    const confirmRemove = t(
-      'This is the last team with access to this project. Removing it will mean only organization owners and managers will be able to access the project pages. Are you sure you want to remove this team from the project %s?',
-      project.slug
-    );
-    const {projectTeams} = this.state;
+    const hasWriteAccess = hasEveryAccess(['project:write'], {organization, project});
+    const isTeamAdmin = hasWriteAccess && !organization.access.includes('project:write');
 
     return (
       <div>
         <SettingsPageHeader title={t('Project Teams for %s', project.slug)} />
+        <TextBlock>
+          {t(
+            'These teams and their members have access to this project. They can be assigned to issues and alerts created in it.'
+          )}
+        </TextBlock>
+        <TextBlock>
+          {isTeamAdmin &&
+            t(
+              'Team Admins can grant other teams access to this project. However, they cannot revoke access unless they are admins for the other teams too.'
+            )}
+        </TextBlock>
         <PermissionAlert project={project} />
+
         <TeamSelectForProject
-          disabled={!hasAccess}
+          disabled={!hasWriteAccess}
           canCreateTeam={canCreateTeam}
           organization={organization}
           project={project}
@@ -148,7 +159,6 @@ class ProjectTeams extends AsyncView<Props, State> {
               this.remountComponent
             );
           }}
-          confirmLastTeamRemoveMessage={confirmRemove}
         />
       </div>
     );

--- a/tests/sentry/api/endpoints/test_project_team_details.py
+++ b/tests/sentry/api/endpoints/test_project_team_details.py
@@ -2,6 +2,7 @@ from rest_framework import status
 
 from sentry.models import ProjectTeam, Rule
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import region_silo_test
 
 
@@ -40,6 +41,7 @@ class ProjectTeamDetailsPostTest(ProjectTeamDetailsTest):
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
+    @with_feature("organizations:team-roles")
     def test_add_team_with_team_role(self):
         user = self.create_user(username="foo")
         team_to_add = self.create_team(organization=self.organization)
@@ -136,6 +138,7 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
+    @with_feature("organizations:team-roles")
     def test_remove_team_with_team_role(self):
         user = self.create_user(username="foo")
         team_to_remove = self.create_team(organization=self.organization)


### PR DESCRIPTION
## For a org-member + team-contributor
<img width="968" alt="Screenshot 2023-05-16 at 3 20 07 PM" src="https://github.com/getsentry/sentry/assets/1748388/c0de4e60-5de9-4dde-aed4-d3a8d82a27ed">


## For a org-member + team-admin
<img width="967" alt="Screenshot 2023-05-16 at 3 20 14 PM" src="https://github.com/getsentry/sentry/assets/1748388/2a3afbe4-a05c-4be1-ae11-59f8aff3c756">

## For a org-owner/org-manager
<img width="966" alt="Screenshot 2023-05-16 at 3 20 20 PM" src="https://github.com/getsentry/sentry/assets/1748388/32e6de65-4b8b-4a93-b487-e1fabf3749a5">
