### PR TITLE
Feat(Hybid Cloud): Removes organization mapping verification logic

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -543,11 +543,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     status=status.HTTP_409_CONFLICT,
                 )
 
-            # Send outbox message to clean up mappings after organization
-            # creation transaction
-            outbox = Organization.outbox_to_verify_mapping(organization.id)
-            outbox.save()
-
             if was_pending_deletion:
                 self.create_audit_entry(
                     request=request,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -978,12 +978,13 @@ CELERYBEAT_SCHEDULE = {
         "schedule": crontab(minute=42),
         "options": {"expires": 3600},
     },
-    "hybrid-cloud-repair-mappings": {
-        "task": "sentry.tasks.organization_mapping.repair_mappings",
-        # Run every hour
-        "schedule": crontab(minute=0, hour="*/1"),
-        "options": {"expires": 3600},
-    },
+    # TODO(HC) Remove or re-enable this once a decision is made on org mapping creation
+    # "hybrid-cloud-repair-mappings": {
+    #     "task": "sentry.tasks.organization_mapping.repair_mappings",
+    #     # Run every hour
+    #     "schedule": crontab(minute=0, hour="*/1"),
+    #     "options": {"expires": 3600},
+    # },
     "auto-enable-codecov": {
         "task": "sentry.tasks.auto_enable_codecov.enable_for_org",
         # Run job once a day at 00:30

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -285,15 +285,6 @@ class Organization(Model, SnowflakeIdMixin):
             object_identifier=org_id,
         )
 
-    @staticmethod
-    def outbox_to_verify_mapping(org_id: int) -> RegionOutbox:
-        return RegionOutbox(
-            shard_scope=OutboxScope.ORGANIZATION_SCOPE,
-            shard_identifier=org_id,
-            category=OutboxCategory.VERIFY_ORGANIZATION_MAPPING,
-            object_identifier=org_id,
-        )
-
     @cached_property
     def is_default(self):
         if not settings.SENTRY_SINGLE_ORGANIZATION:

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -35,14 +35,6 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
 from sentry.signals import member_joined
 
 
-@receiver(process_region_outbox, sender=OutboxCategory.VERIFY_ORGANIZATION_MAPPING)
-def process_organization_mapping_verifications(object_identifier: int, **kwds: Any):
-    if (org := maybe_process_tombstone(Organization, object_identifier)) is None:
-        return
-
-    organization_mapping_service.verify_mappings(organization_id=org.id, slug=org.slug)
-
-
 @receiver(process_region_outbox, sender=OutboxCategory.AUDIT_LOG_EVENT)
 def process_audit_log_event(payload: Any, **kwds: Any):
     # TODO: This will become explicit rpc

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -30,6 +30,7 @@ from sentry.models import (
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.signals import project_created
 from sentry.testutils import APITestCase, TwoFactorAPITestCase, pytest
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils import json
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -779,16 +779,12 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             assert OrganizationMapping.objects.filter(organization_id=org.id, slug="test").exists()
 
         # Drain outbox
-        outbox = Organization.outbox_to_verify_mapping(org.id)
-        outbox.drain_shard()
+        with outbox_runner():
+            pass
 
         with exempt_from_silo_limits():
             assert OrganizationMapping.objects.filter(
-                organization_id=org.id, slug="santry", verified=True, idempotency_key=""
-            ).exists()
-
-            assert not OrganizationMapping.objects.filter(
-                organization_id=org.id, slug="test"
+                organization_id=org.id, slug="santry"
             ).exists()
 
     def test_update_name_with_mapping(self):


### PR DESCRIPTION
In preparation for a full backfill of the OrganizationMapping table we
are planning to:

1. Remove all verification outbox logic (this PR)
2. Delete all `OrganizationMapping` rows from the table
3. Migrate the `OrganizationMapping` schema to ensure org ID is unique in the table
4. Add logic to upsert `OrganizationMapping` objects via the Org Update outbox
5. Backfill the entire `OrganizationMapping` table with the current org data, which should now be a 1:1 relationship

This will ensure that the system is eventually consistent, and that region continues to be the source of truth until we come up with a definitive plan for our distributed `Organization` creation process




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
