### PR TITLE
ref: fix test pollution in test_backup

### DIFF
--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -1,58 +1,40 @@
-import atexit
-import os
-
 import pytest
 from click.testing import CliRunner
 from django.db import IntegrityError
 
 from sentry.runner.commands.backup import export, import_
-from sentry.testutils import CliTestCase
 from sentry.utils import json
 
-tmp_backup_filename = "test_backup.json"
+
+@pytest.fixture
+def backup_json_filename(tmp_path):
+    backup_json = str(tmp_path.joinpath("test_backup.json"))
+    rv = CliRunner().invoke(export, [backup_json], obj={})
+    assert rv.exit_code == 0, rv.output
+    return backup_json
 
 
-class BackupTest(CliTestCase):
-    command = export
-
-    def test_export(self):
-        rv = self.invoke(tmp_backup_filename)
-        assert rv.exit_code == 0, rv.output
-        assert os.path.exists(tmp_backup_filename)
-
-
-# Avoid using CliTestCase/TestCase since it wraps everything in an atomic function,
-# which creates an error with hybrid cloud fixture protect_user_deletion
 @pytest.mark.django_db
-def test_import():
-    rv = CliRunner().invoke(import_, tmp_backup_filename)
+def test_import(backup_json_filename):
+    rv = CliRunner().invoke(import_, backup_json_filename)
     assert rv.exit_code == 0, rv.output
 
 
 @pytest.mark.django_db
-def test_import_duplicate_key():
+def test_import_duplicate_key(backup_json_filename):
     # Adding an element with the same key as the last item in the backed up file
     # to force a duplicate key violation exception
-    with open(tmp_backup_filename) as backup_file:
+    with open(backup_json_filename) as backup_file:
         contents = json.load(backup_file)
         duplicate_key_item = contents[-1]
         duplicate_key_item["pk"] += 1
         contents.append(duplicate_key_item)
-    with open(tmp_backup_filename, "w") as backup_file:
+    with open(backup_json_filename, "w") as backup_file:
         backup_file.write(json.dumps(contents))
-    rv = CliRunner().invoke(import_, tmp_backup_filename)
+    rv = CliRunner().invoke(import_, backup_json_filename)
     assert (
         rv.output
         == ">> Are you restoring from a backup of the same version of Sentry?\n>> Are you restoring onto a clean database?\n>> If so then this IntegrityError might be our fault, you can open an issue here:\n>> https://github.com/getsentry/sentry/issues/new/choose\n"
     )
     assert isinstance(rv.exception, IntegrityError)
     assert rv.exit_code == 1
-
-
-# Cleanup backup file once test suite finishes
-# Using atexit here instead of the teardown hook since
-# we're avoiding using CliTestCase/TestCase due to failing fixture
-@atexit.register
-def cleanup_backup_file():
-    if os.path.exists(tmp_backup_filename):
-        os.remove(tmp_backup_filename)


### PR DESCRIPTION
atexit is unreliable, the tests did not work when run out of order, this threw a file into the working directory and was unreliable with cd

example failure before:

```console
$ pytest tests/sentry/runner/commands/test_backup.py -k test_import_duplicate_key
============================= test session starts ==============================
platform darwin -- Python 3.8.16, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, xdist-3.0.2, cov-4.0.0, django-4.4.0
collected 3 items / 2 deselected / 1 selected                                  

tests/sentry/runner/commands/test_backup.py F                            [100%]

=================================== FAILURES ===================================
__________________________ test_import_duplicate_key ___________________________
tests/sentry/runner/commands/test_backup.py:36: in test_import_duplicate_key
    with open(tmp_backup_filename) as backup_file:
E   FileNotFoundError: [Errno 2] No such file or directory: 'test_backup.json'
=========================== short test summary info ============================
FAILED tests/sentry/runner/commands/test_backup.py::test_import_duplicate_key - FileNotFoundError: [Errno 2] No such file or directory: 'test_backup.json'
======================= 1 failed, 2 deselected in 3.57s ========================
```