### PR TITLE
ref(js): Streamline `handleXhrErrorResponse`

### DIFF
--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -9,11 +9,14 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
     return;
   }
 
-  const {responseJSON} = err;
+  const {responseJSON, status} = err;
 
   Sentry.withScope(scope => {
-    scope.setExtra('status', err.status);
-    scope.setExtra('responseJSON', responseJSON);
+    scope.setExtras({
+      status,
+      responseJSON,
+    });
+
     Sentry.captureException(new Error(message));
   });
 }

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -3,10 +3,9 @@ import * as Sentry from '@sentry/react';
 import RequestError from 'sentry/utils/requestError/requestError';
 
 export function handleXhrErrorResponse(message: string, err: RequestError): void {
-  if (!err) {
-    return;
-  }
-  if (!err.responseJSON) {
+  // Sudo errors are handled separately elsewhere
+  // @ts-ignore Property 'code' does not exist on type 'string'
+  if (!err || !err.responseJSON || err.responseJSON?.detail?.code === 'sudo-required') {
     return;
   }
 
@@ -19,11 +18,6 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
       scope.setExtra('detail', responseJSON.detail);
       Sentry.captureException(new Error(message));
     });
-    return;
-  }
-
-  // Ignore sudo-required errors
-  if (responseJSON.detail && responseJSON.detail.code === 'sudo-required') {
     return;
   }
 

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -11,22 +11,9 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
 
   const {responseJSON} = err;
 
-  // If this is a string then just capture it as error
-  if (typeof responseJSON.detail === 'string') {
-    Sentry.withScope(scope => {
-      scope.setExtra('status', err.status);
-      scope.setExtra('responseJSON', responseJSON);
-      Sentry.captureException(new Error(message));
-    });
-    return;
-  }
-
-  if (responseJSON.detail && typeof responseJSON.detail.message === 'string') {
-    Sentry.withScope(scope => {
-      scope.setExtra('status', err.status);
-      scope.setExtra('responseJSON', responseJSON);
-      Sentry.captureException(new Error(message));
-    });
-    return;
-  }
+  Sentry.withScope(scope => {
+    scope.setExtra('status', err.status);
+    scope.setExtra('responseJSON', responseJSON);
+    Sentry.captureException(new Error(message));
+  });
 }

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -15,7 +15,7 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
   if (typeof responseJSON.detail === 'string') {
     Sentry.withScope(scope => {
       scope.setExtra('status', err.status);
-      scope.setExtra('detail', responseJSON.detail);
+      scope.setExtra('responseJSON', responseJSON);
       Sentry.captureException(new Error(message));
     });
     return;
@@ -24,10 +24,7 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
   if (responseJSON.detail && typeof responseJSON.detail.message === 'string') {
     Sentry.withScope(scope => {
       scope.setExtra('status', err.status);
-      scope.setExtra('detail', responseJSON.detail);
-      // @ts-ignore Property 'code' does not exist on type 'string' (god knows why
-      // it's not mad at the other places in this function we do this, but ¯\_(ツ)_/¯)
-      scope.setExtra('code', responseJSON.detail?.code);
+      scope.setExtra('responseJSON', responseJSON);
       Sentry.captureException(new Error(message));
     });
     return;


### PR DESCRIPTION
This simplifies and cleans up `handleXhrErrorResponse`, prior to other work being done on it. Key changes:

- Consolidate return conditions
- Log the full `responseJSON` object rather than just parts of it
- Remove conditions on capturing an event. We weren't actually using the values we were checking for other than as context data, and the differences there don't matter if we log `responseJSON` in its entirety.