### PR TITLE
feat(issue-states): new GroupActivity type for AUTO_SET_ONGOING

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -261,6 +261,7 @@ export enum GroupActivityType {
   MERGE = 'merge',
   REPROCESS = 'reprocess',
   MARK_REVIEWED = 'mark_reviewed',
+  AUTO_SET_ONGOING = 'auto_set_ongoing',
 }
 
 interface GroupActivityBase {
@@ -400,6 +401,13 @@ interface GroupActivityMerge extends GroupActivityBase {
   type: GroupActivityType.MERGE;
 }
 
+interface GroupActivityAutoSetOngoing extends GroupActivityBase {
+  data: {
+    afterDays?: number;
+  };
+  type: GroupActivityType.AUTO_SET_ONGOING;
+}
+
 export interface GroupActivityAssigned extends GroupActivityBase {
   data: {
     assignee: string;
@@ -445,7 +453,8 @@ export type GroupActivity =
   | GroupActivityRegression
   | GroupActivityUnmergeSource
   | GroupActivityAssigned
-  | GroupActivityCreateIssue;
+  | GroupActivityCreateIssue
+  | GroupActivityAutoSetOngoing;
 
 export type Activity = GroupActivity;
 

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -369,6 +369,16 @@ function GroupActivityItem({activity, organization, projectId, author}: Props) {
           author,
         });
       }
+      case GroupActivityType.AUTO_SET_ONGOING: {
+        return activity.data?.afterDays
+          ? tct(
+              '[author] automatically marked this issue as ongoing after [afterDays] days',
+              {author, afterDays: activity.data.afterDays}
+            )
+          : tct('[author] automatically marked this issue as ongoing', {
+              author,
+            });
+      }
       default:
         return ''; // should never hit (?)
     }


### PR DESCRIPTION
![Screenshot 2023-05-23 at 10 22 58 AM](https://github.com/getsentry/sentry/assets/101606877/038df221-8a8a-432c-8611-72a12fcac38d)

Creates a new GroupActivity type for when an issue automatically transitions from new/regressed to ongoing.