### PR TITLE
feat(api): Support member query by user.id

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -144,6 +144,9 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                 elif key == "id":
                     queryset = queryset.filter(id__in=value)
 
+                elif key == "user.id":
+                    queryset = queryset.filter(user__id__in=value)
+
                 elif key == "scope":
                     queryset = queryset.filter(role__in=[r.id for r in roles.with_any_scope(value)])
 

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -166,6 +166,16 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         assert len(response.data) == 1
         assert response.data[0]["email"] == "billy@localhost"
 
+    def test_user_id_query(self):
+        user = self.create_user("zoo@localhost", username="zoo")
+        OrganizationMember.objects.create(user=user, organization=self.organization)
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": f"user.id:{user.id}"}
+        )
+
+        assert len(response.data) == 1
+        assert response.data[0]["email"] == "zoo@localhost"
+
     def test_query_null_user(self):
         OrganizationMember.objects.create(email="billy@localhost", organization=self.organization)
         response = self.get_success_response(self.organization.slug, qs_params={"query": "bill"})


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/49877, we want to be
able (from the frontend) to query for members with a specific user ID