### PR TITLE
ref(compactSelect): Put focus on search input on key press

### DIFF
--- a/static/app/components/compactSelect/composite.spec.tsx
+++ b/static/app/components/compactSelect/composite.spec.tsx
@@ -243,6 +243,22 @@ describe('CompactSelect', function () {
 
     // Region 2's label isn't rendered because the region is empty
     expect(screen.queryByRole('Region 2')).not.toBeInTheDocument();
+
+    // Clear search value
+    await userEvent.clear(screen.getByPlaceholderText('Search placeholder…'));
+
+    // Move focus to Choice One
+    await userEvent.keyboard('{ArrowDown}');
+    expect(screen.getByRole('option', {name: 'Choice One'})).toHaveFocus();
+
+    // Pressing any chracter key brings focus back to the search box
+    await userEvent.keyboard('two');
+    expect(screen.getByPlaceholderText('Search placeholder…')).toHaveFocus();
+    expect(screen.getByPlaceholderText('Search placeholder…')).toHaveValue('two');
+
+    // only Choice Two should be available, Choice One should be filtered out
+    expect(screen.getByRole('option', {name: 'Choice Two'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Choice One'})).not.toBeInTheDocument();
   });
 
   it('works with grid lists', async function () {

--- a/static/app/components/compactSelect/index.spec.tsx
+++ b/static/app/components/compactSelect/index.spec.tsx
@@ -131,6 +131,22 @@ describe('CompactSelect', function () {
       // only Option Two should be available, Option One should be filtered out
       expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // Clear search value
+      await userEvent.clear(screen.getByPlaceholderText('Search here…'));
+
+      // Move focus to Option One
+      await userEvent.keyboard('{ArrowDown}');
+      expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
+
+      // Pressing any chracter key brings focus back to the search box
+      await userEvent.keyboard('two');
+      expect(screen.getByPlaceholderText('Search here…')).toHaveFocus();
+      expect(screen.getByPlaceholderText('Search here…')).toHaveValue('two');
+
+      // only Option Two should be available, Option One should be filtered out
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
     it('can limit the number of options', async function () {
@@ -161,7 +177,6 @@ describe('CompactSelect', function () {
       expect(screen.getByText('Use search for more options…')).toBeInTheDocument();
 
       // Option Three is not reachable via keyboard, focus wraps back to Option One
-      await userEvent.keyboard(`{ArrowDown}`);
       expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
       await userEvent.keyboard(`{ArrowDown>2}`);
       expect(screen.getByRole('option', {name: 'Option One'})).toHaveFocus();
@@ -395,6 +410,22 @@ describe('CompactSelect', function () {
       // only Option Two should be available, Option One should be filtered out
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // Clear search value
+      await userEvent.clear(screen.getByPlaceholderText('Search here…'));
+
+      // Move focus to Option One
+      await userEvent.keyboard('{ArrowDown}');
+      expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus();
+
+      // Pressing any chracter key brings focus back to the search box
+      await userEvent.keyboard('two');
+      expect(screen.getByPlaceholderText('Search here…')).toHaveFocus();
+      expect(screen.getByPlaceholderText('Search here…')).toHaveValue('two');
+
+      // only Option Two should be available, Option One should be filtered out
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
     it('can limit the number of options', async function () {
@@ -424,7 +455,6 @@ describe('CompactSelect', function () {
       expect(screen.getByText('Use search for more options…')).toBeInTheDocument();
 
       // Option Three is not reachable via keyboard, focus wraps back to Option One
-      await userEvent.keyboard(`{ArrowDown}`);
       expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus();
       await userEvent.keyboard(`{ArrowDown>2}`);
       expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus();

--- a/static/app/components/compactSelect/styles.tsx
+++ b/static/app/components/compactSelect/styles.tsx
@@ -25,8 +25,8 @@ export const ListWrap = styled('ul')`
 
   /* Remove top padding if preceded by search input, since search input already has
   vertical padding */
-  input ~ &&:first-of-type,
-  input ~ div > &&:first-of-type {
+  [data-menu-has-search='true'] > &&:first-of-type,
+  [data-menu-has-search='true'] > div > &&:first-of-type {
     padding-top: 0;
   }
 

--- a/static/app/components/organizations/hybridFilter.spec.tsx
+++ b/static/app/components/organizations/hybridFilter.spec.tsx
@@ -16,9 +16,9 @@ describe('ProjectPageFilter', function () {
   it('renders', async function () {
     render(<HybridFilter {...props} value={[]} onChange={() => {}} />);
 
-    // Open menu, search input is focused & all the options are there
+    // Open menu, search input & all the options are there
     await userEvent.click(screen.getByRole('button', {expanded: false}));
-    expect(screen.getByPlaceholderText('Search…')).toHaveFocus();
+    expect(screen.getByPlaceholderText('Search…')).toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Option One'})).toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Option Three'})).toBeInTheDocument();
@@ -107,12 +107,8 @@ describe('ProjectPageFilter', function () {
     const onChange = jest.fn();
     render(<HybridFilter {...props} value={[]} onChange={onChange} />);
 
-    // Open the menu, focus is on search input
+    // Open the menu, Option One is focused
     await userEvent.click(screen.getByRole('button', {expanded: false}));
-    expect(screen.getByPlaceholderText('Search…')).toHaveFocus();
-
-    // Press Arrow Down to move focus to Option One
-    await userEvent.keyboard('{ArrowDown}');
     expect(screen.getByRole('row', {name: 'Option One'})).toHaveFocus();
 
     // Press Arrow Right to move focus to the checkbox

--- a/static/app/components/organizations/projectPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.spec.tsx
@@ -112,12 +112,10 @@ describe('ProjectPageFilter', function () {
       organization,
     });
 
-    // Open the menu, search input has focus
+    // Open the menu
     await userEvent.click(screen.getByRole('button', {name: 'My Projects'}));
-    expect(screen.getByPlaceholderText('Search…')).toHaveFocus();
 
-    // Move focus to Option One
-    await userEvent.keyboard('{ArrowDown}');
+    // Option One has focus
     const optionOne = screen.getByRole('row', {name: 'project-1'});
     expect(optionOne).toHaveFocus();
 


### PR DESCRIPTION
When the list box is focused, pressing on any character key (e.g. `d`) should start search (moving focus to the search box and adding the typed character to its value).

**Before ——** typing moves focus to the next option that starts with the typed character (`d`)

https://github.com/getsentry/sentry/assets/44172267/8b7e42fc-c1b1-491f-9488-1eddc27a14fd


**After ——** typing moves focus to the search box

https://github.com/getsentry/sentry/assets/44172267/b0065c94-0052-4374-91d2-4886bdb283b3

