### PR TITLE
fix(escalating): Use escalating-issues-ui flag for hiding mark reviewed

### DIFF
--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -176,14 +176,14 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
 
   const {tooltipText, tooltipDescription, reasonBadgeText, tagType} = getReasonDetails();
 
-  const disabledMarkReviewed = organization.features.includes('escalating-issues-ui');
+  const hasEscalatingIssuesUi = organization.features.includes('escalating-issues-ui');
   const tooltip = (tooltipText || tooltipDescription) && (
     <TooltipWrapper>
       {tooltipText && <div>{tooltipText}</div>}
       {tooltipDescription && (
         <TooltipDescription>{tooltipDescription}</TooltipDescription>
       )}
-      {disabledMarkReviewed ? null : (
+      {hasEscalatingIssuesUi ? null : (
         <TooltipDescription>{t('Mark Reviewed to remove this label')}</TooltipDescription>
       )}
     </TooltipWrapper>

--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -176,7 +176,7 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
 
   const {tooltipText, tooltipDescription, reasonBadgeText, tagType} = getReasonDetails();
 
-  const disabledMarkReviewed = organization.features.includes('remove-mark-reviewed');
+  const disabledMarkReviewed = organization.features.includes('escalating-issues-ui');
   const tooltip = (tooltipText || tooltipDescription) && (
     <TooltipWrapper>
       {tooltipText && <div>{tooltipText}</div>}

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -90,7 +90,6 @@ export function Actions(props: Props) {
 
   const hasEscalatingIssues = organization.features.includes('escalating-issues-ui');
   const hasDeleteAccess = organization.access.includes('event:admin');
-  const disabledMarkReviewed = organization.features.includes('remove-mark-reviewed');
 
   const {
     delete: deleteCap,
@@ -412,7 +411,7 @@ export function Actions(props: Props) {
             disabled: disabled || group.subscriptionDetails?.disabled,
             onAction: onToggleSubscribe,
           },
-          ...(disabledMarkReviewed
+          ...(hasEscalatingIssues
             ? []
             : [
                 {

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -100,7 +100,7 @@ function ActionSet({
   // the dropdown menu based on the current screen size
   const theme = useTheme();
   const nestMergeAndReview = useMedia(`(max-width: ${theme.breakpoints.xlarge})`);
-  const disabledMarkReviewed = organization.features.includes('remove-mark-reviewed');
+  const hasEscalatingIssuesUi = organization.features.includes('escalating-issues-ui');
 
   const menuItems: MenuItemProps[] = [
     {
@@ -118,7 +118,7 @@ function ActionSet({
         });
       },
     },
-    ...(disabledMarkReviewed
+    ...(hasEscalatingIssuesUi
       ? []
       : [
           {
@@ -254,7 +254,7 @@ function ActionSet({
           disabled={ignoreDisabled}
         />
       )}
-      {!nestMergeAndReview && !disabledMarkReviewed && (
+      {!nestMergeAndReview && !hasEscalatingIssuesUi && (
         <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />
       )}
       {!nestMergeAndReview && (

--- a/static/app/views/issueList/actions/index.spec.jsx
+++ b/static/app/views/issueList/actions/index.spec.jsx
@@ -298,9 +298,9 @@ describe('IssueListActions', function () {
       expect(screen.getByRole('button', {name: 'Mark Reviewed'})).toBeDisabled();
     });
 
-    it('hides mark reviewed button with remove-mark-reviewed flag', function () {
+    it('hides mark reviewed button with escalating-issues-ui flag', function () {
       render(<WrappedComponent {...defaultProps} />, {
-        organization: {...organization, features: ['remove-mark-reviewed']},
+        organization: {...organization, features: ['escalating-issues-ui']},
       });
 
       expect(

--- a/static/app/views/issueList/actions/reviewAction.tsx
+++ b/static/app/views/issueList/actions/reviewAction.tsx
@@ -17,7 +17,7 @@ type Props = {
 function ReviewAction({disabled, onUpdate, tooltipProps, tooltip}: Props) {
   const organization = useOrganization();
 
-  if (organization.features.includes('remove-mark-reviewed')) {
+  if (organization.features.includes('escalating-issues-ui')) {
     return null;
   }
 


### PR DESCRIPTION
Hides the mark reviewed button w/ the escalating-issues-ui flag instead of the other flag.