### PR TITLE
feat(js): Ensure members/teams are loaded for MemberTeamSelectorField

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -1,10 +1,12 @@
-import {useEffect} from 'react';
+import {useContext, useEffect, useMemo} from 'react';
 
 import Avatar from 'sentry/components/avatar';
 import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useTeams} from 'sentry/utils/useTeams';
+
+import FormContext from '../formContext';
 
 // XXX(epurkhiser): This is wrong, it should not be inheriting these props
 import {InputFieldProps} from './inputField';
@@ -26,6 +28,17 @@ function SentryMemberTeamSelectorField({
   placeholder = t('Choose Teams and Members'),
   ...props
 }: RenderFieldProps) {
+  const {form} = useContext(FormContext);
+  const currentItems = form?.getValue(props.name) as string[] | null;
+
+  // Ensure the current value of the fields members is loaded
+  const ensureUserIds = useMemo(
+    () =>
+      currentItems?.filter(item => item.startsWith('member:')).map(user => user.slice(7)),
+    [currentItems]
+  );
+  useMembers({ids: ensureUserIds});
+
   const {
     members,
     fetching: fetchingMembers,
@@ -41,6 +54,14 @@ function SentryMemberTeamSelectorField({
     label: member.name,
     leadingItems: <Avatar user={member} size={avatarSize} />,
   }));
+
+  // Ensure the current value of the fields teams is loaded
+  const ensureTeamIds = useMemo(
+    () =>
+      currentItems?.filter(item => item.startsWith('team:')).map(user => user.slice(5)),
+    [currentItems]
+  );
+  useTeams({ids: ensureTeamIds});
 
   const {
     teams,


### PR DESCRIPTION
Since it's possible the teams or members may not have been loaded that
are selected, we need to also use these hooks to ensure the specified
user and team IDs are loaded