### PR TITLE
feat(starfish): Show span view filter context

### DIFF
--- a/static/app/views/starfish/views/spans/filter.tsx
+++ b/static/app/views/starfish/views/spans/filter.tsx
@@ -1,0 +1,59 @@
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+type Props = {
+  kkey: string;
+  value: string;
+};
+
+export function Filter({kkey, value}: Props) {
+  return (
+    <FilterWrapper>
+      <Key>{kkey}</Key>
+      <Operator>:</Operator>
+      <Value>{value}</Value>
+    </FilterWrapper>
+  );
+}
+
+const FilterWrapper = styled('span')`
+  --token-bg: ${p => p.theme.searchTokenBackground.valid};
+  --token-border: ${p => p.theme.searchTokenBorder.valid};
+  --token-value-color: ${p => p.theme.blue400};
+
+  position: relative;
+`;
+
+const filterCss = css`
+  background: var(--token-bg);
+  border: 0.5px solid var(--token-border);
+  padding: ${space(0.25)} 0;
+`;
+
+const Key = styled('span')`
+  ${filterCss};
+  border-right: none;
+  font-weight: bold;
+  border-radius: 2px 0 0 2px;
+  padding-left: 1px;
+  margin-left: -2px;
+`;
+
+const Operator = styled('span')`
+  ${filterCss};
+  border-left: none;
+  border-right: none;
+  margin: -1px 0;
+  color: ${p => p.theme.pink400};
+`;
+
+const Value = styled('span')`
+  ${filterCss};
+  border-left: none;
+  border-radius: 0 2px 2px 0;
+  color: var(--token-value-color);
+  margin: -1px -2px -1px 0;
+  padding-right: 1px;
+`;

--- a/static/app/views/starfish/views/spans/index.tsx
+++ b/static/app/views/starfish/views/spans/index.tsx
@@ -1,18 +1,21 @@
 import {useState} from 'react';
 import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import {Filter} from 'sentry/views/starfish/views/spans/filter';
 import SpanDetail from 'sentry/views/starfish/views/spans/spanDetails';
 import {SpanDataRow} from 'sentry/views/starfish/views/spans/spansTable';
 
