### PR TITLE
fix(replays): Show more accurate reasons why replays are not connected to errors

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -50,21 +50,33 @@ function ReplayPreview({orgSlug, replaySlug, event}: Props) {
 
   if (fetchError) {
     const reasons = [
-      t('The replay is still processing'),
-      t('The replay has been deleted by a member in your organization'),
-      t('There is an internal system error'),
+      t('The replay was rate-limited and could not be accepted.'),
+      t('The replay has been deleted by a member in your organization.'),
+      t('There were network errors and the replay was not saved.'),
+      tct('[link:Read the docs] to understand why.', {
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking" />
+        ),
+      }),
     ];
 
     return (
-      <Alert type="info" showIcon data-test-id="replay-error">
+      <Alert
+        type="info"
+        showIcon
+        data-test-id="replay-error"
+        trailingItems={
+          <Button
+            size="xs"
+            href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking"
+          >
+            {t('Read Docs')}
+          </Button>
+        }
+      >
         <p>
-          {tct(
-            'The replay for this event cannot be found. [link:Read the docs to understand why]. This could be due to these reasons:',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking" />
-              ),
-            }
+          {t(
+            'The replay for this event cannot be found. This could be due to these reasons:'
           )}
         </p>
         <List symbol="bullet">

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -67,8 +67,9 @@ function ReplayPreview({orgSlug, replaySlug, event}: Props) {
         data-test-id="replay-error"
         trailingItems={
           <Button
-            size="xs"
+            external
             href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking"
+            size="xs"
           >
             {t('Read Docs')}
           </Button>


### PR DESCRIPTION
Update the copy explaining reasons why a replay is not viewable, even though this event has a replay_id field.

Before:
![Screenshot 2023-05-16 at 12 26 03 PM](https://github.com/getsentry/sentry/assets/187460/c27170f3-71ab-4fd6-8cd0-b6794b1ac61b)


After:
"read docs" is on the right, easier to spot
"read docs" is also in the list as a bullet.

<img width="909" alt="SCR-20230517-onxl" src="https://github.com/getsentry/sentry/assets/187460/d3f6d4b6-4ef5-4c87-88b3-aa7bf1e1de0f">

