### PR TITLE
fix(replays): add replayId existence check to discover query

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -27,6 +27,8 @@ MAX_VALS_PROVIDED = {
     "replay_id": 100,
 }
 
+FILTER_HAS_A_REPLAY = "AND !replayId:''"
+
 
 @region_silo_endpoint
 class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
@@ -100,6 +102,9 @@ def get_replay_id_mappings(
 ) -> dict[str, list[str]]:
 
     select_column, value = get_select_column(request.GET.get("query"))
+    query = request.GET.get("query")
+
+    query = query + FILTER_HAS_A_REPLAY
 
     if select_column == "replay_id":
         # just return a mapping of replay_id:replay_id instead of hitting discover


### PR DESCRIPTION
Right now we do not filter out rows that do not contain replays before attempting to aggregate queries that don't contain a replayId in the discover query on the replay count endpoint. 

This PR updates the discover query so that we do. This should in general speed up the endpoint and likely help with https://github.com/getsentry/team-replay/issues/86 / https://sentry.sentry.io/issues/4189062783/?project=1&referrer=github_integration