### PR TITLE
fix(issue-details): Remove key on issue details which triggered a remount

### DIFF
--- a/static/app/views/issueDetails/index.tsx
+++ b/static/app/views/issueDetails/index.tsx
@@ -21,7 +21,7 @@ function IssueDetailsContainer({selection, ...props}: Props) {
   const {projects} = useProjects();
   const api = useApi();
 
-  const {params, location} = props;
+  const {location} = props;
 
   const projectId = location.query.project;
   const project = projects.find(proj => proj.id === projectId);
@@ -36,7 +36,6 @@ function IssueDetailsContainer({selection, ...props}: Props) {
 
   return (
     <GroupDetails
-      key={`${params.groupId}-envs:${selection.environments.join(',')}`}
       environments={selection.environments}
       organization={organization}
       projects={projects}


### PR DESCRIPTION
When environments are selected, this key triggered a remount after the page filters loaded. If this page was dependent on this remount before, it shouldn't be now that it's been converted to an FC. 