### PR TITLE
ref(hybrid-cloud): Add outboxing for webhook parser

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -41,8 +41,10 @@ def build_assigned_text(identity: RpcIdentity, assignee: str) -> str | None:
         assignee_text = f"#{assigned_actor.slug}"
     elif actor.type == User:
         assignee_identity = identity_service.get_identity(
-            provider_id=identity.idp_id,
-            user_id=assigned_actor.id,
+            filter={
+                "provider_id": identity.idp_id,
+                "user_id": assigned_actor.id,
+            }
         )
         assignee_text = (
             assigned_actor.get_display_name()

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -130,7 +130,12 @@ class SlackRequest:
                 provider_type="slack", provider_ext_id=self.team_id
             )
             self._identity = (
-                identity_service.get_identity(provider_id=provider.id, identity_ext_id=self.user_id)
+                identity_service.get_identity(
+                    filter={
+                        "provider_id": provider.id,
+                        "identity_ext_id": self.user_id,
+                    }
+                )
                 if provider
                 else None
             )

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -131,7 +131,7 @@ class SlackLinkTeamView(BaseView):
             return render_error_page(request, body_text="HTTP 403: Invalid team ID")
 
         ident = identity_service.get_identity(
-            provider_id=idp.id, identity_ext_id=params["slack_id"]
+            filter={"provider_id": idp.id, "identity_ext_id": params["slack_id"]}
         )
         if not ident:
             return render_error_page(request, body_text="HTTP 403: User identity does not exist")

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -96,7 +96,7 @@ class SlackUnlinkTeamView(BaseView):
             )
 
         if not idp or not identity_service.get_identity(
-            provider_id=idp.id, identity_ext_id=params["slack_id"]
+            filter={"provider_id": idp.id, "identity_ext_id": params["slack_id"]}
         ):
             return render_error_page(request, body_text="HTTP 403: User identity does not exist")
 

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -16,6 +16,9 @@ ACTIVE_PARSERS = [SlackRequestParser]
 
 class IntegrationControlMiddleware:
     webhook_prefix: str = "/extensions/"
