### PR TITLE
feat(spans): Create span description clusterer

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -973,6 +973,11 @@ CELERYBEAT_SCHEDULE = {
         "schedule": crontab(minute=17),
         "options": {"expires": 3600},
     },
+    "span.descs.clusterer": {
+        "task": "sentry.ingest.span_clusterer.tasks.spawn_span_cluster_projects",
+        "schedule": crontab(minute=42),
+        "options": {"expires": 3600},
+    },
     "hybrid-cloud-repair-mappings": {
         "task": "sentry.tasks.organization_mapping.repair_mappings",
         # Run every hour

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -108,8 +108,8 @@ def spawn_span_cluster_projects(**kwargs: Any) -> None:
     with sentry_sdk.start_span(op="span_descs-cluster_spawn"):
         project_count = 0
         project_iter = redis.get_active_projects(ClustererNamespace.SPANS)
-        project_iter = filter(
-            lambda p: features.has("projects:span-metrics-extraction", p), project_iter
+        project_iter = (
+            p for p in project_iter if features.has("projects:span-metrics-extraction", p)
         )
         while batch := list(islice(project_iter, PROJECTS_PER_TASK)):
             project_count += len(batch)

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -4,6 +4,7 @@ from typing import Any, Sequence
 import sentry_sdk
 
 from sentry import features
+from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.models import Project
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -101,7 +102,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
     max_retries=5,
     soft_time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT,
     time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT + 2,
-)
+)  # type: ignore
 def spawn_span_cluster_projects(**kwargs: Any) -> None:
     """Look for existing span description sets in redis and spawn clusterers for each"""
     with sentry_sdk.start_span(op="span_descs-cluster_spawn"):
@@ -142,7 +143,7 @@ def cluster_projects_span_descs(projects: Sequence[Project]) -> None:
                     # the clusterer to avoid scrubbing other tokens. The prefix
                     # `**` in the glob ensures we match the prefix but we don't
                     # scrub it.
-                    new_rules = [f"**{r}" for r in new_rules]
+                    new_rules = [ReplacementRule(f"**{r}") for r in new_rules]
 
                 track_clusterer_run(ClustererNamespace.SPANS, project)
 

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -97,7 +97,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
 
 @instrumented_task(
     name="sentry.ingest.span_clusterer.tasks.spawn_span_cluster_projects",
-    queue="span.descs.clusterer",  # XXX(iker): we should use a different queue
+    queue="transactions.name_clusterer",  # XXX(iker): we should use a different queue
     default_retry_delay=5,
     max_retries=5,
     soft_time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT,

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -101,7 +101,7 @@ def cluster_projects(projects: Sequence[Project]) -> None:
     default_retry_delay=5,  # copied from transaction name clusterer
     max_retries=5,  # copied from transaction name clusterer
 )  # type: ignore
-def spawn_span_cluster_projects(**kwargs: Any) -> None:
+def spawn_clusterers_span_descs(**kwargs: Any) -> None:
     """Look for existing span description sets in redis and spawn clusterers for each"""
     with sentry_sdk.start_span(op="span_descs-cluster_spawn"):
         project_count = 0

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -3,6 +3,7 @@ from typing import Any, Sequence
 
 import sentry_sdk
 
