### PR TITLE
feat(issues): Abstract message publishing and encoding from IssueOccurrence type

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -41,7 +41,7 @@ def produce_occurrence_to_kafka(occurrence: IssueOccurrence) -> None:
         lookup_event_and_process_issue_occurrence(occurrence.to_dict())
         return
 
-    _produce_to_kafka(occurence_bytes=occurrence.to_dict())
+    _produce_to_kafka(occurrence=occurrence.to_dict())
 
 
 def _produce_to_kafka(occurrence: Dict[str, Any]) -> None:

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -4,7 +4,7 @@ from atexit import register
 from collections import deque
 from concurrent import futures
 from concurrent.futures import Future
-from typing import Any, Deque, Dict
+from typing import Any, Deque, Dict, cast
 
 from arroyo import Topic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
@@ -41,7 +41,7 @@ def produce_occurrence_to_kafka(occurrence: IssueOccurrence) -> None:
         lookup_event_and_process_issue_occurrence(occurrence.to_dict())
         return
 
-    _produce_to_kafka(occurrence=occurrence.to_dict())
+    _produce_to_kafka(occurrence=cast(Dict[str, Any], occurrence.to_dict()))
 
 
 def _produce_to_kafka(occurrence: Dict[str, Any]) -> None:


### PR DESCRIPTION
The function `produce_occurrence_to_kafka` was coupled to the `IssueOccurrence` object.  Replay is using a different (supported) schema and so we would have to duplicate the publishing behavior.  By handling the concrete type's serialization in a separate function we can abstract the common behavior so other types can utilize it as well.

Some notes:

- The test fallback mechanism `if settings.SENTRY_EVENTSTREAM != "sentry...` should be moved into this new generic function however it has a dependency on `IssueOccurrence` and `IssueOccurrenceData`.  So I left it as is.  Replay will have to implement our own testing fallback until this can be made more generic.