### PR TITLE
fix(transaction-summary): dont refetch totals, so tx list doesnt rerender

### DIFF
--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -77,6 +77,7 @@ type BaseDiscoverQueryProps = {
    * passed, but cursor will be ignored.
    */
   noPagination?: boolean;
+  options?: Omit<Parameters<typeof useQuery>[2], 'initialData'>;
   /**
    * A container for query batching data and functions.
    */

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -108,6 +108,9 @@ function OverviewContentWrapper(props: ChildProps) {
     transactionThresholdMetric,
     referrer: 'api.performance.transaction-summary',
     queryExtras,
+    options: {
+      refetchOnWindowFocus: false,
+    },
   });
 
   // Count has to be total indexed events count because it's only used


### PR DESCRIPTION
- On the Transaction Summary page, currently window focus event (tab in, alt tab) trigger a re-rendering of the transaction list on the summary page. I found this extremely annoying. See the replay in the linked below issue to se what i'm talking about.
- This re-render seems to be triggered by the `getTotalsEventView` `queryData`. I'm not quite sure why, as I believe this table is rendered by https://github.com/getsentry/sentry/blob/66e7314e29f42fe5fe63f6da348fc8cad64411dc/static/app/components/discover/transactionsList.tsx#L365
- Regardless, I've made it so you can pass in `useQuery` options to `BaseDiscoverQueryProps`, and am now passing this parameter in the `queryData` call to `useDiscoverQuery`.
- I don't think this data really goes stale that quickly to where it needs a refresh every page focus, so I think this should be fine. We should consider using this property in other places where we deem its not necessary to refresh this data on window focus.


Resolves https://github.com/getsentry/sentry/issues/47936