+from sentry import features
 from sentry.models import Project
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -90,4 +91,76 @@ def cluster_projects(projects: Sequence[Project]) -> None:
         if unclustered > 0:
             metrics.incr(
                 "txcluster.cluster_projects.unclustered", amount=unclustered, sample_rate=1.0
+            )
+
+
+@instrumented_task(
+    name="sentry.ingest.span_clusterer.tasks.spawn_span_cluster_projects",
+    queue="span.descs.clusterer",  # XXX(iker): we should use a different queue
+    default_retry_delay=5,
+    max_retries=5,
+    soft_time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT,
+    time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT + 2,
+)
+def spawn_span_cluster_projects(**kwargs: Any) -> None:
+    """Look for existing span description sets in redis and spawn clusterers for each"""
+    with sentry_sdk.start_span(op="span_descs-cluster_spawn"):
+        project_count = 0
+        project_iter = redis.get_active_projects(ClustererNamespace.SPANS)
+        project_iter = filter(
+            lambda p: features.has("projects:span-metrics-extraction", p), project_iter
+        )
+        while batch := list(islice(project_iter, PROJECTS_PER_TASK)):
+            project_count += len(batch)
+            cluster_projects_span_descs.delay(batch)
+
+        metrics.incr("span_descs-spawned_projects", amount=project_count, sample_rate=1.0)
+
+
+@instrumented_task(
+    name="sentry.ingest.transaction_clusterer.tasks.cluster_projects_span_descs",
+    queue="transactions.name_clusterer",  # XXX(iker): we should use a different queue
+    default_retry_delay=5,  # copied from transaction name clusterer
+    max_retries=5,  # copied from transaction name clusterer
+    soft_time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT,
+    time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT + 2,  # extra 2s to emit metrics
+)  # type: ignore
+def cluster_projects_span_descs(projects: Sequence[Project]) -> None:
+    num_clustered = 0
+    try:
+        for project in projects:
+            with sentry_sdk.start_span(op="span_descs-cluster") as span:
+                span.set_data("project_id", project.id)
+                descriptions = list(redis.get_span_descriptions(project))
+                new_rules = []
+                if len(descriptions) >= MERGE_THRESHOLD:
+                    clusterer = TreeClusterer(merge_threshold=MERGE_THRESHOLD)
+                    clusterer.add_input(descriptions)
+                    new_rules = clusterer.get_rules()
+                    # Span description rules must match a prefix in the string
+                    # (HTTP verb, domain...), but we only feed the URL path to
+                    # the clusterer to avoid scrubbing other tokens. The prefix
+                    # `**` in the glob ensures we match the prefix but we don't
+                    # scrub it.
+                    new_rules = [f"**{r}" for r in new_rules]
+
+                track_clusterer_run(ClustererNamespace.SPANS, project)
+
+                # The Redis store may have more up-to-date last_seen values,
+                # so we must update the stores to bring these values to
+                # project options, even if there aren't any new rules.
+                num_rules_added = rules.update_rules(ClustererNamespace.SPANS, project, new_rules)
+
+                # Track a global counter of new rules:
+                metrics.incr("span_descs.new_rules_discovered", num_rules_added)
+
+                # Clear transaction names to prevent the set from picking up
+                # noise over a long time range.
+                redis.clear_span_descriptions(project)
+            num_clustered += 1
+    finally:
+        unclustered = len(projects) - num_clustered
+        if unclustered > 0:
+            metrics.incr(
+                "span_descs.cluster_projects.unclustered", amount=unclustered, sample_rate=1.0
             )

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -98,10 +98,8 @@ def cluster_projects(projects: Sequence[Project]) -> None:
 @instrumented_task(
     name="sentry.ingest.span_clusterer.tasks.spawn_span_cluster_projects",
     queue="transactions.name_clusterer",  # XXX(iker): we should use a different queue
-    default_retry_delay=5,
-    max_retries=5,
-    soft_time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT,
-    time_limit=PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT + 2,
+    default_retry_delay=5,  # copied from transaction name clusterer
+    max_retries=5,  # copied from transaction name clusterer
 )  # type: ignore
 def spawn_span_cluster_projects(**kwargs: Any) -> None:
     """Look for existing span description sets in redis and spawn clusterers for each"""

--- a/tests/sentry/ingest/test_span_desc_clusterer.py
+++ b/tests/sentry/ingest/test_span_desc_clusterer.py
@@ -21,7 +21,7 @@ from sentry.ingest.transaction_clusterer.rules import (
 )
 from sentry.ingest.transaction_clusterer.tasks import (
     cluster_projects_span_descs,
-    spawn_span_cluster_projects,
+    spawn_clusterers_span_descs,
 )
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -240,7 +240,7 @@ def test_run_clusterer_task(cluster_projects_span_descs, default_organization):
             == {"first_run": 0, "last_run": 0, "runs": 0}
         )
 
-        spawn_span_cluster_projects()
+        spawn_clusterers_span_descs()
 
         assert cluster_projects_span_descs.call_count == 1
         cluster_projects_span_descs.reset_mock()
@@ -273,7 +273,7 @@ def test_run_clusterer_task(cluster_projects_span_descs, default_organization):
         with mock.patch(
             "sentry.ingest.transaction_clusterer.tasks.PROJECTS_PER_TASK", 1
         ), freeze_time("2000-01-01 01:00:01"):
-            spawn_span_cluster_projects()
+            spawn_clusterers_span_descs()
 
         # One project per batch now:
         assert cluster_projects_span_descs.call_count == 2, cluster_projects_span_descs.call_args

--- a/tests/sentry/ingest/test_span_desc_clusterer.py
+++ b/tests/sentry/ingest/test_span_desc_clusterer.py
@@ -12,11 +12,16 @@ from sentry.ingest.transaction_clusterer.datasource.redis import (
     get_span_descriptions,
     record_span_descriptions,
 )
+from sentry.ingest.transaction_clusterer.meta import get_clusterer_meta
 from sentry.ingest.transaction_clusterer.rules import (
     ProjectOptionRuleStore,
     get_rules,
     get_sorted_rules,
     update_rules,
+)
+from sentry.ingest.transaction_clusterer.tasks import (
+    cluster_projects_span_descs,
+    spawn_span_cluster_projects,
 )
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -204,6 +209,113 @@ def test_save_rules(default_project):
         )
     project_rules = get_rules(ClustererNamespace.SPANS, project)
     assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
