### PR TITLE
feat(issue-states): use most recent regressed GroupHistory entry to determine last activity

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -134,8 +133,6 @@ def auto_transition_issues_regressed_to_ongoing(
             recent_regressed_history__gte=datetime.fromtimestamp(date_added_gte, pytz.UTC)
         )
 
-    logging.error(queryset.query)
-
     groups_with_regressed_history = list(queryset.order_by("recent_regressed_history")[:chunk_size])
 
     for group in groups_with_regressed_history:
@@ -149,7 +146,9 @@ def auto_transition_issues_regressed_to_ongoing(
         auto_transition_issues_regressed_to_ongoing.delay(
             project_id=project_id,
             date_added_lte=date_added_lte,
-            date_added_gte=groups_with_regressed_history[chunk_size - 1].date_added.timestamp(),
+            date_added_gte=groups_with_regressed_history[
+                chunk_size - 1
+            ].recent_regressed_history.timestamp(),
             chunk_size=chunk_size,
             expires=datetime.now(tz=pytz.UTC) + timedelta(hours=1),
         )

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -1,15 +1,16 @@
+import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
 import pytz
+from django.db.models import Max
 from sentry_sdk.crons.decorator import monitor
 
 from sentry import features
 from sentry.issues.ongoing import transition_group_to_ongoing
 from sentry.models import (
     Group,
-    GroupInbox,
-    GroupInboxReason,
+    GroupHistoryStatus,
     GroupStatus,
     Organization,
     OrganizationStatus,
@@ -117,30 +118,38 @@ def auto_transition_issues_regressed_to_ongoing(
     chunk_size: int = 1000,
     **kwargs,
 ) -> None:
-
-    queryset = GroupInbox.objects.filter(
-        project_id=project_id,
-        date_added__lte=datetime.fromtimestamp(date_added_lte, pytz.UTC),
-        reason=GroupInboxReason.REGRESSION.value,
+    queryset = (
+        Group.objects.filter(
+            project_id=project_id,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.REGRESSED,
+            grouphistory__status=GroupHistoryStatus.REGRESSED,
+        )
+        .annotate(recent_regressed_history=Max("grouphistory__date_added"))
+        .filter(recent_regressed_history__lte=datetime.fromtimestamp(date_added_lte, pytz.UTC))
     )
 
     if date_added_gte:
-        queryset = queryset.filter(date_added__gte=datetime.fromtimestamp(date_added_gte, pytz.UTC))
+        queryset = queryset.filter(
+            recent_regressed_history__gte=datetime.fromtimestamp(date_added_gte, pytz.UTC)
+        )
 
-    regressed_inbox = queryset.order_by("date_added")[:chunk_size]
+    logging.error(queryset.query)
 
-    for group in Group.objects.filter(id__in=list({inbox.group_id for inbox in regressed_inbox})):
+    groups_with_regressed_history = list(queryset.order_by("recent_regressed_history")[:chunk_size])
+
+    for group in groups_with_regressed_history:
         transition_group_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.REGRESSED,
             group,
         )
 
-    if len(regressed_inbox) == chunk_size:
+    if len(groups_with_regressed_history) == chunk_size:
         auto_transition_issues_regressed_to_ongoing.delay(
             project_id=project_id,
             date_added_lte=date_added_lte,
-            date_added_gte=regressed_inbox[chunk_size - 1].date_added.timestamp(),
+            date_added_gte=groups_with_regressed_history[chunk_size - 1].date_added.timestamp(),
             chunk_size=chunk_size,
             expires=datetime.now(tz=pytz.UTC) + timedelta(hours=1),
         )


### PR DESCRIPTION
Modifies how we source regressed issues to automatically transition regressed issues to ongoing issues.


`Group.first_seen` and `Group.last_seen` column values can't really be used here since `first_seen` is when the first event groups to the issue and `last_seen` continually gets updated for each new event grouping to that issue. 

We need a way to determine when Groups regressed so we can check if three days has past to transition the regressed issue to ongoing. This PR uses the most recent `GroupHistory.date_added` column to apply that check.

The resulting join query:
```
SELECT "sentry_groupedmessage"."id",
       "sentry_groupedmessage"."project_id",
       "sentry_groupedmessage"."logger",
       "sentry_groupedmessage"."level",
       "sentry_groupedmessage"."message",
       "sentry_groupedmessage"."view",
       "sentry_groupedmessage"."num_comments",
       "sentry_groupedmessage"."platform",
       "sentry_groupedmessage"."status",
       "sentry_groupedmessage"."substatus",
       "sentry_groupedmessage"."times_seen",
       "sentry_groupedmessage"."last_seen",
       "sentry_groupedmessage"."first_seen",
       "sentry_groupedmessage"."first_release_id",
       "sentry_groupedmessage"."resolved_at",
       "sentry_groupedmessage"."active_at",
       "sentry_groupedmessage"."time_spent_total",
       "sentry_groupedmessage"."time_spent_count",
       "sentry_groupedmessage"."score",
       "sentry_groupedmessage"."is_public",
       "sentry_groupedmessage"."data",
       "sentry_groupedmessage"."short_id",
       "sentry_groupedmessage"."type",
       MAX("sentry_grouphistory"."date_added") AS "recent_regressed_history"
FROM "sentry_groupedmessage"
INNER JOIN "sentry_grouphistory" ON ("sentry_groupedmessage"."id" = "sentry_grouphistory"."group_id")
WHERE ("sentry_grouphistory"."status" = 7
       AND "sentry_groupedmessage"."project_id" = 4551977303932932
       AND "sentry_groupedmessage"."status" = 0
       AND "sentry_groupedmessage"."substatus" = 6)
GROUP BY "sentry_groupedmessage"."id" HAVING MAX("sentry_grouphistory"."date_added") <= 2023-05-19 19:19:22+00:00
```

Ran a 'stress test' to make sure this query runs reasonably well with real data. As long as the number of regressed issues `(status=0, substatus=6)` isn't obscenely large (tested with a project_id with 168k+ regressed issues ... and this join query ran in 11 seconds), this query should be performant enough to not cause problems.