### PR TITLE
feat(starfish): Switch top graph to p50

### DIFF
--- a/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
+++ b/static/app/views/starfish/modules/databaseModule/databaseChartView.tsx
@@ -80,7 +80,7 @@ export default function DatabaseChartView({table, onChange}: Props) {
 
     tableGraphData.forEach(datum => {
       seriesByDomain[datum.domain].data.push({
-        value: datum.p75,
+        value: datum.p50,
         name: datum.interval,
       });
       tpmByDomain[datum.domain].data.push({
@@ -124,7 +124,7 @@ export default function DatabaseChartView({table, onChange}: Props) {
 
     topGraphData.forEach(datum => {
       seriesByQuery[datum.action].data.push({
-        value: datum.p75,
+        value: datum.p50,
         name: datum.interval,
       });
       tpmByQuery[datum.action].data.push({
@@ -144,7 +144,7 @@ export default function DatabaseChartView({table, onChange}: Props) {
         <Fragment>
           <ChartsContainer>
             <ChartsContainerItem>
-              <ChartPanel title={t('Slowest Tables P75')}>
+              <ChartPanel title={t('Slowest Tables P50')}>
                 <Chart
                   statsPeriod="24h"
                   height={180}
@@ -194,7 +194,7 @@ export default function DatabaseChartView({table, onChange}: Props) {
             <CompactSelect
               value={table}
               triggerProps={{prefix: t('Table')}}
-              options={parseOptions(tableData, 'p75')}
+              options={parseOptions(tableData, 'p50')}
               menuTitle="Table"
               onChange={opt => onChange(opt.value)}
             />


### PR DESCRIPTION
- This replaces the top graph with p50 instead of p75 to match everywhere else
- Picked p50 sorta arbitrarily TBH, could also be p95, or maybe we should add a third graph later?