### PR TITLE
fix(profiling): Set received on profile metadata

### DIFF
--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -86,6 +86,7 @@ declare namespace Profiling {
       name: string;
       version: string;
     };
+    received: string;
     timestamp: string;
     release: Release | null;
     platform: string;

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -178,6 +178,7 @@ function importSentrySampledProfile(
       profileID: input.event_id,
       projectID: input.project_id,
       release: input.release,
+      received: input.received,
 
       // these don't really work for multiple transactions
       transactionID: input.transaction.id,


### PR DESCRIPTION
Without this, `received` was undefined in the metadata, so when rendering a profile that did not have an associated transaction, it would show the current time in the drawer instead of the actual received time.