### PR TITLE
chore(hybrid-cloud): Delete User.get_from_projects

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -65,18 +65,6 @@ class UserManager(BaseManager, DjangoUserManager):
             is_active=True,
         )
 
-    def get_from_projects(self, organization_id, projects):
-        """
-        Returns users associated with a project based on their teams.
-        """
-        # TODO(hybridcloud) This is doing cross silo joins
-        return self.filter(
-            sentry_orgmember_set__organization_id=organization_id,
-            sentry_orgmember_set__organizationmemberteam__team__projectteam__project__in=projects,
-            sentry_orgmember_set__organizationmemberteam__is_active=True,
-            is_active=True,
-        )
-
     def get_from_organizations(self, organization_ids):
         """Returns users associated with an Organization based on their teams."""
         # TODO(hybridcloud) This is doing cross silo joins

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -149,25 +149,3 @@ class GetUsersFromTeamsTest(TestCase):
         assert list(User.objects.get_from_teams(org2, [team2])) == []
         self.create_member(user=user, organization=org2, role="member", teams=[team2])
         assert list(User.objects.get_from_teams(org2, [team2])) == [user]
-
-
-class GetUsersFromProjectsTest(TestCase):
-    def test(self):
-        user = self.create_user()
-        org = self.create_organization(name="foo", owner=user)
-        team = self.create_team(organization=org)
-        project = self.create_project(organization=org, teams=[team])
-        org2 = self.create_organization(name="bar", owner=None)
-        team2 = self.create_team(organization=org2)
-        user2 = self.create_user("foo@example.com")
-        project2 = self.create_project(organization=org2, teams=[team2])
-        self.create_member(user=user2, organization=org, role="admin", teams=[team])
-
-        assert list(User.objects.get_from_projects(org, [project])) == [user2]
-        user3 = self.create_user("bar@example.com")
-        self.create_member(user=user3, organization=org, role="admin", teams=[team])
-        assert set(list(User.objects.get_from_projects(org, [project]))) == {user2, user3}
-        assert list(User.objects.get_from_projects(org2, [project])) == []
-        assert list(User.objects.get_from_projects(org2, [project2])) == []
-        self.create_member(user=user, organization=org2, role="member", teams=[team2])
-        assert list(User.objects.get_from_projects(org2, [project2])) == [user]


### PR DESCRIPTION
`User.get_from_projects` is un-used and we can delete it so that we do not need to patch it for hybrid cloud.