### PR TITLE
ref(discover): Only show breadcrumbs in orgs that can create saved queries

### DIFF
--- a/static/app/views/discover/resultsHeader.tsx
+++ b/static/app/views/discover/resultsHeader.tsx
@@ -7,6 +7,7 @@ import {stringify} from 'query-string';
 import {fetchHomepageQuery} from 'sentry/actionCreators/discoverHomepageQueries';
 import {fetchSavedQuery} from 'sentry/actionCreators/discoverSavedQueries';
 import {Client} from 'sentry/api';
+import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
@@ -157,12 +158,14 @@ class ResultsHeader extends Component<Props, State> {
             </GuideAnchor>
           ) : (
             <Fragment>
-              <DiscoverBreadcrumb
-                eventView={eventView}
-                organization={organization}
-                location={location}
-                isHomepage={isHomepage}
-              />
+              <Feature features={['organizations:discover-query']}>
+                <DiscoverBreadcrumb
+                  eventView={eventView}
+                  organization={organization}
+                  location={location}
+                  isHomepage={isHomepage}
+                />
+              </Feature>
               <EventInputName
                 savedQuery={savedQuery}
                 organization={organization}


### PR DESCRIPTION
_(Not sure if there was an explicit product decision to keep the breadcrumbs. From a design perspective, they shouldn't be there.)_

Users in orgs that don't have the `discover-query` feature can't create/access saved Discover queries. For them, the breadcrumbs bar is pretty much useless. In the bar, "Discover" and "All Events" are not clickable…
<img width="1290" alt="Screenshot 2023-05-26 at 2 08 35 PM" src="https://github.com/getsentry/sentry/assets/44172267/bf7be957-d0cd-45ad-8609-81a9dc5e4707">

…whereas "Saved Queries" leads to a dead end — an empty page with an access warning:
<img width="1290" alt="Screenshot 2023-05-26 at 2 12 28 PM" src="https://github.com/getsentry/sentry/assets/44172267/366e3cf8-b4ac-435f-babc-82c404be1543">


I think we should just remove the breadcrumbs:
<img width="1290" alt="Screenshot 2023-05-26 at 2 07 58 PM" src="https://github.com/getsentry/sentry/assets/44172267/79ca4f20-2347-4e24-92aa-0d1767f35b5c">
