### PR TITLE
chore(hybrid-cloud): Treat arbitrary RPC response errors as validation errors

### DIFF
--- a/src/sentry/api/endpoints/rpc.py
+++ b/src/sentry/api/endpoints/rpc.py
@@ -1,4 +1,4 @@
-from rest_framework.exceptions import NotFound, ParseError, PermissionDenied
+from rest_framework.exceptions import NotFound, ParseError, PermissionDenied, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -43,5 +43,7 @@ class RpcServiceEndpoint(Endpoint):  # type: ignore
             raise NotFound from e
         except RpcArgumentException as e:
             raise ParseError from e
+        except Exception as e:
+            raise ValidationError from e
 
         return Response(data=result)


### PR DESCRIPTION
We shouldn't trust user inputs to be always nice, so any exception caused by malformed/invalid user input should be treated as an error. I arbitrarily picked `ValidationError` here.