### PR TITLE
ref(crons): Change Recent Check-Ins to Check-Ins

### DIFF
--- a/static/app/views/monitors/components/monitorStats.tsx
+++ b/static/app/views/monitors/components/monitorStats.tsx
@@ -120,7 +120,7 @@ function MonitorStats({monitor, monitorEnvs, orgId}: Props) {
     <React.Fragment>
       <Panel>
         <PanelBody withPadding>
-          <StyledHeaderTitle>{t('Recent Check-Ins')}</StyledHeaderTitle>
+          <StyledHeaderTitle>{t('Check-Ins')}</StyledHeaderTitle>
           <BarChart
             isGroupedByDate
             showTimeInTooltip


### PR DESCRIPTION
Suggestion from robin to simplify, and also users can edit the time range so its not necessarily recent.

![image](https://github.com/getsentry/sentry/assets/9372512/9a90864f-e21a-41dd-bdd9-ff6d9cb6d81c)
