### PR TITLE
chore(hybrid-cloud): Remove dependency on Organization.members for github push webhook event

### DIFF
--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -5,11 +5,19 @@ from django.db import IntegrityError, transaction
 from django.http import Http404
 from django.utils import timezone
 
-from sentry.models import Commit, CommitAuthor, CommitFileChange, Integration, Repository, User
+from sentry.models import (
+    Commit,
+    CommitAuthor,
+    CommitFileChange,
+    Integration,
+    OrganizationMember,
+    Repository,
+)
 from sentry.plugins.providers import RepositoryProvider
 from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.shared_integrations.exceptions import ApiError
 from sentry_plugins.github.client import GithubPluginClient
+from social_auth.models import UserSocialAuth
 
 from . import Webhook, get_external_id, is_anonymous_email
 
@@ -78,25 +86,24 @@ class PushEventWebhook(Webhook):
                                 # even if we can't find a user, set to none so we
                                 # don't re-query
                                 gh_username_cache[gh_username] = None
-                                try:
-                                    user = User.objects.filter(
-                                        social_auth__provider="github",
-                                        social_auth__uid=gh_user["id"],
-                                        org_memberships=organization_id,
-                                    )[0]
-                                except IndexError:
-                                    pass
-                                else:
-                                    author_email = user.email
-                                    gh_username_cache[gh_username] = author_email
-                                    if commit_author is not None:
-                                        try:
-                                            with transaction.atomic():
-                                                commit_author.update(
-                                                    email=author_email, external_id=external_id
-                                                )
-                                        except IntegrityError:
-                                            pass
+                                for social_auth in UserSocialAuth.objects.filter(
+                                    provider="github", uid=gh_user["id"]
+                                ):
+                                    member = OrganizationMember.objects.filter(
+                                        organization_id=organization_id, user_id=social_auth.user.id
+                                    ).first()
+                                    if member is not None:
+                                        author_email = social_auth.user.email
+                                        gh_username_cache[gh_username] = author_email
+                                        if commit_author is not None:
+                                            try:
+                                                with transaction.atomic():
+                                                    commit_author.update(
+                                                        email=author_email, external_id=external_id
+                                                    )
+                                            except IntegrityError:
+                                                pass
+                                        break
 
                         if commit_author is not None:
                             authors[author_email] = commit_author

--- a/tests/sentry_plugins/github/endpoints/test_push_event.py
+++ b/tests/sentry_plugins/github/endpoints/test_push_event.py
@@ -7,6 +7,7 @@ from sentry.models import Commit, CommitAuthor, OrganizationOption, Repository
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
 from sentry_plugins.github.testutils import PUSH_EVENT_EXAMPLE
+from social_auth.models import UserSocialAuth
 
 
 @region_silo_test
@@ -64,6 +65,64 @@ class PushEventWebhookTest(APITestCase):
         assert commit.author.name == "bàxterthehacker"
         assert commit.author.email == "baxterthehacker@users.noreply.github.com"
         assert commit.author.external_id is None
+        assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
+
+    def test_user_email(self):
+        project = self.project  # force creation
+        user = self.create_user(email="alberto@sentry.io")
+        UserSocialAuth.objects.create(provider="github", user=user, uid=6752317)
+        self.create_member(organization=project.organization, user=user, role="member")
+
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
+
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+
+        OrganizationOption.objects.set_value(
+            organization=project.organization, key="github:webhook_secret", value=secret
+        )
+
+        Repository.objects.create(
+            organization_id=project.organization.id,
+            external_id="35129377",
+            provider="github",
+            name="baxterthehacker/public-repo",
+        )
+
+        response = self.client.post(
+            path=url,
+            data=PUSH_EVENT_EXAMPLE,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=98196e70369945ffa6b248cf70f7dc5e46dff241",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+
+        commit_list = list(
+            Commit.objects.filter(organization_id=project.organization_id)
+            .select_related("author")
+            .order_by("-date_added")
+        )
+
+        assert len(commit_list) == 2
+
+        commit = commit_list[0]
+
+        assert commit.key == "133d60480286590a610a0eb7352ff6e02b9674c4"
+        assert commit.message == "Update README.md (àgain)"
+        assert commit.author.name == "bàxterthehacker"
+        assert commit.author.email == "alberto@sentry.io"
+        assert commit.author.external_id == "github:baxterthehacker"
+        assert commit.date_added == datetime(2015, 5, 5, 23, 45, 15, tzinfo=timezone.utc)
+
+        commit = commit_list[1]
+
+        assert commit.key == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        assert commit.message == "Update README.md"
+        assert commit.author.name == "bàxterthehacker"
+        assert commit.author.email == "alberto@sentry.io"
+        assert commit.author.external_id == "github:baxterthehacker"
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
     def test_anonymous_lookup(self):


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/49457, this is preparation to remove foreign keys between `User` and `OrganizationMember`. 