+    """Prefix for all integration requests. See `src/sentry/web/urls.py`"""
+    setup_suffix: str = "/setup/"
+    """Suffix for PipelineAdvancerView on installation. See `src/sentry/web/urls.py`"""
 
     integration_parsers: Mapping[str, Type[BaseRequestParser]] = {
         parser.provider: parser for parser in ACTIVE_PARSERS
@@ -45,8 +48,9 @@ class IntegrationControlMiddleware:
         Determines whether this middleware will operate or just pass the request along.
         """
         is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
-        is_external = request.path.startswith(self.webhook_prefix)
-        return is_correct_silo and is_external
+        is_integration = request.path.startswith(self.webhook_prefix)
+        is_not_setup = not request.path.endswith(self.setup_suffix)
+        return is_correct_silo and is_integration and is_not_setup
 
     def __call__(self, request):
         if not self._should_operate(request):

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -7,9 +7,11 @@ from typing import Callable, Mapping, Sequence
 
 from django.http import HttpRequest, HttpResponse
 from django.urls import ResolverMatch, resolve
+from rest_framework import status
 
 from sentry.models.integrations import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.models.outbox import ControlOutbox
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary, organization_service
 from sentry.silo import SiloLimit, SiloMode
 from sentry.silo.client import RegionSiloClient
@@ -31,12 +33,20 @@ class BaseRequestParser(abc.ABC):
     def provider(self) -> str:
         raise NotImplementedError("'provider' property is required by IntegrationControlMiddleware")
 
+    @property
+    def webhook_identifier(self) -> str:
+        raise NotImplementedError(
+            "'webhook_identifier' property is required for outboxing. Refer to WebhookProviderIdentifier enum."
+        )
+
     def __init__(self, request: HttpRequest, response_handler: Callable):
         self.request = request
         self.match: ResolverMatch = resolve(self.request.path)
         self.response_handler = response_handler
 
-    def _ensure_control_silo(self):
+    # Common Helpers
+
+    def ensure_control_silo(self):
         if SiloMode.get_current_mode() != SiloMode.CONTROL:
             logger.error(
                 "silo_error",
@@ -46,14 +56,19 @@ class BaseRequestParser(abc.ABC):
                 "Integration Request Parsers should only be run on the control silo."
             )
 
+    def is_json_request(self) -> bool:
+        return "application/json" in (self.request.headers or {}).get("Content-Type", "")
+
+    #  Silo Response Helpers
+
     def get_response_from_control_silo(self) -> HttpResponse:
         """
         Used to handle the request directly on the control silo.
         """
-        self._ensure_control_silo()
+        self.ensure_control_silo()
         return self.response_handler(self.request)
 
-    def _get_response_from_region_silo(self, region: Region) -> HttpResponse:
+    def get_response_from_region_silo(self, region: Region) -> HttpResponse:
         region_client = RegionSiloClient(region)
         return region_client.proxy_request(self.request).to_http_response()
 
@@ -63,15 +78,14 @@ class BaseRequestParser(abc.ABC):
         """
         Used to handle the requests on a given list of regions (synchronously).
         Returns a mapping of region name to response/exception.
-        If multiple regions are provided, only the latest response is returned to the requestor.
         """
-        self._ensure_control_silo()
+        self.ensure_control_silo()
 
         region_to_response_map = {}
 
         with ThreadPoolExecutor(max_workers=len(regions)) as executor:
             future_to_region = {
-                executor.submit(self._get_response_from_region_silo, region): region
+                executor.submit(self.get_response_from_region_silo, region): region
                 for region in regions
             }
             for future in as_completed(future_to_region):
@@ -94,6 +108,21 @@ class BaseRequestParser(abc.ABC):
 
         return region_to_response_map
 
+    def get_response_from_outbox_creation(self, regions: Sequence[Region]):
+        """
+        Used to create outboxes for provided regions to handle the webhooks asynchronously.
+        Responds to the webhook provider with a 202 Accepted status.
+        """
+        for outbox in ControlOutbox.for_webhook_update(
+            webhook_identifier=self.webhook_identifier,
+            region_names=[region.name for region in regions],
+            request=self.request,
+        ):
+            outbox.save()
+        return HttpResponse(status=status.HTTP_202_ACCEPTED)
+
+    # Required Overrides
+
     def get_response(self):
         """
         Used to surface a response as part of the middleware.
@@ -108,6 +137,8 @@ class BaseRequestParser(abc.ABC):
         Should be overwritten by implementation.
         """
         return None
+
+    # Optional Overrides
 
     def get_organizations_from_integration(
         self, integration: Integration = None

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -335,7 +335,7 @@ class ControlOutbox(OutboxBase):
         )
 
     @classmethod
-    def get_webhook_payload_from_outbox(self, payload) -> OutboxWebhookPayload:
+    def get_webhook_payload_from_outbox(self, payload: Mapping[str, Any]) -> OutboxWebhookPayload:
         return OutboxWebhookPayload(
             method=payload.get("method"),
             path=payload.get("path"),

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import contextlib
+import dataclasses
 import datetime
 from enum import IntEnum
 from typing import Any, Generator, Iterable, List, Mapping, Type, TypeVar
@@ -9,6 +10,7 @@ from typing import Any, Generator, Iterable, List, Mapping, Type, TypeVar
 from django.db import connections, models, router, transaction
 from django.db.models import Max
 from django.dispatch import Signal
+from django.http import HttpRequest
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -66,6 +68,15 @@ class OutboxCategory(IntEnum):
     @classmethod
     def as_choices(cls):
         return [(i.value, i.value) for i in cls]
+
+
+@dataclasses.dataclass
+class OutboxWebhookPayload:
+    method: str
+    path: str
+    uri: str
+    headers: Mapping[str, Any]
+    body: str
 
 
 class WebhookProviderIdentifier(IntEnum):
@@ -314,13 +325,32 @@ class ControlOutbox(OutboxBase):
         "region_name", "shard_scope", "shard_identifier", "category", "object_identifier"
     )
 
+    def get_webhook_payload_from_request(self, request: HttpRequest) -> OutboxWebhookPayload:
+        return OutboxWebhookPayload(
+            method=request.method,
+            path=request.path,
+            uri=request.get_raw_uri(),
+            headers={k: v for k, v in request.headers.items()},
+            body=request.body.decode(encoding="utf-8"),
+        )
+
+    @classmethod
+    def get_webhook_payload_from_outbox(self, payload) -> OutboxWebhookPayload:
+        return OutboxWebhookPayload(
+            method=payload.get("method"),
+            path=payload.get("path"),
+            uri=payload.get("uri"),
+            headers=payload.get("headers"),
+            body=payload.get("body"),
+        )
+
     @classmethod
     def for_webhook_update(
         cls,
         *,
         webhook_identifier: WebhookProviderIdentifier,
         region_names: List[str],
-        payload=Mapping[str, Any],
+        request: HttpRequest,
     ) -> Iterable[ControlOutbox]:
         for region_name in region_names:
             result = cls()
@@ -329,7 +359,8 @@ class ControlOutbox(OutboxBase):
             result.object_identifier = cls.next_object_identifier()
             result.category = OutboxCategory.WEBHOOK_PROXY
             result.region_name = region_name
-            result.payload = payload
+            payload: OutboxWebhookPayload = result.get_webhook_payload_from_request(request)
+            result.payload = dataclasses.asdict(payload)
             yield result
 
     @classmethod

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -7,6 +7,7 @@ and perform RPC calls to propagate changes to relevant region(s).
 """
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from django.dispatch import receiver
@@ -21,6 +22,8 @@ from sentry.models import (
     process_control_outbox,
 )
 from sentry.receivers.outbox import maybe_process_tombstone
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.USER_UPDATE)
@@ -62,3 +65,26 @@ def process_organization_integration_update(object_identifier: int, **kwds: Any)
     ) is None:
         return
     organization_integration  # Currently we do not sync any other organization integration changes, but if we did, you can use this variable.
