### PR TITLE
feat(sort): consider an error's log_level and stackframe in better priority sort

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -164,9 +164,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         """Temporary function to be used while developing the new priority sort"""
         return {
             "better_priority": {
-                "log_level": request.GET.get("logLevel", 5),
-                "frequency": request.GET.get("frequency", 5),
-                "has_stacktrace": request.GET.get("hasStacktrace", 5),
+                "log_level": request.GET.get("logLevel", 1),
+                "frequency": request.GET.get("frequency", 1),
+                "has_stacktrace": request.GET.get("hasStacktrace", 1),
             }
         }
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -164,9 +164,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         """Temporary function to be used while developing the new priority sort"""
         return {
             "better_priority": {
-                "log_level": request.GET.get("logLevel", 1),
-                "frequency": request.GET.get("frequency", 1),
-                "has_stacktrace": request.GET.get("hasStacktrace", 1),
+                "log_level": request.GET.get("logLevel", 0),
+                "frequency": request.GET.get("frequency", 0),
+                "has_stacktrace": request.GET.get("hasStacktrace", 0),
             }
         }
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -167,6 +167,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 "log_level": request.GET.get("logLevel", 0),
                 "frequency": request.GET.get("frequency", 0),
                 "has_stacktrace": request.GET.get("hasStacktrace", 0),
+                "event_halflife_hours": request.GET.get("eventHalflifeHours", 4),
             }
         }
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -455,7 +455,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
 def better_priority_aggregation(
     start: datetime,
     end: datetime,
-    aggregate_kwargs: Optional[PrioritySortWeights] = None,
+    aggregate_kwargs: PrioritySortWeights,
 ) -> Sequence[str]:
     issue_age_weight = 1  # [0, 5]
     event_age_weight = 1  # [0, 5]

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -458,17 +458,44 @@ def better_priority_aggregation(
     aggregate_kwargs: Optional[PrioritySortWeights] = None,
 ) -> Sequence[str]:
     event_age_hours = "divide(now() - timestamp, 3600)"
-    event_score = 1
+    event_age_weight = 1
     min_score = 0.01
     max_pow = 16
     event_halflife_hours = 4  # halves score every 4 hours
-    aggregate_event_score = f"greatest({min_score}, sum(divide({event_score}, pow(2, least({max_pow}, divide({event_age_hours}, {event_halflife_hours}))))))"
+    aggregate_event_score = f"greatest({min_score}, sum(divide({event_age_weight}, pow(2, least({max_pow}, divide({event_age_hours}, {event_halflife_hours}))))))"
     issue_age_hours = "divide(now() - min(timestamp), 3600)"
-    issue_score = 1
+    issue_age_weight = 1
     issue_halflife_hours = 24 * 7  # issues half in value every week
-    aggregate_issue_score = f"greatest({min_score}, divide({issue_score}, pow(2, least({max_pow}, divide({issue_age_hours}, {issue_halflife_hours})))))"
+    aggregate_issue_score = f"greatest({min_score}, divide({issue_age_weight}, pow(2, least({max_pow}, divide({issue_age_hours}, {issue_halflife_hours})))))"
 
