### PR TITLE
fix(ui): Alignment in search bar phantom, text

### DIFF
--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -222,7 +222,7 @@ const Negation = styled('span')`
   ${filterCss};
   border-right: none;
   padding-left: 1px;
-  margin-left: -2px;
+  margin-left: -1px;
   font-weight: bold;
   border-radius: 2px 0 0 2px;
   color: ${p => p.theme.red400};


### PR DESCRIPTION
The negation operator was cuasing text to go out of alignment since
there was 1px extra of negative margin

<img alt="clipboard.png" width="312" src="https://i.imgur.com/6Kd6HVP.png" />

(The cursor is completely misaligned in this screenshot)