### PR TITLE
styles(profiling): Align the buttons in span profile details

### DIFF
--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -341,7 +341,7 @@ function extractFrames(node: CallTreeNode | null, platform: PlatformType): Frame
 const SpanDetails = styled('div')`
   padding: ${space(2)};
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: ${space(1)};
 `;
 


### PR DESCRIPTION
Using baseline means the buttons are misaligned here. Switching to center.

# Screenshots

## Before

![image](https://github.com/getsentry/sentry/assets/10239353/b4cb9115-7a08-4306-b4f5-f478e04b6799)

## After

![image](https://github.com/getsentry/sentry/assets/10239353/5fbb7b11-b5aa-4be7-b934-b6729bbc4f35)
