### PR TITLE
feat(dev): Add redis-cluster to devservices

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2425,7 +2425,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     ),
     "redis-cluster": lambda settings, options: (
         {
-            "image": "ghcr.io/getsentry/image-mirror-library-grokzen-redis-cluster:7.0.10",
+            "image": "ghcr.io/getsentry/docker-redis-cluster:7.0.10",
             "ports": {f"700{idx}/tcp": f"700{idx}" for idx in range(6)},
             "volumes": {"redis-cluster": {"bind": "/redis-data"}},
             "environment": {"IP": "0.0.0.0"},

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2418,7 +2418,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     ),
     "redis-cluster": lambda settings, options: (
         {
-            "image": "grokzen/redis-cluster:7.0.10",
+            "image": "ghcr.io/getsentry/image-mirror-library-grokzen-redis-cluster:7.0.10",
             "ports": {f"700{idx}/tcp": f"700{idx}" for idx in range(6)},
             "volumes": {"redis-cluster": {"bind": "/redis-data"}},
             "environment": {"IP": "0.0.0.0"},

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2416,6 +2416,14 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
             "volumes": {"redis": {"bind": "/data"}},
         }
     ),
+    "redis-cluster": lambda settings, options: (
+        {
+            "image": "grokzen/redis-cluster:7.0.10",
+            "ports": {f"700{idx}/tcp": f"700{idx}" for idx in range(6)},
+            "volumes": {"redis-cluster": {"bind": "/redis-data"}},
+            "environment": {"IP": "0.0.0.0"},
+        }
+    ),
     "postgres": lambda settings, options: (
         {
             "image": f"ghcr.io/getsentry/image-mirror-library-postgres:{PG_VERSION}-alpine",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2334,6 +2334,13 @@ SENTRY_RELAY_PORT = 7899
 # it as a worker, and devservices will run Kafka.
 SENTRY_DEV_PROCESS_SUBSCRIPTIONS = False
 
+SENTRY_DEV_USE_REDIS_CLUSTER = bool(os.getenv("SENTRY_DEV_USE_REDIS_CLUSTER", False))
+
+# To use RabbitMQ as a Celery tasks broker
+# BROKER_URL = "amqp://guest:guest@localhost:5672/sentry"
+# more info https://develop.sentry.dev/services/queue/
+SENTRY_DEV_USE_RABBITMQ = bool(os.getenv("SENTRY_DEV_USE_RABBITMQ", False))
+
 # The chunk size for attachments in blob store. Should be a power of two.
 SENTRY_ATTACHMENT_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
 
@@ -2422,6 +2429,15 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
             "ports": {f"700{idx}/tcp": f"700{idx}" for idx in range(6)},
             "volumes": {"redis-cluster": {"bind": "/redis-data"}},
             "environment": {"IP": "0.0.0.0"},
+            "only_if": settings.SENTRY_DEV_USE_REDIS_CLUSTER,
+        }
+    ),
+    "rabbitmq": lambda settings, options: (
+        {
+            "image": "ghcr.io/getsentry/image-mirror-library-rabbitmq:3-management",
+            "ports": {"5672/tcp": 5672, "15672/tcp": 15672},
+            "environment": {"IP": "0.0.0.0"},
+            "only_if": settings.SENTRY_DEV_USE_RABBITMQ,
         }
     ),
     "postgres": lambda settings, options: (

--- a/src/sentry/data/config/config.yml.default
+++ b/src/sentry/data/config/config.yml.default
@@ -57,6 +57,21 @@ redis.clusters:
       0:
         host: 127.0.0.1
         port: 6379
+  rc-default:
+    is_redis_cluster: true
+    hosts:
+      - host: 127.0.0.1
+        port: 7000
+      - host: 127.0.0.1
+        port: 7001
+      - host: 127.0.0.1
+        port: 7002
+      - host: 127.0.0.1
+        port: 7003
+      - host: 127.0.0.1
+        port: 7004
+      - host: 127.0.0.1
+        port: 7005
 
 ################
 # File storage #


### PR DESCRIPTION
For testing queues and processing store monitoring for backpressure management of ingest consumers, this PR adds rabbitmq and redis-cluster containers to devservices.

They do not start with the rest of the services by default and need to be enabled using environment variables.

```
export SENTRY_DEV_USE_REDIS_CLUSTER=true
export SENTRY_DEV_USE_RABBITMQ=true
```
afterwards, use `sentry devservices {up | down}` as you would normally do.

One can always manage the services manually even without the above mentioned environment variables in place:

```
sentry devservices {up | down} redis-cluster
sentry devservices {up | down} rabbitmq
```

To use RabbitMQ as your Celery tasks broker you'll need to change your settings:
```
BROKER_URL = "amqp://guest:guest@localhost:5672/sentry"
```
(see https://develop.sentry.dev/services/queue/).

Unless changed in your environment by `SENTRY_CONF` or `DJANGO_CONF` environment variables, this setting lives in `~/.sentry/sentry.conf.py`.

To make use of the `redis-cluster` you will need an additional section in the `redis.clusters` option. See https://github.com/getsentry/sentry/pull/49606/files#diff-94dc6dcb2c82ecd1b4fab0edee177a697e821f1340bd6710392b4095880a0e87R60-R74

Unless changed in your environment by `SENTRY_CONF` or `DJANGO_CONF` environment variables, this setting lives in `~/.sentry/config.yml`.
