### PR TITLE
chore(hybrid-cloud): Update admin to remove references to OrganizationMember.user field

### DIFF
--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -59,8 +59,8 @@ class OrganizationTeamInline(admin.TabularInline):
 class OrganizationMemberInline(admin.TabularInline):
     model = OrganizationMember
     extra = 1
-    fields = ("user", "organization", "role")
-    raw_id_fields = ("user", "organization")
+    fields = ("organization", "role")
+    raw_id_fields = ("organization",)
 
 
 class OrganizationUserInline(OrganizationMemberInline):
@@ -175,7 +175,7 @@ class UserAdmin(admin.ModelAdmin):
     list_filter = ("is_staff", "is_superuser", "is_active", "is_managed")
     search_fields = ("username", "name", "email")
     ordering = ("username",)
-    inlines = (OrganizationUserInline, AuthIdentityInline)
+    inlines = (AuthIdentityInline,)
 
     def get_fieldsets(self, request, obj=None):
         if not obj:


### PR DESCRIPTION
This is a partial step to converting the foreign key on `OrganizationMember.User` to be a `HybridCloudForeignKey`.