### PR TITLE
feat(replay): Change min version in replay onboarding

### DIFF
--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -121,12 +121,12 @@ export function Setup({
   showSnippet: Output;
   visibleTab: TabKey;
 }) {
-  // 7.53.1 as it fixes a bug introduced in 7.50.0
-  const minVersion = '7.53.1';
-
   const organization = useOrganization();
   const {isFetching, needsUpdate} = useProjectSdkNeedsUpdate({
-    minVersion,
+    // Only show update instructions if not >= 7.50.0, but our instructions
+    // will show a different min version as there are known bugs in 7.50 ->
+    // 7.53
+    minVersion: '7.50.0',
     organization,
     projectId,
   });
@@ -136,7 +136,7 @@ export function Setup({
 
   return (
     <SetupInstructions
-      minVersion={minVersion}
+      minVersion="7.53.1"
       sdkNeedsUpdate={sdkNeedsUpdate}
       showSnippet={showSnippet}
       url={url}

--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -121,7 +121,8 @@ export function Setup({
   showSnippet: Output;
   visibleTab: TabKey;
 }) {
-  const minVersion = '7.50.0';
+  // 7.53.1 as it fixes a bug introduced in 7.50.0
+  const minVersion = '7.53.1';
 
   const organization = useOrganization();
   const {isFetching, needsUpdate} = useProjectSdkNeedsUpdate({


### PR DESCRIPTION
For network details onboarding, we keep the logic of when to display the onboarding banner the same (if sdk version < 7.50), however we want the setup instructions to suggest a later min version as there are bugs present in 7.50 -> 7.53 that we want users to avoid.