### PR TITLE
feat(issue-states): Add badge for new states substatus

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -4,6 +4,7 @@ import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import InboxReason from 'sentry/components/group/inboxBadges/inboxReason';
 import InboxShortId from 'sentry/components/group/inboxBadges/shortId';
+import {GroupStatusBadge} from 'sentry/components/group/inboxBadges/statusBadge';
 import TimesTag from 'sentry/components/group/inboxBadges/timesTag';
 import UnhandledTag from 'sentry/components/group/inboxBadges/unhandledTag';
 import IssueReplayCount from 'sentry/components/group/issueReplayCount';
@@ -13,7 +14,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {IconChat} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Group, Organization} from 'sentry/types';
+import type {Group, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -51,19 +52,15 @@ function EventOrGroupExtraDetails({
   const issuesPath = `/organizations/${organization.slug}/issues/`;
 
   const showReplayCount = organization.features.includes('session-replay');
-  const hasEscalatingIssues = organization.features.includes('escalating-issues-ui');
+  const hasEscalatingIssuesUi = organization.features.includes('escalating-issues-ui');
 
   return (
     <GroupExtra>
-      {inbox && <InboxReason inbox={inbox} showDateAdded={showInboxTime} />}
-      {hasEscalatingIssues && status === 'ignored' && (
-        <InboxReason
-          inbox={{
-            reason: 'archived',
-            reason_details: {substatus},
-          }}
-          showDateAdded={false}
-        />
+      {!hasEscalatingIssuesUi && inbox && (
+        <InboxReason inbox={inbox} showDateAdded={showInboxTime} />
+      )}
+      {hasEscalatingIssuesUi && (
+        <GroupStatusBadge status={status} substatus={substatus} />
       )}
       {shortId && (
         <InboxShortId

--- a/static/app/components/group/inboxBadges/groupStatusTag.tsx
+++ b/static/app/components/group/inboxBadges/groupStatusTag.tsx
@@ -1,0 +1,54 @@
+import {Fragment} from 'react';
+import type {Theme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Tag from 'sentry/components/tag';
+import TimeSince from 'sentry/components/timeSince';
+
+interface GroupStatusBadgeProps {
+  children: string;
+  dateAdded?: string;
+  fontSize?: 'sm' | 'md';
+  tooltip?: React.ReactNode;
+  type?: keyof Theme['tag'];
+}
+
+/**
+ * A styled tag shared between the inbox reason badge and the status badge.
+ */
+export function GroupStatusTag({
+  type = 'default',
+  fontSize = 'sm',
+  tooltip,
+  dateAdded,
+  children,
+}: GroupStatusBadgeProps) {
+  return (
+    <StyledTag type={type} tooltipText={tooltip} fontSize={fontSize}>
+      {children}
+      {dateAdded && (
+        <Fragment>
+          <Separator type={type}>{' | '}</Separator>
+          <TimeSince
+            date={dateAdded}
+            suffix=""
+            unitStyle="extraShort"
+            disabledAbsoluteTooltip
+          />
+        </Fragment>
+      )}
+    </StyledTag>
+  );
+}
+
+const StyledTag = styled(Tag, {
+  shouldForwardProp: p => p !== 'fontSize',
+})<{fontSize: 'sm' | 'md'}>`
+  font-size: ${p =>
+    p.fontSize === 'sm' ? p.theme.fontSizeSmall : p.theme.fontSizeMedium};
+`;
+
+const Separator = styled('span')<{type: keyof Theme['tag']}>`
+  color: ${p => p.theme.tag[p.type].border};
+  opacity: 80%;
+`;

--- a/static/app/components/group/inboxBadges/inboxReason.spec.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.spec.tsx
@@ -1,7 +1,7 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import InboxReason from 'sentry/components/group/inboxBadges/inboxReason';
-import {GroupInboxReason, GroupSubstatus} from 'sentry/types';
+import {GroupInboxReason} from 'sentry/types';
 
 describe('InboxReason', () => {
   const inbox = {
@@ -19,21 +19,6 @@ describe('InboxReason', () => {
     render(<InboxReason showDateAdded inbox={inbox} />);
     // Use a pattern so we can work around slowness between beforeEach and here.
     expect(screen.getByText(/\d+(s|ms|m)/i)).toBeInTheDocument();
-  });
-
-  it('displays archived until escalating', async () => {
-    render(
-      <InboxReason
-        inbox={{
-          reason: 'archived',
-          reason_details: {substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING},
-          date_added: inbox.date_added,
-        }}
-      />
-    );
-    expect(screen.getByText('Archived')).toBeInTheDocument();
-    await userEvent.hover(screen.getByText('Archived'));
-    expect(await screen.findByText('Archived until escalating')).toBeInTheDocument();
   });
 
   it('has a tooltip', async () => {

--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -1,25 +1,17 @@
-import {Fragment} from 'react';
-import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import DateTime from 'sentry/components/dateTime';
+import {GroupStatusTag} from 'sentry/components/group/inboxBadges/groupStatusTag';
 import Tag from 'sentry/components/tag';
 import TimeSince from 'sentry/components/timeSince';
 import {t, tct} from 'sentry/locale';
-import {Group, GroupInboxReason, GroupSubstatus, InboxDetails} from 'sentry/types';
+import {GroupInboxReason, InboxDetails} from 'sentry/types';
 import {getDuration} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useOrganization from 'sentry/utils/useOrganization';
 
-/**
- * Since archived issues are not actually in the inbox, we're faking the inbox reason
- */
-type ArchivedReason = {
-  reason: 'archived';
-  reason_details: {substatus: Group['substatus']};
-} & Omit<InboxDetails, 'reason'>;
 type Props = {
-  inbox: InboxDetails | ArchivedReason;
+  inbox: InboxDetails;
   fontSize?: 'sm' | 'md';
   /** Displays the time an issue was added to inbox */
   showDateAdded?: boolean;
@@ -98,8 +90,6 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
     tooltipDescription?: string | React.ReactNode;
     tooltipText?: string;
   } {
-    const hasEscalatingIssues = organization.features.includes('escalating-issues-ui');
-    const hasIssueStates = organization.features.includes('issue-states');
     switch (reason) {
       case GroupInboxReason.UNIGNORED:
         return {
@@ -111,7 +101,7 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
         };
       case GroupInboxReason.REGRESSION:
         return {
-          tagType: hasEscalatingIssues ? 'highlight' : 'error',
+          tagType: 'error',
           reasonBadgeText: t('Regression'),
           tooltipText:
             dateAdded &&
@@ -171,29 +161,7 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
               relative: relativeDateAdded,
             }),
         };
-      case 'archived':
-        return {
-          tagType: 'info',
-          reasonBadgeText: t('Archived'),
-          tooltipText:
-            reasonDetails.substatus === GroupSubstatus.ARCHIVED_FOREVER
-              ? t('Archived forever')
-              : reasonDetails.substatus === GroupSubstatus.ARCHIVED_UNTIL_ESCALATING
-              ? t('Archived until escalating')
-              : t('Archived until condition met'),
-        };
       default:
-        if (hasIssueStates) {
-          return {
-            tagType: 'info',
-            reasonBadgeText: t('Ongoing'),
-            tooltipText:
-              dateAdded &&
-              t('Created %(relative)s', {
-                relative: relativeDateAdded,
-              }),
-          };
-        }
         return {
           tagType: 'warning',
           reasonBadgeText: t('New Issue'),
@@ -222,20 +190,14 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
   );
 
   return (
-    <StyledTag type={tagType} tooltipText={tooltip} fontSize={fontSize}>
+    <GroupStatusTag
+      type={tagType}
+      fontSize={fontSize}
+      tooltip={tooltip}
+      dateAdded={showDateAdded ? dateAdded : undefined}
+    >
       {reasonBadgeText}
-      {showDateAdded && dateAdded && (
-        <Fragment>
-          <Separator type={tagType ?? 'default'}>{' | '}</Separator>
-          <TimeSince
-            date={dateAdded}
-            suffix=""
-            unitStyle="extraShort"
-            disabledAbsoluteTooltip
-          />
-        </Fragment>
-      )}
-    </StyledTag>
+    </GroupStatusTag>
   );
 }
 
@@ -247,16 +209,4 @@ const TooltipWrapper = styled('div')`
 
 const TooltipDescription = styled('div')`
   color: ${p => p.theme.subText};
-`;
-
-const Separator = styled('span')<{type: keyof Theme['tag']}>`
-  color: ${p => p.theme.tag[p.type].border};
-  opacity: 80%;
-`;
-
-const StyledTag = styled(Tag, {
-  shouldForwardProp: p => p !== 'fontSize',
-})<{fontSize: 'sm' | 'md'}>`
-  font-size: ${p =>
-    p.fontSize === 'sm' ? p.theme.fontSizeSmall : p.theme.fontSizeMedium};
 `;

--- a/static/app/components/group/inboxBadges/statusBadge.spec.tsx
+++ b/static/app/components/group/inboxBadges/statusBadge.spec.tsx
@@ -1,0 +1,44 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {GroupStatusBadge} from 'sentry/components/group/inboxBadges/statusBadge';
+import {GroupSubstatus, ResolutionStatus} from 'sentry/types';
+
+describe('GroupStatusBadge', () => {
+  it('should display archived until escalating as a tooltip', async () => {
+    render(
+      <GroupStatusBadge
+        status={ResolutionStatus.IGNORED}
+        substatus={GroupSubstatus.ARCHIVED_UNTIL_ESCALATING}
+      />
+    );
+    await userEvent.hover(screen.getByText('Archived'));
+    expect(await screen.findByText('Archived until escalating')).toBeInTheDocument();
+  });
+  it('should display new', () => {
+    render(
+      <GroupStatusBadge
+        status={ResolutionStatus.UNRESOLVED}
+        substatus={GroupSubstatus.NEW}
+      />
+    );
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+  it('should display escalating', () => {
+    render(
+      <GroupStatusBadge
+        status={ResolutionStatus.UNRESOLVED}
+        substatus={GroupSubstatus.ESCALATING}
+      />
+    );
+    expect(screen.getByText('Escalating')).toBeInTheDocument();
+  });
+  it('should display regression', () => {
+    render(
+      <GroupStatusBadge
+        status={ResolutionStatus.UNRESOLVED}
+        substatus={GroupSubstatus.REGRESSED}
+      />
+    );
+    expect(screen.getByText('Regressed')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/group/inboxBadges/statusBadge.tsx
+++ b/static/app/components/group/inboxBadges/statusBadge.tsx
@@ -1,0 +1,70 @@
+import type {Theme} from '@emotion/react';
+
+import {GroupStatusTag} from 'sentry/components/group/inboxBadges/groupStatusTag';
+import {t} from 'sentry/locale';
+import {Group, GroupSubstatus} from 'sentry/types';
+
+interface SubstatusBadgeProps {
+  status: Group['status'];
+  substatus: Group['substatus'];
+}
+
+function getBadgeProperties(
+  status: Group['status'],
+  substatus: Group['substatus']
+): {status: string; tagType: keyof Theme['tag']; tooltip?: string} | undefined {
+  if (status === 'unresolved') {
+    if (substatus === GroupSubstatus.REGRESSED) {
+      return {
+        tagType: 'highlight',
+        status: t('Regressed'),
+      };
+    }
+    if (substatus === GroupSubstatus.ESCALATING) {
+      return {
+        tagType: 'error',
+        status: t('Escalating'),
+      };
+    }
+    if (substatus === GroupSubstatus.NEW) {
+      return {
+        tagType: 'warning',
+        status: t('New'),
+      };
+    }
+    return {
+      tagType: 'default',
+      status: t('Ongoing'),
+    };
+  }
+  if (status === 'ignored') {
+    return {
+      tagType: 'default',
+      status: t('Archived'),
+      tooltip:
+        substatus === GroupSubstatus.ARCHIVED_FOREVER
+          ? t('Archived forever')
+          : substatus === GroupSubstatus.ARCHIVED_UNTIL_ESCALATING
+          ? t('Archived until escalating')
+          : t('Archived until condition met'),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * A replacement for the inbox badge that uses the group substatus
+ * instead of the group inbox reason.
+ */
+export function GroupStatusBadge(props: SubstatusBadgeProps) {
+  const badge = getBadgeProperties(props.status, props.substatus);
+  if (!badge) {
+    return null;
+  }
+
+  return (
+    <GroupStatusTag type={badge.tagType} tooltip={badge.tooltip}>
+      {badge.status}
+    </GroupStatusTag>
+  );
+}


### PR DESCRIPTION
Instead of using the group inbox reason, we're going to use the group substatus to display a badge. They look very similar to the inbox reason.

![image](https://github.com/getsentry/sentry/assets/1400464/b9cbbec6-d8de-4baa-9b27-83394846e792)