+
+
+# From the test -- number of transactions: 30 == 10 * 2 + 5 * 2
+@mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 30)
+@mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 5)
+@mock.patch(
+    "sentry.ingest.transaction_clusterer.tasks.cluster_projects_span_descs.delay",
+    wraps=cluster_projects_span_descs,  # call immediately
+)
+@pytest.mark.django_db
+@freeze_time("2000-01-01 01:00:00")
+def test_run_clusterer_task(cluster_projects_span_descs, default_organization):
+    def _add_mock_data(proj, number):
+        for i in range(0, number):
+            _store_span_description(proj, f"/user/span.desc-{proj.name}-{i}")
+            _store_span_description(proj, f"/org/span.desc-{proj.name}-{i}")
+
+    with Feature({"projects:span-metrics-extraction", True}):
+        project1 = Project(id=123, name="project1", organization_id=default_organization.id)
+        project2 = Project(id=223, name="project2", organization_id=default_organization.id)
+
+        for project in (project1, project2):
+            project.save()
+            _add_mock_data(project, 4)
+
+        assert (
+            get_clusterer_meta(ClustererNamespace.SPANS, project1)
+            == get_clusterer_meta(ClustererNamespace.SPANS, project2)
+            == {"first_run": 0, "last_run": 0, "runs": 0}
+        )
+
+        spawn_span_cluster_projects()
+
+        assert cluster_projects_span_descs.call_count == 1
+        cluster_projects_span_descs.reset_mock()
+
+        # Not stored enough transactions yet
+        assert get_rules(ClustererNamespace.SPANS, project1) == {}
+        assert get_rules(ClustererNamespace.SPANS, project2) == {}
+
+        assert (
+            get_clusterer_meta(ClustererNamespace.SPANS, project1)
+            == get_clusterer_meta(ClustererNamespace.SPANS, project2)
+            == {"first_run": 946688400, "last_run": 946688400, "runs": 1}
+        )
+
+        # Clear transactions if batch minimum is not met
+        assert list(get_span_descriptions(project1)) == []
+        assert list(get_span_descriptions(project2)) == []
+
+        _add_mock_data(project1, 10)
+        _add_mock_data(project2, 10)
+
+        # add more span descriptions to the project 1
+        for i in range(5):
+            _store_span_description(project1, f"/users/spans.desc/span-{project1.id}-{i}")
+            _store_span_description(project1, f"/test/path/{i}")
+
+        # Add a transaction to project2 so it runs again
+        _store_span_description(project2, "foo")
+
+        with mock.patch(
+            "sentry.ingest.transaction_clusterer.tasks.PROJECTS_PER_TASK", 1
+        ), freeze_time("2000-01-01 01:00:01"):
+            spawn_span_cluster_projects()
+
+        # One project per batch now:
+        assert cluster_projects_span_descs.call_count == 2, cluster_projects_span_descs.call_args
+
+        rules = get_rules(ClustererNamespace.SPANS, project1)
+        assert rules.keys() == {
+            "**/org/*/**",
+            "**/user/*/**",
+            "**/test/path/*/**",
+            "**/users/spans.desc/*/**",
+        }
+
+        assert (
+            get_clusterer_meta(ClustererNamespace.SPANS, project1)
+            == get_clusterer_meta(ClustererNamespace.SPANS, project2)
+            == {"first_run": 946688400, "last_run": 946688401, "runs": 2}
+        )
+
+
+@mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
+@mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 2)
+@mock.patch("sentry.ingest.transaction_clusterer.rules.update_rules")
+@pytest.mark.django_db
+def test_clusterer_only_runs_when_enough_data(mock_update_rules, default_project):
+    project = default_project
+    assert get_rules(ClustererNamespace.SPANS, project) == {}
+
+    _store_span_description(project, "/span-desc/number/1")
+    cluster_projects_span_descs([project])
+    # Clusterer didn't create rules. Still, it updates the stores.
+    assert mock_update_rules.call_count == 1
+    assert mock_update_rules.call_args == mock.call(ClustererNamespace.SPANS, project, [])
+    # Transaction names are deleted if there aren't enough
+    assert get_rules(ClustererNamespace.SPANS, project) == {}
+
+    _store_span_description(project, "/span-desc/number/1")
+    _store_span_description(project, "/span-desc/number/2")
+    cluster_projects_span_descs([project])
+    assert mock_update_rules.call_count == 2
+    assert mock_update_rules.call_args == mock.call(
+        ClustererNamespace.SPANS, project, ["**/span-desc/number/*/**"]
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Creates a span description clusterer, using the data provided in https://github.com/getsentry/sentry/pull/49850.

The task and tests are pretty much copy-pasted from the transaction name clusterer.