### PR TITLE
feat(project-creation): Add analytics code

### DIFF
--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -78,12 +78,15 @@ export function FrameworkSuggestionModal({
   );
 
   useEffect(() => {
-    if (newOrg) {
-      trackAnalytics('onboarding.select_framework_modal_rendered', {
+    trackAnalytics(
+      newOrg
+        ? 'onboarding.select_framework_modal_rendered'
+        : 'project_creation.select_framework_modal_rendered',
+      {
         platform: selectedPlatform.key,
         organization,
-      });
-    }
+      }
+    );
   }, [selectedPlatform.key, organization, newOrg]);
 
   const handleConfigure = useCallback(() => {
@@ -91,13 +94,16 @@ export function FrameworkSuggestionModal({
       return;
     }
 
-    if (newOrg) {
-      trackAnalytics('onboarding.select_framework_modal_configure_sdk_button_clicked', {
+    trackAnalytics(
+      newOrg
+        ? 'onboarding.select_framework_modal_configure_sdk_button_clicked'
+        : 'project_creation.select_framework_modal_configure_sdk_button_clicked',
+      {
         platform: selectedPlatform.key,
         framework: selectedFramework.key,
         organization,
-      });
-    }
+      }
+    );
 
     onConfigure(selectedFramework);
     closeModal();
@@ -111,12 +117,15 @@ export function FrameworkSuggestionModal({
   ]);
 
   const handleSkip = useCallback(() => {
-    if (newOrg) {
-      trackAnalytics('onboarding.select_framework_modal_skip_button_clicked', {
+    trackAnalytics(
+      newOrg
+        ? 'onboarding.select_framework_modal_skip_button_clicked'
+        : 'project_creation.select_framework_modal_skip_button_clicked',
+      {
         platform: selectedPlatform.key,
         organization,
-      });
-    }
+      }
+    );
     onSkip();
     closeModal();
   }, [selectedPlatform, organization, closeModal, onSkip, newOrg]);

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -46,6 +46,10 @@ import {
   ProfilingEventParameters,
 } from './analytics/profilingAnalyticsEvents';
 import {
+  projectCreationEventMap,
+  ProjectCreationEventParameters,
+} from './analytics/projectCreationAnalyticsEvents';
+import {
   releasesEventMap,
   ReleasesEventParameters,
 } from './analytics/releasesAnalyticsEvents';
@@ -82,7 +86,8 @@ type EventParameters = GrowthEventParameters &
   StackTraceEventParameters &
   AiSuggestedSolutionEventParameters &
   EcosystemEventParameters &
-  IntegrationEventParameters;
+  IntegrationEventParameters &
+  ProjectCreationEventParameters;
 
 const allEventMap: Record<string, string | null> = {
   ...coreUIEventMap,
@@ -104,6 +109,7 @@ const allEventMap: Record<string, string | null> = {
   ...aiSuggestedSolutionEventMap,
   ...ecosystemEventMap,
   ...integrationEventMap,
+  ...projectCreationEventMap,
 };
 
 /**

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -1,0 +1,29 @@
+export type ProjectCreationEventParameters = {
+  'project_creation.select_framework_modal_close_button_clicked': {
+    platform: string;
+  };
+  'project_creation.select_framework_modal_configure_sdk_button_clicked': {
+    framework: string;
+    platform: string;
+  };
+  'project_creation.select_framework_modal_rendered': {
+    platform: string;
+  };
+  'project_creation.select_framework_modal_skip_button_clicked': {
+    platform: string;
+  };
+};
+
+export const projectCreationEventMap: Record<
+  keyof ProjectCreationEventParameters,
+  string
+> = {
+  'project_creation.select_framework_modal_close_button_clicked':
+    'Project Creation: Framework Modal Close Button Clicked',
+  'project_creation.select_framework_modal_configure_sdk_button_clicked':
+    'Project Creation: Framework Modal Configure SDK Button Clicked',
+  'project_creation.select_framework_modal_rendered':
+    'Project Creation: Framework Modal Rendered',
+  'project_creation.select_framework_modal_skip_button_clicked':
+    'Project Creation: Framework Modal Skip Button Clicked',
+};

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -178,6 +178,12 @@ function CreateProject() {
       ),
       {
         modalCss,
+        onClose: () => {
+          trackAnalytics('project_creation.select_framework_modal_close_button_clicked', {
+            platform: selectedPlatform.key,
+            organization,
+          });
+        },
       }
     );
   }, [platform, createProject, organization]);


### PR DESCRIPTION
Introduce amplitude analytics code to the project creation flow. The new analytics properties is to track the usage of the framework selection modal.
