### PR TITLE
fix(roles): rename orgRolesFromTeams to groupOrgRoles backend

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -115,7 +115,7 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             attrs[item] = {
                 "user": user,
                 "externalUsers": external_users,
-                "orgRolesFromTeams": self.__sorted_org_roles_for_user(item),
+                "groupOrgRoles": self.__sorted_org_roles_for_user(item),
                 "inviter": inviter,
                 "email": email_map.get(user_id, item.email),
             }
@@ -151,7 +151,7 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             "dateCreated": obj.date_added,
             "inviteStatus": obj.get_invite_status_name(),
             "inviterName": inviter_name,
-            "orgRolesFromTeams": attrs.get("orgRolesFromTeams", []),
+            "groupOrgRoles": attrs.get("groupOrgRoles", []),
         }
 
         if "externalUsers" in self.expand:

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -74,7 +74,7 @@ class OrganizationMemberResponse(OrganizationMemberResponseOptional):
     role: str  # Deprecated: use orgRole
     roleName: str  # Deprecated
     orgRole: str
-    orgRolesFromTeams: List[RoleSerializerResponse]
+    groupOrgRoles: List[RoleSerializerResponse]
     pending: bool
     expired: str
     flags: _OrganizationMemberFlags

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -67,11 +67,11 @@ class OrganizationMemberAllRolesSerializerTest(OrganizationMemberSerializerTest)
         )
         result = serialize(member, self.user_2, OrganizationMemberSerializer())
 
-        assert len(result["orgRolesFromTeams"]) == 3
-        assert result["orgRolesFromTeams"][0]["role"]["id"] == "owner"
-        assert result["orgRolesFromTeams"][0]["teamSlug"] == owner_team.slug
-        assert result["orgRolesFromTeams"][1]["role"]["id"] == "manager"
-        assert result["orgRolesFromTeams"][2]["role"]["id"] == "manager"
+        assert len(result["groupOrgRoles"]) == 3
+        assert result["groupOrgRoles"][0]["role"]["id"] == "owner"
+        assert result["groupOrgRoles"][0]["teamSlug"] == owner_team.slug
+        assert result["groupOrgRoles"][1]["role"]["id"] == "manager"
+        assert result["groupOrgRoles"][2]["role"]["id"] == "manager"
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
Rename `orgRolesFromTeams` to `groupOrgRoles` for better clarity. Frontend at #49562.