### PR TITLE
fix(crons): Fix re-opening closed check-ins on the consumer

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -171,6 +171,18 @@ def _process_message(wrapper: Dict) -> None:
                     monitor=monitor,
                 )
 
+                if check_in.status in CheckInStatus.FINISHED_VALUES:
+                    metrics.incr(
+                        "monitors.checkin.result",
+                        tags={"source": "consumer", "status": "checkin_finished"},
+                    )
+                    logger.debug(
+                        "check-in was finished: attempted update from %s to %s",
+                        check_in.status,
+                        status,
+                    )
+                    return
+
                 if duration is None:
                     duration = int((start_time - check_in.date_added).total_seconds() * 1000)
 


### PR DESCRIPTION
Fixes incorrectly "re-opening" of closed check-ins on the consumer. Validation logic now lines up with HTTP API