### PR TITLE
fix(starfish): Use p50 data for p50 graph

### DIFF
--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -33,7 +33,7 @@ export const getTopDomainsActionsAndOpTimeseries = ({
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `SELECT
  quantile(0.50)(exclusive_time) as p50, domain, action, span_operation, module,
- toStartOfInterval(start_timestamp, INTERVAL 1 HOUR) as interval
+ toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
  ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}

--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -33,7 +33,7 @@ export const getTopDomainsActionsAndOpTimeseries = ({
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `SELECT
  quantile(0.75)(exclusive_time) as p75, domain, action, span_operation, module,
- toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
+ toStartOfInterval(start_timestamp, INTERVAL 1 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
  ${end_timestamp ? `AND lessOrEquals(start_timestamp, '${end_timestamp}')` : ''}

--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -32,7 +32,7 @@ export const getTopDomainsActionsAndOpTimeseries = ({
 }) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `SELECT
- quantile(0.75)(exclusive_time) as p75, domain, action, span_operation, module,
+ quantile(0.50)(exclusive_time) as p50, domain, action, span_operation, module,
  toStartOfInterval(start_timestamp, INTERVAL 1 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
@@ -51,7 +51,7 @@ export const getOtherDomainsActionsAndOpTimeseries = ({
 }) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `SELECT
- quantile(0.75)(exclusive_time) as p75,
+ quantile(0.50)(exclusive_time) as p50,
  toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
@@ -97,7 +97,7 @@ export const getTopDomainsAndMethods = ({transaction}) => {
 
 export const getTopHttpDomains = ({transaction}) => {
   return `SELECT
- quantile(0.75)(exclusive_time) as p75, domain,
+ quantile(0.50)(exclusive_time) as p50, domain,
  toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE domain IN (
@@ -117,7 +117,7 @@ export const getTopHttpDomains = ({transaction}) => {
 
 export const getOtherDomains = ({transaction}) => {
   return `SELECT
-  quantile(0.75)(exclusive_time) as p75,
+  quantile(0.50)(exclusive_time) as p50,
   toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
   FROM default.spans_experimental_starfish
   WHERE domain NOT IN (
@@ -137,7 +137,7 @@ export const getOtherDomains = ({transaction}) => {
 
 export const getDatabaseTimeSpent = ({transaction}) => {
   return `SELECT
-  quantile(0.75)(exclusive_time) as p75,
+  quantile(0.50)(exclusive_time) as p50,
   toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
   FROM default.spans_experimental_starfish
   WHERE startsWith(span_operation, 'db') and span_operation != 'db.redis'

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -185,7 +185,7 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
     topData.forEach(value => {
       seriesByDomain[
         getSegmentLabel(value.span_operation, value.action, value.domain)
-      ].data.push({value: value.p75, name: value.interval});
+      ].data.push({value: value.p50, name: value.interval});
     });
 
     seriesByDomain.Other = {
@@ -195,7 +195,7 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
     };
 
     otherData.forEach(value => {
-      seriesByDomain.Other.data.push({value: value.p75, name: value.interval});
+      seriesByDomain.Other.data.push({value: value.p50, name: value.interval});
     });
   }
 

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -200,7 +200,7 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
   }
 
   const data = Object.values(seriesByDomain).map(series =>
-    zeroFillSeries(series, moment.duration(1, 'hour'), start, end)
+    zeroFillSeries(series, moment.duration(12, 'hour'), start, end)
   );
 
   const initialShowSeries = transformedData.map(

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -200,7 +200,7 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
   }
 
   const data = Object.values(seriesByDomain).map(series =>
-    zeroFillSeries(series, moment.duration(12, 'hour'), start, end)
+    zeroFillSeries(series, moment.duration(1, 'hour'), start, end)
   );
 
   const initialShowSeries = transformedData.map(


### PR DESCRIPTION
Right now it's using p75 data for a chart labelled p50
