### PR TITLE
ref(js): Refactor `sanitizePath` to handle more cases

### DIFF
--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -2,74 +2,116 @@
  * Remove slugs from the path - we do not want them displayed in the Issues Stream (having them in issue details is ok)
  */
 
-const SHORTENED_TYPE = {
-  organizations: 'orgSlug',
-  customers: 'customerSlug',
-  projects: 'projectSlug',
-  teams: 'teamSlug',
-  issues: 'issueId',
-  replays: 'replayId',
+const TYPE_TO_PLACEHOLDER = {
+  'alert-rules': '{ruleId}',
+  customers: '{orgSlug}',
+  environments: '{environmentId}',
+  events: '{eventId}',
+  groups: '{groupId}',
+  issues: '{issueId}',
+  members: '{memberId}',
+  organizations: '{orgSlug}',
+  projects: '{projectSlug}',
+  releases: '{releaseId}',
+  replays: '{replayId}',
+  subscriptions: '{orgSlug}',
+  teams: '{teamSlug}',
 };
 
+function getSlugPlaceholder(rawSlugType: string, slugValue: string): string {
+  if (slugValue === '') {
+    return slugValue;
+  }
+
+  // Pull off the trailing slash, if there is one
+  const slugType = rawSlugType.replace(/\/$/, '');
+  return TYPE_TO_PLACEHOLDER[slugType] + '/' || slugValue;
+}
+
 export function sanitizePath(path: string) {
-  return path.replace(
-    /(?<start>.*?)\/(?<type>organizations|issues|customers|projects|teams)\/(?<primarySlug>[^/]+)\/(?<contentType>[^/]+\/)?(?<tertiarySlug>[^/]+\/)?(?<end>.*)/,
-    function (...args) {
-      const matches = args[args.length - 1];
-      const {start, type, contentType, tertiarySlug, end} = matches;
-      // `customers` is org-like
-      const isOrg = ['organizations', 'customers'].includes(type);
-      const noOrgSlug = type === 'issues';
-      const isProject = type === 'projects';
-      const isRuleConditions = isProject && contentType === 'rule-conditions/';
+  return (
+    path
+      // Remove any querystring
+      .split('?')[0]
+      .replace(
+        /(?<start>.*?\/)(?<type>organizations|issues|groups|customers|subscriptions|projects|teams|users)\/(?<second>[^/]+)\/(?<third>[^/]+\/)?(?<fourth>[^/]+\/)?(?<fifth>[^/]+\/)?(?<sixth>[^/]+\/)?(?<seventh>[^/]+\/)?(?<end>.*)/,
+        function (...args) {
+          const matches = args[args.length - 1];
 
-      // `end` should always match and at least return empty string,
-      // `tertiarySlug` can be undefined
-      let suffix = `${tertiarySlug ?? ''}${end}`;
+          let {type} = matches;
+          const {
+            start,
+            second,
+            third = '',
+            fourth = '',
+            fifth = '',
+            sixth = '',
+            seventh = '',
+            end,
+          } = matches;
 
-      if (isOrg && contentType === 'events/' && typeof tertiarySlug === 'string') {
-        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1004
-        // r"^(?P<organization_slug>[^\/]+)/events/(?P<project_slug>[^\/]+):(?P<event_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
-        suffix = tertiarySlug.replace(/[^:]+(.*)/, '{projectSlug}$1');
-      } else if (isOrg && contentType === 'members/') {
-        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1235
-        // r"^(?P<organization_slug>[^\/]+)/members/(?P<member_id>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
-        suffix = `${tertiarySlug}${end.replace(
-          /teams\/([^/]+)\/$/,
-          'teams/{teamSlug}/'
-        )}`;
-      } else if (isProject && tertiarySlug === 'teams/') {
-        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1894
-        // r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
-        suffix = `${tertiarySlug}{teamSlug}/`;
-      } else if (
-        (isProject && tertiarySlug === 'replays/') ||
-        (isOrg && contentType === 'replays/')
-      ) {
-        // Projct replays endpoint
-        // https://github.com/getsentry/sentry/blob/82074148753c21abf37f6f33408bb95691ed1597/src/sentry/api/urls.py#L2076
-        // r"^(?P<organization_slug>[^/]+)/(?P<project_slug>[^\/]+)/replays/(?P<replay_id>[\w-]+)/$",
+          // The `rule-conditions` endpoint really ought to be an org endpoint,
+          // and it's formatted like one, so for now, let's treat it like one.
+          // We can fix it before we return our final value. See
+          // `ProjectAgnosticRuleConditionsEndpoint` in `sentry/api/urls.py`.
+          if (third === 'rule-conditions/') {
+            type = 'organizations';
+          }
 
-        // Org replays endpoint
-        // https://github.com/getsentry/sentry/blob/e45aafb8a62b5728129aed67574cb37a4bd69075/src/sentry/api/urls.py#L1658
-        // r"^(?P<organization_slug>[^/]+)/replays/(?P<replay_id>[\w-]+)/$"
-        suffix = isOrg ? `{replayId}/` : `replays/{replayId}/`;
-      } else if (isRuleConditions) {
-        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1595
-        // r"^(?P<organization_slug>[^\/]+)/rule-conditions/$",
-        suffix = '';
-      } else if (type === 'issues' && contentType === 'events/') {
-        suffix = contentType + tertiarySlug;
-      }
+          const isOrgLike = [
+            'organizations',
+            'customers',
+            'issues',
+            'groups',
+            'users',
+            'subscriptions',
+          ].includes(type);
+          const isProjectLike = ['projects', 'teams'].includes(type);
 
-      const contentTypeOrSecondarySlug = isOrg
-        ? contentType ?? ''
-        : isRuleConditions
-        ? 'rule-conditions/'
-        : `{${SHORTENED_TYPE[type]}}/`;
+          // Org-like urls look like `/<type>/<slug>/<contentType>/...`, whereas
+          // project-like urls look like `/<type>/<org-slug>/<slug>/<contentType>/...`.
+          const primarySlug = isOrgLike ? second : third;
+          const contentType = isOrgLike ? third : fourth;
+          const secondarySlug = isOrgLike ? fourth : fifth;
+          const contentSubtype = isOrgLike ? fifth : sixth;
+          const tertiarySlug = isOrgLike ? sixth : seventh;
 
-      const orgSlug = noOrgSlug ? '' : '{orgSlug}/';
-      return `${start}/${type}/${orgSlug}${contentTypeOrSecondarySlug}${suffix}`;
-    }
+          let primarySlugPlaceholder = getSlugPlaceholder(type, primarySlug);
+          let secondarySlugPlaceholder = getSlugPlaceholder(contentType, secondarySlug);
+          const tertiarySlugPlaceholder = getSlugPlaceholder(
+            contentSubtype,
+            tertiarySlug
+          );
+
+          if (isProjectLike) {
+            primarySlugPlaceholder = '{orgSlug}/' + primarySlugPlaceholder;
+          }
+
+          if (isOrgLike) {
+            if (contentType === 'events/') {
+              if (secondarySlug.includes(':')) {
+                // OrganizationEventDetailsEndpoint
+                secondarySlugPlaceholder = '{projectSlug}:{eventId}/';
+              } else if (['latest/', 'oldest/'].includes(secondarySlug)) {
+                // GroupEventDetailsEndpoint
+                secondarySlugPlaceholder = secondarySlug;
+              }
+            } else if (contentType === 'plugins/') {
+              if (secondarySlug === 'configs/') {
+                // OrganizationPluginsConfigsEndpoint
+                secondarySlugPlaceholder = secondarySlug;
+              }
+            }
+          }
+
+          // Now that we've handled all our special cases based on type, we can
+          // restore the correct value for `rule-conditions`
+          if (contentType === 'rule-conditions/') {
+            type = 'projects';
+          }
+
+          return `${start}${type}/${primarySlugPlaceholder}${contentType}${secondarySlugPlaceholder}${contentSubtype}${tertiarySlugPlaceholder}${end}`;
+        }
+      )
   );
 }


### PR DESCRIPTION
This is a rewrite of our `sanitizePath` utility (which we use to parameterize paths in events we send to our frontend project) to both make the logic clearer and handle more cases. (The more cases we handle, the better we'll be able to group events and tags.)

Key changes:

- Extract a larger number of path segments in the regex.
- Give path segments generic names, so that meaningful names can be assigned to the correct segments depending on the type of endpoint.
- Classify all paths as either org-like (of the form `/<type>/<slug>/<contentType>/...`) or project-like (of the form `/<type>/<org-slug>/<slug>/<contentType>/...`).
- Default all path segments to the empty string (rather than `undefined`) so we don't have to do things like `contentType ?? ''`.
- Strip all querystrings.
- Test all paths both with and without the `https://sentry.io/api/0` prefix.
- Label all special cases in the function and all test cases with the corresponding endpoint class (rather than a permalink and/or the corresponding regex), both for ease of reading and in order to make the references more evergreen.
- Add a number of new test cases, and remove one or two corresponding to endpoints which no longer exist.