### PR TITLE
fix(stats): include abuse outcomes in total dropped

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -113,6 +113,7 @@ export enum Outcome {
   DROPPED = 'dropped', // this is not a real outcome coming from the server
   RATE_LIMITED = 'rate_limited',
   CLIENT_DISCARD = 'client_discard',
+  ABUSE = 'abuse',
 }
 
 export type IntervalPeriod = ReturnType<typeof getInterval>;

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -93,7 +93,7 @@ describe('OrganizationStats', function () {
 
     // Render the cards
     expect(screen.getAllByText('Total')[0]).toBeInTheDocument();
-    expect(screen.getByText('64')).toBeInTheDocument();
+    expect(screen.getByText('80')).toBeInTheDocument();
 
     expect(screen.getAllByText('Accepted')[0]).toBeInTheDocument();
     expect(screen.getByText('28')).toBeInTheDocument();
@@ -103,7 +103,7 @@ describe('OrganizationStats', function () {
     expect(screen.getAllByText('7')[0]).toBeInTheDocument();
 
     expect(screen.getAllByText('Dropped')[0]).toBeInTheDocument();
-    expect(screen.getAllByText('29')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('45')[0]).toBeInTheDocument();
 
     // Correct API Calls
     const mockExpectations = {
@@ -482,6 +482,19 @@ const mockStatsResponse = {
       },
       series: {
         'sum(quantity)': [2, 2, 2, 2, 2, 2, 3],
+      },
+    },
+    {
+      by: {
+        project: 1,
+        category: 'error',
+        outcome: 'abuse',
+      },
+      totals: {
+        'sum(quantity)': 16,
+      },
+      series: {
+        'sum(quantity)': [2, 2, 2, 2, 2, 3, 3],
       },
     },
   ],

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -346,6 +346,7 @@ class UsageStatsOrganization<
         [Outcome.FILTERED]: 0,
         [Outcome.DROPPED]: 0,
         [Outcome.INVALID]: 0, // Combined with dropped later
+        [Outcome.ABUSE]: 0, // Combined with dropped later
         [Outcome.RATE_LIMITED]: 0, // Combined with dropped later
         [Outcome.CLIENT_DISCARD]: 0, // Not exposed yet
       };
@@ -372,6 +373,7 @@ class UsageStatsOrganization<
             case Outcome.DROPPED:
             case Outcome.RATE_LIMITED:
             case Outcome.INVALID:
+            case Outcome.ABUSE:
               usageStats[i].dropped.total += stat;
               // TODO: add client discards to dropped?
               return;
@@ -381,9 +383,10 @@ class UsageStatsOrganization<
         });
       });
 
-      // Invalid and rate_limited data is combined with dropped
+      // Invalid, rate_limited data, and abused is combined with dropped
       count[Outcome.DROPPED] += count[Outcome.INVALID];
       count[Outcome.DROPPED] += count[Outcome.RATE_LIMITED];
+      count[Outcome.DROPPED] += count[Outcome.ABUSE];
 
       usageStats.forEach(stat => {
         stat.total = stat.accepted + stat.filtered + stat.dropped.total;


### PR DESCRIPTION
It has been reported many times that the numbers on the stats page don't line up. Support has done some digging and it appears that this is due to abuse outcomes not being included in the total count of dropped events. This has been fixed here.