### PR TITLE
fix(crons): Change sidebar wording from late to missed

### DIFF
--- a/static/app/views/monitors/components/detailsSidebar.tsx
+++ b/static/app/views/monitors/components/detailsSidebar.tsx
@@ -80,8 +80,12 @@ export default function DetailsSidebar({monitorEnv, monitor}: Props) {
         <MonitorIcon status={MonitorStatus.MISSED_CHECKIN} size={12} />
         <Text>
           {defined(checkin_margin)
-            ? tn('Check-ins %s min late', 'Check-ins %s mins late', checkin_margin)
-            : t('Check-ins that are late')}
+            ? tn(
+                'Check-ins missed after %s min',
+                'Check-ins missed after %s mins',
+                checkin_margin
+              )
+            : t('Check-ins that are missed')}
         </Text>
         <MonitorIcon status={MonitorStatus.ERROR} size={12} />
         <Text>


### PR DESCRIPTION
Changes the wording here 

From
<img width="321" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/f1da2947-ca53-4468-90d4-f5a31e5d3841">

To
<img width="341" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/906bd892-f470-481c-a3fc-91f55d7fbdfc">


We shouldn't be calling these late checkins because technically the checkin that comes in late will be an okay checkin, but we should explain that we will create a missed check-in instead.