### PR TITLE
ref(pageFilter): Use smaller font for desync message

### DIFF
--- a/static/app/components/organizations/pageFilters/desyncedFilter.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFilter.tsx
@@ -53,6 +53,8 @@ const DesyncedFilterMessageWrap = styled('div')`
   margin: ${space(0.25)} ${space(0.5)} ${space(0.5)};
   padding: ${space(0.75)};
 
+  font-size: ${p => p.theme.fontSizeSmall};
+
   strong {
     display: block;
     font-weight: bold;


### PR DESCRIPTION
**Before ——**
<img width="323" alt="Screenshot 2023-05-26 at 11 03 55 AM" src="https://github.com/getsentry/sentry/assets/44172267/0d2b92d6-ff6f-49ff-b9a2-26d2db46c2bc">

**After ——**
<img width="323" alt="Screenshot 2023-05-26 at 11 03 35 AM" src="https://github.com/getsentry/sentry/assets/44172267/fdae8049-c7bd-4795-9d57-da5bba9e451b">
