### PR TITLE
chore(span): Track open span details for all spans

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -99,7 +99,7 @@ function SpanDetail(props: Props) {
     // Run on mount.
 
     const {span, organization, event} = props;
-    if ('type' in span) {
+    if (!('op' in span)) {
       return;
     }
 


### PR DESCRIPTION
This PR starts tracking opening the span details view for all spans having the op property. Previously, we only tracked this if the span has the type property, which was only valid for the root span of a transaction.

This PR is a follow-up on https://github.com/getsentry/sentry/pull/48322.
