### PR TITLE
fix(starfish) Fix missing charts and numbers from endpoint HTTP spans table

### DIFF
--- a/static/app/views/starfish/modules/APIModule/queries.tsx
+++ b/static/app/views/starfish/modules/APIModule/queries.tsx
@@ -313,7 +313,8 @@ export const getEndpointAggregatesQuery = ({datetime, transaction}) => {
     description,
     toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval,
     count() AS count,
-    quantile(0.5)(exclusive_time) as p50
+    quantile(0.5)(exclusive_time) as p50,
+    quantile(0.95)(exclusive_time) as p95
     FROM spans_experimental_starfish
     WHERE module = 'http'
     ${transaction ? `AND transaction = '${transaction}'` : ''}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -272,7 +272,7 @@ export default function EndpointOverview() {
                             }}
                           />
                         </ChartPanel>
-                        <ChartPanel title={t('Througput')}>
+                        <ChartPanel title={t('Throughput')}>
                           <Chart
                             statsPeriod={(statsPeriod as string) ?? '24h'}
                             height={80}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -50,27 +50,27 @@ const HTTP_SPAN_COLUMN_ORDER = [
   },
   {
     key: 'throughput',
-    name: 'Throughput',
+    name: 'Throughput (SPM)',
     width: 350,
   },
   {
     key: 'p50_trend',
-    name: 'p50 Trend',
-    width: 200,
-  },
-  {
-    key: 'p50(exclusive_time)',
     name: 'p50',
-    width: COL_WIDTH_UNDEFINED,
+    width: 175,
   },
   {
-    key: 'transaction_count',
+    key: 'p95_trend',
+    name: 'p95',
+    width: 175,
+  },
+  {
+    key: 'count_unique(transaction)',
     name: 'Transactions',
     width: COL_WIDTH_UNDEFINED,
   },
 
   {
-    key: 'total_exclusive_time',
+    key: 'sum(span.self_time)',
     name: 'Total Time',
     width: COL_WIDTH_UNDEFINED,
   },

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -250,7 +250,7 @@ export default function EndpointOverview() {
                   {({results, loading}) => {
                     return (
                       <Fragment>
-                        <ChartPanel title={t('p50(duration)')}>
+                        <ChartPanel title={t('p50(Duration)')}>
                           <Chart
                             statsPeriod={(statsPeriod as string) ?? '24h'}
                             height={80}


### PR DESCRIPTION
Whoops! It works now!

**e.g.,**
<img width="1322" alt="Screenshot 2023-05-23 at 9 28 38 PM" src="https://github.com/getsentry/sentry/assets/989898/59f4f2ee-7513-442a-8d13-26952fdcad43">
