### PR TITLE
chore(hybrid-cloud): Properly delete org member records when deleting  the user account

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -254,9 +254,10 @@ class UserDetailsEndpoint(UserEndpoint):
         ]
 
         if remaining_org_ids:
-            OrganizationMember.objects.filter(
+            for member in OrganizationMember.objects.filter(
                 organization__in=remaining_org_ids, user_id=user.id
-            ).delete()
+            ):
+                member.delete()
 
         logging_data = {
             "actor_id": request.user.id,

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -1,5 +1,6 @@
 from sentry.models import (
     Organization,
+    OrganizationMember,
     OrganizationStatus,
     User,
     UserOption,
@@ -7,6 +8,8 @@ from sentry.models import (
     UserRole,
 )
 from sentry.testutils import APITestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
 
 
@@ -239,7 +242,7 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
 
 
 @control_silo_test
-class UserDetailsDeleteTest(UserDetailsTest):
+class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
     method = "delete"
 
     def test_close_account(self):
@@ -298,7 +301,21 @@ class UserDetailsDeleteTest(UserDetailsTest):
         self.create_member(user=user2, organization=org_with_other_owner, role="owner")
         self.create_member(user=self.user, organization=org_as_other_owner, role="owner")
 
-        self.get_success_response(self.user.id, organizations=[], status_code=204)
+        member_records = list(
+            OrganizationMember.objects.filter(
+                organization__in=[org_with_other_owner.id, org_as_other_owner.id],
+                user_id=self.user.id,
+            )
+        )
+
+        for member in member_records:
+            self.assert_org_member_mapping(org_member=member)
+
+        with outbox_runner():
+            self.get_success_response(self.user.id, organizations=[], status_code=204)
+
+        for member in member_records:
+            self.assert_org_member_mapping_not_exists(org_member=member)
 
         # deletes org_single_owner even though it wasn't specified in array
         # because it has a single owner


### PR DESCRIPTION
`delete()` on querysets does not invoke the custom `delete()` method on `OrganizationMember` model.