### PR TITLE
fix(starfish): Use PerformanceMetrics dataset under the hood

### DIFF
--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -31,7 +31,7 @@ def query(
     extra_columns=None,
 ):
     builder = SpansMetricsQueryBuilder(
-        dataset=Dataset.Metrics,
+        dataset=Dataset.PerformanceMetrics,
         params=params,
         snuba_params=snuba_params,
         query=query,


### PR DESCRIPTION
Use `PerformanceMetrics` instead of `Metrics` so that we hit
the correct `generic_metrics` tables for span metrics.

![Screenshot 2023-05-23 at 2 35 31 PM](https://github.com/getsentry/sentry/assets/63818634/d22f3d22-effd-4f8f-a15b-bd612d54e64c)

