### PR TITLE
fix(hybridcloud) Fix serialization errors in RPC responses

### DIFF
--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -423,7 +423,7 @@ def dispatch_to_local_service(
     raw_arguments = service.deserialize_rpc_arguments(method_name, serial_arguments)
     result = method(**raw_arguments.__dict__)
 
-    def result_to_dict(value: Any):
+    def result_to_dict(value: Any) -> Any:
         if isinstance(value, RpcModel):
             return value.dict()
 

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -421,7 +421,18 @@ def dispatch_to_local_service(
     service, method = _look_up_service_method(service_name, method_name)
     raw_arguments = service.deserialize_rpc_arguments(method_name, serial_arguments)
     result = method(**raw_arguments.__dict__)
-    return result.dict() if isinstance(result, RpcModel) else result
+
+    if isinstance(result, RpcModel):
+        return result.dict()
+    if isinstance(result, list):
+        output = []
+        for item in result:
+            if isinstance(item, RpcModel):
+                output.append(item.dict())
+            else:
+                output.append(item)
+        return output
+    return result
 
 
 _RPC_CONTENT_CHARSET = "utf-8"
@@ -467,7 +478,6 @@ def dispatch_remote_call(
 
 def _fire_request(url: str, body: Any, api_token: str) -> urllib.response.addinfourl:
     # TODO: Performance considerations (persistent connections, pooling, etc.)?
-
     data = json.dumps(body).encode(_RPC_CONTENT_CHARSET)
 
     request = Request(url)

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -6,6 +6,7 @@ from django.test import override_settings
 
 from sentry.models import OrganizationMapping
 from sentry.services.hybrid_cloud.actor import RpcActor
+from sentry.services.hybrid_cloud.auth import AuthService
 from sentry.services.hybrid_cloud.organization import (
     OrganizationService,
     RpcOrganizationMemberFlags,
@@ -112,6 +113,16 @@ class RpcServiceTest(TestCase):
         with override_settings(SILO_MODE=SiloMode.REGION):
             service = OrganizationService.create_delegation()
             dispatch_to_local_service(service.key, "add_organization_member", serial_arguments)
+
+    def test_dispatch_to_local_service_list_result(self):
+        organization = self.create_organization()
+
+        args = {"organization_ids": [organization.id]}
+        with override_settings(SILO_MODE=SiloMode.CONTROL):
+            service = AuthService.create_delegation()
+            result = dispatch_to_local_service(service.key, "get_org_auth_config", args)
+            assert len(result) == 1
+            assert result[0]["organization_id"] == organization.id
 
 
 class DispatchRemoteCallTest(TestCase):


### PR DESCRIPTION
When working on the siloed devserver, I encountered RPC responses that didn't correctly deserialize as we were not casting list items into dictionaries. This resulted in list item contents not being parsed when deserializaing the responses of RPC method calls.
