### PR TITLE
fix(span-ops-breakdown): Skip character escaping for transactions

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -119,9 +119,14 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
           if (!provided.widgetData.list.data[selectedListIndex]?.transaction) {
             return null;
           }
-          eventView.additionalConditions.setFilterValues('transaction', [
-            provided.widgetData.list.data[selectedListIndex].transaction as string,
-          ]);
+
+          // Skip character escaping because generating the query for EventsRequest
+          // downstream will already handle escaping
+          eventView.additionalConditions.setFilterValues(
+            'transaction',
+            [provided.widgetData.list.data[selectedListIndex].transaction as string],
+            false
+          );
 
           if (canUseMetricsData(organization)) {
             eventView.additionalConditions.setFilterValues('!transaction', [


### PR DESCRIPTION
Skips character escaping for transaction names because generating the query for EventsRequests triggers a double escape on special characters and events-stats won't be able to find a match to return data.

We can test with [this transaction](https://sentry.localhost:7999/performance/?isDefaultQuery=false&metricSearchSetting=metricsOnly&project=1&query=transaction%3A%22%2Fapi%2F%2A%2Fenvelope%22&statsPeriod=24h)