### PR TITLE
fix(ui): Let note inputs match the parent line-height

### DIFF
--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -296,7 +296,6 @@ const StyledTabList = styled(TabList)`
 
 const NoteInputForm = styled('form')<{error?: string}>`
   font-size: 15px;
-  line-height: 22px;
   transition: padding 0.2s ease-in-out;
 
   ${p => getNoteInputErrorStyles(p)};


### PR DESCRIPTION
It inherits from the body, no need for it to be here