### PR TITLE
ref(js): Filter out events on pages opened locally

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -1,6 +1,6 @@
 import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
 
-import {isFilteredRequestErrorEvent} from './initializeSdk';
+import {isEventWithFileUrl, isFilteredRequestErrorEvent} from './initializeSdk';
 
 describe('isFilteredRequestErrorEvent', () => {
   const methods = ['GET', 'POST', 'PUT', 'DELETE'];
@@ -107,5 +107,25 @@ describe('isFilteredRequestErrorEvent', () => {
 
       expect(isFilteredRequestErrorEvent(event)).toBeFalsy();
     });
+  });
+});
+
+describe('isEventWithFileUrl', () => {
+  it('recognizes events with `file://` urls', () => {
+    const event = {request: {url: 'file://dogs/are/great.html'}};
+
+    expect(isEventWithFileUrl(event)).toBeTruthy();
+  });
+
+  it('rejects events with other urls', () => {
+    const event = {request: {url: 'http://dogs.are.great'}};
+
+    expect(isEventWithFileUrl(event)).toBeFalsy();
+  });
+
+  it('rejects events without urls', () => {
+    const event = {};
+
+    expect(isEventWithFileUrl(event)).toBeFalsy();
   });
 });

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -141,9 +141,11 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
     ],
 
-    // Temporary fix while `ignoreErrors` bug is fixed and request error handling is cleaned up
     beforeSend(event, _hint) {
-      return isFilteredRequestErrorEvent(event) ? null : event;
+      if (isFilteredRequestErrorEvent(event) || isEventWithFileUrl(event)) {
+        return null;
+      }
+      return event;
     },
   });
 
@@ -208,4 +210,8 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
   }
 
   return false;
+}
+
+export function isEventWithFileUrl(event: Event): boolean {
+  return !!event.request?.url?.startsWith('file://');
 }

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -89,7 +89,6 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
      */
     release: SENTRY_RELEASE_VERSION ?? sentryConfig?.release,
     allowUrls: SPA_DSN ? SPA_MODE_ALLOW_URLS : sentryConfig?.whitelistUrls,
-    denyUrls: [/^file:\/\//],
     integrations: getSentryIntegrations(sentryConfig, routes),
     tracesSampleRate,
     // @ts-ignore not part of browser SDK types yet


### PR DESCRIPTION
This reimplements the filter our current `denyUrls` SDK setting was supposed to achieve (stopping events which happen on pages whose urls start with `file://`) as a `beforeSend` filter. 

(The reason `denyUrls` wasn't working is that it filters on the URL of the script that errored, not the URL of the overall page.)

Fixes https://github.com/getsentry/sentry/issues/49440