### PR TITLE
chore(js): Add type to `RequestError.responseJSON`

### DIFF
--- a/static/app/components/events/aiSuggestedSolution/suggestion.tsx
+++ b/static/app/components/events/aiSuggestedSolution/suggestion.tsx
@@ -149,7 +149,7 @@ export function Suggestion({onHideSuggestion, projectSlug, event}: Props) {
             onSetIndividualConsent={() =>
               setSuggestedSolutionLocalConfig({individualConsent: true})
             }
-            restriction={error?.responseJSON?.restriction}
+            restriction={error?.responseJSON?.restriction as any}
             onHideSuggestion={onHideSuggestion}
           />
         ) : (

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -31,7 +31,9 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
     Sentry.withScope(scope => {
       scope.setExtra('status', err.status);
       scope.setExtra('detail', responseJSON.detail);
-      scope.setExtra('code', responseJSON.detail.code);
+      // @ts-ignore Property 'code' does not exist on type 'string' (god knows why
+      // it's not mad at the other places in this function we do this, but ¯\_(ツ)_/¯)
+      scope.setExtra('code', responseJSON.detail?.code);
       Sentry.captureException(new Error(message));
     });
     return;

--- a/static/app/utils/requestError/requestError.tsx
+++ b/static/app/utils/requestError/requestError.tsx
@@ -5,9 +5,19 @@ import {sanitizePath} from './sanitizePath';
 interface ErrorOptionsObject {
   cause: Error;
 }
+
+// Technically, this should include the fact that `responseJSON` can be an
+// array, but since we never actually use its array-ness, it makes the typing
+// significantly simpler if we just rely on the "arrays are objects and we
+// can always check if a given property is defined on an object" principle
+type ResponseJSON = {
+  [key: string]: unknown;
+  detail?: string | {code?: string; message?: string};
+};
+
 export default class RequestError extends Error {
   responseText?: string;
-  responseJSON?: any;
+  responseJSON?: ResponseJSON;
   status?: number;
   statusText?: string;
 

--- a/static/app/utils/useApiRequests.tsx
+++ b/static/app/utils/useApiRequests.tsx
@@ -374,7 +374,7 @@ function useApiRequests<T extends Record<string, any>>({
       if (shouldRenderBadRequests) {
         const badRequests = Object.values(errors)
           .filter(resp => resp?.status === 400 && resp?.responseJSON?.detail)
-          .map(resp => resp.responseJSON.detail);
+          .map(resp => resp.responseJSON?.detail);
 
         if (badRequests.length) {
           return <LoadingError message={[...new Set(badRequests)].join('\n')} />;


### PR DESCRIPTION
This fixes the type of `RequestError.responseJSON` to be more specific than `any`, so that future work involving it will be type-safe. 