### PR TITLE
feat(starfish): update span summary chart labels, use spm() and epm()

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/queries.ts
+++ b/static/app/views/starfish/modules/databaseModule/queries.ts
@@ -602,16 +602,10 @@ export const useQueryTransactionByTPMAndDuration = (
       fields: [
         'transaction',
         'epm()',
-        'count()',
         'p50(transaction.duration)',
         'p95(transaction.duration)',
       ],
-      yAxis: [
-        'epm()',
-        'count()',
-        'p50(transaction.duration)',
-        'p95(transaction.duration)',
-      ],
+      yAxis: ['epm()', 'p50(transaction.duration)', 'p95(transaction.duration)'],
       orderby: '-count',
       query: `transaction:["${transactionNames.join('","')}"]`,
       topEvents: '5',

--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -211,6 +211,7 @@ export default function SpanSummary({location, params}: Props) {
     datetime: pageFilter.selection.datetime,
     groupId,
     module: spanGroupOperation,
+    interval: 12,
   });
 
   const {isLoading: isLoadingSeriesData, data: seriesData} = useQuery({
@@ -240,7 +241,7 @@ export default function SpanSummary({location, params}: Props) {
   const {p50TransactionSeries, p95TransactionSeries, throughputTransactionSeries} =
     getTransactionBasedSeries(transactionAggregateData, dateFilter);
 
-  const [p50Series, p95Series, countSeries, _errorCountSeries] = queryDataToChartData(
+  const [p50Series, p95Series, , spmSeries, _errorCountSeries] = queryDataToChartData(
     seriesData
   ).map(series =>
     zeroFillSeries(series, moment.duration(12, 'hours'), startTime, endTime)
@@ -447,13 +448,13 @@ export default function SpanSummary({location, params}: Props) {
                   <FlexRowItem>
                     <h4>{t('Throughput (SPM)')}</h4>
                     <SidebarChart
-                      series={countSeries}
+                      series={spmSeries}
                       isLoading={isLoadingSeriesData}
                       chartColor={chartColors[0]}
                     />
                   </FlexRowItem>
                   <FlexRowItem>
-                    <h4>{t('Span Duration P50 / P95')}</h4>
+                    <h4>{t('Span Duration (P50 / P95)')}</h4>
                     <Chart
                       statsPeriod="24h"
                       height={140}
@@ -483,7 +484,7 @@ export default function SpanSummary({location, params}: Props) {
 
                 <FlexRowContainer>
                   <FlexRowItem>
-                    <h4>{t('Transaction Throughput')}</h4>
+                    <h4>{t('Throughput (TPM)')}</h4>
                     <Chart
                       statsPeriod="24h"
                       height={140}
@@ -499,7 +500,7 @@ export default function SpanSummary({location, params}: Props) {
                     />
                   </FlexRowItem>
                   <FlexRowItem>
-                    <h4>{t('Transaction Duration P50 / P95')}</h4>
+                    <h4>{t('Transaction Duration (P50 / P95)')}</h4>
                     <Chart
                       statsPeriod="24h"
                       height={140}

--- a/static/app/views/starfish/views/spanSummary/megaChart.tsx
+++ b/static/app/views/starfish/views/spanSummary/megaChart.tsx
@@ -34,6 +34,7 @@ export default function MegaChart({
     datetime: pageFilter.selection.datetime,
     groupId,
     module,
+    interval: 12,
   });
 
   // Also a metrics span query that fetches series data

--- a/static/app/views/starfish/views/spanSummary/queries.tsx
+++ b/static/app/views/starfish/views/spanSummary/queries.tsx
@@ -73,6 +73,7 @@ export const getSidebarSeriesQuery = ({
   datetime,
   groupId,
   module,
+  interval,
 }) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `SELECT
@@ -80,6 +81,7 @@ export const getSidebarSeriesQuery = ({
      quantile(0.5)(exclusive_time) as p50,
      quantile(0.95)(exclusive_time) as p95,
      count() as count,
+     divide(count(), multiply(${interval}, 60)) as spm,
      countIf(greaterOrEquals(status, 400) AND lessOrEquals(status, 599)) as failure_count,
      failure_count / count as failure_rate
      FROM spans_experimental_starfish

--- a/static/app/views/starfish/views/spanSummary/sidebar.tsx
+++ b/static/app/views/starfish/views/spanSummary/sidebar.tsx
@@ -50,6 +50,7 @@ export default function Sidebar({
     datetime: pageFilter.selection.datetime,
     groupId,
     module,
+    interval: 12,
   });
   const aggregatesQuery = getAggregatesQuery({
     description,
@@ -361,7 +362,7 @@ export const getTransactionBasedSeries = (
   const throughputTransactionSeries = queryToSeries(
     data,
     'group',
-    'count()',
+    'epm()',
     dateFilter.startTime,
     dateFilter.endTime,
     12
@@ -369,7 +370,7 @@ export const getTransactionBasedSeries = (
   if (data.length) {
     p50TransactionSeries.seriesName = 'p50()';
     p95TransactionSeries.seriesName = 'p95()';
-    throughputTransactionSeries.seriesName = 'count()';
+    throughputTransactionSeries.seriesName = 'epm()';
   }
 
   return {p50TransactionSeries, p95TransactionSeries, throughputTransactionSeries};


### PR DESCRIPTION
Updates the labels above the charts to match closer to mocks
![image](https://github.com/getsentry/sentry/assets/44422760/fac33118-fbd4-4af9-be67-c757fd9c7c41)

Also updates the queries to use epm() and spm() instead of count(). As that's what we want to show whenever we see throughput.