### PR TITLE
fix(ui): Use standard Button w/ chevrom for AccordionItem

### DIFF
--- a/static/app/views/performance/landing/widgets/components/accordion.tsx
+++ b/static/app/views/performance/landing/widgets/components/accordion.tsx
@@ -1,7 +1,9 @@
 import {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
-import DropdownButton from 'sentry/components/dropdownButton';
+import {Button} from 'sentry/components/button';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface AccordionItemContent {
@@ -50,11 +52,13 @@ function AccordionItem({
     <StyledLineItem>
       <ListItemContainer>
         {children}
-        <StyledDropdownButton
+        <Button
+          icon={<IconChevron size="xs" direction={isExpanded ? 'up' : 'down'} />}
+          aria-label={t('Expand')}
+          aria-expanded={isExpanded}
           size="zero"
           borderless
           onClick={() => setExpandedIndex(index)}
-          isOpen={isExpanded}
         />
       </ListItemContainer>
       <StyledContentContainer>{isExpanded && content}</StyledContentContainer>
@@ -70,12 +74,6 @@ const AccordionContainer = styled('ul')`
   padding: ${space(1)} 0 0 0;
   margin: 0;
   list-style-type: none;
-`;
-
-const StyledDropdownButton = styled(DropdownButton)`
-  svg {
-    margin: 0;
-  }
 `;
 
 const ListItemContainer = styled('div')`


### PR DESCRIPTION
Fixes some visual issues

Before

<img alt="clipboard.png" width="251" src="https://i.imgur.com/2PeNjEk.png" />

After

<img alt="clipboard.png" width="276" src="https://i.imgur.com/O82zD4s.png" />