### PR TITLE
ref(sort): Add another query param to URL

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -147,6 +147,7 @@ type StatEndpointParams = Omit<EndpointParams, 'cursor' | 'page'> & {
 type BetterPriorityEndpointParams = Partial<EndpointParams> & {
   eventHalflifeHours?: number;
   hasStacktrace?: number;
+  issueHalflifeHours?: number;
   logLevel?: number;
   norm?: boolean;
   v2?: boolean;
@@ -868,6 +869,7 @@ class IssueListOverview extends Component<Props, State> {
         logLevel: 0,
         hasStacktrace: 0,
         eventHalflifeHours: 4,
+        issueHalflifeHours: 24 * 7,
         v2: false,
         norm: false,
       });


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/49985 to add a `issueHalflifeHours` default param value to match the backend.