### PR TITLE
fix(starfish): use spm() instead of count() in spans view

### DIFF
--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -102,7 +102,10 @@ export type TooltipSubLabel = {
   parentLabel: string;
 };
 
-type FormatterOptions = Pick<NonNullable<ChartProps['tooltip']>, TooltipFormatters> &
+export type FormatterOptions = Pick<
+  NonNullable<ChartProps['tooltip']>,
+  TooltipFormatters
+> &
   Pick<ChartProps, NeededChartProps> & {
     /**
      * If true seconds will be added to the Axis label time format

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -14,7 +14,10 @@ import {AreaChart, AreaChartProps} from 'sentry/components/charts/areaChart';
 import {BarChart} from 'sentry/components/charts/barChart';
 import BaseChart from 'sentry/components/charts/baseChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
-import {getFormatter} from 'sentry/components/charts/components/tooltip';
+import {
+  FormatterOptions,
+  getFormatter,
+} from 'sentry/components/charts/components/tooltip';
 import {LineChart} from 'sentry/components/charts/lineChart';
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 import ScatterSeries from 'sentry/components/charts/series/scatterSeries';
@@ -55,6 +58,7 @@ type Props = {
   showLegend?: boolean;
   stacked?: boolean;
   throughput?: {count: number; interval: string}[];
+  tooltipFormatterOptions?: FormatterOptions;
 };
 
 function computeMax(data: Series[]) {
@@ -122,6 +126,7 @@ function Chart({
   onClick,
   forwardedRef,
   chartGroup,
+  tooltipFormatterOptions = {},
 }: Props) {
   const router = useRouter();
   const theme = useTheme();
@@ -227,6 +232,7 @@ function Chart({
         isGroupedByDate: true,
         showTimeInTooltip: true,
         utc,
+        ...tooltipFormatterOptions,
       })(params, asyncTicket);
     }
     // Return empty string, ie no tooltip

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -87,7 +87,7 @@ export function SpanTimeCharts({descriptionFilter, queryConditions}: Props) {
 
     return zeroFillSeries(
       {
-        seriesName: label ?? 'P50',
+        seriesName: label ?? 'p50()',
         data: groupData.map(datum => ({
           value: datum.p50,
           name: datum.interval,
@@ -148,6 +148,9 @@ export function SpanTimeCharts({descriptionFilter, queryConditions}: Props) {
             isLineChart
             chartColors={themes.charts.getColorPalette(2)}
             disableXAxis
+            tooltipFormatterOptions={{
+              valueFormatter: value => `${value.toFixed(3)} / ${t('min')}`,
+            }}
           />
         </ChartPanel>
       </ChartsContainerItem>

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -55,7 +55,7 @@ export function SpanTimeCharts({descriptionFilter, queryConditions}: Props) {
       {
         seriesName: label ?? 'Throughput',
         data: groupData.map(datum => ({
-          value: datum.throughput,
+          value: datum.spm,
           name: datum.interval,
         })),
       },
@@ -128,7 +128,7 @@ export function SpanTimeCharts({descriptionFilter, queryConditions}: Props) {
       </ChartsContainerItem>
 
       <ChartsContainerItem>
-        <ChartPanel title={t('Throughput')}>
+        <ChartPanel title={t('Throughput (SPM)')}>
           <Chart
             statsPeriod="24h"
             height={100}
@@ -189,7 +189,7 @@ export const getSpanTotalTimeChartQuery = (
   const validConditions = conditions.filter(Boolean);
 
   return `SELECT
-    count() AS throughput,
+    divide(count(), multiply(12, 60)) as spm,
     sum(exclusive_time) AS total_time,
     quantile(0.50)(exclusive_time) AS p50,
     toStartOfInterval(start_timestamp, INTERVAL 1 DAY) as interval


### PR DESCRIPTION
We were using count() in the spans view instead of SPM() which is used in every one part of the app. This PR fixes the graph to use SPM and updates the tooltip formatter
Before
<img width="444" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/6e8126ff-78c9-45ba-8503-aa7a68a81e19">
After
<img width="403" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/ff100994-82be-4078-b2e1-a6a40022387f">
