### PR TITLE
fix(issues): Avoid adding groups to the store after the component is unmounted

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -396,7 +396,7 @@ export function getAnalyticsDataForGroup(group?: Group | null): CommonGroupAnaly
     has_owner: group?.owners ? group?.owners.length > 0 : false,
     integration_assignment_source: group ? getAssignmentIntegration(group) : '',
     num_participants: group?.participants?.length ?? 0,
-    num_viewers: group?.seenBy.filter(user => user.id !== activeUser?.id).length ?? 0,
+    num_viewers: group?.seenBy?.filter(user => user.id !== activeUser?.id).length ?? 0,
     group_num_user_feedback: group?.userReportCount ?? 0,
   };
 }

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -175,6 +175,7 @@ function isSavedAlertRule(rule: State['rule']): rule is IssueAlertRule {
 class IssueRuleEditor extends AsyncView<Props, State> {
   pollingTimeout: number | undefined = undefined;
   trackIncompatibleAnalytics: boolean = false;
+  isUnmounted = false;
 
   get isDuplicateRule(): boolean {
     const {location} = this.props;
@@ -187,6 +188,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 
   componentWillUnmount() {
+    this.isUnmounted = true;
     GroupStore.reset();
     window.clearTimeout(this.pollingTimeout);
     this.checkIncompatibleRuleDebounced.cancel();
@@ -405,6 +407,10 @@ class IssueRuleEditor extends AsyncView<Props, State> {
         },
       })
       .then(([data, _, resp]) => {
+        if (this.isUnmounted) {
+          return;
+        }
+
         GroupStore.add(data);
 
         const pageLinks = resp?.getResponseHeader('Link');


### PR DESCRIPTION
The alert preview request could finish after the user has navigated to alerts putting the wrong set of data into the group store. Ideally we would stop using the group store this way.

fixes JAVASCRIPT-2M1A
