### PR TITLE
fix(issue-platform): Update all detectors to output correct evidence_display

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -388,3 +388,15 @@ def get_span_evidence_value(
         if not include_op:
             value = desc
     return value
+
+
+def get_notification_attachment_body(op, desc) -> str:
+    """Get the 'span evidence' data for a performance problem. This is displayed in issue alert emails."""
+    value = "no value"
+    if not op and desc:
+        value = desc
+    if op and not desc:
+        value = op
+    if op and desc:
+        value = f"{op} - {desc}"
+    return value

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceConsecutiveDBQueriesGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 from sentry.utils.event_frames import get_sdk_name
 
@@ -147,8 +147,8 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
                 ),
             },
             evidence_display=[
-                IssueEvidenceData(
-                    name="Notification Attachment",
+                IssueEvidence(
+                    name="Offending Spans",
                     value=get_notification_attachment_body(
                         "db",
                         query,

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceConsecutiveDBQueriesGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 from sentry.utils.event_frames import get_sdk_name
 
@@ -146,15 +147,15 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
                 ),
             },
             evidence_display=[
-                {
-                    "name": "Notification Attachment",
-                    "value": get_notification_attachment_body(
+                IssueEvidenceData(
+                    name="Notification Attachment",
+                    value=get_notification_attachment_body(
                         "db",
                         query,
                     ),
                     # Has to be marked important to be displayed in the notifications
-                    "important": True,
-                }
+                    important=True,
+                )
             ],
         )
 

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -16,6 +16,7 @@ from ..base import (
     DetectorType,
     PerformanceDetector,
     fingerprint_spans,
+    get_notification_attachment_body,
     get_span_duration,
     get_span_evidence_value,
 )
@@ -144,7 +145,17 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
                     self.independent_db_spans[0], include_op=False
                 ),
             },
-            evidence_display=[],
+            evidence_display=[
+                {
+                    "name": "Notification Attachment",
+                    "value": get_notification_attachment_body(
+                        "db",
+                        query,
+                    ),
+                    # Has to be marked important to be displayed in the notifications
+                    "important": True,
+                }
+            ],
         )
 
         self._reset_variables()

--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -13,6 +13,7 @@ from ..base import (
     PerformanceDetector,
     fingerprint_http_spans,
     get_duration_between_spans,
+    get_notification_attachment_body,
     get_span_duration,
     get_span_evidence_value,
 )
@@ -92,7 +93,17 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
             cause_span_ids=[],
             parent_span_ids=None,
             offender_span_ids=offender_span_ids,
