### PR TITLE
ref(discover): Only disable persistence inside saved queries

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -758,7 +758,10 @@ function ResultsContainer(props: Props) {
 
   return (
     <PageFiltersContainer
-      disablePersistence
+      disablePersistence={
+        props.organization.features.includes('discover-query') &&
+        !!(props.savedQuery || props.location.query.id)
+      }
       skipLoadLastUsed={
         props.organization.features.includes('global-views') && !!props.savedQuery
       }


### PR DESCRIPTION
Only saved Discover queries have custom filter values and should be excluded from the page filter persistence context.
<img width="1175" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/035e29a2-4044-4118-8438-84a56776462a">

Other pages, like the plain unsaved results page (`/discover/results/…`) should still work with page filters.

