### PR TITLE
chore(js): Use FormFieldProps vs FormField['props']

### DIFF
--- a/static/app/views/alerts/rules/metric/metricField.tsx
+++ b/static/app/views/alerts/rules/metric/metricField.tsx
@@ -3,7 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
-import FormField from 'sentry/components/forms/formField';
+import FormField, {FormFieldProps} from 'sentry/components/forms/formField';
 import {Organization} from 'sentry/types';
 import {
   Aggregation,
@@ -28,7 +28,7 @@ import {
 } from './constants';
 import {Dataset} from './types';
 
-type Props = Omit<FormField['props'], 'children'> & {
+type Props = Omit<FormFieldProps, 'children'> & {
   organization: Organization;
   alertType?: AlertType;
   /**

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -2,7 +2,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
-import FormField from 'sentry/components/forms/formField';
+import FormField, {FormFieldProps} from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
@@ -22,7 +22,7 @@ import {getFieldOptionConfig} from './metricField';
 type MenuOption = {label: string; value: AlertType};
 type GroupedMenuOption = {label: string; options: Array<MenuOption>};
 
-type Props = Omit<FormField['props'], 'children'> & {
+type Props = Omit<FormFieldProps, 'children'> & {
   organization: Organization;
   alertType?: AlertType;
   /**


### PR DESCRIPTION
The later won't work when FormField becomes and FC