### PR TITLE
feat(starfish) Hook up span view filter selectors to production data

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -212,7 +212,7 @@ export interface NewQuery {
   createdBy?: User;
   dataset?: DiscoverDatasets;
   display?: string;
-  end?: string;
+  end?: string | Date;
   environment?: Readonly<string[]>;
   expired?: boolean;
   id?: string;
@@ -220,7 +220,7 @@ export interface NewQuery {
   orderby?: string;
   query?: string;
   range?: string;
-  start?: string;
+  start?: string | Date;
   teams?: Readonly<('myteams' | number)[]>;
   topEvents?: string;
   utc?: boolean | string;

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -23,7 +23,7 @@ export function ActionSelector({value = '', moduleName = ModuleName.ALL}: Props)
 
   const useHTTPActions = moduleName === ModuleName.HTTP;
 
-  const {data: actions} = useSpansQuery<[{action: string}]>({
+  const {data: actions} = useSpansQuery<[{'span.action': string}]>({
     eventView,
     queryString: query,
     initialData: [],
@@ -34,9 +34,9 @@ export function ActionSelector({value = '', moduleName = ModuleName.ALL}: Props)
     ? HTTP_ACTION_OPTIONS
     : [
         {value: '', label: 'All'},
-        ...actions.map(({action}) => ({
-          value: action,
-          label: action,
+        ...actions.map(datum => ({
+          value: datum['span.action'],
+          label: datum['span.action'],
         })),
       ];
 
@@ -76,7 +76,7 @@ const LABEL_FOR_MODULE_NAME: {[key in ModuleName]: ReactNode} = {
 };
 
 function getQuery(moduleName?: string) {
-  return `SELECT action, count()
+  return `SELECT action as "span.action", count()
     FROM spans_experimental_starfish
     WHERE 1 = 1
     ${moduleName ? `AND module = '${moduleName}'` : ''}
@@ -90,10 +90,10 @@ function getQuery(moduleName?: string) {
 function getEventView(moduleName?: string) {
   return EventView.fromSavedQuery({
     name: '',
-    fields: ['action', 'count()'],
+    fields: ['span.action', 'count()'],
     orderby: '-count',
-    query: moduleName ? `module:${moduleName}` : '',
-    dataset: DiscoverDatasets.SPANS_INDEXED,
+    query: moduleName ? `!span.action:"" span.module:${moduleName}` : '!span.action:""',
+    dataset: DiscoverDatasets.SPANS_METRICS,
     projects: [1],
     version: 2,
   });

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -3,9 +3,11 @@ import {browserHistory} from 'react-router';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
+import {PageFilters} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
@@ -17,9 +19,11 @@ type Props = {
 export function ActionSelector({value = '', moduleName = ModuleName.ALL}: Props) {
   // TODO: This only returns the top 25 actions. It should either load them all, or paginate, or allow searching
   //
+  const {selection} = usePageFilters();
+
   const location = useLocation();
   const query = getQuery(moduleName);
-  const eventView = getEventView(moduleName);
+  const eventView = getEventView(moduleName, selection);
 
   const useHTTPActions = moduleName === ModuleName.HTTP;
 
@@ -87,13 +91,16 @@ function getQuery(moduleName?: string) {
   `;
 }
 
-function getEventView(moduleName?: string) {
+function getEventView(moduleName: ModuleName, pageFilters: PageFilters) {
   return EventView.fromSavedQuery({
     name: '',
     fields: ['span.action', 'count()'],
     orderby: '-count',
     query: moduleName ? `!span.action:"" span.module:${moduleName}` : '!span.action:""',
     dataset: DiscoverDatasets.SPANS_METRICS,
+    start: pageFilters.datetime.start ?? undefined,
+    end: pageFilters.datetime.end ?? undefined,
+    range: pageFilters.datetime.period ?? undefined,
     projects: [1],
     version: 2,
   });

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -21,7 +21,7 @@ export function DomainSelector({value = '', moduleName = ModuleName.ALL}: Props)
   const query = getQuery(moduleName);
   const eventView = getEventView(moduleName);
 
-  const {data: operations} = useSpansQuery<[{'span.domain': string}]>({
+  const {data: domains} = useSpansQuery<[{'span.domain': string}]>({
     eventView,
     queryString: query,
     initialData: [],
@@ -30,7 +30,7 @@ export function DomainSelector({value = '', moduleName = ModuleName.ALL}: Props)
 
   const options = [
     {value: '', label: 'All'},
-    ...operations.map(datum => ({
+    ...domains.map(datum => ({
       value: datum['span.domain'],
       label: datum['span.domain'],
     })),

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -21,7 +21,7 @@ export function DomainSelector({value = '', moduleName = ModuleName.ALL}: Props)
   const query = getQuery(moduleName);
   const eventView = getEventView(moduleName);
 
-  const {data: operations} = useSpansQuery<[{domain: string}]>({
+  const {data: operations} = useSpansQuery<[{'span.domain': string}]>({
     eventView,
     queryString: query,
     initialData: [],
@@ -30,9 +30,9 @@ export function DomainSelector({value = '', moduleName = ModuleName.ALL}: Props)
 
   const options = [
     {value: '', label: 'All'},
-    ...operations.map(({domain}) => ({
-      value: domain,
-      label: domain,
+    ...operations.map(datum => ({
+      value: datum['span.domain'],
+      label: datum['span.domain'],
     })),
   ];
 
@@ -64,7 +64,7 @@ const LABEL_FOR_MODULE_NAME: {[key in ModuleName]: ReactNode} = {
 };
 
 function getQuery(moduleName?: string) {
-  return `SELECT domain, count()
+  return `SELECT domain as "span.domain", count()
     FROM spans_experimental_starfish
     WHERE 1 = 1
     ${moduleName ? `AND module = '${moduleName}'` : ''}
@@ -78,9 +78,9 @@ function getQuery(moduleName?: string) {
 function getEventView(moduleName?: string) {
   return EventView.fromSavedQuery({
     name: '',
-    fields: ['domain', 'count()'],
+    fields: ['span.domain', 'count()'],
     orderby: '-count',
-    query: moduleName ? `module:${moduleName}` : '',
+    query: moduleName ? `!span.domain:"" module:${moduleName}` : '!span.domain:""',
     dataset: DiscoverDatasets.SPANS_INDEXED,
     projects: [1],
     version: 2,

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -20,7 +20,7 @@ export function SpanOperationSelector({value = '', moduleName = ModuleName.ALL}:
   const query = getQuery(moduleName);
   const eventView = getEventView();
 
-  const {data: operations} = useSpansQuery<[{span_operation: string}]>({
+  const {data: operations} = useSpansQuery<[{'span.op': string}]>({
     eventView,
     queryString: query,
     initialData: [],
@@ -29,9 +29,9 @@ export function SpanOperationSelector({value = '', moduleName = ModuleName.ALL}:
 
   const options = [
     {value: '', label: 'All'},
-    ...operations.map(({span_operation}) => ({
-      value: span_operation,
-      label: span_operation,
+    ...operations.map(datum => ({
+      value: datum['span.op'],
+      label: datum['span.op'],
     })),
   ];
 
@@ -54,7 +54,7 @@ export function SpanOperationSelector({value = '', moduleName = ModuleName.ALL}:
 }
 
 function getQuery(moduleName: ModuleName) {
-  return `SELECT span_operation, count()
+  return `SELECT span_operation as "span.op", count()
     FROM spans_experimental_starfish
     WHERE span_operation != ''
     ${moduleName !== ModuleName.ALL ? `AND module = '${moduleName}'` : ''}
@@ -67,9 +67,9 @@ function getQuery(moduleName: ModuleName) {
 function getEventView() {
   return EventView.fromSavedQuery({
     name: '',
-    fields: ['span_operation', 'count()'],
+    fields: ['span.op', 'count()'],
     orderby: '-count',
-    dataset: DiscoverDatasets.SPANS_INDEXED,
+    dataset: DiscoverDatasets.SPANS_METRICS,
     projects: [1],
     version: 2,
   });

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -2,9 +2,11 @@ import {browserHistory} from 'react-router';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
+import {PageFilters} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
@@ -16,9 +18,11 @@ type Props = {
 export function SpanOperationSelector({value = '', moduleName = ModuleName.ALL}: Props) {
   // TODO: This only returns the top 25 operations. It should either load them all, or paginate, or allow searching
   //
+  const {selection} = usePageFilters();
+
   const location = useLocation();
   const query = getQuery(moduleName);
-  const eventView = getEventView();
+  const eventView = getEventView(moduleName, selection);
 
   const {data: operations} = useSpansQuery<[{'span.op': string}]>({
     eventView,
@@ -64,11 +68,15 @@ function getQuery(moduleName: ModuleName) {
   `;
 }
 
-function getEventView() {
+function getEventView(moduleName: ModuleName, pageFilters: PageFilters) {
   return EventView.fromSavedQuery({
     name: '',
     fields: ['span.op', 'count()'],
     orderby: '-count',
+    query: moduleName ? `span.module:${moduleName}` : '',
+    start: pageFilters.datetime.start ?? undefined,
+    end: pageFilters.datetime.end ?? undefined,
+    range: pageFilters.datetime.period ?? undefined,
     dataset: DiscoverDatasets.SPANS_METRICS,
     projects: [1],
     version: 2,


### PR DESCRIPTION
Also fix some bug with disobeying date ranges and so on. These lil dudes:
<img width="591" alt="Screenshot 2023-05-30 at 3 31 20 PM" src="https://github.com/getsentry/sentry/assets/989898/1744588d-ae3c-40c0-a26b-dae8503e71fd">
