### PR TITLE
ref(hybridcloud) Remove more user.actor_id usage

### DIFF
--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -1,5 +1,5 @@
 from collections import defaultdict, namedtuple
-from typing import TYPE_CHECKING, List, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Type, Union, cast
 
 import sentry_sdk
 from django.conf import settings
@@ -112,8 +112,8 @@ class Actor(Model):
         return self.get_actor_tuple().get_actor_identifier()
 
 
-def get_actor_id_for_user(user: Union["User", RpcUser]):
-    return get_actor_for_user(user).id
+def get_actor_id_for_user(user: Union["User", RpcUser]) -> int:
+    return cast(int, get_actor_for_user(user).id)
 
 
 def get_actor_for_user(user: Union["User", RpcUser]) -> "Actor":

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -66,13 +66,9 @@ class RpcActor(RpcModel):
 
     @classmethod
     def from_orm_user(cls, user: "User", fetch_actor: bool = True) -> "RpcActor":
-        actor_id = (
-            get_actor_id_for_user(user)
-            if fetch_actor
-            else user.actor_id
-            if hasattr(user, "actor_id")
-            else None
-        )
+        actor_id = None
+        if fetch_actor:
+            actor_id = get_actor_id_for_user(user)
         return cls(
             id=user.id,
             actor_id=actor_id,
@@ -82,13 +78,9 @@ class RpcActor(RpcModel):
 
     @classmethod
     def from_rpc_user(cls, user: RpcUser, fetch_actor: bool = True) -> "RpcActor":
-        actor_id = (
-            get_actor_id_for_user(user)
-            if fetch_actor
-            else user.actor_id
-            if hasattr(user, "actor_id")
-            else None
-        )
+        actor_id = None
+        if fetch_actor:
+            actor_id = get_actor_id_for_user(user)
         return cls(
             id=user.id,
             actor_id=actor_id,

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -88,12 +88,6 @@ class DatabaseBackedUserService(UserService):
                 return list(qs.filter(email__iexact=username))
         return []
 
-    def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[RpcUser]:
-        # TODO(actorid) this method needs to be removed too
-        return [
-            self._FQ.serialize_rpc(u) for u in self._FQ.base_query().filter(actor_id__in=actor_ids)
-        ]
-
     def flush_nonce(self, *, user_id: int) -> None:
         user = User.objects.filter(id=user_id).first()
         if user is not None:

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -83,11 +83,6 @@ class UserService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def get_by_actor_ids(self, *, actor_ids: List[int]) -> List[RpcUser]:
-        pass
-
-    @rpc_method
-    @abstractmethod
     def update_user(self, *, user_id: int, attrs: UserUpdateArgs) -> Any:
         # Returns a serialized user
         pass


### PR DESCRIPTION
- Remove the unused RPC method to look up users by actor_id.
- Remove more reads to user.actor_id.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