-    return [f"multiply({aggregate_event_score}, {aggregate_issue_score})", ""]
+    if aggregate_kwargs is None:
+        return [f"multiply({aggregate_event_score}, {aggregate_issue_score})", ""]
+    else:
+        # probably not needed
+        event_age_weight = 1  # [0, 5]
+        issue_age_weight = 1  # [0, 5]
+        # TODO: we have no way of aggregating to account for frequency:
+        #  (errors within group) / (total events grouped by project)
+        #  keeping this here for now but we should probably delete
+        # frequency_weight = aggregate_kwargs["frequency"]  # [0, 5]
+        # frequency_score = f"countIf(and(greater(toDateTime('{start_str}'), timestamp), lessOrEquals(toDateTime('{end_str}'), timestamp))) / count()"
+
+        # event-level
+        log_level_weight = aggregate_kwargs["log_level"]  # [0, 10]
+        stacktrace_weight = aggregate_kwargs["has_stacktrace"]  # [0, 3]
+
+        log_level_score = "multiIf(equals(level, 'fatal'), 1.0, equals(level, 'error'), 0.66, equals(level, 'warning'), 0.33, 0.0)"
+        stacktrace_score = "if(equals(exception_frames.function, array()), 0.0, 1.0)"
+        event_agg_numerator = f"plus(plus(multiply({log_level_score}, {log_level_weight}), multiply({stacktrace_score}, {stacktrace_weight})), {event_age_weight})"
+        event_agg_denominator = (
+            f"plus(plus({log_level_weight}, {stacktrace_weight}), {event_age_weight})"
+        )
+        event_agg_rank = f"divide({event_agg_numerator}, {event_agg_denominator})"
+
+        aggregate_event_score = f"greatest({min_score}, sum(divide({event_agg_rank}, pow(2, least({max_pow}, divide({event_age_hours}, {event_halflife_hours}))))))"
+        aggregate_issue_score = f"greatest({min_score}, divide({issue_age_weight}, pow(2, least({max_pow}, divide({issue_age_hours}, {issue_halflife_hours})))))"
+
+        return [f"multiply({aggregate_event_score}, {aggregate_issue_score})", ""]
 
 
 class PostgresSnubaQueryExecutor(AbstractQueryExecutor):

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -473,7 +473,7 @@ def better_priority_aggregation(
     # frequency_score = f"countIf(and(greater(toDateTime('{start_str}'), timestamp), lessOrEquals(toDateTime('{end_str}'), timestamp))) / count()"
 
     log_level_score = "multiIf(equals(level, 'fatal'), 1.0, equals(level, 'error'), 0.66, equals(level, 'warning'), 0.33, 0.0)"
-    stacktrace_score = "if(equals(exception_frames.module, array()), 0.0, 1.0)"
+    stacktrace_score = "if(notEmpty(exception_stacks.type), 1.0, 0.0)"
     event_agg_numerator = f"plus(plus(multiply({log_level_score}, {log_level_weight}), multiply({stacktrace_score}, {stacktrace_weight})), {event_age_weight})"
     event_agg_denominator = (
         f"plus(plus({log_level_weight}, {stacktrace_weight}), {event_age_weight})"

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -56,6 +56,7 @@ class PrioritySortWeights(TypedDict):
     log_level: int
     frequency: int
     has_stacktrace: int
+    event_halflife_hours: int
 
 
 def get_search_filter(
@@ -463,7 +464,7 @@ def better_priority_aggregation(
     max_pow = 16
     min_score = 0.01
     event_age_hours = "divide(now() - timestamp, 3600)"
-    event_halflife_hours = 4  # halves score every 4 hours
+    event_halflife_hours = aggregate_kwargs["event_halflife_hours"]  # halves score every 4 hours
     issue_age_hours = "divide(now() - min(timestamp), 3600)"
     issue_halflife_hours = 24 * 7  # issues half in value every week
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -158,6 +158,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             "log_level": 3,
             "frequency": 5,
             "has_stacktrace": 5,
+            "eventHalflifeHours": 4,
         }
 
         response = self.get_success_response(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -374,279 +374,6 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             )
         assert list(results) == [self.group2, self.group1]
 
-    def test_better_priority_sort_old_and_new_events(self):
-        """Test that an issue with only one old event is ranked lower than an issue with only one new event"""
-        new_project = self.create_project(organization=self.project.organization)
-
-        recent_event = self.store_event(
-            data={
-                "fingerprint": ["put-me-in-recent-group"],
-                "event_id": "c" * 32,
-                "message": "group1",
-                "environment": "production",
-                "tags": {"server": "example.com", "sentry:user": "event3@example.com"},
-                "timestamp": iso_format(self.base_datetime),
-                "stacktrace": {"frames": [{"module": "group1"}]},
-            },
-            project_id=new_project.id,
-        )
-        old_event = self.store_event(
-            data={
-                "fingerprint": ["put-me-in-old-group"],
-                "event_id": "a" * 32,
-                "message": "foo. Also, this message is intended to be greater than 256 characters so that we can put some unique string identifier after that point in the string. The purpose of this is in order to verify we are using snuba to search messages instead of Postgres (postgres truncates at 256 characters and clickhouse does not). santryrox.",
-                "environment": "production",
-                "tags": {"server": "example.com", "sentry:user": "old_event@example.com"},
-                "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
-                "stacktrace": {"frames": [{"module": "group1"}]},
-            },
-            project_id=new_project.id,
-        )
-        old_event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
-
-        with self.feature("organizations:issue-list-better-priority-sort"):
-            weights: PrioritySortWeights = {
-                "log_level": 5,
-                "frequency": 5,
-                "has_stacktrace": 5,
-                "event_halflife_hours": 4,
-            }
-            results = self.make_query(
-                sort_by="betterPriority",
-                projects=[new_project],
-                aggregate_kwargs=weights,
-            )
-        recent_group = Group.objects.get(id=recent_event.group.id)
-        old_group = Group.objects.get(id=old_event.group.id)
-        assert list(results) == [recent_group, old_group]
-
-    def test_better_priority_log_level_results(self):
-        """Test that the scoring results change when we pass in different log level weights"""
-        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
-        event1 = self.store_event(
-            data={
-                "fingerprint": ["put-me-in-group1"],
-                "event_id": "a" * 32,
-                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
-                "message": "foo",
-                "stacktrace": {"frames": [{"module": "group1"}]},
-                "environment": "staging",
-                "level": "fatal",
-            },
-            project_id=self.project.id,
-        )
-        event2 = self.store_event(
-            data={
-                "fingerprint": ["put-me-in-group2"],
-                "event_id": "b" * 32,
-                "timestamp": iso_format(base_datetime),
-                "message": "bar",
-                "stacktrace": {"frames": [{"module": "group2"}]},
-                "environment": "staging",
-                "level": "error",
-            },
-            project_id=self.project.id,
-        )
-        group1 = Group.objects.get(id=event1.group.id)
-        group2 = Group.objects.get(id=event2.group.id)
-
-        agg_kwargs = {
-            "better_priority": {
-                "log_level": 0,
-                "frequency": 0,
-                "has_stacktrace": 0,
-                "event_halflife_hours": 4,
-            }
-        }
-        query_executor = self.backend._get_query_executor()
-        results = query_executor.snuba_search(
-            start=None,
-            end=None,
-            project_ids=[self.project.id],
-            environment_ids=[],
-            sort_field="better_priority",
-            organization=self.organization,
-            group_ids=[group1.id, group2.id],
-            limit=150,
-            aggregate_kwargs=agg_kwargs,
-        )[0]
-        group1_score_before = results[0][1]
-        group2_score_before = results[1][1]
-        # initially group 2's score is higher since it has a more recent event
-        assert group2_score_before > group1_score_before
-
-        agg_kwargs["better_priority"].update({"log_level": 5})
-        results = query_executor.snuba_search(
-            start=None,
-            end=None,
-            project_ids=[self.project.id],
-            environment_ids=[],
-            sort_field="better_priority",
-            organization=self.organization,
-            group_ids=[group1.id, group2.id],
-            limit=150,
-            aggregate_kwargs=agg_kwargs,
-        )[0]
-        group1_score_after = results[0][1]
-        group2_score_after = results[1][1]
-        # ensure fatal has a higher score than error
-        assert group1_score_after > group2_score_after
-        # check that passing a higher log level weight changes the score from when it was 0
-        assert group1_score_before != group1_score_after
-        assert group2_score_before != group2_score_after
-
-    def test_better_priority_has_stacktrace_results(self):
-        """Test that the scoring results change when we pass in different has_stacktrace weights"""
-        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
-        agg_kwargs = {
-            "better_priority": {
-                "log_level": 0,
-                "frequency": 0,
-                "has_stacktrace": 0,
-                "event_halflife_hours": 4,
-            }
-        }
-        query_executor = self.backend._get_query_executor()
-
-        no_stacktrace_event = self.store_event(
-            data={
-                "event_id": "d" * 32,
-                "message": "oh no",
-                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
-            },
-            project_id=self.project.id,
-        )
-        group1 = Group.objects.get(id=no_stacktrace_event.group.id)
-
-        stacktrace_event = self.store_event(
-            data={
-                "event_id": "d" * 32,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "AnError",
-                            "value": "Bad request",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "module": "<my module>",
-                                    },
-                                ]
-                            },
-                        }
-                    ]
-                },
-                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
-            },
-            project_id=self.project.id,
-        )
-        group2 = Group.objects.get(id=stacktrace_event.group.id)
-
-        results = query_executor.snuba_search(
-            start=None,
-            end=None,
-            project_ids=[self.project.id],
-            environment_ids=[],
-            sort_field="better_priority",
-            organization=self.organization,
-            group_ids=[group1.id, group2.id],
-            limit=150,
-            aggregate_kwargs=agg_kwargs,
-        )[0]
-        group1_score = results[0][1]
-        group2_score = results[1][1]
-        assert group1_score == group2_score
-
-        agg_kwargs["better_priority"].update({"has_stacktrace": 3})
-        results = query_executor.snuba_search(
-            start=None,
-            end=None,
-            project_ids=[self.project.id],
-            environment_ids=[],
-            sort_field="better_priority",
-            organization=self.organization,
-            group_ids=[group1.id, group2.id],
-            limit=150,
-            aggregate_kwargs=agg_kwargs,
-        )[0]
-        group1_score = results[0][1]
-        group2_score = results[1][1]
-        # check that a group with an event with a stacktrace has a higher weight than one without
-        assert group1_score < group2_score
-
-    def test_better_priority_event_halflife_results(self):
-        """Test that the scoring results change when we pass in different event halflife weights"""
-        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
-        event1 = self.store_event(
-            data={
-                "fingerprint": ["put-me-in-group1"],
-                "event_id": "a" * 32,
-                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
-                "message": "foo",
-                "stacktrace": {"frames": [{"module": "group1"}]},
-                "environment": "staging",
-                "level": "fatal",
-            },
-            project_id=self.project.id,
-        )
-        event2 = self.store_event(
-            data={
-                "fingerprint": ["put-me-in-group2"],
-                "event_id": "b" * 32,
-                "timestamp": iso_format(base_datetime),
-                "message": "bar",
-                "stacktrace": {"frames": [{"module": "group2"}]},
-                "environment": "staging",
-                "level": "error",
-            },
-            project_id=self.project.id,
-        )
-        group1 = Group.objects.get(id=event1.group.id)
-        group2 = Group.objects.get(id=event2.group.id)
-
-        agg_kwargs = {
-            "better_priority": {
-                "log_level": 0,
-                "frequency": 0,
-                "has_stacktrace": 0,
-                "event_halflife_hours": 4,
-            }
-        }
-        query_executor = self.backend._get_query_executor()
-        results = query_executor.snuba_search(
-            start=None,
-            end=None,
-            project_ids=[self.project.id],
-            environment_ids=[],
-            sort_field="better_priority",
-            organization=self.organization,
-            group_ids=[group1.id, group2.id],
-            limit=150,
-            aggregate_kwargs=agg_kwargs,
-        )[0]
-        group1_score_before = results[0][1]
-        group2_score_before = results[1][1]
-        # initially group 2's score is higher since it has a more recent event
-        assert group2_score_before > group1_score_before
-
-        agg_kwargs["better_priority"].update({"event_halflife_hours": 2})
-        results = query_executor.snuba_search(
-            start=None,
-            end=None,
-            project_ids=[self.project.id],
-            environment_ids=[],
-            sort_field="better_priority",
-            organization=self.organization,
-            group_ids=[group1.id, group2.id],
-            limit=150,
-            aggregate_kwargs=agg_kwargs,
-        )[0]
-        group1_score_after = results[0][1]
-        group2_score_after = results[1][1]
-        # check that passing a lower event halflife weight changes the score from when it was 0
-        assert group1_score_before != group1_score_after
-        assert group2_score_before != group2_score_after
-
     def test_sort_with_environment(self):
         for dt in [
             self.group1.first_seen + timedelta(days=1),
@@ -2336,6 +2063,290 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         )
 
         assert len(results) == 0
