### PR TITLE
feat(issue-states): Use group substatus to build weekly summary

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -349,33 +349,33 @@
     </table>
     {% endif %}
 
-    {% if issue_summary.total_inbox_count > 0 %}
+    {% if issue_summary.total_substatus_count > 0 %}
     <table class="issue-breakdown">
       <tr class="mobile-full-width">
         <td>
           <h4>Issues Breakdown</h4>
         </td>
         <td class="legend-inbox">
-          <span class="swatch" style="background-color: #F2B712;"></span>New<span class="quantity"> ({{ issue_summary.new_inbox_count }})</span>
-          <span class="swatch" style="background-color: #E9626E;"></span>Escalating<span class="quantity"> ({{ issue_summary.escalating_inbox_count }})</span>
-          <span class="swatch" style="background-color: #444674;"></span>Regressed<span class="quantity"> ({{ issue_summary.regression_inbox_count }})</span>
-          <span class="swatch" style="background-color: #DBD6E1;"></span>Ongoing<span class="quantity"> ({{ issue_summary.ongoing_inbox_count }})</span>
+          <span class="swatch" style="background-color: #F2B712;"></span>New<span class="quantity"> ({{ issue_summary.new_substatus_count }})</span>
+          <span class="swatch" style="background-color: #E9626E;"></span>Escalating<span class="quantity"> ({{ issue_summary.escalating_substatus_count }})</span>
+          <span class="swatch" style="background-color: #444674;"></span>Regressed<span class="quantity"> ({{ issue_summary.regression_substatus_count }})</span>
+          <span class="swatch" style="background-color: #DBD6E1;"></span>Ongoing<span class="quantity"> ({{ issue_summary.ongoing_substatus_count }})</span>
         </td>
       </tr>
       <tr>
         <td colspan="2">
           <table>
             <tr>
-              <td width="{% widthratio issue_summary.new_inbox_count issue_summary.total_inbox_count 100 %}%" title="New: {{ issue_summary.new_inbox_count }} events" style="background-color: #F2B712">
+              <td width="{% widthratio issue_summary.new_substatus_count issue_summary.total_substatus_count 100 %}%" title="New: {{ issue_summary.new_substatus_count }} events" style="background-color: #F2B712">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.escalating_inbox_count issue_summary.total_inbox_count 100 %}%" title="Reopened: {{ issue_summary.escalating_inbox_count }} events" style="background-color: #E9626E">
+              <td width="{% widthratio issue_summary.escalating_substatus_count issue_summary.total_substatus_count 100 %}%" title="Reopened: {{ issue_summary.escalating_substatus_count }} events" style="background-color: #E9626E">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.regression_inbox_count issue_summary.total_inbox_count 100 %}%" title="Existing: {{ issue_summary.regression_inbox_count }} events" style="background-color: #444674">
+              <td width="{% widthratio issue_summary.regression_substatus_count issue_summary.total_substatus_count 100 %}%" title="Existing: {{ issue_summary.regression_substatus_count }} events" style="background-color: #444674">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.ongoing_inbox_count issue_summary.total_inbox_count 100 %}%" title="Existing: {{ issue_summary.ongoing_inbox_count }} events" style="background-color: #DBD6E1">
+              <td width="{% widthratio issue_summary.ongoing_substatus_count issue_summary.total_substatus_count 100 %}%" title="Existing: {{ issue_summary.ongoing_substatus_count }} events" style="background-color: #DBD6E1">
                 &nbsp;
               </td>
             </tr>
@@ -399,10 +399,10 @@
            href="{% org_url organization issue_detail query='referrer=weekly-email' %}">{{a.group.message}}</a>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
