### PR TITLE
fix(cors) Allow requests to sentry.io from subdomains

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from sentry_sdk import Scope
 
-from sentry import analytics, tsdb
+from sentry import analytics, options, tsdb
 from sentry.apidocs.hooks import HTTP_METHODS_SET
 from sentry.auth import access
 from sentry.models import Environment
@@ -83,7 +83,6 @@ def allow_cors_options(func):
 
     @functools.wraps(func)
     def allow_cors_options_wrapper(self, request: Request, *args, **kwargs):
-
         if request.method == "OPTIONS":
             response = HttpResponse(status=200)
             response["Access-Control-Max-Age"] = "3600"  # don't ask for options again for 1 hour
@@ -109,6 +108,14 @@ def allow_cors_options(func):
             response["Access-Control-Allow-Origin"] = "*"
         else:
             response["Access-Control-Allow-Origin"] = origin
+
+        # If the requesting origin is a subdomain of
+        # the application's base-hostname we should allow cookies
+        # to be sent.
+        basehost = options.get("system.base-hostname")
+        if basehost and origin:
+            if origin.endswith(basehost):
+                response["Access-Control-Allow-Credentials"] = "true"
 
         return response
 


### PR DESCRIPTION
We have a few UX flows that need to get information from an organization that isn't the current one. An example of this is completing a sentry app installation.

We'll also be relying on CORS requests as we continue to separate the control and region silos. If a request comes in with an Origin of a subdomain, we need cookies to be sent.
