### PR TITLE
fix(api): Catch duplicate slug err for proj + team creation

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -20,6 +20,7 @@ from sentry.models import (
 )
 from sentry.search.utils import tokenize_query
 from sentry.signals import team_created
+from sentry.utils.snowflake import MaxSnowflakeRetryError
 
 CONFLICTING_SLUG_ERROR = "A team with this slug already exists."
 
@@ -161,7 +162,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                         idp_provisioned=result.get("idp_provisioned", False),
                         organization=organization,
                     )
-            except IntegrityError:
+            except (IntegrityError, MaxSnowflakeRetryError):
                 return Response(
                     {
                         "non_field_errors": [CONFLICTING_SLUG_ERROR],

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -11,6 +11,7 @@ from sentry.api.serializers import ProjectSummarySerializer, serialize
 from sentry.constants import ObjectStatus
 from sentry.models import Project
 from sentry.signals import project_created
+from sentry.utils.snowflake import MaxSnowflakeRetryError
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
 
@@ -123,7 +124,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
                             organization=team.organization,
                             platform=result.get("platform"),
                         )
-                except IntegrityError:
+                except (IntegrityError, MaxSnowflakeRetryError):
                     return Response(
                         {"detail": "A project with this slug already exists."}, status=409
                     )

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -229,9 +229,13 @@ class OrganizationTeamsCreateTest(APITestCase):
         self.get_success_response(
             self.organization.slug, name="hello world", slug="foobar", status_code=201
         )
-        self.get_error_response(
+        resp = self.get_error_response(
             self.organization.slug, name="hello world", slug="foobar", status_code=409
         )
+        assert resp.data == {
+            "non_field_errors": ["A team with this slug already exists."],
+            "detail": "A team with this slug already exists.",
+        }
 
     def test_name_too_long(self):
         self.get_error_response(

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -136,6 +136,7 @@ class TeamProjectsCreateTest(APITestCase):
         response = self.client.post(path, data={"name": "Test Project", "slug": "test-project"})
 
         assert response.status_code == 409, response.content
+        assert response.data == {"detail": "A project with this slug already exists."}
 
     def test_with_invalid_platform(self):
         user = self.create_user()


### PR DESCRIPTION
Due to [Snowflake IDs](https://vanguard.getsentry.net/p/cl8kqyvst201410ls6q9medy20), trying to create a team or project with a duplicate slug throws a MaxSnowflakeRetryError (seen in src/sentry/utils/snowflake.py:29) instead of the standard IntegrityError

Closes [ER-1566](https://getsentry.atlassian.net/jira/software/c/projects/ER/boards/90?modal=detail&selectedIssue=ER-1566&assignee=63f937644c355259db9e2d1f)

[ER-1566]: https://getsentry.atlassian.net/browse/ER-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