### PR TITLE
feat(starfish): Add span metrics to events

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -30,6 +30,7 @@ from sentry.snuba import (
     metrics_performance,
     profiles,
     spans_indexed,
+    spans_metrics,
 )
 from sentry.utils import snuba
 from sentry.utils.cursors import Cursor
@@ -47,6 +48,7 @@ DATASET_OPTIONS = {
     "issuePlatform": issue_platform,
     "profileFunctions": functions,
     "spansIndexed": spans_indexed,
+    "spansMetrics": spans_metrics,
 }
 
 DATASET_LABELS = {value: key for key, value in DATASET_OPTIONS.items()}

--- a/src/sentry/search/events/builder/__init__.py
+++ b/src/sentry/search/events/builder/__init__.py
@@ -27,6 +27,7 @@ from .spans_indexed import (  # NOQA
     TimeseriesSpanIndexedQueryBuilder,
     TopEventsSpanIndexedQueryBuilder,
 )
+from .spans_metrics import SpansMetricsQueryBuilder  # NOQA
 
 __all__ = [
     "HistogramQueryBuilder",
@@ -39,6 +40,7 @@ __all__ = [
     "HistogramMetricQueryBuilder",
     "MetricsQueryBuilder",
     "TimeseriesMetricQueryBuilder",
+    "SpansMetricsQueryBuilder",
     "ProfilesQueryBuilder",
     "ProfilesTimeseriesQueryBuilder",
     "ProfileFunctionsQueryBuilder",

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -62,6 +62,7 @@ from sentry.search.events.datasets.profile_functions import ProfileFunctionsData
 from sentry.search.events.datasets.profiles import ProfilesDatasetConfig
 from sentry.search.events.datasets.sessions import SessionsDatasetConfig
 from sentry.search.events.datasets.spans_indexed import SpansIndexedDatasetConfig
+from sentry.search.events.datasets.spans_metrics import SpansMetricsDatasetConfig
 from sentry.search.events.types import (
     EventsResponse,
     HistogramParams,
@@ -93,6 +94,8 @@ class BaseQueryBuilder:
 
 class QueryBuilder(BaseQueryBuilder):
     """Builds a discover query"""
+
+    spans_metrics_builder = False
 
     def _dataclass_params(
         self, snuba_params: Optional[SnubaParams], params: ParamsType
@@ -339,7 +342,9 @@ class QueryBuilder(BaseQueryBuilder):
         elif self.dataset == Dataset.Sessions:
             self.config = SessionsDatasetConfig(self)
         elif self.dataset in [Dataset.Metrics, Dataset.PerformanceMetrics]:
-            if self.use_metrics_layer:
+            if self.spans_metrics_builder:
+                self.config = SpansMetricsDatasetConfig(self)
+            elif self.use_metrics_layer:
                 self.config = MetricsLayerDatasetConfig(self)
             else:
                 self.config = MetricsDatasetConfig(self)

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+from sentry.search.events.builder import MetricsQueryBuilder
+
+
+class SpansMetricsQueryBuilder(MetricsQueryBuilder):
+    requires_organization_condition = True
+    spans_metrics_builder = True
+
+    def get_field_type(self, field: str) -> Optional[str]:
+        if field in self.meta_resolver_map:
+            return self.meta_resolver_map[field]
+        if field in ["span.duration", "span.exclusive_time"]:
+            return "duration"
+
+        return None

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -242,6 +242,10 @@ METRICS_MAP = {
     "transaction.duration": "d:transactions/duration@millisecond",
     "user": "s:transactions/user@none",
 }
+SPAN_METRICS_MAP = {
+    "user": "s:transactions/span.user@none",
+    "span.duration": "d:transactions/span.duration@millisecond",
+}
 # 50 to match the size of tables in the UI + 1 for pagination reasons
 METRICS_MAX_LIMIT = 101
 

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Callable, Mapping, Optional
+
+from snuba_sdk import Column, Function, OrderBy
+
+from sentry.api.event_search import SearchFilter
+from sentry.exceptions import IncompatibleMetricsQuery
+from sentry.search.events import builder, constants, fields
+from sentry.search.events.datasets.base import DatasetConfig
+from sentry.search.events.types import SelectType, WhereType
+
+
+class SpansMetricsDatasetConfig(DatasetConfig):
+    missing_function_error = IncompatibleMetricsQuery
+
+    def __init__(self, builder: builder.SpansMetricsQueryBuilder):
+        self.builder = builder
+
+    @property
+    def search_filter_converter(
+        self,
+    ) -> Mapping[str, Callable[[SearchFilter], Optional[WhereType]]]:
+        return {}
+
+    @property
+    def field_alias_converter(self) -> Mapping[str, Callable[[str], SelectType]]:
+        return {}
+
+    def resolve_metric(self, value: str) -> int:
+        metric_id = self.builder.resolve_metric_index(constants.SPAN_METRICS_MAP.get(value, value))
+        # If its still None its not a custom measurement
+        if metric_id is None:
+            raise IncompatibleMetricsQuery(f"Metric: {value} could not be resolved")
+        self.builder.metric_ids.add(metric_id)
+        return metric_id
+
+    def resolve_value(self, value: str) -> int:
+        value_id = self.builder.resolve_tag_value(value)
+
+        return value_id
+
+    @property
+    def function_converter(self) -> Mapping[str, fields.MetricsFunction]:
+        """While the final functions in clickhouse must have their -Merge combinators in order to function, we don't
+        need to add them here since snuba has a FunctionMapper that will add it for us. Basically it turns expressions
+        like quantiles(0.9)(value) into quantilesMerge(0.9)(percentiles)
+        Make sure to update METRIC_FUNCTION_LIST_BY_TYPE when adding functions here, can't be a dynamic list since the
+        Metric Layer will actually handle which dataset each function goes to
+        """
+        resolve_metric_id = {
+            "name": "metric_id",
+            "fn": lambda args: self.resolve_metric(args["column"]),
+        }
+
+        function_converter = {
+            function.name: function
+            for function in [
+                fields.MetricsFunction(
+                    "count_unique",
+                    required_args=[
+                        fields.MetricArg(
+                            "column", allowed_columns=["user"], allow_custom_measurements=False
+                        )
+                    ],
+                    calculated_args=[resolve_metric_id],
+                    snql_set=lambda args, alias: Function(
+                        "uniqIf",
+                        [
+                            Column("value"),
+                            Function("equals", [Column("metric_id"), args["metric_id"]]),
+                        ],
+                        alias,
+                    ),
+                    default_result_type="integer",
+                ),
+            ]
+        }
+
+        for alias, name in constants.FUNCTION_ALIASES.items():
+            if name in function_converter:
+                function_converter[alias] = function_converter[name].alias_as(alias)
+
+        return function_converter
+
+    @property
+    def orderby_converter(self) -> Mapping[str, OrderBy]:
+        return {}

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -1,0 +1,55 @@
+import logging
+
+from sentry.search.events.builder import SpansMetricsQueryBuilder
+from sentry.utils.snuba import Dataset
+
+logger = logging.getLogger(__name__)
+
+
+def query(
+    selected_columns,
+    query,
+    params,
+    snuba_params=None,
+    equations=None,
+    orderby=None,
+    offset=None,
+    limit=50,
+    referrer=None,
+    auto_fields=False,
+    auto_aggregations=False,
+    include_equation_fields=False,
+    allow_metric_aggregates=False,
+    use_aggregate_conditions=False,
+    conditions=None,
+    functions_acl=None,
+    transform_alias_to_input_format=False,
+    sample=None,
+    has_metrics=False,
+    use_metrics_layer=False,
+    skip_tag_resolution=False,
+    extra_columns=None,
+):
+    builder = SpansMetricsQueryBuilder(
+        dataset=Dataset.Metrics,
+        params=params,
+        snuba_params=snuba_params,
+        query=query,
+        selected_columns=selected_columns,
+        equations=equations,
+        orderby=orderby,
+        auto_fields=auto_fields,
+        auto_aggregations=auto_aggregations,
+        use_aggregate_conditions=use_aggregate_conditions,
+        functions_acl=functions_acl,
+        limit=limit,
+        offset=offset,
+        equation_config={"auto_add": include_equation_fields},
+        sample_rate=sample,
+        has_metrics=has_metrics,
+        transform_alias_to_input_format=transform_alias_to_input_format,
+        skip_tag_resolution=skip_tag_resolution,
+    )
+
+    result = builder.process_results(builder.run_query(referrer))
+    return result


### PR DESCRIPTION
- This adds the span metrics "dataset" to the events endpoint
- span metrics are currently stored alongside performance metrics
- so there isn't actually a different dataset, this means the dataset config is a pseudo one