### PR TITLE
fix(slack): Don't alert on deleted channels

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -31,7 +31,7 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):  # type: ignore
             self.get_client().post("/chat.postMessage", data=payload, json=True)
         except ApiError as e:
             message = str(e)
-            if message != "Expired url":
+            if message not in ["Expired url", "channel_not_found"]:
                 logger.error("slack.slash-notify.response-error", extra={"error": message})
 
 


### PR DESCRIPTION
If we try to send a message to a deleted Slack channel, we get this `channel_not_found` error and we can't do anything about it, so we don't need to receive a Sentry issue about it. 

Fixes SENTRY-RZY