### PR TITLE
fix(hybridcloud) Fix errors when serializing memberships

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -344,9 +344,12 @@ class OrganizationMember(Model):
 
     @property
     def legacy_token(self):
+        email = self.get_email()
+        if not email:
+            return ""
         checksum = md5()
         checksum.update(str(self.organization_id).encode("utf-8"))
-        checksum.update(self.get_email().encode("utf-8"))
+        checksum.update(email.encode("utf-8"))
         checksum.update(force_bytes(settings.SECRET_KEY))
         return checksum.hexdigest()
 

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -33,6 +33,14 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         with self.settings(SECRET_KEY="a"):
             assert member.legacy_token == "f3f2aa3e57f4b936dfd4f42c38db003e"
 
+    def test_legacy_token_generation_no_email(self):
+        """
+        We include membership tokens in RPC memberships so it needs to not error
+        for accepted invites.
+        """
+        member = OrganizationMember(organization_id=1, user_id=self.user.id)
+        assert member.legacy_token
+
     def test_legacy_token_generation_unicode_key(self):
         member = OrganizationMember(id=1, organization_id=1, email="foo@example.com")
         with self.settings(


### PR DESCRIPTION
When generating RPC compatible membership records we were hitting errors because accepted memberships have `None` for their email attribute.