### PR TITLE
ref(js): Add handling for empty body causes for API errors

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -521,35 +521,19 @@ export class Client {
           // There's no reason we should be here with a 200 response, but we get
           // tons of events from this codepath with a 200 status nonetheless.
           // Until we know why, let's do what is essentially some very fancy print debugging.
-          if (status === 200) {
-            const responseTextUndefined = responseText === undefined;
-            const responseTextEmpty = responseText === '';
+          if (status === 200 && responseText) {
             const parameterizedPath = sanitizePath(path);
+            const message = '200 treated as error';
 
-            // Pass a scope object rather than using `withScope` to avoid even
-            // the possibility of scope bleed.
             const scope = new Sentry.Scope();
-            scope.setTags({endpoint: `${method} ${parameterizedPath}`});
-
-            if (!responseTextUndefined && !responseTextEmpty) {
-              // Grab everything that could conceivably be helpful to know
-              scope.setTags({errorReason});
-              scope.setExtras({
-                twoHundredErrorReason,
-                responseJSON,
-                // Force `undefined` and the empty string to print so they're differentiable in the UI
-                responseText: String(responseText) || '[empty string]',
-                responseContentType,
-                errorReason,
-              });
-            }
-
-            const message = responseTextUndefined
-              ? '200 API response with undefined responseText'
-              : responseTextEmpty
-              ? '200 API response with empty responseText'
-              : '200 treated as error';
-
+            scope.setTags({endpoint: `${method} ${parameterizedPath}`, errorReason});
+            scope.setExtras({
+              twoHundredErrorReason,
+              responseJSON,
+              responseText,
+              responseContentType,
+              errorReason,
+            });
             // Make sure all of these errors group, so we don't produce a bunch of noise
             scope.setFingerprint([message]);
 

--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -1,6 +1,12 @@
-import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
+import {ERROR_MAP as origErrorMap} from 'sentry/utils/requestError/requestError';
 
 import {isEventWithFileUrl, isFilteredRequestErrorEvent} from './initializeSdk';
+
+const ERROR_MAP = {
+  ...origErrorMap,
+  // remove `UndefinedResponseBodyError` since we don't filter those
+  200: undefined,
+};
 
 describe('isFilteredRequestErrorEvent', () => {
   const methods = ['GET', 'POST', 'PUT', 'DELETE'];

--- a/static/app/utils/handleXhrErrorResponse.spec.jsx
+++ b/static/app/utils/handleXhrErrorResponse.spec.jsx
@@ -16,7 +16,7 @@ describe('handleXhrErrorResponse', function () {
   it('does nothing if we have invalid response', function () {
     handleXhrErrorResponse('', null);
     expect(Sentry.captureException).not.toHaveBeenCalled();
-    handleXhrErrorResponse('', {});
+    handleXhrErrorResponse('', undefined);
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -19,10 +19,15 @@ export function handleXhrErrorResponse(message: string, err: RequestError): void
       responseStatus: status,
       endpoint,
     });
-    scope.setExtras({
-      status,
-      responseJSON,
-    });
+
+    // TODO: If we discover that undefind response bodies don't break anything,
+    // we can revert to bailing when `responseJSON` is falsy and always calling `setExtras`
+    if (err.name !== 'UndefinedResponseBodyError') {
+      scope.setExtras({
+        status,
+        responseJSON,
+      });
+    }
 
     Sentry.captureException(
       // We need to typecheck here even though `err` is typed in the function

--- a/static/app/utils/handleXhrErrorResponse.tsx
+++ b/static/app/utils/handleXhrErrorResponse.tsx
@@ -5,7 +5,7 @@ import RequestError from 'sentry/utils/requestError/requestError';
 export function handleXhrErrorResponse(message: string, err: RequestError): void {
   // Sudo errors are handled separately elsewhere
   // @ts-ignore Property 'code' does not exist on type 'string'
-  if (!err || !err.responseJSON || err.responseJSON?.detail?.code === 'sudo-required') {
+  if (!err || err.responseJSON?.detail?.code === 'sudo-required') {
     return;
   }
 

--- a/static/app/utils/requestError/requestError.tsx
+++ b/static/app/utils/requestError/requestError.tsx
@@ -4,6 +4,7 @@ import {sanitizePath} from './sanitizePath';
 
 export const ERROR_MAP = {
   0: 'CancelledError',
+  200: 'UndefinedResponseBodyError',
   400: 'BadRequestError',
   401: 'UnauthorizedError',
   403: 'ForbiddenError',
@@ -53,6 +54,17 @@ export default class RequestError extends Error {
    */
   addResponseMetadata(resp: ResponseMeta | undefined) {
     if (resp) {
+      // We filter 200's out unless they're the specific case of an undefined
+      // body. For the ones which will eventually get filtered, we don't care
+      // about the data added here and we don't want to change the name (or it
+      // won't match the filter) so bail before any of that happens.
+      //
+      // TODO: If it turns out the undefined ones aren't really a problem, we
+      // can remove this and the `200` entry in `ERROR_MAP` above
+      if (resp.status === 200 && resp.responseText !== undefined) {
+        return;
+      }
+
       this.setNameFromStatus(resp.status);
 
       this.message = `${this.message} ${


### PR DESCRIPTION
Sometimes when our frontend client makes a request to our API, we get a 200 response which is nonetheless considered an error. In https://github.com/getsentry/sentry/pull/49060, we added code to capture a separate event when this happens, as a first step towards investigating what was causing it. After a few refinements of that code, it's now clear that the problem is response bodies coming back with a 200 but no actual data. (According to the code there could be other reasons, but no instances of this have been recorded so far.)

What we still don't know, though, is what downstream effect these empty responses have (if any), because we filter any resulting events out in `beforeSend`. This PR aims to fix that, by switching from recording a separate event to marking and allowing through any resulting errors. Key changes:

- Only capture a separate event for 200-status error responses when the response body isn't empty. (It's possible that in real life this never happens, but according to the code it could, so I left it in.)
- Add a new kind of `RequestError`, called `UndefinedResponseBodyError`, corresponding to a 200 status code and an empty body. Not only does this identify such errors, it also allows them to pass through our existing filters.
- Add a helper in `beforeSend` to tag and fingerprint such errors, so that they're easy to find and so that they group together to prevent noise in the issue stream.

Note: While empty response bodies show up both as `undefined` and as the empty string, the latter case only seems to happen when we hit `internal/health`, specifically when we land [here](https://github.com/getsentry/sentry/blob/bac5c9dcd9b7ad9adb95f51330fe10bc277e6fa6/src/sentry/api/endpoints/system_health.py#L21-L22). Since this seems like the system working as designed, I'm letting those events continue to be filtered, and only special-casing the `undefined` case.

Once this is merged, the next steps will be to a) resolve the existing issues for both empty-body cases, and b) pay attention to new `UndefinedResponseBodyError`s which come in. Ones where the error is captured directly indicate places where we're not wrapping the request error in a more explanatory, "here's what actually didn't work" error, and we should then go in and fix them. Ones where we are doing the wrapping will let us know when these empty bodies are in fact causing downstream problems (and what those problems are), so we can decide if it's something we need to solve.