### PR TITLE
fix(project-creation): calling new endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -3,7 +3,7 @@ import random
 import string
 
 from django.db import IntegrityError, transaction
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
@@ -72,9 +72,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             raise ValidationError(serializer.errors)
         if not self.should_add_creator_to_team(request):
-            raise ValidationError(
-                {"detail": MISSING_PERMISSION_ERROR_STRING},
-            )
+            raise NotAuthenticated("User is not authenticated")
 
         result = serializer.validated_data
         exposed = expt_manager.get(

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -87,9 +87,9 @@ function CreateProject() {
 
       try {
         const projectData = await api.requestPromise(
-          team === null
-            ? `/organizations/${slug}/experimental/projects/`
-            : `/teams/${slug}/${team}/projects/`,
+          team
+            ? `/teams/${slug}/${team}/projects/`
+            : `/organizations/${slug}/experimental/projects/`,
           {
             method: 'POST',
             data: {

--- a/tests/sentry/api/endpoints/test_organization_projects_experiment.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_experiment.py
@@ -57,10 +57,8 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
         OrganizationProjectsExperimentEndpoint, "should_add_creator_to_team", return_value=False
     )
     def test_not_authenticated(self, mock_add_creator):
-        response = self.get_error_response(self.organization.slug, name=self.p1, status_code=400)
-        assert response.data == {
-            "detail": "You do not have permission to join a new team as a Team Admin."
-        }
+        response = self.get_error_response(self.organization.slug, name=self.p1, status_code=401)
+        assert response.data == {"detail": "User is not authenticated"}
         mock_add_creator.assert_called_once()
 
     def test_missing_team_roles_flag(self):


### PR DESCRIPTION
Fixing problem with ===. What we need logically is a ==. need to cover both null and undefined. Also changing error message and code when user is not authenticated in `OrganizationProjectsExperimentEndpoint` from 404 -> 401.
