### PR TITLE
chore: Don't include ORM records in slack tasks

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -201,8 +201,6 @@ class SlackIntegrationProvider(IntegrationProvider):  # type: ignore
         Create Identity records for an organization's users if their emails match in Sentry and Slack
         """
         run_args = {
-            "integration": integration,
-            "organization": organization,
             "integration_id": integration.id,
             "organization_id": organization.id,
         }


### PR DESCRIPTION
The new task signature has been in production for a few days, so we should be safe to remove the ORM parameters for new tasks. I've left handling logic for old and new parameters so that we don't hit any bumps in single-tenant.

Related to #49009