### PR TITLE
fix(issue-states): Issue alert header using group substatus instead of inbox

### DIFF
--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -1,6 +1,5 @@
 import logging
 from enum import Enum
-from typing import Optional
 
 import jsonschema
 from django.db import models
@@ -146,14 +145,3 @@ def get_inbox_details(group_list):
     }
 
     return inbox_stats
-
-
-def get_inbox_reason_text(group_inbox: Optional[GroupInbox]):
-    reason = GroupInboxReason(group_inbox.reason) if group_inbox else None
-    if reason == GroupInboxReason.NEW:
-        return "New issue"
-    elif reason == GroupInboxReason.REGRESSION:
-        return "Regressed issue"
-    elif reason == GroupInboxReason.ONGOING:
-        return "Ongoing issue"
-    return "New Alert"

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -38,7 +38,7 @@ from sentry.utils.http import absolute_uri
 logger = logging.getLogger(__name__)
 
 
-def get_group_substatus_text(group: Group):
+def get_group_substatus_text(group: Group) -> str:
     if group.substatus == GroupSubStatus.NEW:
         return "New issue"
     elif group.substatus == GroupSubStatus.REGRESSED:


### PR DESCRIPTION
A new issue alert header was added in https://github.com/getsentry/sentry/pull/48762 but it used group inbox reason. This switches it to use the group substatus instead

fixes #49419