### PR TITLE
ref(clusterer): Extend namespace with metadata storage

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/__init__.py
+++ b/src/sentry/ingest/transaction_clusterer/__init__.py
@@ -16,7 +16,9 @@ class NamespaceOption:
     persistent_storage: str
     """Option name to store produced rules in the clusterer, in persistent storage."""
     tracker: str
-    """Option name to store tracking data of this namespace."""
+    """Option name to emit tracking data of this namespace, such as metrics."""
+    meta_store: str
+    """Option name to emit store metadata belonging to this namespace."""
 
 
 class ClustererNamespace(Enum):
@@ -26,4 +28,5 @@ class ClustererNamespace(Enum):
         rules="txrules",
         persistent_storage="sentry:transaction_name_cluster_rules",
         tracker="txcluster.rules_per_project",
+        meta_store="sentry:transaction_name_cluster_meta",
     )

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -69,7 +69,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
                     clusterer.add_input(tx_names)
                     new_rules = clusterer.get_rules()
 
-                track_clusterer_run(project)
+                track_clusterer_run(ClustererNamespace.TRANSACTIONS, project)
 
                 # The Redis store may have more up-to-date last_seen values,
                 # so we must update the stores to bring these values to

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -319,7 +319,7 @@ def _get_project_config(
 
     # Mark the project as ready if it has seen >= 10 clusterer runs.
     # This prevents projects from prematurely marking all URL transactions as sanitized.
-    if get_clusterer_meta(project)["runs"] >= MIN_CLUSTERER_RUNS:
+    if get_clusterer_meta(ClustererNamespace.TRANSACTIONS, project)["runs"] >= MIN_CLUSTERER_RUNS:
         config["txNameReady"] = True
 
     if not full_config:

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -215,8 +215,8 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
         _add_mock_data(project, 4)
 
     assert (
-        get_clusterer_meta(project1)
-        == get_clusterer_meta(project2)
+        get_clusterer_meta(ClustererNamespace.TRANSACTIONS, project1)
+        == get_clusterer_meta(ClustererNamespace.TRANSACTIONS, project2)
         == {"first_run": 0, "last_run": 0, "runs": 0}
     )
 
@@ -230,8 +230,8 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
     assert get_rules(ClustererNamespace.TRANSACTIONS, project2) == {}
 
     assert (
-        get_clusterer_meta(project1)
-        == get_clusterer_meta(project2)
+        get_clusterer_meta(ClustererNamespace.TRANSACTIONS, project1)
+        == get_clusterer_meta(ClustererNamespace.TRANSACTIONS, project2)
         == {"first_run": 946688400, "last_run": 946688400, "runs": 1}
     )
 
@@ -267,8 +267,8 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
     }
 
     assert (
-        get_clusterer_meta(project1)
-        == get_clusterer_meta(project2)
+        get_clusterer_meta(ClustererNamespace.TRANSACTIONS, project1)
+        == get_clusterer_meta(ClustererNamespace.TRANSACTIONS, project2)
         == {"first_run": 946688400, "last_run": 946688401, "runs": 2}
     )
 


### PR DESCRIPTION
Extends the clusterer namespace to include the metadata storage. This should have been part of https://github.com/getsentry/sentry/pull/49699.