### PR TITLE
ref: reduce progressbar logspam

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -218,7 +218,13 @@ class WithProgressBar:
             " ",
             progressbar.ETA(),
         ]
-        pbar = progressbar.ProgressBar(widgets=widgets, max_value=self.count)
+        pbar = progressbar.ProgressBar(
+            widgets=widgets,
+            max_value=self.count,
+            # The default update interval is every 0.1s,
+            # which for large migrations would easily logspam GoCD.
+            min_poll_interval=10,
+        )
         pbar.start()
         for idx, item in enumerate(self.iterator):
             yield item


### PR DESCRIPTION
For migrations we often use progressbar which has a default update interval of 0.1s. For large migrations that would take hours, this would lead to massive logs in GoCD which is a new issue as migration progress is no longer inspected via terminal emulator where the line clears would be effective.

Reducing this update interval to 10 seconds should cover all reasonable migrations.