### PR TITLE
fix(js): Add tags to JS url sanitization and fix bug

### DIFF
--- a/static/app/utils/requestError/sanitizePath.spec.tsx
+++ b/static/app/utils/requestError/sanitizePath.spec.tsx
@@ -185,4 +185,10 @@ describe('sanitizePath', function () {
       expect(sanitizePath(prefix + path)).toBe(prefix + expected);
     });
   }
+
+  it('uses original value if placeholder type not found', () => {
+    expect(sanitizePath('/organizations/sentry/dogName/maisey')).toEqual(
+      '/organizations/{orgSlug}/dogName/maisey'
+    );
+  });
 });

--- a/static/app/utils/requestError/sanitizePath.spec.tsx
+++ b/static/app/utils/requestError/sanitizePath.spec.tsx
@@ -58,6 +58,18 @@ describe('sanitizePath', function () {
         '/organizations/{orgSlug}/releases/{releaseId}/deploys/',
       ],
 
+      [
+        // OrganizationTagsEndpoint
+        '/organizations/sentry/tags/',
+        '/organizations/{orgSlug}/tags/',
+      ],
+
+      [
+        // OrganizationTagKeyValuesEndpoint
+        '/organizations/sentry/tags/browser/values/',
+        '/organizations/{orgSlug}/tags/{tagName}/values/',
+      ],
+
       // /projects/ endpoints
       [
         // ProjectAlertRuleDetailsEndpoint

--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -15,6 +15,7 @@ const TYPE_TO_PLACEHOLDER = {
   releases: '{releaseId}',
   replays: '{replayId}',
   subscriptions: '{orgSlug}',
+  tags: '{tagName}',
   teams: '{teamSlug}',
 };
 

--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -26,7 +26,9 @@ function getSlugPlaceholder(rawSlugType: string, slugValue: string): string {
 
   // Pull off the trailing slash, if there is one
   const slugType = rawSlugType.replace(/\/$/, '');
-  return TYPE_TO_PLACEHOLDER[slugType] + '/' || slugValue;
+  return slugType in TYPE_TO_PLACEHOLDER
+    ? TYPE_TO_PLACEHOLDER[slugType] + '/'
+    : slugValue;
 }
 
 export function sanitizePath(path: string) {


### PR DESCRIPTION
This PR does two things:
- Adds `tag` to the list of datatypes for which we have a placeholder.
- Fixes a bug in `getSlugPlaceholder` wherein unknown datatypes didn't return the original value. (I was testing for falsiness after I'd already added the slash to the string, rather than before. Whoops.)