### PR TITLE
fix(dynamic-sampling): Improve performance of sliding window

### DIFF
--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -13,7 +13,7 @@ FALLBACK_SLIDING_WINDOW_SIZE = 24
 # Sentinel value used to mark that an error happened when computing the sliding window sample rate for a specific
 # project.
 SLIDING_WINDOW_CALCULATION_ERROR = "sliding_window_error"
-# We want to keep the entry for 1 hour, so that in case an org is not considered for 1 hour, the system will fallback
+# We want to keep the entry for 1 hour, so that in case an org is not considered for 1 hour, the system will fall back
 # to the blended sample rate.
 EXECUTED_CACHE_KEY_TTL = 60 * 60 * 1000
 

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -22,7 +22,7 @@ def generate_sliding_window_executed_cache_key(org_id: int) -> str:
     return f"ds::o:{org_id}:sliding_window_executed"
 
 
-def mark_sliding_window_executed_for_orgs(org_ids: Sequence[int]):
+def mark_sliding_window_executed_for_orgs(org_ids: Sequence[int]) -> None:
     redis_client = get_redis_client_for_ds()
 
     for org_id in org_ids:
@@ -35,7 +35,7 @@ def was_sliding_window_executed(org_id: int) -> bool:
     redis_client = get_redis_client_for_ds()
     cache_key = generate_sliding_window_executed_cache_key(org_id=org_id)
 
