### PR TITLE
feat(hybrid-cloud) Adds status to organization mapping code

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -487,7 +487,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         Update various attributes and configurable settings for the given
         organization.
 
-        :pparam string organization_slug: the slug of the organization the
+        :param string organization_slug: the slug of the organization the
                                           team should be created for.
         :param string name: an optional new name for the organization.
         :param string slug: an optional new slug for the organization.  Needs

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -532,12 +532,17 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                             status=organization.status,
                         )
                     elif "name" in changed_data or "status" in changed_data:
-                        organization_mapping_service.update(
+                        updated_count = organization_mapping_service.update(
                             organization_id=organization.id,
                             update=RpcOrganizationMappingUpdate(
                                 name=organization.name, status=organization.status
                             ),
                         )
+
+                        # Validate that at least one organization mapping was updated
+                        if updated_count == 0:
+                            raise Exception("Expected to update one or more organization mappings")
+
             # TODO(hybrid-cloud): This will need to be a more generic error
             # when the internal RPC is implemented.
             except IntegrityError:

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -40,10 +40,7 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
-from sentry.services.hybrid_cloud.organization_mapping import (
-    RpcOrganizationMappingUpdate,
-    organization_mapping_service,
-)
+from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
 from sentry.utils.cache import memoize
 
 ERR_DEFAULT_ORG = "You cannot remove the default organization."
@@ -531,17 +528,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                             region_name=settings.SENTRY_REGION or "us",
                             status=organization.status,
                         )
-                    elif "name" in changed_data or "status" in changed_data:
-                        updated_count = organization_mapping_service.update(
-                            organization_id=organization.id,
-                            update=RpcOrganizationMappingUpdate(
-                                name=organization.name, status=organization.status
-                            ),
-                        )
-
-                        # Validate that at least one organization mapping was updated
-                        if updated_count == 0:
-                            raise Exception("Expected to update one or more organization mappings")
 
             # TODO(hybrid-cloud): This will need to be a more generic error
             # when the internal RPC is implemented.

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -526,7 +526,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                             idempotency_key=result.get("idempotencyKey", ""),
                             customer_id=organization.customer_id,
                             region_name=settings.SENTRY_REGION or "us",
-                            status=organization.status,
                         )
 
             # TODO(hybrid-cloud): This will need to be a more generic error

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -534,7 +534,9 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     elif "name" in changed_data or "status" in changed_data:
                         organization_mapping_service.update(
                             organization_id=organization.id,
-                            update=RpcOrganizationMappingUpdate(name=organization.name),
+                            update=RpcOrganizationMappingUpdate(
+                                name=organization.name, status=organization.status
+                            ),
                         )
             # TODO(hybrid-cloud): This will need to be a more generic error
             # when the internal RPC is implemented.

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -529,9 +529,9 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                             idempotency_key=result.get("idempotencyKey", ""),
                             customer_id=organization.customer_id,
                             region_name=settings.SENTRY_REGION or "us",
+                            status=organization.status,
                         )
