### PR TITLE
ref(js): Replace simple substr -> substring

### DIFF
--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -564,7 +564,7 @@ class EventsChart extends Component<EventsChartProps> {
     const yAxisSeriesNames = yAxisArray.map(name => {
       let yAxisLabel = name && isEquation(name) ? getEquation(name) : name;
       if (yAxisLabel && yAxisLabel.length > 60) {
-        yAxisLabel = yAxisLabel.substr(0, 60) + '...';
+        yAxisLabel = yAxisLabel.substring(0, 60) + '...';
       }
       return yAxisLabel;
     });

--- a/static/app/components/highlight.tsx
+++ b/static/app/components/highlight.tsx
@@ -34,9 +34,9 @@ function HighlightComponent({className, children, disabled, text}: Props) {
 
   return (
     <Fragment>
-      {children.substr(0, idx)}
+      {children.substring(0, idx)}
       <span className={className}>{children.substr(idx, highlightText.length)}</span>
-      {children.substr(idx + highlightText.length)}
+      {children.substring(idx + highlightText.length)}
     </Fragment>
   );
 }

--- a/static/app/components/lastCommit.tsx
+++ b/static/app/components/lastCommit.tsx
@@ -32,7 +32,7 @@ function LastCommit({commit, className}: Props) {
 
     const firstLine = message.split(/\n/)[0];
     if (firstLine.length > 100) {
-      let truncated = firstLine.substr(0, 90);
+      let truncated = firstLine.substring(0, 90);
       const words = truncated.split(/ /);
       // try to not have ellipsis mid-word
       if (words.length > 1) {

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -316,7 +316,7 @@ class ApiSource extends Component<Props, State> {
     // Otherwise it'd be constant :spinning_loading_wheel:
     if (
       (nextProps.query.length <= 2 &&
-        nextProps.query.substr(0, 2) !== this.props.query.substr(0, 2)) ||
+        nextProps.query.substring(0, 2) !== this.props.query.substring(0, 2)) ||
       // Also trigger a search if next query value satisfies an eventid/shortid query
       shouldSearchShortIds(nextProps.query) ||
       shouldSearchEventIds(nextProps.query)

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -155,7 +155,7 @@ export function percent(value: number, totalValue: number): number {
 export function toTitleCase(str: string): string {
   return str.replace(
     /\w\S*/g,
-    txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+    txt => txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase()
   );
 }
 
@@ -211,7 +211,7 @@ export function formatBytesBase2(bytes: number, fixPoints: number = 1): string {
 
 export function getShortCommitHash(hash: string): string {
   if (hash.match(/^[a-f0-9]{40}$/)) {
-    hash = hash.substr(0, 7);
+    hash = hash.substring(0, 7);
   }
   return hash;
 }

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -114,7 +114,7 @@ function transformData(_data: Record<string, any>, model: FormModel) {
       return data;
     }
 
-    data.config[k.substr(7)] = v;
+    data.config[k.substring(7)] = v;
     return data;
   }, {});
 }


### PR DESCRIPTION
`substr` is deprecated (and was never in the ECMAscript spec).

Prefer substring. There IS a subtle difference between the two, see [0].

[0]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring