### PR TITLE
ref(tx-clusterer): Generalize clusterer with a namespace

### DIFF
--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -7,8 +7,9 @@ from rest_framework.response import Response
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.utils import get_date_range_from_stats_period
+from sentry.ingest.transaction_clusterer import ClustererRuleNamespace
 from sentry.ingest.transaction_clusterer.datasource import redis, snuba
-from sentry.ingest.transaction_clusterer.rules import get_redis_rules, get_rules
+from sentry.ingest.transaction_clusterer.rules import get_redis_txname_rules, get_rules
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 
 
@@ -53,8 +54,8 @@ class ProjectTransactionNamesCluster(ProjectEndpoint):
                     "unique_transaction_names": transaction_names
                     if return_all_names
                     else len(transaction_names),
-                    "rules_redis": get_redis_rules(project),
-                    "rules_projectoption": get_rules(project),
+                    "rules_redis": get_redis_txname_rules(project),
+                    "rules_projectoption": get_rules(ClustererRuleNamespace.TRANSACTIONS, project),
                 },
             }
         )

--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -8,8 +8,8 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.utils import get_date_range_from_stats_period
 from sentry.ingest.transaction_clusterer import ClustererRuleNamespace
+from sentry.ingest.transaction_clusterer import rules as rule_store
 from sentry.ingest.transaction_clusterer.datasource import redis, snuba
-from sentry.ingest.transaction_clusterer.rules import get_redis_rules, get_rules
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 
 
@@ -54,8 +54,12 @@ class ProjectTransactionNamesCluster(ProjectEndpoint):
                     "unique_transaction_names": transaction_names
                     if return_all_names
                     else len(transaction_names),
-                    "rules_redis": get_redis_rules(project),
-                    "rules_projectoption": get_rules(ClustererRuleNamespace.TRANSACTIONS, project),
+                    "rules_redis": rule_store.get_redis_rules(
+                        ClustererRuleNamespace.TRANSACTIONS, project
+                    ),
+                    "rules_projectoption": rule_store.get_rules(
+                        ClustererRuleNamespace.TRANSACTIONS, project
+                    ),
                 },
             }
         )

--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.utils import get_date_range_from_stats_period
-from sentry.ingest.transaction_clusterer import ClustererRuleNamespace
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer import rules as rule_store
 from sentry.ingest.transaction_clusterer.datasource import redis, snuba
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
@@ -55,10 +55,10 @@ class ProjectTransactionNamesCluster(ProjectEndpoint):
                     if return_all_names
                     else len(transaction_names),
                     "rules_redis": rule_store.get_redis_rules(
-                        ClustererRuleNamespace.TRANSACTIONS, project
+                        ClustererNamespace.TRANSACTIONS, project
                     ),
                     "rules_projectoption": rule_store.get_rules(
-                        ClustererRuleNamespace.TRANSACTIONS, project
+                        ClustererNamespace.TRANSACTIONS, project
                     ),
                 },
             }

--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -9,7 +9,7 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.utils import get_date_range_from_stats_period
 from sentry.ingest.transaction_clusterer import ClustererRuleNamespace
 from sentry.ingest.transaction_clusterer.datasource import redis, snuba
-from sentry.ingest.transaction_clusterer.rules import get_redis_txname_rules, get_rules
+from sentry.ingest.transaction_clusterer.rules import get_redis_rules, get_rules
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 
 
@@ -54,7 +54,7 @@ class ProjectTransactionNamesCluster(ProjectEndpoint):
                     "unique_transaction_names": transaction_names
                     if return_all_names
                     else len(transaction_names),
-                    "rules_redis": get_redis_txname_rules(project),
+                    "rules_redis": get_redis_rules(project),
                     "rules_projectoption": get_rules(ClustererRuleNamespace.TRANSACTIONS, project),
                 },
             }

--- a/src/sentry/ingest/transaction_clusterer/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/__init__.py
@@ -5,22 +5,27 @@ from enum import Enum
 from typing import Dict
 
 
