### PR TITLE
fix(tasks): add @retry to tasks that use max_retries

### DIFF
--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -13,7 +13,7 @@ from sentry.auth.exceptions import ProviderNotRegistered
 from sentry.models import ApiKey, AuditLogEntry, Organization, OrganizationMember, User, UserEmail
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 
@@ -148,6 +148,7 @@ class TwoFactorComplianceTask(OrganizationComplianceTask):
     default_retry_delay=60 * 5,
     max_retries=5,
 )
+@retry
 def remove_2fa_non_compliant_members(org_id, actor_id=None, actor_key_id=None, ip_address=None):
     TwoFactorComplianceTask().remove_non_compliant_members(
         org_id, actor_id, actor_key_id, ip_address
@@ -202,6 +203,7 @@ class VerifiedEmailComplianceTask(OrganizationComplianceTask):
     default_retry_delay=60 * 5,
     max_retries=5,
 )
+@retry
 def remove_email_verification_non_compliant_members(
     org_id, actor_id=None, actor_key_id=None, ip_address=None
 ):

--- a/src/sentry/tasks/auto_archive_issues.py
+++ b/src/sentry/tasks/auto_archive_issues.py
@@ -19,7 +19,7 @@ from sentry.models import (
     record_group_history_from_activity_type,
     remove_group_from_inbox,
 )
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.utils.iterators import chunked
@@ -35,6 +35,7 @@ ITERATOR_CHUNK = 10_000
     queue="auto_transition_issue_states",
     max_retries=3,
 )  # type: ignore
+@retry
 @monitor(monitor_slug="auto-archive-job-monitor")
 def run_auto_archive() -> None:
     """
@@ -62,6 +63,7 @@ def run_auto_archive() -> None:
     time_limit=25 * 60,
     soft_time_limit=20 * 60,
 )  # type: ignore
+@retry
 def run_auto_archive_for_project(project_ids: List[int]) -> None:
     now = datetime.now(tz=pytz.UTC)
     fourteen_days_ago = now - timedelta(days=14)

--- a/src/sentry/tasks/codeowners/update_code_owners_schema.py
+++ b/src/sentry/tasks/codeowners/update_code_owners_schema.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable
 from sentry import features
 from sentry.models import Integration, Organization, Project
 from sentry.services.hybrid_cloud.integration import RpcIntegration
-from sentry.tasks.base import instrumented_task, load_model_from_db
+from sentry.tasks.base import instrumented_task, load_model_from_db, retry
 
 
 @instrumented_task(
@@ -14,6 +14,7 @@ from sentry.tasks.base import instrumented_task, load_model_from_db
     default_retry_delay=5,
     max_retries=5,
 )
+@retry
 def update_code_owners_schema(
     organization: Organization | int,
     integration: Integration | RpcIntegration | int | None = None,

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -1,6 +1,6 @@
 from django.db import DatabaseError, IntegrityError, router
 
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.deletion.scheduled import MAX_RETRIES
 from sentry.utils.db import atomic_transaction
 
@@ -50,6 +50,7 @@ def delete_file(file_blob_model, path, checksum, **kwargs):
     default_retry_delay=60 * 5,
     max_retries=MAX_RETRIES,
 )
+@retry
 def delete_unreferenced_blobs_region(blob_ids):
     from sentry.models import FileBlob, FileBlobIndex
 
@@ -62,6 +63,7 @@ def delete_unreferenced_blobs_region(blob_ids):
     default_retry_delay=60 * 5,
     max_retries=MAX_RETRIES,
 )
+@retry
 def delete_unreferenced_blobs_control(blob_ids):
     from sentry.models import ControlFileBlob, ControlFileBlobIndex
 

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from sentry.locks import locks
 from sentry.models import Commit, Project, Release
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.committers import get_event_file_committers
@@ -121,6 +121,7 @@ def _process_suspect_commits(
     default_retry_delay=5,
     max_retries=5,
 )
+@retry
 def process_suspect_commits(
     event_id,
     event_platform,

--- a/src/sentry/tasks/organization_mapping.py
+++ b/src/sentry/tasks/organization_mapping.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
     default_retry_delay=5,
     max_retries=5,
 )  # type: ignore
+@retry
 def repair_mappings() -> None:
     metrics.incr("sentry.hybrid_cloud.tasks.organizationmapping.start", sample_rate=1.0)
     with metrics.timer("sentry.hybrid_cloud.tasks.organizationmapping.repair", sample_rate=1.0):

--- a/src/sentry/tasks/sentry_functions.py
+++ b/src/sentry/tasks/sentry_functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sentry.api.serializers import serialize
 from sentry.models import Group
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import json
 from sentry.utils.cloudfunctions import publish_message
 
@@ -16,6 +16,7 @@ TASK_OPTIONS = {
 @instrumented_task(
     "sentry.tasks.sentry_functions.send_sentry_function_webhook", acks_late=True, **TASK_OPTIONS
 )
+@retry
 def send_sentry_function_webhook(sentry_function_id, event, issue_id, data=None):
     try:
         data["issue"] = serialize(Group.objects.get(id=issue_id))

--- a/src/sentry/tasks/servicehooks.py
+++ b/src/sentry/tasks/servicehooks.py
@@ -3,7 +3,7 @@ from time import time
 from sentry.api.serializers import serialize
 from sentry.http import safe_urlopen
 from sentry.models import ServiceHook
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import json
 
 
@@ -27,6 +27,7 @@ def get_payload_v0(event):
 @instrumented_task(
     name="sentry.tasks.process_service_hook", default_retry_delay=60 * 5, max_retries=5
 )
+@retry
 def process_service_hook(servicehook_id, event, **kwargs):
     try:
         servicehook = ServiceHook.objects.get(id=servicehook_id)

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -6,7 +6,7 @@ from sentry_sdk.crons.decorator import monitor
 
 from sentry.issues.forecasts import generate_and_save_forecasts
 from sentry.models import Group, GroupStatus, ObjectStatus, Project
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.types.group import GroupSubStatus
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
@@ -53,6 +53,7 @@ def run_escalating_forecast() -> None:
     max_retries=3,
     default_retry_delay=60,
 )  # type: ignore
+@retry  # type: ignore
 def generate_forecasts_for_projects(project_ids: List[int]) -> None:
     for until_escalating_groups in chunked(
         RangeQuerySetWrapper(

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -34,7 +34,7 @@ from sentry.models import (
     User,
 )
 from sentry.snuba.dataset import Dataset
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import instrumented_task, retry
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
@@ -135,6 +135,7 @@ def check_if_ctx_is_empty(ctx):
     max_retries=5,
     acks_late=True,
 )
+@retry
 def schedule_organizations(dry_run=False, timestamp=None, duration=None):
     if timestamp is None:
         # The time that the report was generated
@@ -159,6 +160,7 @@ def schedule_organizations(dry_run=False, timestamp=None, duration=None):
     max_retries=5,
     acks_late=True,
 )
+@retry
 def prepare_organization_report(
     timestamp, duration, organization_id, dry_run=False, target_user=None, email_override=None
 ):


### PR DESCRIPTION
Some of our existing tasks makes use of `max_retries` param but doesn't actually apply retry logic to the task. 

I scanned through the tasks that apply `max_retries` and decorated the function with `@retry` so they can actually be retried X amount of times.