### PR TITLE
feat(issue-details): Convert ExternalIssuesList to FC and useApiQuery

### DIFF
--- a/static/app/components/group/externalIssuesList.spec.tsx
+++ b/static/app/components/group/externalIssuesList.spec.tsx
@@ -21,7 +21,7 @@ describe('ExternalIssuesList', () => {
 
   const setupCTA = 'Track this issue in Jira, GitHub, etc.';
 
-  it('renders setup CTA', () => {
+  it('renders setup CTA', async () => {
     MockApiClient.addMockResponse({
       url: `/groups/${group.id}/integrations/`,
       body: [],
@@ -39,10 +39,10 @@ describe('ExternalIssuesList', () => {
       />,
       {organization}
     );
-    expect(screen.getByText(setupCTA)).toBeInTheDocument();
+    expect(await screen.findByText(setupCTA)).toBeInTheDocument();
   });
 
-  it('renders sentry app issues', () => {
+  it('renders sentry app issues', async () => {
     MockApiClient.addMockResponse({
       url: `/groups/${group.id}/integrations/`,
       body: [],
@@ -66,8 +66,8 @@ describe('ExternalIssuesList', () => {
       />,
       {organization}
     );
+    expect(await screen.findByText('Foo Issue')).toBeInTheDocument();
     expect(screen.queryByText(setupCTA)).not.toBeInTheDocument();
-    expect(screen.getByText('Foo Issue')).toBeInTheDocument();
   });
 
   it('renders integrations with issues first', async () => {

--- a/static/app/components/group/externalIssuesList.tsx
+++ b/static/app/components/group/externalIssuesList.tsx
@@ -1,8 +1,6 @@
-import {Fragment} from 'react';
-import {WithRouterProps} from 'react-router';
+import {Fragment, useEffect} from 'react';
 
 import AlertLink from 'sentry/components/alertLink';
-import AsyncComponent from 'sentry/components/asyncComponent';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalIssueActions from 'sentry/components/group/externalIssueActions';
 import PluginActions from 'sentry/components/group/pluginActions';
@@ -13,39 +11,26 @@ import * as SidebarSection from 'sentry/components/sidebarSection';
 import {t} from 'sentry/locale';
 import ExternalIssueStore from 'sentry/stores/externalIssueStore';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {
   Group,
   GroupIntegration,
-  Organization,
   PlatformExternalIssue,
   Project,
   SentryAppComponent,
-  SentryAppInstallation,
 } from 'sentry/types';
 import type {Event} from 'sentry/types/event';
-import localStorage from 'sentry/utils/localStorage';
-import withOrganization from 'sentry/utils/withOrganization';
+import {ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
-import withSentryRouter from 'sentry/utils/withSentryRouter';
 
-type Props = AsyncComponent['props'] &
-  WithRouterProps & {
-    components: SentryAppComponent[];
-    event: Event;
-    group: Group;
-    organization: Organization;
-    project: Project;
-  };
-
-type State = AsyncComponent['state'] & {
-  externalIssues: PlatformExternalIssue[];
-  integrations: GroupIntegration[];
-  sentryAppInstallations: SentryAppInstallation[];
-  /**
-   * Filter external issues by integration key
-   * Used for demos to limit the number of integrations shown
-   */
-  issueTrackingFilter?: string;
+type Props = {
+  components: SentryAppComponent[];
+  event: Event;
+  group: Group;
+  project: Project;
 };
 
 const issueTrackingFilterKey = 'issueTrackingFilter';
@@ -57,94 +42,84 @@ type ExternalIssueComponent = {
   hasLinkedIssue?: boolean;
 };
 
-class ExternalIssueList extends AsyncComponent<Props, State> {
-  unsubscribables: any[] = [];
+function makeIntegrationsQueryKey(group: Group): ApiQueryKey {
+  return [`/groups/${group.id}/integrations/`];
+}
 
-  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {group} = this.props;
-    return [['integrations', `/groups/${group.id}/integrations/`]];
-  }
+function useFetchIntegrations({group}: {group: Group}) {
+  return useApiQuery<GroupIntegration[]>(makeIntegrationsQueryKey(group), {
+    staleTime: Infinity,
+  });
+}
 
-  constructor(props: Props) {
-    super(props, {});
+// We want to do this explicitly so that we can handle errors gracefully,
+// instead of the entire component not rendering.
+//
+// Part of the API request here is fetching data from the Sentry App, so
+// we need to be more conservative about error cases since we don't have
+// control over those services.
+//
+function useFetchSentryAppData({group}: {group: Group}) {
+  const {data} = useApiQuery<PlatformExternalIssue[]>(
+    [`/groups/${group.id}/external-issues/`],
+    {staleTime: 30_000}
+  );
 
-    // Check for issueTracking query parameter and save to localStorage
-    const issueTracking =
-      this.props.location.query.issueTracking ??
-      localStorage.getItem(issueTrackingFilterKey);
-    if (typeof issueTracking === 'string') {
-      localStorage.setItem(issueTrackingFilterKey, issueTracking.toLowerCase());
+  useEffect(() => {
+    if (data) {
+      ExternalIssueStore.load(data);
     }
+  }, [data]);
+}
 
-    this.state = Object.assign({}, this.state, {
-      sentryAppInstallations: SentryAppInstallationStore.getInitialState(),
-      externalIssues: ExternalIssueStore.getInitialState(),
-      issueTrackingFilter: ['', 'all'].includes(issueTracking)
-        ? undefined
-        : issueTracking,
-    });
-  }
+function useIssueTrackingFilter() {
+  const location = useLocation();
+  const issueTrackingQueryParam = location.query.issueTracking;
+  const [issueTracking, setIssueTracking] = useLocalStorageState<string>(
+    issueTrackingFilterKey,
+    'all'
+  );
+  const issueTrackingFilter = ['', 'all'].includes(issueTracking)
+    ? undefined
+    : issueTracking;
 
-  UNSAFE_componentWillMount() {
-    super.UNSAFE_componentWillMount();
-
-    this.unsubscribables = [
-      SentryAppInstallationStore.listen(this.onSentryAppInstallationChange, this),
-      ExternalIssueStore.listen(this.onExternalIssueChange, this),
-    ];
-
-    this.fetchSentryAppData();
-  }
-
-  componentWillUnmount() {
-    super.componentWillUnmount();
-    this.unsubscribables.forEach(unsubscribe => unsubscribe());
-  }
-
-  onSentryAppInstallationChange = (sentryAppInstallations: SentryAppInstallation[]) => {
-    this.setState({sentryAppInstallations});
-  };
-
-  onExternalIssueChange = (externalIssues: PlatformExternalIssue[]) => {
-    this.setState({externalIssues});
-  };
-
-  // We want to do this explicitly so that we can handle errors gracefully,
-  // instead of the entire component not rendering.
-  //
-  // Part of the API request here is fetching data from the Sentry App, so
-  // we need to be more conservative about error cases since we don't have
-  // control over those services.
-  //
-  fetchSentryAppData() {
-    const {group, project, organization} = this.props;
-
-    if (project && project.id && organization) {
-      this.api
-        .requestPromise(`/groups/${group.id}/external-issues/`)
-        .then(data => {
-          ExternalIssueStore.load(data);
-          this.setState({externalIssues: data});
-        })
-        .catch(_error => {});
+  useEffect(() => {
+    if (typeof issueTrackingQueryParam === 'string') {
+      setIssueTracking(issueTrackingQueryParam);
     }
+  }, [issueTrackingQueryParam, setIssueTracking]);
+
+  return issueTrackingFilter;
+}
+
+function ExternalIssueList({components, group, event, project}: Props) {
+  const organization = useOrganization();
+  const {
+    data: integrations,
+    isLoading,
+    refetch: refetchIntegrations,
+  } = useFetchIntegrations({group});
+  useFetchSentryAppData({group});
+  const issueTrackingFilter = useIssueTrackingFilter();
+
+  const externalIssues = useLegacyStore(ExternalIssueStore);
+  const sentryAppInstallations = useLegacyStore(SentryAppInstallationStore);
+
+  if (isLoading) {
+    return (
+      <SidebarSection.Wrap data-test-id="linked-issues">
+        <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
+        <SidebarSection.Content>
+          <Placeholder height="120px" />
+        </SidebarSection.Content>
+      </SidebarSection.Wrap>
+    );
   }
 
-  async updateIntegrations(onSuccess = () => {}, onError = () => {}) {
-    try {
-      const {group} = this.props;
-      const integrations = await this.api.requestPromise(
-        `/groups/${group.id}/integrations/`
-      );
-      this.setState({integrations}, () => onSuccess());
-    } catch (error) {
-      onError();
+  const renderIntegrationIssues = (): ExternalIssueComponent[] => {
+    if (!integrations) {
+      return [];
     }
-  }
-
-  renderIntegrationIssues(): ExternalIssueComponent[] {
-    const {group} = this.props;
-    const integrations = this.state.integrations ?? [];
 
     const activeIntegrations = integrations.filter(
       integration => integration.status === 'active'
@@ -171,17 +146,14 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
           <ExternalIssueActions
             configurations={configurations}
             group={group}
-            onChange={this.updateIntegrations.bind(this)}
+            onChange={() => refetchIntegrations()}
           />
         ),
       })
     );
-  }
+  };
 
-  renderSentryAppIssues(): ExternalIssueComponent[] {
-    const {externalIssues, sentryAppInstallations} = this.state;
-    const {components, group, organization} = this.props;
-
+  const renderSentryAppIssues = (): ExternalIssueComponent[] => {
     return components
       .map<ExternalIssueComponent | null>(component => {
         const {sentryApp, error: disabled} = component;
@@ -204,7 +176,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
               <SentryAppExternalIssueActions
                 group={group}
                 organization={organization}
-                event={this.props.event}
+                event={event}
                 sentryAppComponent={component}
                 sentryAppInstallation={installation}
                 externalIssue={issue}
@@ -215,22 +187,18 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
         };
       })
       .filter((x): x is ExternalIssueComponent => x !== null);
-  }
+  };
 
-  renderPluginIssues(): ExternalIssueComponent[] {
-    const {group, project} = this.props;
-
+  const renderPluginIssues = (): ExternalIssueComponent[] => {
     return group.pluginIssues?.map((plugin, i) => ({
       key: `plugin-issue-${i}`,
       disabled: false,
       hasLinkedIssue: true,
       component: <PluginActions group={group} project={project} plugin={plugin} />,
     }));
-  }
+  };
 
-  renderPluginActions(): ExternalIssueComponent[] {
-    const {group} = this.props;
-
+  const renderPluginActions = (): ExternalIssueComponent[] => {
     return (
       group.pluginActions?.map((plugin, i) => ({
         key: `plugin-action-${i}`,
@@ -243,63 +211,42 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
         ),
       })) ?? []
     );
-  }
+  };
 
-  renderLoading() {
-    return (
-      <SidebarSection.Wrap data-test-id="linked-issues">
-        <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
-        <SidebarSection.Content>
-          <Placeholder height="120px" />
-        </SidebarSection.Content>
-      </SidebarSection.Wrap>
-    );
-  }
+  const actions = [
+    ...renderSentryAppIssues(),
+    ...renderIntegrationIssues(),
+    ...renderPluginIssues(),
+    ...renderPluginActions(),
+  ].filter(action => !issueTrackingFilter || action.key === issueTrackingFilter);
+  const showSetup = actions.length === 0;
 
-  renderBody() {
-    const {issueTrackingFilter} = this.state;
-    const sentryAppIssues = this.renderSentryAppIssues();
-    const integrationIssues = this.renderIntegrationIssues();
-    const pluginIssues = this.renderPluginIssues();
-    const pluginActions = this.renderPluginActions();
-    const actions = [
-      ...sentryAppIssues,
-      ...integrationIssues,
-      ...pluginIssues,
-      ...pluginActions,
-    ].filter(action => !issueTrackingFilter || action.key === issueTrackingFilter);
-    const showSetup = actions.length === 0;
-
-    return (
-      <SidebarSection.Wrap data-test-id="linked-issues">
-        <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
-        <SidebarSection.Content>
-          {showSetup && (
-            <AlertLink
-              priority="muted"
-              size="small"
-              to={`/settings/${this.props.organization.slug}/integrations/?category=issue%20tracking`}
-            >
-              {t('Track this issue in Jira, GitHub, etc.')}
-            </AlertLink>
-          )}
-          {actions
-            // Put disabled actions last
-            .sort((a, b) => Number(a.disabled) - Number(b.disabled))
-            // Put actions with linked issues first
-            .sort((a, b) => Number(b.hasLinkedIssue) - Number(a.hasLinkedIssue))
-            .map(({component, key}) => (
-              <Fragment key={key}>{component}</Fragment>
-            ))}
-        </SidebarSection.Content>
-      </SidebarSection.Wrap>
-    );
-  }
+  return (
+    <SidebarSection.Wrap data-test-id="linked-issues">
+      <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
+      <SidebarSection.Content>
+        {showSetup && (
+          <AlertLink
+            priority="muted"
+            size="small"
+            to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
+          >
+            {t('Track this issue in Jira, GitHub, etc.')}
+          </AlertLink>
+        )}
+        {actions
+          // Put disabled actions last
+          .sort((a, b) => Number(a.disabled) - Number(b.disabled))
+          // Put actions with linked issues first
+          .sort((a, b) => Number(b.hasLinkedIssue) - Number(a.hasLinkedIssue))
+          .map(({component, key}) => (
+            <Fragment key={key}>{component}</Fragment>
+          ))}
+      </SidebarSection.Content>
+    </SidebarSection.Wrap>
+  );
 }
 
-export default withSentryAppComponents(
-  withOrganization(withSentryRouter(ExternalIssueList)),
-  {
-    componentType: 'issue-link',
-  }
-);
+export default withSentryAppComponents(ExternalIssueList, {
+  componentType: 'issue-link',
+});

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -1,8 +1,10 @@
-import {createStore, StoreDefinition} from 'reflux';
+import {createStore} from 'reflux';
 
+import {CommonStoreDefinition} from 'sentry/stores/types';
 import {PlatformExternalIssue} from 'sentry/types';
 
-interface ExternalIssueStoreDefinition extends StoreDefinition {
+interface ExternalIssueStoreDefinition
+  extends CommonStoreDefinition<PlatformExternalIssue[]> {
   add(issue: PlatformExternalIssue): void;
   getInitialState(): PlatformExternalIssue[];
   load(items: PlatformExternalIssue[]): void;
@@ -14,6 +16,10 @@ const storeConfig: ExternalIssueStoreDefinition = {
     // listeners due to their leaky nature in tests.
 
     this.items = [];
+  },
+
+  getState() {
+    return this.items;
   },
 
   getInitialState(): PlatformExternalIssue[] {

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -1,8 +1,10 @@
-import {createStore, StoreDefinition} from 'reflux';
+import {createStore} from 'reflux';
 
+import {CommonStoreDefinition} from 'sentry/stores/types';
 import {SentryAppInstallation} from 'sentry/types';
 
-interface SentryAppInstallationStoreDefinition extends StoreDefinition {
+interface SentryAppInstallationStoreDefinition
+  extends CommonStoreDefinition<SentryAppInstallation[]> {
   getInitialState(): SentryAppInstallation[];
   load(items: SentryAppInstallation[]): void;
 }
@@ -13,6 +15,10 @@ const storeConfig: SentryAppInstallationStoreDefinition = {
     // listeners due to their leaky nature in tests.
 
     this.items = [];
+  },
+
+  getState() {
+    return this.items;
   },
 
   getInitialState(): SentryAppInstallation[] {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/49226

One more AsyncComponent down.

Right now the page refetches each time you navigate events, these changes prevent that.