### PR TITLE
feat(starfish): Add percentile functions to span metrics

### DIFF
--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -7,6 +7,7 @@ from snuba_sdk import Column, Function, OrderBy
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import IncompatibleMetricsQuery
 from sentry.search.events import builder, constants, fields
+from sentry.search.events.datasets import function_aliases
 from sentry.search.events.datasets.base import DatasetConfig
 from sentry.search.events.types import SelectType, WhereType
 
@@ -73,6 +74,60 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                         alias,
                     ),
                     default_result_type="integer",
+                ),
+                fields.MetricsFunction(
+                    "p50",
+                    optional_args=[
+                        fields.with_default(
+                            "span.duration",
+                            fields.MetricArg(
+                                "column",
+                                allowed_columns=["span.duration"],
+                                allow_custom_measurements=False,
+                            ),
+                        ),
+                    ],
+                    calculated_args=[resolve_metric_id],
+                    snql_distribution=lambda args, alias: function_aliases.resolve_metrics_percentile(
+                        args=args, alias=alias, fixed_percentile=0.50
+                    ),
+                    default_result_type="duration",
+                ),
+                fields.MetricsFunction(
+                    "p75",
+                    optional_args=[
+                        fields.with_default(
+                            "span.duration",
+                            fields.MetricArg(
+                                "column",
+                                allowed_columns=["span.duration"],
+                                allow_custom_measurements=False,
+                            ),
+                        ),
+                    ],
+                    calculated_args=[resolve_metric_id],
+                    snql_distribution=lambda args, alias: function_aliases.resolve_metrics_percentile(
+                        args=args, alias=alias, fixed_percentile=0.75
+                    ),
+                    default_result_type="duration",
+                ),
+                fields.MetricsFunction(
+                    "p95",
+                    optional_args=[
+                        fields.with_default(
+                            "span.duration",
+                            fields.MetricArg(
+                                "column",
+                                allowed_columns=["span.duration"],
+                                allow_custom_measurements=False,
+                            ),
+                        ),
+                    ],
+                    calculated_args=[resolve_metric_id],
+                    snql_distribution=lambda args, alias: function_aliases.resolve_metrics_percentile(
+                        args=args, alias=alias, fixed_percentile=0.95
+                    ),
+                    default_result_type="duration",
                 ),
             ]
         }


### PR DESCRIPTION
Adds the percentile functions to the spans metrics
dataset. We currently have no tests set up for spans
metrics, so that's going to be follow up work.

works with `events` endpoint, follow up to add
timeseries

query that gets run:
```
  SELECT (arrayElement(quantilesMergeIf(0.95)(percentiles, equals((metric_id AS _snuba_metric_id), 9223372036854776209)), 1) AS _snuba_p95)
   FROM generic_metric_distributions_aggregated_local
  WHERE equals(granularity, 2)
    AND greaterOrEquals((timestamp AS _snuba_timestamp), toDateTime('2023-05-11T15:00:00', 'Universal'))
    AND less(_snuba_timestamp, toDateTime('2023-05-25T15:57:01', 'Universal'))
    AND in((project_id AS _snuba_project_id), [1])
    AND equals((org_id AS _snuba_org_id), 1)
    AND in(_snuba_metric_id, [9223372036854776209])
  LIMIT 1

```
