### PR TITLE
Improve sliding window per org for inactive orgs

### DIFF
--- a/src/sentry/dynamic_sampling/rules/helpers/prioritise_project.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/prioritise_project.py
@@ -24,10 +24,10 @@ def get_prioritise_by_project_sample_rate(
         if was_sliding_window_org_executed():
             return 1.0
 
-        # In the other case were the sliding window was not run, maybe because of an issue, we will just fallback to
+        # In the other case were the sliding window was not run, maybe because of an issue, we will just fall back to
         # blended sample rate, to avoid oversampling.
         sentry_sdk.capture_message(
-            "Sliding window org value not stored in cache and sliding window not executed"
+            "Sliding window org value not stored in cache and sliding window org not executed"
         )
         return error_sample_rate_fallback
     # Thrown if the input is not a valid float.

--- a/src/sentry/dynamic_sampling/rules/helpers/prioritise_project.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/prioritise_project.py
@@ -1,3 +1,6 @@
+import sentry_sdk
+
+from sentry.dynamic_sampling.rules.helpers.sliding_window import was_sliding_window_org_executed
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 
 
@@ -8,14 +11,26 @@ def generate_prioritise_by_project_cache_key(org_id: int) -> str:
 def get_prioritise_by_project_sample_rate(
     org_id: int, project_id: int, error_sample_rate_fallback: float
 ) -> float:
-    """
-    This function returns cached sample rate from prioritise by project
-    celery task or fallback to None
-    """
     redis_client = get_redis_client_for_ds()
     cache_key = generate_prioritise_by_project_cache_key(org_id=org_id)
 
     try:
         return float(redis_client.hget(cache_key, project_id))
-    except (TypeError, ValueError):
+    # Thrown if the input is not a string or a float (e.g., None).
+    except TypeError:
+        # In case there is no value in cache, we want to check if the sliding window org was executed. If it was
+        # executed, but we didn't have this project boosted, it means that the entire org didn't have traffic in the
+        # last hour which resulted in the system not considering it at all.
+        if was_sliding_window_org_executed():
+            return 1.0
+
+        # In the other case were the sliding window was not run, maybe because of an issue, we will just fallback to
+        # blended sample rate, to avoid oversampling.
+        sentry_sdk.capture_message(
+            "Sliding window org value not stored in cache and sliding window not executed"
+        )
+        return error_sample_rate_fallback
+    # Thrown if the input is not a valid float.
+    except ValueError:
+        sentry_sdk.capture_message("Invalid sliding window org value stored in cache")
         return error_sample_rate_fallback

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -94,7 +94,7 @@ def mark_sliding_window_org_executed() -> None:
 
 def was_sliding_window_org_executed() -> bool:
     redis_client = get_redis_client_for_ds()
-    cache_key = generate_sliding_window_executed_cache_key()
+    cache_key = generate_sliding_window_org_executed_cache_key()
 
     return bool(redis_client.exists(cache_key))
 

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -59,7 +59,7 @@ def get_sliding_window_sample_rate(
             return error_sample_rate_fallback
 
         return float(value)
-    # Throw if the input is not a string or a float (e.g., None).
+    # Thrown if the input is not a string or a float (e.g., None).
     except TypeError:
         # In case we couldn't convert the value to float, that is, it is a string or the value is not there, we want
         # to fall back to 100% in case we know that the sliding window was executed. We track whether the task was
@@ -78,6 +78,25 @@ def get_sliding_window_sample_rate(
     except ValueError:
         sentry_sdk.capture_message("Invalid sliding window value stored in cache")
         return error_sample_rate_fallback
+
+
+def generate_sliding_window_org_executed_cache_key() -> str:
+    return "ds::sliding_window_org_executed"
+
+
+def mark_sliding_window_org_executed() -> None:
+    redis_client = get_redis_client_for_ds()
+    cache_key = generate_sliding_window_org_executed_cache_key()
+
+    redis_client.set(cache_key, 1)
+    redis_client.pexpire(cache_key, EXECUTED_CACHE_KEY_TTL)
+
+
+def was_sliding_window_org_executed() -> bool:
+    redis_client = get_redis_client_for_ds()
+    cache_key = generate_sliding_window_executed_cache_key()
+
+    return bool(redis_client.exists(cache_key))
 
 
 def generate_sliding_window_org_cache_key(org_id: int) -> str:

--- a/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/sliding_window.py
@@ -16,7 +16,7 @@ FALLBACK_SLIDING_WINDOW_SIZE = 24
 SLIDING_WINDOW_CALCULATION_ERROR = "sliding_window_error"
 # We want to keep the entry for 1 hour, so that in case an org is not considered for 1 hour, the system will fall back
 # to the blended sample rate.
-# Important: this TTL should be a factor of the cron schedule for dynamic-sampling-sliding-window located in
+# Important: this TTL should be a factor of the cron schedule for dynamic-sampling-sliding-window/-org located in
 # sentry.conf.server.py.
 EXECUTED_CACHE_KEY_TTL = 60 * 60 * 1000
 

--- a/src/sentry/dynamic_sampling/tasks.py
+++ b/src/sentry/dynamic_sampling/tasks.py
@@ -41,6 +41,7 @@ from sentry.dynamic_sampling.rules.helpers.sliding_window import (
     get_sliding_window_sample_rate,
     get_sliding_window_size,
     mark_sliding_window_executed,
+    mark_sliding_window_org_executed,
 )
 from sentry.dynamic_sampling.rules.utils import (
     DecisionDropCount,
@@ -540,6 +541,10 @@ def sliding_window_org() -> None:
                     org_ids=orgs, window_size=window_size
                 ).items():
                     adjust_base_sample_rate_per_org(org_id, total_root_count, window_size)
+
+            # Due to the synchronous nature of the sliding window org, when we arrived here, we can confidently say
+            # that the execution of the sliding window org was successful. We will keep this state for 1 hour.
+            mark_sliding_window_org_executed()
 
 
 def adjust_base_sample_rate_per_org(org_id: int, total_root_count: int, window_size: int) -> None:


### PR DESCRIPTION
This PR improves the sliding window per org system to handle an edge case in which an org is inactive and then becomes active again, in this case the new system will give the org 100%.

Closes https://github.com/getsentry/sentry/issues/50055