### PR TITLE
fix(ownership-rules): Fix auto-assignment cache clear on update

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -135,9 +135,10 @@ class ProjectOwnershipSerializer(serializers.Serializer):
             new_values["suspect_committer_auto_assignment"] = False
         if auto_assignment == "Turn off Auto-Assignment":
             autoassignment_types = ProjectOwnership._get_autoassignment_types(ownership)
-            GroupOwner.invalidate_autoassigned_owner_cache(
-                ownership.project_id, autoassignment_types
-            )
+            if autoassignment_types:
+                GroupOwner.invalidate_autoassigned_owner_cache(
+                    ownership.project_id, autoassignment_types
+                )
             new_values["auto_assignment"] = False
             new_values["suspect_committer_auto_assignment"] = False
 

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -121,6 +121,16 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp.status_code == 200
         assert resp.data["autoAssignment"] == "Turn off Auto-Assignment"
 
+        # Test that we can reset autoAssignment for updating in non-UI use case
+        resp = self.client.put(self.path, {"autoAssignment": "Turn off Auto-Assignment"})
+        assert resp.status_code == 200
+        assert resp.data["fallthrough"] is False
+        assert resp.data["autoAssignment"] == "Turn off Auto-Assignment"
+        assert resp.data["raw"] == "*.js admin@localhost #tiger-team"
+        assert resp.data["dateCreated"] is not None
+        assert resp.data["lastUpdated"] is not None
+        assert resp.data["codeownersAutoSync"] is False
+
     def test_audit_log_entry(self):
         resp = self.client.put(self.path, {"autoAssignment": "Auto Assign to Issue Owner"})
         assert resp.status_code == 200


### PR DESCRIPTION
Only clear the auto-assignment cache on update/save if they have auto-assignment types.
The UI prevents this from happening, but we should have this for when users want to update using the endpoint.

Fixes SENTRY-119B