### PR TITLE
ref(source-maps): Add deprecated badge to release bundle & make artifact bundle tab active by default

### DIFF
--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.spec.tsx
@@ -65,6 +65,9 @@ describe('ProjectSourceMaps', function () {
         router: {
           location: {
             query: {},
+            pathname: `/settings/${initializeOrg().organization.slug}/projects/${
+              initializeOrg().project.slug
+            }/source-maps/release-bundles/`,
           },
           params: {},
         },
@@ -96,12 +99,12 @@ describe('ProjectSourceMaps', function () {
       expect(tabs).toHaveLength(2);
 
       // Tab 1
-      expect(tabs[0]).toHaveTextContent('Release Bundles');
-      expect(tabs[0]).toHaveClass('active');
+      expect(tabs[0]).toHaveTextContent('Artifact Bundles');
+      expect(tabs[0]).not.toHaveClass('active');
 
       // Tab 2
-      expect(tabs[1]).toHaveTextContent('Artifact Bundles');
-      expect(tabs[1]).not.toHaveClass('active');
+      expect(tabs[1]).toHaveTextContent('Release Bundles');
+      expect(tabs[1]).toHaveClass('active');
 
       // Search bar
       expect(screen.getByPlaceholderText('Filter by Name')).toBeInTheDocument();
@@ -122,7 +125,7 @@ describe('ProjectSourceMaps', function () {
       });
 
       // Active tab contains correct link
-      expect(screen.getByRole('link', {name: 'Release Bundles'})).toHaveAttribute(
+      expect(screen.getByRole('link', {name: /Release Bundles/})).toHaveAttribute(
         'href',
         '/settings/org-slug/projects/project-slug/source-maps/release-bundles/'
       );
@@ -169,6 +172,9 @@ describe('ProjectSourceMaps', function () {
         router: {
           location: {
             query: {},
+            pathname: `/settings/${initializeOrg().organization.slug}/projects/${
+              initializeOrg().project.slug
+            }/source-maps/release-bundles/`,
           },
           params: {},
         },
@@ -239,12 +245,12 @@ describe('ProjectSourceMaps', function () {
       expect(tabs).toHaveLength(2);
 
       // Tab 1
-      expect(tabs[0]).toHaveTextContent('Release Bundles');
-      expect(tabs[0]).not.toHaveClass('active');
+      expect(tabs[0]).toHaveTextContent('Artifact Bundles');
+      expect(tabs[0]).toHaveClass('active');
 
       // Tab 2
-      expect(tabs[1]).toHaveTextContent('Artifact Bundles');
-      expect(tabs[1]).toHaveClass('active');
+      expect(tabs[1]).toHaveTextContent('Release Bundles');
+      expect(tabs[1]).not.toHaveClass('active');
 
       // Search bar
       expect(screen.getByPlaceholderText('Filter by Bundle ID')).toBeInTheDocument();
@@ -306,7 +312,7 @@ describe('ProjectSourceMaps', function () {
       });
 
       // Switch tab
-      await userEvent.click(screen.getByRole('link', {name: 'Release Bundles'}));
+      await userEvent.click(screen.getByRole('link', {name: /Release Bundles/}));
       expect(router.push).toHaveBeenCalledWith({
         pathname: '/settings/org-slug/projects/project-slug/source-maps/release-bundles/',
         query: undefined,

--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import {Fragment, useCallback, useEffect} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -8,6 +8,7 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import Access from 'sentry/components/acl/access';
+import Badge from 'sentry/components/badge';
 import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import Count from 'sentry/components/count';
@@ -148,7 +149,17 @@ export function ProjectSourceMaps({location, router, project}: Props) {
     `/settings/${organization.slug}/projects/${project.slug}/source-maps/artifact-bundles/`
   );
 
+  const sourceMapsUrl = normalizeUrl(
+    `/settings/${organization.slug}/projects/${project.slug}/source-maps/`
+  );
+
   const tabDebugIdBundlesActive = location.pathname === debugIdsUrl;
+
+  useEffect(() => {
+    if (location.pathname === sourceMapsUrl) {
+      router.replace(debugIdsUrl);
+    }
+  }, [location.pathname, sourceMapsUrl, debugIdsUrl, router]);
 
   const {
     data: archivesData,
@@ -250,11 +261,29 @@ export function ProjectSourceMaps({location, router, project}: Props) {
         )}
       </TextBlock>
       <NavTabs underlined>
-        <ListLink to={releaseBundlesUrl} index isActive={() => !tabDebugIdBundlesActive}>
-          {t('Release Bundles')}
-        </ListLink>
-        <ListLink to={debugIdsUrl} isActive={() => tabDebugIdBundlesActive}>
+        <ListLink to={debugIdsUrl} index isActive={() => tabDebugIdBundlesActive}>
           {t('Artifact Bundles')}
+        </ListLink>
+        <ListLink to={releaseBundlesUrl} isActive={() => !tabDebugIdBundlesActive}>
+          {t('Release Bundles')}
+          <Tooltip
+            title={tct(
+              'Release Bundles have been deprecated in favor of Artifact Bundles. Learn more about [link:Artifact Bundles].',
+              {
+                link: (
+                  <ExternalLink
+                    href="https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/"
+                    onClick={event => {
+                      event.stopPropagation();
+                    }}
+                  />
+                ),
+              }
+            )}
+            isHoverable
+          >
+            <Badge type="warning" text={t('Deprecated')} />
+          </Tooltip>
         </ListLink>
       </NavTabs>
       <SearchBarWithMarginBottom


### PR DESCRIPTION
**Before:**
![image](https://github.com/getsentry/sentry/assets/29228205/e1713989-880b-4450-938e-127e70cb8678)

**After:**

![image](https://github.com/getsentry/sentry/assets/29228205/63232983-5386-43b1-becf-e33338ba2b40)
