### PR TITLE
feat(hybrid-cloud): Flush outboxes when creating or updating org members via SCIM endpoint

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -565,11 +565,12 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
                     organization=organization, email=result["email"], role=result["role"]
                 )
 
+                region_outbox = None
                 if member_query.exists():
                     member = member_query.first()
                     if member.token_expired:
                         member.regenerate_token()
-
+                        region_outbox = member.save()
                 else:
                     member = OrganizationMember(
                         organization=organization,
@@ -583,7 +584,9 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
                     member.flags["idp:role-restricted"] = idp_role_restricted
                     if settings.SENTRY_ENABLE_INVITES:
                         member.token = member.generate_token()
-                    member.save()
+                    region_outbox = member.save()
+                if region_outbox:
+                    region_outbox.drain_shard(max_updates_to_drain=10)
 
             self.create_audit_entry(
                 request=request,


### PR DESCRIPTION
I also fixed a bug where we did not save the org member when refreshing expired tokens.