### PR TITLE
chore(mocks) Fix broken import in load-mocks

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -1284,10 +1284,6 @@ if __name__ == "__main__":
             load_performance_issues=options.load_performance_issues,
             slow=options.slow,
         )
-
-        from sentry.issues.producer import get_occurrence_producer
-
-        get_occurrence_producer().close()
     except Exception:
         # Avoid reporting any issues recursively back into Sentry
         import sys


### PR DESCRIPTION
The get_occurance_producer() function was recently renamed and made 'private'. This change broke `load-mocks`. I'm not confident this is the correct change to make but it solves the immediate problem of `load-mocks` not working.