-class ClustererDataNamespace(Enum):
-    TRANSACTIONS = "txnames"
+class ClustererNamespace(Enum):
+    TRANSACTIONS = "transactions"
 
 
-class ClustererRuleNamespace(Enum):
-    TRANSACTIONS = "txrules"
+class NamespaceOption(Enum):
+
+    DATA = "data"
+    """Prefix to store input data to the clusterer."""
+    RULES = "rules"
+    """Prefix to store produced rules in the clusterer, in non-persistent storage."""
+    PERSISTENT_STORAGE = "storage"
+    """Option name to store produced rules in the clusterer, in persistent storage."""
+    TRACKER = "tracker"
+    """Option name to store tracking data of this namespace."""
 
 
-class PROJECT_OPTION_KEYS(Enum):
-    STORAGE = "storage_option"
-    TRACKER = "tracker_option"
-
-
-PROJECT_OPTION_NAMES: Dict[ClustererRuleNamespace, Dict[PROJECT_OPTION_KEYS, str]] = {
-    ClustererRuleNamespace.TRANSACTIONS: {
-        PROJECT_OPTION_KEYS.STORAGE: "sentry:transaction_name_cluster_rules",
-        PROJECT_OPTION_KEYS.TRACKER: "txcluster.rules_per_project",
+CLUSTERER_NAMESPACE_OPTIONS: Dict[ClustererNamespace, Dict[NamespaceOption, str]] = {
+    ClustererNamespace.TRANSACTIONS: {
+        NamespaceOption.DATA: "txnames",
+        NamespaceOption.RULES: "txrules",
+        NamespaceOption.PERSISTENT_STORAGE: "sentry:transaction_name_cluster_rules",
+        NamespaceOption.TRACKER: "txcluster.rules_per_project",
     }
 }

--- a/src/sentry/ingest/transaction_clusterer/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/__init__.py
@@ -1,1 +1,26 @@
 """ Strategies for clustering high-cardinality transaction names """
+
+
+from enum import Enum
+from typing import Dict
+
+
+class ClustererDataNamespace(Enum):
+    TRANSACTIONS = "txnames"
+
+
+class ClustererRuleNamespace(Enum):
+    TRANSACTIONS = "txrules"
+
+
+class PROJECT_OPTION_KEYS(Enum):
+    STORAGE = "storage_option"
+    TRACKER = "tracker_option"
+
+
+PROJECT_OPTION_NAMES: Dict[ClustererRuleNamespace, Dict[PROJECT_OPTION_KEYS, str]] = {
+    ClustererRuleNamespace.TRANSACTIONS: {
+        PROJECT_OPTION_KEYS.STORAGE: "sentry:transaction_name_cluster_rules",
+        PROJECT_OPTION_KEYS.TRACKER: "txcluster.rules_per_project",
+    }
+}

--- a/src/sentry/ingest/transaction_clusterer/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/__init__.py
@@ -1,31 +1,29 @@
 """ Strategies for clustering high-cardinality transaction names """
 
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
 
 
-class ClustererNamespace(Enum):
-    TRANSACTIONS = "transactions"
-
-
-class NamespaceOption(Enum):
-
-    DATA = "data"
+@dataclass(frozen=True)
+class NamespaceOption:
+    name: str
+    """Human-friendly name of the namespace. For example, logging purposes."""
+    data: str
     """Prefix to store input data to the clusterer."""
-    RULES = "rules"
+    rules: str
     """Prefix to store produced rules in the clusterer, in non-persistent storage."""
-    PERSISTENT_STORAGE = "storage"
+    persistent_storage: str
     """Option name to store produced rules in the clusterer, in persistent storage."""
-    TRACKER = "tracker"
+    tracker: str
     """Option name to store tracking data of this namespace."""
 
 
-CLUSTERER_NAMESPACE_OPTIONS: Dict[ClustererNamespace, Dict[NamespaceOption, str]] = {
-    ClustererNamespace.TRANSACTIONS: {
-        NamespaceOption.DATA: "txnames",
-        NamespaceOption.RULES: "txrules",
-        NamespaceOption.PERSISTENT_STORAGE: "sentry:transaction_name_cluster_rules",
-        NamespaceOption.TRACKER: "txcluster.rules_per_project",
-    }
-}
+class ClustererNamespace(Enum):
+    TRANSACTIONS = NamespaceOption(
+        name="transactions",
+        data="txnames",
+        rules="txrules",
+        persistent_storage="sentry:transaction_name_cluster_rules",
+        tracker="txcluster.rules_per_project",
+    )

--- a/src/sentry/ingest/transaction_clusterer/base.py
+++ b/src/sentry/ingest/transaction_clusterer/base.py
@@ -14,7 +14,7 @@ class Clusterer:
     """
 
     @abstractmethod
-    def add_input(self, transaction_name: Iterable[str]) -> None:
+    def add_input(self, strings: Iterable[str]) -> None:
         """Add a batch of transaction names to the clusterer's state"""
         ...
 

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
+from sentry.ingest.transaction_clusterer import ClustererDataNamespace, ClustererRuleNamespace
 from sentry.ingest.transaction_clusterer.datasource import (
     HTTP_404_TAG,
     TRANSACTION_SOURCE_SANITIZED,
@@ -25,29 +26,28 @@ MAX_SET_SIZE = 2000
 SET_TTL = 24 * 60 * 60
 
 
-REDIS_KEY_PREFIX = "txnames:"
-
 add_to_set = redis.load_script("utils/sadd_capped.lua")
 logger = logging.getLogger(__name__)
 
 
-def _get_redis_key(project: Project) -> str:
-    return f"{REDIS_KEY_PREFIX}o:{project.organization_id}:p:{project.id}"
+def _get_redis_key(namespace: ClustererDataNamespace, project: Project) -> str:
+    return f"{namespace.value}:o:{project.organization_id}:p:{project.id}"
 
 
 def get_redis_client() -> Any:
+    # XXX(iker): we may want to revisit the decision of having a single Redis cluster.
     cluster_key = settings.SENTRY_TRANSACTION_NAMES_REDIS_CLUSTER
     return redis.redis_clusters.get(cluster_key)
 
 
-def _get_all_keys() -> Iterator[str]:
+def _get_all_keys(namespace: ClustererDataNamespace) -> Iterator[str]:
     client = get_redis_client()
-    return client.scan_iter(match=f"{REDIS_KEY_PREFIX}*")  # type: ignore
+    return client.scan_iter(match=f"{namespace.value}:*")  # type: ignore
 
 
-def get_active_projects() -> Iterator[Project]:
+def get_active_projects(namespace: ClustererDataNamespace) -> Iterator[Project]:
     """Scan redis for projects and fetch their db models"""
-    for key in _get_all_keys():
+    for key in _get_all_keys(namespace):
         project_id = int(key.split(":")[-1])
         # NOTE: Would be nice to do a `select_related` on project.organization
         # because we need it for the feature flag, but I don't know how to do
@@ -64,21 +64,21 @@ def get_active_projects() -> Iterator[Project]:
 def _store_transaction_name(project: Project, transaction_name: str) -> None:
     with sentry_sdk.start_span(op="txcluster.store_transaction_name"):
         client = get_redis_client()
-        redis_key = _get_redis_key(project)
+        redis_key = _get_redis_key(ClustererDataNamespace.TRANSACTIONS, project)
         add_to_set(client, [redis_key], [transaction_name, MAX_SET_SIZE, SET_TTL])
 
 
 def get_transaction_names(project: Project) -> Iterator[str]:
     """Return all transaction names stored for the given project"""
     client = get_redis_client()
-    redis_key = _get_redis_key(project)
+    redis_key = _get_redis_key(ClustererDataNamespace.TRANSACTIONS, project)
 
     return client.sscan_iter(redis_key)  # type: ignore
 
 
 def clear_transaction_names(project: Project) -> None:
     client = get_redis_client()
-    redis_key = _get_redis_key(project)
+    redis_key = _get_redis_key(ClustererDataNamespace.TRANSACTIONS, project)
 
     client.delete(redis_key)
 
@@ -133,5 +133,5 @@ def _bump_rule_lifetime(project: Project, event_data: Mapping[str, Any]) -> None
         if len(applied_rule) == 2:
             pattern = applied_rule[0]
             # Only one clustering rule is applied per project
-            clusterer_rules.bump_last_used(project, pattern)
+            clusterer_rules.bump_last_used(ClustererRuleNamespace.TRANSACTIONS, project, pattern)
             return

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -7,11 +7,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
-from sentry.ingest.transaction_clusterer import (
-    CLUSTERER_NAMESPACE_OPTIONS,
-    ClustererNamespace,
-    NamespaceOption,
-)
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.datasource import (
     HTTP_404_TAG,
     TRANSACTION_SOURCE_SANITIZED,
@@ -35,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_redis_key(namespace: ClustererNamespace, project: Project) -> str:
-    prefix = CLUSTERER_NAMESPACE_OPTIONS[namespace][NamespaceOption.DATA]
+    prefix = namespace.value.data
     return f"{prefix}:o:{project.organization_id}:p:{project.id}"
 
 
@@ -47,7 +43,7 @@ def get_redis_client() -> Any:
 
 def _get_all_keys(namespace: ClustererNamespace) -> Iterator[str]:
     client = get_redis_client()
-    prefix = CLUSTERER_NAMESPACE_OPTIONS[namespace][NamespaceOption.DATA]
+    prefix = namespace.value.data
     return client.scan_iter(match=f"{prefix}:*")  # type: ignore
 
 

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -3,6 +3,11 @@ from typing import Dict, List, Mapping, Protocol, Sequence, Tuple
 
 import sentry_sdk
 
+from sentry.ingest.transaction_clusterer import (
+    PROJECT_OPTION_KEYS,
+    PROJECT_OPTION_NAMES,
+    ClustererRuleNamespace,
+)
 from sentry.ingest.transaction_clusterer.datasource.redis import get_redis_client
 from sentry.models import Project
 from sentry.utils import metrics
@@ -40,9 +45,11 @@ class RedisRuleStore:
     responsible for that.
     """
 
-    @staticmethod
-    def _get_rules_key(project: Project) -> str:
-        return f"txrules:o:{project.organization_id}:p:{project.id}"
+    def __init__(self, namespace: ClustererRuleNamespace):
+        self._namespace = namespace
+
+    def _get_rules_key(self, project: Project) -> str:
+        return f"{self._namespace.value}:o:{project.organization_id}:p:{project.id}"
 
     def read(self, project: Project) -> RuleSet:
         client = get_redis_client()
@@ -75,10 +82,14 @@ class RedisRuleStore:
 
 
 class ProjectOptionRuleStore:
-    _option_name = "sentry:transaction_name_cluster_rules"
+    def __init__(self, namespace: ClustererRuleNamespace):
+        self._storage_option_name = PROJECT_OPTION_NAMES[namespace][PROJECT_OPTION_KEYS.STORAGE]
+        self._rule_tracker_option_name = PROJECT_OPTION_NAMES[namespace][
+            PROJECT_OPTION_KEYS.TRACKER
+        ]
 
     def read_sorted(self, project: Project) -> List[Tuple[ReplacementRule, int]]:
-        ret = project.get_option(self._option_name, default=[])
+        ret = project.get_option(self._storage_option_name, default=[])
         # normalize tuple vs. list for json writing
         return [tuple(lst) for lst in ret]  # type: ignore[misc]
 
@@ -97,16 +108,17 @@ class ProjectOptionRuleStore:
         converted_rules = [list(tup) for tup in self._sort(rules)]
 
         # Track the number of rules per project.
-        metrics.timing("txcluster.rules_per_project", len(converted_rules))
+        metrics.timing(self._rule_tracker_option_name, len(converted_rules))
 
-        project.update_option(self._option_name, converted_rules)
+        project.update_option(self._storage_option_name, converted_rules)
 
 
 class CompositeRuleStore:
     #: Maximum number (non-negative integer) of rules to write to stores.
     MERGE_MAX_RULES: int = 50
 
-    def __init__(self, stores: List[RuleStore]):
+    def __init__(self, namespace: ClustererRuleNamespace, stores: List[RuleStore]):
+        self._namespace = namespace
         self._stores = stores
 
     def read(self, project: Project) -> RuleSet:
@@ -136,9 +148,7 @@ class CompositeRuleStore:
 
         if self.MERGE_MAX_RULES < len(rules):
             with sentry_sdk.configure_scope() as scope:
-                sentry_sdk.set_measurement(
-                    "discarded_transactions", len(rules) - self.MERGE_MAX_RULES
-                )
+                sentry_sdk.set_measurement("discarded_rules", len(rules) - self.MERGE_MAX_RULES)
                 scope.set_context(
                     "clustering_rules_max",
                     {
@@ -147,7 +157,8 @@ class CompositeRuleStore:
                         "discarded_rules": sorted_rules[self.MERGE_MAX_RULES :],
                     },
                 )
-                sentry_sdk.capture_message("Transaction clusterer discarded rules", level="warn")
+                sentry_sdk.set_tag("namespace", self._namespace.value)
+                sentry_sdk.capture_message("Clusterer discarded rules", level="warn")
             sorted_rules = sorted_rules[: self.MERGE_MAX_RULES]
 
         return {rule: last_seen for rule, last_seen in sorted_rules}
@@ -168,17 +179,19 @@ def _now() -> int:
     return int(datetime.now(timezone.utc).timestamp())
 
 
-def get_rules(project: Project) -> RuleSet:
+def get_rules(namespace: ClustererRuleNamespace, project: Project) -> RuleSet:
     """Get rules from project options."""
-    return ProjectOptionRuleStore().read(project)
+    return ProjectOptionRuleStore(namespace).read(project)
 
 
-def get_redis_rules(project: Project) -> RuleSet:
+def get_redis_rules(namespace: ClustererRuleNamespace, project: Project) -> RuleSet:
     """Get rules from Redis."""
-    return RedisRuleStore().read(project)
+    return RedisRuleStore(namespace).read(project)
 
 
-def get_sorted_rules(project: Project) -> List[Tuple[ReplacementRule, int]]:
+def get_sorted_rules(
+    namespace: ClustererRuleNamespace, project: Project
+) -> List[Tuple[ReplacementRule, int]]:
     """Public interface for fetching rules for a project.
 
     The rules are fetched from project options rather than redis, because
@@ -187,10 +200,12 @@ def get_sorted_rules(project: Project) -> List[Tuple[ReplacementRule, int]]:
     The rules are ordered by specifity, meaning that rules that go deeper
     into the URL tree occur first.
     """
-    return ProjectOptionRuleStore().read_sorted(project)
+    return ProjectOptionRuleStore(namespace).read_sorted(project)
 
 
-def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> int:
+def update_rules(
+    namespace: ClustererRuleNamespace, project: Project, new_rules: Sequence[ReplacementRule]
+) -> int:
     """Write newly discovered rules to projection option and redis, and update last_used.
 
     Return the number of _new_ rules (that were not already present in project option).
@@ -202,13 +217,14 @@ def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> int:
 
     last_seen = _now()
     new_rule_set = {rule: last_seen for rule in new_rules}
-    project_option = ProjectOptionRuleStore()
+    project_option = ProjectOptionRuleStore(namespace)
     rule_store = CompositeRuleStore(
+        namespace,
         [
-            RedisRuleStore(),
+            RedisRuleStore(namespace),
             project_option,
             LocalRuleStore(new_rule_set),
-        ]
+        ],
     )
 
     rule_store.merge(project)
@@ -218,10 +234,10 @@ def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> int:
     return num_rules_added
 
 
-def bump_last_used(project: Project, pattern: str) -> None:
+def bump_last_used(namespace: ClustererRuleNamespace, project: Project, pattern: str) -> None:
     """If an entry for `pattern` exists, bump its last_used timestamp in redis.
 
     The updated last_used timestamps are transferred from redis to project options
     in the `cluster_projects` task.
     """
-    RedisRuleStore().update_rule(project, pattern, _now())
+    RedisRuleStore(namespace).update_rule(project, pattern, _now())

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -7,7 +7,7 @@ from sentry.models import Project
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 
-from . import ClustererDataNamespace, ClustererRuleNamespace, rules
+from . import ClustererNamespace, rules
 from .datasource import redis
 from .meta import track_clusterer_run
 from .tree import TreeClusterer
@@ -40,7 +40,7 @@ def spawn_clusterers(**kwargs: Any) -> None:
     """Look for existing transaction name sets in redis and spawn clusterers for each"""
     with sentry_sdk.start_span(op="txcluster_spawn"):
         project_count = 0
-        project_iter = redis.get_active_projects(ClustererDataNamespace.TRANSACTIONS)
+        project_iter = redis.get_active_projects(ClustererNamespace.TRANSACTIONS)
         while batch := list(islice(project_iter, PROJECTS_PER_TASK)):
             project_count += len(batch)
             cluster_projects.delay(batch)
@@ -75,7 +75,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 # so we must update the stores to bring these values to
                 # project options, even if there aren't any new rules.
                 num_rules_added = rules.update_rules(
-                    ClustererRuleNamespace.TRANSACTIONS, project, new_rules
+                    ClustererNamespace.TRANSACTIONS, project, new_rules
                 )
 
                 # Track a global counter of new rules:

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -7,7 +7,7 @@ from sentry.models import Project
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 
-from . import rules
+from . import ClustererDataNamespace, ClustererRuleNamespace, rules
 from .datasource import redis
 from .meta import track_clusterer_run
 from .tree import TreeClusterer
@@ -40,7 +40,7 @@ def spawn_clusterers(**kwargs: Any) -> None:
     """Look for existing transaction name sets in redis and spawn clusterers for each"""
     with sentry_sdk.start_span(op="txcluster_spawn"):
         project_count = 0
-        project_iter = redis.get_active_projects()
+        project_iter = redis.get_active_projects(ClustererDataNamespace.TRANSACTIONS)
         while batch := list(islice(project_iter, PROJECTS_PER_TASK)):
             project_count += len(batch)
             cluster_projects.delay(batch)
@@ -74,7 +74,9 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                 # The Redis store may have more up-to-date last_seen values,
                 # so we must update the stores to bring these values to
                 # project options, even if there aren't any new rules.
-                num_rules_added = rules.update_rules(project, new_rules)
+                num_rules_added = rules.update_rules(
+                    ClustererRuleNamespace.TRANSACTIONS, project, new_rules
+                )
 
                 # Track a global counter of new rules:
                 metrics.incr("txcluster.new_rules_discovered", num_rules_added)

--- a/src/sentry/ingest/transaction_clusterer/tree.py
+++ b/src/sentry/ingest/transaction_clusterer/tree.py
@@ -78,9 +78,9 @@ class TreeClusterer(Clusterer):
         self._tree = Node()
         self._rules: Optional[List[ReplacementRule]] = None
 
-    def add_input(self, transaction_names: Iterable[str]) -> None:
-        for tx_name in transaction_names:
-            parts = tx_name.split(SEP)
+    def add_input(self, strings: Iterable[str]) -> None:
+        for string in strings:
+            parts = string.split(SEP)
             node = self._tree
             for part in parts:
                 node = node.setdefault(part, Node())
@@ -96,7 +96,7 @@ class TreeClusterer(Clusterer):
 
     def _extract_rules(self) -> None:
         """Merge high-cardinality nodes in the graph and extract rules"""
-        with sentry_sdk.start_span(op="txcluster_merge"):
+        with sentry_sdk.start_span(op="cluster_merge"):
             self._tree.merge(self._merge_threshold)
 
         # Generate exactly 1 rule for every merge

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -31,7 +31,7 @@ from sentry.ingest.inbound_filters import (
     get_all_filter_specs,
     get_filter_key,
 )
-from sentry.ingest.transaction_clusterer import ClustererRuleNamespace
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.meta import get_clusterer_meta
 from sentry.ingest.transaction_clusterer.rules import (
     TRANSACTION_NAME_RULE_TTL_SECS,
@@ -222,7 +222,7 @@ def get_transaction_names_config(project: Project) -> Optional[Sequence[Transact
     if not features.has("organizations:transaction-name-normalize", project.organization):
         return None
 
-    cluster_rules = get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, project)
+    cluster_rules = get_sorted_rules(ClustererNamespace.TRANSACTIONS, project)
     if not cluster_rules:
         return None
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -31,6 +31,7 @@ from sentry.ingest.inbound_filters import (
     get_all_filter_specs,
     get_filter_key,
 )
+from sentry.ingest.transaction_clusterer import ClustererRuleNamespace
 from sentry.ingest.transaction_clusterer.meta import get_clusterer_meta
 from sentry.ingest.transaction_clusterer.rules import (
     TRANSACTION_NAME_RULE_TTL_SECS,
@@ -221,7 +222,7 @@ def get_transaction_names_config(project: Project) -> Optional[Sequence[Transact
     if not features.has("organizations:transaction-name-normalize", project.organization):
         return None
 
-    cluster_rules = get_sorted_rules(project)
+    cluster_rules = get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, project)
     if not cluster_rules:
         return None
 

--- a/tests/sentry/api/endpoints/test_project_transaction_names.py
+++ b/tests/sentry/api/endpoints/test_project_transaction_names.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from sentry.ingest.transaction_clusterer import ClustererDataNamespace
 from sentry.ingest.transaction_clusterer.datasource.redis import _get_redis_key, get_redis_client
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -34,7 +35,9 @@ class ProjectTransactionNamesClusterTest(APITestCase):
             event["transaction_info"] = {"source": "url"}
             self.store_event(event, project_id=self.project.id)
 
-            redis_client.sadd(_get_redis_key(self.project), transaction)
+            redis_client.sadd(
+                _get_redis_key(ClustererDataNamespace.TRANSACTIONS, self.project), transaction
+            )
 
     def _test_get(self, datasource):
         response = self.client.get(

--- a/tests/sentry/api/endpoints/test_project_transaction_names.py
+++ b/tests/sentry/api/endpoints/test_project_transaction_names.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from sentry.ingest.transaction_clusterer import ClustererDataNamespace
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.datasource.redis import _get_redis_key, get_redis_client
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -36,7 +36,7 @@ class ProjectTransactionNamesClusterTest(APITestCase):
             self.store_event(event, project_id=self.project.id)
 
             redis_client.sadd(
-                _get_redis_key(ClustererDataNamespace.TRANSACTIONS, self.project), transaction
+                _get_redis_key(ClustererNamespace.TRANSACTIONS, self.project), transaction
             )
 
     def _test_get(self, datasource):

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from freezegun import freeze_time
 
+from sentry.ingest.transaction_clusterer import ClustererDataNamespace, ClustererRuleNamespace
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _store_transaction_name,
@@ -133,7 +134,7 @@ def test_record_transactions(mocked_record, default_organization, source, txname
 
 def test_sort_rules():
     rules = {"/a/*/**": 1, "/a/**": 2, "/a/*/c/**": 3}
-    assert ProjectOptionRuleStore()._sort(rules) == [
+    assert ProjectOptionRuleStore(ClustererRuleNamespace.TRANSACTIONS)._sort(rules) == [
         ("/a/*/c/**", 3),
         ("/a/*/**", 1),
         ("/a/**", 2),
@@ -143,38 +144,60 @@ def test_sort_rules():
 @mock.patch("sentry.ingest.transaction_clusterer.rules.CompositeRuleStore.MERGE_MAX_RULES", 2)
 @pytest.mark.django_db
 def test_max_rule_threshold_merge_composite_store(default_project):
-    assert len(get_sorted_rules(default_project)) == 0
+    assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 0
 
     with freeze_time("2000-01-01 01:00:00"):
-        update_rules(default_project, [ReplacementRule("foo/foo")])
-        update_rules(default_project, [ReplacementRule("bar/bar")])
+        update_rules(
+            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("foo/foo")]
+        )
+        update_rules(
+            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("bar/bar")]
+        )
 
-    assert get_sorted_rules(default_project) == [("foo/foo", 946688400), ("bar/bar", 946688400)]
+    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        ("foo/foo", 946688400),
+        ("bar/bar", 946688400),
+    ]
 
     with freeze_time("2000-01-01 02:00:00"):
-        update_rules(default_project, [ReplacementRule("baz/baz")])
-        assert len(get_sorted_rules(default_project)) == 2
-        update_rules(default_project, [ReplacementRule("qux/qux")])
-        assert len(get_sorted_rules(default_project)) == 2
+        update_rules(
+            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("baz/baz")]
+        )
+        assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 2
+        update_rules(
+            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("qux/qux")]
+        )
+        assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 2
 
-    assert get_sorted_rules(default_project) == [("baz/baz", 946692000), ("qux/qux", 946692000)]
+    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        ("baz/baz", 946692000),
+        ("qux/qux", 946692000),
+    ]
 
 
 @pytest.mark.django_db
 def test_save_rules(default_project):
     project = default_project
 
-    project_rules = get_rules(project)
+    project_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project)
     assert project_rules == {}
 
     with freeze_time("2012-01-14 12:00:01"):
-        assert 2 == update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
-    project_rules = get_rules(project)
+        assert 2 == update_rules(
+            ClustererRuleNamespace.TRANSACTIONS,
+            default_project,
+            [ReplacementRule("foo"), ReplacementRule("bar")],
+        )
+    project_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project)
     assert project_rules == {"foo": 1326542401, "bar": 1326542401}
 
     with freeze_time("2012-01-14 12:00:02"):
-        assert 1 == update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
-    project_rules = get_rules(project)
+        assert 1 == update_rules(
+            ClustererRuleNamespace.TRANSACTIONS,
+            default_project,
+            [ReplacementRule("bar"), ReplacementRule("zap")],
+        )
+    project_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project)
     assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
 
 
@@ -211,8 +234,8 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
     cluster_projects_delay.reset_mock()
 
     # Not stored enough transactions yet
-    assert get_rules(project1) == {}
-    assert get_rules(project2) == {}
+    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {}
+    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project2) == {}
 
     assert (
         get_clusterer_meta(project1)
@@ -243,7 +266,7 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
     # One project per batch now:
     assert cluster_projects_delay.call_count == 2, cluster_projects_delay.call_args
 
-    pr_rules = get_rules(project1)
+    pr_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project1)
     assert pr_rules.keys() == {
         "/org/*/**",
         "/user/*/**",
@@ -264,27 +287,32 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
 @pytest.mark.django_db
 def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default_project):
     project = default_project
-    assert get_rules(project) == {}
+    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project) == {}
 
     _store_transaction_name(project, "/transaction/number/1")
     cluster_projects([project])
     # Clusterer didn't create rules. Still, it updates the stores.
     assert mock_update_rules.call_count == 1
-    assert mock_update_rules.call_args == mock.call(project, [])
-    assert get_rules(project) == {}  # Transaction names are deleted if there aren't enough
+    assert mock_update_rules.call_args == mock.call(
+        ClustererRuleNamespace.TRANSACTIONS, project, []
+    )
+    # Transaction names are deleted if there aren't enough
+    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project) == {}
 
     _store_transaction_name(project, "/transaction/number/1")
     _store_transaction_name(project, "/transaction/number/2")
     cluster_projects([project])
     assert mock_update_rules.call_count == 2
-    assert mock_update_rules.call_args == mock.call(project, ["/transaction/number/*/**"])
+    assert mock_update_rules.call_args == mock.call(
+        ClustererRuleNamespace.TRANSACTIONS, project, ["/transaction/number/*/**"]
+    )
 
 
 @pytest.mark.django_db
 def test_get_deleted_project():
     deleted_project = Project(pk=666, organization=Organization(pk=666))
     _store_transaction_name(deleted_project, "foo")
-    assert list(get_active_projects()) == []
+    assert list(get_active_projects(ClustererDataNamespace.TRANSACTIONS)) == []
 
 
 @pytest.mark.django_db
@@ -301,7 +329,7 @@ def test_transaction_clusterer_generates_rules(default_project):
         assert _get_projconfig_tx_rules(default_project) is None
 
     rules = {"/rule/*/0/**": 0, "/rule/*/1/**": 1}
-    ProjectOptionRuleStore().write(default_project, rules)
+    ProjectOptionRuleStore(ClustererRuleNamespace.TRANSACTIONS).write(default_project, rules)
 
     with Feature({feature: False}):
         assert _get_projconfig_tx_rules(default_project) is None
@@ -341,7 +369,7 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 1):
             spawn_clusterers()
 
-        assert get_rules(project1) == {"/user/*/**": 1}
+        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
 
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 2):
             record_transaction_name(
@@ -361,14 +389,14 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
             )
 
         # _get_rules fetches from project options, which arent updated yet.
-        assert get_redis_rules(project1) == {"/user/*/**": 2}
-        assert get_rules(project1) == {"/user/*/**": 1}
+        assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
+        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
         # Update rules to update the project option storage.
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 3):
-            assert 0 == update_rules(project1, [])
+            assert 0 == update_rules(ClustererRuleNamespace.TRANSACTIONS, project1, [])
         # After project options are updated, the last_seen should also be updated.
-        assert get_redis_rules(project1) == {"/user/*/**": 2}
-        assert get_rules(project1) == {"/user/*/**": 2}
+        assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
+        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 3)
@@ -409,31 +437,49 @@ def test_dont_store_inexisting_rules(_, default_organization):
             rogue_transaction,
         )
 
