### PR TITLE
fix(replays): Only show the Replay Onboarding for Backend  & Frontend platforms, not Mobile

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -15,9 +15,18 @@ type Props = {
   replayId: undefined | string;
 };
 
-function useProjectFromSlug({projectSlug}: {projectSlug: string}) {
-  const {fetching, projects} = useProjects({slugs: [projectSlug]});
-  return fetching ? projects[0] : undefined;
+function useProjectFromSlug({
+  organization,
+  projectSlug,
+}: {
+  organization: Organization;
+  projectSlug: string;
+}) {
+  const {fetching, projects} = useProjects({
+    slugs: [projectSlug],
+    orgId: organization.slug,
+  });
+  return fetching ? undefined : projects[0];
 }
 
 export default function EventReplay({replayId, organization, projectSlug, event}: Props) {
@@ -27,7 +36,7 @@ export default function EventReplay({replayId, organization, projectSlug, event}
   const onboardingPanel = useCallback(() => import('./replayInlineOnboardingPanel'), []);
   const replayPreview = useCallback(() => import('./replayPreview'), []);
 
-  const project = useProjectFromSlug({projectSlug});
+  const project = useProjectFromSlug({organization, projectSlug});
   const isReplayRelated = projectCanLinkToReplay(project);
 
   if (!hasReplaysFeature || fetching || !isReplayRelated) {

--- a/static/app/utils/replays/projectSupportsReplay.spec.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.spec.tsx
@@ -1,0 +1,58 @@
+import type {PlatformKey} from 'sentry/data/platformCategories';
+import type {MinimalProject} from 'sentry/types';
+import projectSupportsReplay, {
+  projectCanLinkToReplay,
+} from 'sentry/utils/replays/projectSupportsReplay';
+
+function mockProject(platform: PlatformKey): MinimalProject {
+  return {
+    id: '1',
+    slug: 'test-project',
+    platform,
+  };
+}
+
+describe('projectSupportsReplay & projectCanLinkToReplay', () => {
+  it.each([
+    'javascript-angular' as PlatformKey,
+    'javascript-nextjs' as PlatformKey,
+    'javascript-react' as PlatformKey,
+    'javascript' as PlatformKey,
+  ])('should SUPPORT & LINK frontend platform %s', platform => {
+    const project = mockProject(platform);
+    expect(projectSupportsReplay(project)).toBeTruthy();
+    expect(projectCanLinkToReplay(project)).toBeTruthy();
+  });
+
+  it.each(['javascript-angularjs' as PlatformKey])(
+    'should FAIL for old, unsupported frontend framework %s',
+    platform => {
+      const project = mockProject(platform);
+      expect(projectSupportsReplay(project)).toBeFalsy();
+      expect(projectCanLinkToReplay(project)).toBeFalsy();
+    }
+  );
+
+  it.each([
+    'dotnet' as PlatformKey,
+    'java' as PlatformKey,
+    'node' as PlatformKey,
+    'php' as PlatformKey,
+    'rust' as PlatformKey,
+  ])('should NOT SUPPORT but CAN LINK for Backend framework %s', platform => {
+    const project = mockProject(platform);
+    expect(projectSupportsReplay(project)).toBeFalsy();
+    expect(projectCanLinkToReplay(project)).toBeTruthy();
+  });
+
+  it.each([
+    'apple-macos' as PlatformKey,
+    'electron' as PlatformKey,
+    'flutter' as PlatformKey,
+    'unity' as PlatformKey,
+  ])('should FAIL for Desktop framework %s', platform => {
+    const project = mockProject(platform);
+    expect(projectSupportsReplay(project)).toBeFalsy();
+    expect(projectCanLinkToReplay(project)).toBeFalsy();
+  });
+});

--- a/static/app/utils/replays/projectSupportsReplay.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.tsx
@@ -16,14 +16,13 @@ function projectSupportsReplay(project: MinimalProject) {
  * Basically: is this a backend or frontend project
  */
 export function projectCanLinkToReplay(project: undefined | MinimalProject) {
-  if (!project) {
+  if (!project || !project.platform) {
     return false;
   }
-  const {platform} = project;
-  return Boolean(
-    platform &&
-      replayPlatforms.includes(platform) &&
-      backend.some(val => val === platform) // TS doesn't like `includes()` here :(
+
+  return (
+    replayPlatforms.includes(project.platform) ||
+    backend.some(val => val === project.platform)
   );
 }
 

--- a/static/app/utils/replays/projectSupportsReplay.tsx
+++ b/static/app/utils/replays/projectSupportsReplay.tsx
@@ -1,8 +1,30 @@
-import {replayPlatforms} from 'sentry/data/platformCategories';
+import {backend, replayPlatforms} from 'sentry/data/platformCategories';
 import type {MinimalProject} from 'sentry/types';
 
+/**
+ * Are you able to send a Replay into the project?
+ *
+ * Basically: is this a frontend project
+ */
 function projectSupportsReplay(project: MinimalProject) {
   return Boolean(project.platform && replayPlatforms.includes(project.platform));
+}
+
+/**
+ * Can this project be related to a Replay?
+ *
+ * Basically: is this a backend or frontend project
+ */
+export function projectCanLinkToReplay(project: undefined | MinimalProject) {
+  if (!project) {
+    return false;
+  }
+  const {platform} = project;
+  return Boolean(
+    platform &&
+      replayPlatforms.includes(platform) &&
+      backend.some(val => val === platform) // TS doesn't like `includes()` here :(
+  );
 }
 
 export default projectSupportsReplay;


### PR DESCRIPTION
Problem:

We were showing this onboarding banner for all projects, but it's not relevant to iOS or Android, or desktop platforms because replay cannot capture html replays.
It is however relevant to all server-side platforms, because they could be linked to a web frontend, and therefore linked to a replay.

Here's the banner that's being shown/hidden (banner is unchanged):
![CleanShot 2023-05-17 at 13 50 07](https://github.com/getsentry/sentry/assets/187460/403d4d2d-dc1f-4d96-953f-371e5bebac30)



Follows https://github.com/getsentry/sentry/pull/48100