### PR TITLE
fix(group): don't mutate group when adding group inbox

### DIFF
--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -12,7 +12,6 @@ from sentry.models import Activity
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import inbox_in, inbox_out
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
 
 INBOX_REASON_DETAILS = {
     "type": ["object", "null"],
@@ -88,14 +87,7 @@ def add_group_to_inbox(group, reason, reason_details=None):
         },
     )
 
-    if reason == GroupInboxReason.REGRESSION:
-        group.substatus = GroupSubStatus.REGRESSED
-        group.save(update_fields=["substatus"])
-
-    if reason is GroupInboxReason.NEW:
-        group.substatus = GroupSubStatus.NEW
-        group.save(update_fields=["substatus"])
-    else:
+    if reason is not GroupInboxReason.NEW:
         # Ignore new issues, too many events
         inbox_in.send_robust(
             project=group.project,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -637,6 +637,7 @@ def process_inbox_adds(job: PostProcessJob) -> None:
             from sentry.models.groupinbox import add_group_to_inbox
 
             if is_reprocessed and is_new:
+                # keep Group.status=UNRESOLVED and Group.substatus=ONGOING if its reprocessed
                 add_group_to_inbox(event.group, GroupInboxReason.REPROCESSED)
             elif (
                 not is_reprocessed and not has_reappeared

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -622,6 +622,9 @@ def update_event_groups(event: Event, group_states: Optional[GroupStates] = None
 
 
 def process_inbox_adds(job: PostProcessJob) -> None:
+    from sentry.models import Group, GroupStatus
+    from sentry.types.group import GroupSubStatus
+
     with metrics.timer("post_process.process_inbox_adds.duration"):
         with sentry_sdk.start_span(op="tasks.post_process_group.add_group_to_inbox"):
             event = job["event"]
@@ -639,9 +642,25 @@ def process_inbox_adds(job: PostProcessJob) -> None:
                 not is_reprocessed and not has_reappeared
             ):  # If true, we added the .ONGOING reason already
                 if is_new:
-                    add_group_to_inbox(event.group, GroupInboxReason.NEW)
+                    updated = (
+                        Group.objects.filter(id=event.group.id)
+                        .exclude(substatus=GroupSubStatus.NEW)
+                        .update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW)
+                    )
+                    if updated:
+                        event.group.status = GroupStatus.UNRESOLVED
+                        event.group.substatus = GroupSubStatus.NEW
+                        add_group_to_inbox(event.group, GroupInboxReason.NEW)
                 elif is_regression:
-                    add_group_to_inbox(event.group, GroupInboxReason.REGRESSION)
+                    updated = (
+                        Group.objects.filter(id=event.group.id)
+                        .exclude(substatus=GroupSubStatus.REGRESSED)
+                        .update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.REGRESSED)
+                    )
+                    if updated:
+                        event.group.status = GroupStatus.UNRESOLVED
+                        event.group.substatus = GroupSubStatus.REGRESSED
+                        add_group_to_inbox(event.group, GroupInboxReason.REGRESSION)
 
 
 def process_snoozes(job: PostProcessJob) -> None:

--- a/tests/sentry/models/test_groupinbox.py
+++ b/tests/sentry/models/test_groupinbox.py
@@ -12,7 +12,6 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
 
 
 @region_silo_test(stable=True)
@@ -29,7 +28,6 @@ class GroupInboxTestCase(TestCase):
         assert GroupInbox.objects.filter(
             group=self.group, reason=GroupInboxReason.NEW.value
         ).exists()
-        assert self.group.substatus == GroupSubStatus.REGRESSED
         assert inbox_in.called
 
     @patch("sentry.signals.inbox_out.send_robust")

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -20,7 +20,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         now = datetime.now(tz=pytz.UTC)
         project = self.create_project()
         group = self.create_group(
-            project=project,
+            project=project, status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW
         )
         group_inbox = add_group_to_inbox(group, GroupInboxReason.NEW)
         group_inbox.date_added = now - timedelta(days=3, hours=1)
@@ -189,7 +189,7 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
         now = datetime.now(tz=pytz.UTC)
         project = self.create_project()
         group = self.create_group(
-            project=project,
+            project=project, status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.REGRESSED
         )
         group_inbox = add_group_to_inbox(group, GroupInboxReason.REGRESSION)
         group_inbox.date_added = now - timedelta(days=14, hours=1)


### PR DESCRIPTION
Instead of updating the `substatus` value when adding the group to inbox, we should just be adding a GroupInbox row in `add_group_to_inbox` and doing any other side-effects related to GroupInbox before/after calling that method. 

