### PR TITLE
feat(starfish): add x-axis on all charts and update formatting

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -309,6 +309,9 @@ function Chart({
         maxInterval: xAxisInterval,
         axisLabel: {
           formatter: function (value: number) {
+            if (endTime.diff(startTime, 'days') > 30) {
+              return moment(value).format('MMMM DD');
+            }
             if (startTime.isSame(endTime, 'day')) {
               return moment(value).format('HH:mm');
             }
@@ -407,6 +410,9 @@ export function useSynchronizeCharts(deps: boolean[] = []) {
 
 const getXAxisInterval = (startTime: moment.Moment, endTime: moment.Moment) => {
   const dateRange = endTime.diff(startTime);
+  if (dateRange >= 30 * DAY) {
+    return 7 * DAY;
+  }
   if (dateRange >= 3 * DAY) {
     return DAY;
   }

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -103,7 +103,6 @@ export function SpanTimeCharts({queryConditions}: Props) {
             stacked
             isLineChart
             chartColors={[THROUGHPUT_COLOR]}
-            disableXAxis
             tooltipFormatterOptions={{
               valueFormatter: value => `${value.toFixed(3)} / ${t('min')}`,
             }}
@@ -131,7 +130,6 @@ export function SpanTimeCharts({queryConditions}: Props) {
             stacked
             isLineChart
             chartColors={[DURATION_COLOR]}
-            disableXAxis
           />
         </ChartPanel>
       </ChartsContainerItem>


### PR DESCRIPTION
![image](https://github.com/getsentry/sentry/assets/44422760/668f37ad-549f-420a-ab93-a258efe3d1a7)

Adds x-axis label on all charts, and adds formats values accordingly.

Personally i'm not a big fan of the 4:00 everywhere, but that's how the data comes back from the server. We'd either need to do some more echarts magic to move the ticks to match the start of the day OR allow the server to return back data at the start of the day.