-        assert get_rules(project1) == {"/user/*/**": 1}
+        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
 
 
 @pytest.mark.django_db
 def test_stale_rules_arent_saved(default_project):
-    assert len(get_sorted_rules(default_project)) == 0
+    assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 0
 
     with freeze_time("2000-01-01 01:00:00"):
-        update_rules(default_project, [ReplacementRule("foo/foo")])
-    assert get_sorted_rules(default_project) == [("foo/foo", 946688400)]
+        update_rules(
+            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("foo/foo")]
+        )
+    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        ("foo/foo", 946688400)
+    ]
 
     with freeze_time("2000-02-02 02:00:00"):
-        update_rules(default_project, [ReplacementRule("bar/bar")])
-    assert get_sorted_rules(default_project) == [("bar/bar", 949456800), ("foo/foo", 946688400)]
+        update_rules(
+            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("bar/bar")]
+        )
+    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        ("bar/bar", 949456800),
+        ("foo/foo", 946688400),
+    ]
 
     with freeze_time("2001-01-01 01:00:00"):
-        update_rules(default_project, [ReplacementRule("baz/baz")])
-    assert get_sorted_rules(default_project) == [("baz/baz", 978310800)]
+        update_rules(
+            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("baz/baz")]
+        )
+    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        ("baz/baz", 978310800)
+    ]
 
 
 def test_bump_last_used():
     """Redis update works and does not delete other keys in the set."""
     project1 = Project(id=123, name="project1")
