### PR TITLE
fix(starfish): units missing on xAxis in span summary duration chart

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -123,7 +123,7 @@ function Chart({
   );
 
   let dataMax = durationOnly
-    ? computeAxisMax([...data, ...(scatterPlot ?? [])])
+    ? computeAxisMax([...data, ...(scatterPlot?.[0]?.data?.length ? scatterPlot : [])])
     : percentOnly
     ? computeMax(data)
     : undefined;


### PR DESCRIPTION
Fixes a bug where the units were missing on the duration chart when the samples scatter plot was not enabled.