### PR TITLE
fix(api-docs): securitySchemes not preserved from deprecated docs

### DIFF
--- a/src/sentry/apidocs/build.py
+++ b/src/sentry/apidocs/build.py
@@ -12,6 +12,17 @@ def get_old_json_paths(filename: str) -> json.JSONData:
     return old_raw_paths
 
 
+def get_old_json_components(filename: str) -> json.JSONData:
+    try:
+        with open(filename) as f:
+            old_raw_components = json.load(f)["components"]
+    except OSError:
+        raise Exception(
+            "Generate old OpenAPI files before running this command. Run `make build-api-docs` directly."
+        )
+    return old_raw_components
+
+
 OPENAPI_TAGS = [
     {
         "name": "Teams",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1138,7 +1138,7 @@ REST_FRAMEWORK = {
 
 if os.environ.get("OPENAPIGENERATE", False):
     OLD_OPENAPI_JSON_PATH = "tests/apidocs/openapi-deprecated.json"
-    from sentry.apidocs.build import OPENAPI_TAGS, get_old_json_paths
+    from sentry.apidocs.build import OPENAPI_TAGS, get_old_json_components, get_old_json_paths
 
     SPECTACULAR_SETTINGS = {
         "PREPROCESSING_HOOKS": ["sentry.apidocs.hooks.custom_preprocessing_hook"],
@@ -1157,6 +1157,7 @@ if os.environ.get("OPENAPIGENERATE", False):
         "SERVERS": [{"url": "https://sentry.io/"}],
         "PARSER_WHITELIST": ["rest_framework.parsers.JSONParser"],
         "APPEND_PATHS": get_old_json_paths(OLD_OPENAPI_JSON_PATH),
+        "APPEND_COMPONENTS": get_old_json_components(OLD_OPENAPI_JSON_PATH),
         "SORT_OPERATION_PARAMETERS": False,
     }
 


### PR DESCRIPTION
The old deprecated API docs sometimes use a DSN security type, which was correctly added to openapi.json, however drf-spectacular wasn't preserving that securityScheme type.

This uses a drf-spectacular setting to append those components.