### PR TITLE
fix(replay): Fix accessing undefined `cursor`

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -312,7 +312,7 @@ async function* fetchPaginatedReplayErrors(
     results: true,
     href: '',
   };
-  while (cursor.results) {
+  while (cursor?.results) {
     const [{data}, , resp] = await next(cursor.cursor);
     const pageLinks = resp?.getResponseHeader('Link') ?? null;
     cursor = parseLinkHeader(pageLinks)?.next;


### PR DESCRIPTION
`cursor` can potentially be defined (e.g. when there is no `next` page?)

Fixes JAVASCRIPT-2DAP
