### PR TITLE
fix(starfish): Fixes chart axis sync sometimes not working and slideoverpanel initial state

### DIFF
--- a/static/app/views/starfish/components/slideOverPanel.tsx
+++ b/static/app/views/starfish/components/slideOverPanel.tsx
@@ -35,7 +35,7 @@ function SlideOverPanel(
 
 const _SlideOverPanel = styled(motion.div, {
   shouldForwardProp: prop =>
-    ['animate', 'transition'].includes(prop) ||
+    ['animate', 'transition', 'initial'].includes(prop) ||
     (prop !== 'collapsed' && isPropValid(prop)),
 })<{
   collapsed: boolean;

--- a/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
+++ b/static/app/views/starfish/modules/APIModule/APIModuleView.tsx
@@ -10,7 +10,7 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Series} from 'sentry/types/echarts';
+import {ReactEchartsRef, Series} from 'sentry/types/echarts';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -210,7 +210,9 @@ export default function APIModuleView({location, onSelect}: Props) {
     'p75(transaction.duration)'
   );
 
-  useSynchronizeCharts([!isGraphLoading]);
+  const loading = isGraphLoading || isTopTransactionDataLoading;
+
+  useSynchronizeCharts([!loading]);
 
   return (
     <Fragment>
@@ -226,37 +228,31 @@ export default function APIModuleView({location, onSelect}: Props) {
       <ChartsContainer>
         <ChartsContainerItem>
           <ChartPanel title={t('Top Transactions Throughput')}>
-            <APIModuleChart
-              data={tpmTransactionSeries}
-              loading={isTopTransactionDataLoading}
-            />
+            <APIModuleChart data={tpmTransactionSeries} loading={loading} />
           </ChartPanel>
         </ChartsContainerItem>
         <ChartsContainerItem>
           <ChartPanel title={t('Top Transactions p75')}>
-            <APIModuleChart
-              data={p75TransactionSeries}
-              loading={isTopTransactionDataLoading}
-            />
+            <APIModuleChart data={p75TransactionSeries} loading={loading} />
           </ChartPanel>
         </ChartsContainerItem>
       </ChartsContainer>
       <ChartsContainer>
         <ChartsContainerItem>
           <ChartPanel title={t('Throughput')}>
-            <APIModuleChart data={zeroFilledCounts} loading={isGraphLoading} />
+            <APIModuleChart data={zeroFilledCounts} loading={loading} />
           </ChartPanel>
         </ChartsContainerItem>
         <ChartsContainerItem>
           <ChartPanel title={t('Response Time')}>
-            <APIModuleChart data={zeroFilledQuantiles} loading={isGraphLoading} />
+            <APIModuleChart data={zeroFilledQuantiles} loading={loading} />
           </ChartPanel>
         </ChartsContainerItem>
         <ChartsContainerItem>
           <ChartPanel title={t('Error Rate')}>
             <APIModuleChart
               data={zeroFilledFailureRate}
-              loading={isGraphLoading}
+              loading={loading}
               chartColors={[themes.charts.getColorPalette(2)[2]]}
             />
           </ChartPanel>
@@ -306,10 +302,14 @@ function APIModuleChart({
   data,
   loading,
   chartColors,
+  forwardedRef,
+  chartGroup,
 }: {
   data: Series[];
   loading: boolean;
   chartColors?: string[];
+  chartGroup?: string;
+  forwardedRef?: React.RefObject<ReactEchartsRef>;
 }) {
   return (
     <Chart
@@ -331,6 +331,8 @@ function APIModuleChart({
       isLineChart
       chartColors={chartColors}
       disableXAxis
+      forwardedRef={forwardedRef}
+      chartGroup={chartGroup}
     />
   );
 }

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -20,7 +20,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import withApi from 'sentry/utils/withApi';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {insertClickableAreasIntoSeries} from 'sentry/views/starfish/utils/insertClickableAreasIntoSeries';
 import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/endpointDetails';
@@ -267,6 +267,8 @@ export function StarfishView(props: BasePerformanceViewProps) {
       </EventsRequest>
     );
   }
+
+  useSynchronizeCharts();
 
   return (
     <div data-test-id="starfish-view">


### PR DESCRIPTION
Fixes an issue with synced y axis sometimes not syncing all charts (especially in api module) and fixes slideOverPanel sometimes displaying initially incorrectly

TODO: Still some bugs with chart axis not syncing in some scenarios (changing page filters)