### PR TITLE
fix(issue-states): pass through amount of days passed to Activity for AUTO_SET_ONGOING

### DIFF
--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping, Optional
+
 from django.db.models.signals import post_save
 
 from sentry.models import (
@@ -14,7 +16,10 @@ from sentry.types.group import GroupSubStatus
 
 
 def transition_group_to_ongoing(
-    from_status: GroupStatus, from_substatus: GroupSubStatus, group: Group
+    from_status: GroupStatus,
+    from_substatus: GroupSubStatus,
+    group: Group,
+    activity_data: Optional[Mapping[str, Any]] = None,
 ) -> None:
     # make sure we don't update the Group when its already updated by conditionally updating the Group
     updated = Group.objects.filter(
@@ -35,7 +40,7 @@ def transition_group_to_ongoing(
         add_group_to_inbox(group, GroupInboxReason.ONGOING)
 
         Activity.objects.create_group_activity(
-            group, ActivityType.AUTO_SET_ONGOING, send_notification=False
+            group, ActivityType.AUTO_SET_ONGOING, data=activity_data, send_notification=False
         )
 
         record_group_history_from_activity_type(

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -19,6 +19,8 @@ from sentry.tasks.base import instrumented_task
 from sentry.types.group import GroupSubStatus
 from sentry.utils.query import RangeQuerySetWrapper
 
+TRANSITION_AFTER_DAYS = 3
+
 
 @instrumented_task(
     name="sentry.tasks.schedule_auto_transition_new",
@@ -27,7 +29,7 @@ from sentry.utils.query import RangeQuerySetWrapper
 @monitor(monitor_slug="schedule_auto_transition_new")
 def schedule_auto_transition_new() -> None:
     now = datetime.now(tz=pytz.UTC)
-    three_days_past = now - timedelta(days=3)
+    three_days_past = now - timedelta(days=TRANSITION_AFTER_DAYS)
 
     for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
         if features.has("organizations:issue-states-auto-transition-new-ongoing", org):
@@ -71,7 +73,7 @@ def auto_transition_issues_new_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.NEW,
             group,
-            activity_data={"after_days": 3},
+            activity_data={"after_days": TRANSITION_AFTER_DAYS},
         )
 
     if len(new_groups) == chunk_size:
@@ -91,7 +93,7 @@ def auto_transition_issues_new_to_ongoing(
 @monitor(monitor_slug="schedule_auto_transition_regressed")
 def schedule_auto_transition_regressed() -> None:
     now = datetime.now(tz=pytz.UTC)
-    three_days_past = now - timedelta(days=3)
+    three_days_past = now - timedelta(days=TRANSITION_AFTER_DAYS)
 
     for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
         if features.has("organizations:issue-states-auto-transition-regressed-ongoing", org):
@@ -141,7 +143,7 @@ def auto_transition_issues_regressed_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.REGRESSED,
             group,
-            activity_data={"after_days": 3},
+            activity_data={"after_days": TRANSITION_AFTER_DAYS},
         )
 
     if len(groups_with_regressed_history) == chunk_size:

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -71,6 +71,7 @@ def auto_transition_issues_new_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.NEW,
             group,
+            activity_data={"after_days": 3},
         )
 
     if len(new_groups) == chunk_size:
@@ -140,6 +141,7 @@ def auto_transition_issues_regressed_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.REGRESSED,
             group,
+            activity_data={"after_days": 3},
         )
 
     if len(groups_with_regressed_history) == chunk_size:

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -6,6 +6,7 @@ import pytz
 from sentry.models import (
     Activity,
     Group,
+    GroupHistory,
     GroupHistoryStatus,
     GroupInbox,
     GroupInboxReason,
@@ -51,6 +52,8 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
             group=group, type=ActivityType.AUTO_SET_ONGOING.value
         ).get()
         assert set_ongoing_activity.data == {"after_days": 3}
+
+        assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ONGOING).exists()
 
     @patch("sentry.signals.inbox_in.send_robust")
     def test_reprocessed(self, inbox_in):
@@ -224,3 +227,7 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
             group=group, type=ActivityType.AUTO_SET_ONGOING.value
         ).get()
         assert set_ongoing_activity.data == {"after_days": 3}
+
+        assert GroupHistory.objects.filter(
+            group=group, status=GroupHistoryStatus.ONGOING.value
+        ).exists()

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -228,6 +228,4 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
         ).get()
         assert set_ongoing_activity.data == {"after_days": 3}
 
-        assert GroupHistory.objects.filter(
-            group=group, status=GroupHistoryStatus.ONGOING.value
-        ).exists()
+        assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ONGOING).exists()


### PR DESCRIPTION
Include extra metadata about when we transitioned new/regressed issues to ongoing when we create the Activity.