### PR TITLE
fix(replays): allow querying replay errors without FE error

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -59,6 +59,18 @@ describe('useReplayData', () => {
       count_segments: 0,
       error_ids: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      body: {
+        data: [],
+      },
+      headers: {
+        Link: [
+          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:1:0"',
+          '<http://localhost/?cursor=0:2:0>; rel="next"; results="false"; cursor="0:1:0"',
+        ].join(','),
+      },
+    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
@@ -97,6 +109,19 @@ describe('useReplayData', () => {
       count_errors: 0,
       count_segments: 2,
       error_ids: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      body: {
+        data: [],
+      },
+      headers: {
+        Link: [
+          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:1:0"',
+          '<http://localhost/?cursor=0:2:0>; rel="next"; results="false"; cursor="0:1:0"',
+        ].join(','),
+      },
     });
 
     const mockSegmentResponse1 = TestStubs.ReplaySegmentInit({timestamp: startedAt});
@@ -339,6 +364,19 @@ describe('useReplayData', () => {
       count_errors: 0,
       count_segments: 0,
       error_ids: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      body: {
+        data: [],
+      },
+      headers: {
+        Link: [
+          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:1:0"',
+          '<http://localhost/?cursor=0:2:0>; rel="next"; results="false"; cursor="0:1:0"',
+        ].join(','),
+      },
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -161,11 +161,6 @@ function useReplayData({
       return;
     }
 
-    if (!replayRecord.error_ids.length) {
-      setState(prev => ({...prev, fetchingErrors: false}));
-      return;
-    }
-
     // Clone the `finished_at` time and bump it up one second because finishedAt
     // has the `ms` portion truncated, while replays-events-meta operates on
     // timestamps with `ms` attached. So finishedAt could be at time `12:00:00.000Z`


### PR DESCRIPTION
## Summary
A `replayRecord.error_ids` would only contain a front-end project's `error_ids`. The guard clause in place would prevent us from loading backend errors if there were no front-end errors on the `replayRecord`.

This PR removes the guard clause and as a result we always query for errors associated to a replay.

See slack thread: https://sentry.slack.com/archives/C04RDSY3ML1/p1684364133578849?thread_ts=1684363044.358459&cid=C04RDSY3ML1

**Before**
![image](https://github.com/getsentry/sentry/assets/7349258/89d9c881-66db-4b37-84d7-65e16658aa96)

**After**
![image](https://github.com/getsentry/sentry/assets/7349258/9d50ba5c-b577-4f57-82b4-51d6ac00ff41)
