### PR TITLE
chore(debug-meta): Expand Debug Meta images details upon scrolling

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -126,7 +126,10 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
     const {searchTerm} = this.state;
 
     if (store.filter !== searchTerm) {
-      this.setState({searchTerm: store.filter}, this.filterImagesBySearchTerm);
+      this.setState(
+        {searchTerm: store.filter, isOpen: true},
+        this.filterImagesBySearchTerm
+      );
     }
   };
 


### PR DESCRIPTION
Just stumbled upon this - when we click on the Stackframe Address it automatically scrolls to the "Images Loaded" section, but it doesn't expand the section, so it looked weird and this PR simply fixes this.

(Nevermind the lagged scrolling, this is because I converted mp4 to gifs with a lower quality) 

### Before
![before](https://github.com/getsentry/sentry/assets/4999776/c7095059-e057-4168-a9ba-20ac1ead5141)

### After
![after](https://github.com/getsentry/sentry/assets/4999776/eee13538-2203-455f-b1c1-5ced6a97e722)
