### PR TITLE
feat(large-payload): Improve extension detection

### DIFF
--- a/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
+++ b/tests/sentry/utils/performance_issues/test_large_http_payload_detector.py
@@ -78,3 +78,122 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
         event = create_event(spans)
         assert self.find_problems(event) == []
+
+    def test_does_not_issue_if_url_is_not_a_json_asset(self):
+        spans = [
+            create_span(
+                "http.client",
+                hash="hash1",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.mp3",
+                duration=1000.0,
+                data={
+                    "http.transfer_size": 50_000_000,
+                    "http.response_content_length": 50_000_000,
+                    "http.decoded_response_content_length": 50_000_000,
+                },
+            )
+        ]
+        event = create_event(spans)
+        assert self.find_problems(event) == []
+
+    def test_issues_if_url_is_a_json_asset(self):
+        spans = [
+            create_span(
+                "http.client",
+                hash="hash1",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json",
+                duration=1000.0,
+                data={
+                    "http.transfer_size": 50_000_000,
+                    "http.response_content_length": 50_000_000,
+                    "http.decoded_response_content_length": 50_000_000,
+                },
+            )
+        ]
+        event = create_event(spans)
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1015-707544115c386d60b7b550634d582d8e47d9c5dd",
+                op="http",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json",
+                type=PerformanceLargeHTTPPayloadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                    "op": "http",
+                },
+                evidence_display=[],
+            )
+        ]
+
+    def test_ignores_query_parameters(self):
+        spans = [
+            create_span(
+                "http.client",
+                hash="hash1",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json?foo=bar",
+                duration=1000.0,
+                data={
+                    "http.transfer_size": 50_000_000,
+                    "http.response_content_length": 50_000_000,
+                    "http.decoded_response_content_length": 50_000_000,
+                },
+            )
+        ]
+        event = create_event(spans)
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1015-707544115c386d60b7b550634d582d8e47d9c5dd",
+                op="http",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json",
+                type=PerformanceLargeHTTPPayloadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                    "op": "http",
+                },
+                evidence_display=[],
+            )
+        ]
+
+    def test_ignores_query_parameters_with_trailing_slash(self):
+        spans = [
+            create_span(
+                "http.client",
+                hash="hash1",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json/?foo=bar",
+                duration=1000.0,
+                data={
+                    "http.transfer_size": 50_000_000,
+                    "http.response_content_length": 50_000_000,
+                    "http.decoded_response_content_length": 50_000_000,
+                },
+            )
+        ]
+        event = create_event(spans)
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1015-e84e3f3951f80edcd72d5a0a08adae09e333e2ea",
+                op="http",
+                desc="GET https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.json",
+                type=PerformanceLargeHTTPPayloadGroupType,
+                parent_span_ids=None,
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                    "op": "http",
+                },
+                evidence_display=[],
+            )
+        ]


### PR DESCRIPTION
Uses a regex to grab the extension in the span description, ignoring the query parameters at the end. If there is an extension, only allow detection if it's a JSON file