### PR TITLE
fix(crons): Randomize slug on deletion

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.db import transaction
+from django.utils.crypto import get_random_string
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -218,6 +219,10 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
                 return self.respond(status=404)
 
             for monitor_object in monitor_objects_list:
+                # randomize slug on monitor deletion to prevent re-creation side effects
+                if type(monitor_object) == Monitor:
+                    monitor_object.update(slug=get_random_string(length=24))
+
                 schedule = ScheduledDeletion.schedule(monitor_object, days=0, actor=request.user)
                 self.create_audit_entry(
                     request=request,

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -415,6 +415,7 @@ class DeleteMonitorTest(MonitorTestCase):
 
     def test_simple(self):
         monitor = self._create_monitor()
+        old_slug = monitor.slug
 
         self.get_success_response(
             self.organization.slug, monitor.slug, method="DELETE", status_code=202
@@ -422,6 +423,8 @@ class DeleteMonitorTest(MonitorTestCase):
 
         monitor = Monitor.objects.get(id=monitor.id)
         assert monitor.status == ObjectStatus.PENDING_DELETION
+        # Slug should update on deletion
+        assert monitor.slug != old_slug
         # ScheduledDeletion only available in control silo
         assert ScheduledDeletion.objects.filter(object_id=monitor.id, model_name="Monitor").exists()
 


### PR DESCRIPTION
Randomize slug on `Monitor` deletion to prevent unwanted upsert/recreate behavior across multiple endpoints.

Closes https://github.com/getsentry/sentry/issues/49859