### PR TITLE
feat(issue-states): auto transition new and regressed issues to ongoing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1010,14 +1010,14 @@ CELERYBEAT_SCHEDULE = {
     },
     "schedule_auto_transition_new": {
         "task": "sentry.tasks.schedule_auto_transition_new",
-        # Run job once a day at 00:30
-        "schedule": crontab(minute=30, hour="0"),
+        # Run job every 6 hours
+        "schedule": crontab(minute=0, hour="*/6"),
         "options": {"expires": 3600},
     },
     "schedule_auto_transition_regressed": {
         "task": "sentry.tasks.schedule_auto_transition_regressed",
-        # Run job once a day at 02:30
-        "schedule": crontab(minute=30, hour="2"),
+        # Run job every 6 hours
+        "schedule": crontab(minute=0, hour="*/6"),
         "options": {"expires": 3600},
     },
 }

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -1,3 +1,5 @@
+from django.db.models.signals import post_save
+
 from sentry.models import (
     Activity,
     Group,
@@ -11,28 +13,29 @@ from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 
 
-def transition_new_to_ongoing(group: Group) -> None:
-    if group.status == GroupStatus.UNRESOLVED and group.substatus == GroupSubStatus.NEW:
-        _transition_group_to_ongoing(group)
+def transition_group_to_ongoing(
+    from_status: GroupStatus, from_substatus: GroupSubStatus, group: Group
+) -> None:
+    # make sure we don't update the Group when its already updated by conditionally updating the Group
+    updated = Group.objects.filter(
+        id=group.id, status=from_status, substatus=from_substatus
+    ).update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
+    if updated:
+        post_save.send_robust(
+            sender=Group,
+            instance=group,
+            created=False,
+            update_fields=["status", "substatus"],
+        )
 
+        remove_group_from_inbox(group)
 
-def transition_regressed_to_ongoing(group: Group) -> None:
-    if group.status == GroupStatus.UNRESOLVED and group.substatus == GroupSubStatus.REGRESSED:
-        _transition_group_to_ongoing(group)
+        add_group_to_inbox(group, GroupInboxReason.ONGOING)
 
+        Activity.objects.create_group_activity(
+            group, ActivityType.AUTO_SET_ONGOING, send_notification=False
+        )
 
-def _transition_group_to_ongoing(group: Group) -> None:
-    group.substatus = GroupSubStatus.ONGOING
-    group.save(update_fields=["substatus"])
-
-    remove_group_from_inbox(group)
-
-    add_group_to_inbox(group, GroupInboxReason.ONGOING)
-
-    Activity.objects.create_group_activity(
-        group, ActivityType.AUTO_SET_ONGOING, send_notification=False
-    )
-
-    record_group_history_from_activity_type(
-        group, activity_type=ActivityType.AUTO_SET_ONGOING.value, actor=None
-    )
+        record_group_history_from_activity_type(
+            group, activity_type=ActivityType.AUTO_SET_ONGOING.value, actor=None
+        )

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -21,6 +21,8 @@ def transition_group_to_ongoing(
         id=group.id, status=from_status, substatus=from_substatus
     ).update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
     if updated:
+        group.status = GroupStatus.UNRESOLVED
+        group.substatus = GroupSubStatus.ONGOING
         post_save.send_robust(
             sender=Group,
             instance=group,

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -5,9 +5,11 @@ import pytz
 from sentry_sdk.crons.decorator import monitor
 
 from sentry import features
-from sentry.issues.ongoing import transition_new_to_ongoing, transition_regressed_to_ongoing
-from sentry.models import Group, GroupInbox, GroupInboxReason, Organization, Project
+from sentry.issues.ongoing import transition_group_to_ongoing
+from sentry.models import Group, GroupStatus, Organization, OrganizationStatus, Project
 from sentry.tasks.base import instrumented_task
+from sentry.types.group import GroupSubStatus
+from sentry.utils.query import RangeQuerySetWrapper
 
 
 @instrumented_task(
@@ -19,24 +21,16 @@ def schedule_auto_transition_new() -> None:
     now = datetime.now(tz=pytz.UTC)
     three_days_past = now - timedelta(days=3)
 
-    for project_id in (
-        GroupInbox.objects.filter(
-            date_added__lte=three_days_past,
-            reason__in=(GroupInboxReason.NEW.value, GroupInboxReason.REPROCESSED.value),
-        )
-        .distinct()
-        .values_list("project_id", flat=True)
-    ):
-        org = Organization.objects.get_from_cache(
-            id=Project.objects.get_from_cache(id=project_id).organization_id
-        )
-
+    for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
         if features.has("organizations:issue-states-auto-transition-new-ongoing", org):
-            auto_transition_issues_new_to_ongoing.delay(
-                project_id=project_id,
-                date_added_lte=int(three_days_past.timestamp()),
-                expires=now + timedelta(hours=1),
-            )
+            for project_id in Project.objects.filter(organization_id=org.id).values_list(
+                "id", flat=True
+            ):
+                auto_transition_issues_new_to_ongoing.delay(
+                    project_id=project_id,
+                    last_seen_lte=int(three_days_past.timestamp()),
+                    expires=now + timedelta(hours=1),
+                )
 
 
 @instrumented_task(
@@ -47,31 +41,35 @@ def schedule_auto_transition_new() -> None:
 )  # type: ignore
 def auto_transition_issues_new_to_ongoing(
     project_id: int,
-    date_added_lte: int,
-    date_added_gte: Optional[int] = None,
+    last_seen_lte: int,
+    last_seen_gte: Optional[int] = None,
     chunk_size: int = 1000,
     **kwargs,
 ) -> None:
-
-    queryset = GroupInbox.objects.filter(
+    queryset = Group.objects.filter(
         project_id=project_id,
-        date_added__lte=datetime.fromtimestamp(date_added_lte, pytz.UTC),
-        reason__in=(GroupInboxReason.NEW.value, GroupInboxReason.REPROCESSED.value),
+        status=GroupStatus.UNRESOLVED,
+        substatus=GroupSubStatus.NEW,
+        last_seen__lte=datetime.fromtimestamp(last_seen_lte, pytz.UTC),
     )
 
-    if date_added_gte:
-        queryset = queryset.filter(date_added__gte=datetime.fromtimestamp(date_added_gte, pytz.UTC))
+    if last_seen_gte:
+        queryset = queryset.filter(last_seen__gte=datetime.fromtimestamp(last_seen_gte, pytz.UTC))
 
-    new_inbox = queryset.order_by("date_added")[:chunk_size]
+    new_groups = list(queryset.order_by("last_seen")[:chunk_size])
 
-    for group in Group.objects.filter(id__in=list({inbox.group_id for inbox in new_inbox})):
-        transition_new_to_ongoing(group)
+    for group in new_groups:
+        transition_group_to_ongoing(
+            GroupStatus.UNRESOLVED,
+            GroupSubStatus.NEW,
+            group,
+        )
 
-    if len(new_inbox) == chunk_size:
+    if len(new_groups) == chunk_size:
         auto_transition_issues_new_to_ongoing.delay(
             project_id=project_id,
-            date_added_lte=date_added_lte,
-            date_added_gte=new_inbox[chunk_size - 1].date_added.timestamp(),
+            last_seen_lte=last_seen_lte,
+            last_seen_gte=new_groups[chunk_size - 1].last_seen.timestamp(),
             chunk_size=chunk_size,
             expires=datetime.now(tz=pytz.UTC) + timedelta(hours=1),
         )
@@ -86,24 +84,16 @@ def schedule_auto_transition_regressed() -> None:
     now = datetime.now(tz=pytz.UTC)
     fourteen_days_past = now - timedelta(days=14)
 
-    for project_id in (
-        GroupInbox.objects.filter(
-            date_added__lte=fourteen_days_past,
-            reason=GroupInboxReason.REGRESSION.value,
-        )
-        .distinct()
-        .values_list("project_id", flat=True)
-    ):
-        org = Organization.objects.get_from_cache(
-            id=Project.objects.get_from_cache(id=project_id).organization_id
-        )
-
+    for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
         if features.has("organizations:issue-states-auto-transition-regressed-ongoing", org):
-            auto_transition_issues_regressed_to_ongoing.delay(
-                project_id=project_id,
-                date_added_lte=int(fourteen_days_past.timestamp()),
-                expires=now + timedelta(hours=1),
-            )
+            for project_id in Project.objects.filter(organization_id=org.id).values_list(
+                "id", flat=True
+            ):
+                auto_transition_issues_regressed_to_ongoing.delay(
+                    project_id=project_id,
+                    last_seen_lte=int(fourteen_days_past.timestamp()),
+                    expires=now + timedelta(hours=1),
+                )
 
 
 @instrumented_task(
@@ -114,31 +104,35 @@ def schedule_auto_transition_regressed() -> None:
 )  # type: ignore
 def auto_transition_issues_regressed_to_ongoing(
     project_id: int,
-    date_added_lte: int,
-    date_added_gte: Optional[int] = None,
+    last_seen_lte: int,
+    last_seen_gte: Optional[int] = None,
     chunk_size: int = 1000,
     **kwargs,
 ) -> None:
-
-    queryset = GroupInbox.objects.filter(
+    queryset = Group.objects.filter(
         project_id=project_id,
-        date_added__lte=datetime.fromtimestamp(date_added_lte, pytz.UTC),
-        reason=GroupInboxReason.REGRESSION.value,
+        status=GroupStatus.UNRESOLVED,
+        substatus=GroupSubStatus.REGRESSED,
+        last_seen__lte=datetime.fromtimestamp(last_seen_lte, pytz.UTC),
     )
 
-    if date_added_gte:
-        queryset = queryset.filter(date_added__gte=datetime.fromtimestamp(date_added_gte, pytz.UTC))
+    if last_seen_gte:
+        queryset = queryset.filter(last_seen__gte=datetime.fromtimestamp(last_seen_gte, pytz.UTC))
 
-    regressed_inbox = queryset.order_by("date_added")[:chunk_size]
+    regressed_groups = list(queryset.order_by("last_seen")[:chunk_size])
 
-    for group in Group.objects.filter(id__in=list({inbox.group_id for inbox in regressed_inbox})):
-        transition_regressed_to_ongoing(group)
+    for group in regressed_groups:
+        transition_group_to_ongoing(
+            GroupStatus.UNRESOLVED,
+            GroupSubStatus.REGRESSED,
+            group,
+        )
 
-    if len(regressed_inbox) == chunk_size:
+    if len(regressed_groups) == chunk_size:
         auto_transition_issues_regressed_to_ongoing.delay(
             project_id=project_id,
-            date_added_lte=date_added_lte,
-            date_added_gte=regressed_inbox[chunk_size - 1].date_added.timestamp(),
+            last_seen_lte=last_seen_lte,
+            last_seen_gte=regressed_groups[chunk_size - 1].last_seen.timestamp(),
             chunk_size=chunk_size,
             expires=datetime.now(tz=pytz.UTC) + timedelta(hours=1),
         )

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -82,7 +82,7 @@ def auto_transition_issues_new_to_ongoing(
 @monitor(monitor_slug="schedule_auto_transition_regressed")
 def schedule_auto_transition_regressed() -> None:
     now = datetime.now(tz=pytz.UTC)
-    fourteen_days_past = now - timedelta(days=14)
+    three_days_past = now - timedelta(days=3)
 
     for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
         if features.has("organizations:issue-states-auto-transition-regressed-ongoing", org):
@@ -91,7 +91,7 @@ def schedule_auto_transition_regressed() -> None:
             ):
                 auto_transition_issues_regressed_to_ongoing.delay(
                     project_id=project_id,
-                    first_seen_lte=int(fourteen_days_past.timestamp()),
+                    first_seen_lte=int(three_days_past.timestamp()),
                     expires=now + timedelta(hours=1),
                 )
 

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -182,7 +182,7 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
             project=project,
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.REGRESSED,
-            first_seen=now - timedelta(days=14, hours=1),
+            first_seen=now - timedelta(days=3, hours=1),
         )
 
         with self.tasks():

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytz
 
-from sentry.models import Group, GroupInbox, GroupInboxReason, GroupStatus
+from sentry.models import Group, GroupInbox, GroupInboxReason, GroupStatus, add_group_to_inbox
 from sentry.tasks.auto_ongoing_issues import (
     schedule_auto_transition_new,
     schedule_auto_transition_regressed,
@@ -184,6 +184,9 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
             substatus=GroupSubStatus.REGRESSED,
             first_seen=now - timedelta(days=3, hours=1),
         )
+        group_inbox = add_group_to_inbox(group, GroupInboxReason.REGRESSION)
+        group_inbox.date_added = now - timedelta(days=3, hours=1)
+        group_inbox.save(update_fields=["date_added"])
 
         with self.tasks():
             schedule_auto_transition_regressed()

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -22,7 +22,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         group = self.create_group(
             project=project, status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW
         )
-        group.last_seen = now - timedelta(days=3, hours=1)
+        group.first_seen = now - timedelta(days=3, hours=1)
         group.save()
 
         with self.tasks():
@@ -46,7 +46,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         group = self.create_group(
             project=project, status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.NEW
         )
-        group.last_seen = now - timedelta(days=3, hours=1)
+        group.first_seen = now - timedelta(days=3, hours=1)
         group.save()
 
         with self.tasks():
@@ -89,11 +89,11 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
                 status=GroupStatus.UNRESOLVED,
                 substatus=GroupSubStatus.NEW,
             )
-            last_seen = now - timedelta(days=day, hours=hours)
-            group.last_seen = last_seen
+            first_seen = now - timedelta(days=day, hours=hours)
+            group.first_seen = first_seen
             group.save()
 
-            if (now - last_seen).days >= 3:
+            if (now - first_seen).days >= 3:
                 older_groups.append(group)
             else:
                 new_groups.append(group)
@@ -139,7 +139,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
                     project=project,
                     status=GroupStatus.UNRESOLVED,
                     substatus=GroupSubStatus.NEW,
-                    last_seen=now - timedelta(days=3, hours=idx, minutes=1),
+                    first_seen=now - timedelta(days=3, hours=idx, minutes=1),
                 )
                 for idx in range(1010)
             ]
@@ -182,7 +182,7 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
             project=project,
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.REGRESSED,
-            last_seen=now - timedelta(days=14, hours=1),
+            first_seen=now - timedelta(days=14, hours=1),
         )
 
         with self.tasks():


### PR DESCRIPTION
We already had two tasks that automatically transitioned new or regressed issues to ongoing after a certain inactive period (3 days for new and 3 days for regressed). This PR updates those tasks to source new and regressed issues based off the `Group.status` and `Group.substatus` values instead of relying on `GroupInbox` to 

This PR also increases the frequency when the task runs from once per day to once every 6 hours.