### PR TITLE
fix(dashboard-widget-builder-page-filters): Added better instructions.

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/buildStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/buildStep.tsx
@@ -39,8 +39,8 @@ const Heading = styled('h5')`
   color: ${p => p.theme.gray500};
 `;
 
-const SubHeading = styled('small')`
-  color: ${p => p.theme.gray300};
+export const SubHeading = styled('small')`
+  color: ${p => p.theme.gray400};
   padding: ${space(0.25)} ${space(2)} ${space(2)} 0;
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -10,7 +10,7 @@ import Input from 'sentry/components/input';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import {IconAdd, IconDelete} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
 import {decodeList} from 'sentry/utils/queryString';
@@ -24,7 +24,7 @@ import {
   WidgetType,
 } from 'sentry/views/dashboards/types';
 
-import {BuildStep} from '../buildStep';
+import {BuildStep, SubHeading} from '../buildStep';
 
 interface Props {
   canAddSearchConditions: boolean;
@@ -102,15 +102,12 @@ export function FilterResultsStep({
   return (
     <BuildStep
       title={t('Filter your results')}
-      description={
-        canAddSearchConditions
-          ? t(
-              'Projects, environments, and date range have been preselected at the dashboard level. Filter down your search here. You can add multiple queries to compare data for each overlay.'
-            )
-          : t(
-              'Projects, environments, and date range have been preselected at the dashboard level. Filter down your search here.'
-            )
-      }
+      description={tct(
+        'Projects, environments, date range and releases have been preselected in the dashboard that this widget belongs to. You can filter the results by these fields further using the search bar. For example, typing [releaseQuery] narrows down the results specific to that release.',
+        {
+          releaseQuery: <StyledReleaseQuery>release:1.0.0</StyledReleaseQuery>,
+        }
+      )}
     >
       <StyledPageFilterBar>
         <ProjectPageFilter disabled />
@@ -128,6 +125,13 @@ export function FilterResultsStep({
           />
         </ReleasesProvider>
       </StyledPageFilterBar>
+      <SubHeading>
+        {canAddSearchConditions
+          ? t(
+              'Filter down your search here. You can add multiple queries to compare data for each overlay:'
+            )
+          : t('Filter down your search here:')}
+      </SubHeading>
       <div>
         {queries.map((query, queryIndex) => {
           return (
@@ -218,4 +222,9 @@ const SearchConditionsWrapper = styled('div')`
   > * + * {
     margin-left: ${space(1)};
   }
+`;
+
+const StyledReleaseQuery = styled('span')`
+  font-family: ${p => p.theme.text.familyMono};
+  color: ${p => p.theme.pink300};
 `;


### PR DESCRIPTION
1. Added clearer instructions. 

Before:
<img width="925" alt="Screenshot 2023-05-24 at 1 08 07 PM" src="https://github.com/getsentry/sentry/assets/60121741/cd40fa78-fab5-4ca6-9c92-aba80fbd4ff2">

After: 
<img width="846" alt="Screenshot 2023-05-24 at 1 08 27 PM" src="https://github.com/getsentry/sentry/assets/60121741/40e92f7f-3951-442d-90b4-4a9c5fc19a54">
