### PR TITLE
fix(discover): Use local filtering context in Discover

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -758,6 +758,7 @@ function ResultsContainer(props: Props) {
 
   return (
     <PageFiltersContainer
+      disablePersistence
       skipLoadLastUsed={
         props.organization.features.includes('global-views') && !!props.savedQuery
       }


### PR DESCRIPTION
Isolate the "Saved Query" page in Discover from the global page filter context. Changes to the page filters in this page shouldn't affect any other pages. This is the same behavior as in the "Dashboard Details" page.

<img width="1496" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/d0c8f7fc-e1b7-44c9-9799-e665d7f1a02e">

Doing this helps prevent false-positive desync messages, like this one:
<img width="469" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/1f3ffd08-8b9d-4de7-8a02-8ca000342efe">

