### PR TITLE
fix(clusterer): Fix clusterer datasource in test endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -32,33 +32,32 @@ class ProjectTransactionNamesCluster(ProjectEndpoint):
         merge_threshold = int(params.get("threshold", 100))
         return_all_names = params.get("returnAllNames")
         namespace = params.get("namespace")
+
         if namespace == "spans":
             namespace = ClustererNamespace.SPANS
+            data = redis.get_span_descriptions(project)
         else:
             namespace = ClustererNamespace.TRANSACTIONS
+            if datasource == "redis":
+                # NOTE: redis ignores the time range parameters
+                data = islice(redis.get_transaction_names(project), limit)
+            else:
+                data = snuba.fetch_unique_transaction_names(
+                    project,
+                    (start, end),
+                    limit,
+                )
 
-        if datasource == "redis":
-            # NOTE: redis ignores the time range parameters
-            transaction_names = islice(redis.get_transaction_names(project), limit)
-        else:
-            transaction_names = snuba.fetch_unique_transaction_names(
-                project,
-                (start, end),
-                limit,
-            )
-
-        transaction_names = list(transaction_names)
+        data = list(data)
 
         clusterer = TreeClusterer(merge_threshold=merge_threshold)
-        clusterer.add_input(transaction_names)
+        clusterer.add_input(data)
 
         return Response(
             {
                 "rules": clusterer.get_rules(),
                 "meta": {
-                    "unique_transaction_names": transaction_names
-                    if return_all_names
-                    else len(transaction_names),
+                    "unique_transaction_names": data if return_all_names else len(data),
                     "rules_redis": rule_store.get_redis_rules(namespace, project),
                     "rules_projectoption": rule_store.get_rules(namespace, project),
                 },


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/49852 a small fix is introduced in the test clustering endpoint, but it doesn't really fix the endpoint. This PR intends to, by using the correct datasource.