### PR TITLE
feat(issue-platform): Support passing `event_data` to `produce_occurrence_to_kafka`.

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -4,7 +4,7 @@ from atexit import register
 from collections import deque
 from concurrent import futures
 from concurrent.futures import Future
-from typing import Any, Deque, Dict, Optional
+from typing import Any, Deque, Dict, MutableMapping, Optional, cast
 
 from arroyo import Topic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
@@ -49,7 +49,7 @@ def produce_occurrence_to_kafka(
         else:
             lookup_event_and_process_issue_occurrence(occurrence.to_dict())
         return
-    payload_data = occurrence.to_dict()
+    payload_data = cast(MutableMapping[str, Any], occurrence.to_dict())
     if event_data:
         payload_data["event"] = event_data
     payload = KafkaPayload(None, json.dumps(payload_data).encode("utf-8"), [])

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -12,7 +12,6 @@ from arroyo.types import BrokerValue
 from django.conf import settings
 
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.utils import json
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options
 
@@ -40,7 +39,10 @@ def produce_occurrence_to_kafka(
     if settings.SENTRY_EVENTSTREAM != "sentry.eventstream.kafka.KafkaEventStream":
         # If we're not running Kafka then we're just in dev. Skip producing to Kafka and just
         # write to the issue platform directly
-        from sentry.issues.occurrence_consumer import lookup_event_and_process_issue_occurrence
+        from sentry.issues.occurrence_consumer import (
+            lookup_event_and_process_issue_occurrence,
+            process_event_and_issue_occurrence,
+        )
 
         if event_data:
             process_event_and_issue_occurrence(occurrence.to_dict(), event_data)

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -4,9 +4,11 @@ from unittest.mock import Mock, patch
 
 from django.test.utils import override_settings
 
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import produce_occurrence_to_kafka, track_occurrence_producer_futures
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
@@ -35,14 +37,14 @@ def test_track_occurrence_producer_futures_with_multiple() -> None:
         second_future_mock.assert_not_called()
 
 
-class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
-    def test_event_id_mismatch(self):
+class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):  # type: ignore
+    def test_event_id_mismatch(self) -> None:
         with self.assertRaisesMessage(
             ValueError, "Event id on occurrence and event_data must be the same"
         ):
             produce_occurrence_to_kafka(self.build_occurrence(), {"event_id": uuid.uuid4().hex})
 
-    def test_with_event(self):
+    def test_with_event(self) -> None:
         occurrence = self.build_occurrence()
         produce_occurrence_to_kafka(
             occurrence,
@@ -56,3 +58,16 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
                 "received": before_now(minutes=1).isoformat(),
             },
         )
+        stored_occurrence = IssueOccurrence.fetch(occurrence.id, occurrence.project_id)
+        assert stored_occurrence
+        assert occurrence.event_id == stored_occurrence.event_id
+
+    def test_with_only_occurrence(self) -> None:
+        event = self.store_event(data=load_data("transaction"), project_id=self.project.id)
+        occurrence = self.build_occurrence(event_id=event.event_id, project_id=self.project.id)
+        produce_occurrence_to_kafka(
+            occurrence,
+        )
+        stored_occurrence = IssueOccurrence.fetch(occurrence.id, occurrence.project_id)
+        assert stored_occurrence
+        assert occurrence.event_id == stored_occurrence.event_id

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -1,9 +1,13 @@
+import uuid
 from collections import deque
 from unittest.mock import Mock, patch
 
 from django.test.utils import override_settings
 
-from sentry.issues.producer import track_occurrence_producer_futures
+from sentry.issues.producer import produce_occurrence_to_kafka, track_occurrence_producer_futures
+from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import before_now
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 def test_track_occurrence_producer_futures() -> None:
@@ -29,3 +33,26 @@ def test_track_occurrence_producer_futures_with_multiple() -> None:
         track_occurrence_producer_futures(second_future_mock)
         first_future_mock.result.assert_called_once_with()
         second_future_mock.assert_not_called()
+
+
+class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
+    def test_event_id_mismatch(self):
+        with self.assertRaisesMessage(
+            ValueError, "Event id on occurrence and event_data must be the same"
+        ):
+            produce_occurrence_to_kafka(self.build_occurrence(), {"event_id": uuid.uuid4().hex})
+
+    def test_with_event(self):
+        occurrence = self.build_occurrence()
+        produce_occurrence_to_kafka(
+            occurrence,
+            {
+                "event_id": occurrence.event_id,
+                "project_id": self.project.id,
+                "title": "some problem",
+                "platform": "python",
+                "tags": {"my_tag": "2"},
+                "timestamp": before_now(minutes=1).isoformat(),
+                "received": before_now(minutes=1).isoformat(),
+            },
+        )


### PR DESCRIPTION
This makes `produce_occurrence_to_kafka` able to send occurrences that have event data passed along with them, instead of just having an event id.