### PR TITLE
feat(migrations): Add approximate version of `RangeQuerySetWrapperWithProgressBar`

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -174,13 +174,31 @@ class RangeQuerySetWrapper:
 
 
 class RangeQuerySetWrapperWithProgressBar(RangeQuerySetWrapper):
+    def get_total_count(self):
+        return self.queryset.count()
+
     def __iter__(self):
-        total_count = self.queryset.count()
-        if not total_count:
-            return iter([])
+        total_count = self.get_total_count()
         iterator = super().__iter__()
         label = self.queryset.model._meta.verbose_name_plural.title()
         return iter(WithProgressBar(iterator, total_count, label))
+
+
+class RangeQuerySetWrapperWithProgressBarApprox(RangeQuerySetWrapperWithProgressBar):
+    """
+    Works the same as `RangeQuerySetWrapperWithProgressBar`, but approximates the number of rows
+    in the table. This is intended for use on very large tables where we end up timing out
+    attempting to get an accurate count.
+
+    Note: This is only intended for queries that are iterating over an entire table. Will not
+    produce a useful total count on filtered queries.
+    """
+
+    def get_total_count(self):
+        query = f"SELECT reltuples AS estimate FROM pg_class WHERE relname = '{self.queryset.model._meta.db_table}';"
+        cursor = connections[self.queryset.using_replica().db].cursor()
+        cursor.execute(query)
+        return cursor.fetchone()[0]
 
 
 class WithProgressBar:
@@ -192,26 +210,25 @@ class WithProgressBar:
         self.caption = str(caption or "Progress")
 
     def __iter__(self):
-        if self.count != 0:
-            widgets = [
-                f"{self.caption}: ",
-                progressbar.Percentage(),
-                " ",
-                progressbar.Bar(),
-                " ",
-                progressbar.ETA(),
-            ]
-            pbar = progressbar.ProgressBar(widgets=widgets, max_value=self.count)
-            pbar.start()
-            for idx, item in enumerate(self.iterator):
-                yield item
-                # It's possible that we've exceeded the maxval, but instead
-                # of exploding on a ValueError, let's just cap it so we don't.
-                # this could happen if new rows were added between calculating `count()`
-                # and actually beginning iteration where we're iterating slightly more
-                # than we thought.
-                pbar.update(min(idx, self.count))
-            pbar.finish()
+        widgets = [
+            f"{self.caption}: ",
+            progressbar.Percentage(),
+            " ",
+            progressbar.Bar(),
+            " ",
+            progressbar.ETA(),
+        ]
+        pbar = progressbar.ProgressBar(widgets=widgets, max_value=self.count)
+        pbar.start()
+        for idx, item in enumerate(self.iterator):
+            yield item
+            # It's possible that we've exceeded the maxval, but instead
+            # of exploding on a ValueError, let's just cap it so we don't.
+            # this could happen if new rows were added between calculating `count()`
+            # and actually beginning iteration where we're iterating slightly more
+            # than we thought.
+            pbar.update(min(idx, self.count))
+        pbar.finish()
 
 
 def bulk_delete_objects(

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -3,7 +3,12 @@ from sentry.models import Organization, User
 from sentry.models.userreport import UserReport
 from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils.query import RangeQuerySetWrapper, bulk_delete_objects
+from sentry.utils.query import (
+    RangeQuerySetWrapper,
+    RangeQuerySetWrapperWithProgressBar,
+    RangeQuerySetWrapperWithProgressBarApprox,
+    bulk_delete_objects,
+)
 
 
 class InIexactQueryTest(TestCase):
@@ -19,6 +24,8 @@ class InIexactQueryTest(TestCase):
 
 @control_silo_test(stable=True)
 class RangeQuerySetWrapperTest(TestCase):
+    range_wrapper = RangeQuerySetWrapper
+
     def test_basic(self):
         total = 10
 
@@ -27,8 +34,8 @@ class RangeQuerySetWrapperTest(TestCase):
 
         qs = User.objects.all()
 
-        assert len(list(RangeQuerySetWrapper(qs, step=2))) == total
-        assert len(list(RangeQuerySetWrapper(qs, limit=5))) == 5
+        assert len(list(self.range_wrapper(qs, step=2))) == total
+        assert len(list(self.range_wrapper(qs, limit=5))) == 5
 
     def test_loop_and_delete(self):
         total = 10
@@ -37,10 +44,24 @@ class RangeQuerySetWrapperTest(TestCase):
 
         qs = User.objects.all()
 
-        for user in RangeQuerySetWrapper(qs, step=2):
+        for user in self.range_wrapper(qs, step=2):
             user.delete()
 
         assert User.objects.all().count() == 0
+
+    def test_empty(self):
+        qs = User.objects.all()
+        assert len(list(self.range_wrapper(qs, step=2))) == 0
+
+
+@control_silo_test(stable=True)
+class RangeQuerySetWrapperWithProgressBarTest(RangeQuerySetWrapperTest):
+    range_wrapper = RangeQuerySetWrapperWithProgressBar
+
+
+@control_silo_test(stable=True)
+class RangeQuerySetWrapperWithProgressBarApproxTest(RangeQuerySetWrapperTest):
+    range_wrapper = RangeQuerySetWrapperWithProgressBarApprox
 
 
 class BulkDeleteObjectsTest(TestCase):


### PR DESCRIPTION
When using `RangeQuerySetWrapperWithProgressBar` on large tables we're often timing out producing the initial count of rows. This pr introduces `RangeQuerySetWrapperWithProgressBarApprox`, which works the same way, but pulls an estimate from Postgres. This means the counts won't be correct, and we'll likely finish iteration at either under/over 100%, but should avoid these timeouts.

This method only works when we're iterating over a whole table, the count will be completely inaccurate if any filters are applied.
