### PR TITLE
fix(stacktrace): monofont for hex instead of f(x) 

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -346,12 +346,12 @@ function NativeFrame({
 export default withSentryAppComponents(NativeFrame, {componentType: 'stacktrace-link'});
 
 const AddressCell = styled('div')`
+  font-family: ${p => p.theme.text.familyMono};
   ${p => p.onClick && `cursor: pointer`};
   ${p => p.onClick && `color:` + p.theme.linkColor};
 `;
 
 const FunctionNameCell = styled('div')`
-  font-family: ${p => p.theme.text.familyMono};
   word-break: break-all;
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {


### PR DESCRIPTION
**Before:**
<img width="849" alt="Screenshot 2023-05-23 at 8 06 25 PM" src="https://github.com/getsentry/sentry/assets/4830259/0a1b1619-a7f6-4acd-a99f-d438ba37b1bf">

**After:** 
<img width="852" alt="Screenshot 2023-05-23 at 8 05 55 PM" src="https://github.com/getsentry/sentry/assets/4830259/0c66b8eb-fe1e-4b1f-a4fa-da24dbe9d67d">