### PR TITLE
fix(js): Fix VSCode JS debug profile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,13 +30,24 @@
       "cwd": "${workspaceRoot}"
     },
     {
-      "name": "jest",
+      "name": "jest - current file",
       "type": "node",
       "request": "launch",
-      "protocol": "inspector",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "internalConsoleOptions": "openOnSessionStart",
-      "args": ["--runInBand"]
+      "args": [
+        // this runs one test at a time, rather than running them in parallel
+        // (necessary for debugging so that you know you're hitting a single
+        // test's breakpoints, in order)
+        "--runInBand",
+        "--watch",
+        "--verbose",
+        "${file}"],
+      // if we don't set this, output goes to the VSCode debug terminal, which
+      // only prints the test output if "outputCapture" is also set, and even
+      // then won't print in color
+      "console": "integratedTerminal",
+      // since we're not using it, don't automatically switch to it
+      "internalConsoleOptions": "neverOpen",
     },
     {
       "name": "pytest - current file",


### PR DESCRIPTION
This makes a few changes to our VSCode debug profile for running jest tests, both to make it work correctly (which it currently doesn't - no output shows) and to make it more user-friendly.

Key changes:
- Remove obsolete `protocol` option.
- Make the tests run in watch mode.
- Restrict jest to running the current test file. We have something on the order of 6000 tests, which makes the debugger unusable if you run it with our full complement of JS tests - the test you're interested in might take 10+ minutes to even get queued to run!
- Run the tests in verbose mode, since the current-file restriction makes this feasible and when you're debugging, the more complete the explanation for a failing test, the better.
- Run the tests in VSCode's integrated console rather than its debug console, in order to be able to see Jest's output. (You can use another setting, `outputCapture`, to force output to show in the debug console, but none of the helpful color-formatting comes through.)
- Rename the profile in light of the current-file restriction.