-                        # Add status as modifiable field
-                    elif "name" in changed_data:
+                    elif "name" in changed_data or "status" in changed_data:
                         organization_mapping_service.update(
                             organization_id=organization.id,
                             update=RpcOrganizationMappingUpdate(name=organization.name),

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -522,7 +522,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     result = serializer.validated_data
 
                     if "slug" in changed_data:
-                        organization_mapping_service.create(
+                        organization_mapping_service.reserve_slug_for_organization(
                             organization_id=organization.id,
                             slug=organization.slug,
                             name=organization.name,
@@ -530,6 +530,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                             customer_id=organization.customer_id,
                             region_name=settings.SENTRY_REGION or "us",
                         )
+                        # Add status as modifiable field
                     elif "name" in changed_data:
                         organization_mapping_service.update(
                             organization_id=organization.id,

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -215,7 +215,6 @@ class OrganizationIndexEndpoint(Endpoint):
                         name=org.name,
                         idempotency_key=result.get("idempotencyKey", ""),
                         region_name=settings.SENTRY_REGION or "us",
-                        status=org.status,
                     )
                     rpc_org_member = organization_service.add_organization_member(
                         organization_id=org.id,

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -209,7 +209,7 @@ class OrganizationIndexEndpoint(Endpoint):
                 with transaction.atomic():
                     org = Organization.objects.create(name=result["name"], slug=result.get("slug"))
 
-                    organization_mapping_service.create(
+                    organization_mapping_service.reserve_slug_for_organization(
                         organization_id=org.id,
                         slug=org.slug,
                         name=org.name,

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -215,6 +215,7 @@ class OrganizationIndexEndpoint(Endpoint):
                         name=org.name,
                         idempotency_key=result.get("idempotencyKey", ""),
                         region_name=settings.SENTRY_REGION or "us",
+                        status=org.status,
                     )
                     rpc_org_member = organization_service.add_organization_member(
                         organization_id=org.id,

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -250,6 +250,9 @@ class OrganizationIndexEndpoint(Endpoint):
                         actor_id=request.user.id if request.user.is_authenticated else None,
                     )
 
+                    # Queue outbox event to verify the new organization's mapping
+                    Organization.outbox_to_verify_mapping(org.id).save()
+
             # TODO(hybrid-cloud): We'll need to catch a more generic error
             # when the internal RPC is implemented.
             except IntegrityError:

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -216,6 +216,10 @@ class OrganizationIndexEndpoint(Endpoint):
                         idempotency_key=result.get("idempotencyKey", ""),
                         region_name=settings.SENTRY_REGION or "us",
                     )
+
+                    # Queue outbox event to verify the new organization's mapping
+                    Organization.outbox_to_verify_mapping(org.id).save()
+
                     rpc_org_member = organization_service.add_organization_member(
                         organization_id=org.id,
                         default_org_role=org.default_role,
@@ -248,9 +252,6 @@ class OrganizationIndexEndpoint(Endpoint):
                         org,
                         actor_id=request.user.id if request.user.is_authenticated else None,
                     )
-
-                    # Queue outbox event to verify the new organization's mapping
-                    Organization.outbox_to_verify_mapping(org.id).save()
 
             # TODO(hybrid-cloud): We'll need to catch a more generic error
             # when the internal RPC is implemented.

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from django.db import transaction
 
-from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
     OrganizationMappingService,
@@ -58,7 +57,6 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
         region_name: str,
         idempotency_key: Optional[str] = "",
         customer_id: Optional[str] = None,
-        status: Optional[OrganizationStatus] = None,
     ) -> RpcOrganizationMapping:
         return self.create(
             name=name,

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -23,7 +23,6 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
         idempotency_key: Optional[str] = "",
         # There's only a customer_id when updating an org slug
         customer_id: Optional[str] = None,
-        status: Optional[OrganizationStatus] = None,
     ) -> RpcOrganizationMapping:
 
         if idempotency_key:
@@ -36,7 +35,6 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
                     "organization_id": organization_id,
                     "customer_id": customer_id,
                     "name": name,
-                    "status": status,
                 },
             )
         else:
@@ -47,7 +45,6 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
                 idempotency_key=idempotency_key,
                 region_name=region_name,
                 customer_id=customer_id,
-                status=status,
             )
 
         return serialize_organization_mapping(org_mapping)
@@ -70,7 +67,6 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
             region_name=region_name,
             idempotency_key=idempotency_key,
             customer_id=customer_id,
-            status=status,
         )
 
     def update(self, organization_id: int, update: RpcOrganizationMappingUpdate) -> int:

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -73,18 +73,15 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
             status=status,
         )
 
-    def update(self, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
+    def update(self, organization_id: int, update: RpcOrganizationMappingUpdate) -> int:
         with transaction.atomic():
-            updated_mappings = (
+            updated_mapping_count: int = (
                 OrganizationMapping.objects.filter(organization_id=organization_id)
                 .select_for_update()
                 .update(**update)
             )
 
-            if len(updated_mappings) == 0:
-                raise Exception(
-                    "Expected to update 1 or more organization mappings, but 0 were updated"
-                )
+            return updated_mapping_count
 
     def verify_mappings(self, organization_id: int, slug: str) -> None:
         try:

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from django.db import transaction
 
+from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
     OrganizationMappingService,
@@ -23,6 +24,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
         # There's only a customer_id when updating an org slug
         customer_id: Optional[str] = None,
         user: Optional[int] = None,
+        status: Optional[OrganizationStatus] = None,
     ) -> RpcOrganizationMapping:
 
         if idempotency_key:
@@ -30,10 +32,11 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
                 slug=slug,
                 idempotency_key=idempotency_key,
                 region_name=region_name,
+                organization_id=organization_id,
                 defaults={
                     "customer_id": customer_id,
-                    "organization_id": organization_id,
                     "name": name,
+                    "status": status,
                 },
             )
         else:
@@ -44,6 +47,7 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
                 idempotency_key=idempotency_key,
                 region_name=region_name,
                 customer_id=customer_id,
