### PR TITLE
ref(ui): Improve Activity Item Note

### DIFF
--- a/static/app/components/activity/author.tsx
+++ b/static/app/components/activity/author.tsx
@@ -5,4 +5,4 @@ const ActivityAuthor = styled('span')`
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-export default ActivityAuthor;
+export {ActivityAuthor};

--- a/static/app/components/activity/item/avatar.tsx
+++ b/static/app/components/activity/item/avatar.tsx
@@ -36,7 +36,7 @@ function ActivityAvatar({className, type, user, size = 38}: Props) {
   );
 }
 
-export default ActivityAvatar;
+export {ActivityAvatar};
 
 type SystemAvatarProps = {
   size: number;
@@ -56,3 +56,7 @@ const SystemAvatar = styled('span')<SystemAvatarProps>`
 const StyledIconSentry = styled(IconSentry)`
   padding-bottom: 3px;
 `;
+
+const DO_NOT_USE_ACTIVITY_AVATAR = ActivityAvatar;
+
+export default DO_NOT_USE_ACTIVITY_AVATAR;

--- a/static/app/components/activity/item/bubble.tsx
+++ b/static/app/components/activity/item/bubble.tsx
@@ -48,4 +48,4 @@ const ActivityBubble = styled('div')<ActivityBubbleProps>`
   }
 `;
 
-export default ActivityBubble;
+export {ActivityBubble};

--- a/static/app/components/activity/item/index.tsx
+++ b/static/app/components/activity/item/index.tsx
@@ -6,14 +6,11 @@ import TimeSince from 'sentry/components/timeSince';
 import {space} from 'sentry/styles/space';
 import textStyles from 'sentry/styles/text';
 import {AvatarUser} from 'sentry/types';
-import {isRenderFunc} from 'sentry/utils/isRenderFunc';
 
-import ActivityAvatar from './avatar';
-import ActivityBubble, {ActivityBubbleProps} from './bubble';
+import {ActivityAvatar} from './avatar';
+import {ActivityBubble, ActivityBubbleProps} from './bubble';
 
 export type ActivityAuthorType = 'user' | 'system';
-
-type ChildFunction = () => React.ReactNode;
 
 interface ActivityItemProps {
   /**
@@ -26,43 +23,38 @@ interface ActivityItemProps {
     type: ActivityAuthorType;
     user?: AvatarUser;
   };
-  // Size of the avatar.
   avatarSize?: number;
   bubbleProps?: ActivityBubbleProps;
-
-  children?: React.ReactChild | ChildFunction;
+  children?: React.ReactNode;
 
   className?: string;
-
   /**
    * If supplied, will show the time that the activity started
    */
   date?: string | Date;
-
   /**
    * Can be a react node or a render function. render function will not include default wrapper
    */
-  footer?: React.ReactNode | ChildFunction;
-
+  header?: React.ReactNode;
   /**
-   * Can be a react node or a render function. render function will not include default wrapper
+   * Do not show the date in the header
    */
-  header?: React.ReactNode | ChildFunction;
-
-  // Hides date in header
   hideDate?: boolean;
-
   /**
    * This is used to uniquely identify the activity item for use as an anchor
    */
   id?: string;
-
   /**
    * If supplied, will show the interval that the activity occurred in
    */
   interval?: number;
-
-  // Instead of showing a relative time/date, show the time
+  /**
+   * Removes padding on the activtiy body
+   */
+  noPadding?: boolean;
+  /**
+   * Show exact time instead of relative date/time.
+   */
   showTime?: boolean;
 }
 
