### PR TITLE
fix(sourcemaps): fix bug with setting fields for sourcemaps

### DIFF
--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -221,7 +221,7 @@ class Frame(Interface):
             data["addrMode"] = self.addr_mode
 
         # TODO(dcramer): abstract out this API
-        if self.data and "sourcemap" in data:
+        if self.data and "sourcemap" in self.data:
             data.update(
                 {
                     "map": self.data["sourcemap"].rsplit("/", 1)[-1],


### PR DESCRIPTION
I think there is a bug where we check `data` instead of `self.data` which controls whether we send certain fields back. I'm intending to use the `map` field to determine if something is actually source mapped.