### PR TITLE
feat(starfish) Fill in new span summary page

### DIFF
--- a/static/app/views/starfish/colours.tsx
+++ b/static/app/views/starfish/colours.tsx
@@ -1,0 +1,5 @@
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+
+export const THROUGHPUT_COLOR = CHART_PALETTE[0][0];
+export const DURATION_COLOR = CHART_PALETTE[1][1];
+export const ERRORS_COLOR = CHART_PALETTE[2][2];

--- a/static/app/views/starfish/components/formattedCode.tsx
+++ b/static/app/views/starfish/components/formattedCode.tsx
@@ -5,7 +5,6 @@ import {space} from 'sentry/styles/space';
 export const FormattedCode = styled('div')`
   padding: ${space(1)};
   margin-bottom: ${space(3)};
-  background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   overflow-x: auto;
   white-space: pre;

--- a/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
@@ -14,6 +14,11 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import {
+  DURATION_COLOR,
+  ERRORS_COLOR,
+  THROUGHPUT_COLOR,
+} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spans/spanSummaryPanel';
 import {ReleasePreview} from 'sentry/views/starfish/views/spans/spanSummaryPanel/releasePreview';
@@ -141,6 +146,7 @@ function SpanSummaryPage({params}: Props) {
                     start=""
                     end=""
                     loading={false}
+                    chartColors={[THROUGHPUT_COLOR]}
                     utc={false}
                     stacked
                     isLineChart
@@ -177,7 +183,7 @@ function SpanSummaryPage({params}: Props) {
                     start=""
                     end=""
                     loading={false}
-                    chartColors={theme.charts.getColorPalette(4).slice(3, 5)}
+                    chartColors={[DURATION_COLOR]}
                     utc={false}
                     stacked
                     isLineChart
@@ -195,7 +201,7 @@ function SpanSummaryPage({params}: Props) {
                       start=""
                       end=""
                       loading={false}
-                      chartColors={[theme.charts.getColorPalette(2)[2]]}
+                      chartColors={[ERRORS_COLOR]}
                       utc={false}
                       stacked
                       isLineChart

--- a/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
@@ -1,8 +1,6 @@
 import {RouteComponentProps} from 'react-router';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import MarkLine from 'sentry/components/charts/components/markLine';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -14,15 +12,11 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
-import {
-  DURATION_COLOR,
-  ERRORS_COLOR,
-  THROUGHPUT_COLOR,
-} from 'sentry/views/starfish/colours';
+import {ERRORS_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
+import {SpanBaselineTable} from 'sentry/views/starfish/views/spans/spanSummaryPage/spanBaselineTable';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spans/spanSummaryPanel';
 import {ReleasePreview} from 'sentry/views/starfish/views/spans/spanSummaryPanel/releasePreview';
-import {SpanDescription} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanDescription';
 import {SpanTransactionsTable} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable';
 import {useApplicationMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useApplicationMetrics';
 import {useSpanById} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanById';
@@ -39,8 +33,6 @@ type Props = {
 
 function SpanSummaryPage({params}: Props) {
   const {groupId} = params;
-
-  const theme = useTheme();
 
   const {data: span} = useSpanById(groupId, 'span-summary-page');
   const {data: applicationMetrics} = useApplicationMetrics();
@@ -107,91 +99,8 @@ function SpanSummaryPage({params}: Props) {
                   )}
                 </Block>
               </BlockContainer>
-              <BlockContainer>
-                {span && (
-                  <Block title={t('Description')}>
-                    <SpanDescription span={span} />
-                  </Block>
-                )}
-              </BlockContainer>
-              <BlockContainer>
-                <Block
-                  title={t('Span Throughput (SPM)')}
-                  description={t('Spans per minute')}
-                >
-                  <Chart
-                    statsPeriod="24h"
-                    height={140}
-                    data={[
-                      {
-                        ...spanMetricSeries.spm,
-                        markLine: spanMetrics?.p50
-                          ? MarkLine({
-                              silent: true,
-                              animation: false,
-                              lineStyle: {color: theme.blue300, type: 'dotted'},
-                              data: [
-                                {
-                                  yAxis: spanMetrics.spm,
-                                },
-                              ],
-                              label: {
-                                show: true,
-                                position: 'insideStart',
-                              },
-                            })
-                          : undefined,
-                      },
-                    ]}
-                    start=""
-                    end=""
-                    loading={false}
-                    chartColors={[THROUGHPUT_COLOR]}
-                    utc={false}
-                    stacked
-                    isLineChart
-                    disableXAxis
-                    hideYAxisSplitLine
-                  />
-                </Block>
 
-                <Block title={t('Span Duration (p50)')} description={t('Exclusive time')}>
-                  <Chart
-                    statsPeriod="24h"
-                    height={140}
-                    data={[
-                      {
-                        ...spanMetricSeries.p50,
-                        markLine: spanMetrics?.p50
-                          ? MarkLine({
-                              silent: true,
-                              animation: false,
-                              lineStyle: {color: theme.blue300, type: 'dotted'},
-                              data: [
-                                {
-                                  yAxis: spanMetrics.p50,
-                                },
-                              ],
-                              label: {
-                                show: true,
-                                position: 'insideStart',
-                              },
-                            })
-                          : undefined,
-                      },
-                    ]}
-                    start=""
-                    end=""
-                    loading={false}
-                    chartColors={[DURATION_COLOR]}
-                    utc={false}
-                    stacked
-                    isLineChart
-                    disableXAxis
-                    hideYAxisSplitLine
-                  />
-                </Block>
-
+              <BlockContainer>
                 {span?.span_operation === 'http.client' ? (
                   <Block title={t('Failure Rate')} description={t('Non-200 HTTP status')}>
                     <Chart
@@ -211,6 +120,8 @@ function SpanSummaryPage({params}: Props) {
                   </Block>
                 ) : null}
               </BlockContainer>
+
+              {span && <SpanBaselineTable span={span} />}
               {span && <SpanTransactionsTable span={span} />}
             </Layout.Main>
           </Layout.Body>

--- a/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
@@ -11,15 +11,12 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
-import {ERRORS_COLOR} from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
 import {SpanBaselineTable} from 'sentry/views/starfish/views/spans/spanSummaryPage/spanBaselineTable';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spans/spanSummaryPanel';
 import {ReleasePreview} from 'sentry/views/starfish/views/spans/spanSummaryPanel/releasePreview';
 import {SpanTransactionsTable} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable';
 import {useSpanById} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanById';
 import {useSpanMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics';
-import {useSpanMetricSeries} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries';
 import {
   useSpanFirstSeenEvent,
   useSpanLastSeenEvent,
@@ -34,7 +31,6 @@ function SpanSummaryPage({params}: Props) {
 
   const {data: span} = useSpanById(groupId, 'span-summary-page');
   const {data: spanMetrics} = useSpanMetrics({group_id: groupId});
-  const {data: spanMetricSeries} = useSpanMetricSeries(span);
   const {data: firstSeenSpanEvent} = useSpanFirstSeenEvent({group_id: groupId});
   const {data: lastSeenSpanEvent} = useSpanLastSeenEvent({group_id: groupId});
 
@@ -75,27 +71,6 @@ function SpanSummaryPage({params}: Props) {
                     <ReleasePreview release={lastSeenSpanEvent?.release} />
                   )}
                 </Block>
-              </BlockContainer>
-
-              <BlockContainer>
-                {span?.span_operation === 'http.client' ? (
-                  <Block title={t('Failure Rate')} description={t('Non-200 HTTP status')}>
-                    <Chart
-                      statsPeriod="24h"
-                      height={140}
-                      data={[spanMetricSeries.failure_rate]}
-                      start=""
-                      end=""
-                      loading={false}
-                      chartColors={[ERRORS_COLOR]}
-                      utc={false}
-                      stacked
-                      isLineChart
-                      disableXAxis
-                      hideYAxisSplitLine
-                    />
-                  </Block>
-                ) : null}
               </BlockContainer>
 
               {span && <SpanBaselineTable span={span} />}

--- a/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
@@ -7,7 +7,6 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {formatPercentage} from 'sentry/utils/formatters';
 import {
   PageErrorAlert,
   PageErrorProvider,
@@ -18,7 +17,6 @@ import {SpanBaselineTable} from 'sentry/views/starfish/views/spans/spanSummaryPa
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spans/spanSummaryPanel';
 import {ReleasePreview} from 'sentry/views/starfish/views/spans/spanSummaryPanel/releasePreview';
 import {SpanTransactionsTable} from 'sentry/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable';
-import {useApplicationMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useApplicationMetrics';
 import {useSpanById} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanById';
 import {useSpanMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics';
 import {useSpanMetricSeries} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries';
@@ -35,7 +33,6 @@ function SpanSummaryPage({params}: Props) {
   const {groupId} = params;
 
   const {data: span} = useSpanById(groupId, 'span-summary-page');
-  const {data: applicationMetrics} = useApplicationMetrics();
   const {data: spanMetrics} = useSpanMetrics({group_id: groupId});
   const {data: spanMetricSeries} = useSpanMetricSeries(span);
   const {data: firstSeenSpanEvent} = useSpanFirstSeenEvent({group_id: groupId});
@@ -76,26 +73,6 @@ function SpanSummaryPage({params}: Props) {
                   <TimeSince date={spanMetrics?.last_seen} />
                   {lastSeenSpanEvent?.release && (
                     <ReleasePreview release={lastSeenSpanEvent?.release} />
-                  )}
-                </Block>
-
-                <Block
-                  title={t('Total Spans')}
-                  description={t(
-                    'The total number of times this span was seen in all time'
-                  )}
-                >
-                  {spanMetrics?.count}
-                </Block>
-
-                <Block
-                  title={t('App Impact')}
-                  description={t(
-                    'The total exclusive time taken up by this span vs. entire application'
-                  )}
-                >
-                  {formatPercentage(
-                    spanMetrics?.total_time / applicationMetrics?.total_time
                   )}
                 </Block>
               </BlockContainer>

--- a/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
@@ -50,6 +50,7 @@ function SpanSummaryPage({params}: Props) {
                 <DatePageFilter alignDropdown="left" />
               </FilterOptionsContainer>
               <BlockContainer>
+                <Block title={t('Operation')}>{span?.span_operation}</Block>
                 <Block
                   title={t('First Seen')}
                   description={t(

--- a/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/index.tsx
@@ -211,9 +211,7 @@ function SpanSummaryPage({params}: Props) {
                   </Block>
                 ) : null}
               </BlockContainer>
-              <BlockContainer>
-                {span && <SpanTransactionsTable span={span} />}
-              </BlockContainer>
+              {span && <SpanTransactionsTable span={span} />}
             </Layout.Main>
           </Layout.Body>
         </PageErrorProvider>

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
@@ -47,6 +47,7 @@ export function SpanTransactionsTable({span}: Props) {
     spanTransactions.map(row => row.transaction)
   );
   const {data: spanTransactionMetricsSeries} = useSpanTransactionMetricSeries(
+    span,
     spanTransactions.map(row => row.transaction)
   );
 
@@ -119,8 +120,8 @@ function TransactionCell({span, column, row}: CellProps) {
 
 function P50Cell({row}: CellProps) {
   const theme = useTheme();
-  const p50 = row.metrics?.['p50(transaction.duration)'];
-  const p50Series = row.metricSeries?.['p50(transaction.duration)'];
+  const p50 = row.metrics?.p50;
+  const p50Series = row.metricSeries?.p50;
 
   return (
     <Fragment>
@@ -139,8 +140,8 @@ function P50Cell({row}: CellProps) {
 
 function EPMCell({row}: CellProps) {
   const theme = useTheme();
-  const epm = row.metrics?.['epm()'];
-  const epmSeries = row.metricSeries?.['epm()'];
+  const epm = row.metrics?.spm;
+  const epmSeries = row.metricSeries?.spm;
 
   return (
     <Fragment>

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
@@ -102,8 +102,6 @@ function TransactionCell({span, column, row}: CellProps) {
       >
         <Truncate value={row[column.key]} maxLength={50} />
       </Link>
-
-      <span>{row.count} spans</span>
     </Fragment>
   );
 }

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
@@ -2,7 +2,10 @@ import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 import * as qs from 'query-string';
 
-import GridEditable, {GridColumnHeader as Column} from 'sentry/components/gridEditable';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnHeader as Column,
+} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import Truncate from 'sentry/components/truncate';
 import {Series} from 'sentry/types/echarts';
@@ -100,7 +103,7 @@ function TransactionCell({span, column, row}: CellProps) {
           transaction: row.transaction,
         })}`}
       >
