### PR TITLE
fix(crons) Don't create mock data with bad data

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -428,8 +428,6 @@ def main(
                     defaults={
                         "status": ObjectStatus.DISABLED,
                         "config": {"schedule": next(MONITOR_SCHEDULES)},
-                        "next_checkin": timezone.now() + timedelta(minutes=60),
-                        "last_checkin": timezone.now(),
                     },
                 )
 


### PR DESCRIPTION
The last_checkin and next_checkin fields have been removed. Removing these allowed me to run load-mocks cleanly.