### PR TITLE
fix(crons): Allow alert_rule_id for config validator

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -54,6 +54,7 @@ MONITOR_CONFIG = {
         "timezone": {"type": ["string", "null"]},
         "schedule_type": {"type": "integer"},
         "schedule": {"type": ["string", "array"]},
+        "alert_rule_id": {"type": ["integer", "null"]},
     },
     # TODO(davidenwang): Old monitors may not have timezone or schedule_type, these should be added here once we've cleaned up old data
     "required": ["checkin_margin", "max_runtime", "schedule"],

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -341,3 +341,26 @@ class MonitorEnvironmentTestCase(TestCase):
             "max_runtime": 10,
             "alert_rule_id": 1,
         }
+
+    def test_config_validator(self):
+        monitor = Monitor.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            type=MonitorType.CRON_JOB,
+            name="Unicron",
+            slug="unicron",
+            config={
+                "checkin_margin": None,
+                "max_runtime": None,
+                "schedule": [1, "month"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "alert_rule_id": 1,
+            },
+        )
+        validated_config = monitor.get_validated_config()
+        assert validated_config is not None
+
+        # Check to make sure bad config fails validation
+        validated_config["bad_key"] = 100
+        monitor.config = validated_config
+        assert monitor.get_validated_config() is None


### PR DESCRIPTION
Allows `alert_rule_id` to live in the `Monitor` config and pass the validator

Fixes SENTRY-11FG
Fixes SENTRY-11FH
Fixes SENTRY-11FK
Fixes SENTRY-11FJ
Fixes SENTRY-11FM