### PR TITLE
profiling(ref): pass profiles ID for the flamegraph generation to vroom directly

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -51,11 +51,13 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
             return Response(status=404)
 
         params = self.get_snuba_params(request, organization, check_global_views=False)
-        project_id = params["project_id"][0]
+        project_ids = params["project_id"]
+        if len(project_ids) > 1:
+            raise ParseError(detail="You cannot get a flamegraph from multiple projects.")
         profile_ids = get_profiles_id(params, request.query_params.get("query", None))
         kwargs: Dict[str, Any] = {
             "method": "POST",
-            "path": f"/organizations/{organization.id}/projects/{project_id}/flamegraph",
+            "path": f"/organizations/{organization.id}/projects/{project_ids[0]}/flamegraph",
             "json_data": profile_ids,
         }
         return proxy_profiling_service(**kwargs)

--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -12,6 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Organization
+from sentry.profiles.flamegraph import get_profiles_id
 from sentry.profiles.utils import parse_profile_filters, proxy_profiling_service
 
 
@@ -41,3 +42,20 @@ class OrganizationProfilingFiltersEndpoint(OrganizationProfilingBaseEndpoint):
         kwargs = {"params": params}
 
         return proxy_profiling_service("GET", f"/organizations/{organization.id}/filters", **kwargs)
+
+
+@region_silo_endpoint
+class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint):
+    def get(self, request: Request, organization: Organization) -> HttpResponse:
+        if not features.has("organizations:profiling", organization, actor=request.user):
+            return Response(status=404)
+
+        params = self.get_snuba_params(request, organization, check_global_views=False)
+        project_id = params["project_id"][0]
+        profile_ids = get_profiles_id(params, request.query_params.get("query", None))
+        kwargs: Dict[str, Any] = {
+            "method": "POST",
+            "path": f"/organizations/{organization.id}/projects/{project_id}/flamegraph",
+            "json_data": profile_ids,
+        }
+        return proxy_profiling_service(**kwargs)

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
 from typing import Any, Dict
 
 from django.http import HttpResponse, HttpResponseRedirect
@@ -16,7 +17,7 @@ from sentry.api.utils import generate_organization_url
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.project import Project
 from sentry.models.release import Release
