### PR TITLE
feat(starfish): remove not needed sidebar metrics in span summary

### DIFF
--- a/static/app/views/starfish/views/spanSummary/sidebar.tsx
+++ b/static/app/views/starfish/views/spanSummary/sidebar.tsx
@@ -1,10 +1,8 @@
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
-import capitalize from 'lodash/capitalize';
 import moment, {Moment} from 'moment';
 
-import DateTime from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -69,18 +67,17 @@ export default function Sidebar({
     initialData: [],
   });
 
-  const {isLoading: _isLoadingSideBarOverallAggregateData, data: overallAggregateData} =
-    useQuery({
-      queryKey: ['overall-aggregates'],
-      queryFn: () =>
-        fetch(
-          `${HOST}/?query=${getOverallAggregatesQuery(
-            pageFilter.selection.datetime
-          )}&referrer=overall-aggregates`
-        ).then(res => res.json()),
-      retry: false,
-      initialData: [],
-    });
+  const {isLoading: _isLoadingSideBarOverallAggregateData} = useQuery({
+    queryKey: ['overall-aggregates'],
+    queryFn: () =>
+      fetch(
+        `${HOST}/?query=${getOverallAggregatesQuery(
+          pageFilter.selection.datetime
+        )}&referrer=overall-aggregates`
+      ).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
 
   // Also a metrics span query that fetches series data
   const {isLoading: isLoadingSeriesData, data: seriesData} = useQuery({
@@ -114,16 +111,8 @@ export default function Sidebar({
     initialData: [],
   });
 
-  const {
-    failure_rate,
-    count,
-    total_exclusive_time,
-    count_unique_transaction_id,
-    first_seen,
-    last_seen,
-  } = spanAggregateData[0] || {};
-
-  const {overall_total_exclusive_time} = overallAggregateData[0] || {};
+  const {failure_rate, count, total_exclusive_time, count_unique_transaction_id} =
+    spanAggregateData[0] || {};
 
   const [_, num, unit] = pageFilter.selection.datetime.period?.match(PERIOD_REGEX) ?? [];
   const startTime =
@@ -156,39 +145,26 @@ export default function Sidebar({
   return (
     <FlexContainer>
       <FlexItem>
-        <SidebarItemHeader>{t('First Seen')}</SidebarItemHeader>
-        <SidebarItemValueContainer>
-          <DateTime date={first_seen} timeZone seconds utc />
-        </SidebarItemValueContainer>
-      </FlexItem>
-      <FlexItem>
-        <SidebarItemHeader>{t('Last Seen')}</SidebarItemHeader>
-        <SidebarItemValueContainer>
-          <DateTime date={last_seen} timeZone seconds utc />
-        </SidebarItemValueContainer>
-      </FlexItem>
-      <FlexItem>
-        <SidebarItemHeader>{t('Total Self Time')}</SidebarItemHeader>
+        <SidebarItemHeader>{t('Total Time')}</SidebarItemHeader>
         <SidebarItemValueContainer>
           <Duration seconds={total_exclusive_time / 1000} fixedDigits={2} abbreviation />{' '}
-          ({formatPercentage(total_exclusive_time / overall_total_exclusive_time)})
         </SidebarItemValueContainer>
       </FlexItem>
       <FlexItem>
-        <SidebarItemHeader>{`${getGroupLabel({spanGroupOperation, capitalize: true})} ${t(
-          ' Frequency'
-        )}`}</SidebarItemHeader>
+        <SidebarItemHeader>{t('Total Spans')}</SidebarItemHeader>
+        <SidebarItemValueContainer>{count}</SidebarItemValueContainer>
+      </FlexItem>
+      <FlexItem>
+        <SidebarItemHeader>{t('Frequency')}</SidebarItemHeader>
         <SidebarItemValueContainer>
           {formatPercentage(spanFrequency)}
         </SidebarItemValueContainer>
       </FlexItem>
       <FlexItem>
-        <SidebarItemHeader>{`${getGroupLabel({
-          spanGroupOperation,
-          capitalize: true,
-          plural: true,
-        })} ${t(' Per Event')}`}</SidebarItemHeader>
-        <SidebarItemValueContainer>{spansPerEvent}</SidebarItemValueContainer>
+        <SidebarItemHeader>{t('Avg Spans')}</SidebarItemHeader>
+        <SidebarItemValueContainer>
+          {spansPerEvent} {t('per event')}
+        </SidebarItemValueContainer>
       </FlexItem>
 
       {
@@ -311,30 +287,6 @@ export function getQueries(spanGroupOperation: string) {
       };
   }
 }
-
-const getGroupLabel = (options: {
-  spanGroupOperation: string;
-  capitalize?: boolean;
-  plural?: boolean;
-}) => {
-  let label = '';
-  switch (options.spanGroupOperation) {
-    case 'db':
-      label = options.plural ? t('queries') : t('query');
-      break;
-    case 'http.client':
-      label = options.plural ? t('requests') : t('request');
-      break;
-
-    default:
-      label = options.plural ? t('spans') : t('span');
-      break;
-  }
-  if (options.capitalize) {
-    return capitalize(label);
-  }
-  return label;
-};
 
 export const getTransactionBasedSeries = (
   data: any[],


### PR DESCRIPTION
Removes the metrics that we decided were not necessary on the sidebar span summary.
Also cleans up the labels of the metrics to match the mocks.
<img width="820" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/85a25711-f4ba-46df-9833-c91967a09de1">
