### PR TITLE
fix(issues): Move call to future.result() outside of the try except block

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -55,9 +55,10 @@ def track_occurrence_producer_futures(future: Future[BrokerValue[KafkaPayload]])
     if len(occurrence_producer_futures) >= settings.SENTRY_ISSUE_PLATFORM_FUTURES_MAX_LIMIT:
         try:
             future = occurrence_producer_futures.popleft()
-            future.result()
         except IndexError:
             return
+        else:
+            future.result()
 
 
 def handle_occurrence_producer() -> None:


### PR DESCRIPTION
`future.result()` can raise an `IndexError` which should not be squashed.  We only want to squash `IndexError`s raised from the call to `popleft()`.