### PR TITLE
fix(stacktrace-linking): Fix error in stack trace linking when we have no org integration

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -107,6 +107,8 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
     def get_client(self) -> GitHubClientMixin:
+        if not self.org_integration:
+            raise IntegrationError("Organization Integration does not exist")
         return GitHubAppsClient(integration=self.model, org_integration_id=self.org_integration.id)
 
     def get_trees_for_org(self, cache_seconds: int = 3600 * 24) -> Dict[str, RepoTree]:

--- a/src/sentry/integrations/mixins/repositories.py
+++ b/src/sentry/integrations/mixins/repositories.py
@@ -8,7 +8,7 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.models import Identity, Repository
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 
 class RepositoryMixin:
@@ -36,7 +36,7 @@ class RepositoryMixin:
         filepath = filepath.lstrip("/")
         try:
             client = self.get_client()
-        except Identity.DoesNotExist:
+        except (Identity.DoesNotExist, IntegrationError):
             return None
         try:
             response = client.check_file(repo, filepath, branch)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -71,6 +71,8 @@ metadata = IntegrationMetadata(
 
 class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):  # type: ignore
     def get_client(self) -> SlackClient:
+        if not self.org_integration:
+            raise IntegrationError("Organization Integration does not exist")
         return SlackClient(org_integration_id=self.org_integration.id)
 
     def get_config_data(self) -> Mapping[str, str]:

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -508,6 +508,36 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert not result
 
     @responses.activate
+    def test_get_stacktrace_link_no_org_integration(self):
+        self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id=123,
+            config={"name": "Test-Organization/foo"},
+            integration_id=integration.id,
+        )
+        path = "README.md"
+        version = "master"
+        default = "master"
+        responses.add(
+            responses.HEAD,
+            self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
+            status=404,
+        )
+        OrganizationIntegration.objects.get(
+            integration=integration, organization_id=self.organization.id
+        ).delete()
+        installation = integration.get_installation(self.organization.id)
+        result = installation.get_stacktrace_link(repo, path, default, version)
+
+        assert not result
+
+    @responses.activate
     def test_get_stacktrace_link_use_default_if_version_404(self):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)


### PR DESCRIPTION
If an org integration has been deleted from github we end up throwing an error when we attempt to access it. Just return no link instead.

Fixes SENTRY-11CC
