### PR TITLE
fix(starfish): Span summary baseline comparison calculation

### DIFF
--- a/static/app/views/starfish/views/spanSummary/index.tsx
+++ b/static/app/views/starfish/views/spanSummary/index.tsx
@@ -258,8 +258,8 @@ export default function SpanSummary({location, params}: Props) {
     if (column.key === 'p50_comparison') {
       const diff = row.spanDuration - p50;
 
-      if (diff === p50) {
-        return 'At baseline';
+      if (Math.floor(row.spanDuration) === Math.floor(p50)) {
+        return <PlaintextLabel>{t('At baseline')}</PlaintextLabel>;
       }
 
       const labelString =
@@ -468,6 +468,10 @@ const FilterOptionsSubContainer = styled('div')`
 const ToggleLabel = styled('span')<{active?: boolean}>`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => (p.active ? p.theme.purple300 : p.theme.gray300)};
+`;
+
+const PlaintextLabel = styled('div')`
+  text-align: right;
 `;
 
 const ComparisonLabel = styled('div')<{value: number}>`


### PR DESCRIPTION
The calculation was wrong before, now we can see the label properly for baseline samples:

![image](https://github.com/getsentry/sentry/assets/16740047/55fa5b2e-1b89-4182-a4d6-3ba6b39507d4)