-      {% if a.inbox_reason and a.inbox_color %}
-      <span style="background-color: {{a.inbox_color}}; border: 1px solid {{a.inbox_color_border}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.inbox_reason}}</span>
+      {% if a.group_substatus and a.group_substatus_color %}
+      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border: 1px solid {{a.inbox_color_border}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
       {% endif %}
       </div>
     {% endfor %}

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -8,8 +8,6 @@ from django.utils import timezone
 from sentry.models import Group, Organization, Project
 from sentry.tasks.weekly_reports import (
     ONE_DAY,
-    GroupInbox,
-    GroupInboxReason,
     OrganizationReportContext,
     ProjectContext,
     render_template_context,
@@ -19,7 +17,7 @@ from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
 
 from .mail import MailPreviewView
 
-DEBUG_ESCALATING_ISSUES = False
+DEBUG_ISSUE_STATES = True
 
 
 def get_random(request):
@@ -80,24 +78,21 @@ class DebugWeeklyReportView(MailPreviewView):
             project_context.dropped_transaction_count = int(
                 random.weibullvariate(5, 1) * random.paretovariate(0.2)
             )
-            group_inbox = (
-                GroupInbox(reason=GroupInboxReason.ESCALATING) if DEBUG_ESCALATING_ISSUES else None
-            )
             project_context.key_errors = [
-                (g, None, group_inbox, random.randint(0, 1000)) for g in Group.objects.all()[:3]
+                (g, None, random.randint(0, 1000)) for g in Group.objects.all()[:3]
             ]
 
-            if DEBUG_ESCALATING_ISSUES:
+            if DEBUG_ISSUE_STATES:
                 # For organizations:issue-states
-                project_context.new_inbox_count = random.randint(5, 200)
-                project_context.escalating_inbox_count = random.randint(5, 200)
-                project_context.regression_inbox_count = random.randint(5, 200)
-                project_context.ongoing_inbox_count = random.randint(20, 3000)
-                project_context.total_inbox_count = (
-                    project_context.new_inbox_count
-                    + project_context.escalating_inbox_count
-                    + project_context.regression_inbox_count
-                    + project_context.ongoing_inbox_count
+                project_context.new_substatus_count = random.randint(5, 200)
+                project_context.escalating_substatus_count = random.randint(5, 200)
+                project_context.regression_substatus_count = random.randint(5, 200)
+                project_context.ongoing_substatus_count = random.randint(20, 3000)
+                project_context.total_substatus_count = (
+                    project_context.new_substatus_count
+                    + project_context.escalating_substatus_count
+                    + project_context.regression_substatus_count
+                    + project_context.ongoing_substatus_count
                 )
             else:
                 # Removed after organizations:issue-states GA

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -11,19 +11,12 @@ from freezegun import freeze_time
 
 from sentry.constants import DataCategory
 from sentry.db.postgres.roles import in_test_psql_role_override
-from sentry.models import (
-    GroupInboxReason,
-    GroupStatus,
-    OrganizationMember,
-    Project,
-    UserOption,
-    add_group_to_inbox,
-)
+from sentry.models import GroupStatus, GroupSubStatus, OrganizationMember, Project, UserOption
 from sentry.tasks.weekly_reports import (
     ONE_DAY,
     OrganizationReportContext,
     deliver_reports,
-    organization_project_issue_inbox_summaries,
+    organization_project_issue_substatus_summaries,
     organization_project_issue_summaries,
     prepare_organization_report,
     schedule_organizations,
@@ -177,7 +170,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
         assert project_ctx.all_issue_count == 2
 
     @with_feature("organizations:issue-states")
-    def test_organization_project_issue_inbox_summaries(self):
+    def test_organization_project_issue_substatus_summaries(self):
         self.login_as(user=self.user)
 
         now = timezone.now()
@@ -193,7 +186,8 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        add_group_to_inbox(event1.group, GroupInboxReason.NEW)
+        event1.group.substatus = GroupSubStatus.ONGOING
+        event1.group.save()
 
         event2 = self.store_event(
             data={
@@ -205,19 +199,20 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        add_group_to_inbox(event2.group, GroupInboxReason.ONGOING)
+        event2.group.substatus = GroupSubStatus.NEW
+        event2.group.save()
         timestamp = to_timestamp(now)
 
         ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        organization_project_issue_inbox_summaries(ctx)
+        organization_project_issue_substatus_summaries(ctx)
 
         project_ctx = ctx.projects[self.project.id]
 
-        assert project_ctx.new_inbox_count == 1
-        assert project_ctx.escalating_inbox_count == 0
-        assert project_ctx.ongoing_inbox_count == 1
-        assert project_ctx.regression_inbox_count == 0
-        assert project_ctx.total_inbox_count == 2
+        assert project_ctx.new_substatus_count == 1
+        assert project_ctx.escalating_substatus_count == 0
+        assert project_ctx.ongoing_substatus_count == 1
+        assert project_ctx.regression_substatus_count == 0
+        assert project_ctx.total_substatus_count == 2
 
     @mock.patch("sentry.tasks.weekly_reports.MessageBuilder")
     def test_message_builder_simple(self, message_builder):
@@ -304,11 +299,11 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
                 "new_issue_count": 2,
                 "reopened_issue_count": 0,
                 # New escalating-issues
-                "escalating_inbox_count": 0,
-                "new_inbox_count": 0,
-                "ongoing_inbox_count": 0,
-                "regression_inbox_count": 0,
-                "total_inbox_count": 0,
+                "escalating_substatus_count": 0,
+                "new_substatus_count": 0,
+                "ongoing_substatus_count": 0,
+                "regression_substatus_count": 0,
+                "total_substatus_count": 0,
             }
             assert len(context["key_errors"]) == 2
             assert context["trends"]["total_error_count"] == 2
@@ -317,10 +312,8 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
 
     @mock.patch("sentry.tasks.weekly_reports.MessageBuilder")
     @with_feature("organizations:issue-states")
-    def test_message_builder_inbox_simple(self, message_builder):
+    def test_message_builder_substatus_simple(self, message_builder):
         now = timezone.now()
-
-        two_days_ago = now - timedelta(days=2)
         three_days_ago = now - timedelta(days=3)
 
         self.create_member(
@@ -337,7 +330,9 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        add_group_to_inbox(event1.group, GroupInboxReason.NEW)
+        group1 = event1.group
+        group1.substatus = GroupSubStatus.NEW
+        group1.save()
 
         event2 = self.store_event(
             data={
@@ -349,42 +344,8 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        self.store_outcomes(
-            {
-                "org_id": self.organization.id,
-                "project_id": self.project.id,
-                "outcome": Outcome.ACCEPTED,
-                "category": DataCategory.ERROR,
-                "timestamp": three_days_ago,
-                "key_id": 1,
-            },
-            num_times=2,
-        )
-        add_group_to_inbox(event2.group, GroupInboxReason.ONGOING)
-
-        self.store_outcomes(
-            {
-                "org_id": self.organization.id,
-                "project_id": self.project.id,
-                "outcome": Outcome.ACCEPTED,
-                "category": DataCategory.TRANSACTION,
-                "timestamp": three_days_ago,
-                "key_id": 1,
-            },
-            num_times=10,
-        )
-
-        group1 = event1.group
         group2 = event2.group
-
-        group1.status = GroupStatus.RESOLVED
-        group1.substatus = None
-        group1.resolved_at = two_days_ago
-        group1.save()
-
-        group2.status = GroupStatus.RESOLVED
-        group2.substatus = None
-        group2.resolved_at = two_days_ago
+        group2.substatus = GroupSubStatus.ONGOING
         group2.save()
 
         prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
@@ -402,16 +363,12 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
                 "existing_issue_count": 0,
                 "new_issue_count": 0,
                 "reopened_issue_count": 0,
-                "escalating_inbox_count": 0,
-                "new_inbox_count": 1,
-                "ongoing_inbox_count": 1,
-                "regression_inbox_count": 0,
-                "total_inbox_count": 2,
+                "escalating_substatus_count": 0,
+                "new_substatus_count": 1,
+                "ongoing_substatus_count": 1,
+                "regression_substatus_count": 0,
+                "total_substatus_count": 2,
             }
-            assert len(context["key_errors"]) == 2
-            assert context["trends"]["total_error_count"] == 2
-            assert context["trends"]["total_transaction_count"] == 10
-            assert "Weekly Report for" in message_params["subject"]
 
     @mock.patch("sentry.tasks.weekly_reports.MessageBuilder")
     def test_message_builder_advanced(self, message_builder):


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/48047 I used group inbox reason to add issue states to the weekly email. This turned out to be the wrong approach and we want to use the new substatus to get our issue counts.

fixes #49417

