### PR TITLE
ref(js): Force `responseText` value to print, even if undefined or empty

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -533,7 +533,8 @@ export class Client {
               scope.setExtras({
                 twoHundredErrorReason,
                 responseJSON,
-                responseText,
+                // Force `undefined` and the empty string to print so they're differentiable in the UI
+                responseText: String(responseText) || '[empty string]',
                 responseContentType,
                 errorReason,
               });


### PR DESCRIPTION
When capturing an event, the JS SDK drops undefined context values. Meanwhile, the Sentry UI doesn't display context values which are the empty string. This makes debugging values which might be one or the other tricky, because there's no way to tell (without opening up the JSON) which value you have. This forces both values into (non-empty) string form, so that it's possible to differentiate them.

