### PR TITLE
feat(escalating-issues): A/B test forecasting thresholds

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1218,6 +1218,8 @@ SENTRY_FEATURES = {
     "organizations:escalating-issues": False,
     # Enable archive/escalating issue workflow UI, enable everything except post processing
     "organizations:escalating-issues-ui": False,
+    # Enable escalating forecast threshold a/b experiment
+    "organizations:escalating-issues-experiment-group": False,
     # Enable the new issue states and substates
     "organizations:issue-states": False,
     # Enable the new issue states and substates

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -213,6 +213,7 @@ default_manager.add("organizations:dynamic-sampling", OrganizationFeature, Featu
 default_manager.add("organizations:dynamic-sampling-transaction-name-priority", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:escalating-issues", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-issues-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:escalating-issues-experiment-group", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:issue-states", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:remove-mark-reviewed", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:event-attachments", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/issues/forecasts.py
+++ b/src/sentry/issues/forecasts.py
@@ -6,14 +6,18 @@ import logging
 from datetime import datetime
 from typing import Sequence
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.issues.escalating import (
     ParsedGroupsCount,
     parse_groups_past_counts,
     query_groups_past_counts,
 )
 from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
-from sentry.issues.escalating_issues_alg import generate_issue_forecast
+from sentry.issues.escalating_issues_alg import (
+    generate_issue_forecast,
+    looser_version,
+    standard_version,
+)
 from sentry.models import Group
 
 logger = logging.getLogger(__name__)
@@ -31,12 +35,21 @@ def save_forecast_per_group(
     time = datetime.now()
     group_dict = {group.id: group for group in until_escalating_groups}
     for group_id, group_count in group_counts.items():
-        forecasts = generate_issue_forecast(group_count, time)
-        forecasts_list = [forecast["forecasted_value"] for forecast in forecasts]
+        group = group_dict.get(group_id)
+        if group:
+            forecast_threshold_version = (
+                looser_version
+                if features.has(
+                    "organization:escalating-issues-experiment-group", group.project.organization
+                )
+                else standard_version
+            )
 
-        if group_dict.get(group_id):
+            forecasts = generate_issue_forecast(group_count, time, forecast_threshold_version)
+            forecasts_list = [forecast["forecasted_value"] for forecast in forecasts]
+
             escalating_group_forecast = EscalatingGroupForecast(
-                group_dict[group_id].project.id, group_id, forecasts_list, time
+                group.project.id, group_id, forecasts_list, time
             )
             escalating_group_forecast.save()
     logger.info(


### PR DESCRIPTION
## Objective:
We want a different escalating threshold split for the 1k org closed beta. There should be two escalating thresholds, one that we’ve been using for internal and 100 closed beta customer test and another that is a higher threshold which I spoke with @npusarla about.