@@ -74,7 +66,7 @@ function ActivityItem({
   children,
   date,
   interval,
-  footer,
+  noPadding,
   id,
   header,
   hideDate = false,
@@ -98,8 +90,7 @@ function ActivityItem({
       )}
 
       <StyledActivityBubble {...bubbleProps}>
-        {header && isRenderFunc<ChildFunction>(header) && header()}
-        {header && !isRenderFunc<ChildFunction>(header) && (
+        {header && (
           <ActivityHeader>
             <ActivityHeaderContent>{header}</ActivityHeaderContent>
             {date && showDate && !showTime && <StyledTimeSince date={date} />}
@@ -115,15 +106,7 @@ function ActivityItem({
           </ActivityHeader>
         )}
 
-        {children && isRenderFunc<ChildFunction>(children) && children()}
-        {children && !isRenderFunc<ChildFunction>(children) && (
-          <ActivityBody>{children}</ActivityBody>
-        )}
-
-        {footer && isRenderFunc<ChildFunction>(footer) && footer()}
-        {footer && !isRenderFunc<ChildFunction>(footer) && (
-          <ActivityFooter>{footer}</ActivityFooter>
-        )}
+        {children && (noPadding ? children : <ActivityBody>{children}</ActivityBody>)}
       </StyledActivityBubble>
     </ActivityItemWrapper>
   );
@@ -134,12 +117,10 @@ const ActivityItemWrapper = styled('div')`
   margin-bottom: ${space(2)};
 `;
 
-const HeaderAndFooter = styled('div')`
-  padding: 6px ${space(2)};
-`;
-
-const ActivityHeader = styled(HeaderAndFooter)`
+const ActivityHeader = styled('div')`
   display: flex;
+  align-items: center;
+  padding: 6px ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
   font-size: ${p => p.theme.fontSizeMedium};
 
@@ -150,12 +131,6 @@ const ActivityHeader = styled(HeaderAndFooter)`
 
 const ActivityHeaderContent = styled('div')`
   flex: 1;
-`;
-
-const ActivityFooter = styled(HeaderAndFooter)`
-  display: flex;
-  border-top: 1px solid ${p => p.theme.border};
-  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const ActivityBody = styled('div')`
@@ -184,4 +159,4 @@ const StyledActivityBubble = styled(ActivityBubble)`
   overflow-wrap: break-word;
 `;
 
-export default ActivityItem;
+export {ActivityItem};

--- a/static/app/components/activity/note/body.tsx
+++ b/static/app/components/activity/note/body.tsx
@@ -1,18 +1,56 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
 import marked from 'sentry/utils/marked';
 
 type Props = {
   text: string;
-  className?: string;
 };
 
-function NoteBody({className, text}: Props) {
+function NoteBody({text}: Props) {
   return (
-    <div
-      className={className}
+    <StyledNoteBody
       data-test-id="activity-note-body"
       dangerouslySetInnerHTML={{__html: marked(text)}}
     />
   );
 }
 
-export default NoteBody;
+const StyledNoteBody = styled('div')`
+  ul {
+    list-style: disc;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  p,
+  ul:not(.nav),
+  ol,
+  pre,
+  hr,
+  blockquote {
+    margin-bottom: ${space(2)};
+  }
+
+  ul,
+  ol {
+    padding-left: 20px;
+  }
+
+  p {
+    a {
+      word-wrap: break-word;
+    }
+  }
+
+  blockquote {
+    font-size: 15px;
+    border-left: 5px solid ${p => p.theme.innerBorder};
+    padding-left: ${space(1)};
+    margin-left: 0;
+  }
+`;
+
+export {NoteBody};

--- a/static/app/components/activity/note/editorTools.tsx
+++ b/static/app/components/activity/note/editorTools.tsx
@@ -1,7 +1,0 @@
-import styled from '@emotion/styled';
-
-const EditorTools = styled('span')`
-  display: none;
-`;
-
-export default EditorTools;

--- a/static/app/components/activity/note/header.tsx
+++ b/static/app/components/activity/note/header.tsx
@@ -1,14 +1,13 @@
-import {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import ActivityAuthor from 'sentry/components/activity/author';
-import LinkWithConfirmation from 'sentry/components/links/linkWithConfirmation';
-import {Tooltip} from 'sentry/components/tooltip';
+import {ActivityAuthor} from 'sentry/components/activity/author';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
+import {space} from 'sentry/styles/space';
 import {User} from 'sentry/types';
-
-import EditorTools from './editorTools';
 
 type Props = {
   authorName: string;
@@ -22,56 +21,53 @@ function NoteHeader({authorName, user, onEdit, onDelete}: Props) {
   const canEdit = activeUser && (activeUser.isSuperuser || user?.id === activeUser.id);
 
   return (
-    <div>
+    <Container>
       <ActivityAuthor>{authorName}</ActivityAuthor>
       {canEdit && (
-        <EditorTools>
-          <Tooltip
-            title={t('You can edit this comment due to your superuser status')}
-            disabled={!activeUser.isSuperuser}
-          >
-            <Edit onClick={onEdit}>{t('Edit')}</Edit>
-          </Tooltip>
-          <Tooltip
-            title={t('You can delete this comment due to your superuser status')}
-            disabled={!activeUser.isSuperuser}
-          >
-            <LinkWithConfirmation
-              title={t('Remove')}
-              message={t('Are you sure you wish to delete this comment?')}
-              onConfirm={onDelete}
-            >
-              <Remove>{t('Remove')}</Remove>
-            </LinkWithConfirmation>
-          </Tooltip>
-        </EditorTools>
+        <DropdownMenu
+          offset={4}
+          size="sm"
+          triggerProps={{
+            size: 'xs',
+            showChevron: false,
+            borderless: true,
+            icon: <IconEllipsis size="xs" />,
+            'aria-label': t('Comment Actions'),
+          }}
+          items={[
+            {
+              key: 'edit',
+              label: t('Edit'),
+              onAction: onEdit,
+              tooltip: activeUser.isSuperuser
+                ? t('You can edit this comment due to your superuser status')
+                : undefined,
+            },
+            {
+              key: 'delete',
+              label: t('Remove'),
+              priority: 'danger',
+              onAction: () =>
+                openConfirmModal({
+                  header: t('Remove'),
+                  message: t('Are you sure you wish to delete this comment?'),
+                  onConfirm: onDelete,
+                }),
+              tooltip: activeUser.isSuperuser
+                ? t('You can delete this comment due to your superuser status')
+                : undefined,
+            },
+          ]}
+        />
       )}
-    </div>
+    </Container>
   );
 }
 
-const getActionStyle = (p: {theme: Theme}) => `
-  padding: 0 7px;
-  color: ${p.theme.gray200};
-  font-weight: normal;
+const Container = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
 `;
 
-const Edit = styled('a')`
-  ${getActionStyle};
-  margin-left: 7px;
-
-  &:hover {
-    color: ${p => p.theme.gray300};
-  }
-`;
-
-const Remove = styled('span')`
-  ${getActionStyle};
-  border-left: 1px solid ${p => p.theme.border};
-
-  &:hover {
-    color: ${p => p.theme.error};
-  }
-`;
-
-export default NoteHeader;
+export {NoteHeader};

--- a/static/app/components/activity/note/index.tsx
+++ b/static/app/components/activity/note/index.tsx
@@ -1,16 +1,13 @@
 import {useState} from 'react';
-import styled from '@emotion/styled';
 
-import ActivityItem, {ActivityAuthorType} from 'sentry/components/activity/item';
-import {space} from 'sentry/styles/space';
+import {ActivityAuthorType, ActivityItem} from 'sentry/components/activity/item';
 import {User} from 'sentry/types';
 import {NoteType} from 'sentry/types/alerts';
 import {ActivityType} from 'sentry/views/alerts/types';
 
-import NoteBody from './body';
-import EditorTools from './editorTools';
-import NoteHeader from './header';
-import NoteInput from './input';
+import {NoteBody} from './body';
+import {NoteHeader} from './header';
+import {NoteInput} from './input';
 
 type Props = {
   /**
@@ -88,27 +85,9 @@ function Note(props: Props) {
     date: dateCreated,
   };
 
-  if (!editing) {
-    const header = (
-      <NoteHeader
-        {...{authorName, user}}
-        onEdit={() => setEditing(true)}
-        onDelete={() => onDelete(props)}
-      />
-    );
-
+  if (editing) {
     return (
-      <ActivityItemWithEditing {...activityItemProps} header={header}>
-        <NoteBody text={text} />
-      </ActivityItemWithEditing>
-    );
-  }
-
-  // When editing, `NoteInput` has its own header, pass render func to control
-  // rendering of bubble body
-  return (
-    <ActivityItemNote {...activityItemProps}>
-      {() => (
+      <ActivityItem noPadding {...activityItemProps}>
         <NoteInput
           {...{noteId, minHeight, text, projectSlugs}}
           onEditFinish={() => setEditing(false)}
@@ -118,55 +97,24 @@ function Note(props: Props) {
           }}
           onCreate={note => onCreate?.(note)}
         />
-      )}
-    </ActivityItemNote>
+      </ActivityItem>
+    );
+  }
+
+  const header = (
+    <NoteHeader
+      user={user}
+      authorName={authorName}
+      onEdit={() => setEditing(true)}
+      onDelete={() => onDelete(props)}
+    />
+  );
+
+  return (
+    <ActivityItem {...activityItemProps} header={header}>
+      <NoteBody text={text} />
+    </ActivityItem>
   );
 }
 
-const ActivityItemNote = styled(ActivityItem)`
-  /* this was nested under ".activity-note.activity-bubble" */
-  ul {
-    list-style: disc;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  p,
-  ul:not(.nav),
-  ol,
-  pre,
-  hr,
-  blockquote {
-    margin-bottom: ${space(2)};
-  }
-
-  ul,
-  ol {
-    padding-left: 20px;
-  }
-
-  p {
-    a {
-      word-wrap: break-word;
-    }
-  }
-
-  blockquote {
-    font-size: 15px;
-    border-left: 5px solid ${p => p.theme.innerBorder};
-    padding-left: ${space(1)};
-    margin-left: 0;
-  }
-`;
-
-const ActivityItemWithEditing = styled(ActivityItemNote)`
-  &:hover {
-    ${EditorTools} {
-      display: inline-block;
-    }
-  }
-`;
-
-export default Note;
+export {Note};

--- a/static/app/components/activity/note/input.spec.tsx
+++ b/static/app/components/activity/note/input.spec.tsx
@@ -1,20 +1,16 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import NoteInput from 'sentry/components/activity/note/input';
+import {NoteInput} from 'sentry/components/activity/note/input';
 
 describe('NoteInput', function () {
   describe('New item', function () {
-    const props = {
-      group: {project: {}, id: 'groupId'},
-    };
-
     it('renders', function () {
-      render(<NoteInput {...props} />);
+      render(<NoteInput />);
     });
 
     it('submits when meta + enter is pressed', async function () {
       const onCreate = jest.fn();
-      render(<NoteInput {...props} onCreate={onCreate} />);
+      render(<NoteInput onCreate={onCreate} />);
 
       await userEvent.type(screen.getByRole('textbox'), 'something{Meta>}{Enter}');
       expect(onCreate).toHaveBeenCalled();
@@ -22,7 +18,7 @@ describe('NoteInput', function () {
 
     it('submits when ctrl + enter is pressed', async function () {
       const onCreate = jest.fn();
-      render(<NoteInput {...props} onCreate={onCreate} />);
+      render(<NoteInput onCreate={onCreate} />);
 
       await userEvent.type(screen.getByRole('textbox'), 'something{Control>}{Enter}');
       expect(onCreate).toHaveBeenCalled();
@@ -30,7 +26,7 @@ describe('NoteInput', function () {
 
     it('does not submit when nothing is entered', async function () {
       const onCreate = jest.fn();
-      render(<NoteInput {...props} onCreate={onCreate} />);
+      render(<NoteInput onCreate={onCreate} />);
 
       const textbox = screen.getByRole('textbox');
       await userEvent.type(textbox, '{Control}{enter}');
@@ -39,20 +35,20 @@ describe('NoteInput', function () {
 
     it('handles errors', async function () {
       const errorJSON = {detail: {message: 'Note is bad', code: 401, extra: ''}};
-      render(<NoteInput {...props} error={!!errorJSON} errorJSON={errorJSON} />);
+      render(<NoteInput error={!!errorJSON} errorJSON={errorJSON} />);
 
       await userEvent.type(screen.getByRole('textbox'), 'something{Control>}{enter}');
       expect(screen.getByText('Note is bad')).toBeInTheDocument();
     });
 
     it('has a disabled submit button when no text is entered', function () {
-      render(<NoteInput {...props} />);
+      render(<NoteInput />);
 
       expect(screen.getByRole('button', {name: 'Post Comment'})).toBeDisabled();
     });
 
     it('enables the submit button when text is entered', async function () {
-      render(<NoteInput {...props} />);
+      render(<NoteInput />);
       await userEvent.type(screen.getByRole('textbox'), 'something');
 
       expect(screen.getByRole('button', {name: 'Post Comment'})).toBeEnabled();
@@ -61,7 +57,6 @@ describe('NoteInput', function () {
 
   describe('Existing Item', function () {
     const props = {
-      group: {project: {}, id: 'groupId'},
       noteId: 'item-id',
       text: 'an existing item',
     };

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -7,16 +7,15 @@ import {Button} from 'sentry/components/button';
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import {IconMarkdown} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import MemberListStore from 'sentry/stores/memberListStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import textStyles from 'sentry/styles/text';
 import {NoteType} from 'sentry/types/alerts';
 import domId from 'sentry/utils/domId';
 import marked from 'sentry/utils/marked';
+import {useMembers} from 'sentry/utils/useMembers';
 import {useTeams} from 'sentry/utils/useTeams';
 
-import mentionStyle from './mentionStyle';
+import {mentionStyle} from './mentionStyle';
 import {CreateError, MentionChangeEvent, Mentioned} from './types';
 
 type Props = {
@@ -63,16 +62,17 @@ function NoteInput({
 }: Props) {
   const theme = useTheme();
 
-  const members = useLegacyStore(MemberListStore).members.map(member => ({
+  const {members} = useMembers();
+  const {teams} = useTeams();
+
+  const suggestMembers = members.map(member => ({
     id: `user:${member.id}`,
     display: member.name,
-    email: member.email,
   }));
 
-  const teams = useTeams().teams.map(team => ({
+  const suggestTeams = teams.map(team => ({
     id: `team:${team.id}`,
     display: `#${team.slug}`,
-    email: team.id,
   }));
 
   const [value, setValue] = useState(text ?? '');
@@ -177,7 +177,7 @@ function NoteInput({
             >
               <Mention
                 trigger="@"
-                data={members}
+                data={suggestMembers}
                 onAdd={handleAddMember}
                 displayTransform={(_id, display) => `@${display}`}
                 markup="**[sentry.strip:member]__display__**"
@@ -185,7 +185,7 @@ function NoteInput({
               />
               <Mention
                 trigger="#"
-                data={teams}
+                data={suggestTeams}
                 onAdd={handleAddTeam}
                 markup="**[sentry.strip:team]__display__**"
                 appendSpaceOnAdd
@@ -229,7 +229,7 @@ function NoteInput({
   );
 }
 
-export default NoteInput;
+export {NoteInput};
 
 type NotePreviewProps = {
   minHeight: Props['minHeight'];
@@ -295,7 +295,6 @@ const StyledTabList = styled(TabList)`
 `;
 
 const NoteInputForm = styled('form')<{error?: string}>`
-  font-size: 15px;
   transition: padding 0.2s ease-in-out;
 
   ${p => getNoteInputErrorStyles(p)};
@@ -313,7 +312,6 @@ const Footer = styled('div')`
 `;
 
 const FooterButton = styled(Button)<{error?: boolean}>`
-  font-size: 13px;
   margin: -1px -1px -1px;
   border-radius: 0 0 ${p => p.theme.borderRadius};
 
@@ -344,5 +342,4 @@ const MarkdownIndicator = styled('div')`
 
 const NotePreview = styled('div')<{minHeight: Props['minHeight']}>`
   ${p => getNotePreviewCss(p)};
-  padding-bottom: ${space(1)};
 `;

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -2,7 +2,7 @@ import {useCallback, useMemo} from 'react';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
 
-import NoteInput from 'sentry/components/activity/note/input';
+import {NoteInput} from 'sentry/components/activity/note/input';
 import {MentionChangeEvent} from 'sentry/components/activity/note/types';
 import {NoteType} from 'sentry/types/alerts';
 import localStorage from 'sentry/utils/localStorage';

--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -11,7 +11,16 @@ type Options = {
  * Note this is an object for `react-mentions` component and
  * not a styled component/emotion style
  */
-export default function mentionStyle({theme, minHeight}: Options) {
+export function mentionStyle({theme, minHeight}: Options) {
+  const inputProps = {
+    fontSize: theme.fontSizeMedium,
+    padding: `${space(1.5)} ${space(2)}`,
+    outline: 0,
+    border: 0,
+    minHeight,
+    overflow: 'auto',
+  };
+
   return {
     control: {
       backgroundColor: `${theme.background}`,
@@ -46,23 +55,15 @@ export default function mentionStyle({theme, minHeight}: Options) {
         minHeight,
       },
 
-      highlighter: {
-        padding: 20,
-        minHeight,
-      },
-
-      input: {
-        padding: `${space(1.5)} ${space(2)} 0`,
-        minHeight,
-        overflow: 'auto',
-        outline: 0,
-        border: 0,
-      },
+      // Use the same props for the highliter to keep the phantom text aligned
+      highlighter: inputProps,
+      input: inputProps,
     },
 
     suggestions: {
       list: {
-        maxHeight: 150,
+        maxHeight: 142,
+        minWidth: 220,
         overflow: 'auto',
         backgroundColor: `${theme.background}`,
         border: '1px solid rgba(0,0,0,0.15)',
@@ -72,7 +73,7 @@ export default function mentionStyle({theme, minHeight}: Options) {
       },
 
       item: {
-        padding: '5px 15px',
+        padding: space(0.5),
         borderRadius: theme.borderRadius,
         '&focused': {
           backgroundColor: theme.hover,

--- a/static/app/components/events/userFeedback.tsx
+++ b/static/app/components/events/userFeedback.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import ActivityAuthor from 'sentry/components/activity/author';
-import ActivityItem from 'sentry/components/activity/item';
+import {ActivityAuthor} from 'sentry/components/activity/author';
+import {ActivityItem} from 'sentry/components/activity/item';
 import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
 import {IconCopy} from 'sentry/icons';

--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import ActivityAvatar from 'sentry/components/activity/item/avatar';
+import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
 import Card from 'sentry/components/card';
 import Link, {LinkProps} from 'sentry/components/links/link';
 import {t} from 'sentry/locale';

--- a/static/app/views/discover/querycard.tsx
+++ b/static/app/views/discover/querycard.tsx
@@ -1,7 +1,7 @@
 import {PureComponent} from 'react';
 import styled from '@emotion/styled';
 
-import ActivityAvatar from 'sentry/components/activity/item/avatar';
+import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
 import Card from 'sentry/components/card';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Link from 'sentry/components/links/link';

--- a/static/app/views/issueDetails/groupActivity.spec.jsx
+++ b/static/app/views/issueDetails/groupActivity.spec.jsx
@@ -318,7 +318,8 @@ describe('GroupActivity', function () {
         GroupStore.removeActivity('1337', 'note-1');
       });
 
-      await userEvent.click(screen.getByText('Remove'));
+      await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Remove'}));
       expect(
         screen.getByText('Are you sure you wish to delete this comment?')
       ).toBeInTheDocument();
@@ -331,7 +332,8 @@ describe('GroupActivity', function () {
       createWrapper();
       renderGlobalModal();
 
-      await userEvent.click(screen.getByText('Remove'));
+      await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Remove'}));
       expect(
         screen.getByText('Are you sure you wish to delete this comment?')
       ).toBeInTheDocument();

--- a/static/app/views/issueDetails/groupActivity.tsx
+++ b/static/app/views/issueDetails/groupActivity.tsx
@@ -9,9 +9,9 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
-import ActivityAuthor from 'sentry/components/activity/author';
-import ActivityItem from 'sentry/components/activity/item';
-import Note from 'sentry/components/activity/note';
+import {ActivityAuthor} from 'sentry/components/activity/author';
+import {ActivityItem} from 'sentry/components/activity/item';
+import {Note} from 'sentry/components/activity/note';
 import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithStorage';
 import {CreateError} from 'sentry/components/activity/note/types';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -159,19 +159,17 @@ class GroupActivity extends Component<Props, State> {
 
         <Layout.Body>
           <Layout.Main>
-            <ActivityItem author={{type: 'user', user: me}}>
-              {() => (
-                <NoteInputWithStorage
-                  key={this.state.inputId}
-                  storageKey="groupinput:latest"
-                  itemKey={group.id}
-                  onCreate={this.handleNoteCreate}
-                  busy={this.state.createBusy}
-                  error={this.state.error}
-                  errorJSON={this.state.errorJSON}
-                  {...noteProps}
-                />
-              )}
+            <ActivityItem noPadding author={{type: 'user', user: me}}>
+              <NoteInputWithStorage
+                key={this.state.inputId}
+                storageKey="groupinput:latest"
+                itemKey={group.id}
+                onCreate={this.handleNoteCreate}
+                busy={this.state.createBusy}
+                error={this.state.error}
+                errorJSON={this.state.errorJSON}
+                {...noteProps}
+              />
             </ActivityItem>
 
             <Teams

--- a/static/app/views/organizationActivity/activityFeedItem.tsx
+++ b/static/app/views/organizationActivity/activityFeedItem.tsx
@@ -1,7 +1,7 @@
 import {Component, createRef} from 'react';
 import styled from '@emotion/styled';
 
-import ActivityAvatar from 'sentry/components/activity/item/avatar';
+import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
 import CommitLink from 'sentry/components/commitLink';
 import Duration from 'sentry/components/duration';
 import IssueLink from 'sentry/components/issueLink';

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import ActivityAvatar from 'sentry/components/activity/item/avatar';
+import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import DateTime from 'sentry/components/dateTime';
 import SelectControl from 'sentry/components/forms/controls/selectControl';


### PR DESCRIPTION
- All named exports

 - Simplify API of ActivityItem

   - Small header alignment adjustments.
   - Comments added to all props.
   - `footer` Prop is removed, this was completely unused.
   - `children` and `header` no longer accept a render-prop style
     renderer. This was only used to remove padding. Instead I've added
     a more clear `noPadding` prop for this.

 - The NoteHeader now uses a DropdownMenu for an overflow menu instead
   of anchor links for remove and edit.

 - NoteBody now has formatting styles applied to it, before these were
   applied to the entire note component causing issues in the tabs
   component

   Before bulllets were added to tabs

   <img alt="clipboard.png" width="212" src="https://i.imgur.com/8kF7dYR.png" />

 - Note test is converted jsx -> tsx

 - Note input now uses `useMembers`. This doesn't absolutely fix the
   fact that users won't be loaded at all on this page, but it gets us
   closer.

 - Fixed various styles for the mentions menu.