-            evidence_display=[],
+            evidence_display=[
+                {
+                    "name": "Notification Attachment",
+                    "value": get_notification_attachment_body(
+                        "http",
+                        desc,
+                    ),
+                    # Has to be marked important to be displayed in the notifications
+                    "important": True,
+                }
+            ],
             evidence_data={
                 "parent_span_ids": [],
                 "cause_span_ids": [],

--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.safe import get_path
@@ -94,15 +95,15 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
             parent_span_ids=None,
             offender_span_ids=offender_span_ids,
             evidence_display=[
-                {
-                    "name": "Notification Attachment",
-                    "value": get_notification_attachment_body(
+                IssueEvidenceData(
+                    name="Notification Attachment",
+                    value=get_notification_attachment_body(
                         "http",
                         desc,
                     ),
                     # Has to be marked important to be displayed in the notifications
-                    "important": True,
-                }
+                    important=True,
+                )
             ],
             evidence_data={
                 "parent_span_ids": [],

--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.safe import get_path
@@ -95,8 +95,8 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
             parent_span_ids=None,
             offender_span_ids=offender_span_ids,
             evidence_display=[
-                IssueEvidenceData(
-                    name="Notification Attachment",
+                IssueEvidence(
+                    name="Offending Spans",
                     value=get_notification_attachment_body(
                         "http",
                         desc,

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -12,6 +12,7 @@ from sentry.issues.grouptype import (
     PerformanceDBMainThreadGroupType,
     PerformanceFileIOMainThreadGroupType,
 )
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project, ProjectDebugFile
 
 from ..base import (
@@ -80,15 +81,15 @@ class BaseIOMainThreadDetector(PerformanceDetector):
                         "num_repeating_spans": str(len(offender_spans)),
                     },
                     evidence_display=[
-                        {
-                            "name": "Notification Attachment",
-                            "value": get_notification_attachment_body(
+                        IssueEvidenceData(
+                            name="Notification Attachment",
+                            value=get_notification_attachment_body(
                                 span_list[0].get("op"),
                                 span_list[0].get("description", ""),
                             ),
                             # Has to be marked important to be displayed in the notifications
-                            "important": True,
-                        }
+                            important=True,
+                        )
                     ],
                 )
 

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -14,7 +14,13 @@ from sentry.issues.grouptype import (
 )
 from sentry.models import Organization, Project, ProjectDebugFile
 
-from ..base import DetectorType, PerformanceDetector, get_span_evidence_value, total_span_time
+from ..base import (
+    DetectorType,
+    PerformanceDetector,
+    get_notification_attachment_body,
+    get_span_evidence_value,
+    total_span_time,
+)
 from ..performance_problem import PerformanceProblem
 from ..types import Span
 
@@ -73,7 +79,17 @@ class BaseIOMainThreadDetector(PerformanceDetector):
                         ),
                         "num_repeating_spans": str(len(offender_spans)),
                     },
-                    evidence_display=[],
+                    evidence_display=[
+                        {
+                            "name": "Notification Attachment",
+                            "value": get_notification_attachment_body(
+                                span_list[0].get("op"),
+                                span_list[0].get("description", ""),
+                            ),
+                            # Has to be marked important to be displayed in the notifications
+                            "important": True,
+                        }
+                    ],
                 )
 
     def is_creation_allowed_for_project(self, project: Project) -> bool:

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -12,7 +12,7 @@ from sentry.issues.grouptype import (
     PerformanceDBMainThreadGroupType,
     PerformanceFileIOMainThreadGroupType,
 )
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project, ProjectDebugFile
 
 from ..base import (
@@ -81,8 +81,8 @@ class BaseIOMainThreadDetector(PerformanceDetector):
                         "num_repeating_spans": str(len(offender_spans)),
                     },
                     evidence_display=[
-                        IssueEvidenceData(
-                            name="Notification Attachment",
+                        IssueEvidence(
+                            name="Offending Spans",
                             value=get_notification_attachment_body(
                                 span_list[0].get("op"),
                                 span_list[0].get("description", ""),

--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -58,15 +59,15 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
             parent_span_ids=None,
             offender_span_ids=offender_span_ids,
             evidence_display=[
-                {
-                    "name": "Notification Attachment",
-                    "value": get_notification_attachment_body(
+                IssueEvidenceData(
+                    name="Notification Attachment",
+                    value=get_notification_attachment_body(
                         "http",
                         desc,
                     ),
                     # Has to be marked important to be displayed in the notifications
-                    "important": True,
-                }
+                    important=True,
+                )
             ],
             evidence_data={
                 "parent_span_ids": [],

--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -59,8 +59,8 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
             parent_span_ids=None,
             offender_span_ids=offender_span_ids,
             evidence_display=[
-                IssueEvidenceData(
-                    name="Notification Attachment",
+                IssueEvidence(
+                    name="Offending Spans",
                     value=get_notification_attachment_body(
                         "http",
                         desc,

--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -8,6 +8,7 @@ from ..base import (
     DetectorType,
     PerformanceDetector,
     fingerprint_http_spans,
+    get_notification_attachment_body,
     get_span_evidence_value,
 )
 from ..performance_problem import PerformanceProblem
@@ -56,7 +57,17 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
             cause_span_ids=[],
             parent_span_ids=None,
             offender_span_ids=offender_span_ids,
-            evidence_display=[],
+            evidence_display=[
+                {
+                    "name": "Notification Attachment",
+                    "value": get_notification_attachment_body(
+                        "http",
+                        desc,
+                    ),
+                    # Has to be marked important to be displayed in the notifications
+                    "important": True,
+                }
+            ],
             evidence_data={
                 "parent_span_ids": [],
                 "cause_span_ids": [],

--- a/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
@@ -12,7 +12,7 @@ from sentry.issues.grouptype import (
     PerformanceMNPlusOneDBQueriesGroupType,
     PerformanceNPlusOneGroupType,
 )
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -199,8 +199,8 @@ class ContinuingMNPlusOne(MNPlusOneState):
                 "number_repeating_spans": str(len(offender_spans)),
             },
             evidence_display=[
-                IssueEvidenceData(
-                    name="Notification Attachment",
+                IssueEvidence(
+                    name="Offending Spans",
                     value=get_notification_attachment_body(
                         "db",
                         db_span["description"],

--- a/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
@@ -14,7 +14,13 @@ from sentry.issues.grouptype import (
 )
 from sentry.models import Organization, Project
 
-from ..base import DetectorType, PerformanceDetector, get_span_evidence_value, total_span_time
+from ..base import (
+    DetectorType,
+    PerformanceDetector,
+    get_notification_attachment_body,
+    get_span_evidence_value,
+    total_span_time,
+)
 from ..performance_problem import PerformanceProblem
 from ..types import Span
 
@@ -191,7 +197,17 @@ class ContinuingMNPlusOne(MNPlusOneState):
                 ),
                 "number_repeating_spans": str(len(offender_spans)),
             },
-            evidence_display=[],
+            evidence_display=[
+                {
+                    "name": "Notification Attachment",
+                    "value": get_notification_attachment_body(
+                        "db",
+                        db_span["description"],
+                    ),
+                    # Has to be marked important to be displayed in the notifications
+                    "important": True,
+                }
+            ],
         )
 
     def _first_db_span(self) -> Optional[Span]:

--- a/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
@@ -12,6 +12,7 @@ from sentry.issues.grouptype import (
     PerformanceMNPlusOneDBQueriesGroupType,
     PerformanceNPlusOneGroupType,
 )
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -198,15 +199,15 @@ class ContinuingMNPlusOne(MNPlusOneState):
                 "number_repeating_spans": str(len(offender_spans)),
             },
             evidence_display=[
-                {
-                    "name": "Notification Attachment",
-                    "value": get_notification_attachment_body(
+                IssueEvidenceData(
+                    name="Notification Attachment",
+                    value=get_notification_attachment_body(
                         "db",
                         db_span["description"],
                     ),
                     # Has to be marked important to be displayed in the notifications
-                    "important": True,
-                }
+                    important=True,
+                )
             ],
         )
 

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -12,6 +12,7 @@ from django.utils.encoding import force_bytes
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceNPlusOneAPICallsGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -191,17 +192,17 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
                 "parameters": self._get_parameters(),
             },
             evidence_display=[
-                {
-                    "name": "Notification Attachment",
-                    "value": get_notification_attachment_body(
+                IssueEvidenceData(
+                    name="Notification Attachment",
+                    value=get_notification_attachment_body(
                         last_span["op"],
                         os.path.commonprefix(
                             [span.get("description", "") or "" for span in self.spans]
                         ),
                     ),
                     # Has to be marked important to be displayed in the notifications
-                    "important": True,
-                }
+                    important=True,
+                )
             ],
         )
 

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -19,6 +19,7 @@ from ..base import (
     DetectorType,
     PerformanceDetector,
     fingerprint_http_spans,
+    get_notification_attachment_body,
     get_span_duration,
     get_span_evidence_value,
     get_url_from_span,
@@ -189,7 +190,19 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
                 "repeating_spans_compact": get_span_evidence_value(self.spans[0], include_op=False),
                 "parameters": self._get_parameters(),
             },
-            evidence_display=[],
+            evidence_display=[
+                {
+                    "name": "Notification Attachment",
+                    "value": get_notification_attachment_body(
+                        last_span["op"],
+                        os.path.commonprefix(
+                            [span.get("description", "") or "" for span in self.spans]
+                        ),
+                    ),
+                    # Has to be marked important to be displayed in the notifications
+                    "important": True,
+                }
+            ],
         )
 
     def _get_parameters(self) -> List[str]:

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -12,7 +12,7 @@ from django.utils.encoding import force_bytes
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceNPlusOneAPICallsGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -192,8 +192,8 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
                 "parameters": self._get_parameters(),
             },
             evidence_display=[
-                IssueEvidenceData(
-                    name="Notification Attachment",
+                IssueEvidence(
+                    name="Offending Spans",
                     value=get_notification_attachment_body(
                         last_span["op"],
                         os.path.commonprefix(

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import Optional
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
@@ -217,15 +218,15 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                 cause_span_ids=[self.source_span.get("span_id", None)],
                 offender_span_ids=offender_span_ids,
                 evidence_display=[
-                    {
-                        "name": "Notification Attachment",
-                        "value": get_notification_attachment_body(
+                    IssueEvidenceData(
+                        name="Notification Attachment",
+                        value=get_notification_attachment_body(
                             "db",
                             self.n_spans[0].get("description", ""),
                         ),
                         # Has to be marked important to be displayed in the notifications
-                        "important": True,
-                    }
+                        important=True,
+                    )
                 ],
                 evidence_data={
                     "transaction_name": self._event.get("transaction", ""),

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from typing import Optional
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
@@ -218,8 +218,8 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                 cause_span_ids=[self.source_span.get("span_id", None)],
                 offender_span_ids=offender_span_ids,
                 evidence_display=[
-                    IssueEvidenceData(
-                        name="Notification Attachment",
+                    IssueEvidence(
+                        name="Offending Spans",
                         value=get_notification_attachment_body(
                             "db",
                             self.n_spans[0].get("description", ""),

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
@@ -14,6 +14,7 @@ from ..base import (
     PARAMETERIZED_SQL_QUERY_REGEX,
     DetectorType,
     PerformanceDetector,
+    get_notification_attachment_body,
     get_span_duration,
     get_span_evidence_value,
 )
@@ -215,7 +216,17 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                 parent_span_ids=[parent_span_id],
                 cause_span_ids=[self.source_span.get("span_id", None)],
                 offender_span_ids=offender_span_ids,
-                evidence_display=[],
+                evidence_display=[
+                    {
+                        "name": "Notification Attachment",
+                        "value": get_notification_attachment_body(
+                            "db",
+                            self.n_spans[0].get("description", ""),
+                        ),
+                        # Has to be marked important to be displayed in the notifications
+                        "important": True,
+                    }
+                ],
                 evidence_data={
                     "transaction_name": self._event.get("transaction", ""),
                     "op": "db",

--- a/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
@@ -11,6 +11,7 @@ from ..base import (
     DetectorType,
     PerformanceDetector,
     fingerprint_resource_span,
+    get_notification_attachment_body,
     get_span_duration,
     get_span_evidence_value,
 )
@@ -92,7 +93,17 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
                         "repeating_spans": get_span_evidence_value(span),
                         "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
                     },
-                    evidence_display=[],
+                    evidence_display=[
+                        {
+                            "name": "Notification Attachment",
+                            "value": get_notification_attachment_body(
+                                op,
+                                span.get("description") or "",
+                            ),
+                            # Has to be marked important to be displayed in the notifications
+                            "important": True,
+                        }
+                    ],
                 )
 
         # If we visit a span that starts after FCP, then we know we've already

--- a/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping, Optional
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceRenderBlockingAssetSpanGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -94,15 +95,15 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
                         "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
                     },
                     evidence_display=[
-                        {
-                            "name": "Notification Attachment",
-                            "value": get_notification_attachment_body(
+                        IssueEvidenceData(
+                            name="Notification Attachment",
+                            value=get_notification_attachment_body(
                                 op,
                                 span.get("description") or "",
                             ),
                             # Has to be marked important to be displayed in the notifications
-                            "important": True,
-                        }
+                            important=True,
+                        )
                     ],
                 )
 

--- a/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, Optional
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceRenderBlockingAssetSpanGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -95,8 +95,8 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
                         "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
                     },
                     evidence_display=[
-                        IssueEvidenceData(
-                            name="Notification Attachment",
+                        IssueEvidence(
+                            name="Offending Spans",
                             value=get_notification_attachment_body(
                                 op,
                                 span.get("description") or "",

--- a/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -78,15 +79,15 @@ class SlowDBQueryDetector(PerformanceDetector):
                     "num_repeating_spans": str(len(spans_involved)),
                 },
                 evidence_display=[
-                    {
-                        "name": "Notification Attachment",
-                        "value": get_notification_attachment_body(
+                    IssueEvidenceData(
+                        name="Notification Attachment",
+                        value=get_notification_attachment_body(
                             op,
                             description,
                         ),
                         # Has to be marked important to be displayed in the notifications
-                        "important": True,
-                    }
+                        important=True,
+                    )
                 ],
             )
 

--- a/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -79,8 +79,8 @@ class SlowDBQueryDetector(PerformanceDetector):
                     "num_repeating_spans": str(len(spans_involved)),
                 },
                 evidence_display=[
-                    IssueEvidenceData(
-                        name="Notification Attachment",
+                    IssueEvidence(
+                        name="Offending Spans",
                         value=get_notification_attachment_body(
                             op,
                             description,

--- a/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
@@ -13,6 +13,7 @@ from ..base import (
     DetectorType,
     PerformanceDetector,
     fingerprint_span,
+    get_notification_attachment_body,
     get_span_evidence_value,
 )
 from ..performance_problem import PerformanceProblem
@@ -76,7 +77,17 @@ class SlowDBQueryDetector(PerformanceDetector):
                     "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
                     "num_repeating_spans": str(len(spans_involved)),
                 },
-                evidence_display=[],
+                evidence_display=[
+                    {
+                        "name": "Notification Attachment",
+                        "value": get_notification_attachment_body(
+                            op,
+                            description,
+                        ),
+                        # Has to be marked important to be displayed in the notifications
+                        "important": True,
+                    }
+                ],
             )
 
     def is_creation_allowed_for_organization(self, organization: Optional[Organization]) -> bool:

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceUncompressedAssetsGroupType
+from sentry.issues.issue_occurrence import IssueEvidenceData
 from sentry.models import Organization, Project
 
 from ..base import (
     DetectorType,
     PerformanceDetector,
     fingerprint_resource_span,
+    get_notification_attachment_body,
     get_span_duration,
     get_span_evidence_value,
 )
@@ -104,7 +106,17 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
                     "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
                     "num_repeating_spans": str(len(span.get("span_id", None))),
                 },
-                evidence_display=[],
+                evidence_display=[
+                    IssueEvidenceData(
+                        name="Notification Attachment",
+                        value=get_notification_attachment_body(
+                            op,
+                            description,
+                        ),
+                        # Has to be marked important to be displayed in the notifications
+                        important=True,
+                    )
+                ],
             )
 
     def _fingerprint(self, span) -> str:

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceUncompressedAssetsGroupType
-from sentry.issues.issue_occurrence import IssueEvidenceData
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models import Organization, Project
 
 from ..base import (
@@ -107,8 +107,8 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
                     "num_repeating_spans": str(len(span.get("span_id", None))),
                 },
                 evidence_display=[
-                    IssueEvidenceData(
-                        name="Notification Attachment",
+                    IssueEvidence(
+                        name="Offending Spans",
                         value=get_notification_attachment_body(
                             op,
                             description,

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -454,7 +454,15 @@ class IssueEventSerializerTest(TestCase):
                 "transactionName": "/books/",
                 "numRepeatingSpans": "10",
             },
-            "evidenceDisplay": [],
+            "evidenceDisplay": [
+                {
+                    "important": True,
+                    "name": "Offending Spans",
+                    "value": "db - SELECT `books_author`.`id`, "
+                    "`books_author`.`name` FROM `books_author` "
+                    "WHERE `books_author`.`id` = %s LIMIT 21",
+                }
+            ],
         }
 
     @override_options({"performance.issues.all.problem-detection": 1.0})

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -238,11 +238,10 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         with self.feature("organizations:performance-issues"):
             attachments = SlackIssuesMessageBuilder(event.group, event).build()
         assert attachments["title"] == "N+1 Query"
-        # TODO: Uncomment this once we fix the `evidence_display` for occurrences
-        # assert (
-        #     attachments["text"]
-        #     == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        # )
+        assert (
+            attachments["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
         assert attachments["text"] == ""
         assert attachments["fallback"] == f"[{self.project.slug}] N+1 Query"
         assert attachments["color"] == "#2788CE"  # blue for info level

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -242,7 +242,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             attachments["text"]
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
-        assert attachments["text"] == ""
         assert attachments["fallback"] == f"[{self.project.slug}] N+1 Query"
         assert attachments["color"] == "#2788CE"  # blue for info level
 


### PR DESCRIPTION
Evidence display will be used to generate notification body. This broke after the migration so this ensures that new notifications will have the correct body