### PR TITLE
chore(flags): merge organizations:issue-states into organizations:escalating-issues usage

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -284,7 +284,7 @@ def convert_query_values(
         includes_substatus_filter = False
         for search_filter in search_filters:
             if search_filter.key.name == "substatus":
-                if not features.has("organizations:issue-states", org):
+                if not features.has("organizations:escalating-issues", org):
                     raise InvalidSearchQuery(
                         "The substatus filter is not supported for this organization"
                     )

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -150,7 +150,7 @@ class AlertRuleNotification(ProjectNotification):
             "has_alert_integration": has_alert_integration(self.project),
             "issue_type": self.group.issue_type.description,
             "subtitle": self.event.title,
-            "has_issue_states": features.has("organizations:issue-states", self.organization),
+            "has_issue_states": features.has("organizations:escalating-issues", self.organization),
         }
 
         # if the organization has enabled enhanced privacy controls we don't send

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -37,7 +37,7 @@ def schedule_auto_transition_new() -> None:
     three_days_past = now - timedelta(days=TRANSITION_AFTER_DAYS)
 
     for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
-        if features.has("organizations:issue-states", org):
+        if features.has("organizations:escalating-issues", org):
             for project_id in Project.objects.filter(organization_id=org.id).values_list(
                 "id", flat=True
             ):
@@ -109,7 +109,7 @@ def schedule_auto_transition_regressed() -> None:
     three_days_past = now - timedelta(days=TRANSITION_AFTER_DAYS)
 
     for org in RangeQuerySetWrapper(Organization.objects.filter(status=OrganizationStatus.ACTIVE)):
-        if features.has("organizations:issue-states", org):
+        if features.has("organizations:escalating-issues", org):
             for project_id in Project.objects.filter(organization_id=org.id).values_list(
                 "id", flat=True
             ):

--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -25,13 +25,7 @@ def clear_expired_snoozes():
 
     for group in ignored_groups:
         if features.has("organizations:escalating-issues", group.organization):
-            snooze_details = {"until": groups_with_snoozes.get(group.id, {}).get("until")}
-
-            manage_issue_states(group, GroupInboxReason.ESCALATING, snooze_details=snooze_details)
-
-        elif features.has("organizations:issue-states", group.organization):
-            manage_issue_states(group, GroupInboxReason.ONGOING)
-
+            manage_issue_states(group, GroupInboxReason.ESCALATING)
         else:
             manage_issue_states(group, GroupInboxReason.UNIGNORED)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -740,10 +740,6 @@ def process_snoozes(job: PostProcessJob) -> None:
 
             if features.has("organizations:escalating-issues", group.organization):
                 manage_issue_states(group, GroupInboxReason.ESCALATING, event, snooze_details)
-
-            elif features.has("organizations:issue-states", group.organization):
-                manage_issue_states(group, GroupInboxReason.ONGOING, event, snooze_details)
-
             else:
                 manage_issue_states(group, GroupInboxReason.UNIGNORED, event, snooze_details)
 

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -79,8 +79,8 @@ class ProjectContext:
     existing_issue_count = 0
     reopened_issue_count = 0
     new_issue_count = 0
-
-    # For organizations:issue-states
+    # we merged organizations:issue-states flag to organizations:escalating-issues, so delete when
+    # organizations:escalating-issues GA
     new_substatus_count = 0
     ongoing_substatus_count = 0
     escalating_substatus_count = 0
