### PR TITLE
fix(issue-details): Properly display error message when project no longer exists

### DIFF
--- a/static/app/views/issueDetails/groupDetails.spec.jsx
+++ b/static/app/views/issueDetails/groupDetails.spec.jsx
@@ -79,6 +79,7 @@ describe('groupDetails', () => {
   };
 
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
     OrganizationStore.onUpdate(defaultInit.organization);
     act(() => ProjectsStore.loadInitialData(defaultInit.organization.projects));
 
@@ -284,5 +285,22 @@ describe('groupDetails', () => {
     createWrapper();
 
     expect(await screen.findByText(SAMPLE_EVENT_ALERT_TEXT)).toBeInTheDocument();
+  });
+
+  it('renders error when project does not exist', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/other-project-slug/issues/`,
+      method: 'PUT',
+    });
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/`,
+      body: {...group, project: {slug: 'other-project-slug'}},
+    });
+
+    createWrapper();
+
+    expect(
+      await screen.findByText('The project other-project-slug does not exist')
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -716,6 +716,12 @@ function GroupDetailsPageContent(props: GroupDetailsProps & FetchGroupDetailsSta
     return <StyledLoadingError message={t('Error loading the specified project')} />;
   }
 
+  if (projectSlug && !errorFetchingProjects && projectsLoaded && !projectWithFallback) {
+    return (
+      <StyledLoadingError message={t('The project %s does not exist', projectSlug)} />
+    );
+  }
+
   if (!projectsLoaded || !projectWithFallback || !props.group) {
     return <LoadingIndicator />;
   }


### PR DESCRIPTION
You can see in replays for JAVASCRIPT-2MDG that the loading spinner shows forever in some cases.

This seems to happen when the issue is part of a project that no longer exists in the org. The solution here is to actually display a helpful error message in that case. 