### PR TITLE
fix(txnames): Always count clusterer run

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -68,7 +68,8 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                     clusterer = TreeClusterer(merge_threshold=MERGE_THRESHOLD)
                     clusterer.add_input(tx_names)
                     new_rules = clusterer.get_rules()
-                    track_clusterer_run(project)
+
+                track_clusterer_run(project)
 
                 # The Redis store may have more up-to-date last_seen values,
                 # so we must update the stores to bring these values to


### PR DESCRIPTION
Count a clusterer run whenever the clusterer spawn job is scheduled and a project has collected at least one transaction since the last run.

Projects that have very few unique transaction names (i.e. low cardinality) should get those metrics tagged by the original transaction name, instead of being stuck in `<< unparameterized >>` forever.

https://github.com/getsentry/sentry/pull/49087 already lowered the threshold, but we're still seeing a high percentage of URL transactions not getting relabeled.

ref: https://github.com/getsentry/team-ingest/issues/124