### PR TITLE
feat(replays): DOM Click search results open DOM tab

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -1,0 +1,43 @@
+import {Location} from 'history';
+
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import {useLocation} from 'sentry/utils/useLocation';
+
+jest.mock('react-router');
+jest.mock('sentry/utils/useLocation');
+
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+
+function mockLocation(query: string = '') {
+  mockUseLocation.mockReturnValue({
+    action: 'PUSH',
+    hash: '',
+    key: '',
+    pathname: '',
+    query: {query},
+    search: '',
+    state: undefined,
+  } as Location);
+}
+
+describe('useActiveReplayTab', () => {
+  beforeEach(() => {
+    mockLocation();
+  });
+
+  it('should use Console as a default', () => {
+    const {result} = reactHooks.renderHook(useActiveReplayTab);
+
+    expect(result.current.getActiveTab()).toBe(TabKey.console);
+  });
+
+  it('should use DOM as a default, when there is a click search in the url', () => {
+    mockLocation('click.tag:button');
+
+    const {result} = reactHooks.renderHook(useActiveReplayTab);
+
+    expect(result.current.getActiveTab()).toBe(TabKey.dom);
+  });
+});

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -1,5 +1,8 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
+import {parseSearch} from 'sentry/components/searchSyntax/parser';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import useUrlParams from 'sentry/utils/useUrlParams';
 
 export enum TabKey {
@@ -15,22 +18,38 @@ function isReplayTab(tab: string): tab is TabKey {
   return tab in TabKey;
 }
 
-const DEFAULT_TAB = TabKey.console;
+function useDefaultTab() {
+  const location = useLocation();
+
+  const hasClickSearch = useMemo(() => {
+    const parsed = parseSearch(decodeScalar(location.query.query) || '');
+    return parsed?.some(
+      token => token.type === 'filter' && token.key.text.startsWith('click.')
+    );
+  }, [location.query.query]);
+
+  if (hasClickSearch) {
+    return TabKey.dom;
+  }
+
+  return TabKey.console;
+}
 
 function useActiveReplayTab() {
-  const {getParamValue, setParamValue} = useUrlParams('t_main', DEFAULT_TAB);
+  const defaultTab = useDefaultTab();
+  const {getParamValue, setParamValue} = useUrlParams('t_main', defaultTab);
 
   const paramValue = getParamValue();
 
   return {
     getActiveTab: useCallback(
-      () => (isReplayTab(paramValue || '') ? (paramValue as TabKey) : DEFAULT_TAB),
-      [paramValue]
+      () => (isReplayTab(paramValue || '') ? (paramValue as TabKey) : defaultTab),
+      [paramValue, defaultTab]
     ),
     setActiveTab: useCallback(
       (value: string) =>
-        isReplayTab(value) ? setParamValue(value) : setParamValue(DEFAULT_TAB),
-      [setParamValue]
+        isReplayTab(value) ? setParamValue(value) : setParamValue(defaultTab),
+      [setParamValue, defaultTab]
     ),
   };
 }

--- a/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
@@ -46,12 +46,20 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
   const [isLoading, setIsLoading] = useState(true);
   const [breadcrumbRefs, setBreadcrumbReferences] = useState<Extraction[]>([]);
 
+  const crumbs = replay?.getCrumbsWithRRWebNodes();
+  const rrwebEvents = replay?.getRRWebEvents();
+  const finishedAt = replay?.getReplay().finished_at;
+
   useEffect(() => {
     requestIdleCallback(
       () => {
-        if (!replay) {
+        if (!crumbs || !rrwebEvents || rrwebEvents.length < 2 || !finishedAt) {
           return () => {};
         }
+
+        // Get a list of the breadcrumbs that relate directly to the DOM, for each
+        // crumb we will extract the referenced HTML.
+
         let isMounted = true;
 
         const domRoot = document.createElement('div');
@@ -64,11 +72,6 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
         style.overflow = 'hidden';
 
         document.body.appendChild(domRoot);
-
-        // Get a list of the breadcrumbs that relate directly to the DOM, for each
-        // crumb we will extract the referenced HTML.
-        const crumbs = replay.getCrumbsWithRRWebNodes();
-        const rrwebEvents = replay.getRRWebEvents();
 
         // Grab the last event, but skip the synthetic `replay-end` event that the
         // ReplayerReader added. RRWeb will skip that event when it comes time to render
@@ -105,7 +108,7 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
 
         try {
           // Run the replay to the end, we will capture data as it streams into the plugin
-          replayerRef.pause(replay.getReplay().finished_at.getTime());
+          replayerRef.pause(finishedAt.getTime());
         } catch (error) {
           Sentry.captureException(error);
         }
@@ -120,7 +123,7 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
         timeout: 2500,
       }
     );
-  }, [replay]);
+  }, [crumbs, rrwebEvents, finishedAt]);
 
   return {
     isLoading,

--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -66,7 +66,7 @@ function isLayout(val: string): val is LayoutKey {
   return val in LayoutKey;
 }
 
-function useActiveReplayTab() {
+function useReplayLayout() {
   const collapsed = !!useLegacyStore(PreferencesStore).collapsed;
   const defaultLayout = getDefaultLayout(collapsed);
   const organization = useOrganization();
@@ -97,4 +97,4 @@ function useActiveReplayTab() {
   };
 }
 
-export default useActiveReplayTab;
+export default useReplayLayout;


### PR DESCRIPTION
This PR opens the DOM tab by default when you've done a Dom-click search on the replay index page.

It's not inserting the searched-for text to filter the dom click list. There are some edge cases with that still :(

Fixes https://github.com/getsentry/sentry/issues/49546