### PR TITLE
ref(js): Filter out request errors when used as cause

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -1,90 +1,111 @@
+import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
+
 import {isFilteredRequestErrorEvent} from './initializeSdk';
 
 describe('isFilteredRequestErrorEvent', () => {
-  it.each(['GET', 'POST', 'PUT', 'DELETE'])('filters 200 %s events', method => {
-    const requestErrorEvent = {
-      exception: {
-        values: [{type: 'RequestError', value: `${method} /dogs/are/great/ 200`}],
-      },
-    };
+  const methods = ['GET', 'POST', 'PUT', 'DELETE'];
+  const stati = [200, 401, 403, 404, 429];
 
-    expect(isFilteredRequestErrorEvent(requestErrorEvent)).toBeTruthy();
+  describe('matching error type, matching message', () => {
+    for (const method of methods) {
+      describe(`${method} requests`, () => {
+        for (const status of stati) {
+          // We have to filter out falsy values here because 200 isn't in `ERROR_MAP`
+          // and will never appear with any other error name besides `RequestError`
+          for (const errorName of ['RequestError', ERROR_MAP[status]].filter(Boolean)) {
+            describe('main error', () => {
+              it(`recognizes ${status} ${method} events of type ${errorName}`, () => {
+                const event = {
+                  exception: {
+                    values: [
+                      {type: errorName, value: `${method} /dogs/are/great/ ${status}`},
+                    ],
+                  },
+                };
+
+                expect(isFilteredRequestErrorEvent(event)).toBeTruthy();
+              });
+            });
+
+            describe('cause error', () => {
+              it(`recognizes ${status} ${method} events of type ${errorName} as causes`, () => {
+                const event = {
+                  exception: {
+                    values: [
+                      {type: errorName, value: `${method} /dogs/are/great/ ${status}`},
+                      {type: 'InsufficientTreatsError', value: 'Not enough treats!'},
+                    ],
+                  },
+                };
+
+                expect(isFilteredRequestErrorEvent(event)).toBeTruthy();
+              });
+            });
+          }
+        }
+      });
+    }
   });
 
-  it.each(['GET', 'POST', 'PUT', 'DELETE'])('filters 401 %s events', method => {
-    const unauthorizedErrorEvent = {
-      exception: {
-        values: [{type: 'UnauthorizedError', value: `${method} /dogs/are/great/ 401`}],
-      },
-    };
-    const requestErrorEvent = {
-      exception: {
-        values: [{type: 'RequestError', value: `${method} /dogs/are/great/ 401`}],
-      },
-    };
+  describe('matching error type, non-matching message', () => {
+    for (const status of stati) {
+      // We have to filter out falsy values here because 200 isn't in `ERROR_MAP`
+      // and will never appear with any other error name besides `RequestError`
+      for (const errorName of ['RequestError', ERROR_MAP[status]].filter(Boolean)) {
+        describe('main error', () => {
+          it(`rejects other errors of type ${errorName}`, () => {
+            const event = {
+              exception: {
+                values: [
+                  {type: errorName, value: "Failed to fetch requested object: 'ball'"},
+                ],
+              },
+            };
 
-    expect(isFilteredRequestErrorEvent(unauthorizedErrorEvent)).toBeTruthy();
-    expect(isFilteredRequestErrorEvent(requestErrorEvent)).toBeTruthy();
+            expect(isFilteredRequestErrorEvent(event)).toBeFalsy();
+          });
+        });
+
+        describe('cause error', () => {
+          it(`rejects other errors of type ${errorName} as causes`, () => {
+            const event = {
+              exception: {
+                values: [
+                  {type: errorName, value: "Failed to fetch requested object: 'ball'"},
+                  {type: 'InsufficientTreatsError', value: 'Not enough treats!'},
+                ],
+              },
+            };
+
+            expect(isFilteredRequestErrorEvent(event)).toBeFalsy();
+          });
+        });
+      }
+    }
   });
 
-  it.each(['GET', 'POST', 'PUT', 'DELETE'])('filters 403 %s events', method => {
-    const forbiddenErrorEvent = {
-      exception: {
-        values: [{type: 'ForbiddenError', value: `${method} /dogs/are/great/ 403`}],
-      },
-    };
-    const requestErrorEvent = {
-      exception: {
-        values: [{type: 'RequestError', value: `${method} /dogs/are/great/ 403`}],
-      },
-    };
-
-    expect(isFilteredRequestErrorEvent(forbiddenErrorEvent)).toBeTruthy();
-    expect(isFilteredRequestErrorEvent(requestErrorEvent)).toBeTruthy();
-  });
-
-  it.each(['GET', 'POST', 'PUT', 'DELETE'])('filters 404 %s events', method => {
-    const notFoundErrorEvent = {
-      exception: {
-        values: [{type: 'NotFoundError', value: `${method} /dogs/are/great/ 404`}],
-      },
-    };
-    const requestErrorEvent = {
-      exception: {
-        values: [{type: 'RequestError', value: `${method} /dogs/are/great/ 404`}],
-      },
-    };
-
-    expect(isFilteredRequestErrorEvent(notFoundErrorEvent)).toBeTruthy();
-    expect(isFilteredRequestErrorEvent(requestErrorEvent)).toBeTruthy();
-  });
-
-  it.each(['GET', 'POST', 'PUT', 'DELETE'])('filters 429 %s events', method => {
-    const notFoundErrorEvent = {
-      exception: {
-        values: [{type: 'TooManyRequestsError', value: `${method} /dogs/are/great/ 429`}],
-      },
-    };
-    const requestErrorEvent = {
-      exception: {
-        values: [{type: 'RequestError', value: `${method} /dogs/are/great/ 429`}],
-      },
-    };
-
-    expect(isFilteredRequestErrorEvent(notFoundErrorEvent)).toBeTruthy();
-    expect(isFilteredRequestErrorEvent(requestErrorEvent)).toBeTruthy();
-  });
-
-  it.each(['NotFoundError', 'ForbiddenError', 'UnauthorizedError'])(
-    "doesn't filter other %s events",
-    errorType => {
+  describe('non-matching error type, non-matching message', () => {
+    it(`rejects other errors`, () => {
       const event = {
         exception: {
-          values: [{type: errorType, value: 'Not enough treats!'}],
+          values: [{type: 'UncaughtSquirrelError', value: 'Squirrel was not caught'}],
         },
       };
 
       expect(isFilteredRequestErrorEvent(event)).toBeFalsy();
-    }
-  );
+    });
+
+    it(`rejects other errors as causes`, () => {
+      const event = {
+        exception: {
+          values: [
+            {type: 'UncaughtSquirrelError', value: 'Squirrel was not caught'},
+            {type: 'InsufficientTreatsError', value: 'Not enough treats!'},
+          ],
+        },
+      };
+
+      expect(isFilteredRequestErrorEvent(event)).toBeFalsy();
+    });
+  });
 });

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -179,25 +179,33 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
   }
 
   // In case there's a chain, we take the last entry, because that's the one
-  // passed to `captureException`
-  const mainError = exceptionValues[exceptionValues.length - 1];
+  // passed to `captureException`, and the one right before that, since
+  // `RequestError`s are used as the main error's `cause` value in
+  // `handleXhrErrorResponse`
+  const mainAndMaybeCauseErrors = exceptionValues.slice(-2);
 
-  const {type = '', value = ''} = mainError;
+  for (const error of mainAndMaybeCauseErrors) {
+    const {type = '', value = ''} = error;
 
-  const is200 =
-    ['RequestError'].includes(type) && !!value.match('(GET|POST|PUT|DELETE) .* 200');
-  const is401 =
-    ['UnauthorizedError', 'RequestError'].includes(type) &&
-    !!value.match('(GET|POST|PUT|DELETE) .* 401');
-  const is403 =
-    ['ForbiddenError', 'RequestError'].includes(type) &&
-    !!value.match('(GET|POST|PUT|DELETE) .* 403');
-  const is404 =
-    ['NotFoundError', 'RequestError'].includes(type) &&
-    !!value.match('(GET|POST|PUT|DELETE) .* 404');
-  const is429 =
-    ['TooManyRequestsError', 'RequestError'].includes(type) &&
-    !!value.match('(GET|POST|PUT|DELETE) .* 429');
+    const is200 =
+      ['RequestError'].includes(type) && !!value.match('(GET|POST|PUT|DELETE) .* 200');
+    const is401 =
+      ['UnauthorizedError', 'RequestError'].includes(type) &&
+      !!value.match('(GET|POST|PUT|DELETE) .* 401');
+    const is403 =
+      ['ForbiddenError', 'RequestError'].includes(type) &&
+      !!value.match('(GET|POST|PUT|DELETE) .* 403');
+    const is404 =
+      ['NotFoundError', 'RequestError'].includes(type) &&
+      !!value.match('(GET|POST|PUT|DELETE) .* 404');
+    const is429 =
+      ['TooManyRequestsError', 'RequestError'].includes(type) &&
+      !!value.match('(GET|POST|PUT|DELETE) .* 429');
 
-  return is200 || is401 || is403 || is404 || is429;
+    if (is200 || is401 || is403 || is404 || is429) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/static/app/utils/requestError/requestError.tsx
+++ b/static/app/utils/requestError/requestError.tsx
@@ -2,7 +2,7 @@ import {ResponseMeta} from 'sentry/api';
 
 import {sanitizePath} from './sanitizePath';
 
-const ERROR_MAP = {
+export const ERROR_MAP = {
   0: 'CancelledError',
   400: 'BadRequestError',
   401: 'UnauthorizedError',


### PR DESCRIPTION
This builds upon https://github.com/getsentry/sentry/pull/49045 and https://github.com/getsentry/sentry/pull/49415 (which filter request errors based on their status code) and https://github.com/getsentry/sentry/pull/49385 (which includes request errors as `cause` when appropriate) to filter out the same types of errors when they appear as the main error's cause.