### PR TITLE
ref(starfish): Remove users column in span samples

### DIFF
--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -48,11 +48,6 @@ const COLUMN_ORDER = [
     width: 200,
   },
   {
-    key: 'user',
-    name: 'User',
-    width: 200,
-  },
-  {
     key: 'timestamp',
     name: 'Timestamp',
     width: 300,


### PR DESCRIPTION
This column is currently adding nothing but empty space, and I don't think `User` is valuable for choosing which sample to pick (we can loop back on this later if we decide otherwise)