### PR TITLE
fix(replays): fetchReplayList on replay index and issue details replays

### DIFF
--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -51,8 +51,10 @@ async function fetchReplayList({
       query: {
         ...payload,
         cursor: location.query.cursor,
+        // when queryReferrer === 'issueReplays' we override the global view check on the backend
+        // we also require a project param otherwise we won't yield results
         queryReferrer,
-        project: ALL_ACCESS_PROJECTS,
+        project: queryReferrer === 'issueReplays' ? ALL_ACCESS_PROJECTS : payload.project,
       },
     });
 

--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react';
 import type {Location} from 'history';
 
 import type {Client} from 'sentry/api';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import type {Organization} from 'sentry/types';
 import type EventView from 'sentry/utils/discover/eventView';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
@@ -51,6 +52,7 @@ async function fetchReplayList({
         ...payload,
         cursor: location.query.cursor,
         queryReferrer,
+        project: ALL_ACCESS_PROJECTS,
       },
     });
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -132,7 +132,7 @@ describe('GroupReplays', () => {
                 'user',
               ],
               per_page: 50,
-              project: [],
+              project: -1,
               queryReferrer: 'issueReplays',
               query: `id:[${REPLAY_ID_1},${REPLAY_ID_2}]`,
               sort: '-started_at',

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import type {Group, Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -34,7 +35,7 @@ function useReplayFromIssue({
             returnIds: true,
             query: `issue.id:[${group.id}]`,
             statsPeriod: '14d',
-            project: -1,
+            project: ALL_ACCESS_PROJECTS,
           },
         }
       );


### PR DESCRIPTION
## Summary
Fixes an issue where we would display a replayCount but the list would not load due to a missing query param.

Slack thread: https://sentry.slack.com/archives/C03USURCFBJ/p1684220401490959

Initial Reverted PR due to bug: https://github.com/getsentry/sentry/pull/49202