### PR TITLE
feat(starfish): Span metrics timeseries

### DIFF
--- a/src/sentry/search/events/builder/__init__.py
+++ b/src/sentry/search/events/builder/__init__.py
@@ -27,7 +27,7 @@ from .spans_indexed import (  # NOQA
     TimeseriesSpanIndexedQueryBuilder,
     TopEventsSpanIndexedQueryBuilder,
 )
-from .spans_metrics import SpansMetricsQueryBuilder  # NOQA
+from .spans_metrics import SpansMetricsQueryBuilder, TimeseriesSpansMetricsQueryBuilder  # NOQA
 
 __all__ = [
     "HistogramQueryBuilder",
@@ -51,4 +51,5 @@ __all__ = [
     "TimeseriesSpanIndexedQueryBuilder",
     "TopEventsSpanIndexedQueryBuilder",
     "TimeseriesSessionsV2QueryBuilder",
+    "TimeseriesSpansMetricsQueryBuilder",
 ]

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from sentry.search.events.builder import MetricsQueryBuilder
+from sentry.search.events.builder import MetricsQueryBuilder, TimeseriesMetricQueryBuilder
 
 
 class SpansMetricsQueryBuilder(MetricsQueryBuilder):
@@ -14,3 +14,7 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
             return "duration"
 
         return None
+
+
+class TimeseriesSpansMetricsQueryBuilder(SpansMetricsQueryBuilder, TimeseriesMetricQueryBuilder):
+    pass


### PR DESCRIPTION
Adds support for span metrics timeseries.
Need to follow up with support for ton-n queries

```
  SELECT (toStartOfInterval((timestamp AS _snuba_timestamp), toIntervalSecond(3600), 'Universal') AS _snuba_time), (uniqCombined64MergeIf((value AS _snuba_value), equals((metric_id AS _snuba_metric_id), 9223372036854776208)) AS _snuba_count_unique_user)
   FROM generic_metric_sets_local
  WHERE equals(granularity, 2)
    AND greaterOrEquals(_snuba_timestamp, toDateTime('2023-05-18T18:00:00', 'Universal'))
    AND less(_snuba_timestamp, toDateTime('2023-05-25T18:45:01', 'Universal'))
    AND in((project_id AS _snuba_project_id), [1])
    AND equals((org_id AS _snuba_org_id), 1)
    AND in(_snuba_metric_id, [9223372036854776208])
  GROUP BY _snuba_time
  ORDER BY _snuba_time ASC
  LIMIT 10000
 OFFSET 0
```