-    return redis_client.exists(cache_key)
+    return bool(redis_client.exists(cache_key))
 
 
 def generate_sliding_window_cache_key(org_id: int) -> str:

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -55,8 +55,8 @@ def get_sliding_window_sample_rate(
             return error_sample_rate_fallback
 
         return float(value)
-    # Thrown if the input is not a valid float.
-    except ValueError:
+    # Throw if the input is not a string or a float (e.g., None).
+    except TypeError:
         # In case we couldn't convert the value to float, that is, it is a string or the value is not there, we want
         # to fall back to 100% in case we know that the sliding window was executed. We track whether the task was
         # executed and completed successfully under the assumption that, if that is the case, all orgs and projects
@@ -67,8 +67,8 @@ def get_sliding_window_sample_rate(
         # In the other case were the sliding window was not run, maybe because of an issue, we will just fallback to
         # blended sample rate, to avoid oversampling.
         return error_sample_rate_fallback
-    # Throw if the input is not a string or a float.
-    except TypeError:
+    # Thrown if the input is not a valid float.
+    except ValueError:
         return error_sample_rate_fallback
 
 

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -27,7 +27,8 @@ def get_sliding_window_sample_rate(
 
     try:
         value = redis_client.hget(cache_key, project_id)
-        # In case we had an explicit error, we want to fetch the blended sample rate to avoid oversampling.
+        # In case we had an explicit error or the sliding window was not run, we want to fetch the blended sample
+        # rate to avoid oversampling.
         if value == SLIDING_WINDOW_CALCULATION_ERROR:
             return error_sample_rate_fallback
 

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -55,7 +55,8 @@ def get_sliding_window_sample_rate(
             return error_sample_rate_fallback
 
         return float(value)
-    except (TypeError, ValueError):
+    # Thrown if the input is not a valid float.
+    except ValueError:
         # In case we couldn't convert the value to float, that is, it is a string or the value is not there, we want
         # to fall back to 100% in case we know that the sliding window was executed. We track whether the task was
         # executed and completed successfully under the assumption that, if that is the case, all orgs and projects
@@ -65,6 +66,9 @@ def get_sliding_window_sample_rate(
 
         # In the other case were the sliding window was not run, maybe because of an issue, we will just fallback to
         # blended sample rate, to avoid oversampling.
+        return error_sample_rate_fallback
+    # Throw if the input is not a string or a float.
+    except TypeError:
         return error_sample_rate_fallback
 
 

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -1,6 +1,6 @@
 from calendar import IllegalMonthError, monthrange
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Sequence
 
 import pytz
 
@@ -13,6 +13,29 @@ FALLBACK_SLIDING_WINDOW_SIZE = 24
 # Sentinel value used to mark that an error happened when computing the sliding window sample rate for a specific
 # project.
 SLIDING_WINDOW_CALCULATION_ERROR = "sliding_window_error"
+# We want to keep the entry for 1 hour, so that in case an org is not considered for 1 hour, the system will fallback
+# to the blended sample rate.
+EXECUTED_CACHE_KEY_TTL = 60 * 60 * 1000
+
+
+def generate_sliding_window_executed_cache_key(org_id: int) -> str:
+    return f"ds::o:{org_id}:sliding_window_executed"
+
+
+def mark_sliding_window_executed_for_orgs(org_ids: Sequence[int]):
+    redis_client = get_redis_client_for_ds()
+
+    for org_id in org_ids:
+        cache_key = generate_sliding_window_executed_cache_key(org_id=org_id)
+        redis_client.set(cache_key, 1)
+        redis_client.pexpire(cache_key, EXECUTED_CACHE_KEY_TTL)
+
+
+def was_sliding_window_executed(org_id: int) -> bool:
+    redis_client = get_redis_client_for_ds()
+    cache_key = generate_sliding_window_executed_cache_key(org_id=org_id)
+
+    return redis_client.exists(cache_key)
 
 
 def generate_sliding_window_cache_key(org_id: int) -> str:
@@ -27,16 +50,20 @@ def get_sliding_window_sample_rate(
 
     try:
         value = redis_client.hget(cache_key, project_id)
-        # In case we had an explicit error or the sliding window was not run, we want to fetch the blended sample
-        # rate to avoid oversampling.
+        # In case we had an explicit error or the sliding window was not run, we want to return the error fallback
+        # sample rate.
         if value == SLIDING_WINDOW_CALCULATION_ERROR:
             return error_sample_rate_fallback
 
         return float(value)
     except (TypeError, ValueError):
         # In case we couldn't convert the value to float, that is, it is a string or the value is not there, we want
-        # to fall back to 100%. This case is different from the sentinel value because it's generic.
-        return 1.0
+        # to fall back to 100% in case we know that the sliding window was executed for this org.
+        if was_sliding_window_executed(org_id=org_id):
+            return 1.0
+
+        # Otherwise we consider the situation an error and we just return the fallback sample rate.
+        return error_sample_rate_fallback
 
 
 def generate_sliding_window_org_cache_key(org_id: int) -> str:

--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -431,7 +431,7 @@ def process_sliding_window(
     window_size: int,
 ) -> None:
     with metrics.timer(
-        "sentry.tasks.dynamic_sampling.process_sliding_window.adjust_base_sample_rate_per_project"
+        "sentry.dynamic_sampling.tasks.sliding_window.adjust_base_sample_rate_per_project"
     ):
         adjust_base_sample_rate_per_project(org_id, projects_with_total_root_count, window_size)
 

--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -416,6 +416,10 @@ def sliding_window() -> None:
                             org_id, projects_with_total_root_count, window_size
                         )
 
+            # Due to the synchronous nature of the sliding window, when we arrived here, we can confidently say that the
+            # execution of the sliding window was successful. We will keep this state for 1 hour.
+            mark_sliding_window_executed()
+
 
 def adjust_base_sample_rate_per_project(
     org_id: int, projects_with_total_root_count: Sequence[Tuple[ProjectId, int]], window_size: int
@@ -467,10 +471,6 @@ def adjust_base_sample_rate_per_project(
             )
 
         pipeline.execute()
-
-    # Due to the synchronous nature of the sliding window, when we arrived here, we can confidently say that the
-    # execution of the sliding window was successful. We will keep this state for 1 hour.
-    mark_sliding_window_executed()
 
 
 @instrumented_task(

--- a/tests/sentry/dynamic_sampling/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/test_tasks.py
@@ -762,17 +762,55 @@ class TestSlidingWindowTask(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
 
         org = self.create_organization(name="sample-org")
 
-        project = self.create_project_without_metrics("a", org)
+        # In case an org has at least one project with metrics and all the other ones without, the ones without should
+        # fall back to 100%.
+        project_a = self.create_project_and_add_metrics("a", 100, org)
+        project_b = self.create_project_without_metrics("b", org)
 
         with self.tasks():
             sliding_window()
 
         with self.feature("organizations:ds-sliding-window"):
-            # We expect that the system forecasts 100% sample rate, since a project with no metrics is considered
-            # as having 0 transactions.
-            assert generate_rules(project)[0]["samplingValue"] == {
+            assert generate_rules(project_a)[0]["samplingValue"] == {
+                "type": "sampleRate",
+                "value": 0.2,
+            }
+            assert generate_rules(project_b)[0]["samplingValue"] == {
                 "type": "sampleRate",
                 "value": 1.0,
+            }
+
+    @patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+    @patch("sentry.dynamic_sampling.rules.base.quotas.get_transaction_sampling_tier_for_volume")
+    @patch("sentry.dynamic_sampling.tasks.extrapolate_monthly_volume")
+    def test_sliding_window_with_all_projects_without_metrics(
+        self,
+        extrapolate_monthly_volume,
+        get_transaction_sampling_tier_for_volume,
+        get_blended_sample_rate,
+    ):
+        extrapolate_monthly_volume.side_effect = self.forecasted_volume_side_effect
+        get_transaction_sampling_tier_for_volume.side_effect = self.sampling_tier_side_effect
+        get_blended_sample_rate.return_value = 0.5
+
+        org = self.create_organization(name="sample-org")
+
+        # In case an org has all projects without metrics, we can't do much, we will fall back to the error sample rate
+        # which is our case is the blended sample rate.
+        project_a = self.create_project_without_metrics("a", org)
+        project_b = self.create_project_without_metrics("b", org)
+
+        with self.tasks():
+            sliding_window()
+
+        with self.feature("organizations:ds-sliding-window"):
+            assert generate_rules(project_a)[0]["samplingValue"] == {
+                "type": "sampleRate",
+                "value": 0.5,
+            }
+            assert generate_rules(project_b)[0]["samplingValue"] == {
+                "type": "sampleRate",
+                "value": 0.5,
             }
 
     def test_sliding_window_with_none_window_size(self):

--- a/tests/sentry/dynamic_sampling/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/test_tasks.py
@@ -795,8 +795,6 @@ class TestSlidingWindowTask(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
 
         org = self.create_organization(name="sample-org")
 
-        # In case an org has all projects without metrics, we can't do much, we will fall back to the error sample rate
-        # which is our case is the blended sample rate.
         project_a = self.create_project_without_metrics("a", org)
         project_b = self.create_project_without_metrics("b", org)
 
@@ -806,11 +804,11 @@ class TestSlidingWindowTask(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
         with self.feature("organizations:ds-sliding-window"):
             assert generate_rules(project_a)[0]["samplingValue"] == {
                 "type": "sampleRate",
-                "value": 0.5,
+                "value": 1.0,
             }
             assert generate_rules(project_b)[0]["samplingValue"] == {
                 "type": "sampleRate",
-                "value": 0.5,
+                "value": 1.0,
             }
 
     def test_sliding_window_with_none_window_size(self):


### PR DESCRIPTION
This PR removes the unneeded backfill of projects with zero counts, which was mistakenly added to this bias even though there wasn't the need.