### PR TITLE
chore(hc): Change default control silo port to 8000

### DIFF
--- a/scripts/silo/rpcsetup.py
+++ b/scripts/silo/rpcsetup.py
@@ -67,7 +67,7 @@ def format_env_vars(env_vars: Mapping[str, str]) -> str:
 @click.option(
     "--control-port",
     type=int,
-    default=8001,
+    default=8000,
     help=(
         """Port on which to bind the control silo.
 


### PR DESCRIPTION
Originally the default port was set to 8001, to distinguish it from the default monolith setup that runs on 8000. It may have been useful to run a monolith instance and a siloed instance side-by-side. But it turns out that devserver reserves a few consecutive ports, so binding the base web servers to 8000 and 8001 simultaneously isn't possible anyway.

Change it to 8000 so that the control silo behaves more like the monolith case.