### PR TITLE
chore(hybrid-cloud): Flush outboxes when approving org member invite

### DIFF
--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -470,13 +470,14 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
     def test_approve_join_request(self):
         other_user = self.create_user()
-        member = OrganizationMember.objects.create(
+        member = self.create_member(
             organization=self.organization,
             email="hello@sentry.io",
             role="member",
             inviter_id=other_user.id,
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
+        self.assert_org_member_mapping(org_member=member)
 
         callback_id = json.dumps({"member_id": member.id, "member_email": "hello@sentry.io"})
 
@@ -485,6 +486,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.status_code == 200, resp.content
 
         member.refresh_from_db()
+        self.assert_org_member_mapping(org_member=member)
         assert member.invite_status == InviteStatus.APPROVED.value
 
         manage_url = absolute_uri(

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -278,10 +278,12 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
 
         member.approve_invite()
         member.save()
+        member.outbox_for_create().drain_shard(max_updates_to_drain=10)
 
         member = OrganizationMember.objects.get(id=member.id)
         assert member.invite_approved
         assert member.invite_status == InviteStatus.APPROVED.value
+        self.assert_org_member_mapping(org_member=member)
 
     def test_scopes_with_member_admin_config(self):
         member = OrganizationMember.objects.create(
@@ -446,6 +448,7 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         )
         user = self.create_user()
         member.approve_member_invitation(user)
+        self.assert_org_member_mapping(org_member=member)
         assert member.invite_status == InviteStatus.APPROVED.value
 
     def test_reject_member_invitation(self):


### PR DESCRIPTION
We do this to sync invite status to org member maps.