### PR TITLE
fix(sourcemaps): Use correct atomic transaction

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import List, Mapping, Optional, Sequence, Set, Tuple
 
 import pytz
-from django.db import transaction
+from django.db import router
 from django.http import Http404, HttpResponse, StreamingHttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -28,6 +28,7 @@ from sentry.models import (
     ReleaseFile,
 )
 from sentry.utils import metrics
+from sentry.utils.db import atomic_transaction
 
 logger = logging.getLogger("sentry.api")
 
@@ -184,7 +185,7 @@ def renew_artifact_bundles(used_artifact_bundles: Mapping[int, datetime]):
         if date_added <= threshold_date:
             metrics.incr("artifact_lookup.get.renew_artifact_bundles.renewed")
             # We want to use a transaction, in order to keep the `date_added` consistent across multiple tables.
-            with transaction.atomic():
+            with atomic_transaction(using=router.db_for_write(File)):
                 # We check again for the date_added condition in order to achieve consistency, this is done because
                 # the `can_be_renewed` call is using a time which differs from the one of the actual update in the db.
                 updated_rows_count = ArtifactBundle.objects.filter(

--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -185,7 +185,14 @@ def renew_artifact_bundles(used_artifact_bundles: Mapping[int, datetime]):
         if date_added <= threshold_date:
             metrics.incr("artifact_lookup.get.renew_artifact_bundles.renewed")
             # We want to use a transaction, in order to keep the `date_added` consistent across multiple tables.
-            with atomic_transaction(using=router.db_for_write(File)):
+            with atomic_transaction(
+                using=(
+                    router.db_for_write(ArtifactBundle),
+                    router.db_for_write(ProjectArtifactBundle),
+                    router.db_for_write(ReleaseArtifactBundle),
+                    router.db_for_write(DebugIdArtifactBundle),
+                )
+            ):
                 # We check again for the date_added condition in order to achieve consistency, this is done because
                 # the `can_be_renewed` call is using a time which differs from the one of the actual update in the db.
                 updated_rows_count = ArtifactBundle.objects.filter(


### PR DESCRIPTION
This PR fixes the wrong usage of atomic transaction.