### PR TITLE
feat(starfish): cleanup span summary queries

### DIFF
--- a/static/app/views/starfish/modules/APIModule/queries.tsx
+++ b/static/app/views/starfish/modules/APIModule/queries.tsx
@@ -277,44 +277,6 @@ export const getEndpointDetailTableEventView = ({
   });
 };
 
-export const getSpanInTransactionQuery = ({groupId, datetime}) => {
-  const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
-  // TODO - add back `module = <moudle> to filter data
-  return `
-    SELECT
-      count() AS count,
-      quantile(0.5)(exclusive_time) as p50,
-      span_operation,
-      action,
-      description
-    FROM
-      spans_experimental_starfish
-    WHERE
-    group_id = '${groupId}'
-    ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
-    ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
-    GROUP BY
-      span_operation,
-      description,
-      action
- `;
-};
-
-export const getSpanFacetBreakdownQuery = ({groupId, datetime, transactionName}) => {
-  const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
-  // TODO - add back `module = <moudle> to filter data
-  return `
-    SELECT
-      user, domain
-    FROM spans_experimental_starfish
-    WHERE
-    group_id = '${groupId}'
-    AND transaction = '${transactionName}'
-    ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
-    ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
- `;
-};
-
 export const getHostStatusBreakdownQuery = ({domain, datetime}) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `

--- a/static/app/views/starfish/views/spanSummary/queries.tsx
+++ b/static/app/views/starfish/views/spanSummary/queries.tsx
@@ -1,5 +1,13 @@
 import {DateTimeObject} from 'sentry/components/charts/utils';
-import {datetimeToClickhouseFilterTimestamps} from 'sentry/views/starfish/utils/dates';
+import {DefinedUseQueryResult, useQueries, useQuery} from 'sentry/utils/queryClient';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {getEndpointDetailSeriesQuery} from 'sentry/views/starfish/modules/APIModule/queries';
+import {getDateQueryFilter} from 'sentry/views/starfish/modules/databaseModule/queries';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import {
+  datetimeToClickhouseFilterTimestamps,
+  getDateFilters,
+} from 'sentry/views/starfish/utils/dates';
 
 export enum SamplePopulationType {
   FASTEST = 'fastest',
@@ -7,7 +15,239 @@ export enum SamplePopulationType {
   SLOWEST = 'slowest',
 }
 
-export const getSpanSamplesQuery = ({
+export const useQueryGetSpanSamples = (options: {
+  groupId: string;
+  transactionName: string;
+  user: string;
+  p50?: number;
+}) => {
+  const {groupId, transactionName, user, p50} = options;
+
+  const pageFilter = usePageFilters();
+
+  const commonQueryOptions = {
+    queryKey: [
+      groupId,
+      transactionName,
+      user,
+      pageFilter.selection.datetime,
+      'spanSamples',
+    ],
+    retry: false,
+    initialData: [],
+  };
+
+  const commonSamplesQueryOptions = {
+    groupId,
+    transactionName,
+    user,
+    datetime: pageFilter.selection.datetime,
+    p50,
+  };
+
+  const results = useQueries({
+    queries: [
+      {
+        ...commonQueryOptions,
+        queryKey: [...commonQueryOptions.queryKey, 'spanSamplesSlowest'],
+        queryFn: () =>
+          fetch(
+            `${HOST}/?query=${getSpanSamplesQuery({
+              ...commonSamplesQueryOptions,
+              populationType: SamplePopulationType.SLOWEST,
+            })}`
+          ).then(res => res.json()),
+      },
+      {
+        ...commonQueryOptions,
+        queryKey: [...commonQueryOptions.queryKey, 'spanSamplesMedian'],
+        queryFn: () =>
+          fetch(
+            `${HOST}/?query=${getSpanSamplesQuery({
+              ...commonSamplesQueryOptions,
+              populationType: SamplePopulationType.MEDIAN,
+            })}`
+          ).then(res => res.json()),
+      },
+      {
+        ...commonQueryOptions,
+        queryKey: [...commonQueryOptions.queryKey, 'spanSamplesFastest'],
+        queryFn: () =>
+          fetch(
+            `${HOST}/?query=${getSpanSamplesQuery({
+              ...commonSamplesQueryOptions,
+              populationType: SamplePopulationType.FASTEST,
+            })}`
+          ).then(res => res.json()),
+      },
+    ],
+  });
+
+  return results;
+};
+
+export const useQueryGetFacetsBreakdown = (options: {
+  groupId: string;
+  transactionName: string;
+}): DefinedUseQueryResult<{domain: string; user: string}[]> => {
+  const {groupId, transactionName} = options;
+  const pageFilter = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilter);
+  const dateFilters = getDateQueryFilter(startTime, endTime);
+
+  const query = `
+      SELECT
+      user, domain
+    FROM spans_experimental_starfish
+    WHERE
+    group_id = '${groupId}'
+    AND transaction = '${transactionName}'
+    ${dateFilters}
+  `;
+
+  return useQuery({
+    queryKey: ['facetBreakdown', groupId, transactionName],
+    queryFn: () => fetch(`${HOST}/?query=${query}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+};
+
+export const useQuerySpansInTransaction = (options: {
+  groupId: string;
+}): DefinedUseQueryResult<
+  {
+    action: string;
+    count: number;
+    description: string;
+    formatted_desc: string;
+    module: 'http' | 'db' | 'cache' | 'none';
+    p50: number;
+    span_operation: string;
+  }[]
+> => {
+  const {groupId} = options;
+  const pageFilter = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilter);
+  const dateFilters = getDateQueryFilter(startTime, endTime);
+
+  const query = `
+      SELECT
+      count() AS count,
+      quantile(0.5)(exclusive_time) as p50,
+      span_operation,
+      action,
+      module,
+      description
+    FROM
+      spans_experimental_starfish
+    WHERE
+    group_id = '${groupId}'
+    ${dateFilters}
+    GROUP BY
+      span_operation,
+      description,
+      action,
+      module
+  `;
+
+  return useQuery({
+    queryKey: ['spansInTransaction', groupId],
+    queryFn: () => fetch(`${HOST}/?query=${query}&format=sql`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
+};
+
+export const useQueryGetSpanAggregatesQuery = (options: {
+  groupId: string;
+  transactionName: string;
+  description?: string;
+  module?: string;
+}): DefinedUseQueryResult<
+  {
+    count: number;
+    count_unique_transaction: number;
+    count_unique_transaction_id: number;
+    failure_rate: number;
+    faiure_count: number;
+    first_seen: string;
+    last_seen: string;
+    p50: number;
+    p95: number;
+    total_exclusive_time: number;
+  }[]
+> => {
+  const {description, groupId, transactionName, module} = options;
+  const pageFilter = usePageFilters();
+
+  const aggregatesQuery = getSidebarAggregatesQuery({
+    description,
+    transactionName,
+    datetime: pageFilter.selection.datetime,
+    groupId,
+    module,
+  });
+
+  return useQuery({
+    queryKey: ['span-aggregates', transactionName, groupId, description],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${aggregatesQuery}&referrer=sidebar-aggregates`).then(res =>
+        res.json()
+      ),
+    retry: false,
+    initialData: [],
+  });
+};
+
+export const useQueryGetSpanSeriesData = (options: {
+  groupId: string;
+  spanGroupOperation: string;
+  transactionName: string;
+  description?: string;
+  module?: string;
+}): DefinedUseQueryResult<
+  {
+    count: number;
+    failure_count: number;
+    failure_rate: number;
+    interval: string;
+    p50: number;
+    p95: number;
+    spm: number;
+  }[]
+> => {
+  const {description, groupId, spanGroupOperation, transactionName, module} = options;
+  const pageFilter = usePageFilters();
+  const {getSeriesQuery} = getQueries(spanGroupOperation);
+
+  const aggregatesQuery = getSeriesQuery({
+    datetime: pageFilter.selection.datetime,
+    groupId,
+    module,
+    description,
+    interval: 12,
+    transactionName,
+  });
+
+  return useQuery({
+    queryKey: [
+      'seriesdata',
+      transactionName,
+      module,
+      pageFilter.selection.datetime,
+      groupId,
+    ],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${aggregatesQuery}&referrer=sidebar-aggregates`).then(res =>
+        res.json()
+      ),
+    retry: false,
+    initialData: [],
+  });
+};
+
+const getSpanSamplesQuery = ({
   groupId,
   transactionName,
   user,
@@ -45,18 +285,33 @@ export const getSpanSamplesQuery = ({
 };
 
 // Metrics request to get total count of events for a transaction
-export const getUniqueTransactionCountQuery = ({transactionName, datetime}) => {
-  return `?field=count%28%29&query=transaction%3A${encodeURIComponent(transactionName)}${
+export const useQueryGetUniqueTransactionCount = (options: {transactionName: string}) => {
+  const {transactionName} = options;
+  const {
+    selection: {datetime},
+  } = usePageFilters();
+
+  const query = `?field=count%28%29&query=transaction%3A${encodeURIComponent(
+    transactionName
+  )}${
     datetime
       ? datetime.period
         ? `&statsPeriod=${datetime.period}`
         : datetime.start && datetime.end
         ? `&start=${encodeURIComponent(
-            datetime.start.toISOString()
-          )}&end=${encodeURIComponent(datetime.end.toISOString())}`
+            (datetime.start as Date).toISOString()
+          )}&end=${encodeURIComponent((datetime.end as Date).toISOString())}`
         : null
       : null
   }&dataset=metricsEnhanced&project=1`;
+
+  return useQuery({
+    queryKey: ['uniqueTransactionCount', transactionName],
+    queryFn: () =>
+      fetch(`/api/0/organizations/sentry/events/${query}`).then(res => res.json()),
+    retry: false,
+    initialData: [],
+  });
 };
 
 export const getSidebarSeriesQuery = ({
@@ -135,4 +390,25 @@ export function getOverallAggregatesQuery(datetime) {
     ${start_timestamp ? `AND greaterOrEquals(start_timestamp, '${start_timestamp}')` : ''}
     ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}
   `;
+}
+
+export function getQueries(spanGroupOperation: string) {
+  switch (spanGroupOperation) {
+    case 'db':
+    case 'cache':
+      return {
+        getSeriesQuery: getSidebarSeriesQuery,
+        getAggregatesQuery: getSidebarAggregatesQuery,
+      };
+    case 'http.client':
+      return {
+        getSeriesQuery: getEndpointDetailSeriesQuery,
+        getAggregatesQuery: getSidebarAggregatesQuery,
+      };
+    default:
+      return {
+        getSeriesQuery: getSidebarSeriesQuery,
+        getAggregatesQuery: getSidebarAggregatesQuery,
+      };
+  }
 }


### PR DESCRIPTION
This cleans up span summary queries to be more similar to db module. 

1. The span summary components was getting a bit bloated with all the `useQueries` making a bit harder to work with. Now rather then the queries file returning the query string, we now just return the queryHook. Once we have real data, we can just return the discover query hook instead with minimal changes outside `queries.tsx`
2. Some span summary specific queries were defined in the api module queries file, this PR moves them over too.