### PR TITLE
fix(issue-states): retry tasks up to three times

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -25,6 +25,8 @@ TRANSITION_AFTER_DAYS = 3
 @instrumented_task(
     name="sentry.tasks.schedule_auto_transition_new",
     queue="auto_transition_issue_states",
+    max_retries=3,
+    default_retry_delay=60,
 )  # type: ignore
 @monitor(monitor_slug="schedule_auto_transition_new")
 def schedule_auto_transition_new() -> None:
@@ -48,6 +50,8 @@ def schedule_auto_transition_new() -> None:
     queue="auto_transition_issue_states",
     time_limit=25 * 60,
     soft_time_limit=20 * 60,
+    max_retries=3,
+    default_retry_delay=60,
 )  # type: ignore
 def auto_transition_issues_new_to_ongoing(
     project_id: int,
@@ -89,6 +93,8 @@ def auto_transition_issues_new_to_ongoing(
 @instrumented_task(
     name="sentry.tasks.schedule_auto_transition_regressed",
     queue="auto_transition_issue_states",
+    max_retries=3,
+    default_retry_delay=60,
 )  # type: ignore
 @monitor(monitor_slug="schedule_auto_transition_regressed")
 def schedule_auto_transition_regressed() -> None:
@@ -112,6 +118,8 @@ def schedule_auto_transition_regressed() -> None:
     queue="auto_transition_issue_states",
     time_limit=25 * 60,
     soft_time_limit=20 * 60,
+    max_retries=3,
+    default_retry_delay=60,
 )  # type: ignore
 def auto_transition_issues_regressed_to_ongoing(
     project_id: int,

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -30,7 +30,7 @@ TRANSITION_AFTER_DAYS = 3
     default_retry_delay=60,
     acks_late=True,
 )  # type: ignore
-@retry(on=(OperationalError,))
+@retry(on=(OperationalError,))  # type: ignore
 @monitor(monitor_slug="schedule_auto_transition_new")
 def schedule_auto_transition_new() -> None:
     now = datetime.now(tz=pytz.UTC)
@@ -57,7 +57,7 @@ def schedule_auto_transition_new() -> None:
     default_retry_delay=60,
     acks_late=True,
 )  # type: ignore
-@retry(on=(OperationalError,))
+@retry(on=(OperationalError,))  # type: ignore
 def auto_transition_issues_new_to_ongoing(
     project_id: int,
     first_seen_lte: int,
@@ -102,7 +102,7 @@ def auto_transition_issues_new_to_ongoing(
     default_retry_delay=60,
     acks_late=True,
 )  # type: ignore
-@retry(on=(OperationalError,))
+@retry(on=(OperationalError,))  # type: ignore
 @monitor(monitor_slug="schedule_auto_transition_regressed")
 def schedule_auto_transition_regressed() -> None:
     now = datetime.now(tz=pytz.UTC)
@@ -129,7 +129,7 @@ def schedule_auto_transition_regressed() -> None:
     default_retry_delay=60,
     acks_late=True,
 )  # type: ignore
-@retry(on=(OperationalError,))
+@retry(on=(OperationalError,))  # type: ignore
 def auto_transition_issues_regressed_to_ongoing(
     project_id: int,
     date_added_lte: int,


### PR DESCRIPTION
We're running into query timeouts when querying for the groups to auto-transition to ongoing status. 

This timeout seems to happen intermittently, so retrying it after some delay probably makes sense.

Resolves SENTRY-11MD, SENTRY-11MC