-        <Truncate value={row[column.key]} maxLength={50} />
+        <Truncate value={row[column.key]} maxLength={75} />
       </Link>
     </Fragment>
   );
@@ -149,17 +152,17 @@ function EPMCell({row}: CellProps) {
 const COLUMN_ORDER = [
   {
     key: 'transaction',
-    name: 'Transaction',
-    width: -1,
+    name: 'In Endpoint',
+    width: 500,
   },
   {
     key: 'epm()',
-    name: 'Txn Throughput (TPM)',
-    width: -1,
+    name: 'Throughput (TPM)',
+    width: COL_WIDTH_UNDEFINED,
   },
   {
     key: 'p50(transaction.duration)',
-    name: 'Txn Duration (p50)',
-    width: -1,
+    name: 'Duration (P50)',
+    width: COL_WIDTH_UNDEFINED,
   },
 ];

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/spanTransactionsTable.tsx
@@ -5,9 +5,9 @@ import * as qs from 'query-string';
 import GridEditable, {GridColumnHeader as Column} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import Truncate from 'sentry/components/truncate';
-import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {Series} from 'sentry/types/echarts';
 import {useLocation} from 'sentry/utils/useLocation';
+import {DURATION_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Sparkline, {
   generateHorizontalLine,
 } from 'sentry/views/starfish/components/sparkline';
@@ -117,7 +117,7 @@ function P50Cell({row}: CellProps) {
     <Fragment>
       {p50Series ? (
         <Sparkline
-          color={CHART_PALETTE[3][0]}
+          color={DURATION_COLOR}
           series={p50Series}
           markLine={
             p50 ? generateHorizontalLine(`${p50.toFixed(2)}`, p50, theme) : undefined
@@ -137,7 +137,7 @@ function EPMCell({row}: CellProps) {
     <Fragment>
       {epmSeries ? (
         <Sparkline
-          color={CHART_PALETTE[3][1]}
+          color={THROUGHPUT_COLOR}
           series={epmSeries}
           markLine={
             epm ? generateHorizontalLine(`${epm.toFixed(2)}`, epm, theme) : undefined

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useApplicationMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useApplicationMetrics.tsx
@@ -31,5 +31,5 @@ export const useApplicationMetrics = (referrer = 'application-metrics') => {
     initialData: [],
   });
 
-  return {isLoading, error, data: data[0]};
+  return {isLoading, error, data: data[0] ?? {}};
 };

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanById.ts
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanById.ts
@@ -8,7 +8,7 @@ export const useSpanById = (groupId: string, referrer: string) => {
     group_id,
     action,
     description,
-    span_operation,
+    span_operation
     FROM spans_experimental_starfish
     WHERE group_id = '${groupId}'
     LIMIT 1

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetricSeries.tsx
@@ -3,7 +3,10 @@ import moment from 'moment';
 
 import {Series} from 'sentry/types/echarts';
 import {useQuery} from 'sentry/utils/queryClient';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {HOST} from 'sentry/views/starfish/utils/constants';
+import {getDateFilters} from 'sentry/views/starfish/utils/dates';
+import {getDateQueryFilter} from 'sentry/views/starfish/utils/getDateQueryFilter';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 
@@ -17,7 +20,27 @@ type Metric = {
 };
 
 export const useSpanMetricSeries = (span?: Span, referrer = 'span-metrics-series') => {
-  const query = span ? getQuery(span) : '';
+  const pageFilters = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilters);
+  const dateFilters = getDateQueryFilter(startTime, endTime);
+
+  const query = span
+    ? `
+  SELECT
+    toStartOfInterval(start_timestamp, INTERVAL ${INTERVAL} HOUR) as interval,
+    count() as count,
+    divide(count, multiply(${INTERVAL}, 60)) as spm,
+    quantile(0.95)(exclusive_time) as p95,
+    quantile(0.50)(exclusive_time) as p50,
+    countIf(greaterOrEquals(status, 400) AND lessOrEquals(status, 599)) as "failure_count",
+    "failure_count" / "count" as "failure_rate"
+  FROM spans_experimental_starfish
+  WHERE group_id = '${span.group_id}'
+  ${dateFilters}
+  GROUP BY interval
+  ORDER BY interval
+`
+    : '';
 
   const {isLoading, error, data} = useQuery<Metric[]>({
     queryKey: ['span-metrics-series', span?.group_id],
@@ -41,21 +64,4 @@ export const useSpanMetricSeries = (span?: Span, referrer = 'span-metrics-series
   );
 
   return {isLoading, error, data: parsedData};
-};
-
-const getQuery = (span: Span) => {
-  return `
-  SELECT
-    toStartOfInterval(start_timestamp, INTERVAL ${INTERVAL} HOUR) as interval,
-    count() as count,
-    divide(count, multiply(${INTERVAL}, 60)) as spm,
-    quantile(0.95)(exclusive_time) as p95,
-    quantile(0.50)(exclusive_time) as p50,
-    countIf(greaterOrEquals(status, 400) AND lessOrEquals(status, 599)) as "failure_count",
-    "failure_count" / "count" as "failure_rate"
-  FROM spans_experimental_starfish
-  WHERE group_id = '${span.group_id}'
-  GROUP BY interval
-  ORDER BY interval
-`;
 };

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
@@ -1,5 +1,8 @@
 import {useQuery} from 'sentry/utils/queryClient';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {HOST} from 'sentry/views/starfish/utils/constants';
+import {getDateFilters} from 'sentry/views/starfish/utils/dates';
+import {getDateQueryFilter} from 'sentry/views/starfish/utils/getDateQueryFilter';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 
 const INTERVAL = 12;
@@ -17,7 +20,24 @@ export const useSpanMetrics = (
   span?: Pick<Span, 'group_id'>,
   referrer = 'span-metrics'
 ) => {
-  const query = span ? getQuery(span) : '';
+  const pageFilters = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilters);
+  const dateFilters = getDateQueryFilter(startTime, endTime);
+
+  const query = span
+    ? `
+  SELECT
+  count() as count,
+  min(timestamp) as first_seen,
+  max(timestamp) as last_seen,
+  sum(exclusive_time) as total_time,
+  quantile(0.5)(exclusive_time) as p50,
+  divide(count, multiply(${INTERVAL}, 60)) as spm
+  FROM spans_experimental_starfish
+  WHERE group_id = '${span.group_id}'
+  ${dateFilters}
+`
+    : '';
 
   const {isLoading, error, data} = useQuery<Metrics[]>({
     queryKey: ['span-metrics', span?.group_id],
@@ -29,18 +49,4 @@ export const useSpanMetrics = (
   });
 
   return {isLoading, error, data: data[0] ?? {}};
-};
-
-const getQuery = (span: Pick<Span, 'group_id'>) => {
-  return `
-    SELECT
-    count() as count,
-    min(timestamp) as first_seen,
-    max(timestamp) as last_seen,
-    sum(exclusive_time) as total_time,
-    quantile(0.5)(exclusive_time) as p50,
-    divide(count, multiply(${INTERVAL}, 60)) as spm
-    FROM spans_experimental_starfish
-    WHERE group_id = '${span.group_id}'
- `;
 };

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
@@ -28,7 +28,7 @@ export const useSpanMetrics = (
     enabled: Boolean(span),
   });
 
-  return {isLoading, error, data: data[0]};
+  return {isLoading, error, data: data[0] ?? {}};
 };
 
 const getQuery = (span: Pick<Span, 'group_id'>) => {

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetricSeries.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetricSeries.tsx
@@ -3,75 +3,73 @@ import keyBy from 'lodash/keyBy';
 import moment from 'moment';
 
 import {Series} from 'sentry/types/echarts';
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {useQuery} from 'sentry/utils/queryClient';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useWrappedDiscoverTimeseriesQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import {getDateFilters} from 'sentry/views/starfish/utils/dates';
+import {getDateQueryFilter} from 'sentry/views/starfish/utils/getDateQueryFilter';
 import {zeroFillSeries} from 'sentry/views/starfish/utils/zeroFillSeries';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 
 const INTERVAL = 12;
 
+type Metric = {
+  count: number;
+  interval: string;
+  p50: number;
+  p95: number;
+};
+
 export const useSpanTransactionMetricSeries = (
+  span?: Span,
   transactions?: string[],
   referrer: string = 'span-transaction-metrics-series'
 ) => {
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-  const {isLoading, data} = useWrappedDiscoverTimeseriesQuery({
-    eventView: getEventView({
-      transactions: transactions!,
-      datetime,
-      interval: `${INTERVAL}h`,
-    }),
+  const pageFilters = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilters);
+  const dateFilters = getDateQueryFilter(startTime, endTime);
+
+  const query =
+    span && transactions && transactions.length > 0
+      ? `SELECT
+     transaction,
+     toStartOfInterval(start_timestamp, INTERVAL ${INTERVAL} hour) as interval,
+     quantile(0.50)(exclusive_time) AS p50,
+     divide(count(), multiply(${INTERVAL}, 60)) as spm
+   FROM spans_experimental_starfish
+   WHERE
+     transaction IN ('${transactions.join("','")}')
+     AND group_id = '${span.group_id}'
+     ${dateFilters}
+   GROUP BY transaction, interval
+   ORDER BY transaction, interval
+ `
+      : '';
+
+  const {isLoading, error, data} = useQuery<Metric[]>({
+    queryKey: ['span-metrics-series', span?.group_id, transactions?.join(',') || ''],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${query}&referrer=${referrer}`).then(res => res.json()),
+    retry: false,
     initialData: [],
-    enabled: transactions && transactions.length > 0,
-    referrer,
+    enabled: Boolean(query),
   });
 
   const parsedData: Record<string, Record<string, Series>> = {};
-  const dataByTransaction = groupBy(data, 'group');
+  const dataByTransaction = groupBy(data, 'transaction');
   Object.keys(dataByTransaction).forEach(transaction => {
     const parsedTransactionData = keyBy(
-      ['epm()', 'p50(transaction.duration)'].map(seriesName => {
+      ['spm', 'p50'].map(seriesName => {
         const series: Series = {
           seriesName,
           data: data.map(datum => ({value: datum[seriesName], name: datum.interval})),
         };
-
         return zeroFillSeries(series, moment.duration(INTERVAL, 'hours'));
       }),
       'seriesName'
     );
-
     parsedData[transaction] = parsedTransactionData;
   });
 
-  return {isLoading, data: parsedData};
-};
-
-const getEventView = ({
-  transactions,
-  datetime,
-  interval,
-}: {
-  datetime;
-  interval;
-  transactions: string[];
-}) => {
-  return EventView.fromSavedQuery({
-    name: '',
-    fields: ['transaction', 'epm()', 'p50(transaction.duration)'],
-    yAxis: ['epm()', 'p50(transaction.duration)'],
-    orderby: 'transaction',
-    query: `transaction:["${transactions.join('","')}"]`,
-    topEvents: '5',
-    start: datetime.start as string,
-    end: datetime.end as string,
-    range: datetime.period as string,
-    dataset: DiscoverDatasets.METRICS,
-    interval,
-    projects: [1],
-    version: 2,
-  });
+  return {isLoading, error, data: parsedData};
 };

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetrics.tsx
@@ -1,7 +1,10 @@
 import keyBy from 'lodash/keyBy';
 
 import {useQuery} from 'sentry/utils/queryClient';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {HOST} from 'sentry/views/starfish/utils/constants';
+import {getDateFilters} from 'sentry/views/starfish/utils/dates';
+import {getDateQueryFilter} from 'sentry/views/starfish/utils/getDateQueryFilter';
 import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
 
 const INTERVAL = 12;
@@ -16,8 +19,25 @@ export const useSpanTransactionMetrics = (
   transactions?: string[],
   referrer = 'span-transaction-metrics'
 ) => {
+  const pageFilters = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilters);
+  const dateFilters = getDateQueryFilter(startTime, endTime);
+
   const query =
-    span && transactions && transactions.length > 0 ? getQuery(span, transactions) : '';
+    span && transactions && transactions.length > 0
+      ? `
+    SELECT
+      transaction,
+      quantile(0.5)(exclusive_time) as p50,
+      sum(exclusive_time) as "sum(span.self_time)",
+      divide(count(), multiply(${INTERVAL}, 60)) as spm
+    FROM spans_experimental_starfish
+    WHERE group_id = '${span.group_id}'
+    ${dateFilters}
+    AND transaction IN ('${transactions.join("','")}')
+    GROUP BY transaction
+ `
+      : '';
 
   const {isLoading, error, data} = useQuery<Metric[]>({
     queryKey: [
@@ -35,18 +55,4 @@ export const useSpanTransactionMetrics = (
   const parsedData = keyBy(data, 'transaction');
 
   return {isLoading, error, data: parsedData};
-};
-
-const getQuery = (span: Span, transactions: string[]) => {
-  return `
-     SELECT
-       transaction,
-       quantile(0.5)(exclusive_time) as p50,
-       sum(exclusive_time) as "sum(span.self_time)",
-       divide(count(), multiply(${INTERVAL}, 60)) as spm
-     FROM spans_experimental_starfish
-     WHERE group_id = '${span.group_id}'
-     AND transaction IN ('${transactions.join("','")}')
-     GROUP BY transaction
-  `;
 };

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetrics.tsx
@@ -1,39 +1,52 @@
 import keyBy from 'lodash/keyBy';
 
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {useQuery} from 'sentry/utils/queryClient';
+import {HOST} from 'sentry/views/starfish/utils/constants';
+import type {Span} from 'sentry/views/starfish/views/spans/spanSummaryPanel/types';
+
+const INTERVAL = 12;
+
+type Metric = {
+  p50: number;
+  spm: number;
+};
 
 export const useSpanTransactionMetrics = (
+  span?: Span,
   transactions?: string[],
   referrer = 'span-transaction-metrics'
 ) => {
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-  const {isLoading, data} = useWrappedDiscoverQuery({
-    eventView: getEventView({transactions: transactions ?? [], datetime}),
+  const query =
+    span && transactions && transactions.length > 0 ? getQuery(span, transactions) : '';
+
+  const {isLoading, error, data} = useQuery<Metric[]>({
+    queryKey: [
+      'span-transactions-metrics',
+      span?.group_id,
+      transactions?.join(',') || '',
+    ],
+    queryFn: () =>
+      fetch(`${HOST}/?query=${query}&referrer=${referrer}`).then(res => res.json()),
+    retry: false,
     initialData: [],
-    referrer,
+    enabled: Boolean(query),
   });
 
   const parsedData = keyBy(data, 'transaction');
 
-  return {isLoading, data: parsedData};
+  return {isLoading, error, data: parsedData};
 };
 
-const getEventView = ({transactions, datetime}: {datetime; transactions: string[]}) => {
-  return EventView.fromSavedQuery({
-    name: '',
-    fields: ['transaction', 'epm()', 'p50(transaction.duration)'],
-    orderby: 'transaction',
-    query: `transaction:["${transactions.join('","')}"]`,
-    start: datetime.start as string,
-    end: datetime.end as string,
-    range: datetime.period as string,
-    dataset: DiscoverDatasets.METRICS,
-    projects: [1],
-    version: 2,
-  });
+const getQuery = (span: Span, transactions: string[]) => {
+  return `
+     SELECT
+       transaction,
+       quantile(0.5)(exclusive_time) as p50,
+       sum(exclusive_time) as "sum(span.self_time)",
+       divide(count(), multiply(${INTERVAL}, 60)) as spm
+     FROM spans_experimental_starfish
+     WHERE group_id = '${span.group_id}'
+     AND transaction IN ('${transactions.join("','")}')
+     GROUP BY transaction
+  `;
 };

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -218,7 +218,7 @@ function renderBodyCell(
   if (column.key === 'description') {
     return (
       <OverflowEllipsisTextContainer>
-        <Link to={`/starfish/span/${row.group_id}`}>
+        <Link to={`/starfish/span-summary/${row.group_id}`}>
           {row.span_operation === 'db' ? (
             <StyledFormattedCode>
               {(row as unknown as SpanDataRow).formatted_desc}


### PR DESCRIPTION
A lot of changes all coming together. Makes the page look much closer to the mockup by filling in the right charts and numbers.

- Link modules to new span summary
- Fix malformed query
- Use consistent chart colors
- Remove span count from table
- Improve table layout
- Add app impact column
- Render span information as a table
- Remove unnecessary information
- Remove API error chart
- Add span operation block
- Obey date ranges
- Fix series query
