### PR TITLE
ref(ui): Improve alignment of replay network tab close

### DIFF
--- a/static/app/views/replays/detail/network/details/index.tsx
+++ b/static/app/views/replays/detail/network/details/index.tsx
@@ -115,6 +115,8 @@ const CloseButtonWrapper = styled('div')`
   height: 100%;
   padding: ${space(1)};
   z-index: ${p => p.theme.zIndex.initial};
+  display: flex;
+  align-items: center;
 `;
 
 const StyledSplitDivider = styled(SplitDivider)<{isHeld: boolean}>`


### PR DESCRIPTION
Before
<img alt="clipboard.png" width="756" src="https://i.imgur.com/sBLl25k.png" />

After
<img alt="clipboard.png" width="776" src="https://i.imgur.com/2SjFE0I.png" />