### PR TITLE
feat(replay): Remove "new" badge from Replay

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -9,7 +9,6 @@ import ListItem from 'sentry/components/list/listItem';
 import Placeholder from 'sentry/components/placeholder';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
-import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {IconPlay} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -125,7 +124,6 @@ function ReplayPreview({orgSlug, replaySlug, event}: Props) {
         </CTAOverlay>
         <BadgeContainer>
           <FeatureText>{t('Replays')}</FeatureText>
-          <ReplaysFeatureBadge />
         </BadgeContainer>
       </PlayerContainer>
     </ReplayContextProvider>

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import BaseBadge from 'sentry/components/idBadge/baseBadge';
 import HeaderPlaceholder from 'sentry/components/replays/header/headerPlaceholder';
-import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {getShortEventId} from 'sentry/utils/events';
@@ -24,10 +23,7 @@ function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
   const project = projects.find(p => p.id === replayRecord?.project_id);
 
   const labelTitle = replayRecord ? (
-    <Fragment>
-      {getShortEventId(replayRecord?.id)}
-      <ReplaysFeatureBadge />
-    </Fragment>
+    <Fragment>{getShortEventId(replayRecord?.id)}</Fragment>
   ) : (
     <HeaderPlaceholder width="100%" height="16px" />
   );

--- a/static/app/components/replays/replaysFeatureBadge.tsx
+++ b/static/app/components/replays/replaysFeatureBadge.tsx
@@ -1,9 +1,0 @@
-import FeatureBadge from 'sentry/components/featureBadge';
-
-function ReplaysFeatureBadge(
-  props: Omit<React.ComponentProps<typeof FeatureBadge>, 'type'>
-) {
-  return <FeatureBadge {...props} type="new" />;
-}
-
-export default ReplaysFeatureBadge;

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -311,7 +311,6 @@ function Sidebar({location, organization}: Props) {
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"
-        isNew
       />
     </Feature>
   );

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -19,7 +19,6 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
 import ReplayCountBadge from 'sentry/components/replays/replayCountBadge';
-import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import useReplaysCount from 'sentry/components/replays/useReplaysCount';
 import ShortId from 'sentry/components/shortId';
 import {TabList} from 'sentry/components/tabs';
@@ -178,7 +177,6 @@ function GroupHeaderTabs({
       >
         {t('Replays')}
         <ReplayCountBadge count={replaysCount} />
-        <ReplaysFeatureBadge tooltipProps={{disabled: true}} />
       </TabList.Item>
     </StyledTabList>
   );

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -10,7 +10,6 @@ import FeatureBadge from 'sentry/components/featureBadge';
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ReplayCountBadge from 'sentry/components/replays/replayCountBadge';
-import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import useReplaysCount from 'sentry/components/replays/useReplaysCount';
 import {TabList} from 'sentry/components/tabs';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -217,7 +216,6 @@ function TransactionHeader({
               >
                 {t('Replays')}
                 <ReplayCountBadge count={replaysCount} />
-                <ReplaysFeatureBadge tooltipProps={{disabled: true}} />
               </TabList.Item>
               <TabList.Item
                 key={Tab.Profiling}

--- a/static/app/views/replays/list/container.tsx
+++ b/static/app/views/replays/list/container.tsx
@@ -1,7 +1,6 @@
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
-import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import useReplayPageview from 'sentry/utils/replays/hooks/useReplayPageview';
@@ -25,7 +24,6 @@ function ReplaysListContainer() {
               )}
               docsUrl="https://docs.sentry.io/product/session-replay/"
             />
-            <ReplaysFeatureBadge />
           </Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>


### PR DESCRIPTION
Session Replay is no longer considered "new" as we launched it 3 months ago.

Removes the new badge from:
* Sidebar
* Replay preview (e.g. on issue details)
* Replay details
* Replay list
* Issue details tab bar
* Transaction summary tab bar

Closes #49793