### PR TITLE
feat: List queues relevant for backpressure management

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1043,6 +1043,8 @@ PROCESSING_QUEUES = [
     "events.reprocessing.symbolicate_event",
     "events.reprocessing.symbolicate_event_low_priority",
     "events.preprocess_event",
+    "profiles.process",
+    "replays.ingest_replay",
 ]
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1026,10 +1026,16 @@ CELERYBEAT_SCHEDULE = {
 # Queues that belong to the processing pipeline and need to be monitored
 # for backpressure management
 PROCESSING_QUEUES = [
-    "events.save_event",
-    "events.save_event_transaction",
-    "events.save_event_attachments",
+    "events.preprocess_event",
     "events.process_event",
+    "events.reprocess_events",
+    "events.reprocessing.preprocess_event",
+    "events.reprocessing.process_event",
+    "events.reprocessing.symbolicate_event",
+    "events.reprocessing.symbolicate_event_low_priority",
+    "events.save_event",
+    "events.save_event_attachments",
+    "events.save_event_transaction",
     "events.symbolicate_event",
     "events.symbolicate_event_low_priority",
     "events.symbolicate_js_event",
@@ -1037,12 +1043,6 @@ PROCESSING_QUEUES = [
     "post_process_errors",
     "post_process_issue_platform",
     "post_process_transactions",
-    "events.reprocess_events",
-    "events.reprocessing.preprocess_event",
-    "events.reprocessing.process_event",
-    "events.reprocessing.symbolicate_event",
-    "events.reprocessing.symbolicate_event_low_priority",
-    "events.preprocess_event",
     "profiles.process",
     "replays.ingest_replay",
 ]

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1022,6 +1022,30 @@ CELERYBEAT_SCHEDULE = {
     },
 }
 
+
+# Queues that belong to the processing pipeline and need to be monitored
+# for backpressure management
+PROCESSING_QUEUES = [
+    "events.save_event",
+    "events.save_event_transaction",
+    "events.save_event_attachments",
+    "events.process_event",
+    "events.symbolicate_event",
+    "events.symbolicate_event_low_priority",
+    "events.symbolicate_js_event",
+    "events.symbolicate_js_event_low_priority",
+    "post_process_errors",
+    "post_process_issue_platform",
+    "post_process_transactions",
+    "events.reprocess_events",
+    "events.reprocessing.preprocess_event",
+    "events.reprocessing.process_event",
+    "events.reprocessing.symbolicate_event",
+    "events.reprocessing.symbolicate_event_low_priority",
+    "events.preprocess_event",
+]
+
+
 # We prefer using crontab, as the time for timedelta will reset on each deployment. More information:  https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#periodic-tasks
 TIMEDELTA_ALLOW_LIST = {
     "flush-buffers",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1044,7 +1044,6 @@ PROCESSING_QUEUES = [
     "post_process_issue_platform",
     "post_process_transactions",
     "profiles.process",
-    "replays.ingest_replay",
 ]
 
 


### PR DESCRIPTION
IIUC we only need the names of these queues so that we can check how full they are with `bulk_get_sizes`.

Closes https://github.com/getsentry/team-ingest/issues/479.