### PR TITLE
fix(hybridcloud) Add name to silo limited tasks

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -52,6 +52,8 @@ class TaskSiloLimit(SiloLimit):
                 setattr(decorated_task, attr_name, limited_attr)
 
         limited_func = self.create_override(decorated_task)
+        if hasattr(decorated_task, "name"):
+            limited_func.name = decorated_task.name
         return limited_func
 
 


### PR DESCRIPTION
When wrapping a task with a silo limiter we need to preserve the task's name. There are a few tests in getsentry for task names and this helps those tests stay green.