### PR TITLE
ref(js): More improvements to 200 response error capturing

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -527,10 +527,10 @@ export class Client {
             // Pass a scope object rather than using `withScope` to avoid even
             // the possibility of scope bleed.
             const scope = new Sentry.Scope();
-            scope.setTags({errorReason});
 
             if (!responseTextUndefined && !responseTextEmpty) {
               // Grab everything that could conceivably be helpful to know
+              scope.setTags({errorReason});
               scope.setExtras({
                 twoHundredErrorReason,
                 responseJSON,

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -14,6 +14,7 @@ import {metric} from 'sentry/utils/analytics';
 import getCsrfToken from 'sentry/utils/getCsrfToken';
 import {uniqueId} from 'sentry/utils/guid';
 import RequestError from 'sentry/utils/requestError/requestError';
+import {sanitizePath} from 'sentry/utils/requestError/sanitizePath';
 
 export class Request {
   /**
@@ -523,6 +524,7 @@ export class Client {
           if (status === 200) {
             const responseTextUndefined = responseText === undefined;
             const responseTextEmpty = responseText === '';
+            const parameterizedPath = sanitizePath(path);
 
             // Pass a scope object rather than using `withScope` to avoid even
             // the possibility of scope bleed.
@@ -550,7 +552,10 @@ export class Client {
             // Make sure all of these errors group, so we don't produce a bunch of noise
             scope.setFingerprint([message]);
 
-            Sentry.captureException(new Error(`${message}: ${method} ${path}`), scope);
+            Sentry.captureException(
+              new Error(`${message}: ${method} ${parameterizedPath}`),
+              scope
+            );
           }
 
           const shouldSkipErrorHandler =

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -529,6 +529,7 @@ export class Client {
             // Pass a scope object rather than using `withScope` to avoid even
             // the possibility of scope bleed.
             const scope = new Sentry.Scope();
+            scope.setTags({endpoint: `${method} ${parameterizedPath}`});
 
             if (!responseTextUndefined && !responseTextEmpty) {
               // Grab everything that could conceivably be helpful to know

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -522,13 +522,14 @@ export class Client {
           // Until we know why, let's do what is essentially some very fancy print debugging.
           if (status === 200) {
             const responseTextUndefined = responseText === undefined;
+            const responseTextEmpty = responseText === '';
 
             // Pass a scope object rather than using `withScope` to avoid even
             // the possibility of scope bleed.
             const scope = new Sentry.Scope();
             scope.setTags({errorReason});
 
-            if (!responseTextUndefined) {
+            if (!responseTextUndefined && !responseTextEmpty) {
               // Grab everything that could conceivably be helpful to know
               scope.setExtras({
                 twoHundredErrorReason,
@@ -542,6 +543,8 @@ export class Client {
 
             const message = responseTextUndefined
               ? '200 API response with undefined responseText'
+              : responseTextEmpty
+              ? '200 API response with empty responseText'
               : '200 treated as error';
 
             // Make sure all of these errors group, so we don't produce a bunch of noise


### PR DESCRIPTION
This makes a few more small improvements to the way we're capturing data about when we consider a 200-status API response to a frontend client request an error. 

Key changes:

- Separate `responseText` being empty out into a separate issue by giving it its own error message and fingerprint.
- Only add `errorReason` tag if it's not one of our known cases.
- Use parameterize the path used in the error message.
- Add an `endpoint` tag, so that we can see a breakdown of which endpoints this is happening on.