### PR TITLE
fix(issue-platform):  correct issue stats calculation for queries that return errors and issue platform groups

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1257,10 +1257,13 @@ def aliased_query_params(
             if condition_resolver
             else resolve_func
         )
-        for (i, condition) in enumerate(conditions):
-            replacement = resolve_condition(condition, column_resolver)
-            conditions[i] = replacement
-        conditions = [c for c in conditions if c]
+        replacement_conditions = []
+        for condition in conditions:
+            replacement = resolve_condition(deepcopy(condition), column_resolver)
+            if replacement:
+                replacement_conditions.append(replacement)
+    else:
+        replacement_conditions = conditions
 
     if orderby:
         # Don't mutate in case we have a default order passed.
@@ -1276,7 +1279,7 @@ def aliased_query_params(
         start=start,
         end=end,
         groupby=groupby,
-        conditions=conditions,
+        conditions=replacement_conditions,
         aggregations=aggregations,
         selected_columns=selected_columns,
         filter_keys=filter_keys,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1227,7 +1227,7 @@ def resolve_conditions(
 
     replacement_conditions = []
     for condition in conditions:
-        replacement = resolve_condition(condition, column_resolver)
+        replacement = resolve_condition(deepcopy(condition), column_resolver)
         if replacement:
             replacement_conditions.append(replacement)
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1219,6 +1219,21 @@ def _aliased_query_impl(**kwargs):
     return raw_query(**aliased_query_params(**kwargs))
 
 
+def resolve_conditions(
+    conditions: Optional[Sequence[Any]], column_resolver: Callable[[str], str]
+) -> Optional[Sequence[Any]]:
+    if conditions is None:
+        return conditions
+
+    replacement_conditions = []
+    for condition in conditions:
+        replacement = resolve_condition(condition, column_resolver)
+        if replacement:
+            replacement_conditions.append(replacement)
+
+    return replacement_conditions
+
+
 def aliased_query_params(
     start=None,
     end=None,
@@ -1257,13 +1272,9 @@ def aliased_query_params(
             if condition_resolver
             else resolve_func
         )
-        replacement_conditions = []
-        for condition in conditions:
-            replacement = resolve_condition(deepcopy(condition), column_resolver)
-            if replacement:
-                replacement_conditions.append(replacement)
+        resolved_conditions = resolve_conditions(conditions, column_resolver)
     else:
-        replacement_conditions = conditions
+        resolved_conditions = conditions
 
     if orderby:
         # Don't mutate in case we have a default order passed.
@@ -1279,7 +1290,7 @@ def aliased_query_params(
         start=start,
         end=end,
         groupby=groupby,
-        conditions=replacement_conditions,
+        conditions=resolved_conditions,
         aggregations=aggregations,
         selected_columns=selected_columns,
         filter_keys=filter_keys,


### PR DESCRIPTION
Fixes two things:
* we were mutating the passed in conditions list in `aliased_query_params` which caused subsequent uses of `self.conditions` to be inconsistent.
* update tsdb to resolve the filter conditions based on the group type and only pass in the dataset-appropriate conditions to the query.

Resolves SENTRY-10KX, SENTRY-112T