### PR TITLE
feat(trends): Handle empty counts

### DIFF
--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -448,26 +448,35 @@ function TrendsListItem(props: TrendsListItemProps) {
   return (
     <ListItemContainer data-test-id={'trends-list-item-' + trendChangeType}>
       <ItemRadioContainer color={color}>
-        <Tooltip
-          title={
-            <TooltipContent>
-              <span>{t('Total Events')}</span>
-              <span>
-                <Count value={transaction.count_range_1} />
-                <StyledIconArrow direction="right" size="xs" />
-                <Count value={transaction.count_range_2} />
-              </span>
-            </TooltipContent>
-          }
-          disableForVisualTest // Disabled tooltip in snapshots because of overlap order issues.
-        >
+        {transaction.count_range_1 && transaction.count_range_2 ? (
+          <Tooltip
+            title={
+              <TooltipContent>
+                <span>{t('Total Events')}</span>
+                <span>
+                  <Count value={transaction.count_range_1} />
+                  <StyledIconArrow direction="right" size="xs" />
+                  <Count value={transaction.count_range_2} />
+                </span>
+              </TooltipContent>
+            }
+            disableForVisualTest // Disabled tooltip in snapshots because of overlap order issues.
+          >
+            <RadioLineItem index={index} role="radio">
+              <Radio
+                checked={isSelected}
+                onChange={() => handleSelectTransaction(transaction)}
+              />
+            </RadioLineItem>
+          </Tooltip>
+        ) : (
           <RadioLineItem index={index} role="radio">
             <Radio
               checked={isSelected}
               onChange={() => handleSelectTransaction(transaction)}
             />
           </RadioLineItem>
-        </Tooltip>
+        )}
       </ItemRadioContainer>
       <TransactionSummaryLink {...props} />
       <ItemTransactionPercentage>

--- a/static/app/views/performance/trends/types.tsx
+++ b/static/app/views/performance/trends/types.tsx
@@ -70,14 +70,14 @@ export type TrendsTransaction = {
   aggregate_range_2: number;
   count: number;
 
-  count_percentage: number;
-  count_range_1: number;
-  count_range_2: number;
   project: string;
   transaction: string;
   trend_difference: number;
   trend_percentage: number;
   breakpoint?: number;
+  count_percentage?: number;
+  count_range_1?: number;
+  count_range_2?: number;
 };
 
 export type TrendsDataEvents = {


### PR DESCRIPTION
when `count_range_1` and `count_range_2` are empty hide the tooltip 