### PR TITLE
fix(sourcemaps): Add correct atomic transactions and fix error

### DIFF
--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from django.db import transaction
+from django.db import router
 from django.db.models import Q
 from rest_framework import status
 from rest_framework.request import Request
@@ -13,6 +13,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.artifactbundle import ArtifactBundlesSerializer
 from sentry.models import ArtifactBundle, ProjectArtifactBundle
+from sentry.utils.db import atomic_transaction
 
 
 class InvalidSortByParameter(SentryAPIException):
@@ -96,8 +97,10 @@ class ArtifactBundlesEndpoint(ProjectEndpoint, ArtifactBundlesMixin):
 
         if bundle_id:
             try:
-                with transaction.atomic():
-                    ArtifactBundle.objects.get(
+                # Since there were cases in which users could have uploaded multiple bundles with the same id, this call
+                # had to be refactored to delete multiple ones at the same time.
+                with atomic_transaction(using=(router.db_for_write(ArtifactBundle))):
+                    ArtifactBundle.objects.filter(
                         organization_id=project.organization_id, bundle_id=bundle_id
                     ).delete()
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -3,7 +3,7 @@ import logging
 from os import path
 from typing import List, Optional, Set, Tuple
 
-from django.db import IntegrityError, router, transaction
+from django.db import IntegrityError, router
 from django.db.models import Q
 from django.utils import timezone
 from symbolic import SymbolicError, normalize_debug_id
@@ -285,12 +285,11 @@ def _extract_debug_ids_from_manifest(
 
 
 def _remove_duplicate_artifact_bundles(bundle: ArtifactBundle, bundle_id: str):
-    with transaction.atomic():
-        # Even though we delete via a QuerySet the associated file is also deleted, because django will still
-        # fire the on_delete signal.
-        ArtifactBundle.objects.filter(
-            ~Q(id=bundle.id), bundle_id=bundle_id, organization_id=bundle.organization_id
-        ).delete()
+    # Even though we delete via a QuerySet the associated file is also deleted, because django will still
+    # fire the on_delete signal.
+    ArtifactBundle.objects.filter(
+        ~Q(id=bundle.id), bundle_id=bundle_id, organization_id=bundle.organization_id
+    ).delete()
 
 
 def _create_artifact_bundle(
@@ -309,47 +308,55 @@ def _create_artifact_bundle(
         if len(debug_ids_with_types) > 0 or version:
             now = timezone.now()
 
-            artifact_bundle = ArtifactBundle.objects.create(
-                organization_id=org_id,
-                # In case we didn't find the bundle_id in the manifest, we will just generate our own.
-                bundle_id=bundle_id or uuid.uuid4().hex,
-                file=archive_file,
-                artifact_count=artifact_count,
-                # For now these two fields will have the same value but in separate tasks we will update "date_added"
-                # in order to perform partitions rebalancing in the database.
-                date_added=now,
-                date_uploaded=now,
-            )
-
-            # If a release version is passed, we want to create the weak association between a bundle and a release.
-            if version:
-                ReleaseArtifactBundle.objects.create(
+            with atomic_transaction(
+                using=(
+                    router.db_for_write(ArtifactBundle),
+                    router.db_for_write(ReleaseArtifactBundle),
+                    router.db_for_write(ProjectArtifactBundle),
+                    router.db_for_write(DebugIdArtifactBundle),
+                )
+            ):
+                artifact_bundle = ArtifactBundle.objects.create(
                     organization_id=org_id,
-                    release_name=version,
-                    # In case no dist is provided, we will fall back to "" which is the NULL equivalent for our tables.
-                    dist_name=dist or "",
-                    artifact_bundle=artifact_bundle,
+                    # In case we didn't find the bundle_id in the manifest, we will just generate our own.
+                    bundle_id=bundle_id or uuid.uuid4().hex,
+                    file=archive_file,
+                    artifact_count=artifact_count,
+                    # For now these two fields will have the same value but in separate tasks we will update "date_added"
+                    # in order to perform partitions rebalancing in the database.
                     date_added=now,
+                    date_uploaded=now,
                 )
 
-            for project_id in project_ids or ():
-                ProjectArtifactBundle.objects.create(
-                    organization_id=org_id,
-                    project_id=project_id,
-                    artifact_bundle=artifact_bundle,
-                    date_added=now,
-                )
+                # If a release version is passed, we want to create the weak association between a bundle and a release.
+                if version:
+                    ReleaseArtifactBundle.objects.create(
+                        organization_id=org_id,
+                        release_name=version,
+                        # In case no dist is provided, we will fall back to "" which is the NULL equivalent for our tables.
+                        dist_name=dist or "",
+                        artifact_bundle=artifact_bundle,
+                        date_added=now,
+                    )
 
-            for source_file_type, debug_id in debug_ids_with_types:
-                DebugIdArtifactBundle.objects.create(
-                    organization_id=org_id,
-                    debug_id=debug_id,
-                    artifact_bundle=artifact_bundle,
-                    source_file_type=source_file_type.value,
-                    date_added=now,
-                )
+                for project_id in project_ids or ():
+                    ProjectArtifactBundle.objects.create(
+                        organization_id=org_id,
+                        project_id=project_id,
+                        artifact_bundle=artifact_bundle,
+                        date_added=now,
+                    )
 
-            _remove_duplicate_artifact_bundles(artifact_bundle, bundle_id)
+                for source_file_type, debug_id in debug_ids_with_types:
+                    DebugIdArtifactBundle.objects.create(
+                        organization_id=org_id,
+                        debug_id=debug_id,
+                        artifact_bundle=artifact_bundle,
+                        source_file_type=source_file_type.value,
+                        date_added=now,
+                    )
+
+                _remove_duplicate_artifact_bundles(artifact_bundle, bundle_id)
         else:
             raise AssembleArtifactsError(
                 "uploading a bundle without debug ids or release is prohibited"


### PR DESCRIPTION
This PR fixes a problem with atomic transactions and allows the deletion of multiple bundles with the same bundle_id, since now the db contains inconsistent state.

Closes https://github.com/getsentry/sentry/issues/49837