### PR TITLE
ref(sort): Add better priority to dropdown

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -1,3 +1,4 @@
+import Feature from 'sentry/components/acl/feature';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
@@ -29,6 +30,18 @@ function getSortTooltip(key: IssueSortOptions) {
   }
 }
 
+function getSortOptions(sortKeys: IssueSortOptions[], hasBetterPrioritySort = false) {
+  const combinedSortKeys = [
+    ...sortKeys,
+    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []),
+  ];
+  return combinedSortKeys.map(key => ({
+    value: key,
+    label: getSortLabel(key),
+    details: getSortTooltip(key),
+  }));
+}
+
 function IssueListSortOptions({onSelect, sort, query}: Props) {
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
@@ -36,26 +49,25 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
     IssueSortOptions.PRIORITY,
-    IssueSortOptions.BETTER_PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];
 
   return (
-    <CompactSelect
-      size="sm"
-      onChange={opt => onSelect(opt.value)}
-      options={sortKeys.map(key => ({
-        value: key,
-        label: getSortLabel(key),
-        details: getSortTooltip(key),
-      }))}
-      value={sortKey}
-      triggerProps={{
-        size: 'xs',
-        icon: <IconSort size="xs" />,
-      }}
-    />
+    <Feature features={['issue-list-better-priority-sort']}>
+      {({hasFeature: hasBetterPrioritySort}) => (
+        <CompactSelect
+          size="sm"
+          onChange={opt => onSelect(opt.value)}
+          options={getSortOptions(sortKeys, hasBetterPrioritySort)}
+          value={sortKey}
+          triggerProps={{
+            size: 'xs',
+            icon: <IconSort size="xs" />,
+          }}
+        />
+      )}
+    </Feature>
   );
 }
 

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -17,6 +17,8 @@ function getSortTooltip(key: IssueSortOptions) {
       return t('First time the issue occurred.');
     case IssueSortOptions.PRIORITY:
       return t('Recent issues trending upward.');
+    case IssueSortOptions.BETTER_PRIORITY:
+      return t('Issues you care about.');
     case IssueSortOptions.FREQ:
       return t('Number of events.');
     case IssueSortOptions.USER:
@@ -34,6 +36,7 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
     IssueSortOptions.PRIORITY,
+    IssueSortOptions.BETTER_PRIORITY,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -37,11 +37,11 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
   );
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
-    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []),
     ...(query === Query.FOR_REVIEW ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
     IssueSortOptions.PRIORITY,
+    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []),
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
   ];

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -1,7 +1,7 @@
-import Feature from 'sentry/components/acl/feature';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 import {getSortLabel, IssueSortOptions, Query} from 'sentry/views/issueList/utils';
 
 type Props = {
@@ -30,21 +30,14 @@ function getSortTooltip(key: IssueSortOptions) {
   }
 }
 
-function getSortOptions(sortKeys: IssueSortOptions[], hasBetterPrioritySort = false) {
-  const combinedSortKeys = [
-    ...sortKeys,
-    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []),
-  ];
-  return combinedSortKeys.map(key => ({
-    value: key,
-    label: getSortLabel(key),
-    details: getSortTooltip(key),
-  }));
-}
-
 function IssueListSortOptions({onSelect, sort, query}: Props) {
+  const organization = useOrganization();
+  const hasBetterPrioritySort = organization.features.includes(
+    'issue-list-better-priority-sort'
+  );
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
+    ...(hasBetterPrioritySort ? [IssueSortOptions.BETTER_PRIORITY] : []),
     ...(query === Query.FOR_REVIEW ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
@@ -54,20 +47,20 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
   ];
 
   return (
-    <Feature features={['issue-list-better-priority-sort']}>
-      {({hasFeature: hasBetterPrioritySort}) => (
-        <CompactSelect
-          size="sm"
-          onChange={opt => onSelect(opt.value)}
-          options={getSortOptions(sortKeys, hasBetterPrioritySort)}
-          value={sortKey}
-          triggerProps={{
-            size: 'xs',
-            icon: <IconSort size="xs" />,
-          }}
-        />
-      )}
-    </Feature>
+    <CompactSelect
+      size="sm"
+      onChange={opt => onSelect(opt.value)}
+      options={sortKeys.map(key => ({
+        value: key,
+        label: getSortLabel(key),
+        details: getSortTooltip(key),
+      }))}
+      value={sortKey}
+      triggerProps={{
+        size: 'xs',
+        icon: <IconSort size="xs" />,
+      }}
+    />
   );
 }
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -853,8 +853,11 @@ class IssueListOverview extends Component<Props, State> {
       organization: this.props.organization,
       sort,
     });
