### PR TITLE
chore(flamegraph): Migrate flamegraph to new endpoint

### DIFF
--- a/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
+++ b/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
@@ -1,32 +1,36 @@
+import {useMemo} from 'react';
+
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import {useCurrentProjectFromRouteParam} from 'sentry/utils/profiling/hooks/useCurrentProjectFromRouteParam';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 export function useAggregateFlamegraphQuery({transaction}: {transaction: string}) {
-  const {selection} = usePageFilters();
   const organization = useOrganization();
-  const project = useCurrentProjectFromRouteParam();
-  const url = `/projects/${organization.slug}/${project?.slug}/profiling/flamegraph/`;
-  const conditions = new MutableSearch([]);
-  conditions.setFilterValues('transaction_name', [transaction]);
+  const {selection} = usePageFilters();
 
-  return useApiQuery<Profiling.Schema>(
-    [
-      url,
-      {
-        query: {
-          query: conditions.formatString(),
-          ...normalizeDateTimeParams(selection.datetime),
-        },
-      },
-    ],
-    {
-      staleTime: 0,
-      retry: false,
-      enabled: Boolean(organization?.slug && project?.slug && selection.datetime),
-    }
-  );
+  const path = `/organizations/${organization.slug}/profiling/flamegraph/`;
+
+  const query = useMemo(() => {
+    // TODO: this should contain the user query
+    // wait util we fully switch over to the transactions dataset
+    const conditions = new MutableSearch([]);
+    conditions.setFilterValues('transaction', [transaction]);
+    return conditions.formatString();
+  }, [transaction]);
+
+  const endpointOptions = {
+    query: {
+      project: selection.projects,
+      environment: selection.environments,
+      ...normalizeDateTimeParams(selection.datetime),
+      query,
+    },
+  };
+
+  return useApiQuery<Profiling.Schema>([path, endpointOptions], {
+    staleTime: 0,
+    retry: false,
+  });
 }


### PR DESCRIPTION
The flamegraph endpoint has changed and moved to a new url. This migrates us over to the new endpoint.