### PR TITLE
test(ui): Add types to initialize org

### DIFF
--- a/static/app/components/charts/optionSelector.spec.tsx
+++ b/static/app/components/charts/optionSelector.spec.tsx
@@ -49,7 +49,6 @@ describe('Charts > OptionSelector (Multiple)', function () {
       router: {
         location: {query: {query: 'tag:value'}},
       },
-      project: 1,
       projects: [],
     });
 

--- a/static/app/components/environmentPageFilter.spec.tsx
+++ b/static/app/components/environmentPageFilter.spec.tsx
@@ -11,7 +11,7 @@ const {organization, router, routerContext} = initializeOrg({
   project: undefined,
   projects: [
     {
-      id: 2,
+      id: '2',
       slug: 'project-2',
       environments: ['prod', 'staging'],
     },

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
@@ -16,7 +16,6 @@ describe('Breadcrumb Data Default', function () {
     router: {
       location: {query: {project: '0'}},
     },
-    project: '0',
     projects: [project],
   });
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
@@ -16,7 +16,6 @@ describe('Breadcrumb Data Exception', function () {
     router: {
       location: {query: {project: '0'}},
     },
-    project: '0',
     projects: [project],
   });
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
@@ -16,7 +16,6 @@ describe('Breadcrumb Data Http', function () {
     router: {
       location: {query: {project: '0'}},
     },
-    project: '0',
     projects: [project],
   });
 

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -18,7 +18,6 @@ describe('Exception Content', function () {
       router: {
         location: {query: {project: '0'}},
       },
-      project: '0',
       projects: [project],
     });
 

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -16,7 +16,6 @@ describe('Frame Variables', function () {
       router: {
         location: {query: {project: '0'}},
       },
-      project: '0',
       projects: [project],
     });
 

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
@@ -30,10 +30,8 @@ describe('Modals -> AddDashboardWidgetModal', function () {
   const initialData = initializeOrg({
     organization: {
       features: ['performance-view', 'discover-query'],
-      apdexThreshold: 400,
     },
     router: {},
-    project: 1,
     projects: [],
   });
   let mockQuery;

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -86,12 +86,10 @@ describe('Modals -> WidgetViewerModal', function () {
     initialData = initializeOrg({
       organization: {
         features: ['discover-query'],
-        apdexThreshold: 400,
       },
       router: {
         location: {query: {}},
       },
-      project: 1,
       projects: [TestStubs.Project()],
     });
 

--- a/static/app/components/organizations/environmentPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.spec.tsx
@@ -11,8 +11,8 @@ const {organization, router, routerContext} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   project: undefined,
   projects: [
-    {id: 1, slug: 'project-1', environments: ['prod', 'staging']},
-    {id: 2, slug: 'project-2', environments: ['prod', 'stage']},
+    {id: '1', slug: 'project-1', environments: ['prod', 'staging']},
+    {id: '2', slug: 'project-2', environments: ['prod', 'stage']},
   ],
   router: {
     location: {
@@ -144,8 +144,8 @@ describe('EnvironmentPageFilter', function () {
       organization: {features: ['global-views', 'open-membership']},
       project: undefined,
       projects: [
-        {id: 1, slug: 'project-1', environments: ['prod', 'staging']},
-        {id: 2, slug: 'project-2', environments: ['prod', 'stage']},
+        {id: '1', slug: 'project-1', environments: ['prod', 'staging']},
+        {id: '2', slug: 'project-2', environments: ['prod', 'stage']},
       ],
       router: {
         location: {

--- a/static/app/components/organizations/projectPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.spec.tsx
@@ -19,9 +19,9 @@ const {organization, router, routerContext} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   project: undefined,
   projects: [
-    {id: 1, slug: 'project-1', isMember: true},
-    {id: 2, slug: 'project-2', isMember: true},
-    {id: 3, slug: 'project-3', isMember: false},
+    {id: '1', slug: 'project-1', isMember: true},
+    {id: '2', slug: 'project-2', isMember: true},
+    {id: '3', slug: 'project-3', isMember: false},
   ],
   router: {
     location: {
@@ -215,9 +215,9 @@ describe('ProjectPageFilter', function () {
       organization: {features: ['global-views', 'open-membership']},
       project: undefined,
       projects: [
-        {id: 1, slug: 'project-1', isMember: true},
-        {id: 2, slug: 'project-2', isMember: true},
-        {id: 3, slug: 'project-3', isMember: false},
+        {id: '1', slug: 'project-1', isMember: true},
+        {id: '2', slug: 'project-2', isMember: true},
+        {id: '3', slug: 'project-3', isMember: false},
       ],
       router: {
         location: {

--- a/static/app/components/projectPageFilter.spec.tsx
+++ b/static/app/components/projectPageFilter.spec.tsx
@@ -11,7 +11,7 @@ const {organization, router, routerContext} = initializeOrg({
   project: undefined,
   projects: [
     {
-      id: 2,
+      id: '2',
       slug: 'project-2',
     },
   ],

--- a/static/app/components/timeRangeSelector.spec.tsx
+++ b/static/app/components/timeRangeSelector.spec.tsx
@@ -8,9 +8,9 @@ const {organization, routerContext} = initializeOrg({
   organization: {features: ['global-views', 'open-membership']},
   project: undefined,
   projects: [
-    {id: 1, slug: 'project-1', isMember: true},
-    {id: 2, slug: 'project-2', isMember: true},
-    {id: 3, slug: 'project-3', isMember: false},
+    {id: '1', slug: 'project-1', isMember: true},
+    {id: '2', slug: 'project-2', isMember: true},
+    {id: '3', slug: 'project-3', isMember: false},
   ],
   router: {
     location: {

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -61,7 +61,7 @@ export interface Organization extends OrganizationSummary {
     maxRateInterval: number | null;
     projectLimit: number | null;
   };
-  relayPiiConfig: string;
+  relayPiiConfig: string | null;
   safeFields: string[];
   scrapeJavaScript: boolean;
   scrubIPAddresses: boolean;

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -58,7 +58,7 @@ describe('Dashboards > Dashboard', () => {
   let initialData, tagsMock;
 
   beforeEach(() => {
-    initialData = initializeOrg({organization, router: {}, project: 1, projects: []});
+    initialData = initializeOrg({organization, router: {}, projects: []});
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/dashboards/widgets/`,
       method: 'POST',

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -17,7 +17,6 @@ describe('OrgDashboards', () => {
   beforeEach(() => {
     initialData = initializeOrg({
       organization,
-      project: 1,
       projects: [],
       router: {
         location: TestStubs.location(),
@@ -177,7 +176,6 @@ describe('OrgDashboards', () => {
   it('does not add query params for page filters if one of the filters is defined', () => {
     initialData = initializeOrg({
       organization,
-      project: 1,
       projects: [],
       router: {
         location: {

--- a/static/app/views/discover/chartFooter.spec.tsx
+++ b/static/app/views/discover/chartFooter.spec.tsx
@@ -34,7 +34,6 @@ describe('Discover > ChartFooter', function () {
       router: {
         location: {query: {query: 'tag:value'}},
       },
-      project: 1,
       projects: [],
     });
 
@@ -75,7 +74,6 @@ describe('Discover > ChartFooter', function () {
       router: {
         location: {query: {query: 'tag:value'}},
       },
-      project: 1,
       projects: [],
     });
 

--- a/static/app/views/discover/miniGraph.spec.tsx
+++ b/static/app/views/discover/miniGraph.spec.tsx
@@ -56,7 +56,6 @@ describe('Discover > MiniGraph', function () {
       router: {
         location,
       },
-      project: 1,
       projects: [],
     });
     eventView = EventView.fromSavedQueryOrLocation(undefined, location);

--- a/static/app/views/discover/resultsChart.spec.tsx
+++ b/static/app/views/discover/resultsChart.spec.tsx
@@ -22,7 +22,6 @@ describe('Discover > ResultsChart', function () {
     router: {
       location,
     },
-    project: 1,
     projects: [],
   });
 

--- a/static/app/views/performance/transactionEvents.spec.tsx
+++ b/static/app/views/performance/transactionEvents.spec.tsx
@@ -19,7 +19,6 @@ function initializeData({features: additionalFeatures = [], query = {}}: Data = 
   const organization = TestStubs.Organization({
     features,
     projects: [TestStubs.Project()],
-    apdexThreshold: 400,
   });
   return initializeOrg({
     organization,
@@ -33,7 +32,6 @@ function initializeData({features: additionalFeatures = [], query = {}}: Data = 
         },
       },
     },
-    project: 1,
     projects: [],
   });
 }

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -19,7 +19,6 @@ function initializeData() {
   const organization = TestStubs.Organization({
     features: ['discover-basic', 'performance-view'],
     projects: [TestStubs.Project()],
-    apdexThreshold: 400,
   });
   const initialData = initializeOrg({
     organization,
@@ -32,7 +31,6 @@ function initializeData() {
         },
       },
     },
-    project: 1,
     projects: [],
   });
   act(() => void ProjectsStore.loadInitialData(initialData.organization.projects));

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -61,7 +61,6 @@ function initializeData({features: additionalFeatures = []}: Data = {}) {
   const organization = TestStubs.Organization({
     features,
     projects: [TestStubs.Project()],
-    apdexThreshold: 400,
   });
   const initialData = initializeOrg({
     organization,
@@ -74,7 +73,6 @@ function initializeData({features: additionalFeatures = []}: Data = {}) {
         },
       },
     },
-    project: 1,
     projects: [],
   });
   ProjectsStore.loadInitialData(initialData.organization.projects);

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -16,17 +16,15 @@ function initialize(project, query, additionalFeatures: string[] = []) {
     features,
     projects: [project],
   });
-  const initialOrgData = {
+  const initialData = initializeOrg({
     organization,
     router: {
       location: {
         query: {...query},
       },
     },
-    project: parseInt(project.id, 10),
     projects: [],
-  };
-  const initialData = initializeOrg(initialOrgData);
+  });
   const eventView = EventView.fromNewQueryWithLocation(
     {
       id: undefined,

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -30,7 +30,6 @@ function initializeData({
   const organization = TestStubs.Organization({
     features,
     projects: [project],
-    apdexThreshold: 400,
   });
   const initialData = initializeOrg({
     organization,

--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.spec.tsx
@@ -30,7 +30,6 @@ function initializeData({query} = {query: {}}) {
         },
       },
     },
-    project: 1,
     projects: [],
   });
 

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.jsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.spec.jsx
@@ -4,7 +4,7 @@ import ProjectApdexScoreCard from 'sentry/views/projectDetail/projectScoreCards/
 
 describe('ProjectDetail > ProjectApdex', function () {
   let endpointMock;
-  const organization = TestStubs.Organization({apdexThreshold: 500});
+  const organization = TestStubs.Organization();
 
   const selection = {
     projects: [1],

--- a/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
+++ b/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
@@ -7,7 +7,7 @@ import {Applications, MethodType, PiiConfig, Rule, RuleDefault, RuleType} from '
 // For the time being the PII config format is documented at
 // https://getsentry.github.io/relay/pii-config/
 
-export function convertRelayPiiConfig(relayPiiConfig?: string): Rule[] {
+export function convertRelayPiiConfig(relayPiiConfig?: string | null): Rule[] {
   const piiConfig = relayPiiConfig ? JSON.parse(relayPiiConfig) : {};
   const rules: PiiConfig = piiConfig.rules || {};
   const applications: Applications = piiConfig.applications || {};

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -34,7 +34,7 @@ type Props = {
   disabled?: boolean;
   onSubmitSuccess?: (data: {relayPiiConfig: string}) => void;
   project?: Project;
-  relayPiiConfig?: string;
+  relayPiiConfig?: string | null;
 };
 
 export function DataScrubbing({

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -1,3 +1,5 @@
+import type {Organization, Project} from 'sentry/types';
+
 /**
  * Creates stubs for:
  *   - a project or projects
@@ -10,7 +12,12 @@ export function initializeOrg({
   project: additionalProject,
   projects: additionalProjects,
   router: additionalRouter,
-}: {organization?: any; project?: any; projects?: any[]; router?: any} = {}) {
+}: {
+  organization?: Partial<Organization>;
+  project?: Partial<Project>;
+  projects?: any[];
+  router?: any;
+} = {}) {
   const projects = (
     additionalProjects ||
     (additionalProject && [additionalProject]) || [{}]

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -15,7 +15,7 @@ export function initializeOrg({
 }: {
   organization?: Partial<Organization>;
   project?: Partial<Project>;
-  projects?: any[];
+  projects?: Partial<Project>[];
   router?: any;
 } = {}) {
   const projects = (

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -15,7 +15,7 @@ export interface initializeDataSettings {
   project?: any; // TODO(k-fish): Fix this project type.
   projects?: Project[];
   query?: {};
-  selectedProject?: number | string;
+  selectedProject?: any;
 }
 
 export function initializeData(settings?: initializeDataSettings) {


### PR DESCRIPTION
Adds types to the test initializeOrg function. `apdexThreshold` doesn't seem to exist outside of a few tests. There was a lot of `project: 1,` which as far as i can tell does nothing.