### PR TITLE
feat(starfish) Generic span view side panel

### DIFF
--- a/static/app/views/starfish/views/spans/spanDetails.tsx
+++ b/static/app/views/starfish/views/spans/spanDetails.tsx
@@ -4,6 +4,7 @@ import EndpointDetail, {
   EndpointDataRow,
 } from 'sentry/views/starfish/views/endpointDetails';
 import {SpanDataRow} from 'sentry/views/starfish/views/spans/spansTable';
+import {SpanSummaryPanel} from 'sentry/views/starfish/views/spans/spanSummaryPanel';
 
 type SpanDetailBodyProps = {
   row: SpanDataRow;
@@ -30,6 +31,6 @@ export default function SpanDetail({
         />
       );
     default:
-      return null;
+      return <SpanSummaryPanel span={row} onClose={onClose} />;
   }
 }

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
@@ -5,6 +5,7 @@ import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import Detail from 'sentry/views/starfish/components/detailPanel';
+import {SpanDescription} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanDescription';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 import {useSpanMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics';
 
@@ -18,9 +19,7 @@ export function SpanSummaryPanel({span, onClose}: Props) {
 
   return (
     <Detail detailKey={span?.group_id} onClose={onClose}>
-      <h2>{t('Span Summary')}</h2>
-      <SubHeader>{t('Description')}</SubHeader>
-      <pre>{span?.description}</pre>
+      <Header>{t('Span Summary')}</Header>
 
       <FlexRowContainer>
         <Block title={t('First Seen')}>
@@ -39,6 +38,14 @@ export function SpanSummaryPanel({span, onClose}: Props) {
           />
         </Block>
       </FlexRowContainer>
+
+      <FlexRowContainer>
+        {span && (
+          <Block title={t('Description')}>
+            <SpanDescription span={span} />
+          </Block>
+        )}
+      </FlexRowContainer>
     </Detail>
   );
 }
@@ -56,6 +63,8 @@ function Block({title, children}: BlockProps) {
     </FlexRowItem>
   );
 }
+
+const Header = styled('h2')``;
 
 const SubHeader = styled('h3')`
   color: ${p => p.theme.gray300};

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+
+import Detail from 'sentry/views/starfish/components/detailPanel';
+
+type Span = {
+  group_id: string;
+  action?: string;
+  description?: string;
+  domain?: string;
+};
+
+type Props = {
+  onClose: () => void;
+  span?: Span;
+};
+
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+export function SpanSummaryPanel({span, onClose}: Props) {
+  if (!span) {
+    return null;
+  }
+
+  return (
+    <Detail detailKey={span.group_id} onClose={onClose}>
+      <h2>{t('Span Summary')}</h2>
+      <SubHeader>{t('Description')}</SubHeader>
+      <pre>{span?.description}</pre>
+    </Detail>
+  );
+}
+
+const SubHeader = styled('h3')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin: 0;
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
@@ -8,6 +8,7 @@ import {space} from 'sentry/styles/space';
 import Chart from 'sentry/views/starfish/components/chart';
 import Detail from 'sentry/views/starfish/components/detailPanel';
 import {SpanDescription} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanDescription';
+import {SpanTransactionsTable} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 import {useSpanMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics';
 import {useSpanMetricSeries} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries';
@@ -27,7 +28,7 @@ export function SpanSummaryPanel({span, onClose}: Props) {
     <Detail detailKey={span?.group_id} onClose={onClose}>
       <Header>{t('Span Summary')}</Header>
 
-      <FlexRowContainer>
+      <BlockContainer>
         <Block title={t('First Seen')}>
           <TimeSince date={spanMetrics?.first_seen} />
         </Block>
@@ -43,17 +44,17 @@ export function SpanSummaryPanel({span, onClose}: Props) {
             abbreviation
           />
         </Block>
-      </FlexRowContainer>
+      </BlockContainer>
 
-      <FlexRowContainer>
+      <BlockContainer>
         {span && (
           <Block title={t('Description')}>
             <SpanDescription span={span} />
           </Block>
         )}
-      </FlexRowContainer>
+      </BlockContainer>
 
-      <FlexRowContainer>
+      <BlockContainer>
         <Block title={t('SPM')}>
           <Chart
             statsPeriod="24h"
@@ -86,7 +87,9 @@ export function SpanSummaryPanel({span, onClose}: Props) {
             hideYAxisSplitLine
           />
         </Block>
-      </FlexRowContainer>
+      </BlockContainer>
+
+      <BlockContainer>{span && <SpanTransactionsTable span={span} />}</BlockContainer>
     </Detail>
   );
 }
@@ -98,10 +101,10 @@ type BlockProps = {
 
 function Block({title, children}: BlockProps) {
   return (
-    <FlexRowItem>
+    <BlockWrapper>
       <SubHeader>{title}</SubHeader>
       <SubSubHeader>{children}</SubSubHeader>
-    </FlexRowItem>
+    </BlockWrapper>
   );
 }
 
@@ -119,7 +122,7 @@ const SubSubHeader = styled('h4')`
   font-weight: normal;
 `;
 
-const FlexRowContainer = styled('div')`
+const BlockContainer = styled('div')`
   display: flex;
   & > div:last-child {
     padding-right: ${space(1)};
@@ -127,7 +130,7 @@ const FlexRowContainer = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-const FlexRowItem = styled('div')`
+const BlockWrapper = styled('div')`
   padding-right: ${space(4)};
   flex: 1;
 `;

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
@@ -1,13 +1,10 @@
 import styled from '@emotion/styled';
 
