### PR TITLE
ref(crons): Enable crons by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1504,6 +1504,8 @@ SENTRY_FEATURES = {
     "organizations:ds-sliding-window": False,
     # If true certain Slack messages will be escaped to prevent rendering markdown
     "organizations:slack-escape-messages": False,
+    # Enable crons product by default
+    "organizations:monitors": True,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -110,7 +110,7 @@ default_manager.add("organizations:anr-analyze-frames", OrganizationFeature, Fea
 default_manager.add("organizations:anr-rate", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:device-classification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:monitors", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:monitors", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:new-page-filter", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:new-weekly-report", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:notification-all-recipients", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -72,6 +72,7 @@ class OrganizationSerializerTest(TestCase):
             "invite-members",
             "invite-members-rate-limits",
             "minute-resolution-sessions",
+            "monitors",
             "open-membership",
             "project-stats",
             "relay",


### PR DESCRIPTION
Previously managed by flagr, but for development environments we shouldn't need to manually set this to enabled in the configuration. And then we can delete the flag in flagr

We also did this a while back https://github.com/getsentry/getsentry/blob/master/getsentry/conf/settings/singletenant.py#LL543C26-L543C26 which should keep the feature disabled in single tenant. 

Self-hosted may now have this on if they haven't turned it on before, but I don't think there should be any issue with that.