### PR TITLE
dev: Quick fix for topic autocreation in the devserver

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -351,7 +351,7 @@ and run `sentry devservices up kafka zookeeper`.
 
         for (topic_name, topic_data) in settings.KAFKA_TOPICS.items():
             if topic_data is not None:
-                create_topics(topic_data["cluster"], [topic_name])
+                create_topics(topic_data["cluster"], [topic_name], force=True)
 
     from sentry.runner.commands.devservices import _prepare_containers
 

--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -57,7 +57,7 @@ def wait_for_topics(admin_client: AdminClient, topics: List[str], timeout: int =
                 )
 
 
-def create_topics(cluster_name: str, topics: List[str]):
+def create_topics(cluster_name: str, topics: List[str], force: bool = False) -> None:
     """If configured to do so, create topics and make sure that they exist
 
     topics must be from the same cluster.

--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -62,7 +62,7 @@ def create_topics(cluster_name: str, topics: List[str], force: bool = False) -> 
 
     topics must be from the same cluster.
     """
-    if settings.KAFKA_CONSUMER_AUTO_CREATE_TOPICS:
+    if settings.KAFKA_CONSUMER_AUTO_CREATE_TOPICS or force:
         conf = kafka_config.get_kafka_admin_cluster_options(cluster_name)
         admin_client = AdminClient(conf)
         wait_for_topics(admin_client, topics)


### PR DESCRIPTION
This ensures all topics are created when running sentry devserver.

settings.KAFKA_CONSUMER_AUTO_CREATE_TOPICS will be eventually deprecated, and `create_topics()` only called from devserver and not from all the consumers individually