### PR TITLE
feat(starfish): Add p95 to response time chart

### DIFF
--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -24,8 +24,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import withApi from 'sentry/utils/withApi';
 import Chart from 'sentry/views/starfish/components/chart';
-import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {FacetInsights} from 'sentry/views/starfish/components/facetInsights';
+import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {SampleEvents} from 'sentry/views/starfish/components/sampleEvents';
 import EndpointTable from 'sentry/views/starfish/modules/APIModule/endpointTable';
 import DatabaseTableView, {
@@ -227,9 +227,9 @@ export default function EndpointOverview() {
                 <SpanGroupBreakdownContainer transaction={transaction as string} />
               </ChartsContainerItem>
               <ChartsContainerItem2>
-                <ChartPanel title={t('Error Rate')}>
+                <MiniChartPanel title={t('Error Rate')}>
                   {renderFailureRateChart()}
-                </ChartPanel>
+                </MiniChartPanel>
                 <EventsRequest
                   query={query.formatString()}
                   includePrevious={false}
@@ -244,26 +244,29 @@ export default function EndpointOverview() {
                   start={pageFilter.selection.datetime.start}
                   end={pageFilter.selection.datetime.end}
                   organization={organization}
-                  yAxis={['tpm()', 'p50(transaction.duration)']}
+                  yAxis={[
+                    'tpm()',
+                    'p95(transaction.duration)',
+                    'p50(transaction.duration)',
+                  ]}
                   queryExtras={{dataset: 'metrics'}}
                 >
                   {({results, loading}) => {
                     return (
                       <Fragment>
-                        <ChartPanel title={t('p50(duration)')}>
+                        <MiniChartPanel title={t('Response Times')}>
                           <Chart
                             statsPeriod={(statsPeriod as string) ?? '24h'}
-                            height={80}
-                            data={results?.[1] ? [results?.[1]] : []}
+                            height={110}
+                            data={results?.[1] ? [results?.[1], results?.[2]] : []}
                             start=""
                             end=""
                             loading={loading}
                             utc={false}
-                            stacked
                             isLineChart
                             disableXAxis
                             definedAxisTicks={2}
-                            chartColors={[theme.charts.getColorPalette(0)[1]]}
+                            chartColors={theme.charts.getColorPalette(2)}
                             grid={{
                               left: '0',
                               right: '0',
@@ -271,8 +274,8 @@ export default function EndpointOverview() {
                               bottom: '16px',
                             }}
                           />
-                        </ChartPanel>
-                        <ChartPanel title={t('Througput')}>
+                        </MiniChartPanel>
+                        <MiniChartPanel title={t('Througput')}>
                           <Chart
                             statsPeriod={(statsPeriod as string) ?? '24h'}
                             height={80}
@@ -293,7 +296,7 @@ export default function EndpointOverview() {
                               bottom: '16px',
                             }}
                           />
-                        </ChartPanel>
+                        </MiniChartPanel>
                       </Fragment>
                     );
                   }}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -275,7 +275,7 @@ export default function EndpointOverview() {
                             }}
                           />
                         </MiniChartPanel>
-                        <MiniChartPanel title={t('Througput')}>
+                        <MiniChartPanel title={t('Throughput')}>
                           <Chart
                             statsPeriod={(statsPeriod as string) ?? '24h'}
                             height={80}

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -225,11 +225,8 @@ export function StarfishView(props: BasePerformanceViewProps) {
         start={eventView.start}
         end={eventView.end}
         organization={organization}
-        yAxis="p50(transaction.duration)"
+        yAxis={['p95(transaction.duration)', 'p50(transaction.duration)']}
         queryExtras={{dataset: 'metrics'}}
-        orderby="-sum_transaction_duration"
-        topEvents={5}
-        field={['transaction', 'sum(transaction.duration)', 'p50(transaction.duration)']}
       >
         {({loading, results}) => {
           const transformedData: Series[] | undefined = results?.map(series => ({
@@ -260,7 +257,6 @@ export function StarfishView(props: BasePerformanceViewProps) {
               chartColors={theme.charts.getColorPalette(2)}
               disableXAxis
               aggregateOutputFormat="duration"
-              showLegend
             />
           );
         }}
@@ -279,7 +275,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
             <MiniChartPanel title={t('Error Rate')}>
               {renderFailureRateChart()}
             </MiniChartPanel>
-            <MiniChartPanel title={t('Top Endpoint Response Times')}>
+            <MiniChartPanel title={t('Response Times')}>
               {renderEndpointPercentileChart()}
             </MiniChartPanel>
             <MiniChartPanel title={t('Throughput')}>

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -275,7 +275,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
             <MiniChartPanel title={t('Error Rate')}>
               {renderFailureRateChart()}
             </MiniChartPanel>
-            <MiniChartPanel title={t('Response Times')}>
+            <MiniChartPanel title={t('Duration')}>
               {renderEndpointPercentileChart()}
             </MiniChartPanel>
             <MiniChartPanel title={t('Throughput')}>


### PR DESCRIPTION
I don't know how useful response time of
top x endpoints is, so adding p50 + p95 response
time charts to wsv (and endpoint overview)