### PR TITLE
feat(ui): Always default select control to "auto"

### DIFF
--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -449,6 +449,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
 
   return (
     <SelectPicker<OptionType>
+      menuPlacement="auto"
       filterOption={filterOptions}
       styles={mappedStyles}
       components={{...replacedComponents, ...components}}

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -181,7 +181,6 @@ function AddToDashboardModal({
         <Wrapper>
           <SelectControl
             disabled={dashboards === null}
-            menuPlacement="auto"
             name="dashboard"
             placeholder={t('Select Dashboard')}
             value={selectedDashboardId}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/index.tsx
@@ -97,7 +97,6 @@ export function SortByStep({
               <ResultsLimitSelector
                 disabled={disableSortDirection && disableSort}
                 name="resultsLimit"
-                menuPlacement="auto"
                 options={[...Array(maxLimit).keys()].map(resultLimit => {
                   const value = resultLimit + 1;
                   return {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -81,7 +81,6 @@ export function SortBySelectors({
         <SelectControl
           name="sortDirection"
           aria-label="Sort direction"
-          menuPlacement="auto"
           disabled={disableSortDirection}
           options={Object.keys(sortDirections).map(value => ({
             label: sortDirections[value],
@@ -104,7 +103,6 @@ export function SortBySelectors({
           <SelectControl
             name="sortBy"
             aria-label="Sort by"
-            menuPlacement="auto"
             disabled={disableSort}
             placeholder={`${t('Select a column')}\u{2026}`}
             value={values.sortBy}

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -533,7 +533,6 @@ class QueryField extends Component<Props> {
           <SelectControl
             key="dropdown"
             name="dropdown"
-            menuPlacement="auto"
             placeholder={t('Select value')}
             options={descriptor.options}
             value={descriptor.value}

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -263,7 +263,6 @@ function CreateProject() {
               <TeamSelector
                 name="select-team"
                 aria-label={t('Select a Team')}
-                menuPlacement="auto"
                 clearable={false}
                 value={team}
                 placeholder={t('Select a Team')}


### PR DESCRIPTION
Fixes select menus to open upwards when there's not enough space