### PR TITLE
chore(profiling): Add referrers to profiling queries frontend

### DIFF
--- a/static/app/components/profiling/profilingTransactionHovercard.tsx
+++ b/static/app/components/profiling/profilingTransactionHovercard.tsx
@@ -98,7 +98,7 @@ export function ProfilingTransactionHovercardBody({
   } = useProfilingTransactionQuickSummary({
     transaction,
     project,
-    referrer: 'api.profiling.profiling-transaction-hovercard',
+    referrer: 'api.profiling.transaction-hovercard',
   });
 
   const linkToFlamechartRoute = (

--- a/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
+++ b/static/app/utils/profiling/hooks/useProfilingTransactionQuickSummary.tsx
@@ -31,18 +31,18 @@ export function useProfilingTransactionQuickSummary(
     skipSlowestProfile = false,
   } = options;
 
-  const baseQueryOptions: Omit<UseProfileEventsOptions, 'sort'> = {
+  const baseQueryOptions: Omit<UseProfileEventsOptions, 'sort' | 'referrer'> = {
     query: `transaction:"${transaction}"`,
     fields: getProfilesTableFields(project.platform),
     enabled: Boolean(transaction),
     limit: 1,
-    referrer,
     refetchOnMount: false,
     projects: [project.id],
   };
 
   const slowestProfileQuery = useProfileEvents({
     ...baseQueryOptions,
+    referrer: `${referrer}.slowest`,
     sort: {
       key: 'transaction.duration',
       order: 'desc',
@@ -52,6 +52,7 @@ export function useProfilingTransactionQuickSummary(
 
   const latestProfileQuery = useProfileEvents({
     ...baseQueryOptions,
+    referrer: `${referrer}.latest`,
     sort: {
       key: 'timestamp',
       order: 'desc',
@@ -68,7 +69,7 @@ export function useProfilingTransactionQuickSummary(
 
   const functionsQuery = useProfileFunctions<FunctionsField>({
     fields: functionsFields,
-    referrer: 'api.profiling.landing-functions-card',
+    referrer: `${referrer}.functions`,
     sort: {
       key: 'sum()',
       order: 'desc',

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -267,7 +267,12 @@ function ProfilingContent({location}: ProfilingContentProps) {
                 <Fragment>
                   <PanelsGrid>
                     <ProfilingSlowestTransactionsPanel />
-                    <ProfileCharts query={query} selection={selection} hideCount />
+                    <ProfileCharts
+                      referrer="api.profiling.landing-chart"
+                      query={query}
+                      selection={selection}
+                      hideCount
+                    />
                   </PanelsGrid>
                   <ProfileEventsTable
                     columns={fields.slice()}

--- a/static/app/views/profiling/landing/profileCharts.tsx
+++ b/static/app/views/profiling/landing/profileCharts.tsx
@@ -17,6 +17,7 @@ import useRouter from 'sentry/utils/useRouter';
 
 interface ProfileChartsProps {
   query: string;
+  referrer: string;
   compact?: boolean;
   hideCount?: boolean;
   selection?: PageFilters;
@@ -29,6 +30,7 @@ const SERIES_ORDER = ['count()', 'p99()', 'p95()', 'p75()'] as const;
 
 export function ProfileCharts({
   query,
+  referrer,
   selection,
   hideCount,
   compact = false,
@@ -45,7 +47,7 @@ export function ProfileCharts({
 
   const profileStats = useProfileEventsStats({
     query,
-    referrer: 'api.profiling.landing-chart',
+    referrer,
     yAxes: seriesOrder,
   });
 

--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -68,7 +68,12 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
   return (
     <Fragment>
       <Layout.Main fullWidth>
-        <ProfileCharts query={props.query} hideCount compact />
+        <ProfileCharts
+          referrer="api.profiling.profile-summary-chart"
+          query={props.query}
+          hideCount
+          compact
+        />
         <AggregateFlamegraphPanel transaction={props.transaction} />
         <SuspectFunctionsTable
           project={props.project}

--- a/static/app/views/profiling/profileSummary/index.tsx
+++ b/static/app/views/profiling/profileSummary/index.tsx
@@ -93,7 +93,7 @@ function ProfileSummaryPage(props: ProfileSummaryPageProps) {
   const profilesAggregateQuery = useProfileEvents<'count()'>({
     fields: ['count()'],
     sort: {key: 'count()', order: 'desc'},
-    referrer: 'api.profiling.profile-summary-table', // TODO
+    referrer: 'api.profiling.profile-summary-totals',
     query,
     enabled: profilingUsingTransactions,
   });


### PR DESCRIPTION
We were sharing referrers across multiple queries. This cleans things up to use 1 referrer per query.