-
-    this.transitionTo({sort});
+    if (sort === 'betterPriority') {
+      this.transitionTo({sort, logLevel: 0, hasStacktrace: 0, eventHalflifeHours: 4});
+    } else {
+      this.transitionTo({sort});
+    }
   };
 
   onCursorChange: CursorHandler = (nextCursor, _path, _query, delta) => {

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -144,6 +144,14 @@ type StatEndpointParams = Omit<EndpointParams, 'cursor' | 'page'> & {
   expand?: string | string[];
 };
 
+type BetterPriorityEndpointParams = Partial<EndpointParams> & {
+  eventHalflifeHours: number;
+  hasStacktrace: number;
+  logLevel: number;
+  norm: boolean;
+  v2: boolean;
+};
+
 class IssueListOverview extends Component<Props, State> {
   state: State = this.getInitialState();
 
@@ -904,7 +912,7 @@ class IssueListOverview extends Component<Props, State> {
   }
 
   transitionTo = (
-    newParams: Partial<EndpointParams> = {},
+    newParams: Partial<EndpointParams> | Partial<BetterPriorityEndpointParams> = {},
     savedSearch: (SavedSearch & {projectId?: number}) | null = this.props.savedSearch
   ) => {
     const query = {

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -861,7 +861,7 @@ class IssueListOverview extends Component<Props, State> {
       organization: this.props.organization,
       sort,
     });
-    if (sort === 'betterPriority') {
+    if (sort === IssueSortOptions.BETTER_PRIORITY) {
       this.transitionTo({
         sort,
         logLevel: 0,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -860,6 +860,7 @@ class IssueListOverview extends Component<Props, State> {
         hasStacktrace: 0,
         eventHalflifeHours: 4,
         v2: false,
+        norm: false,
       });
     } else {
       this.transitionTo({sort});

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -854,7 +854,13 @@ class IssueListOverview extends Component<Props, State> {
       sort,
     });
     if (sort === 'betterPriority') {
-      this.transitionTo({sort, logLevel: 0, hasStacktrace: 0, eventHalflifeHours: 4});
+      this.transitionTo({
+        sort,
+        logLevel: 0,
+        hasStacktrace: 0,
+        eventHalflifeHours: 4,
+        v2: false,
+      });
     } else {
       this.transitionTo({sort});
     }

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -864,6 +864,7 @@ class IssueListOverview extends Component<Props, State> {
     if (sort === IssueSortOptions.BETTER_PRIORITY) {
       this.transitionTo({
         sort,
+        statsPeriod: '7d',
         logLevel: 0,
         hasStacktrace: 0,
         eventHalflifeHours: 4,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -145,11 +145,11 @@ type StatEndpointParams = Omit<EndpointParams, 'cursor' | 'page'> & {
 };
 
 type BetterPriorityEndpointParams = Partial<EndpointParams> & {
-  eventHalflifeHours: number;
-  hasStacktrace: number;
-  logLevel: number;
-  norm: boolean;
-  v2: boolean;
+  eventHalflifeHours?: number;
+  hasStacktrace?: number;
+  logLevel?: number;
+  norm?: boolean;
+  v2?: boolean;
 };
 
 class IssueListOverview extends Component<Props, State> {

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -166,6 +166,7 @@ export enum IssueSortOptions {
   DATE = 'date',
   NEW = 'new',
   PRIORITY = 'priority',
+  BETTER_PRIORITY = 'betterPriority',
   FREQ = 'freq',
   USER = 'user',
   INBOX = 'inbox',
@@ -183,6 +184,8 @@ export function getSortLabel(key: string) {
       return t('First Seen');
     case IssueSortOptions.PRIORITY:
       return t('Priority');
+    case IssueSortOptions.BETTER_PRIORITY:
+      return t('Better Priority');
     case IssueSortOptions.FREQ:
       return t('Events');
     case IssueSortOptions.USER:


### PR DESCRIPTION
Add a new "better priority" option to the dropdown and populate some default params in the URL to make internal testing easier. Once we push to EA the new option will usurp the existing priority option. 