### PR TITLE
chore(CapMan): Add tenant_ids to Search Issues tests

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2387,7 +2387,7 @@ SENTRY_DEVSERVICES = {
     ),
     "snuba": lambda settings, options: (
         {
-            "image": "ghcr.io/getsentry/snuba:latest",
+            "image": "us.gcr.io/sentryio/snuba:eeef4d6774891158ea54c0c05b39eb1532cbb17e",
             "pull": True,
             "ports": {"1218/tcp": 1218, "1219/tcp": 1219},
             "command": ["devserver"]

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2387,7 +2387,7 @@ SENTRY_DEVSERVICES = {
     ),
     "snuba": lambda settings, options: (
         {
-            "image": "us.gcr.io/sentryio/snuba:eeef4d6774891158ea54c0c05b39eb1532cbb17e",
+            "image": "us.gcr.io/sentryio/snuba:fe0921b5418cf09aeb1f28f11fd55209dec8331f",
             "pull": True,
             "ports": {"1218/tcp": 1218, "1219/tcp": 1219},
             "command": ["devserver"]

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2387,7 +2387,7 @@ SENTRY_DEVSERVICES = {
     ),
     "snuba": lambda settings, options: (
         {
-            "image": "us.gcr.io/sentryio/snuba:fe0921b5418cf09aeb1f28f11fd55209dec8331f",
+            "image": "ghcr.io/getsentry/snuba:latest",
             "pull": True,
             "ports": {"1218/tcp": 1218, "1219/tcp": 1219},
             "command": ["devserver"]

--- a/tests/sentry/api/serializers/test_group_stream.py
+++ b/tests/sentry/api/serializers/test_group_stream.py
@@ -60,7 +60,9 @@ class StreamGroupSerializerTestCase(
     def test_perf_issue(self):
         event = self.create_performance_issue()
         group = event.group
-        serialized = serialize(group, serializer=StreamGroupSerializerSnuba(stats_period="24h"))
+        serialized = serialize(
+            group, serializer=StreamGroupSerializerSnuba(stats_period="24h", organization_id=1)
+        )
         assert serialized["count"] == "1"
         assert serialized["issueCategory"] == "performance"
         assert serialized["issueType"] == "performance_n_plus_one_db_queries"
@@ -76,7 +78,8 @@ class StreamGroupSerializerTestCase(
         )
         assert group_info
         serialized = serialize(
-            group_info.group, serializer=StreamGroupSerializerSnuba(stats_period="24h")
+            group_info.group,
+            serializer=StreamGroupSerializerSnuba(stats_period="24h", organization_id=1),
         )
         assert serialized["count"] == "1"
         assert serialized["issueCategory"] == str(GroupCategory.PROFILE.name).lower()

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -264,7 +264,10 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
             ],
         )
         request = Request(
-            dataset=Dataset.IssuePlatform.value, app_id="test_eventstream", query=query
+            dataset=Dataset.IssuePlatform.value,
+            app_id="test_eventstream",
+            query=query,
+            tenant_ids={"referrer": "test_eventstream", "organization_id": 1},
         )
         result = snuba.raw_snql_query(
             request,

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -60,7 +60,7 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignore
             selected_columns=["event_id", "group_id", "occurrence_id"],
             groupby=None,
             filter_keys={"project_id": [self.project.id], "event_id": [event.event_id]},
-            tenant_ids={"referrer": "test", "organization_id": 1},
+            tenant_ids={"referrer": "r", "organization_id": 1},
         )
         assert len(result["data"]) == 1
         assert result["data"][0]["group_id"] == group_info.group.id

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -60,6 +60,7 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignore
             selected_columns=["event_id", "group_id", "occurrence_id"],
             groupby=None,
             filter_keys={"project_id": [self.project.id], "event_id": [event.event_id]},
+            tenant_ids={"referrer": "test", "organization_id": 1},
         )
         assert len(result["data"]) == 1
         assert result["data"][0]["group_id"] == group_info.group.id

--- a/tests/sentry/issues/test_search_issues_dataset.py
+++ b/tests/sentry/issues/test_search_issues_dataset.py
@@ -26,6 +26,7 @@ class DatasetTest(SnubaTestCase, TestCase):  # type: ignore[misc]
             ],
             "aggregations": [["count()", "", "count"]],
             "consistent": False,
+            "tenant_ids": {"referrer": "search_issues", "organization_id": 1},
         }
         request = json_to_snql(json_body, "search_issues")
         request.validate()

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -128,6 +128,7 @@ class SearchIssueTestMixin(OccurrenceTestMixin):
             groupby=None,
             filter_keys={"project_id": [project_id], "event_id": [event.event_id]},
             referrer="test_utils.store_search_issue",
+            tenant_ids={"referrer": "test_utils.store_search_issue", "organization_id": 1},
         )
         assert len(result["data"]) == 1
         assert result["data"][0]["project_id"] == project_id

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -1290,9 +1290,13 @@ class ProfilingTagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
             [self.project.id],
             group_ids=[first_group.id, second_group.id],
             environment_ids=[self.environment.id],
+            tenant_ids={"referrer": "r", "organization_id": 1234},
         ) == {first_group.id: 2, second_group.id: 3}
         assert self.ts.get_generic_groups_user_counts(
-            [self.project.id], group_ids=[first_group.id, second_group.id], environment_ids=None
+            [self.project.id],
+            group_ids=[first_group.id, second_group.id],
+            environment_ids=None,
+            tenant_ids={"referrer": "r", "organization_id": 1234},
         ) == {first_group.id: 3, second_group.id: 4}
 
     def test_get_profiling_group_list_tag_value_by_environment(self):
