### PR TITLE
chore(issue-platform): Remove project level sentry:performance_issue_send_to_issues_platform option

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -614,14 +614,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings["sentry:dynamic_sampling_biases"] = result[
                     "dynamicSamplingBiases"
                 ]
-        if "performanceIssueSendToPlatform" in result:
-            if project.update_option(
-                "sentry:performance_issue_send_to_issues_platform",
-                result["performanceIssueSendToPlatform"],
-            ):
-                changed_proj_settings["sentry:performance_issue_send_to_issues_platform"] = result[
-                    "performanceIssueSendToPlatform"
-                ]
         # TODO(dcramer): rewrite options to use standard API config
         if has_project_write:
             options = request.data.get("options", {})

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -196,12 +196,6 @@ def format_options(attrs: defaultdict(dict)):
             options.get("sentry:csp_ignored_sources", []) or []
         ),
         "sentry:reprocessing_active": bool(options.get("sentry:reprocessing_active", False)),
-        "sentry:performance_issue_send_to_issues_platform": options.get(
-            "sentry:performance_issue_send_to_issues_platform"
-        ),
-        "sentry:performance_issue_create_issue_through_plaform": options.get(
-            "sentry:performance_issue_create_issue_through_plaform"
-        ),
         "filters:blacklisted_ips": "\n".join(options.get("sentry:blacklisted_ips", [])),
         "filters:react-hydration-errors": bool(options.get("filters:react-hydration-errors", True)),
         f"filters:{FilterTypes.RELEASES}": "\n".join(
@@ -919,12 +913,6 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "relayPiiConfig": attrs["options"].get("sentry:relay_pii_config"),
                 "builtinSymbolSources": get_value_with_default("sentry:builtin_symbol_sources"),
                 "dynamicSamplingBiases": get_value_with_default("sentry:dynamic_sampling_biases"),
-                "performanceIssueSendToPlatform": get_value_with_default(
-                    "sentry:performance_issue_send_to_issues_platform"
-                ),
-                "performanceIssueCreationThroughPlatform": get_value_with_default(
-                    "sentry:performance_issue_create_issue_through_plaform"
-                ),
                 "eventProcessing": {
                     "symbolicationDegraded": False,
                 },

--- a/src/sentry/issues/utils.py
+++ b/src/sentry/issues/utils.py
@@ -15,6 +15,4 @@ def write_occurrence_to_platform(performance_problem: PerformanceProblem, projec
         performance_problem.type.category == GroupCategory.PERFORMANCE.value
         # system-wide option
         and options.get("performance.issues.send_to_issues_platform", False)
-        # more-granular per-project option
-        and project.get_option("sentry:performance_issue_send_to_issues_platform", True)
     )

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -51,8 +51,6 @@ OPTION_KEYS = frozenset(
         "sentry:dynamic_sampling_biases",
         "sentry:breakdowns",
         "sentry:span_attributes",
-        "sentry:performance_issue_send_to_issues_platform",
-        "sentry:performance_issue_create_issue_through_plaform",
         "sentry:transaction_name_cluster_rules",
         "quotas:spike-protection-disabled",
         "feedback:branding",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -97,10 +97,6 @@ register(key="sentry:transaction_metrics_custom_tags", epoch_defaults={1: []})
 # Default span attributes config
 register(key="sentry:span_attributes", epoch_defaults={1: ["exclusive-time"]})
 
-# Rate at which performance problems are sent to issues platform. Defaults to False, system flags and options will determine if an organization sends perf problems to platform.
-# Can be used to turn off writing occurrences for users if there is a project-specific issue.
-register(key="sentry:performance_issue_send_to_issues_platform", default=True)
-
 DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS = {
     "n_plus_one_db_detection_rate": 1.0,
     "n_plus_one_api_calls_detection_rate": 1.0,


### PR DESCRIPTION
Also removes remainder of `sentry:performance_issue_create_issue_through_plaform` that I missed cleaning up before