@@ -168,7 +168,7 @@ def prepare_organization_report(
     set_tag("org.slug", organization.slug)
     set_tag("org.id", organization_id)
     ctx = OrganizationReportContext(timestamp, duration, organization)
-    has_issue_states = features.has("organizations:issue-states", organization)
+    has_issue_states = features.has("organizations:escalating-issues", organization)
 
     # Run organization passes
     with sentry_sdk.start_span(op="weekly_reports.user_project_ownership"):
@@ -413,7 +413,7 @@ def fetch_key_error_groups(ctx):
         group_id_to_group[group.id] = group
 
     group_id_to_group_history = {}
-    if not features.has("organizations:issue-states", ctx.organization):
+    if not features.has("organizations:escalating-issues", ctx.organization):
         group_history = (
             GroupHistory.objects.filter(
                 group_id__in=all_key_error_group_ids, organization_id=ctx.organization.id
@@ -701,7 +701,7 @@ def render_template_context(ctx, user):
         # If user is None, or if the user is not a member of the organization, we assume that the email was directed to a user who joined all teams.
         user_projects = ctx.projects.values()
 
-    has_issue_states = features.has("organizations:issue-states", ctx.organization)
+    has_issue_states = features.has("organizations:escalating-issues", ctx.organization)
 
     # Render the first section of the email where we had the table showing the
     # number of accepted/dropped errors/transactions for each project.

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -83,7 +83,7 @@ class DebugWeeklyReportView(MailPreviewView):
             ]
 
             if DEBUG_ISSUE_STATES:
-                # For organizations:issue-states
+                # For organizations:escalating-issues
                 project_context.new_substatus_count = random.randint(5, 200)
                 project_context.escalating_substatus_count = random.randint(5, 200)
                 project_context.regression_substatus_count = random.randint(5, 200)
@@ -95,7 +95,7 @@ class DebugWeeklyReportView(MailPreviewView):
                     + project_context.ongoing_substatus_count
                 )
             else:
-                # Removed after organizations:issue-states GA
+                # Removed after organizations:escalating-issues GA
                 project_context.existing_issue_count = random.randint(0, 10000)
                 project_context.reopened_issue_count = random.randint(0, 1000)
                 project_context.new_issue_count = random.randint(0, 1000)

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -220,7 +220,7 @@ class ConvertStatusValueTest(TestCase):
             convert_query_values(filters, [self.project], self.user, None)
 
 
-@apply_feature_flag_on_cls("organizations:issue-states")
+@apply_feature_flag_on_cls("organizations:escalating-issues")
 class ConvertSubStatusValueTest(TestCase):
     def test_valid(self):
         for substatus_string, substatus_val in SUBSTATUS_UPDATE_CHOICES.items():

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1103,7 +1103,7 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
                 [],
             )
 
-    @with_feature("organizations:issue-states")
+    @with_feature("organizations:escalating-issues")
     def test_group_substatus_header(self):
         event = self.store_event(
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -24,7 +24,7 @@ from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 
 
-@apply_feature_flag_on_cls("organizations:issue-states")
+@apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoNewOngoingIssuesTest(TestCase):
     @patch("sentry.signals.inbox_in.send_robust")
     def test_simple(self, inbox_in):
@@ -190,7 +190,7 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         ) == {g.id for g in groups}
 
 
-@apply_feature_flag_on_cls("organizations:issue-states")
+@apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
     @patch("sentry.signals.inbox_in.send_robust")
     def test_simple(self, inbox_in):

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -170,7 +170,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
         assert project_ctx.existing_issue_count == 0
         assert project_ctx.all_issue_count == 2
 
-    @with_feature("organizations:issue-states")
+    @with_feature("organizations:escalating-issues")
     def test_organization_project_issue_substatus_summaries(self):
         self.login_as(user=self.user)
 
@@ -312,7 +312,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             assert "Weekly Report for" in message_params["subject"]
 
     @mock.patch("sentry.tasks.weekly_reports.MessageBuilder")
-    @with_feature("organizations:issue-states")
+    @with_feature("organizations:escalating-issues")
     def test_message_builder_substatus_simple(self, message_builder):
         now = timezone.now()
         three_days_ago = now - timedelta(days=3)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1669,7 +1669,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["inbox"]["reason"] == GroupInboxReason.UNIGNORED.value
         assert response.data[0]["inbox"]["reason_details"] == snooze_details
 
-    @with_feature("organizations:issue-states")
+    @with_feature("organizations:escalating-issues")
     def test_inbox_fields_issue_states(self):
         event = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
@@ -1938,7 +1938,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             query="is:unresolved",
         )
 
-        with Feature("organizations:issue-states"):
+        with Feature("organizations:escalating-issues"):
             response1 = get_query_response(
                 query="is:ongoing"
             )  # (status=unresolved, substatus=(ongoing))
@@ -1991,7 +1991,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             self.get_response, sort_by="date", limit=10, expand="inbox", collapse="stats"
         )
 
-        with Feature("organizations:issue-states"):
+        with Feature("organizations:escalating-issues"):
             response1 = get_query_response(query="is:escalating")
             response2 = get_query_response(query="is:new")
             response3 = get_query_response(query="is:regressed")

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -437,7 +437,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         )
 
     def test_substatus(self):
-        with Feature("organizations:issue-states"):
+        with Feature("organizations:escalating-issues"):
             results = self.make_query(search_filter_query="is:ongoing")
             assert set(results) == {self.group1}
 


### PR DESCRIPTION
Replaces `organizations:issue-states` usage with `organization:escalating-issues`. These two features are being released at the same time so we should consolidate the feature flags.