### PR TITLE
feat(hc): Parallel RPCs to multiple regions (spike)

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -34,14 +34,14 @@ class ByOrganizationMembership(RegionResolution):
         member_mappings = OrganizationMemberMapping.objects.filter(user_id=user_id)
         organization_ids = member_mappings.values_list("organization_id", flat=True)
         mappings = self.organization_mapping_manager.filter(organization_id__in=organization_ids)
-        return [self._resolve_from_mapping(mapping) for mapping in mappings]
+        return {self._resolve_from_mapping(mapping) for mapping in mappings}
 
 
 class ByMultipleOrganizationIds(RegionResolution):
     def resolve(self, arguments: ArgumentDict) -> Collection[Region]:
         organization_ids: List[int] = arguments["organization_ids"]
         mappings = self.organization_mapping_manager.filter(organization_id__in=organization_ids)
-        return [self._resolve_from_mapping(mapping) for mapping in mappings]
+        return {self._resolve_from_mapping(mapping) for mapping in mappings}
 
 
 class OrganizationService(RpcService):


### PR DESCRIPTION
This was a brief investigation into how much code complexity would be involved in having an RPC that automagically "fans out" from the control silo to multiple regions.

There are several reasons not to actually do this. Performance isn't necessarily one of them: we can mitigate the time costs of multiple RPCs by making them in parallel, and the overall cost in system load isn't necessarily a concern. But having each call to a Hybrid Cloud service cause at most one RPC is valuable as a simplifying principle. Multiple calls make failure modes more complex: if we query several regions and one fails, does the entire operation fail? When would it make sense to degrade gracefully with a partial set of results? (Thanks @corps for pointing this out.) Better to force the callers to figure out both whether it's truly worth calling multiple regions and how to compose the results if so.

But I wanted to do the spike anyway, so please review if you're curious. It's an interesting option to keep in our back pocket and we may get the chance to reuse some of the code for parallel RPCs in a narrower, more deliberately chosen context.