+                status=status,
             )
 
         return serialize_organization_mapping(org_mapping)

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -75,11 +75,16 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
 
     def update(self, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
         with transaction.atomic():
-            (
+            updated_mappings = (
                 OrganizationMapping.objects.filter(organization_id=organization_id)
                 .select_for_update()
                 .update(**update)
             )
+
+            if len(updated_mappings) == 0:
+                raise Exception(
+                    "Expected to update 1 or more organization mappings, but 0 were updated"
+                )
 
     def verify_mappings(self, organization_id: int, slug: str) -> None:
         try:

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -12,7 +12,7 @@ from sentry.services.hybrid_cloud.organization_mapping.serial import serialize_o
 
 
 class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
-    def create(
+    def reserve_slug_for_organization(
         self,
         *,
         organization_id: int,

--- a/src/sentry/services/hybrid_cloud/organization_mapping/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/model.py
@@ -21,6 +21,7 @@ class RpcOrganizationMapping(RpcModel):
     date_created: datetime = Field(default_factory=timezone.now)
     verified: bool = False
     customer_id: Optional[str] = None
+    status: Optional[int] = None
 
 
 class RpcOrganizationMappingUpdate(TypedDict):
@@ -33,3 +34,4 @@ class RpcOrganizationMappingUpdate(TypedDict):
 
     name: str
     customer_id: Optional[str]
+    status: Optional[int]

--- a/src/sentry/services/hybrid_cloud/organization_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/service.py
@@ -6,6 +6,7 @@
 from abc import abstractmethod
 from typing import Optional, cast
 
+from sentry.models.organization import OrganizationStatus
 from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMapping,
     RpcOrganizationMappingUpdate,
@@ -28,6 +29,24 @@ class OrganizationMappingService(RpcService):
 
     @rpc_method
     @abstractmethod
+    def create(
+        self,
+        *,
+        organization_id: int,
+        slug: str,
+        name: str,
+        region_name: str,
+        idempotency_key: Optional[str] = "",
+        customer_id: Optional[str],
+        status: Optional[OrganizationStatus],
+    ) -> RpcOrganizationMapping:
+        """
+        Old deprecated name for `reserve_slug_for_organization`, which will be phased out in a later commit
+        """
+        pass
+
+    @rpc_method
+    @abstractmethod
     def reserve_slug_for_organization(
         self,
         *,
@@ -37,7 +56,7 @@ class OrganizationMappingService(RpcService):
         region_name: str,
         idempotency_key: Optional[str] = "",
         customer_id: Optional[str],
-        user: Optional[int] = None,
+        status: Optional[OrganizationStatus],
     ) -> RpcOrganizationMapping:
         """
         This method returns a new or recreated OrganizationMapping object.
@@ -50,7 +69,16 @@ class OrganizationMappingService(RpcService):
         :param slug:
         A slug to reserve for this organization
         :param customer_id:
-        A unique per customer billing identifier
+        :param name:
+        The organization's name
+        A unique per-customer billing identifier
+        :param region_name:
+        The name of the region where the org exists
+        :param idempotency_key:
+        A unique string that ensures subsequent creation requests for an org
+        mapping will always succeed given the same parameters
+        :param status:
+        The current status of the organization
         :return:
         """
         pass

--- a/src/sentry/services/hybrid_cloud/organization_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/service.py
@@ -88,7 +88,7 @@ class OrganizationMappingService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def update(self, *, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
+    def update(self, *, organization_id: int, update: RpcOrganizationMappingUpdate) -> int:
         pass
 
     @rpc_method

--- a/src/sentry/services/hybrid_cloud/organization_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/service.py
@@ -28,7 +28,7 @@ class OrganizationMappingService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def create(
+    def reserve_slug_for_organization(
         self,
         *,
         organization_id: int,

--- a/src/sentry/services/hybrid_cloud/organization_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/service.py
@@ -6,7 +6,6 @@
 from abc import abstractmethod
 from typing import Optional, cast
 
-from sentry.models.organization import OrganizationStatus
 from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMapping,
     RpcOrganizationMappingUpdate,
@@ -38,7 +37,6 @@ class OrganizationMappingService(RpcService):
         region_name: str,
         idempotency_key: Optional[str] = "",
         customer_id: Optional[str],
-        status: Optional[OrganizationStatus],
     ) -> RpcOrganizationMapping:
         """
         Old deprecated name for `reserve_slug_for_organization`, which will be phased out in a later commit
@@ -56,7 +54,6 @@ class OrganizationMappingService(RpcService):
         region_name: str,
         idempotency_key: Optional[str] = "",
         customer_id: Optional[str],
-        status: Optional[OrganizationStatus],
     ) -> RpcOrganizationMapping:
         """
         This method returns a new or recreated OrganizationMapping object.
@@ -77,8 +74,6 @@ class OrganizationMappingService(RpcService):
         :param idempotency_key:
         A unique string that ensures subsequent creation requests for an org
         mapping will always succeed given the same parameters
-        :param status:
-        The current status of the organization
         :return:
         """
         pass

--- a/src/sentry/services/hybrid_cloud/region.py
+++ b/src/sentry/services/hybrid_cloud/region.py
@@ -53,7 +53,8 @@ class ByOrganizationId(RegionResolution):
 
     def resolve(self, arguments: ArgumentDict) -> Region:
         organization_id = arguments[self.parameter_name]
-        mapping = self.organization_mapping_manager.get(organization_id=organization_id)
+        # Validate invariant that all org mappings for org exist in the same region
+        mapping = self.organization_mapping_manager.filter(organization_id=organization_id).first()
         return self._resolve_from_mapping(mapping)
 
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -284,6 +284,7 @@ class Factories:
         kwds.setdefault("name", org.name)
         kwds.setdefault("idempotency_key", uuid4().hex)
         kwds.setdefault("region_name", "test-region")
+        kwds.setdefault("status", org.status)
         return OrganizationMapping.objects.create(**kwds)
 
     @staticmethod

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -30,6 +30,7 @@ from sentry.models import (
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.signals import project_created
 from sentry.testutils import APITestCase, TwoFactorAPITestCase, pytest
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils import json
 
@@ -798,6 +799,10 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         org = Organization.objects.get(id=organization_id)
         assert org.name == "SaNtRy"
 
+        # Process outbox to generate organization mapping
+        with outbox_runner():
+            pass
+
         with exempt_from_silo_limits():
             assert OrganizationMapping.objects.filter(
                 organization_id=organization_id, name="SaNtRy"
@@ -813,6 +818,10 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         org.refresh_from_db()
         assert org.name == "SaNtRy"
+
+        # Process outbox to generate organization mapping
+        with outbox_runner():
+            pass
 
         with exempt_from_silo_limits():
             org_mapping_query = OrganizationMapping.objects.filter(

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -832,36 +832,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             org_mapping = org_mapping_query.first()
             assert org_mapping.status == OrganizationStatus.PENDING_DELETION
 
-    def test_slug_update_with_idempotency_key_matching_different_validated_org_mapping(self):
-        org_to_update = Organization.objects.get(id=self.organization.id)
-        existing_slug_name = org_to_update.slug
-        existing_org_name = org_to_update.name
-
-        OrganizationMapping.objects.create(
-            organization_id=999,
-            slug="taken-santry",
-            verified=True,
-            region_name="us",
-            idempotency_key="bad-key",
-        )
-        self.get_error_response(
-            existing_slug_name,
-            name="SaNtRy",
-            slug="taken-santry",
-            idempotencyKey="bad-key",
-            status_code=409,
-        )
-
-        with exempt_from_silo_limits():
-            org_mapping_query = OrganizationMapping.objects.filter(
-                organization_id=self.organization.id
-            )
-            assert org_mapping_query.exists()
-            assert len(org_mapping_query) == 1
-            org_mapping = org_mapping_query.first()
-            assert org_mapping.slug == existing_slug_name
-            assert org_mapping.name == existing_org_name
-
     def test_org_mapping_already_taken(self):
         OrganizationMapping.objects.create(organization_id=999, slug="taken", region_name="us")
         self.get_error_response(self.organization.slug, slug="taken", status_code=409)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -823,6 +823,36 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             org_mapping = org_mapping_query.first()
             assert org_mapping.status == OrganizationStatus.PENDING_DELETION
 
+    def test_slug_update_with_idempotency_key_matching_different_validated_org_mapping(self):
+        org_to_update = Organization.objects.get(id=self.organization.id)
+        existing_slug_name = org_to_update.slug
+        existing_org_name = org_to_update.name
+
+        OrganizationMapping.objects.create(
+            organization_id=999,
+            slug="taken-santry",
+            verified=True,
+            region_name="us",
+            idempotency_key="bad-key",
+        )
+        self.get_error_response(
+            existing_slug_name,
+            name="SaNtRy",
+            slug="taken-santry",
+            idempotencyKey="bad-key",
+            status_code=409,
+        )
+
+        with exempt_from_silo_limits():
+            org_mapping_query = OrganizationMapping.objects.filter(
+                organization_id=self.organization.id
+            )
+            assert org_mapping_query.exists()
+            assert len(org_mapping_query) == 1
+            org_mapping = org_mapping_query.first()
+            assert org_mapping.slug == existing_slug_name
+            assert org_mapping.name == existing_org_name
+
     def test_org_mapping_already_taken(self):
         OrganizationMapping.objects.create(organization_id=999, slug="taken", region_name="us")
         self.get_error_response(self.organization.slug, slug="taken", status_code=409)

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -2,10 +2,18 @@ import re
 from unittest.mock import patch
 
 from sentry.auth.authenticators import TotpInterface
-from sentry.models import Authenticator, Organization, OrganizationMember, OrganizationStatus
+from sentry.models import (
+    Authenticator,
+    Organization,
+    OrganizationMember,
+    OrganizationStatus,
+    OutboxCategory,
+    RegionOutbox,
+)
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.testutils import APITestCase, TwoFactorAPITestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 
 
@@ -209,6 +217,25 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
                 name=data["name"],
                 idempotency_key=data["idempotencyKey"],
             ).exists()
+
+    def test_organization_verification_after_org_post(self):
+        # Clear outbox of fixture generated data
+        with outbox_runner():
+            pass
+
+        data = {"slug": "santry", "name": "SaNtRy", "idempotencyKey": "1234"}
+        response = self.get_success_response(**data)
+
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
+        assert org.slug == data["slug"]
+        assert org.name == data["name"]
+
+        outbox_items = list(RegionOutbox.objects.filter())
+
+        assert len(outbox_items) == 1
+        assert outbox_items[0].category == OutboxCategory.VERIFY_ORGANIZATION_MAPPING
+        assert outbox_items[0].object_identifier == org.id
 
     def test_slug_already_taken(self):
         OrganizationMapping.objects.create(organization_id=999, slug="taken", region_name="us")

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -21,7 +21,7 @@ class OrganizationMappingTest(TransactionTestCase):
             "name": "test name",
             "region_name": "us",
         }
-        rpc_org_mapping = organization_mapping_service.create(**fields)
+        rpc_org_mapping = organization_mapping_service.reserve_slug_for_organization(**fields)
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         assert org_mapping.idempotency_key == ""
         assert (
@@ -43,7 +43,7 @@ class OrganizationMappingTest(TransactionTestCase):
         }
         self.create_organization_mapping(self.organization, **data)
         next_organization_id = 7654321
-        rpc_org_mapping = organization_mapping_service.create(
+        rpc_org_mapping = organization_mapping_service.reserve_slug_for_organization(
             **{**data, "organization_id": next_organization_id}
         )
 
@@ -68,7 +68,7 @@ class OrganizationMappingTest(TransactionTestCase):
         self.create_organization_mapping(self.organization, **data)
 
         with pytest.raises(IntegrityError):
-            organization_mapping_service.create(
+            organization_mapping_service.reserve_slug_for_organization(
                 **{
                     **data,
                     "organization_id": 7654321,
@@ -85,7 +85,7 @@ class OrganizationMappingTest(TransactionTestCase):
             "slug": self.organization.slug,
             "region_name": "us",
         }
-        rpc_org_mapping = organization_mapping_service.create(**fields)
+        rpc_org_mapping = organization_mapping_service.reserve_slug_for_organization(**fields)
         assert rpc_org_mapping.customer_id is None
 
         organization_mapping_service.update(

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import ContextManager
 from unittest.mock import call, patch
 
+import pytest
 import responses
 from django.test import RequestFactory, override_settings
 from freezegun import freeze_time
@@ -28,6 +29,14 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits, region_silo_test
 from sentry.types.region import MONOLITH_REGION_NAME, Region, RegionCategory
+
+
+@pytest.fixture(autouse=True, scope="function")
+@pytest.mark.django_db(transaction=True)
+def setup_clear_fixture_outbox_messages():
+    with outbox_runner():
+        # flush all outbox messages associated with fixture setup to ensure a default empty state
+        pass
 
 
 @control_silo_test(stable=True)


### PR DESCRIPTION
- Renames `organizationmapping_service.create` method to `reserve_slug_for_organization`
- Updates `region.resolve` method to handle multi-organization mapping reality
- Updates `organization_mapping` create and updates to include status

<!-- Describe your PR here. -->
This PR is a precursor for a full backfill of the `organization_mapping` table, which required the following changes:
- Renaming `organizationmapping_service.create`  for clarity on the intended behavior
- Changes to region resolution by organization to handle 1 *or more* `organization_mapping` for a given org
- A change to ensure duplicate idempotency keys will not accidentally resolve to a different' organization's mapping
- Queueing of additional outbox items for the organization lifecycle 
    - On create/update verification
    - On update -> Organization update


