### PR TITLE
fix(escalating): Use substatus to tell if archived until escalating

### DIFF
--- a/static/app/components/archivedBox.spec.tsx
+++ b/static/app/components/archivedBox.spec.tsx
@@ -1,44 +1,79 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {GroupSubstatus} from 'sentry/types';
+
 import ArchivedBox from './archivedBox';
 
 describe('ArchivedBox', function () {
   it('handles ignoreUntil', function () {
-    render(<ArchivedBox statusDetails={{ignoreUntil: '2017-06-21T19:45:10Z'}} />);
+    render(
+      <ArchivedBox
+        substatus={GroupSubstatus.ARCHIVED_UNTIL_CONDITION_MET}
+        statusDetails={{ignoreUntil: '2017-06-21T19:45:10Z'}}
+      />
+    );
     expect(screen.getByText(/This issue has been archived until/)).toBeInTheDocument();
   });
   it('handles ignoreCount', function () {
-    render(<ArchivedBox statusDetails={{ignoreUserCount: 100}} />);
+    render(
+      <ArchivedBox
+        substatus={GroupSubstatus.ARCHIVED_UNTIL_CONDITION_MET}
+        statusDetails={{ignoreUserCount: 100}}
+      />
+    );
     expect(
       screen.getByText(/This issue has been archived until it affects/)
     ).toBeInTheDocument();
   });
   it('handles ignoreCount with ignoreWindow', function () {
-    render(<ArchivedBox statusDetails={{ignoreCount: 100, ignoreWindow: 1}} />);
+    render(
+      <ArchivedBox
+        substatus={GroupSubstatus.ARCHIVED_UNTIL_CONDITION_MET}
+        statusDetails={{ignoreCount: 100, ignoreWindow: 1}}
+      />
+    );
     expect(
       screen.getByText(/This issue has been archived until it occurs/)
     ).toBeInTheDocument();
   });
   it('handles ignoreUserCount', function () {
-    render(<ArchivedBox statusDetails={{ignoreUserCount: 100}} />);
+    render(
+      <ArchivedBox
+        substatus={GroupSubstatus.ARCHIVED_UNTIL_CONDITION_MET}
+        statusDetails={{ignoreUserCount: 100}}
+      />
+    );
     expect(
       screen.getByText(/This issue has been archived until it affects/)
     ).toBeInTheDocument();
   });
   it('handles ignoreUserCount with ignoreUserWindow', function () {
-    render(<ArchivedBox statusDetails={{ignoreUserCount: 100, ignoreUserWindow: 1}} />);
+    render(
+      <ArchivedBox
+        substatus={GroupSubstatus.ARCHIVED_UNTIL_CONDITION_MET}
+        statusDetails={{ignoreUserCount: 100, ignoreUserWindow: 1}}
+      />
+    );
     expect(
       screen.getByText(/This issue has been archived until it affects/)
     ).toBeInTheDocument();
   });
   it('handles archived forever', function () {
-    render(<ArchivedBox statusDetails={{}} />);
+    render(
+      <ArchivedBox substatus={GroupSubstatus.ARCHIVED_FOREVER} statusDetails={{}} />
+    );
     expect(screen.getByText(/This issue has been archived forever/)).toBeInTheDocument();
   });
   it('handes archived until escalating', function () {
-    render(<ArchivedBox statusDetails={{ignoreUntilEscalating: true}} />, {
-      organization: TestStubs.Organization({features: ['escalating-issues-ui']}),
-    });
+    render(
+      <ArchivedBox
+        substatus={GroupSubstatus.ARCHIVED_UNTIL_ESCALATING}
+        statusDetails={{ignoreUntilEscalating: true}}
+      />,
+      {
+        organization: TestStubs.Organization({features: ['escalating-issues-ui']}),
+      }
+    );
     expect(
       screen.getByText(
         /This issue has been archived\. It'll return to your inbox if it escalates/

--- a/static/app/components/archivedBox.tsx
+++ b/static/app/components/archivedBox.tsx
@@ -3,24 +3,19 @@ import Duration from 'sentry/components/duration';
 import {BannerContainer, BannerSummary} from 'sentry/components/events/styles';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t} from 'sentry/locale';
-import type {ResolutionStatusDetails} from 'sentry/types';
+import {Group, GroupSubstatus, ResolutionStatusDetails} from 'sentry/types';
 
-type Props = {
+interface ArchivedBoxProps {
   statusDetails: ResolutionStatusDetails;
-};
+  substatus: Group['substatus'];
+}
 
-function ArchivedBox({statusDetails}: Props) {
+function ArchivedBox({substatus, statusDetails}: ArchivedBoxProps) {
   function renderReason() {
-    const {
-      ignoreUntil,
-      ignoreCount,
-      ignoreWindow,
-      ignoreUserCount,
-      ignoreUserWindow,
-      ignoreUntilEscalating,
-    } = statusDetails;
+    const {ignoreUntil, ignoreCount, ignoreWindow, ignoreUserCount, ignoreUserWindow} =
+      statusDetails;
 
-    if (ignoreUntilEscalating) {
+    if (substatus === GroupSubstatus.ARCHIVED_UNTIL_ESCALATING) {
       return t(
         "This issue has been archived. It'll return to your inbox if it escalates. To learn more, %s",
         <ExternalLink href="https://docs.sentry.io/product/issues/states-triage/">

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -143,7 +143,10 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
       return (
         <GroupStatusBannerWrapper>
           {hasEscalatingIssuesUi ? (
-            <ArchivedBox statusDetails={group.statusDetails} />
+            <ArchivedBox
+              substatus={group.substatus}
+              statusDetails={group.statusDetails}
+            />
           ) : (
             <MutedBox statusDetails={group.statusDetails} />
           )}


### PR DESCRIPTION
Uses the group substatus instead of the group statusDetails