### PR TITLE
chore(hybrid-cloud): Delete User.get_from_teams

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any, List, Sequence
+from typing import Any, List, Sequence
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -34,9 +34,6 @@ from sentry.utils.http import absolute_uri
 
 audit_logger = logging.getLogger("sentry.audit.user")
 
-if TYPE_CHECKING:
-    from sentry.models import Team
-
 
 class UserManager(BaseManager, DjangoUserManager):
     def get_team_members_with_verified_email_for_projects(
@@ -54,15 +51,6 @@ class UserManager(BaseManager, DjangoUserManager):
             ),
             is_active=True,
         ).distinct()
-
-    def get_from_teams(self, organization_id: int, teams: Sequence["Team"]) -> QuerySet:
-        # TODO(hybridcloud) This is doing cross silo joins
-        return self.filter(
-            sentry_orgmember_set__organization_id=organization_id,
-            sentry_orgmember_set__organizationmemberteam__team__in=teams,
-            sentry_orgmember_set__organizationmemberteam__is_active=True,
-            is_active=True,
-        )
 
     def get_from_organizations(self, organization_ids):
         """Returns users associated with an Organization based on their teams."""

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -129,23 +129,3 @@ class UserMergeToTest(TestCase):
 
         assert member.role == "owner"
         assert list(member.teams.all().order_by("pk")) == [team_1, team_2, team_3]
-
-
-class GetUsersFromTeamsTest(TestCase):
-    def test(self):
-        user = self.create_user()
-        org = self.create_organization(name="foo", owner=user)
-        team = self.create_team(organization=org)
-        org2 = self.create_organization(name="bar", owner=None)
-        team2 = self.create_team(organization=org2)
-        user2 = self.create_user("foo@example.com")
-        self.create_member(user=user2, organization=org, role="admin", teams=[team])
-
-        assert list(User.objects.get_from_teams(org, [team])) == [user2]
-        user3 = self.create_user("bar@example.com")
-        self.create_member(user=user3, organization=org, role="admin", teams=[team])
-        assert set(list(User.objects.get_from_teams(org, [team]))) == {user2, user3}
-        assert list(User.objects.get_from_teams(org2, [team])) == []
-        assert list(User.objects.get_from_teams(org2, [team2])) == []
-        self.create_member(user=user, organization=org2, role="member", teams=[team2])
-        assert list(User.objects.get_from_teams(org2, [team2])) == [user]


### PR DESCRIPTION
`User.get_from_teams` is un-used and we can delete it so that we do not need to patch it for hybrid cloud.