### PR TITLE
fix(trends): Handle mismatched transaction names

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trendsv2.py
+++ b/src/sentry/api/endpoints/organization_events_trendsv2.py
@@ -207,8 +207,6 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 "data": None,
                 "sort": None,
                 "trendFunction": None,
-                "start": None,
-                "end": None,
             }
 
             trends_request["sort"] = request.GET.get("sort", "trend_percentage()")
@@ -226,7 +224,13 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 transaction_name = t["transaction"]
                 project = t["project"]
                 t_p_key = project + "," + transaction_name
-                trending_transaction_names_stats[t_p_key] = response.data[t_p_key]
+                if t_p_key in response.data:
+                    trending_transaction_names_stats[t_p_key] = response.data[t_p_key]
+                else:
+                    logger.warning(
+                        "trends.trends-request.timeseries.key-mismatch",
+                        extra={"result_key": t_p_key, "timeseries_keys": response.data.keys()},
+                    )
 
             # send the results back to the client
             return Response(

--- a/src/sentry/api/endpoints/organization_events_trendsv2.py
+++ b/src/sentry/api/endpoints/organization_events_trendsv2.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import sentry_sdk
 from django.conf import settings
@@ -90,7 +91,9 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             )
 
         def generate_top_transaction_query(events):
-            top_transaction_names = [event.get("transaction") for event in events]
+            top_transaction_names = [
+                re.sub(r'"', '\\"', event.get("transaction")) for event in events
+            ]
             top_transaction_as_str = ", ".join(
                 f'"{transaction}"' for transaction in top_transaction_names
             )


### PR DESCRIPTION
Fixing two cases that are throwing errors. For the first error, for some reason when trying to match transaction name in the trend output to its timeseries the key doesn't exist. I'm logging the mismatched key so that I can debug this when this happens again. For the second error, whenever a transaction name contains a quote we didn't escape it and that would throw an error. I'm escaping quotes now.

Fixes SENTRY-11NB