### PR TITLE
meta(product-owners.yml) Exit cleanly when there are no changes to make

### DIFF
--- a/bin/react-to-product-owners-yml-changes.sh
+++ b/bin/react-to-product-owners-yml-changes.sh
@@ -14,6 +14,6 @@ git checkout -b "$branch"
 git add .github/labels.yml
 git add .github/ISSUE_TEMPLATE/bug.yml
 git add .github/ISSUE_TEMPLATE/feature.yml
-git commit -n -m "$message"
+git commit -n -m "$message" || exit 0
 git push --set-upstream origin "$branch"
 gh pr create --title "meta(routing) $message" --body="Syncing with [``product-owners.yml``](https://github.com/getsentry/security-as-code/blob/$sha/rbac/lib/product-owners.yml) ([docs](https://www.notion.so/473791bae5bf43399d46093050b77bf0))."


### PR DESCRIPTION
In the automation to react to `product-owner.yml` changes, if there is nothing to commit we can exit cleanly.

cf. https://github.com/getsentry/sentry-docs/pull/6970, seeing this [behave as expected](https://github.com/getsentry/sentry-docs/actions/runs/4997467526/jobs/8951860470#step:5:54).