### PR TITLE
feat(starfish): Api module make url statsperiod functional and fixes transaction metrics charts bad zerofilling

### DIFF
--- a/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
+++ b/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
@@ -202,22 +202,12 @@ export default function APIModuleView({location, onSelect}: Props) {
       interval
     );
 
-  const tpmTransactionSeries = queryToSeries(
-    topTransactionsData,
-    'group',
-    'epm()',
-    startTime,
-    endTime,
-    24
-  );
+  const tpmTransactionSeries = queryToSeries(topTransactionsData, 'group', 'epm()');
 
   const p75TransactionSeries = queryToSeries(
     topTransactionsData,
     'group',
-    'p75(transaction.duration)',
-    startTime,
-    endTime,
-    24
+    'p75(transaction.duration)'
   );
 
   return (
@@ -231,6 +221,24 @@ export default function APIModuleView({location, onSelect}: Props) {
         />
         <DatePageFilter alignDropdown="left" />
       </FilterOptionsContainer>
+      <ChartsContainer>
+        <ChartsContainerItem>
+          <ChartPanel title={t('Top Transactions Throughput')}>
+            <APIModuleChart
+              data={tpmTransactionSeries}
+              loading={isTopTransactionDataLoading}
+            />
+          </ChartPanel>
+        </ChartsContainerItem>
+        <ChartsContainerItem>
+          <ChartPanel title={t('Top Transactions p75')}>
+            <APIModuleChart
+              data={p75TransactionSeries}
+              loading={isTopTransactionDataLoading}
+            />
+          </ChartPanel>
+        </ChartsContainerItem>
+      </ChartsContainer>
       <ChartsContainer>
         <ChartsContainerItem>
           <ChartPanel title={t('Throughput')}>
@@ -248,22 +256,6 @@ export default function APIModuleView({location, onSelect}: Props) {
               data={zeroFilledFailureRate}
               loading={isGraphLoading}
               chartColors={[themes.charts.getColorPalette(2)[2]]}
-            />
-          </ChartPanel>
-        </ChartsContainerItem>
-        <ChartsContainerItem>
-          <ChartPanel title={t('Top Transactions Throughput')}>
-            <APIModuleChart
-              data={tpmTransactionSeries}
-              loading={isTopTransactionDataLoading}
-            />
-          </ChartPanel>
-        </ChartsContainerItem>
-        <ChartsContainerItem>
-          <ChartPanel title={t('Top Transactions p75')}>
-            <APIModuleChart
-              data={p75TransactionSeries}
-              loading={isTopTransactionDataLoading}
             />
           </ChartPanel>
         </ChartsContainerItem>

--- a/static/app/views/starfish/modules/APIModule/index.tsx
+++ b/static/app/views/starfish/modules/APIModule/index.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 import {Location} from 'history';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {t} from 'sentry/locale';
 import {
   PageErrorAlert,
@@ -38,8 +39,10 @@ export default function APIModule(props: Props) {
         <Layout.Body>
           <Layout.Main fullWidth>
             <PageErrorAlert />
-            <APIModuleView {...props} onSelect={setSelectedRow} />
-            <EndpointDetail row={selectedRow} onClose={unsetSelectedSpanGroup} />
+            <PageFiltersContainer>
+              <APIModuleView {...props} onSelect={setSelectedRow} />
+              <EndpointDetail row={selectedRow} onClose={unsetSelectedSpanGroup} />
+            </PageFiltersContainer>
           </Layout.Main>
         </Layout.Body>
       </PageErrorProvider>

--- a/static/app/views/starfish/modules/databaseModule/utils.ts
+++ b/static/app/views/starfish/modules/databaseModule/utils.ts
@@ -7,9 +7,9 @@ export const queryToSeries = (
   data: (Record<string, any> & {interval: string})[],
   groupByProperty: string,
   seriesValueProperty: string,
-  startTime: moment.Moment,
-  endTime: moment.Moment,
-  interval: number,
+  startTime?: moment.Moment,
+  endTime?: moment.Moment,
+  interval?: number,
   zerofillValue?: any
 ): Series[] => {
   const seriesMap: Record<string, Series> = {};
@@ -22,10 +22,13 @@ export const queryToSeries = (
         data: [],
       };
     }
-    if (dataEntry.value) {
+    if (dataEntry.value !== undefined) {
       seriesMap[row[groupByProperty]].data.push(dataEntry);
     }
   });
+  if (!startTime || !endTime || !interval) {
+    return Object.values(seriesMap);
+  }
   return Object.values(seriesMap).map(series =>
     zeroFillSeries(
       series,


### PR DESCRIPTION
Api module now properly uses the stats period from the url. Also updates the transaction metrics charts to not use zerofilling since its not needed

