### PR TITLE
feat(issue-states): Use matching substatus strings in post/get

### DIFF
--- a/static/app/components/actions/archive.spec.tsx
+++ b/static/app/components/actions/archive.spec.tsx
@@ -20,7 +20,7 @@ describe('ArchiveActions', () => {
     expect(onUpdate).toHaveBeenCalledWith({
       status: ResolutionStatus.IGNORED,
       statusDetails: {},
-      substatus: 'until_escalating',
+      substatus: 'archived_until_escalating',
     });
   });
 
@@ -33,6 +33,7 @@ describe('ArchiveActions', () => {
     expect(onUpdate).toHaveBeenCalledWith({
       status: 'ignored',
       statusDetails: {},
+      substatus: 'archived_forever',
     });
   });
 
@@ -54,7 +55,7 @@ describe('ArchiveActions', () => {
     expect(onUpdate).toHaveBeenCalledWith({
       status: ResolutionStatus.IGNORED,
       statusDetails: {},
-      substatus: 'until_escalating',
+      substatus: 'archived_until_escalating',
     });
   });
 

--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -7,7 +7,7 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {GroupStatusResolution, ResolutionStatus} from 'sentry/types';
+import {GroupStatusResolution, GroupSubstatus, ResolutionStatus} from 'sentry/types';
 
 interface ArchiveActionProps {
   onUpdate: (params: GroupStatusResolution) => void;
@@ -23,11 +23,12 @@ interface ArchiveActionProps {
 const ARCHIVE_UNTIL_ESCALATING: GroupStatusResolution = {
   status: ResolutionStatus.IGNORED,
   statusDetails: {},
-  substatus: 'until_escalating',
+  substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING,
 };
 const ARCHIVE_FOREVER: GroupStatusResolution = {
   status: ResolutionStatus.IGNORED,
   statusDetails: {},
+  substatus: GroupSubstatus.ARCHIVED_FOREVER,
 };
 
 export function getArchiveActions({

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -519,7 +519,7 @@ export type ResolutionStatusDetails = {
 export type GroupStatusResolution = {
   status: ResolutionStatus;
   statusDetails: ResolutionStatusDetails;
-  substatus?: 'until_escalating';
+  substatus?: GroupSubstatus;
 };
 
 export type GroupRelease = {
@@ -580,7 +580,7 @@ export interface GroupResolution
   // A proper fix for this would be to make the status field an enum or string and correctly extend it.
   extends Omit<BaseGroup, 'status'>,
     GroupStats,
-    Omit<GroupStatusResolution, 'substatus'> {}
+    GroupStatusResolution {}
 
 export type Group = GroupResolution | GroupReprocessing;
 export interface GroupCollapseRelease

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -322,13 +322,17 @@ describe('GroupActions', function () {
     expect(issuesApi).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        data: {status: 'ignored', statusDetails: {}, substatus: 'until_escalating'},
+        data: {
+          status: 'ignored',
+          statusDetails: {},
+          substatus: 'archived_until_escalating',
+        },
       })
     );
     expect(analyticsSpy).toHaveBeenCalledWith(
       'issue_details.action_clicked',
       expect.objectContaining({
-        action_substatus: 'until_escalating',
+        action_substatus: 'archived_until_escalating',
         action_type: 'ignored',
       })
     );


### PR DESCRIPTION
In #49642 we added the ability to use `substatus: archived_until_escalating` to update the group. When we optimistically update the group, the substatus will now match.
