### PR TITLE
fix(alerts): Missing string in Document Title

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -233,7 +233,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     const ruleName = rule?.name;
 
     return routeTitleGen(
-      ruleName ? t('Alert %s', ruleName) : '',
+      ruleName ? t('Alert - %s', ruleName) : t('New Alert Rule'),
       organization.slug,
       false,
       project?.slug
@@ -331,6 +331,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       );
     }
   }
+
   pollHandler = async (quitTime: number) => {
     if (Date.now() > quitTime) {
       addErrorMessage(t('Looking for that channel took too long :('));


### PR DESCRIPTION
### Before
<img width="430" alt="Screenshot 2023-05-18 at 2 55 25 PM" src="https://github.com/getsentry/sentry/assets/1748388/15f8693e-5b12-40cf-9fa3-58bf985fc430">

### After
<img width="425" alt="Screenshot 2023-05-18 at 2 58 02 PM" src="https://github.com/getsentry/sentry/assets/1748388/83c9602a-7c8f-42b6-9753-29c2211ff059">
