### PR TITLE
fix(dropdownMenu): Fix submenu hover issue

### DIFF
--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -113,7 +113,7 @@ function BaseDropdownMenuItem(
       return;
     }
     if (isSubmenu) {
-      state.selectionManager.select(node.key);
+      state.selectionManager.toggleSelection(node.key);
       return;
     }
     onAction?.(key);
@@ -134,7 +134,7 @@ function BaseDropdownMenuItem(
 
     if (isHovered && isFocused) {
       if (isSubmenu) {
-        state.selectionManager.select(node.key);
+        state.selectionManager.replaceSelection(node.key);
         return;
       }
       state.selectionManager.clearSelection();
@@ -162,7 +162,7 @@ function BaseDropdownMenuItem(
       }
 
       if (e.key === 'ArrowRight' && isSubmenu) {
-        state.selectionManager.select(node.key);
+        state.selectionManager.replaceSelection(node.key);
         return;
       }
 


### PR DESCRIPTION
**Before ——** when in a submenu, hovering over the parent menu item unexpectedly closes it

https://github.com/getsentry/sentry/assets/44172267/03274dac-939f-4881-86e3-26e5b26b5acb


**After ——**

https://github.com/getsentry/sentry/assets/44172267/0c34d12b-beda-4768-b25e-84013ea0bd79

