### PR TITLE
fix(escalating-issues): Use fallback when forecast is out of range

### DIFF
--- a/src/sentry/issues/escalating_group_forecast.py
+++ b/src/sentry/issues/escalating_group_forecast.py
@@ -6,6 +6,7 @@ Sentry's NodeStore. The forecasts are stored for 2 weeks.
 from __future__ import annotations
 
 import hashlib
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import List, TypedDict, cast
@@ -22,6 +23,9 @@ class EscalatingGroupForecastData(TypedDict):
     group_id: int
     forecast: List[int]
     date_added: float
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -60,6 +64,10 @@ class EscalatingGroupForecast:
         date_now = datetime.now().date()
         escalating_forecast = EscalatingGroupForecast.fetch(project_id, group_id)
         forecast_today_index = (date_now - escalating_forecast.date_added.date()).days
+        if forecast_today_index >= len(escalating_forecast.forecast):
+            logger.error("Forecast list index is out of range")
+            # Use last available forecast as a fallback
+            forecast_today_index = -1
         return escalating_forecast.forecast[forecast_today_index]
 
     @classmethod

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -289,11 +289,11 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
             self.archive_until_escalating(archived_group)
 
             # The escalating forecast was added 15 days ago, and thus is out of the 14 day range
-            forecast_values = [1] * 13 + [10]
+            forecast_values = [10] * 13 + [1]
             self.save_mock_escalating_group_forecast(
                 group=archived_group,
                 forecast_values=forecast_values,
                 date_added=datetime.now() - timedelta(15),
             )
-            assert is_escalating(archived_group) == (False, None)
+            assert is_escalating(archived_group) == (True, 1)
             logger.error.assert_called_once_with("Forecast list index is out of range")

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -274,3 +274,26 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
 
         # Events are aggregated in the hourly count query by date rather than the last 24hrs
         assert get_group_hourly_count(group) == 1
+
+    @freeze_time(TIME_YESTERDAY)
+    def test_is_forecast_out_of_range(self) -> None:
+        """
+        Test that when an archived until escalating issue does not have a forecast that is in range,
+        the last forecast is used as a fallback and an error is reported
+        """
+        with self.feature("organizations:escalating-issues") and patch(
+            "sentry.issues.escalating_group_forecast.logger"
+        ) as logger:
+            event = self._create_events_for_group(count=2)
+            archived_group = event.group
+            self.archive_until_escalating(archived_group)
+
+            # The escalating forecast was added 15 days ago, and thus is out of the 14 day range
+            forecast_values = [1] * 13 + [10]
+            self.save_mock_escalating_group_forecast(
+                group=archived_group,
+                forecast_values=forecast_values,
+                date_added=datetime.now() - timedelta(15),
+            )
+            assert is_escalating(archived_group) == (False, None)
+            logger.error.assert_called_once_with("Forecast list index is out of range")


### PR DESCRIPTION
If the escalating forecast list index is out of range:
- Send an error
- Use the last available forecast as a fallback

Fixes SENTRY-11NN
Fixes SENTRY-FOR-SENTRY-VZK
Fixes https://github.com/getsentry/sentry/issues/49778
Fixes https://github.com/getsentry/sentry/issues/49812