### PR TITLE
feat(project-creation): allowlist flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1487,6 +1487,8 @@ SENTRY_FEATURES = {
     "organizations:u2f-superuser-form": False,
     # Enable project creation for all
     "organizations:team-project-creation-all": False,
+    # Enable project creation for all and puts organization into test group
+    "organizations:team-project-creation-all-allowlist": False,
     # Enable setting team-level roles and receiving permissions from them
     "organizations:team-roles": False,
     # Enable team member role provisioning through scim

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -180,6 +180,7 @@ default_manager.add("organizations:starfish-test-endpoint", OrganizationFeature,
 default_manager.add("organizations:streamline-targeting-context", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add('organizations:team-project-creation-all', OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add('organizations:team-project-creation-all-allowlist', OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:team-roles", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION

Seiji already created a flag to enable project creation for all but since we're A/B testing we're opening the feature to only 50% of those who have the feature flag.

I'm creating an allowlist flag which forces organization to be in test group mostly for team dogfooding.
