### PR TITLE
perf(issue-details): Use collase=fullRelease on event endpoint

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -670,6 +670,24 @@ export type EventOccurrence = {
   type: number;
 };
 
+type EventRelease = Pick<
+  Release,
+  | 'commitCount'
+  | 'data'
+  | 'dateCreated'
+  | 'dateReleased'
+  | 'deployCount'
+  | 'id'
+  | 'lastCommit'
+  | 'lastDeploy'
+  | 'ref'
+  | 'status'
+  | 'url'
+  | 'userAgent'
+  | 'version'
+  | 'versionInfo'
+>;
+
 interface EventBase {
   contexts: EventContexts;
   crashFile: IssueAttachment | null;
@@ -715,7 +733,7 @@ interface EventBase {
   platform?: PlatformType;
   previousEventID?: string | null;
   projectSlug?: string;
-  release?: Release | null;
+  release?: EventRelease | null;
   sdk?: {
     name: string;
     version: string;

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -343,7 +343,7 @@ function useFetchGroupDetails({
 
   const eventUrl = `/issues/${groupId}/events/${eventId}/`;
 
-  const eventQuery: {environment?: string[]} = {};
+  const eventQuery: Record<string, string | string[]> = {collapse: ['fullRelease']};
   if (environments.length !== 0) {
     eventQuery.environment = environments;
   }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/49018

This will fetch a simplified release for the event endpoint, which still has all the info needed for the details page.