### PR TITLE
Avoid double-processing non-`processed_by_symbolicator` events

### DIFF
--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -44,7 +44,9 @@ class JavascriptPlugin(Plugin2):
         return []
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
-        if data.get("processed_by_symbolicator", False):
+        if data.get("processed_by_symbolicator", False) and not data.get(
+            "symbolicator_stacktraces"
+        ):
             return []
 
         if "javascript" in platforms or "node" in platforms:

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -198,6 +198,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     ]
 
     metrics.incr("sourcemaps.symbolicator.events")
+    data["processed_by_symbolicator"] = True
 
     if not any(stacktrace["frames"] for stacktrace in stacktraces):
         metrics.incr("sourcemaps.symbolicator.events.skipped")
@@ -259,8 +260,6 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
     if should_do_ab_test:
         data["symbolicator_stacktraces"] = symbolicator_stacktraces
-    else:
-        data["processed_by_symbolicator"] = True
 
     return data
 


### PR DESCRIPTION
The mechanism to symbolicate mixed stack traces by scheduling another native `symbolicate_event` did not work correctly for events missing the `processed_by_symbolicator` marker. They would just go through JS symbolication a second time. Which means events without eligible stack traces, and events that were sampled for A/B testing were being run through the symbolicate task again. Which means being skipped again, and with a high likelyhood not sampled for A/B testing the second time around.