### PR TITLE
Revert "fix(Snuba): Pass Org ID to Snuba for Organization Group Index endpoint"

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -291,7 +291,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             expand=expand,
             collapse=collapse,
             project_ids=project_ids,
-            organization_id=organization.id,
         )
 
         # we ignore date range for both short id and event ids


### PR DESCRIPTION
Reverts getsentry/sentry#49161

This seems to be breaking master symbolicator tests.