### PR TITLE
fix(sort): coerce string to proper type when parsing better priority test params

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -1,6 +1,6 @@
 import functools
 from datetime import datetime, timedelta
-from typing import Any, List, Mapping, Optional, Sequence
+from typing import Any, List, Mapping, Optional, Sequence, Type, TypeVar
 
 from django.utils import timezone
 from rest_framework.exceptions import ParseError, PermissionDenied
@@ -178,31 +178,48 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :param norm: boolean to switch between normalizing the individual contribution scores to [0, 1] or not
         """
 
-        if request.GET.get("v2", False):
+        R = TypeVar("R")
+
+        def _coerce(val: Optional[str], func: Type[R], default: R) -> R:
+            return func(val) if val is not None else default
+
+        if _coerce(request.GET.get("v2"), bool, "false"):
             return {
                 "better_priority": {
-                    "log_level": request.GET.get(
-                        "logLevel", V2_DEFAULT_PRIORITY_WEIGHTS["log_level"]
+                    "log_level": _coerce(
+                        request.GET.get("logLevel"), int, V2_DEFAULT_PRIORITY_WEIGHTS["log_level"]
                     ),
-                    "has_stacktrace": request.GET.get(
-                        "hasStacktrace", V2_DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"]
+                    "has_stacktrace": _coerce(
+                        request.GET.get("hasStacktrace"),
+                        int,
+                        V2_DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
                     ),
-                    "event_halflife_hours": request.GET.get(
-                        "eventHalflifeHours", V2_DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"]
+                    "event_halflife_hours": _coerce(
+                        request.GET.get("eventHalflifeHours"),
+                        int,
+                        V2_DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"],
                     ),
-                    "issue_halflife_hours": request.GET.get(
-                        "issueHalflifeHours", V2_DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"]
+                    "issue_halflife_hours": _coerce(
+                        request.GET.get("issueHalflifeHours"),
+                        int,
+                        V2_DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"],
                     ),
                     "v2": True,
-                    "norm": request.GET.get("norm", V2_DEFAULT_PRIORITY_WEIGHTS["norm"]),
+                    "norm": _coerce(
+                        request.GET.get("norm"), bool, V2_DEFAULT_PRIORITY_WEIGHTS["norm"]
+                    ),
                 }
             }
         else:
             return {
                 "better_priority": {
-                    "log_level": request.GET.get("logLevel", DEFAULT_PRIORITY_WEIGHTS["log_level"]),
-                    "has_stacktrace": request.GET.get(
-                        "hasStacktrace", DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"]
+                    "log_level": _coerce(
+                        request.GET.get("logLevel"), int, DEFAULT_PRIORITY_WEIGHTS["log_level"]
+                    ),
+                    "has_stacktrace": _coerce(
+                        request.GET.get("hasStacktrace"),
+                        int,
+                        DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
                     ),
                     "event_halflife_hours": DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"],
                     "issue_halflife_hours": DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"],

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -165,9 +165,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         },
     }
 
-    def build_better_priority_sort_kwargs(
-        self, request: Request
-    ) -> Mapping[str, PrioritySortWeights]:
+    @staticmethod
+    def build_better_priority_sort_kwargs(request: Request) -> Mapping[str, PrioritySortWeights]:
         """
         Temporary function to be used while developing the new priority sort. Parses the query params in the request.
 
@@ -181,9 +180,12 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         R = TypeVar("R")
 
         def _coerce(val: Optional[str], func: Type[R], default: R) -> R:
+            if func == bool:
+                func = lambda x: str(x).lower() == "true"
+
             return func(val) if val is not None else default
 
-        if _coerce(request.GET.get("v2"), bool, "false"):
+        if _coerce(request.GET.get("v2"), bool, False):
             return {
                 "better_priority": {
                     "log_level": _coerce(

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -49,7 +49,6 @@ from sentry.search.events.constants import (
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
 )
-from sentry.search.snuba.executors import PrioritySortWeights
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -154,13 +153,13 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
         self.login_as(user=self.user)
 
-        aggregate_kwargs: PrioritySortWeights = {
-            "log_level": 3,
-            "has_stacktrace": 5,
-            "event_halflife_hours": 4,
-            "issue_halflife_hours": 4,
-            "v2": False,
-            "norm": False,
+        aggregate_kwargs: dict = {
+            "log_level": "3",
+            "has_stacktrace": "5",
+            "event_halflife_hours": "4",
+            "issue_halflife_hours": "4",
+            "v2": "true",
+            "norm": "False",
         }
 
         response = self.get_success_response(
@@ -169,7 +168,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             limit=25,
             start=iso_format(before_now(days=1)),
             end=iso_format(before_now(seconds=1)),
-            aggregate_kwargs={"better_priority": aggregate_kwargs},
+            **aggregate_kwargs,
         )
         assert len(response.data) == 2
         assert [item["id"] for item in response.data] == [str(group.id), str(group_2.id)]


### PR DESCRIPTION
We weren't parsing the test params properly before. 