### PR TITLE
feat(js): Add linked error in `handleXhrErrorResponse`

### DIFF
--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -17,6 +17,10 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
       responseJSON,
     });
 
-    Sentry.captureException(new Error(message));
+    Sentry.captureException(
+      // We need to typecheck here even though `err` is typed in the function
+      // signature because TS doesn't type thrown or rejected errors
+      err instanceof Error ? new Error(message, {cause: err}) : new Error(message)
+    );
   });
 }


### PR DESCRIPTION
This changes `handleXhrErrorResponse` to use the incoming `RequestError` as the `cause` for the new error it creates, which allows us to see much more of the stacktrace.

Before:

![image](https://github.com/getsentry/sentry/assets/14812505/32fe776f-24f7-4ce0-82d3-87af313f7d77)


After:

![image](https://github.com/getsentry/sentry/assets/14812505/5a8c3510-5f1c-483b-8acd-e3c0523797f5)
