### PR TITLE
feat(js): Add response tags in `handleXhrErrorResponse`

### DIFF
--- a/static/app/utils/handleXhrErrorResponse.spec.jsx
+++ b/static/app/utils/handleXhrErrorResponse.spec.jsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react';
 
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
+import RequestError from 'sentry/utils/requestError/requestError';
 
 describe('handleXhrErrorResponse', function () {
   const stringError = {responseJSON: {detail: 'Error'}, status: 400};
@@ -28,6 +29,7 @@ describe('handleXhrErrorResponse', function () {
     handleXhrErrorResponse('Object error', objError);
     expect(Sentry.captureException).toHaveBeenCalledWith(new Error('Object error'));
   });
+
   it('ignores `sudo-required` errors', function () {
     handleXhrErrorResponse('Sudo required error', {
       status: 401,
@@ -39,5 +41,33 @@ describe('handleXhrErrorResponse', function () {
       },
     });
     expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('adds data to the scope', () => {
+    const status = 404;
+    const responseJSON = {
+      detail: {
+        code: 'distracted-by-squirrel',
+        detail: 'Got distracted by a squirrel',
+      },
+    };
+    const err = new RequestError('GET', '/ball', new Error('API error'), {
+      status,
+      responseJSON,
+    });
+
+    const mockScope = new Sentry.Scope();
+    const setExtrasSpy = jest.spyOn(mockScope, 'setExtras');
+    const setTagsSpy = jest.spyOn(mockScope, 'setTags');
+    const hub = Sentry.getCurrentHub();
+    jest.spyOn(hub, 'pushScope').mockReturnValueOnce(mockScope);
+
+    handleXhrErrorResponse("Can't fetch ball", err);
+
+    expect(setExtrasSpy).toHaveBeenCalledWith({status, responseJSON});
+    expect(setTagsSpy).toHaveBeenCalledWith({
+      responseStatus: status,
+      endpoint: 'GET /ball',
+    });
   });
 });

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -9,9 +9,16 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
     return;
   }
 
-  const {responseJSON, status} = err;
+  const {responseJSON, status, message: causeMessage} = err;
 
   Sentry.withScope(scope => {
+    // Turn `GET /dogs/are/great 500` into just `GET /dogs/are/great`
+    const endpoint = causeMessage?.replace(new RegExp(` ${status}$`), '');
+
+    scope.setTags({
+      responseStatus: status,
+      endpoint,
+    });
     scope.setExtras({
       status,
       responseJSON,


### PR DESCRIPTION
This adds two tags (`responseStatus` and `endpoint`) to events captured by `handleXhrErrorResponse`, in order that issues with generic titles like "unable to fetch project details" will have a breakdown of the two key facts about the cause: which endpoint was hit, and what the response code was.