-    RedisRuleStore().write(project1, {"foo": 1, "bar": 2})
-    assert get_redis_rules(project1) == {"foo": 1, "bar": 2}
+    RedisRuleStore(namespace=ClustererRuleNamespace.TRANSACTIONS).write(
+        project1, {"foo": 1, "bar": 2}
+    )
+    assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"foo": 1, "bar": 2}
     with freeze_time("2000-01-01 01:00:00"):
-        bump_last_used(project1, "bar")
-    assert get_redis_rules(project1) == {"foo": 1, "bar": 946688400}
+        bump_last_used(ClustererRuleNamespace.TRANSACTIONS, project1, "bar")
+    assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {
+        "foo": 1,
+        "bar": 946688400,
+    }

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from freezegun import freeze_time
 
-from sentry.ingest.transaction_clusterer import ClustererDataNamespace, ClustererRuleNamespace
+from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _store_transaction_name,
@@ -134,7 +134,7 @@ def test_record_transactions(mocked_record, default_organization, source, txname
 
 def test_sort_rules():
     rules = {"/a/*/**": 1, "/a/**": 2, "/a/*/c/**": 3}
-    assert ProjectOptionRuleStore(ClustererRuleNamespace.TRANSACTIONS)._sort(rules) == [
+    assert ProjectOptionRuleStore(ClustererNamespace.TRANSACTIONS)._sort(rules) == [
         ("/a/*/c/**", 3),
         ("/a/*/**", 1),
         ("/a/**", 2),
@@ -144,32 +144,24 @@ def test_sort_rules():
 @mock.patch("sentry.ingest.transaction_clusterer.rules.CompositeRuleStore.MERGE_MAX_RULES", 2)
 @pytest.mark.django_db
 def test_max_rule_threshold_merge_composite_store(default_project):
-    assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 0
+    assert len(get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project)) == 0
 
     with freeze_time("2000-01-01 01:00:00"):
-        update_rules(
-            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("foo/foo")]
-        )
-        update_rules(
-            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("bar/bar")]
-        )
+        update_rules(ClustererNamespace.TRANSACTIONS, default_project, [ReplacementRule("foo/foo")])
+        update_rules(ClustererNamespace.TRANSACTIONS, default_project, [ReplacementRule("bar/bar")])
 
