### PR TITLE
ref(js): Allow useOrganization to have a `allowNull`

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -1,4 +1,4 @@
-import {useContext, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -11,7 +11,7 @@ import {ExceptionType, Project} from 'sentry/types';
 import {Event, ExceptionValue} from 'sentry/types/event';
 import {STACK_TYPE} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
-import {OrganizationContext} from 'sentry/views/organizationContext';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {Mechanism} from './mechanism';
 import {RelatedExceptions} from './relatedExceptions';
@@ -135,7 +135,7 @@ export function Content({
   // Organization context may be unavailable for the shared event view, so we
   // avoid using the `useOrganization` hook here and directly useContext
   // instead.
-  const organization = useContext(OrganizationContext);
+  const organization = useOrganization({allowNull: true});
   if (!values) {
     return null;
   }

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useContext} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
@@ -10,9 +10,9 @@ import {IconAdd, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {OrganizationSummary} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
 import useResolveRoute from 'sentry/utils/useResolveRoute';
 import withOrganizations from 'sentry/utils/withOrganizations';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import Divider from './divider.styled';
 
@@ -38,7 +38,7 @@ function OrganizationMenuItem({organization}: {organization: OrganizationSummary
 }
 
 function CreateOrganization({canCreateOrganization}: {canCreateOrganization: boolean}) {
-  const currentOrganization = useContext(OrganizationContext);
+  const currentOrganization = useOrganization({allowNull: true});
   const route = useResolveRoute('/organizations/new/');
 
   if (!canCreateOrganization) {

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -12,9 +12,9 @@ import EventView, {
 } from 'sentry/utils/discover/eventView';
 import {QueryBatching} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import {PerformanceEventViewContext} from 'sentry/utils/performance/contexts/performanceEventViewContext';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import useApi from '../useApi';
+import useOrganization from '../useOrganization';
 
 export class QueryError {
   message: string;
@@ -303,7 +303,7 @@ class _GenericDiscoverQuery<T, P> extends Component<Props<T, P>, State<T>> {
 // Shim to allow us to use generic discover query or any specialization with or without passing org slug or eventview, which are now contexts.
 // This will help keep tests working and we can remove extra uses of context-provided props and update tests as we go.
 export function GenericDiscoverQuery<T, P>(props: OuterProps<T, P>) {
-  const organizationSlug = useContext(OrganizationContext)?.slug;
+  const organizationSlug = useOrganization({allowNull: true})?.slug;
   const performanceEventView = useContext(PerformanceEventViewContext)?.eventView;
 
   const orgSlug = props.orgSlug ?? organizationSlug;

--- a/static/app/utils/useOrganization.tsx
+++ b/static/app/utils/useOrganization.tsx
@@ -1,12 +1,35 @@
 import {useContext} from 'react';
 
+import {Organization} from 'sentry/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
-function useOrganization() {
+interface Options<AllowNull extends boolean = boolean> {
+  /**
+   * Allows null to be returned when there is no organization in context. This
+   * can happen when the user is not part of an orgaiozation
+   *
+   * @default false
+   */
+  allowNull?: AllowNull;
+}
+
+// The additional signatures provide proper type hints for when we set
+// `allowNull` to true.
+
+function useOrganization(opts?: Options<false>): Organization;
+function useOrganization(opts?: Options<true>): Organization | null;
+
+function useOrganization({allowNull}: Options = {}) {
   const organization = useContext(OrganizationContext);
+
+  if (allowNull) {
+    return organization;
+  }
+
   if (!organization) {
     throw new Error('useOrganization called but organization is not set.');
   }
+
   return organization;
 }
 

--- a/static/app/utils/useOrganization.tsx
+++ b/static/app/utils/useOrganization.tsx
@@ -6,7 +6,7 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 interface Options<AllowNull extends boolean = boolean> {
   /**
    * Allows null to be returned when there is no organization in context. This
-   * can happen when the user is not part of an orgaiozation
+   * can happen when the user is not part of an organization
    *
    * @default false
    */

--- a/static/app/utils/useResolveRoute.tsx
+++ b/static/app/utils/useResolveRoute.tsx
@@ -1,11 +1,9 @@
-import {useContext} from 'react';
-
 import ConfigStore from 'sentry/stores/configStore';
 import {OrganizationSummary} from 'sentry/types';
 import {extractSlug} from 'sentry/utils/extractSlug';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import shouldUseLegacyRoute from './shouldUseLegacyRoute';
+import useOrganization from './useOrganization';
 import {normalizeUrl} from './withDomainRequired';
 
 /**
@@ -32,7 +30,7 @@ function localizeDomain(domain?: string) {
  * use the sentry URL as the prefix.
  */
 function useResolveRoute(route: string, organization?: OrganizationSummary) {
-  const currentOrganization = useContext(OrganizationContext);
+  const currentOrganization = useOrganization({allowNull: true});
   const hasCustomerDomain = currentOrganization?.features.includes('customer-domains');
   const sentryUrl = localizeDomain(ConfigStore.get('links').sentryUrl);
 

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -1,4 +1,3 @@
-import {useContext} from 'react';
 import {formatPattern, RouteComponent, RouteComponentProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 import trimEnd from 'lodash/trimEnd';
@@ -9,7 +8,8 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import Redirect from 'sentry/utils/redirect';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import useOrganization from './useOrganization';
 
 /**
  * withDomainRedirect is a higher-order component (HOC) meant to be used with <Route /> components within
@@ -35,7 +35,7 @@ function withDomainRedirect<P extends RouteComponentProps<{}, {}>>(
   return function WithDomainRedirectWrapper(props: P) {
     const {customerDomain, links} = window.__initialData;
     const {sentryUrl} = links;
-    const currentOrganization = useContext(OrganizationContext);
+    const currentOrganization = useOrganization({allowNull: true});
 
     if (customerDomain) {
       // Customer domain is being used on a route that has an :orgId parameter.


### PR DESCRIPTION
Improved DX for the `useOrganization` hook, which allows us ask for it even if it's null (without an error)