### PR TITLE
fix(dynamic-sampling): Disable prioritize by project for specific org

### DIFF
--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -258,7 +258,8 @@ def prioritise_projects() -> None:
             for org_id, projects_with_tx_count_and_rates in fetch_projects_with_total_volumes(
                 org_ids=orgs
             ).items():
-                process_projects_sample_rates.delay(org_id, projects_with_tx_count_and_rates)
+                if org_id not in [228005]:
+                    process_projects_sample_rates.delay(org_id, projects_with_tx_count_and_rates)
 
 
 @instrumented_task(


### PR DESCRIPTION
This PR disables the dynamic sampling background job for a specific org which has lots of projects. This is a temporary fix waiting for a future PR that should solve the issue.