### PR TITLE
feat(project-creation): solidify creation logic

### DIFF
--- a/static/app/components/noProjectMessage.tsx
+++ b/static/app/components/noProjectMessage.tsx
@@ -5,6 +5,7 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import NoProjectEmptyState from 'sentry/components/illustrations/NoProjectEmptyState';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {canViewerCreateProjects} from 'sentry/components/projects/utils';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
@@ -25,7 +26,7 @@ function NoProjectMessage({
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
 
   const orgSlug = organization.slug;
-  const canCreateProject = organization.access.includes('project:write');
+  const canCreateProject = canViewerCreateProjects(organization);
   const canJoinTeam = organization.access.includes('team:read');
 
   const {isSuperuser} = ConfigStore.get('user');

--- a/static/app/components/noProjectMessage.tsx
+++ b/static/app/components/noProjectMessage.tsx
@@ -5,7 +5,7 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import NoProjectEmptyState from 'sentry/components/illustrations/NoProjectEmptyState';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {canViewerCreateProjects} from 'sentry/components/projects/utils';
+import {canCreateProject} from 'sentry/components/projects/utils';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
@@ -26,7 +26,7 @@ function NoProjectMessage({
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
 
   const orgSlug = organization.slug;
-  const canCreateProject = canViewerCreateProjects(organization);
+  const canCreate = canCreateProject(organization);
   const canJoinTeam = organization.access.includes('team:read');
 
   const {isSuperuser} = ConfigStore.get('user');
@@ -58,12 +58,8 @@ function NoProjectMessage({
 
   const createProjectAction = (
     <Button
-      title={
-        canCreateProject
-          ? undefined
-          : t('You do not have permission to create a project.')
-      }
-      disabled={!canCreateProject}
+      title={canCreate ? undefined : t('You do not have permission to create a project.')}
+      disabled={!canCreate}
       priority={orgHasProjects ? 'default' : 'primary'}
       to={`/organizations/${orgSlug}/projects/new/`}
     >

--- a/static/app/components/projects/utils.spec.jsx
+++ b/static/app/components/projects/utils.spec.jsx
@@ -1,15 +1,15 @@
-const {canViewerCreateProjects} = require('./utils');
+const {canCreateProject} = require('./utils');
 
 describe('ProjectUtils', function () {
   it('passes project creation eligibility for project admin', function () {
     const org = TestStubs.Organization();
-    expect(canViewerCreateProjects(org)).toBeTruthy();
+    expect(canCreateProject(org)).toBeTruthy();
   });
 
   it('fails project creation eligibility for org members', function () {
     const org = TestStubs.Organization({
       access: ['org:read', 'team:read', 'project:read'],
     });
-    expect(canViewerCreateProjects(org)).toBeFalsy();
+    expect(canCreateProject(org)).toBeFalsy();
   });
 });

--- a/static/app/components/projects/utils.spec.jsx
+++ b/static/app/components/projects/utils.spec.jsx
@@ -1,0 +1,15 @@
+const {canViewerCreateProjects} = require('./utils');
+
+describe('ProjectUtils', function () {
+  it('passes project creation eligibility for project admin', function () {
+    const org = TestStubs.Organization();
+    expect(canViewerCreateProjects(org)).toBeTruthy();
+  });
+
+  it('fails project creation eligibility for org members', function () {
+    const org = TestStubs.Organization({
+      access: ['org:read', 'team:read', 'project:read'],
+    });
+    expect(canViewerCreateProjects(org)).toBeFalsy();
+  });
+});

--- a/static/app/components/projects/utils.tsx
+++ b/static/app/components/projects/utils.tsx
@@ -3,7 +3,7 @@ import {Organization} from 'sentry/types';
 /**
  * Used to determine if viewer can see project creation button
  */
-export function canViewerCreateProjects(organization: Organization): boolean {
+export function canCreateProject(organization: Organization): boolean {
   return (
     organization.access.includes('project:admin') ||
     organization.access.includes('project:write')

--- a/static/app/components/projects/utils.tsx
+++ b/static/app/components/projects/utils.tsx
@@ -1,0 +1,11 @@
+import {Organization} from 'sentry/types';
+
+/**
+ * Used to determine if viewer can see project creation button
+ */
+export function canViewerCreateProjects(organization: Organization): boolean {
+  return (
+    organization.access.includes('project:admin') ||
+    organization.access.includes('project:write')
+  );
+}

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -11,6 +11,7 @@ import Input from 'sentry/components/input';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import PlatformPicker from 'sentry/components/platformPicker';
+import {canViewerCreateProjects} from 'sentry/components/projects/utils';
 import TeamSelector from 'sentry/components/teamSelector';
 import categoryList from 'sentry/data/platformCategories';
 import {IconAdd} from 'sentry/icons';
@@ -172,6 +173,7 @@ function CreateProject() {
   const canSubmitForm =
     !inFlight &&
     team &&
+    canViewerCreateProjects(organization) &&
     projectName !== '' &&
     (!shouldCreateCustomRule || conditions?.every?.(condition => condition.value));
 

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -11,7 +11,7 @@ import Input from 'sentry/components/input';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import PlatformPicker from 'sentry/components/platformPicker';
-import {canViewerCreateProjects} from 'sentry/components/projects/utils';
+import {canCreateProject} from 'sentry/components/projects/utils';
 import TeamSelector from 'sentry/components/teamSelector';
 import categoryList from 'sentry/data/platformCategories';
 import {IconAdd} from 'sentry/icons';
@@ -173,7 +173,7 @@ function CreateProject() {
   const canSubmitForm =
     !inFlight &&
     team &&
-    canViewerCreateProjects(organization) &&
+    canCreateProject(organization) &&
     projectName !== '' &&
     (!shouldCreateCustomRule || conditions?.every?.(condition => condition.value));
 

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -15,7 +15,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
-import {canViewerCreateProjects} from 'sentry/components/projects/utils';
+import {canCreateProject} from 'sentry/components/projects/utils';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
@@ -95,7 +95,7 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
     return <LoadingError message={t('An error occurred while fetching your projects')} />;
   }
 
-  const canCreateProjects = canViewerCreateProjects(organization);
+  const canCreateProjects = canCreateProject(organization);
   const canJoinTeam = organization.access.includes('team:read');
 
   const selectedTeams = getTeamParams(location ? location.query.team : '');

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -15,6 +15,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import {canViewerCreateProjects} from 'sentry/components/projects/utils';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
@@ -94,7 +95,7 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
     return <LoadingError message={t('An error occurred while fetching your projects')} />;
   }
 
-  const canCreateProjects = organization.access.includes('project:admin');
+  const canCreateProjects = canViewerCreateProjects(organization);
   const canJoinTeam = organization.access.includes('team:read');
 
   const selectedTeams = getTeamParams(location ? location.query.team : '');

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -10,6 +10,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
+import {canViewerCreateProjects} from 'sentry/components/projects/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {replayPlatforms} from 'sentry/data/platformCategories';
 import {IconInfo} from 'sentry/icons';
@@ -43,7 +44,7 @@ export default function ReplayOnboardingPanel() {
   const pageFilters = usePageFilters();
   const projects = useProjects();
   const organization = useOrganization();
-  const canCreateProjects = organization.access.includes('project:admin');
+  const canCreateProjects = canViewerCreateProjects(organization);
 
   const selectedProjects = projects.projects.filter(p =>
     pageFilters.selection.projects.includes(Number(p.id))

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -10,7 +10,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
-import {canViewerCreateProjects} from 'sentry/components/projects/utils';
+import {canCreateProject} from 'sentry/components/projects/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {replayPlatforms} from 'sentry/data/platformCategories';
 import {IconInfo} from 'sentry/icons';
@@ -44,7 +44,7 @@ export default function ReplayOnboardingPanel() {
   const pageFilters = usePageFilters();
   const projects = useProjects();
   const organization = useOrganization();
-  const canCreateProjects = canViewerCreateProjects(organization);
+  const canCreateProjects = canCreateProject(organization);
 
   const selectedProjects = projects.projects.filter(p =>
     pageFilters.selection.projects.includes(Number(p.id))

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -9,6 +9,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
+import {canViewerCreateProjects} from 'sentry/components/projects/utils';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -80,7 +81,7 @@ class OrganizationProjects extends AsyncView<Props, State> {
   renderBody(): React.ReactNode {
     const {projectList, projectListPageLinks, projectStats} = this.state;
     const {organization} = this.props;
-    const canCreateProjects = organization.access.includes('project:admin');
+    const canCreateProjects = canViewerCreateProjects(organization);
 
     const action = (
       <Button

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -9,7 +9,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
-import {canViewerCreateProjects} from 'sentry/components/projects/utils';
+import {canCreateProject} from 'sentry/components/projects/utils';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -81,7 +81,7 @@ class OrganizationProjects extends AsyncView<Props, State> {
   renderBody(): React.ReactNode {
     const {projectList, projectListPageLinks, projectStats} = this.state;
     const {organization} = this.props;
-    const canCreateProjects = canViewerCreateProjects(organization);
+    const canCreateProjects = canCreateProject(organization);
 
     const action = (
       <Button


### PR DESCRIPTION


There are multiple places in the codebase that decide if we want to show "create project" button to the user. This commit solidifies the logic for 2 reasons:
1. We don't want these paths to have different logic. Eligibility has to stay the same no matter what product is calling it.
2. We're going to experiment with showing the button to more people and this helps keep experimentation code in one place too.