### PR TITLE
ref(mute alerts): Don't send muted alerts to integrations

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -104,7 +104,8 @@ def send_notification_as_slack(
     shared_context: Mapping[str, Any],
     extra_context_by_actor: Mapping[RpcActor, Mapping[str, Any]] | None,
 ) -> None:
-    """Send an "activity" or "alert rule" notification to a Slack user or team."""
+    """Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
+    Sending Slack notifications to a channel is in integrations/slack/actions/notification.py"""
     with sentry_sdk.start_span(
         op="notification.send_slack", description="gen_channel_integration_map"
     ):

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -53,7 +53,6 @@ class RuleProcessorTest(TestCase):
             project=self.group_event.project,
             data={"conditions": [EVERY_EVENT_COND_DATA], "actions": [EMAIL_ACTION_DATA]},
         )
-        self.integration = install_slack(self.organization)
 
     # this test relies on a few other tests passing
     def test_integrated(self):
@@ -124,15 +123,16 @@ class RuleProcessorTest(TestCase):
         results = list(rp.apply())
         assert len(results) == 0
 
-    def test_muted_rule(self):
+    def test_muted_slack_rule(self):
         """Test that we don't sent a notification for a muted Slack rule"""
+        integration = install_slack(self.organization)
         action_data = [
             {
                 "channel": "#my-channel",
                 "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
                 "name": "Send a notification to the funinthesun Slack workspace to #secrets and show tags [] in notification",
                 "tags": "",
-                "workspace": self.integration.id,
+                "workspace": integration.id,
             },
         ]
         slack_rule = self.create_project_rule(self.project, action_data)


### PR DESCRIPTION
We shouldn't send a notification to an integration if the rule has been muted for everyone - this specifically covers the case where the rule action says to notify a channel, rather than the case where you notify a user or team and we follow the notification settings.

Fixes #49338 