### PR TITLE
chore(hybrid-cloud): Update User.merge_to

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -354,8 +354,12 @@ class User(BaseModel, AbstractBaseUser):
 
         for obj in OrganizationMember.objects.filter(user_id=from_user.id):
             try:
+                region_outbox = None
                 with transaction.atomic():
-                    obj.update(user_id=to_user.id)
+                    obj.user_id = to_user.id
+                    region_outbox = obj.save()
+                if region_outbox:
+                    region_outbox.drain_shard(max_updates_to_drain=10)
             # this will error if both users are members of obj.org
             except IntegrityError:
                 pass
@@ -367,7 +371,12 @@ class User(BaseModel, AbstractBaseUser):
                 organization=obj.organization_id, user_id=to_user.id
             )
             if roles.get(obj.role).priority > roles.get(to_member.role).priority:
-                to_member.update(role=obj.role)
+                region_outbox = None
+                with transaction.atomic():
+                    to_member.role = obj.role
+                    region_outbox = to_member.save()
+                if region_outbox:
+                    region_outbox.drain_shard(max_updates_to_drain=10)
 
             for team in obj.teams.all():
                 try:


### PR DESCRIPTION
Update `User.merge_to` to propagate changes via outboxaes. 

Note that `update()` on querysets does not invoke the overriden `save()` method on the `OrganizationMember` model.