-    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+    assert get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project) == [
         ("foo/foo", 946688400),
         ("bar/bar", 946688400),
     ]
 
     with freeze_time("2000-01-01 02:00:00"):
-        update_rules(
-            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("baz/baz")]
-        )
-        assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 2
-        update_rules(
-            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("qux/qux")]
-        )
-        assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 2
+        update_rules(ClustererNamespace.TRANSACTIONS, default_project, [ReplacementRule("baz/baz")])
+        assert len(get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project)) == 2
+        update_rules(ClustererNamespace.TRANSACTIONS, default_project, [ReplacementRule("qux/qux")])
+        assert len(get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project)) == 2
 
-    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+    assert get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project) == [
         ("baz/baz", 946692000),
         ("qux/qux", 946692000),
     ]
@@ -179,25 +171,25 @@ def test_max_rule_threshold_merge_composite_store(default_project):
 def test_save_rules(default_project):
     project = default_project
 
-    project_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project)
+    project_rules = get_rules(ClustererNamespace.TRANSACTIONS, project)
     assert project_rules == {}
 
     with freeze_time("2012-01-14 12:00:01"):
         assert 2 == update_rules(
-            ClustererRuleNamespace.TRANSACTIONS,
+            ClustererNamespace.TRANSACTIONS,
             default_project,
             [ReplacementRule("foo"), ReplacementRule("bar")],
         )
-    project_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project)
+    project_rules = get_rules(ClustererNamespace.TRANSACTIONS, project)
     assert project_rules == {"foo": 1326542401, "bar": 1326542401}
 
     with freeze_time("2012-01-14 12:00:02"):
         assert 1 == update_rules(
-            ClustererRuleNamespace.TRANSACTIONS,
+            ClustererNamespace.TRANSACTIONS,
             default_project,
             [ReplacementRule("bar"), ReplacementRule("zap")],
         )
-    project_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project)
+    project_rules = get_rules(ClustererNamespace.TRANSACTIONS, project)
     assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
 
 
@@ -234,8 +226,8 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
     cluster_projects_delay.reset_mock()
 
     # Not stored enough transactions yet
-    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {}
-    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project2) == {}
+    assert get_rules(ClustererNamespace.TRANSACTIONS, project1) == {}
+    assert get_rules(ClustererNamespace.TRANSACTIONS, project2) == {}
 
     assert (
         get_clusterer_meta(project1)
@@ -266,7 +258,7 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
     # One project per batch now:
     assert cluster_projects_delay.call_count == 2, cluster_projects_delay.call_args
 
-    pr_rules = get_rules(ClustererRuleNamespace.TRANSACTIONS, project1)
+    pr_rules = get_rules(ClustererNamespace.TRANSACTIONS, project1)
     assert pr_rules.keys() == {
         "/org/*/**",
         "/user/*/**",
@@ -287,24 +279,22 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
 @pytest.mark.django_db
 def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default_project):
     project = default_project
-    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project) == {}
+    assert get_rules(ClustererNamespace.TRANSACTIONS, project) == {}
 
     _store_transaction_name(project, "/transaction/number/1")
     cluster_projects([project])
     # Clusterer didn't create rules. Still, it updates the stores.
     assert mock_update_rules.call_count == 1
