### PR TITLE
fix(issues): Hide resolved/archived button icon on issue details

### DIFF
--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -22,7 +22,6 @@ import {Button} from 'sentry/components/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import {
-  IconArchive,
   IconCheckmark,
   IconEllipsis,
   IconMute,
@@ -502,13 +501,7 @@ export function Actions(props: Props) {
           }
           size="sm"
           icon={
-            isResolved ? (
-              <IconCheckmark />
-            ) : hasEscalatingIssues ? (
-              <IconArchive />
-            ) : (
-              <IconMute />
-            )
+            hasEscalatingIssues ? null : isResolved ? <IconCheckmark /> : <IconMute />
           }
           disabled={disabled || isAutoResolved}
           onClick={() =>


### PR DESCRIPTION
For escalating issues we're dropping the icon for the button in the resolved or archived state.

![image](https://github.com/getsentry/sentry/assets/1400464/771d9ad7-7885-4673-8c38-b8fa4de49046)
