### PR TITLE
fix(dashboard-widget-builder-pagefilters): Altered useOverlay hook to…

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -275,6 +275,7 @@ export function Control({
     overlayRef,
     overlayProps,
   } = useOverlay({
+    disableTrigger: disabled,
     type: grid ? 'menu' : 'listbox',
     position,
     offset,

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -75,6 +75,7 @@ export interface UseOverlayProps
   extends Partial<OverlayProps>,
     Partial<OverlayTriggerProps>,
     Partial<OverlayTriggerStateProps> {
+  disableTrigger?: boolean;
   /**
    * Offset along the main axis.
    */
@@ -105,6 +106,7 @@ function useOverlay({
   isKeyboardDismissDisabled,
   shouldCloseOnInteractOutside,
   onInteractOutside,
+  disableTrigger,
 }: UseOverlayProps = {}) {
   // Callback refs for react-popper
   const [triggerElement, setTriggerElement] = useState<HTMLButtonElement | null>(null);
@@ -194,7 +196,10 @@ function useOverlay({
   } = usePopper(triggerElement, overlayElement, {modifiers, placement: position});
 
   // Get props for trigger button
-  const {buttonProps} = useButton({onPress: openState.toggle}, triggerRef);
+  const {buttonProps} = useButton(
+    {onPress: openState.toggle, isDisabled: disableTrigger},
+    triggerRef
+  );
   const {triggerProps, overlayProps: overlayTriggerProps} = useOverlayTrigger(
     {type},
     openState,


### PR DESCRIPTION
Pagefilter dropdowns  would open even when visibly disabled:

<img width="736" alt="Screenshot 2023-05-23 at 4 20 49 PM" src="https://github.com/getsentry/sentry/assets/60121741/52f57ce9-e1de-4cef-b1f9-127c9367694e">




