### PR TITLE
ref(scorecard): Use baseline flex alignment

### DIFF
--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -92,7 +92,7 @@ const HeaderWrapper = styled('div')`
 export const ScoreWrapper = styled('div')`
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: baseline;
   max-width: 100%;
 `;
 


### PR DESCRIPTION
**Before ——** the two numbers are not horizontally aligned
<img width="403" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/25a16d9f-852e-400b-8605-62119e097fbd">

**After ——**
<img width="403" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/3f53e0c1-aaea-4e57-a33e-c19aae6b1b7f">
