### PR TITLE
feat(trends): Remove count query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trendsv2.py
+++ b/src/sentry/api/endpoints/organization_events_trendsv2.py
@@ -235,7 +235,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                         request,
                         organization,
                         params["project_id"],
-                        {"data": [trends["data"]], "meta": {"isMetricsData": True}},
+                        {"data": trending_events, "meta": {"isMetricsData": True}},
                         True,
                     ),
                     "stats": trending_transaction_names_stats,

--- a/src/sentry/api/endpoints/organization_events_trendsv2.py
+++ b/src/sentry/api/endpoints/organization_events_trendsv2.py
@@ -220,8 +220,8 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             sentry_sdk.set_tag("performance.trendsv2.trends", len(trends.get("data", [])) > 0)
 
             trending_transaction_names_stats = {}
-            trending_events = trends["data"]
-
+            # TODO add proper pagination
+            trending_events = trends["data"][:5]
             for t in trending_events:
                 transaction_name = t["transaction"]
                 project = t["project"]


### PR DESCRIPTION
Do not query count timeseries for every transaction. In the follow up PR I will query count before and after a breakpoint for the displayed transactions instead. This should speed up the query. Until pagination is implemented, the endpoint will return first 5 transactions and not the whole set

should be merged after https://github.com/getsentry/sentry/pull/49487 to ensure that frontend rendering doesn't break

fixes SENTRY-11DX