+
+
+@receiver(process_control_outbox, sender=OutboxCategory.WEBHOOK_PROXY)
+def process_async_webhooks(payload: Any, region_name: str, **kwds: Any):
+    from sentry.models.outbox import ControlOutbox
+    from sentry.silo.client import RegionSiloClient
+    from sentry.types.region import get_region_by_name
+
+    region = get_region_by_name(name=region_name)
+    webhook_payload = ControlOutbox.get_webhook_payload_from_outbox(payload=payload)
+
+    response = RegionSiloClient(region=region).request(
+        method=webhook_payload.method,
+        path=webhook_payload.path,
+        headers=webhook_payload.headers,
+        # We need to send the body as raw bytes to avoid interfering with webhook signatures
+        data=webhook_payload.body,
+        json=False,
+        raw_response=True,
+    )
+    logger.info(
+        "webhook_proxy.complete", extra={"status": response.status_code, "url": response.url}
+    )

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -8,7 +8,7 @@ and perform RPC calls to propagate changes to relevant region(s).
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Mapping
 
 from django.dispatch import receiver
 

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -68,7 +68,7 @@ def process_organization_integration_update(object_identifier: int, **kwds: Any)
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.WEBHOOK_PROXY)
-def process_async_webhooks(payload: Any, region_name: str, **kwds: Any):
+def process_async_webhooks(payload: Mapping[str, Any], region_name: str, **kwds: Any):
     from sentry.models.outbox import ControlOutbox
     from sentry.silo.client import RegionSiloClient
     from sentry.types.region import get_region_by_name

--- a/src/sentry/services/hybrid_cloud/identity/model.py
+++ b/src/sentry/services/hybrid_cloud/identity/model.py
@@ -2,6 +2,7 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
+from typing_extensions import TypedDict
 
 from sentry.services.hybrid_cloud import RpcModel
 
@@ -17,3 +18,11 @@ class RpcIdentity(RpcModel):
     idp_id: int
     user_id: int
     external_id: str
+
+
+class IdentityFilterArgs(TypedDict, total=False):
+    user_id: int
+    identity_ext_id: str
+    provider_id: int
+    provider_ext_id: str
+    provider_type: str

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -65,7 +65,7 @@ class IntegrationProxyClient(ApiClient):  # type: ignore
 
     def finalize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
         """
-        Every request through this subclassed clients run this method.
+        Every request through these subclassed clients run this method.
         If running as a monolith/control, we must authorize each request before sending.
         If running as a region, we don't authorize and instead, send it to our proxy endpoint,
         where tokens are added in by Control Silo. We do this to avoid race conditions around

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -64,8 +64,10 @@ class BaseSiloClient(BaseApiClient):
         method: str,
         path: str,
         headers: Mapping[str, Any] | None = None,
-        data: Mapping[str, Any] | None = None,
+        data: Any | None = None,
         params: Mapping[str, Any] | None = None,
+        json: bool = True,
+        raw_response: bool = False,
     ) -> BaseApiResponseX:
         """
         Use the BaseApiClient interface to send a cross-region request.
@@ -79,8 +81,9 @@ class BaseSiloClient(BaseApiClient):
             headers=clean_proxy_headers(headers),
             data=data,
             params=params,
-            json=True,
+            json=json,
             allow_text=True,
+            raw_response=raw_response,
         )
         # TODO: Establish a scheme to check/log the Sentry Version of the requestor and server
         # optionally raising an error to alert developers of version drift

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from typing import ContextManager
 from unittest.mock import call, patch
 
-import pytest
 from django.test import RequestFactory
 from freezegun import freeze_time
 from pytest import raises
