### PR TITLE
feat(js): Add `URITooLongError` to `createRequestError` status lookup

### DIFF
--- a/static/app/utils/requestError/createRequestError.tsx
+++ b/static/app/utils/requestError/createRequestError.tsx
@@ -8,6 +8,7 @@ const ERROR_MAP = {
   401: 'UnauthorizedError',
   403: 'ForbiddenError',
   404: 'NotFoundError',
+  414: 'URITooLongError',
   426: 'UpgradeRequiredError',
   429: 'TooManyRequestsError',
   500: 'InternalServerError',


### PR DESCRIPTION
It's not common, but we do occasionally get [status 414](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414) responses:

![image](https://github.com/getsentry/sentry/assets/14812505/0c870ea4-39e0-4112-90bc-fec624e52b3f)

This adds the corresponding error type to the lookup in `createRequestError`.