### PR TITLE
ref(button): Use light shadows on XS buttons

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -243,22 +243,24 @@ const getBoxShadow = ({
   borderless,
   translucentBorder,
   disabled,
+  size,
   theme,
 }: StyledButtonProps) => {
+  if (disabled || borderless || priority === 'link') {
+    return 'box-shadow: none';
+  }
+
   const themeName = disabled ? 'disabled' : priority || 'default';
   const {borderTranslucent} = theme.button[themeName];
   const translucentBorderString = translucentBorder
     ? `0 0 0 1px ${borderTranslucent},`
     : '';
-
-  if (disabled || borderless || priority === 'link') {
-    return 'box-shadow: none';
-  }
+  const dropShadow = size === 'xs' ? theme.dropShadowLight : theme.dropShadowMedium;
 
   return `
-      box-shadow: ${translucentBorderString} ${theme.dropShadowMedium};
+      box-shadow: ${translucentBorderString} ${dropShadow};
       &:active {
-        box-shadow: ${translucentBorderString} inset ${theme.dropShadowMedium};
+        box-shadow: ${translucentBorderString} inset ${dropShadow};
       }
     `;
 };


### PR DESCRIPTION
XS buttons don't need shadows as heavy as those on MD/SM buttons.

**Before ——**
<img width="311" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/dbb4b0d9-4b1f-4896-90b7-d8c8afd03b63">

**After ——**
<img width="311" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/9d10c02c-a3e9-433d-bb7d-87c8f2c93605">
