### PR TITLE
feat(starfish): add span info to span sample page

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -18,11 +18,6 @@ const COLUMN_ORDER: TableColumnHeader[] = [
     width: 200,
   },
   {
-    key: 'timestamp',
-    name: 'Timestamp',
-    width: 300,
-  },
-  {
     key: 'duration',
     name: 'Span Duration',
     width: 200,

--- a/static/app/views/starfish/views/spans/spanSummaryPage/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/sampleInfo/index.tsx
@@ -1,0 +1,33 @@
+import {t} from 'sentry/locale';
+import {formatPercentage} from 'sentry/utils/formatters';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spans/spanSummaryPanel';
+import {useApplicationMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useApplicationMetrics';
+import {useSpanTransactionMetrics} from 'sentry/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetrics';
+
+type Props = {
+  groupId: string;
+  transactionName: string;
+};
+
+function SampleInfo(props: Props) {
+  const {groupId, transactionName} = props;
+
+  const {data: spanMetrics} = useSpanTransactionMetrics({group_id: groupId}, [
+    transactionName,
+  ]);
+  const {data: applicationMetrics} = useApplicationMetrics();
+  const spm = spanMetrics[transactionName]?.spm;
+  const p50 = spanMetrics[transactionName]?.p50;
+  const total_time = spanMetrics[transactionName]?.total_time;
+  return (
+    <BlockContainer>
+      <Block title={t('Throughput')}>{spm?.toFixed(2)} / min</Block>
+      <Block title={t('Duration (P50)')}>{p50?.toFixed(2)} ms</Block>
+      <Block title={t('App Impact')}>
+        {formatPercentage(total_time / applicationMetrics?.total_time)} %
+      </Block>
+    </BlockContainer>
+  );
+}
+
+export default SampleInfo;

--- a/static/app/views/starfish/views/spans/spanSummaryPage/sampleList.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPage/sampleList.tsx
@@ -4,6 +4,7 @@ import {t} from 'sentry/locale';
 import useRouter from 'sentry/utils/useRouter';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
 import DurationChart from 'sentry/views/starfish/views/spans/spanSummaryPage/durationChart';
+import SampleInfo from 'sentry/views/starfish/views/spans/spanSummaryPage/sampleInfo';
 
 type Props = {
   groupId: string;
@@ -25,8 +26,8 @@ function SampleList({groupId, transactionName, spanDescription}: Props) {
       }}
     >
       <h3>{transactionName}</h3>
+      <SampleInfo groupId={groupId} transactionName={transactionName} />
       <h5>{t('Duration (p50)')}</h5>
-
       <DurationChart
         groupId={groupId}
         transactionName={transactionName}

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanMetrics.tsx
@@ -18,11 +18,16 @@ type Metrics = {
 
 export const useSpanMetrics = (
   span?: Pick<Span, 'group_id'>,
+  queryFilters: {transactionName?: string} = {},
   referrer = 'span-metrics'
 ) => {
   const pageFilters = usePageFilters();
   const {startTime, endTime} = getDateFilters(pageFilters);
   const dateFilters = getDateQueryFilter(startTime, endTime);
+  const filters: string[] = [];
+  if (queryFilters.transactionName) {
+    filters.push(`transaction = ${queryFilters.transactionName}`);
+  }
 
   const query = span
     ? `
@@ -36,7 +41,7 @@ export const useSpanMetrics = (
   FROM spans_experimental_starfish
   WHERE group_id = '${span.group_id}'
   ${dateFilters}
-`
+  ${filters.join(' AND ')}`
     : '';
 
   const {isLoading, error, data} = useQuery<Metrics[]>({

--- a/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/views/spans/spanSummaryPanel/useSpanTransactionMetrics.tsx
@@ -12,10 +12,11 @@ const INTERVAL = 12;
 type Metric = {
   p50: number;
   spm: number;
+  total_time: number;
 };
 
 export const useSpanTransactionMetrics = (
-  span?: Span,
+  span?: Pick<Span, 'group_id'>,
   transactions?: string[],
   referrer = 'span-transaction-metrics'
 ) => {
@@ -30,6 +31,7 @@ export const useSpanTransactionMetrics = (
       transaction,
       quantile(0.5)(exclusive_time) as p50,
       sum(exclusive_time) as "sum(span.self_time)",
+      sum(exclusive_time) as total_time,
       divide(count(), multiply(${INTERVAL}, 60)) as spm
     FROM spans_experimental_starfish
     WHERE group_id = '${span.group_id}'


### PR DESCRIPTION
Adds throughput, p50, and app impact to the top.
Also removes the `timestamp` column to better match the mocks. We'll need to plot these samples to account for this change.
<img width="1260" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/83dc0e0d-6573-496d-98da-6ba399a99363">