### PR TITLE
fix(starfish): Zerofill round up

### DIFF
--- a/static/app/views/starfish/utils/zeroFillSeries.tsx
+++ b/static/app/views/starfish/utils/zeroFillSeries.tsx
@@ -2,8 +2,6 @@ import moment from 'moment';
 
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
 
-const TWELVE_HOURS_IN_MS = 12 * 60 * 60 * 1000;
-
 export function zeroFillSeries(
   series: Series,
   interval: moment.Duration,
@@ -28,7 +26,8 @@ export function zeroFillSeries(
 
   const newData: SeriesDataUnit[] = [];
 
-  const startTimeNearestInterval = startTime && roundUpToNearest12HourInterval(startTime);
+  const startTimeNearestInterval =
+    startTime && roundDownToNearest12HourInterval(startTime);
   const endTimeNearestInterval = endTime && roundDownToNearest12HourInterval(endTime);
 
   const seriesData = [
@@ -84,15 +83,6 @@ export function zeroFillSeries(
     ...series,
     data: newData,
   };
-}
-
-function roundUpToNearest12HourInterval(time: moment.Moment) {
-  return roundDownToNearest12HourInterval(
-    time
-      .clone()
-      .add(12, 'hour')
-      .subtract(TWELVE_HOURS_IN_MS - 1, 'ms')
-  );
 }
 
 function roundDownToNearest12HourInterval(time: moment.Moment) {

--- a/static/app/views/starfish/utils/zeroFillSeries.tsx
+++ b/static/app/views/starfish/utils/zeroFillSeries.tsx
@@ -85,7 +85,9 @@ export function zeroFillSeries(
 }
 
 function roundUpToNearest12HourInterval(time: moment.Moment) {
-  return roundDownToNearest12HourInterval(time.clone().add(12, 'hour').subtract(1, 'ms'));
+  return roundDownToNearest12HourInterval(
+    time.clone().add(12, 'hour').subtract(43199999, 'ms')
+  );
 }
 
 function roundDownToNearest12HourInterval(time: moment.Moment) {

--- a/static/app/views/starfish/utils/zeroFillSeries.tsx
+++ b/static/app/views/starfish/utils/zeroFillSeries.tsx
@@ -2,6 +2,8 @@ import moment from 'moment';
 
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
 
+const TWELVE_HOURS_IN_MS = 12 * 60 * 60 * 1000;
+
 export function zeroFillSeries(
   series: Series,
   interval: moment.Duration,
@@ -86,7 +88,10 @@ export function zeroFillSeries(
 
 function roundUpToNearest12HourInterval(time: moment.Moment) {
   return roundDownToNearest12HourInterval(
-    time.clone().add(12, 'hour').subtract(43199999, 'ms')
+    time
+      .clone()
+      .add(12, 'hour')
+      .subtract(TWELVE_HOURS_IN_MS - 1, 'ms')
   );
 }
 


### PR DESCRIPTION
Fix zerofill start point since we do
timestampToStartOfHour queries on
CH. So we want to get the earliest
possible "start of" bucket.
![Screenshot 2023-05-23 at 10 05 51 AM](https://github.com/getsentry/sentry/assets/63818634/2545b29b-af3a-4858-9a26-9bda548ea463)

(the funky part here is me using 1 day intervals
updated to use 12 hour intervals in a separate PR)
![Screenshot 2023-05-23 at 10 08 17 AM](https://github.com/getsentry/sentry/assets/63818634/3ba5ebb3-11e5-4257-96b9-bb4f2a927bd2)

