### PR TITLE
ref(crons): Sort timeout above missed for monitors

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitors.py
+++ b/src/sentry/monitors/endpoints/organization_monitors.py
@@ -51,8 +51,8 @@ from rest_framework.response import Response
 
 DEFAULT_ORDERING = [
     MonitorStatus.ERROR,
-    MonitorStatus.MISSED_CHECKIN,
     MonitorStatus.TIMEOUT,
+    MonitorStatus.MISSED_CHECKIN,
     MonitorStatus.OK,
     MonitorStatus.ACTIVE,
     MonitorStatus.DISABLED,

--- a/tests/sentry/monitors/endpoints/test_organization_monitors.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitors.py
@@ -81,8 +81,8 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
             [
                 monitor_error,
                 monitor_error_older_checkin,
-                monitor_missed_checkin,
                 monitor_timed_out,
+                monitor_missed_checkin,
                 monitor_ok,
                 monitor_active,
                 monitor_disabled,


### PR DESCRIPTION
Changes sort order for `MISSED` status monitors