### PR TITLE
feat(escalating-issues): Add expired snooze details to SET_ESCALATING activity records

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, TypedDict
 
+import jsonschema
 from django.db.models.signals import post_save
 from snuba_sdk import (
     Column,
@@ -26,6 +27,7 @@ from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.escalating_issues_alg import GroupCount
 from sentry.issues.grouptype import GroupCategory
 from sentry.models import (
+    INBOX_REASON_DETAILS,
     Activity,
     ActivityType,
     Group,
@@ -333,6 +335,15 @@ def manage_issue_states(
             )
             if data and activity_data:
                 data.update(activity_data)
+            if data and snooze_details:
+                try:
+                    jsonschema.validate(snooze_details, INBOX_REASON_DETAILS)
+
+                except jsonschema.ValidationError:
+                    logging.error(f"Expired snooze_details invalid jsonschema: {snooze_details}")
+
+                data.update({"expired_snooze": snooze_details})
+
             Activity.objects.create(
                 project=group.project,
                 group=group,

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -340,7 +340,7 @@ def manage_issue_states(
                     jsonschema.validate(snooze_details, INBOX_REASON_DETAILS)
 
                 except jsonschema.ValidationError:
-                    logging.error(f"Expired snooze_details invalid jsonschema: {snooze_details}")
+                    logging.error("Expired snooze_details invalid jsonschema", extra=snooze_details)
 
                 data.update({"expired_snooze": snooze_details})
 

--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -10,18 +10,24 @@ from sentry.tasks.base import instrumented_task
 @instrumented_task(name="sentry.tasks.clear_expired_snoozes", time_limit=65, soft_time_limit=60)
 def clear_expired_snoozes():
     groupsnooze_list = list(
-        GroupSnooze.objects.filter(until__lte=timezone.now()).values_list("id", "group")[:1000]
+        GroupSnooze.objects.filter(until__lte=timezone.now()).values_list("id", "group", "until")[
+            :1000
+        ]
     )
     group_snooze_ids = [gs[0] for gs in groupsnooze_list]
-    group_list = [gs[1] for gs in groupsnooze_list]
+    groups_with_snoozes = {gs[1]: {"id": gs[0], "until": gs[2]} for gs in groupsnooze_list}
 
-    ignored_groups = list(Group.objects.filter(id__in=group_list, status=GroupStatus.IGNORED))
+    ignored_groups = list(
+        Group.objects.filter(id__in=groups_with_snoozes.keys(), status=GroupStatus.IGNORED)
+    )
 
     GroupSnooze.objects.filter(id__in=group_snooze_ids).delete()
 
     for group in ignored_groups:
         if features.has("organizations:escalating-issues", group.organization):
-            manage_issue_states(group, GroupInboxReason.ESCALATING)
+            snooze_details = {"until": groups_with_snoozes.get(group.id, {}).get("until")}
+
+            manage_issue_states(group, GroupInboxReason.ESCALATING, snooze_details=snooze_details)
 
         elif features.has("organizations:issue-states", group.organization):
             manage_issue_states(group, GroupInboxReason.ONGOING)


### PR DESCRIPTION
## Objective:

We want to add the expired snooze details to the SET_ESCALATING Activity records. We will want to render the reason why the Issue was moved into Escalating in the Issue's Activity feed.