### PR TITLE
fix: Normalize non-handled frames in_app value

### DIFF
--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -440,7 +440,7 @@ class TestJavascriptIntegration(RelayStoreHelper):
             assert frame_list[2].in_app  # should not be touched and retain `in_app: true`
 
             raw_frame_list = exception.values[0].raw_stacktrace.frames
-            # none of raw frames should not be altered
+            # none of the raw frames should be altered
             assert raw_frame_list[0].in_app
             assert raw_frame_list[1].in_app
             assert raw_frame_list[2].in_app


### PR DESCRIPTION
Right now JS SDK sends `in_app: true` for almost all its frames. We want to make sure that some of them are always not marked as such, even when processing was skipped.