### PR TITLE
fix(ui): Ignore Failed to execute 'removeChild' on 'Node'

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -131,6 +131,11 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
        * that has been removed.
        */
       "TypeError: can't access dead object",
+      /**
+       * React internal error thrown when something outside react modifies the DOM
+       * This is usually because of a browser extension or chrome translate page
+       */
+      "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
     ],
 
     // Temporary fix while `ignoreErrors` bug is fixed and request error handling is cleaned up


### PR DESCRIPTION
These errors seem to happen when updating the dom and something else has modified the dom like chrome's translate feature. https://sentry.sentry.io/issues/?project=11276&query=removed+is+not+a+child+of+this+node+issue.category%3Aerror&referrer=issue-list&statsPeriod=90d from the replays the text flashes and it does seem like they're using translate.

Either way we never fix or look at these errors