@@ -21,295 +20,290 @@ from sentry.models import (
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.silo import SiloMode
 from sentry.tasks.deliver_from_outbox import enqueue_outbox_jobs
+from sentry.testutils import TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits, region_silo_test
 from sentry.types.region import MONOLITH_REGION_NAME
 
 
-@pytest.mark.django_db(transaction=True)
-@region_silo_test(stable=True)
-def test_creating_org_outboxes():
-    Organization.outbox_for_update(10).save()
-    OrganizationMember(organization_id=12, id=15).outbox_for_update().save()
-    assert RegionOutbox.objects.count() == 2
-
-    with exempt_from_silo_limits(), outbox_runner():
-        # drain outboxes
-        pass
-    assert RegionOutbox.objects.count() == 0
-
-
-@pytest.mark.django_db(transaction=True)
 @control_silo_test(stable=True)
-def test_creating_user_outboxes():
-    with exempt_from_silo_limits():
-        org = Factories.create_organization(no_mapping=True)
-        Factories.create_org_mapping(org, region_name="a")
-        user1 = Factories.create_user()
-        organization_service.add_organization_member(
-            organization_id=org.id,
-            default_org_role=org.default_role,
-            user_id=user1.id,
-        )
-
-        org2 = Factories.create_organization(no_mapping=True)
-        Factories.create_org_mapping(org2, region_name="b")
-        organization_service.add_organization_member(
-            organization_id=org2.id,
-            default_org_role=org2.default_role,
-            user_id=user1.id,
-        )
-
-    for outbox in User.outboxes_for_update(user1.id):
-        outbox.save()
-
-    expected_counts = 1 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 2
-    assert ControlOutbox.objects.count() == expected_counts
-
-
-@pytest.mark.django_db(transaction=True)
-@region_silo_test(stable=True)
-@patch("sentry.models.outbox.metrics")
-def test_concurrent_coalesced_object_processing(mock_metrics):
-    # Two objects coalesced
-    outbox = OrganizationMember(id=1, organization_id=1).outbox_for_update()
-    outbox.save()
-    OrganizationMember(id=1, organization_id=1).outbox_for_update().save()
-
-    # Unrelated
-    OrganizationMember(organization_id=1, id=2).outbox_for_update().save()
-    OrganizationMember(organization_id=2, id=2).outbox_for_update().save()
-
-    assert len(list(RegionOutbox.find_scheduled_shards())) == 2
-
-    ctx: ContextManager = outbox.process_coalesced()
-    try:
-        ctx.__enter__()
-        assert RegionOutbox.objects.count() == 4
-        assert outbox.select_coalesced_messages().count() == 2
-
-        # concurrent write of coalesced object update.
-        OrganizationMember(organization_id=1, id=1).outbox_for_update().save()
-        assert RegionOutbox.objects.count() == 5
-        assert outbox.select_coalesced_messages().count() == 3
-
-        ctx.__exit__(None, None, None)
-
-        # does not remove the concurrent write, which is still going to update.
-        assert RegionOutbox.objects.count() == 3
-        assert outbox.select_coalesced_messages().count() == 1
-        assert len(list(RegionOutbox.find_scheduled_shards())) == 2
-
-        expected = [
-            call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-            call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-            call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-            call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-            call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-            call("outbox.processed", 2, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-        ]
-        assert mock_metrics.incr.mock_calls == expected
-    except Exception as e:
-        ctx.__exit__(type(e), e, None)
-        raise e
-
-
-@pytest.mark.django_db(transaction=True)
-@region_silo_test(stable=True)
-def test_region_sharding_keys():
-    org1 = Factories.create_organization(no_mapping=True)
-    org2 = Factories.create_organization(no_mapping=True)
-
-    Organization.outbox_for_update(org1.id).save()
-    Organization.outbox_for_update(org2.id).save()
-
-    OrganizationMember(organization_id=org1.id, id=1).outbox_for_update().save()
-    OrganizationMember(organization_id=org2.id, id=2).outbox_for_update().save()
-
-    shards = {
-        (row["shard_scope"], row["shard_identifier"])
-        for row in RegionOutbox.find_scheduled_shards()
-    }
-    assert shards == {
-        (OutboxScope.ORGANIZATION_SCOPE.value, org1.id),
-        (OutboxScope.ORGANIZATION_SCOPE.value, org2.id),
-    }
-
-
-@pytest.mark.django_db(transaction=True)
-@control_silo_test(stable=True)
-def test_control_sharding_keys():
-    request = RequestFactory().get("/extensions/slack/webhook/")
-    with exempt_from_silo_limits():
-        org = Factories.create_organization(no_mapping=True)
-        Factories.create_org_mapping(org, region_name=MONOLITH_REGION_NAME)
-        user1 = Factories.create_user()
-        user2 = Factories.create_user()
-        organization_service.add_organization_member(
-            organization_id=org.id,
-            default_org_role=org.default_role,
-            user_id=user1.id,
-        )
-        organization_service.add_organization_member(
-            organization_id=org.id,
-            default_org_role=org.default_role,
-            user_id=user2.id,
-        )
-
-    for inst in User.outboxes_for_update(user1.id):
-        inst.save()
-    for inst in User.outboxes_for_update(user2.id):
-        inst.save()
-
-    for inst in ControlOutbox.for_webhook_update(
-        webhook_identifier=WebhookProviderIdentifier.SLACK,
-        region_names=[MONOLITH_REGION_NAME, "special-slack-region"],
-        request=request,
-    ):
-        inst.save()
-
-    for inst in ControlOutbox.for_webhook_update(
-        webhook_identifier=WebhookProviderIdentifier.GITHUB,
-        region_names=[MONOLITH_REGION_NAME, "special-github-region"],
-        request=request,
-    ):
-        inst.save()
-
-    shards = {
-        (row["shard_scope"], row["shard_identifier"], row["region_name"])
-        for row in ControlOutbox.find_scheduled_shards()
-    }
-    assert shards == {
-        (OutboxScope.USER_SCOPE.value, user1.id, MONOLITH_REGION_NAME),
-        (OutboxScope.USER_SCOPE.value, user2.id, MONOLITH_REGION_NAME),
-        (OutboxScope.WEBHOOK_SCOPE.value, WebhookProviderIdentifier.SLACK, MONOLITH_REGION_NAME),
-        (OutboxScope.WEBHOOK_SCOPE.value, WebhookProviderIdentifier.GITHUB, MONOLITH_REGION_NAME),
-        (OutboxScope.WEBHOOK_SCOPE.value, WebhookProviderIdentifier.SLACK, "special-slack-region"),
-        (
-            OutboxScope.WEBHOOK_SCOPE.value,
-            WebhookProviderIdentifier.GITHUB,
-            "special-github-region",
-        ),
-    }
-
-
-@pytest.mark.django_db(transaction=True)
-@control_silo_test(stable=True)
-def test_control_outbox_for_webhooks():
-    request = RequestFactory().post(
-        "/extensions/github/webhook/",
-        data={"installation": {"id": "github:1"}},
-        content_type="application/json",
-        HTTP_X_GITHUB_EMOTICON=">:^]",
-    )
-    [outbox] = ControlOutbox.for_webhook_update(
-        webhook_identifier=WebhookProviderIdentifier.GITHUB,
-        region_names=["webhook-region"],
-        request=request,
-    )
-    assert outbox.shard_scope == OutboxScope.WEBHOOK_SCOPE
-    assert outbox.shard_identifier == WebhookProviderIdentifier.GITHUB
-    assert outbox.category == OutboxCategory.WEBHOOK_PROXY
-    assert outbox.region_name == "webhook-region"
-
-    payload_from_request = outbox.get_webhook_payload_from_request(request)
-    assert outbox.payload == dataclasses.asdict(payload_from_request)
-    payload_from_outbox = outbox.get_webhook_payload_from_outbox(outbox.payload)
-    assert payload_from_request == payload_from_outbox
-
-    assert outbox.payload["method"] == "POST"
-    assert outbox.payload["path"] == "/extensions/github/webhook/"
-    assert outbox.payload["uri"] == "http://testserver/extensions/github/webhook/"
-    # Request factory expects transformed headers, but the outbox stores raw headers
-    assert outbox.payload["headers"]["X-Github-Emoticon"] == ">:^]"
-    assert outbox.payload["body"] == '{"installation": {"id": "github:1"}}'
-
-    # After saving, data shouldn't mutate
-    outbox.save()
-    outbox = ControlOutbox.objects.all().first()
-    assert outbox.payload["method"] == "POST"
-    assert outbox.payload["path"] == "/extensions/github/webhook/"
-    assert outbox.payload["uri"] == "http://testserver/extensions/github/webhook/"
-    # Request factory expects transformed headers, but the outbox stores raw headers
-    assert outbox.payload["headers"]["X-Github-Emoticon"] == ">:^]"
-    assert outbox.payload["body"] == '{"installation": {"id": "github:1"}}'
-
-
-@pytest.mark.django_db(transaction=True)
-@region_silo_test(stable=True)
-def test_outbox_rescheduling(task_runner):
-    with patch("sentry.models.outbox.process_region_outbox.send") as mock_process_region_outbox:
-
-        def raise_exception(**kwds):
-            raise ValueError("This is just a test mock exception")
-
-        def run_with_error():
-            mock_process_region_outbox.side_effect = raise_exception
-            mock_process_region_outbox.reset_mock()
-            with task_runner():
-                with raises(ValueError):
-                    enqueue_outbox_jobs()
-                assert mock_process_region_outbox.call_count == 1
-
-        def ensure_converged():
-            mock_process_region_outbox.reset_mock()
-            with task_runner():
-                enqueue_outbox_jobs()
-                assert mock_process_region_outbox.call_count == 0
-
-        def assert_called_for_org(org):
-            mock_process_region_outbox.assert_called_with(
-                sender=OutboxCategory.ORGANIZATION_UPDATE,
-                payload=None,
-                object_identifier=org,
-                shard_identifier=org,
+class ControlOutboxTest(TestCase):
+    def test_creating_user_outboxes(self):
+        with exempt_from_silo_limits():
+            org = Factories.create_organization(no_mapping=True)
+            Factories.create_org_mapping(org, region_name="a")
+            user1 = Factories.create_user()
+            organization_service.add_organization_member(
+                organization_id=org.id,
+                default_org_role=org.default_role,
+                user_id=user1.id,
             )
 
-        Organization.outbox_for_update(org_id=10001).save()
-        Organization.outbox_for_update(org_id=10002).save()
+            org2 = Factories.create_organization(no_mapping=True)
+            Factories.create_org_mapping(org2, region_name="b")
+            organization_service.add_organization_member(
+                organization_id=org2.id,
+                default_org_role=org2.default_role,
+                user_id=user1.id,
+            )
 
-        start_time = datetime(2022, 10, 1, 0)
-        with freeze_time(start_time):
-            run_with_error()
-            assert_called_for_org(10001)
+        for outbox in User.outboxes_for_update(user1.id):
+            outbox.save()
 
-        # Runs things in ascending order of the scheduled_for
-        with freeze_time(start_time + timedelta(minutes=10)):
-            run_with_error()
-            assert_called_for_org(10002)
+        expected_counts = 1 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 2
+        assert ControlOutbox.objects.count() == expected_counts
 
-        # Has rescheduled all objects into the future.
-        with freeze_time(start_time):
-            ensure_converged()
+    def test_control_sharding_keys(self):
+        request = RequestFactory().get("/extensions/slack/webhook/")
+        with exempt_from_silo_limits():
+            org = Factories.create_organization(no_mapping=True)
+            Factories.create_org_mapping(org, region_name=MONOLITH_REGION_NAME)
+            user1 = Factories.create_user()
+            user2 = Factories.create_user()
+            organization_service.add_organization_member(
+                organization_id=org.id,
+                default_org_role=org.default_role,
+                user_id=user1.id,
+            )
+            organization_service.add_organization_member(
+                organization_id=org.id,
+                default_org_role=org.default_role,
+                user_id=user2.id,
+            )
 
-        # Next would run the original rescheduled org1 entry
-        with freeze_time(start_time + timedelta(minutes=10)):
-            run_with_error()
-            assert_called_for_org(10001)
-            ensure_converged()
+        for inst in User.outboxes_for_update(user1.id):
+            inst.save()
+        for inst in User.outboxes_for_update(user2.id):
+            inst.save()
 
-            # Concurrently added items still follow the largest retry schedule
-            Organization.outbox_for_update(10002).save()
-            ensure_converged()
+        for inst in ControlOutbox.for_webhook_update(
+            webhook_identifier=WebhookProviderIdentifier.SLACK,
+            region_names=[MONOLITH_REGION_NAME, "special-slack-region"],
+            request=request,
+        ):
+            inst.save()
+
+        for inst in ControlOutbox.for_webhook_update(
+            webhook_identifier=WebhookProviderIdentifier.GITHUB,
+            region_names=[MONOLITH_REGION_NAME, "special-github-region"],
+            request=request,
+        ):
+            inst.save()
+
+        shards = {
+            (row["shard_scope"], row["shard_identifier"], row["region_name"])
+            for row in ControlOutbox.find_scheduled_shards()
+        }
+        assert shards == {
+            (OutboxScope.USER_SCOPE.value, user1.id, MONOLITH_REGION_NAME),
+            (OutboxScope.USER_SCOPE.value, user2.id, MONOLITH_REGION_NAME),
+            (
+                OutboxScope.WEBHOOK_SCOPE.value,
+                WebhookProviderIdentifier.SLACK,
+                MONOLITH_REGION_NAME,
+            ),
+            (
+                OutboxScope.WEBHOOK_SCOPE.value,
+                WebhookProviderIdentifier.GITHUB,
+                MONOLITH_REGION_NAME,
+            ),
+            (
+                OutboxScope.WEBHOOK_SCOPE.value,
+                WebhookProviderIdentifier.SLACK,
+                "special-slack-region",
+            ),
+            (
+                OutboxScope.WEBHOOK_SCOPE.value,
+                WebhookProviderIdentifier.GITHUB,
+                "special-github-region",
+            ),
+        }
+
+    def test_control_outbox_for_webhooks(self):
+        request = RequestFactory().post(
+            "/extensions/github/webhook/",
+            data={"installation": {"id": "github:1"}},
+            content_type="application/json",
+            HTTP_X_GITHUB_EMOTICON=">:^]",
+        )
+        [outbox] = ControlOutbox.for_webhook_update(
+            webhook_identifier=WebhookProviderIdentifier.GITHUB,
+            region_names=["webhook-region"],
+            request=request,
+        )
+        assert outbox.shard_scope == OutboxScope.WEBHOOK_SCOPE
+        assert outbox.shard_identifier == WebhookProviderIdentifier.GITHUB
+        assert outbox.category == OutboxCategory.WEBHOOK_PROXY
+        assert outbox.region_name == "webhook-region"
+
+        payload_from_request = outbox.get_webhook_payload_from_request(request)
+        assert outbox.payload == dataclasses.asdict(payload_from_request)
+        payload_from_outbox = outbox.get_webhook_payload_from_outbox(outbox.payload)
+        assert payload_from_request == payload_from_outbox
+
+        assert outbox.payload["method"] == "POST"
+        assert outbox.payload["path"] == "/extensions/github/webhook/"
+        assert outbox.payload["uri"] == "http://testserver/extensions/github/webhook/"
+        # Request factory expects transformed headers, but the outbox stores raw headers
+        assert outbox.payload["headers"]["X-Github-Emoticon"] == ">:^]"
+        assert outbox.payload["body"] == '{"installation": {"id": "github:1"}}'
+
+        # After saving, data shouldn't mutate
+        outbox.save()
+        outbox = ControlOutbox.objects.all().first()
+        assert outbox.payload["method"] == "POST"
+        assert outbox.payload["path"] == "/extensions/github/webhook/"
+        assert outbox.payload["uri"] == "http://testserver/extensions/github/webhook/"
+        # Request factory expects transformed headers, but the outbox stores raw headers
+        assert outbox.payload["headers"]["X-Github-Emoticon"] == ">:^]"
+        assert outbox.payload["body"] == '{"installation": {"id": "github:1"}}'
 
 
-@pytest.mark.django_db(transaction=True)
 @region_silo_test(stable=True)
-def test_outbox_converges(task_runner):
-    with patch("sentry.models.outbox.process_region_outbox.send") as mock_process_region_outbox:
-        Organization.outbox_for_update(10001).save()
-        Organization.outbox_for_update(10001).save()
+class RegionOutboxTest(TestCase):
+    def test_creating_org_outboxes(self):
+        Organization.outbox_for_update(10).save()
+        OrganizationMember(organization_id=12, id=15).outbox_for_update().save()
+        assert RegionOutbox.objects.count() == 2
 
-        Organization.outbox_for_update(10002).save()
-        Organization.outbox_for_update(10002).save()
+        with exempt_from_silo_limits(), outbox_runner():
+            # drain outboxes
+            pass
+        assert RegionOutbox.objects.count() == 0
 
-        last_call_count = 0
-        while True:
-            with task_runner():
-                enqueue_outbox_jobs()
-                if last_call_count == mock_process_region_outbox.call_count:
-                    break
-                last_call_count = mock_process_region_outbox.call_count
+    @patch("sentry.models.outbox.metrics")
+    def test_concurrent_coalesced_object_processing(self, mock_metrics):
+        # Two objects coalesced
+        outbox = OrganizationMember(id=1, organization_id=1).outbox_for_update()
+        outbox.save()
+        OrganizationMember(id=1, organization_id=1).outbox_for_update().save()
 
-        assert last_call_count == 2
+        # Unrelated
+        OrganizationMember(organization_id=1, id=2).outbox_for_update().save()
+        OrganizationMember(organization_id=2, id=2).outbox_for_update().save()
+
+        assert len(list(RegionOutbox.find_scheduled_shards())) == 2
+
+        ctx: ContextManager = outbox.process_coalesced()
+        try:
+            ctx.__enter__()
+            assert RegionOutbox.objects.count() == 4
+            assert outbox.select_coalesced_messages().count() == 2
+
+            # concurrent write of coalesced object update.
+            OrganizationMember(organization_id=1, id=1).outbox_for_update().save()
+            assert RegionOutbox.objects.count() == 5
+            assert outbox.select_coalesced_messages().count() == 3
+
+            ctx.__exit__(None, None, None)
+
+            # does not remove the concurrent write, which is still going to update.
+            assert RegionOutbox.objects.count() == 3
+            assert outbox.select_coalesced_messages().count() == 1
+            assert len(list(RegionOutbox.find_scheduled_shards())) == 2
+
+            expected = [
+                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+                call("outbox.processed", 2, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+            ]
+            assert mock_metrics.incr.mock_calls == expected
+        except Exception as e:
+            ctx.__exit__(type(e), e, None)
+            raise e
+
+    def test_outbox_rescheduling(self):
+        with patch("sentry.models.outbox.process_region_outbox.send") as mock_process_region_outbox:
+
+            def raise_exception(**kwds):
+                raise ValueError("This is just a test mock exception")
+
+            def run_with_error():
+                mock_process_region_outbox.side_effect = raise_exception
+                mock_process_region_outbox.reset_mock()
+                with self.tasks():
+                    with raises(ValueError):
+                        enqueue_outbox_jobs()
+                    assert mock_process_region_outbox.call_count == 1
+
+            def ensure_converged():
+                mock_process_region_outbox.reset_mock()
+                with self.tasks():
+                    enqueue_outbox_jobs()
+                    assert mock_process_region_outbox.call_count == 0
+
+            def assert_called_for_org(org):
+                mock_process_region_outbox.assert_called_with(
+                    sender=OutboxCategory.ORGANIZATION_UPDATE,
+                    payload=None,
+                    object_identifier=org,
+                    shard_identifier=org,
+                )
+
+            Organization.outbox_for_update(org_id=10001).save()
+            Organization.outbox_for_update(org_id=10002).save()
+
+            start_time = datetime(2022, 10, 1, 0)
+            with freeze_time(start_time):
+                run_with_error()
+                assert_called_for_org(10001)
+
+            # Runs things in ascending order of the scheduled_for
+            with freeze_time(start_time + timedelta(minutes=10)):
+                run_with_error()
+                assert_called_for_org(10002)
+
+            # Has rescheduled all objects into the future.
+            with freeze_time(start_time):
+                ensure_converged()
+
+            # Next would run the original rescheduled org1 entry
+            with freeze_time(start_time + timedelta(minutes=10)):
+                run_with_error()
+                assert_called_for_org(10001)
+                ensure_converged()
+
+                # Concurrently added items still follow the largest retry schedule
+                Organization.outbox_for_update(10002).save()
+                ensure_converged()
+
+    def test_outbox_converges(self):
+        with patch("sentry.models.outbox.process_region_outbox.send") as mock_process_region_outbox:
+            Organization.outbox_for_update(10001).save()
+            Organization.outbox_for_update(10001).save()
+
+            Organization.outbox_for_update(10002).save()
+            Organization.outbox_for_update(10002).save()
+
+            last_call_count = 0
+            while True:
+                with self.tasks():
+                    enqueue_outbox_jobs()
+                    if last_call_count == mock_process_region_outbox.call_count:
+                        break
+                    last_call_count = mock_process_region_outbox.call_count
+
+            assert last_call_count == 2
+
+    def test_region_sharding_keys(self):
+        org1 = Factories.create_organization(no_mapping=True)
+        org2 = Factories.create_organization(no_mapping=True)
+
+        Organization.outbox_for_update(org1.id).save()
+        Organization.outbox_for_update(org2.id).save()
+
+        OrganizationMember(organization_id=org1.id, id=1).outbox_for_update().save()
+        OrganizationMember(organization_id=org2.id, id=2).outbox_for_update().save()
+
+        shards = {
+            (row["shard_scope"], row["shard_identifier"])
+            for row in RegionOutbox.find_scheduled_shards()
+        }
+        assert shards == {
+            (OutboxScope.ORGANIZATION_SCOPE.value, org1.id),
+            (OutboxScope.ORGANIZATION_SCOPE.value, org2.id),
+        }

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -1,22 +1,36 @@
 from unittest.mock import patch
 
+import responses
+from django.test import RequestFactory, override_settings
+from pytest import raises
+from rest_framework import status
+
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
+from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
 from sentry.models.user import User
 from sentry.receivers.outbox.control import (
     process_api_application_updates,
+    process_async_webhooks,
     process_integration_updates,
     process_organization_integration_update,
     process_sentry_app_installation_updates,
     process_user_updates,
 )
+from sentry.shared_integrations.exceptions.base import ApiError
+from sentry.silo.base import SiloMode
 from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.types.region import Region, RegionCategory
 
 
+@control_silo_test(stable=True)
 class ProcessControlOutboxTest(TestCase):
     identifier = 1
+    region = Region("eu", 1, "http://eu.testserver", RegionCategory.MULTI_TENANT)
+    region_config = (region,)
 
     @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
     def test_process_user_updates(self, mock_maybe_process):
@@ -43,6 +57,62 @@ class ProcessControlOutboxTest(TestCase):
         process_organization_integration_update(object_identifier=self.identifier)
         mock_maybe_process.assert_called_with(OrganizationIntegration, self.identifier)
 
-    def test_process_async_webhooks(self):
-        # process_async_webhooks
-        pass
+    @responses.activate
+    @override_settings(SENTRY_REGION_CONFIG=region_config)
+    def test_process_async_webhooks_success(self):
+        request = RequestFactory().post(
+            "/extensions/github/webhook/",
+            data={"installation": {"id": "github:1"}},
+            content_type="application/json",
+            HTTP_X_GITHUB_EMOTICON=">:^]",
+        )
+        [outbox] = ControlOutbox.for_webhook_update(
+            webhook_identifier=WebhookProviderIdentifier.GITHUB,
+            region_names=[self.region.name],
+            request=request,
+        )
+        outbox.save()
+        outbox.refresh_from_db()
+
+        mock_response = responses.add(
+            request.method,
+            f"{self.region.address}{request.path}",
+            status=status.HTTP_200_OK,
+        )
+        process_async_webhooks(payload=outbox.payload, region_name=self.region.name)
+        request_claim = (
+            mock_response.call_count == 1
+            if SiloMode.get_current_mode() == SiloMode.CONTROL
+            else mock_response.call_count == 0
+        )
+        assert request_claim
+
+    @responses.activate
+    @override_settings(SENTRY_REGION_CONFIG=region_config)
+    def test_process_async_webhooks_failure(self):
+        request = RequestFactory().post(
+            "/extensions/github/webhook/",
+            data={"installation": {"id": "github:1"}},
+            content_type="application/json",
+            HTTP_X_GITHUB_EMOTICON=">:^]",
+        )
+        [outbox] = ControlOutbox.for_webhook_update(
+            webhook_identifier=WebhookProviderIdentifier.GITHUB,
+            region_names=[self.region.name],
+            request=request,
+        )
+        outbox.save()
+        outbox.refresh_from_db()
+
+        mock_response = responses.add(
+            request.method,
+            f"{self.region.address}{request.path}",
+            status=status.HTTP_504_GATEWAY_TIMEOUT,
+        )
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            with raises(ApiError):
+                process_async_webhooks(payload=outbox.payload, region_name=self.region.name)
+            assert mock_response.call_count == 1
+        else:
+            process_async_webhooks(payload=outbox.payload, region_name=self.region.name)
+            assert mock_response.call_count == 0

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from sentry.models.apiapplication import ApiApplication
+from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
+from sentry.models.user import User
+from sentry.receivers.outbox.control import (
+    process_api_application_updates,
+    process_integration_updates,
+    process_organization_integration_update,
+    process_sentry_app_installation_updates,
+    process_user_updates,
+)
+from sentry.testutils import TestCase
+
+
+class ProcessControlOutboxTest(TestCase):
+    identifier = 1
+
+    @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
+    def test_process_user_updates(self, mock_maybe_process):
+        process_user_updates(object_identifier=self.identifier)
+        mock_maybe_process.assert_called_with(User, self.identifier)
+
+    @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
+    def test_process_integration_updatess(self, mock_maybe_process):
+        process_integration_updates(object_identifier=self.identifier)
+        mock_maybe_process.assert_called_with(Integration, self.identifier)
+
+    @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
+    def test_process_api_application_updates(self, mock_maybe_process):
+        process_api_application_updates(object_identifier=self.identifier)
+        mock_maybe_process.assert_called_with(ApiApplication, self.identifier)
+
+    @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
+    def test_process_sentry_app_installation_updates(self, mock_maybe_process):
+        process_sentry_app_installation_updates(object_identifier=self.identifier)
+        mock_maybe_process.assert_called_with(SentryAppInstallation, self.identifier)
+
+    @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
+    def test_process_organization_integration_update(self, mock_maybe_process):
+        process_organization_integration_update(object_identifier=self.identifier)
+        mock_maybe_process.assert_called_with(OrganizationIntegration, self.identifier)
+
+    def test_process_async_webhooks(self):
+        # process_async_webhooks
+        pass


### PR DESCRIPTION
This PR is a spin off of https://github.com/getsentry/sentry/pull/49379. The original PR was meant to focus on getting the github integration forwarding, but as the changes piled, the diff became unfocused.

This PR takes the non-github changes apart so that it can stand as a reference for building out future webhook parsers.

The changes in this diff are:
- Convert `identity_service` to using a filter argument
- Add outbox creation to base request parser
- Add receiver for webhook outboxes
- Refactor Slack to directly reference classes instead of class name (not sure why I didn't do this initially)