### PR TITLE
fix(perf): Fix min/max range function

### DIFF
--- a/static/app/utils/discover/charts.spec.tsx
+++ b/static/app/utils/discover/charts.spec.tsx
@@ -154,6 +154,45 @@ describe('findRangeOfMultiSeries()', () => {
     expect(findRangeOfMultiSeries(series)).toStrictEqual({max: 2300, min: 50});
   });
 
+  it('should find min and max when series is unordered', () => {
+    const mixedSeries = [series[1], series[0], series[2]];
+    expect(findRangeOfMultiSeries(mixedSeries)).toStrictEqual({max: 2300, min: 50});
+  });
+
+  it('should find min and max when one of the series has all 0 values', () => {
+    const mixedSeries = [
+      {
+        seriesName: 'p75(spans.db)',
+        data: [
+          {name: 1, value: 0},
+          {name: 2, value: 0},
+          {name: 3, value: 0},
+        ],
+      },
+      series[1],
+      series[0],
+      series[2],
+    ];
+    expect(findRangeOfMultiSeries(mixedSeries)).toStrictEqual({max: 2300, min: 0});
+  });
+
+  it('should find min and max when one of the series has negative values', () => {
+    const mixedSeries = [
+      {
+        seriesName: 'p75(custom.measurement)',
+        data: [
+          {name: 1, value: 10},
+          {name: 2, value: -10},
+          {name: 3, value: 10},
+        ],
+      },
+      series[1],
+      series[0],
+      series[2],
+    ];
+    expect(findRangeOfMultiSeries(mixedSeries)).toStrictEqual({max: 2300, min: -10});
+  });
+
   it('should find min and max when series has no data', () => {
     const noDataSeries: Series[] = [
       {

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -1,4 +1,4 @@
-import {captureException, captureMessage} from '@sentry/react';
+import {captureMessage} from '@sentry/react';
 import {LegendComponentOption} from 'echarts';
 
 import {t} from 'sentry/locale';


### PR DESCRIPTION
The function previously was relying on an assumption that the multiseries would be ordered. There isn't a way to tell if the series is, so it's better to check all series max/min.