@@ -1322,6 +1326,7 @@ class ProfilingTagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin):
             [self.environment.id],
             "environment",
             self.environment.name,
+            tenant_ids={"referrer": "r", "organization_id": 1234},
         )
 
         assert group_seen_stats == {

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -287,7 +287,11 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
 
     def test_get_group_tag_keys_and_top_values_generic_issue(self):
         group, env = self.generic_group_and_env
-        result = list(self.ts.get_group_tag_keys_and_top_values(group, [env.id]))
+        result = list(
+            self.ts.get_group_tag_keys_and_top_values(
+                group, [env.id], tenant_ids={"referrer": "r", "organization_id": 1234}
+            )
+        )
         tags = [r.key for r in result]
         assert set(tags) == {"foo", "biz", "environment", "sentry:user", "level", "sentry:release"}
 
@@ -309,6 +313,7 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
                 group,
                 [env.id],
                 keys=["environment", "sentry:release"],
+                tenant_ids={"referrer": "r", "organization_id": 1234},
             )
         )
         tags = [r.key for r in result]
@@ -360,7 +365,9 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
 
     def test_get_top_group_tag_values_generic(self):
         group, env = self.generic_group_and_env
-        resp = self.ts.get_top_group_tag_values(group, env.id, "foo", 1)
+        resp = self.ts.get_top_group_tag_values(
+            group, env.id, "foo", 1, tenant_ids={"referrer": "r", "organization_id": 1234}
+        )
         assert len(resp) == 1
         assert resp[0].times_seen == 1
         assert resp[0].key == "foo"
@@ -555,7 +562,12 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
             == "foo"
         )
 
-        keys = {k.key: k for k in self.ts.get_group_tag_keys(group, [env.id])}
+        keys = {
+            k.key: k
+            for k in self.ts.get_group_tag_keys(
+                group, [env.id], tenant_ids={"referrer": "r", "organization_id": 1234}
+            )
+        }
         assert set(keys) == {"biz", "environment", "foo", "sentry:user", "level", "sentry:release"}
 
     def test_get_group_tag_value(self):

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -690,6 +690,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
                 series[0],
                 series[-1],
                 rollup=None,
+                tenant_ids={"referrer": "test", "organization_id": 1},
             ) == {group_info.group.id: [(ts, 1) for ts in series_ts]}
 
     def test_range_groups_mult(self):
@@ -718,6 +719,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
             dts[0],
             dts[-1],
             rollup=3600,
