### PR TITLE
ref(indexer): Don't create Kafka topic in indexer code

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -12,7 +12,6 @@ from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
 from arroyo.processing.strategies import ProcessingStrategyFactory
 from arroyo.processing.strategies.transform import ParallelTransformStep
 from arroyo.types import Commit, FilteredPayload, Message, Partition, Topic
-from django.conf import settings
 
 from sentry.sentry_metrics.configuration import (
     MetricsIngestConfiguration,
@@ -30,7 +29,6 @@ from sentry.sentry_metrics.consumers.indexer.routing_producer import (
     RoutingProducerStep,
 )
 from sentry.sentry_metrics.consumers.indexer.slicing_router import SlicingRouter
-from sentry.utils.batching_kafka_consumer import create_topics
 
 logger = logging.getLogger(__name__)
 
@@ -198,9 +196,6 @@ def get_parallel_metrics_consumer(
         config=indexer_profile,
         slicing_router=slicing_router,
     )
-
-    cluster_name: str = settings.KAFKA_TOPICS[indexer_profile.input_topic]["cluster"]
-    create_topics(cluster_name, [indexer_profile.input_topic])
 
     return StreamProcessor(
         KafkaConsumer(


### PR DESCRIPTION
This is done by the devserver in dev and manually in other environments.

Starting with the indexer, will apply to all other consumers as a follow up.