### PR TITLE
fix(task): increase timelimits for task that auto transitions to ongoing issues

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1012,13 +1012,13 @@ CELERYBEAT_SCHEDULE = {
         "task": "sentry.tasks.schedule_auto_transition_new",
         # Run job once a day at 00:30
         "schedule": crontab(minute=30, hour="0"),
-        "options": {"expires": 10 * 60},
+        "options": {"expires": 3600},
     },
     "schedule_auto_transition_regressed": {
         "task": "sentry.tasks.schedule_auto_transition_regressed",
         # Run job once a day at 02:30
         "schedule": crontab(minute=30, hour="2"),
-        "options": {"expires": 10 * 60},
+        "options": {"expires": 3600},
     },
 }
 

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -42,8 +42,8 @@ def schedule_auto_transition_new() -> None:
 @instrumented_task(
     name="sentry.tasks.auto_transition_issues_new_to_ongoing",
     queue="auto_transition_issue_states",
-    time_limit=1.25 * 5 * 60,
-    soft_time_limit=5 * 60,
+    time_limit=25 * 60,
+    soft_time_limit=20 * 60,
 )  # type: ignore
 def auto_transition_issues_new_to_ongoing(
     project_id: int,
@@ -109,8 +109,8 @@ def schedule_auto_transition_regressed() -> None:
 @instrumented_task(
     name="sentry.tasks.auto_transition_issues_regressed_to_ongoing",
     queue="auto_transition_issue_states",
-    time_limit=1.25 * 5 * 60,
-    soft_time_limit=5 * 60,
+    time_limit=25 * 60,
+    soft_time_limit=20 * 60,
 )  # type: ignore
 def auto_transition_issues_regressed_to_ongoing(
     project_id: int,


### PR DESCRIPTION
Running into time limits when these tasks are running. 10 minutes may not be enough to iterate through all the orgs.

Resolves SENTRY-10X5