### PR TITLE
fix(hybridcloud) Fix unserializable type in parameters

### DIFF
--- a/src/sentry/services/hybrid_cloud/user_option/model.py
+++ b/src/sentry/services/hybrid_cloud/user_option/model.py
@@ -3,7 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, Iterable, List, Optional
+from typing import Any, List, Optional
 
 from typing_extensions import TypedDict
 
@@ -20,7 +20,7 @@ class RpcUserOption(RpcModel):
 
 
 class UserOptionFilterArgs(TypedDict, total=False):
-    user_ids: Iterable[int]
+    user_ids: List[int]
     keys: List[str]
     key: str
     project_id: Optional[int]


### PR DESCRIPTION
When pydantic encounters an `Iterable` when serializing values it creates a `list_iterable` instance which cannot be converted to JSON. Instead we need to use a simpler type annotation.

This was causing failures when making RPC calls to get user options.