+            tenant_ids={"referrer": "test", "organization_id": 1},
         ) == {
             group.id: [
                 (timestamp(dts[0]), 6),
@@ -757,6 +759,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
             dts[0],
             dts[-1],
             rollup=3600,
+            tenant_ids={"referrer": "test", "organization_id": 1},
         ) == {
             group.id: [
                 (timestamp(dts[0]), len(ids)),
@@ -789,7 +792,17 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
                 (timestamp(dts[3]), 3),
             ],
         }
-        assert self.db.get_range(TSDBModel.group_generic, [], dts[0], dts[-1], rollup=3600) == {}
+        assert (
+            self.db.get_range(
+                TSDBModel.group_generic,
+                [],
+                dts[0],
+                dts[-1],
+                rollup=3600,
+                tenant_ids={"referrer": "test", "organization_id": 1},
+            )
+            == {}
+        )
 
     def test_get_distinct_counts_totals_users(self):
         assert self.db.get_distinct_counts_totals(
@@ -798,6 +811,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
             self.now,
             self.now + timedelta(hours=4),
             rollup=3600,
+            tenant_ids={"referrer": "test", "organization_id": 1},
         ) == {
             self.proj1group1.id: 5  # 5 unique users overall
         }
@@ -829,6 +843,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
             keys=[self.proj1group1.id, self.proj1group2.id],
             start=self.now,
             end=self.now + timedelta(hours=4),
+            tenant_ids={"referrer": "test", "organization_id": 1},
         ) == {self.proj1group1.id: 12, self.proj1group2.id: 12}
 
     def test_get_data_or_conditions_parsed(self):
@@ -851,12 +866,14 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
             conditions=conditions,
             start=self.now,
             end=self.now + timedelta(hours=4),
+            tenant_ids={"referrer": "test", "organization_id": 1},
         )
         data2 = self.db.get_data(
             model=TSDBModel.group_generic,
             keys=[self.proj1group1.id, self.proj1group2.id],
             start=self.now,
             end=self.now + timedelta(hours=4),
+            tenant_ids={"referrer": "test", "organization_id": 1},
         )
 
         # the above queries should return the same data since all groups either have:

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -403,6 +403,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             self.now,
             self.now + timedelta(hours=4),
             rollup=3600,
+            tenant_ids={"referrer": "r", "organization_id": 1234},
         ) == {
             self.proj1group1.id: 2  # 2 unique users overall
         }
@@ -413,6 +414,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             self.now,
             self.now,
             rollup=3600,
+            tenant_ids={"referrer": "r", "organization_id": 1234},
         ) == {
             self.proj1group1.id: 1  # Only 1 unique user in the first hour
         }
@@ -423,6 +425,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             self.now,
             self.now + timedelta(hours=4),
             rollup=3600,
+            tenant_ids={"referrer": "r", "organization_id": 1234},
         ) == {self.proj1.id: 2}
 
         assert (
@@ -432,6 +435,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
                 self.now,
                 self.now + timedelta(hours=4),
                 rollup=3600,
+                tenant_ids={"referrer": "r", "organization_id": 1234},
             )
             == {}
         )
@@ -788,6 +792,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
             dts[0],
             dts[-1],
             rollup=3600,
+            tenant_ids={"referrer": "test", "organization_id": 1},
         ) == {
             self.proj1group1.id: [
                 (timestamp(dts[0]), 3),

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -219,7 +219,17 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             ],
         }
 
-        assert self.db.get_range(TSDBModel.group, [], dts[0], dts[-1], rollup=3600) == {}
+        assert (
+            self.db.get_range(
+                TSDBModel.group,
+                [],
+                dts[0],
+                dts[-1],
+                rollup=3600,
+                tenant_ids={"referrer": "test", "organization_id": 1},
+            )
+            == {}
+        )
 
     def test_range_releases(self):
         dts = [self.now + timedelta(hours=i) for i in range(4)]
@@ -822,6 +832,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
             self.now,
             self.now,
             rollup=3600,
+            tenant_ids={"referrer": "test", "organization_id": 1},
         ) == {
             self.proj1group1.id: 1  # Only 1 unique user in the first hour
         }
@@ -833,6 +844,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
                 self.now,
                 self.now + timedelta(hours=4),
                 rollup=3600,
+                tenant_ids={"referrer": "test", "organization_id": 1},
             )
             == {}
         )


### PR DESCRIPTION
### Overview
- As part of the Capacity Management project over on Search team, we're adding an allocation policy that requires `tenant_ids` for all Search Issues queries
- This PR updates the tests that would block that policy from being added