### PR TITLE
feat(hybrid-cloud): Add user_service.get_user_by_social_auth

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -103,6 +103,18 @@ class DatabaseBackedUserService(UserService):
             User.objects.filter(id=user_id).update(**attrs)
         return self.serialize_many(filter=dict(user_ids=[user_id]))[0]
 
+    def get_user_by_social_auth(
+        self, organization_id: int, provider: str, uid: str
+    ) -> Optional[RpcUser]:
+        user = User.objects.filter(
+            social_auth__provider=provider,
+            social_auth__uid=uid,
+            orgmembermapping_set__organization_id=organization_id,
+        ).first()
+        if user is None:
+            return None
+        return serialize_rpc_user(user)
+
     def close(self) -> None:
         pass
 

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -106,5 +106,11 @@ class UserService(RpcService):
         else:
             return None
 
+    @rpc_method
+    def get_user_by_social_auth(
+        self, organization_id: int, provider: str, uid: str
+    ) -> Optional[RpcUser]:
+        pass
+
 
 user_service: UserService = cast(UserService, UserService.create_delegation())

--- a/src/sentry_plugins/github/webhooks/events/pull_request.py
+++ b/src/sentry_plugins/github/webhooks/events/pull_request.py
@@ -1,7 +1,8 @@
 from django.db import IntegrityError
 from django.http import Http404
 
-from sentry.models import CommitAuthor, PullRequest, Repository, User
+from sentry.models import CommitAuthor, PullRequest, Repository
+from sentry.services.hybrid_cloud.user.service import user_service
 
 from . import Webhook, get_external_id
 
@@ -53,16 +54,13 @@ class PullRequestEventWebhook(Webhook):
             )
             author_email = commit_author.email
         except CommitAuthor.DoesNotExist:
-            try:
-                user_model = User.objects.filter(
-                    social_auth__provider="github",
-                    social_auth__uid=user["id"],
-                    sentry_orgmember_set__organization_id=organization.id,
-                )[0]
-            except IndexError:
-                pass
-            else:
-                author_email = user_model.email
+            rpc_user = user_service.get_user_by_social_auth(
+                organization_id=organization.id,
+                provider="github",
+                uid=user["id"],
+            )
+            if rpc_user is not None:
+                author_email = rpc_user.email
 
         try:
             author = CommitAuthor.objects.get(

--- a/src/sentry_plugins/github/webhooks/events/pull_request.py
+++ b/src/sentry_plugins/github/webhooks/events/pull_request.py
@@ -57,7 +57,7 @@ class PullRequestEventWebhook(Webhook):
                 user_model = User.objects.filter(
                     social_auth__provider="github",
                     social_auth__uid=user["id"],
-                    org_memberships=organization,
+                    sentry_orgmember_set__organization_id=organization.id,
                 )[0]
             except IndexError:
                 pass

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -5,9 +5,10 @@ from django.db import IntegrityError, transaction
 from django.http import Http404
 from django.utils import timezone
 
-from sentry.models import Commit, CommitAuthor, CommitFileChange, Integration, Repository, User
+from sentry.models import Commit, CommitAuthor, CommitFileChange, Integration, Repository
 from sentry.plugins.providers import RepositoryProvider
 from sentry.services.hybrid_cloud import coerce_id_from
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry_plugins.github.client import GithubPluginClient
 
@@ -78,15 +79,12 @@ class PushEventWebhook(Webhook):
                                 # even if we can't find a user, set to none so we
                                 # don't re-query
                                 gh_username_cache[gh_username] = None
-                                try:
-                                    user = User.objects.filter(
-                                        social_auth__provider="github",
-                                        social_auth__uid=gh_user["id"],
-                                        sentry_orgmember_set__organization_id=organization_id,
-                                    )[0]
-                                except IndexError:
-                                    pass
-                                else:
+                                user = user_service.get_user_by_social_auth(
+                                    organization_id=organization_id,
+                                    provider="github",
+                                    uid=gh_user["id"],
+                                )
+                                if user is not None:
                                     author_email = user.email
                                     gh_username_cache[gh_username] = author_email
                                     if commit_author is not None:

--- a/src/sentry_plugins/github/webhooks/events/push.py
+++ b/src/sentry_plugins/github/webhooks/events/push.py
@@ -82,7 +82,7 @@ class PushEventWebhook(Webhook):
                                     user = User.objects.filter(
                                         social_auth__provider="github",
                                         social_auth__uid=gh_user["id"],
-                                        org_memberships=organization_id,
+                                        sentry_orgmember_set__organization_id=organization_id,
                                     )[0]
                                 except IndexError:
                                     pass

--- a/tests/sentry_plugins/github/endpoints/test_push_event.py
+++ b/tests/sentry_plugins/github/endpoints/test_push_event.py
@@ -7,6 +7,7 @@ from sentry.models import Commit, CommitAuthor, OrganizationOption, Repository
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
 from sentry_plugins.github.testutils import PUSH_EVENT_EXAMPLE
+from social_auth.models import UserSocialAuth
 
 
 @region_silo_test
@@ -64,6 +65,64 @@ class PushEventWebhookTest(APITestCase):
         assert commit.author.name == "bàxterthehacker"
         assert commit.author.email == "baxterthehacker@users.noreply.github.com"
         assert commit.author.external_id is None
+        assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
+
+    def test_user_email(self):
+        project = self.project  # force creation
+        user = self.create_user(email="alberto@sentry.io")
+        UserSocialAuth.objects.create(provider="github", user=user, uid=6752317)
+        self.create_member(organization=project.organization, user=user, role="member")
+
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
+
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+
+        OrganizationOption.objects.set_value(
+            organization=project.organization, key="github:webhook_secret", value=secret
+        )
+
+        Repository.objects.create(
+            organization_id=project.organization.id,
+            external_id="35129377",
+            provider="github",
+            name="baxterthehacker/public-repo",
+        )
+
+        response = self.client.post(
+            path=url,
+            data=PUSH_EVENT_EXAMPLE,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=98196e70369945ffa6b248cf70f7dc5e46dff241",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+
+        commit_list = list(
+            Commit.objects.filter(organization_id=project.organization_id)
+            .select_related("author")
+            .order_by("-date_added")
+        )
+
+        assert len(commit_list) == 2
+
+        commit = commit_list[0]
+
+        assert commit.key == "133d60480286590a610a0eb7352ff6e02b9674c4"
+        assert commit.message == "Update README.md (àgain)"
+        assert commit.author.name == "bàxterthehacker"
+        assert commit.author.email == "alberto@sentry.io"
+        assert commit.author.external_id == "github:baxterthehacker"
+        assert commit.date_added == datetime(2015, 5, 5, 23, 45, 15, tzinfo=timezone.utc)
+
+        commit = commit_list[1]
+
+        assert commit.key == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        assert commit.message == "Update README.md"
+        assert commit.author.name == "bàxterthehacker"
+        assert commit.author.email == "alberto@sentry.io"
+        assert commit.author.external_id == "github:baxterthehacker"
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
     def test_anonymous_lookup(self):


### PR DESCRIPTION
This pull request adds `user_service.get_user_by_social_auth()`, which will be consumed by a few Github webhook event handlers to populate emails on commit objects.

⚠️  **NOTE:** not to be merged until all org member mapping writes are accounted for.