### PR TITLE
chore(js): Add `Hub` and `Scope` to mock of JS SDK

### DIFF
--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -112,6 +112,8 @@ jest.mock('@sentry/react', function sentryReact() {
     lastEventId: jest.fn(),
     getCurrentHub: jest.spyOn(SentryReact, 'getCurrentHub'),
     withScope: jest.spyOn(SentryReact, 'withScope'),
+    Hub: SentryReact.Hub,
+    Scope: SentryReact.Scope,
     Severity: SentryReact.Severity,
     withProfiler: SentryReact.withProfiler,
     BrowserClient: jest.fn().mockReturnValue({


### PR DESCRIPTION
This adds `Hub` and `Scope` (the real versions) to our mock of the JS SDK, in order that we may be able to mock things like the return value of `withScope`.