### PR TITLE
ref(js): Stop sending 429 errors from frontend client requests

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -59,6 +59,22 @@ describe('isFilteredRequestErrorEvent', () => {
     expect(isFilteredRequestErrorEvent(requestErrorEvent)).toBeTruthy();
   });
 
+  it.each(['GET', 'POST', 'PUT', 'DELETE'])('filters 429 %s events', method => {
+    const notFoundErrorEvent = {
+      exception: {
+        values: [{type: 'TooManyRequestsError', value: `${method} /dogs/are/great/ 429`}],
+      },
+    };
+    const requestErrorEvent = {
+      exception: {
+        values: [{type: 'RequestError', value: `${method} /dogs/are/great/ 429`}],
+      },
+    };
+
+    expect(isFilteredRequestErrorEvent(notFoundErrorEvent)).toBeTruthy();
+    expect(isFilteredRequestErrorEvent(requestErrorEvent)).toBeTruthy();
+  });
+
   it.each(['NotFoundError', 'ForbiddenError', 'UnauthorizedError'])(
     "doesn't filter other %s events",
     errorType => {

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -195,6 +195,9 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
   const is404 =
     ['NotFoundError', 'RequestError'].includes(type) &&
     !!value.match('(GET|POST|PUT|DELETE) .* 404');
+  const is429 =
+    ['TooManyRequestsError', 'RequestError'].includes(type) &&
+    !!value.match('(GET|POST|PUT|DELETE) .* 429');
 
-  return is200 || is401 || is403 || is404;
+  return is200 || is401 || is403 || is404 || is429;
 }


### PR DESCRIPTION
This adds 429s to the filter we use in `beforeSend` to screen out certain types of request errors.