### PR TITLE
feat(derived_code_mappings): Only query Github integrations that are active

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Tuple
 from sentry_sdk import set_tag, set_user
 
 from sentry import features
+from sentry.constants import ObjectStatus
 from sentry.db.models.fields.node import NodeData
 from sentry.integrations.utils.code_mapping import CodeMapping, CodeMappingTreesHelper
 from sentry.locks import locks
@@ -171,7 +172,9 @@ def get_installation(
     organization: Organization,
 ) -> Tuple[IntegrationInstallation | None, RpcOrganizationIntegration | None]:
     integrations = integration_service.get_integrations(
-        organization_id=organization.id, providers=["github"]
+        organization_id=organization.id,
+        providers=["github"],
+        status=ObjectStatus.ACTIVE,
     )
     if len(integrations) == 0:
         return None, None


### PR DESCRIPTION
[This event](https://sentry.sentry.io/issues/4188009977/events/c0459e0ec92745d6ae74f99b101c4d57/?project=1) shows a 404 in the HTTPError:
```
404 Client Error: Not Found for url: https://api.github.com/app/installations/<some_id>/access_tokens
```

After finding the org and I noticed that their Github integration is marked as disabled in the UI even though it is installed. Redash shows that the status is set to 1.

[The code](https://github.com/getsentry/sentry/blob/a5f0b1033b9dc01a0ef547ad7ae7ebd235191c62/src/sentry/models/integrations/integration.py#L31) for the model shows that we need to use the `ObjectStatus.ACTIVE` to only get the active integrations.

Fixes [SENTRY-11C3](https://sentry.sentry.io/issues/4188009977/?project=1)