### PR TITLE
feat(issue-stream): Keep all query params when navigating the issue stream

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -898,6 +898,7 @@ class IssueListOverview extends Component<Props, State> {
     savedSearch: (SavedSearch & {projectId?: number}) | null = this.props.savedSearch
   ) => {
     const query = {
+      ...this.props.location.query,
       referrer: 'issue-list',
       ...this.getEndpointParams(),
       ...newParams,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -898,7 +898,7 @@ class IssueListOverview extends Component<Props, State> {
     savedSearch: (SavedSearch & {projectId?: number}) | null = this.props.savedSearch
   ) => {
     const query = {
-      ...this.props.location.query,
+      ...omit(this.props.location.query, ['page', 'cursor']),
       referrer: 'issue-list',
       ...this.getEndpointParams(),
       ...newParams,


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/49806

Query params are still overwritten when necessary, this just keeps other ones around when clicking next page, using the tabs, searching, etc.