### PR TITLE
bug(replays): Fix Replay Search box overflow/wrapping

### DIFF
--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -51,7 +51,7 @@ const FilterContainer = styled('div')`
   width: 100%;
   margin-bottom: ${space(2)};
 
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
+  @media (max-width: ${p => p.theme.breakpoints.large}) {
     grid-template-columns: minmax(0, 1fr);
   }
 `;


### PR DESCRIPTION
**Before:**
we would see the search placeholder wrap too often


![Image](https://github.com/getsentry/sentry/assets/187460/fe2c029d-32e8-4068-8e27-2ec80e19763f)


**After:**
Now we break the filters into two lines more aggressively. This is consistent with the Issues Steam.

| window width | screen |
| --- | --- |
| 1211px starts to wrap :( | ![SCR-20230531-iiqx](https://github.com/getsentry/sentry/assets/187460/5256b56e-f537-4466-a431-8266795bf5ce) |
| 1200px down to new line | ![SCR-20230531-iitg](https://github.com/getsentry/sentry/assets/187460/20b3590f-ca0e-4eca-8b0b-6392b998c2f6) |
| 992px sidebar moves, no text wrapping | ![SCR-20230531-ilvs](https://github.com/getsentry/sentry/assets/187460/d464a861-74c8-4031-ba0c-15e01cab655f) |
| 571px text wrapping is back | ![SCR-20230531-ilyh](https://github.com/getsentry/sentry/assets/187460/8a95041f-f266-4fe4-88c9-23018935f35d) |

With this quick change, we only get text wrapping when the window is between 1201px and 1211px. 

Fixes https://github.com/getsentry/sentry/issues/49496