-    assert mock_update_rules.call_args == mock.call(
-        ClustererRuleNamespace.TRANSACTIONS, project, []
-    )
+    assert mock_update_rules.call_args == mock.call(ClustererNamespace.TRANSACTIONS, project, [])
     # Transaction names are deleted if there aren't enough
-    assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project) == {}
+    assert get_rules(ClustererNamespace.TRANSACTIONS, project) == {}
 
     _store_transaction_name(project, "/transaction/number/1")
     _store_transaction_name(project, "/transaction/number/2")
     cluster_projects([project])
     assert mock_update_rules.call_count == 2
     assert mock_update_rules.call_args == mock.call(
-        ClustererRuleNamespace.TRANSACTIONS, project, ["/transaction/number/*/**"]
+        ClustererNamespace.TRANSACTIONS, project, ["/transaction/number/*/**"]
     )
 
 
@@ -312,7 +302,7 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
 def test_get_deleted_project():
     deleted_project = Project(pk=666, organization=Organization(pk=666))
     _store_transaction_name(deleted_project, "foo")
-    assert list(get_active_projects(ClustererDataNamespace.TRANSACTIONS)) == []
+    assert list(get_active_projects(ClustererNamespace.TRANSACTIONS)) == []
 
 
 @pytest.mark.django_db
@@ -329,7 +319,7 @@ def test_transaction_clusterer_generates_rules(default_project):
         assert _get_projconfig_tx_rules(default_project) is None
 
     rules = {"/rule/*/0/**": 0, "/rule/*/1/**": 1}
-    ProjectOptionRuleStore(ClustererRuleNamespace.TRANSACTIONS).write(default_project, rules)
+    ProjectOptionRuleStore(ClustererNamespace.TRANSACTIONS).write(default_project, rules)
 
     with Feature({feature: False}):
         assert _get_projconfig_tx_rules(default_project) is None
@@ -369,7 +359,7 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 1):
             spawn_clusterers()
 
-        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
+        assert get_rules(ClustererNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
 
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 2):
             record_transaction_name(
@@ -389,14 +379,14 @@ def test_transaction_clusterer_bumps_rules(_, default_organization):
             )
 
         # _get_rules fetches from project options, which arent updated yet.
-        assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
-        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
+        assert get_redis_rules(ClustererNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
+        assert get_rules(ClustererNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
         # Update rules to update the project option storage.
         with mock.patch("sentry.ingest.transaction_clusterer.rules._now", lambda: 3):
-            assert 0 == update_rules(ClustererRuleNamespace.TRANSACTIONS, project1, [])
+            assert 0 == update_rules(ClustererNamespace.TRANSACTIONS, project1, [])
         # After project options are updated, the last_seen should also be updated.
-        assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
-        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
+        assert get_redis_rules(ClustererNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
+        assert get_rules(ClustererNamespace.TRANSACTIONS, project1) == {"/user/*/**": 2}
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 3)
@@ -437,35 +427,29 @@ def test_dont_store_inexisting_rules(_, default_organization):
             rogue_transaction,
         )
 
-        assert get_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
+        assert get_rules(ClustererNamespace.TRANSACTIONS, project1) == {"/user/*/**": 1}
 
 
 @pytest.mark.django_db
 def test_stale_rules_arent_saved(default_project):
-    assert len(get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project)) == 0
+    assert len(get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project)) == 0
 
     with freeze_time("2000-01-01 01:00:00"):
-        update_rules(
-            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("foo/foo")]
-        )
-    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        update_rules(ClustererNamespace.TRANSACTIONS, default_project, [ReplacementRule("foo/foo")])
+    assert get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project) == [
         ("foo/foo", 946688400)
     ]
 
     with freeze_time("2000-02-02 02:00:00"):
-        update_rules(
-            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("bar/bar")]
-        )
-    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        update_rules(ClustererNamespace.TRANSACTIONS, default_project, [ReplacementRule("bar/bar")])
+    assert get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project) == [
         ("bar/bar", 949456800),
         ("foo/foo", 946688400),
     ]
 
     with freeze_time("2001-01-01 01:00:00"):
-        update_rules(
-            ClustererRuleNamespace.TRANSACTIONS, default_project, [ReplacementRule("baz/baz")]
-        )
-    assert get_sorted_rules(ClustererRuleNamespace.TRANSACTIONS, default_project) == [
+        update_rules(ClustererNamespace.TRANSACTIONS, default_project, [ReplacementRule("baz/baz")])
+    assert get_sorted_rules(ClustererNamespace.TRANSACTIONS, default_project) == [
         ("baz/baz", 978310800)
     ]
 
@@ -473,13 +457,11 @@ def test_stale_rules_arent_saved(default_project):
 def test_bump_last_used():
     """Redis update works and does not delete other keys in the set."""
     project1 = Project(id=123, name="project1")
-    RedisRuleStore(namespace=ClustererRuleNamespace.TRANSACTIONS).write(
-        project1, {"foo": 1, "bar": 2}
-    )
-    assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {"foo": 1, "bar": 2}
+    RedisRuleStore(namespace=ClustererNamespace.TRANSACTIONS).write(project1, {"foo": 1, "bar": 2})
+    assert get_redis_rules(ClustererNamespace.TRANSACTIONS, project1) == {"foo": 1, "bar": 2}
     with freeze_time("2000-01-01 01:00:00"):
-        bump_last_used(ClustererRuleNamespace.TRANSACTIONS, project1, "bar")
-    assert get_redis_rules(ClustererRuleNamespace.TRANSACTIONS, project1) == {
+        bump_last_used(ClustererNamespace.TRANSACTIONS, project1, "bar")
+    assert get_redis_rules(ClustererNamespace.TRANSACTIONS, project1) == {
         "foo": 1,
         "bar": 946688400,
     }


### PR DESCRIPTION
Refactor the transaction name clusterer to accept a namespace for both stored transaction names and computed rules. This is the first step to introduce the clusterer for span descriptions, which will come in another namespace.