+
+
+class EventsBetterPriorityTest(SharedSnubaTest):
+    @property
+    def backend(self):
+        return EventsDatasetSnubaSearchBackend()
+
+    def test_better_priority_sort_old_and_new_events(self):
+        """Test that an issue with only one old event is ranked lower than an issue with only one new event"""
+        new_project = self.create_project(organization=self.project.organization)
+        base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+
+        recent_event = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-recent-group"],
+                "event_id": "c" * 32,
+                "message": "group1",
+                "environment": "production",
+                "tags": {"server": "example.com", "sentry:user": "event3@example.com"},
+                "timestamp": iso_format(base_datetime),
+                "stacktrace": {"frames": [{"module": "group1"}]},
+            },
+            project_id=new_project.id,
+        )
+        old_event = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-old-group"],
+                "event_id": "a" * 32,
+                "message": "foo. Also, this message is intended to be greater than 256 characters so that we can put some unique string identifier after that point in the string. The purpose of this is in order to verify we are using snuba to search messages instead of Postgres (postgres truncates at 256 characters and clickhouse does not). santryrox.",
+                "environment": "production",
+                "tags": {"server": "example.com", "sentry:user": "old_event@example.com"},
+                "timestamp": iso_format(base_datetime - timedelta(days=20)),
+                "stacktrace": {"frames": [{"module": "group1"}]},
+            },
+            project_id=new_project.id,
+        )
+        old_event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
+
+        with self.feature("organizations:issue-list-better-priority-sort"):
+            weights: PrioritySortWeights = {
+                "log_level": 5,
+                "frequency": 5,
+                "has_stacktrace": 5,
+                "event_halflife_hours": 4,
+            }
+            results = self.make_query(
+                sort_by="betterPriority",
+                projects=[new_project],
+                aggregate_kwargs=weights,
+            )
+        recent_group = Group.objects.get(id=recent_event.group.id)
+        old_group = Group.objects.get(id=old_event.group.id)
+        assert list(results) == [recent_group, old_group]
+
+    def test_better_priority_log_level_results(self):
+        """Test that the scoring results change when we pass in different log level weights"""
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+        event1 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group1"],
+                "event_id": "c" * 32,
+                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
+                "message": "foo",
+                "stacktrace": {"frames": [{"module": "group1"}]},
+                "environment": "staging",
+                "level": "fatal",
+            },
+            project_id=self.project.id,
+        )
+        event2 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group2"],
+                "event_id": "d" * 32,
+                "timestamp": iso_format(base_datetime),
+                "message": "bar",
+                "stacktrace": {"frames": [{"module": "group2"}]},
+                "environment": "staging",
+                "level": "error",
+            },
+            project_id=self.project.id,
+        )
+        group1 = Group.objects.get(id=event1.group.id)
+        group2 = Group.objects.get(id=event2.group.id)
+
+        agg_kwargs = {
+            "better_priority": {
+                "log_level": 0,
+                "frequency": 0,
+                "has_stacktrace": 0,
+                "event_halflife_hours": 4,
+            }
+        }
+        query_executor = self.backend._get_query_executor()
+        results_zero_log_level = query_executor.snuba_search(
+            start=None,
+            end=None,
+            project_ids=[self.project.id],
+            environment_ids=[],
+            sort_field="better_priority",
+            organization=self.organization,
+            group_ids=[group1.id, group2.id],
+            limit=150,
+            aggregate_kwargs=agg_kwargs,
+        )[0]
+        group1_score_before = results_zero_log_level[0][1]
+        group2_score_before = results_zero_log_level[1][1]
+        # initially group 2's score is higher since it has a more recent event
+        assert group2_score_before > group1_score_before
+
+        # agg_kwargs["better_priority"].update({"log_level": 5})
+        agg_kwargs_after = {
+            "better_priority": {
+                "log_level": 10,
+                "frequency": 0,
+                "has_stacktrace": 0,
+                "event_halflife_hours": 4,
+            }
+        }
+
+        results2 = query_executor.snuba_search(
+            start=None,
+            end=None,
+            project_ids=[self.project.id],
+            environment_ids=[],
+            sort_field="better_priority",
+            organization=self.organization,
+            group_ids=[group1.id, group2.id],
+            limit=150,
+            aggregate_kwargs=agg_kwargs_after,
+        )[0]
+        group1_score_after = results2[0][1]
+        group2_score_after = results2[1][1]
+        # ensure fatal has a higher score than error
+        assert group1_score_after > group2_score_after
+
+    def test_better_priority_has_stacktrace_results(self):
+        """Test that the scoring results change when we pass in different has_stacktrace weights"""
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+        agg_kwargs = {
+            "better_priority": {
+                "log_level": 0,
+                "frequency": 0,
+                "has_stacktrace": 0,
+                "event_halflife_hours": 4,
+            }
+        }
+        query_executor = self.backend._get_query_executor()
+
+        no_stacktrace_event = self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "message": "oh no",
+                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
+            },
+            project_id=self.project.id,
+        )
+        group1 = Group.objects.get(id=no_stacktrace_event.group.id)
+
+        stacktrace_event = self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "exception": {
+                    "values": [
+                        {
+                            "type": "AnError",
+                            "value": "Bad request",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "module": "<my module>",
+                                    },
+                                ]
+                            },
+                        }
+                    ]
+                },
+                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
+            },
+            project_id=self.project.id,
+        )
+        group2 = Group.objects.get(id=stacktrace_event.group.id)
+
+        results = query_executor.snuba_search(
+            start=None,
+            end=None,
+            project_ids=[self.project.id],
+            environment_ids=[],
+            sort_field="better_priority",
+            organization=self.organization,
+            group_ids=[group1.id, group2.id],
+            limit=150,
+            aggregate_kwargs=agg_kwargs,
+        )[0]
+        group1_score = results[0][1]
+        group2_score = results[1][1]
+        assert group1_score == group2_score
+
+        agg_kwargs["better_priority"].update({"has_stacktrace": 3})
+        results = query_executor.snuba_search(
+            start=None,
+            end=None,
+            project_ids=[self.project.id],
+            environment_ids=[],
+            sort_field="better_priority",
+            organization=self.organization,
+            group_ids=[group1.id, group2.id],
+            limit=150,
+            aggregate_kwargs=agg_kwargs,
+        )[0]
+        group1_score = results[0][1]
+        group2_score = results[1][1]
+        # check that a group with an event with a stacktrace has a higher weight than one without
+        assert group1_score < group2_score
+
+    def test_better_priority_event_halflife_results(self):
+        """Test that the scoring results change when we pass in different event halflife weights"""
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+        event1 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group1"],
+                "event_id": "a" * 32,
+                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
+                "message": "foo",
+                "stacktrace": {"frames": [{"module": "group1"}]},
+                "environment": "staging",
+                "level": "fatal",
+            },
+            project_id=self.project.id,
+        )
+        event2 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group2"],
+                "event_id": "b" * 32,
+                "timestamp": iso_format(base_datetime),
+                "message": "bar",
+                "stacktrace": {"frames": [{"module": "group2"}]},
+                "environment": "staging",
+                "level": "error",
+            },
+            project_id=self.project.id,
+        )
+        group1 = Group.objects.get(id=event1.group.id)
+        group2 = Group.objects.get(id=event2.group.id)
+
+        agg_kwargs = {
+            "better_priority": {
+                "log_level": 0,
+                "frequency": 0,
+                "has_stacktrace": 0,
+                "event_halflife_hours": 4,
+            }
+        }
+        query_executor = self.backend._get_query_executor()
+        results = query_executor.snuba_search(
+            start=None,
+            end=None,
+            project_ids=[self.project.id],
+            environment_ids=[],
+            sort_field="better_priority",
+            organization=self.organization,
+            group_ids=[group1.id, group2.id],
+            limit=150,
+            aggregate_kwargs=agg_kwargs,
+        )[0]
+        group1_score_before = results[0][1]
+        group2_score_before = results[1][1]
+        # initially group 2's score is higher since it has a more recent event
+        assert group2_score_before > group1_score_before
+
+        agg_kwargs["better_priority"].update({"event_halflife_hours": 2})
+        results = query_executor.snuba_search(
+            start=None,
+            end=None,
+            project_ids=[self.project.id],
+            environment_ids=[],
+            sort_field="better_priority",
+            organization=self.organization,
+            group_ids=[group1.id, group2.id],
+            limit=150,
+            aggregate_kwargs=agg_kwargs,
+        )[0]
+        group1_score_after = results[0][1]
+        group2_score_after = results[1][1]
+        assert group1_score_after < group2_score_after
 
 
 class EventsTransactionsSnubaSearchTest(SharedSnubaTest):

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -484,7 +484,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
     def test_better_priority_has_stacktrace_results(self):
         """Test that the scoring results change when we pass in different has_stacktrace weights"""
         base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
-        agg_kwargs = {"better_priority": {"log_level": 1, "frequency": 1, "has_stacktrace": 1}}
+        agg_kwargs = {"better_priority": {"log_level": 1, "frequency": 1, "has_stacktrace": 0}}
         query_executor = self.backend._get_query_executor()
 
         no_stacktrace_event = self.store_event(
@@ -500,7 +500,22 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         stacktrace_event = self.store_event(
             data={
                 "event_id": "d" * 32,
-                "stacktrace": {"frames": [{"module": "group2"}]},
+                "exception": {
+                    "values": [
+                        {
+                            "type": "AnError",
+                            "value": "Bad request",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "module": "<my module>",
+                                        # "function": "main",
+                                    },
+                                ]
+                            },
+                        }
+                    ]
+                },
                 "timestamp": iso_format(base_datetime - timedelta(hours=1)),
             },
             project_id=self.project.id,


### PR DESCRIPTION
Add the aggregate kwargs `log_level`, `has_stacktrace`, and `event_halflife_hours` into the sort algorithm so we can test internally. 