-import SpansView from './spansView';
+import SpansView, {SPAN_FILTER_KEY_LABELS} from './spansView';
 
 type State = {
   selectedRow?: SpanDataRow;
@@ -27,12 +30,32 @@ export default function Spans(props: Props) {
   const unsetSelectedSpanGroup = () => setState({selectedRow: undefined});
   const {selectedRow} = state;
   const setSelectedRow = (row: SpanDataRow) => setState({selectedRow: row});
+
+  const appliedFilters = Object.keys(props.location.query)
+    .map(queryKey => {
+      const queryKeyLabel = SPAN_FILTER_KEY_LABELS[queryKey];
+      const queryValue = props.location.query[queryKey];
+
+      return queryKeyLabel && queryValue
+        ? {kkey: queryKeyLabel, value: queryValue}
+        : null;
+    })
+    .filter((item): item is NonNullable<typeof item> => Boolean(item));
+
   return (
     <Layout.Page>
       <PageErrorProvider>
         <Layout.Header>
           <Layout.HeaderContent>
             <Layout.Title>{t('Spans')}</Layout.Title>
+            {appliedFilters.length > 0 ? (
+              <FiltersContainer>
+                Applied Filters:
+                {appliedFilters.map(filterProps => {
+                  return <Filter key={filterProps.kkey} {...filterProps} />;
+                })}
+              </FiltersContainer>
+            ) : null}
           </Layout.HeaderContent>
         </Layout.Header>
 
@@ -49,3 +72,9 @@ export default function Spans(props: Props) {
     </Layout.Page>
   );
 }
+
+const FiltersContainer = styled('span')`
+  display: flex;
+  gap: ${space(1)};
+  padding: ${space(1)};
+`;

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -225,8 +225,16 @@ function getColumns(queryConditions: string[]): GridColumnOrder[] {
 
   const domain = getDomainHeader(queryConditions);
 
+  const doQueryConditionsIncludeDomain = queryConditions.some(condition =>
+    condition.includes('domain =')
+  );
+
+  const doQueryConditionsIncludeSpanOperation = queryConditions.some(condition =>
+    condition.includes('span_operation =')
+  );
+
   const order: Array<GridColumnOrder | false> = [
-    {
+    !doQueryConditionsIncludeSpanOperation && {
       key: 'span_operation',
       name: 'Operation',
       width: COL_WIDTH_UNDEFINED,
@@ -236,7 +244,7 @@ function getColumns(queryConditions: string[]): GridColumnOrder[] {
       name: description,
       width: COL_WIDTH_UNDEFINED,
     },
-    {
+    !doQueryConditionsIncludeDomain && {
       key: 'domain',
       name: domain,
       width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -164,7 +164,7 @@ function renderBodyCell(
               {(row as unknown as DataRow).formatted_desc}
             </StyledFormattedCode>
           ) : (
-            row.description
+            row.description || '<null>'
           )}
         </Link>
       </OverflowEllipsisTextContainer>

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -37,6 +37,7 @@ export default function SpansView(props: Props) {
 
   const descriptionFilter = didConfirmSearch && searchTerm ? `${searchTerm}` : undefined;
   const queryConditions = buildQueryFilterFromLocation(location);
+
   const {isLoading: areSpansLoading, data: spansData} = useQuery<SpanDataRow[]>({
     queryKey: ['spans', descriptionFilter, orderBy, pageFilter.selection.datetime],
     queryFn: () =>
@@ -128,7 +129,12 @@ const FilterOptionsContainer = styled(PaddedContainer)`
   margin-bottom: ${space(2)};
 `;
 
-const SPAN_FILTER_KEYS = ['action', 'span_operation', 'domain'];
+export const SPAN_FILTER_KEYS = ['action', 'span_operation', 'domain'];
+export const SPAN_FILTER_KEY_LABELS = {
+  action: 'Action',
+  span_operation: 'Operation',
+  domain: 'Domain',
+};
 
 const buildQueryFilterFromLocation = (location: Location) => {
   const {query} = location;

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -76,44 +76,52 @@ export default function SpansView(props: Props) {
 
   return (
     <Fragment>
-      <div>
-        <FilterOptionsContainer>
-          <DatePageFilter alignDropdown="left" />
-        </FilterOptionsContainer>
-      </div>
+      <FilterOptionsContainer>
+        <DatePageFilter alignDropdown="left" />
+      </FilterOptionsContainer>
 
-      <SearchBar
-        onChange={value => {
-          setSearchTerm(value);
-          setDidConfirmSearch(false);
-        }}
-        placeholder="Search Spans"
-        query={searchTerm}
-        onSearch={() => {
-          setDidConfirmSearch(true);
-        }}
-      />
+      <PaddedContainer>
+        <SearchBar
+          onChange={value => {
+            setSearchTerm(value);
+            setDidConfirmSearch(false);
+          }}
+          placeholder="Search Spans"
+          query={searchTerm}
+          onSearch={() => {
+            setDidConfirmSearch(true);
+          }}
+        />
+      </PaddedContainer>
 
-      <SpanTimeCharts
-        descriptionFilter={descriptionFilter || ''}
-        queryConditions={queryConditions}
-      />
+      <PaddedContainer>
+        <SpanTimeCharts
+          descriptionFilter={descriptionFilter || ''}
+          queryConditions={queryConditions}
+        />
+      </PaddedContainer>
 
-      <SpansTable
-        location={props.location}
-        queryConditions={queryConditions}
-        isLoading={areSpansLoading || areSpansTrendsLoading}
-        spansData={spansData}
-        orderBy={orderBy}
-        onSetOrderBy={newOrderBy => setState({orderBy: newOrderBy})}
-        spansTrendsData={spansTrendsData}
-        onSelect={props.onSelect}
-      />
+      <PaddedContainer>
+        <SpansTable
+          location={props.location}
+          queryConditions={queryConditions}
+          isLoading={areSpansLoading || areSpansTrendsLoading}
+          spansData={spansData}
+          orderBy={orderBy}
+          onSetOrderBy={newOrderBy => setState({orderBy: newOrderBy})}
+          spansTrendsData={spansTrendsData}
+          onSelect={props.onSelect}
+        />
+      </PaddedContainer>
     </Fragment>
   );
 }
 
-const FilterOptionsContainer = styled('div')`
+const PaddedContainer = styled('div')`
+  margin: ${space(2)};
+`;
+
+const FilterOptionsContainer = styled(PaddedContainer)`
   display: flex;
   flex-direction: row;
   gap: ${space(1)};


### PR DESCRIPTION
The view is pretty disorienting because you might land on it from the WSV, and have no idea what filters are applied. Also, once they're applied, why are they in the table? It's just wasted space? Anyway. Also some other fixes for awkward UI.

**Before:**
![Screenshot 2023-05-16 at 7 10 41 PM](https://github.com/getsentry/sentry/assets/989898/1bee809e-5679-4d23-8748-3ee645c1ea54)

**After:**
![Screenshot 2023-05-16 at 7 12 24 PM](https://github.com/getsentry/sentry/assets/989898/c36c674c-07a8-46b8-a251-54155cd8b799)

