### PR TITLE
feat(project-creation): use experimental endpoint

### DIFF
--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -157,6 +157,38 @@ describe('CreateProject', function () {
     expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled();
   });
 
+  it('can create a new team before project creation if org owner', async function () {
+    const {organization} = initializeOrg({
+      organization: {
+        access: ['project:admin'],
+      },
+    });
+
+    render(<CreateProject />, {
+      context: TestStubs.routerContext([
+        {
+          organization: {
+            id: '1',
+            slug: 'testOrg',
+            access: ['project:read'],
+          },
+        },
+      ]),
+      organization,
+    });
+
+    renderGlobalModal();
+    await userEvent.click(screen.getByRole('button', {name: 'Create a team'}));
+
+    expect(
+      await screen.findByText(
+        'Members of a team have access to specific areas, such as a new release or a new application feature.'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
+  });
+
   it('should only allow teams which the user is a team-admin', async function () {
     const organization = TestStubs.Organization();
     renderFrameworkModalMockRequests({organization, teamSlug: 'team-two'});

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -10,6 +10,7 @@ import {
 import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {Organization} from 'sentry/types';
+import * as useExperiment from 'sentry/utils/useExperiment';
 import {CreateProject} from 'sentry/views/projectInstall/createProject';
 
 function renderFrameworkModalMockRequests({
@@ -84,25 +85,77 @@ describe('CreateProject', function () {
     expect(container).toSnapshot();
   });
 
-  // it('can create a new team', async function () {
-  //   render(<CreateProject />, {
-  //     context: TestStubs.routerContext([
-  //       {organization: {id: '1', slug: 'testOrg', access: ['project:read']}},
-  //     ]),
-  //   });
+  it('can create a new team as admin', async function () {
+    const {organization} = initializeOrg({
+      organization: {
+        access: ['project:admin'],
+      },
+    });
+    renderFrameworkModalMockRequests({organization, teamSlug: 'team-two'});
+    TeamStore.loadUserTeams([
+      TestStubs.Team({id: 2, slug: 'team-two', access: ['team:admin']}),
+    ]);
 
-  //   renderGlobalModal();
+    render(<CreateProject />, {
+      context: TestStubs.routerContext([
+        {
+          organization: {
+            id: '1',
+            slug: 'testOrg',
+            access: ['project:read'],
+          },
+        },
+      ]),
+      organization,
+    });
 
-  //   await userEvent.click(screen.getByRole('button', {name: 'Create a team'}));
+    renderGlobalModal();
 
-  //   expect(
-  //     await screen.findByText(
-  //       'Members of a team have access to specific areas, such as a new release or a new application feature.'
-  //     )
-  //   ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Create a team'}));
 
-  //   await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
-  // });
+    expect(
+      await screen.findByText(
+        'Members of a team have access to specific areas, such as a new release or a new application feature.'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
+  });
+
+  it('can create a new project without team as org member', async function () {
+    const {organization} = initializeOrg({
+      organization: {
+        access: ['project:read'],
+        features: ['organizations:team-project-creation-all'],
+      },
+    });
+
+    jest.spyOn(useExperiment, 'useExperiment').mockReturnValue({
+      experimentAssignment: 1,
+      logExperiment: jest.fn(),
+    });
+    renderFrameworkModalMockRequests({organization, teamSlug: 'team-two'});
+    TeamStore.loadUserTeams([TestStubs.Team({id: 2, slug: 'team-two', access: []})]);
+
+    render(<CreateProject />, {
+      context: TestStubs.routerContext([
+        {
+          organization: {
+            id: '1',
+            slug: 'testOrg',
+            access: ['project:read'],
+          },
+        },
+      ]),
+      organization,
+    });
+
+    renderGlobalModal();
+    await userEvent.click(screen.getByTestId('platform-apple-ios'));
+    const createTeamButton = screen.queryByRole('button', {name: 'Create a team'});
+    expect(createTeamButton).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled();
+  });
 
   it('should only allow teams which the user is a team-admin', async function () {
     const organization = TestStubs.Organization();

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -84,25 +84,25 @@ describe('CreateProject', function () {
     expect(container).toSnapshot();
   });
 
-  it('can create a new team', async function () {
-    render(<CreateProject />, {
-      context: TestStubs.routerContext([
-        {organization: {id: '1', slug: 'testOrg', access: ['project:read']}},
-      ]),
-    });
+  // it('can create a new team', async function () {
+  //   render(<CreateProject />, {
+  //     context: TestStubs.routerContext([
+  //       {organization: {id: '1', slug: 'testOrg', access: ['project:read']}},
+  //     ]),
+  //   });
 
-    renderGlobalModal();
+  //   renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Create a team'}));
+  //   await userEvent.click(screen.getByRole('button', {name: 'Create a team'}));
 
-    expect(
-      await screen.findByText(
-        'Members of a team have access to specific areas, such as a new release or a new application feature.'
-      )
-    ).toBeInTheDocument();
+  //   expect(
+  //     await screen.findByText(
+  //       'Members of a team have access to specific areas, such as a new release or a new application feature.'
+  //     )
+  //   ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
-  });
+  //   await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
+  // });
 
   it('should only allow teams which the user is a team-admin', async function () {
     const organization = TestStubs.Organization();

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -219,9 +219,12 @@ function CreateProject() {
   const {shouldCreateCustomRule, conditions} = alertRuleConfig || {};
   const {canCreateProject} = useProjectCreationAccess({organization, teams: accessTeams});
 
+  const isOrgMemberWithNoAccess =
+    accessTeams.length === 0 && !organization.access.includes('project:admin');
+
   const canSubmitForm =
     !inFlight &&
-    (team || accessTeams.length === 0) &&
+    (team || isOrgMemberWithNoAccess) &&
     canCreateProject &&
     projectName !== '' &&
     (!shouldCreateCustomRule || conditions?.every?.(condition => condition.value));
@@ -252,7 +255,7 @@ function CreateProject() {
             />
           </ProjectNameInputWrap>
         </div>
-        {accessTeams.length > 0 && (
+        {!isOrgMemberWithNoAccess && (
           <div>
             <FormLabel>{t('Team')}</FormLabel>
             <TeamSelectInput>
@@ -297,7 +300,7 @@ function CreateProject() {
   );
 
   return (
-    <Access access={canCreateProject ? ['project:read'] : ['project:write']}>
+    <Access access={canCreateProject ? ['project:read'] : ['project:admin']}>
       {error && <Alert type="error">{error}</Alert>}
       <div data-test-id="onboarding-info">
         <Layout.Title withMargins>{t('Create a new project in 3 steps')}</Layout.Title>

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -85,14 +85,19 @@ function CreateProject() {
       setInFlight(true);
 
       try {
-        const projectData = await api.requestPromise(`/teams/${slug}/${team}/projects/`, {
-          method: 'POST',
-          data: {
-            name: projectName,
-            platform: selectedPlatform,
-            default_rules: defaultRules ?? true,
-          },
-        });
+        const projectData = await api.requestPromise(
+          team === null
+            ? `/organizations/${slug}/experimental/projects/`
+            : `/teams/${slug}/${team}/projects/`,
+          {
+            method: 'POST',
+            data: {
+              name: projectName,
+              platform: selectedPlatform,
+              default_rules: defaultRules ?? true,
+            },
+          }
+        );
 
         let ruleId: string | undefined;
         if (shouldCreateCustomRule) {
@@ -216,7 +221,7 @@ function CreateProject() {
 
   const canSubmitForm =
     !inFlight &&
-    team &&
+    (team || accessTeams.length === 0) &&
     canCreateProject &&
     projectName !== '' &&
     (!shouldCreateCustomRule || conditions?.every?.(condition => condition.value));
@@ -247,34 +252,36 @@ function CreateProject() {
             />
           </ProjectNameInputWrap>
         </div>
-        <div>
-          <FormLabel>{t('Team')}</FormLabel>
-          <TeamSelectInput>
-            <TeamSelector
-              name="select-team"
-              aria-label={t('Select a Team')}
-              menuPlacement="auto"
-              clearable={false}
-              value={team}
-              placeholder={t('Select a Team')}
-              onChange={choice => setTeam(choice.value)}
-              teamFilter={(tm: Team) => tm.access.includes('team:admin')}
-            />
-            <Button
-              borderless
-              data-test-id="create-team"
-              icon={<IconAdd isCircled />}
-              onClick={() =>
-                openCreateTeamModal({
-                  organization,
-                  onClose: ({slug}) => setTeam(slug),
-                })
-              }
-              title={t('Create a team')}
-              aria-label={t('Create a team')}
-            />
-          </TeamSelectInput>
-        </div>
+        {accessTeams.length > 0 && (
+          <div>
+            <FormLabel>{t('Team')}</FormLabel>
+            <TeamSelectInput>
+              <TeamSelector
+                name="select-team"
+                aria-label={t('Select a Team')}
+                menuPlacement="auto"
+                clearable={false}
+                value={team}
+                placeholder={t('Select a Team')}
+                onChange={choice => setTeam(choice.value)}
+                teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+              />
+              <Button
+                borderless
+                data-test-id="create-team"
+                icon={<IconAdd isCircled />}
+                onClick={() =>
+                  openCreateTeamModal({
+                    organization,
+                    onClose: ({slug}) => setTeam(slug),
+                  })
+                }
+                title={t('Create a team')}
+                aria-label={t('Create a team')}
+              />
+            </TeamSelectInput>
+          </div>
+        )}
         <div>
           <Button
             type="submit"


### PR DESCRIPTION
Frontend changes to let org members create project using new endpoint:
1. don't show them team selection dropdown (they have none)
2. replace url
