### PR TITLE
fix(crons): Add back DSN/MONITOR_ROOT setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1623,6 +1623,9 @@ SENTRY_REPROCESSING_APM_SAMPLING = 0
 # end APM config
 # ----
 
+# DSN to use for Sentry monitors
+SENTRY_MONITOR_DSN = None
+SENTRY_MONITOR_API_ROOT = None
 
 # Web Service
 SENTRY_WEB_HOST = "127.0.0.1"


### PR DESCRIPTION
This was removed when we turned on [auto instrumentation for celery-beat](https://github.com/getsentry/sentry/pull/49177/files), but because it is referenced in getsentry to power a monitor which validates that our legacy endpoint is working correctly, we need to keep this in for dev/single-tenant environments.

Previously to work around this, entries were added to the dev settings file in getsentry, but might just be better to add them here in `sentry` and then remove the entries from the dev file and remove the need to add them to the single tenant settings file.
https://github.com/getsentry/getsentry/pull/10568