-from sentry.profiles.flamegraph import get_profiles_id
+from sentry.profiles.flamegraph import MAX_RETENTION_DAYS, get_profiles_id
 from sentry.profiles.utils import (
     get_from_profiling_service,
     parse_profile_filters,
@@ -146,8 +147,8 @@ class ProjectProfilingFlamegraphEndpoint(ProjectProfilingBaseEndpoint):
             project.organization_id,
             project.id,
             params["transaction_name"],
-            params.get("start"),
-            params.get("end"),
+            params.get("start", datetime.utcnow() - timedelta(days=MAX_RETENTION_DAYS)),
+            params.get("end", datetime.utcnow()),
         )
         kwargs: Dict[str, Any] = {
             "method": "POST",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -332,7 +332,10 @@ from .endpoints.organization_onboarding_continuation_email import (
 from .endpoints.organization_onboarding_tasks import OrganizationOnboardingTaskEndpoint
 from .endpoints.organization_pinned_searches import OrganizationPinnedSearchEndpoint
 from .endpoints.organization_processingissues import OrganizationProcessingIssuesEndpoint
-from .endpoints.organization_profiling_profiles import OrganizationProfilingFiltersEndpoint
+from .endpoints.organization_profiling_profiles import (
+    OrganizationProfilingFiltersEndpoint,
+    OrganizationProfilingFlamegraphEndpoint,
+)
 from .endpoints.organization_projects import (
     OrganizationProjectsCountEndpoint,
     OrganizationProjectsEndpoint,
@@ -1752,6 +1755,18 @@ ORGANIZATION_URLS = [
                     r"^filters/$",
                     OrganizationProfilingFiltersEndpoint.as_view(),
                     name="sentry-api-0-organization-profiling-filters",
+                ),
+            ],
+        ),
+    ),
+    url(
+        r"^(?P<organization_slug>[^/]+)/profiling/",
+        include(
+            [
+                url(
+                    r"^flamegraph/$",
+                    OrganizationProfilingFlamegraphEndpoint.as_view(),
+                    name="sentry-api-0-organization-profiling-flamegraph",
                 ),
             ],
         ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1756,13 +1756,6 @@ ORGANIZATION_URLS = [
                     OrganizationProfilingFiltersEndpoint.as_view(),
                     name="sentry-api-0-organization-profiling-filters",
                 ),
-            ],
-        ),
-    ),
-    url(
-        r"^(?P<organization_slug>[^/]+)/profiling/",
-        include(
-            [
                 url(
                     r"^flamegraph/$",
                     OrganizationProfilingFlamegraphEndpoint.as_view(),

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from snuba_sdk import Column, Condition, Entity, Op, Query, Request
+
+from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.referrer import Referrer
+from sentry.utils.snuba import raw_snql_query
+
+MAX_RETENTION_DAYS = 90
+
+
+def get_profiles_id(
+    organization_id: int,
+    project_id: int,
+    transaction_name: str,
+    start: datetime = None,
+    end: datetime = None,
+) -> Dict[str, List[str]]:
+    where_conditions = []
+    if start is not None:
+        where_conditions.append(Condition(Column("received"), Op.GTE, start))
+    else:
+        where_conditions.append(
+            Condition(
+                Column("received"), Op.GTE, datetime.utcnow() - timedelta(days=MAX_RETENTION_DAYS)
+            )
+        )
+    if end is not None:
+        where_conditions.append(Condition(Column("received"), Op.LT, end))
+    else:
+        where_conditions.append(Condition(Column("received"), Op.LT, datetime.utcnow()))
+    query = Query(
+        match=Entity(EntityKey.Profiles.value),
+        select=[
+            Column("profile_id"),
+        ],
+        where=where_conditions
+        + [
+            Condition(Column("organization_id"), Op.EQ, organization_id),
+            Condition(Column("project_id"), Op.EQ, project_id),
+            Condition(Column("transaction_name"), Op.EQ, transaction_name),
+        ],
+    ).set_limit(100)
+    request = Request(
+        dataset=Dataset.Profiles.value,
+        app_id="default",
+        query=query,
+        tenant_ids={
+            "referrer": Referrer.API_PROFILING_PROFILE_SUMMARY_TABLE.value,
+            "organization_id": 8,
+        },
+    )
+    data = raw_snql_query(
+        request,
+        referrer=Referrer.API_PROFILING_PROFILE_SUMMARY_TABLE.value,
+    )["data"]
+    return {"profiles_id": [row["profile_id"] for row in data]}

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -116,8 +116,11 @@ def proxy_profiling_service(
     path: str,
     params: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
+    json_data: Any = None,
 ) -> SentryResponse:
-    profiling_response = get_from_profiling_service(method, path, params=params, headers=headers)
+    profiling_response = get_from_profiling_service(
+        method, path, params=params, headers=headers, json_data=json_data
+    )
     return SentryResponse(
         content=profiling_response.data,
         status=profiling_response.status,

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -33,3 +33,4 @@ class EntityKey(Enum):
     GenericMetricsCounters = "generic_metrics_counters"
     GenericOrgMetricsCounters = "generic_org_metrics_counters"
     IssuePlatform = "search_issues"
+    Profiles = "profiles"

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -33,4 +33,3 @@ class EntityKey(Enum):
     GenericMetricsCounters = "generic_metrics_counters"
     GenericOrgMetricsCounters = "generic_org_metrics_counters"
     IssuePlatform = "search_issues"
-    Profiles = "profiles"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -327,6 +327,7 @@ class ReferrerBase(Enum):
     API_PROFILING_LANDING_FUNCTIONS_CARD = "api.profiling.landing-functions-card"
     API_PROFILING_PROFILE_SUMMARY_TABLE = "api.profiling.profile-summary-table"
     API_PROFILING_PROFILE_SUMMARY_FUNCTIONS_TABLE = "api.profiling.profile-summary-functions-table"
+    API_PROFILING_PROFILE_FLAMEGRAPH = "api.profiling.profile-flamegraph"
     API_PROJECT_EVENTS = "api.project-events"
     API_RELEASES_RELEASE_DETAILS_CHART = "api.releases.release-details-chart"
     API_REPLAY_DETAILS_PAGE = "api.replay.details-page"


### PR DESCRIPTION
Fetches the list of profiles ID that will be used for the generation of the `flamegraph` and passes them over to `vroom`.