+import Duration from 'sentry/components/duration';
+import TimeSince from 'sentry/components/timeSince';
 import Detail from 'sentry/views/starfish/components/detailPanel';
-
-type Span = {
-  group_id: string;
-  action?: string;
-  description?: string;
-  domain?: string;
-};
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+import {useSpanMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics';
 
 type Props = {
   onClose: () => void;
@@ -18,16 +15,46 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 export function SpanSummaryPanel({span, onClose}: Props) {
-  if (!span) {
-    return null;
-  }
+  const {data: spanMetrics} = useSpanMetrics(span);
 
   return (
-    <Detail detailKey={span.group_id} onClose={onClose}>
+    <Detail detailKey={span?.group_id} onClose={onClose}>
       <h2>{t('Span Summary')}</h2>
       <SubHeader>{t('Description')}</SubHeader>
       <pre>{span?.description}</pre>
+
+      <FlexRowContainer>
+        <Block title={t('First Seen')}>
+          <TimeSince date={spanMetrics?.first_seen} />
+        </Block>
+
+        <Block title={t('Last Seen')}>
+          <TimeSince date={spanMetrics?.last_seen} />
+        </Block>
+
+        <Block title={t('Total Time')}>
+          <Duration
+            seconds={spanMetrics?.total_time / 1000}
+            fixedDigits={2}
+            abbreviation
+          />
+        </Block>
+      </FlexRowContainer>
     </Detail>
+  );
+}
+
+type BlockProps = {
+  children: React.ReactNode;
+  title: React.ReactNode;
+};
+
+function Block({title, children}: BlockProps) {
+  return (
+    <FlexRowItem>
+      <SubHeader>{title}</SubHeader>
+      <SubSubHeader>{children}</SubSubHeader>
+    </FlexRowItem>
   );
 }
 
@@ -36,4 +63,22 @@ const SubHeader = styled('h3')`
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0;
   margin-bottom: ${space(1)};
+`;
+
+const SubSubHeader = styled('h4')`
+  margin: 0;
+  font-weight: normal;
+`;
+
+const FlexRowContainer = styled('div')`
+  display: flex;
+  & > div:last-child {
+    padding-right: ${space(1)};
+  }
+  padding-bottom: ${space(2)};
+`;
+
+const FlexRowItem = styled('div')`
+  padding-right: ${space(4)};
+  flex: 1;
 `;

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 import Duration from 'sentry/components/duration';
 import TimeSince from 'sentry/components/timeSince';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import Detail from 'sentry/views/starfish/components/detailPanel';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 import {useSpanMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics';
@@ -10,9 +12,6 @@ type Props = {
   onClose: () => void;
   span?: Span;
 };
-
-import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 export function SpanSummaryPanel({span, onClose}: Props) {
   const {data: spanMetrics} = useSpanMetrics(span);

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/index.tsx
@@ -1,13 +1,16 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Duration from 'sentry/components/duration';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import Chart from 'sentry/views/starfish/components/chart';
 import Detail from 'sentry/views/starfish/components/detailPanel';
 import {SpanDescription} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanDescription';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 import {useSpanMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics';
+import {useSpanMetricSeries} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries';
 
 type Props = {
   onClose: () => void;
@@ -15,7 +18,10 @@ type Props = {
 };
 
 export function SpanSummaryPanel({span, onClose}: Props) {
+  const theme = useTheme();
+
   const {data: spanMetrics} = useSpanMetrics(span);
+  const {data: spanMetricSeries} = useSpanMetricSeries(span);
 
   return (
     <Detail detailKey={span?.group_id} onClose={onClose}>
@@ -45,6 +51,41 @@ export function SpanSummaryPanel({span, onClose}: Props) {
             <SpanDescription span={span} />
           </Block>
         )}
+      </FlexRowContainer>
+
+      <FlexRowContainer>
+        <Block title={t('SPM')}>
+          <Chart
+            statsPeriod="24h"
+            height={140}
+            data={[spanMetricSeries.spm]}
+            start=""
+            end=""
+            loading={false}
+            utc={false}
+            stacked
+            isLineChart
+            disableXAxis
+            hideYAxisSplitLine
+          />
+        </Block>
+
+        <Block title={t('Duration')}>
+          <Chart
+            statsPeriod="24h"
+            height={140}
+            data={[spanMetricSeries.p50, spanMetricSeries.p95]}
+            start=""
+            end=""
+            loading={false}
+            chartColors={theme.charts.getColorPalette(4).slice(3, 5)}
+            utc={false}
+            stacked
+            isLineChart
+            disableXAxis
+            hideYAxisSplitLine
+          />
+        </Block>
       </FlexRowContainer>
     </Detail>
   );

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/spanDescription.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/spanDescription.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+
+import {FormattedCode} from 'sentry/views/starfish/components/formattedCode';
+import {highlightSql} from 'sentry/views/starfish/modules/databaseModule/panel';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+
+export function SpanDescription({span}: {span: Span}) {
+  if (span.span_operation.startsWith('db')) {
+    return <DatabaseSpanDescription span={span} />;
+  }
+
+  return <div>{span.description}</div>;
+}
+
+function DatabaseSpanDescription({span}: {span: Span}) {
+  return (
+    <CodeWrapper>
+      <FormattedCode>
+        {highlightSql(span.formatted_desc || span.description || '', {
+          action: span.action || '',
+          domain: span.domain || '',
+        })}
+      </FormattedCode>
+    </CodeWrapper>
+  );
+}
+
+const CodeWrapper = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+`;

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
@@ -5,6 +5,7 @@ import GridEditable, {GridColumnHeader as Column} from 'sentry/components/gridEd
 import Link from 'sentry/components/links/link';
 import Truncate from 'sentry/components/truncate';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+import {Series} from 'sentry/types/echarts';
 import {useLocation} from 'sentry/utils/useLocation';
 import Sparkline from 'sentry/views/starfish/components/sparkline';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
@@ -1,0 +1,79 @@
+import {Fragment} from 'react';
+import * as qs from 'query-string';
+
+import GridEditable, {GridColumnHeader as Column} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
+import Truncate from 'sentry/components/truncate';
+import {useLocation} from 'sentry/utils/useLocation';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+import {useSpanTransactions} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanTransactions';
+
+type Props = {
+  span: Span;
+};
+
+type Row = {
+  count: number;
+  transaction: string;
+};
+
+export function SpanTransactionsTable({span}: Props) {
+  const location = useLocation();
+  const {data: spanTransactions, isLoading} = useSpanTransactions(span);
+
+  const renderHeadCell = column => {
+    return <span>{column.name}</span>;
+  };
+
+  const renderBodyCell = (column, row: Row) => {
+    return <BodyCell span={span} column={column} row={row} />;
+  };
+
+  return (
+    <GridEditable
+      isLoading={isLoading}
+      data={spanTransactions}
+      columnOrder={COLUMN_ORDER}
+      columnSortBy={[]}
+      grid={{
+        renderHeadCell,
+        renderBodyCell,
+      }}
+      location={location}
+    />
+  );
+}
+
+type CellProps = {column: Column; row: Row; span: Span};
+
+function BodyCell({span, column, row}: CellProps) {
+  if (column.key === 'transaction') {
+    return <TransactionCell span={span} row={row} column={column} />;
+  }
+
+  return <span>{row[column.key]}</span>;
+}
+
+function TransactionCell({span, column, row}: CellProps) {
+  return (
+    <Fragment>
+      <Link
+        to={`/starfish/span/${encodeURIComponent(span.group_id)}?${qs.stringify({
+          transaction: row.transaction,
+        })}`}
+      >
+        <Truncate value={row[column.key]} maxLength={50} />
+      </Link>
+
+      <span>{row.count} spans</span>
+    </Fragment>
+  );
+}
+
+const COLUMN_ORDER = [
+  {
+    key: 'transaction',
+    name: 'Transaction',
+    width: 400,
+  },
+];

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/types.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/types.tsx
@@ -6,9 +6,3 @@ export type Span = {
   domain?: string;
   formatted_desc?: string;
 };
-
-export type SpanMetrics = {
-  first_seen: string;
-  last_seen: string;
-  total_time: number;
-};

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/types.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/types.tsx
@@ -1,0 +1,12 @@
+export type Span = {
+  group_id: string;
+  action?: string;
+  description?: string;
+  domain?: string;
+};
+
+export type SpanMetrics = {
+  first_seen: string;
+  last_seen: string;
+  total_time: number;
+};

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/types.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/types.tsx
@@ -1,8 +1,10 @@
 export type Span = {
   group_id: string;
+  span_operation: string;
   action?: string;
   description?: string;
   domain?: string;
+  formatted_desc?: string;
 };
 
 export type SpanMetrics = {

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries.tsx
@@ -1,0 +1,60 @@
+import keyBy from 'lodash/keyBy';
+import moment from 'moment';
+
+import {Series} from 'sentry/types/echarts';
+import {useQuery} from 'sentry/utils/queryClient';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+
+const INTERVAL = 12;
+
+type Metric = {
+  count: number;
+  interval: string;
+  p50: number;
+  p95: number;
+};
+
+export const useSpanMetricSeries = (span?: Span, referrer = 'span-metrics-series') => {
+  const aggregatesQuery = span ? getQuery(span) : '';
+
+  const {isLoading, error, data} = useQuery<Metric[]>({
+    queryKey: ['span-metrics-series', span?.group_id],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${aggregatesQuery}&referrer=${referrer}`).then(res =>
+        res.json()
+      ),
+    retry: false,
+    initialData: [],
+    enabled: Boolean(span),
+  });
+
+  const parsedData = keyBy(
+    ['spm', 'p50', 'p95'].map(seriesName => {
+      const series: Series = {
+        seriesName,
+        data: data.map(datum => ({value: datum[seriesName], name: datum.interval})),
+      };
+
+      return zeroFillSeries(series, moment.duration(INTERVAL, 'hours'));
+    }),
+    'seriesName'
+  );
+
+  return {isLoading, error, data: parsedData};
+};
+
+const getQuery = (span: Span) => {
+  return `
+  SELECT
+    toStartOfInterval(start_timestamp, INTERVAL ${INTERVAL} HOUR) as interval,
+    quantile(0.95)(exclusive_time) as p95,
+    quantile(0.50)(exclusive_time) as p50,
+    divide(count(), multiply(${INTERVAL}, 60)) as spm
+  FROM spans_experimental_starfish
+  WHERE group_id = '${span.group_id}'
+  GROUP BY interval
+  ORDER BY interval
+`;
+};

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries.tsx
@@ -17,14 +17,12 @@ type Metric = {
 };
 
 export const useSpanMetricSeries = (span?: Span, referrer = 'span-metrics-series') => {
-  const aggregatesQuery = span ? getQuery(span) : '';
+  const query = span ? getQuery(span) : '';
 
   const {isLoading, error, data} = useQuery<Metric[]>({
     queryKey: ['span-metrics-series', span?.group_id],
     queryFn: () =>
-      fetch(`${HOST}/?query=${aggregatesQuery}&referrer=${referrer}`).then(res =>
-        res.json()
-      ),
+      fetch(`${HOST}/?query=${query}&referrer=${referrer}`).then(res => res.json()),
     retry: false,
     initialData: [],
     enabled: Boolean(span),

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
@@ -1,0 +1,35 @@
+import {useQuery} from 'sentry/utils/queryClient';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import type {
+  Span,
+  SpanMetrics,
+} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+
+export const useSpanMetrics = (span?: Span, referrer = 'span-metrics') => {
+  const aggregatesQuery = span ? getAggregatesQuery(span) : '';
+
+  const {isLoading, error, data} = useQuery<SpanMetrics[]>({
+    queryKey: ['span-metrics', span?.group_id],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${aggregatesQuery}&referrer=${referrer}`).then(res =>
+        res.json()
+      ),
+    retry: false,
+    initialData: [],
+    enabled: Boolean(span),
+  });
+
+  return {isLoading, error, data: data[0]};
+};
+
+const getAggregatesQuery = (span: Span) => {
+  return `
+    SELECT
+    min(timestamp) as first_seen,
+    max(timestamp) as last_seen,
+    sum(exclusive_time) as total_time
+    FROM spans_experimental_starfish
+    WHERE 1 == 1
+    AND group_id = '${span.group_id}'
+ `;
+};

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
@@ -1,19 +1,20 @@
 import {useQuery} from 'sentry/utils/queryClient';
 import {HOST} from 'sentry/views/starfish/utils/constants';
-import type {
-  Span,
-  SpanMetrics,
-} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+
+type Metrics = {
+  first_seen: string;
+  last_seen: string;
+  total_time: number;
+};
 
 export const useSpanMetrics = (span?: Span, referrer = 'span-metrics') => {
-  const aggregatesQuery = span ? getAggregatesQuery(span) : '';
+  const query = span ? getQuery(span) : '';
 
-  const {isLoading, error, data} = useQuery<SpanMetrics[]>({
+  const {isLoading, error, data} = useQuery<Metrics[]>({
     queryKey: ['span-metrics', span?.group_id],
     queryFn: () =>
-      fetch(`${HOST}/?query=${aggregatesQuery}&referrer=${referrer}`).then(res =>
-        res.json()
-      ),
+      fetch(`${HOST}/?query=${query}&referrer=${referrer}`).then(res => res.json()),
     retry: false,
     initialData: [],
     enabled: Boolean(span),
@@ -22,7 +23,7 @@ export const useSpanMetrics = (span?: Span, referrer = 'span-metrics') => {
   return {isLoading, error, data: data[0]};
 };
 
-const getAggregatesQuery = (span: Span) => {
+const getQuery = (span: Span) => {
   return `
     SELECT
     min(timestamp) as first_seen,

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetricSeries.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetricSeries.tsx
@@ -1,0 +1,71 @@
+import groupBy from 'lodash/groupBy';
+import keyBy from 'lodash/keyBy';
+import moment from 'moment';
+
+import {Series} from 'sentry/types/echarts';
+import {useQuery} from 'sentry/utils/queryClient';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+
+const INTERVAL = 12;
+
+type Metric = {
+  count: number;
+  interval: string;
+  p50: number;
+  p95: number;
+};
+
+export const useSpanTransactionMetricSeries = (
+  span?: Span,
+  transactions?: string[],
+  referrer: string = 'span-transaction-metrics-series'
+) => {
+  const query =
+    span && transactions && transactions.length > 0 ? getQuery(span, transactions) : '';
+
+  const {isLoading, error, data} = useQuery<Metric[]>({
+    queryKey: ['span-metrics-series', span?.group_id, transactions?.join(',') || ''],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${query}&referrer=${referrer}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+    enabled: Boolean(query),
+  });
+
+  const parsedData: Record<string, Record<string, Series>> = {};
+  const dataByTransaction = groupBy(data, 'transaction');
+  Object.keys(dataByTransaction).forEach(transaction => {
+    const parsedTransactionData = keyBy(
+      ['spm', 'p50'].map(seriesName => {
+        const series: Series = {
+          seriesName,
+          data: data.map(datum => ({value: datum[seriesName], name: datum.interval})),
+        };
+
+        return zeroFillSeries(series, moment.duration(INTERVAL, 'hours'));
+      }),
+      'seriesName'
+    );
+
+    parsedData[transaction] = parsedTransactionData;
+  });
+
+  return {isLoading, error, data: parsedData};
+};
+
+const getQuery = (span: Span, transactions: string[]) => {
+  return `SELECT
+    transaction,
+    toStartOfInterval(start_timestamp, INTERVAL ${INTERVAL} hour) as interval,
+    quantile(0.50)(exclusive_time) AS p50,
+    divide(count(), multiply(${INTERVAL}, 60)) as spm
+  FROM spans_experimental_starfish
+  WHERE
+    transaction IN ('${transactions.join("','")}')
+    AND group_id = '${span.group_id}'
+  GROUP BY transaction, interval
+  ORDER BY transaction, interval
+`;
+};

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactions.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactions.tsx
@@ -1,0 +1,37 @@
+import {useQuery} from 'sentry/utils/queryClient';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+
+type Transaction = {
+  count: number;
+  transaction: string;
+};
+
+export const useSpanTransactions = (span?: Span, referrer = 'span-transactions') => {
+  const query = span ? getQuery(span) : '';
+
+  const {isLoading, error, data} = useQuery<Transaction[]>({
+    queryKey: ['span-transactions', span?.group_id],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${query}&referrer=${referrer}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+    enabled: Boolean(span),
+  });
+
+  return {isLoading, error, data};
+};
+
+const getQuery = (span: Span) => {
+  return `
+    SELECT
+      transaction,
+      count() AS count
+    FROM spans_experimental_starfish
+    WHERE
+      group_id = '${span.group_id}'
+    GROUP BY transaction
+    ORDER BY -power(10, floor(log10(count()))), -quantile(0.75)(exclusive_time)
+    LIMIT 5
+`;
+};

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -130,8 +130,6 @@ function getRenderHeadCell(orderBy: string, onSetOrderBy: (orderBy: string) => v
   return renderHeadCell;
 }
 
-const SPAN_OPS_WITH_DETAIL = ['http.client', 'db'];
-
 function renderBodyCell(
   column: GridColumnHeader,
   row: SpanDataRow,
@@ -151,14 +149,7 @@ function renderBodyCell(
     const formattedRow = mapRowKeys(row, row.span_operation);
     return (
       <OverflowEllipsisTextContainer>
-        <Link
-          onClick={() => onSelect?.(formattedRow)}
-          to={
-            SPAN_OPS_WITH_DETAIL.includes(row.span_operation)
-              ? ''
-              : `/starfish/span/${encodeURIComponent(row.group_id)}`
-          }
-        >
+        <Link onClick={() => onSelect?.(formattedRow)} to="">
           {row.span_operation === 'db' ? (
             <StyledFormattedCode>
               {(row as unknown as DataRow).formatted_desc}


### PR DESCRIPTION
Eventually this will replace the two different side panels (the one in the Database module and the one in the API module) but for now this is a generic span summary side panel. It opens up if you select a span with an unknown type in the span view.

**e.g.,**
![Screenshot 2023-05-18 at 9 22 04 AM](https://github.com/getsentry/sentry/assets/989898/82ab8135-1027-4388-b81b-c13e2a89f75a)
