### PR TITLE
fix(crons): Prevent refetching on monitor details page for stats graph

### DIFF
--- a/static/app/views/monitors/components/monitorStats.tsx
+++ b/static/app/views/monitors/components/monitorStats.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {AreaChart, AreaChartSeries} from 'sentry/components/charts/areaChart';
@@ -29,12 +29,14 @@ function MonitorStats({monitor, monitorEnvs, orgId}: Props) {
   const {selection} = usePageFilters();
   const {start, end, period} = selection.datetime;
 
+  const nowRef = useRef<Date>(new Date());
+
   let since: number, until: number;
   if (start && end) {
     until = new Date(end).getTime() / 1000;
     since = new Date(start).getTime() / 1000;
   } else {
-    until = Math.floor(new Date().getTime() / 1000);
+    until = Math.floor(nowRef.current.getTime() / 1000);
     const intervalSeconds = intervalToMilliseconds(period ?? '30d') / 1000;
     since = until - intervalSeconds;
   }


### PR DESCRIPTION
Before, this page would have an infinite loading spinner if the request for the graph took longer than a second due to the follow set of events:

<img width="915" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/f831f0aa-b608-4338-b841-9272ff84ad7b">

1. We generate a `since`, `until` based on the current Date `new Date()`
2. useApiQuery fires off a request with those values
3. The data is fetched and the component rerenders, which causes a new `since`, `until` to be generated with a more recent `new Date()`
4. useApiQuery detects that we are now making a different request than before due to query params changing
5. refetches, keeping the component in the loading state

Now we store a ref to the time of the component being rendered so that we are locked to a time