### PR TITLE
feat(sort): add relative volume weight

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -196,6 +196,11 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                         int,
                         V2_DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
                     ),
+                    "relative_volume": _coerce(
+                        request.GET.get("relativeVolume"),
+                        int,
+                        V2_DEFAULT_PRIORITY_WEIGHTS["relative_volume"],
+                    ),
                     "event_halflife_hours": _coerce(
                         request.GET.get("eventHalflifeHours"),
                         int,
@@ -223,6 +228,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                         int,
                         DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
                     ),
+                    "relative_volume": DEFAULT_PRIORITY_WEIGHTS["relative_volume"],
                     "event_halflife_hours": DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"],
                     "issue_halflife_hours": DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"],
                     "v2": False,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -566,7 +566,7 @@ def better_priority_aggregation(
 
         if not normalize:
             return [
-                f"multiply(multiply({aggregate_issue_score}, {aggregate_event_score}), {scaled_relative_volume_score})",
+                f"multiply(multiply({aggregate_issue_score}, {aggregate_event_score}), greatest({min_score}, {scaled_relative_volume_score}))",
                 "",
             ]
         else:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -553,10 +553,13 @@ def better_priority_aggregation(
             "countIf(lessOrEquals(minus(now(), timestamp), 604800))"  # 604800 = 3600 * 24 * 7
         )
         relative_volume_weight = aggregate_kwargs["relative_volume"]  # [0, 10]
+        max_relative_volume_weight = 10
+        if relative_volume_weight > max_relative_volume_weight:
+            relative_volume_weight = max_relative_volume_weight
         relative_volume_score = (
             f"divide({event_count_60_mins}, plus({avg_hourly_event_count_last_7_days}, 1))"
         )
-        scaled_relative_volume_score = f"if({relative_volume_weight}==0, {min_score}, divide({relative_volume_score}, {relative_volume_weight}))"
+        scaled_relative_volume_score = f"divide(multiply({relative_volume_weight}, {relative_volume_score}), {max_relative_volume_weight})"
         aggregate_issue_score = f"greatest({min_score}, divide({issue_age_weight}, pow(2, least({max_pow}, divide({issue_age_hours}, {issue_halflife_hours})))))"
 
         normalize = aggregate_kwargs["norm"]

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -55,6 +55,7 @@ from sentry.utils.snuba import SnubaQueryParams, aliased_query_params, bulk_raw_
 class PrioritySortWeights(TypedDict):
     log_level: int
     has_stacktrace: int
+    relative_volume: int
     event_halflife_hours: int
     issue_halflife_hours: int
     v2: bool
@@ -64,6 +65,7 @@ class PrioritySortWeights(TypedDict):
 DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
     "log_level": 0,
     "has_stacktrace": 0,
+    "relative_volume": 0,
     "event_halflife_hours": 4,
     "issue_halflife_hours": 24 * 7,
     "v2": False,
@@ -73,6 +75,7 @@ DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
 V2_DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
     "log_level": 0,
     "has_stacktrace": 0,
+    "relative_volume": 1,
     "event_halflife_hours": 12,
     "issue_halflife_hours": 4,
     "v2": False,
@@ -522,7 +525,8 @@ def better_priority_aggregation(
         #  * add an extra 'relative volume score' (# of events in past 60 mins / # of events in the past 7 days)
         #    to factor in the volume of events that recently were fired versus the past. This will up-rank issues
         #    that are more recently active as a function of the overall amount of events grouped to that issue
-        #  * conditionally normalize all the scores so the range of values sweeps from 0.0 to 1.0 -
+        #  * add a configurable weight to 'relative volume score'
+        #  * conditionally normalize all the scores so the range of values sweeps from 0.0 to 1.0
 
         # aggregate_event_score:
         #
@@ -548,16 +552,18 @@ def better_priority_aggregation(
         avg_hourly_event_count_last_7_days = (
             "countIf(lessOrEquals(minus(now(), timestamp), 604800))"  # 604800 = 3600 * 24 * 7
         )
+        relative_volume_weight = aggregate_kwargs["relative_volume"]  # [0, 10]
         relative_volume_score = (
-            f"divide(plus({event_count_60_mins}, 1), plus({avg_hourly_event_count_last_7_days}, 1))"
+            f"divide({event_count_60_mins}, plus({avg_hourly_event_count_last_7_days}, 1))"
         )
+        scaled_relative_volume_score = f"if({relative_volume_weight}==0, {min_score}, divide({relative_volume_score}, {relative_volume_weight}))"
         aggregate_issue_score = f"greatest({min_score}, divide({issue_age_weight}, pow(2, least({max_pow}, divide({issue_age_hours}, {issue_halflife_hours})))))"
 
         normalize = aggregate_kwargs["norm"]
 
         if not normalize:
             return [
-                f"multiply(multiply({aggregate_issue_score}, {aggregate_event_score}), {relative_volume_score})",
+                f"multiply(multiply({aggregate_issue_score}, {aggregate_event_score}), {scaled_relative_volume_score})",
                 "",
             ]
         else:
@@ -570,7 +576,7 @@ def better_priority_aggregation(
             #            2^(x/k)
             normalized_aggregate_issue_score = aggregate_issue_score  # already ranges from 1 to 0
             normalized_relative_volume_score = (
-                relative_volume_score  # already normalized since it's a percentage
+                scaled_relative_volume_score  # already normalized since it's a percentage
             )
 
             # aggregate_event_score ranges from [0, +inf], as the amount of events grouped to this issue

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -156,6 +156,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         aggregate_kwargs: dict = {
             "log_level": "3",
             "has_stacktrace": "5",
+            "relative_volume": "1",
             "event_halflife_hours": "4",
             "issue_halflife_hours": "4",
             "v2": "true",

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -365,6 +365,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             weights: PrioritySortWeights = {
                 "log_level": 5,
                 "has_stacktrace": 5,
+                "relative_volume": 1,
                 "event_halflife_hours": 4,
                 "issue_halflife_hours": 24 * 7,
                 "v2": False,
@@ -2107,6 +2108,7 @@ class EventsBetterPriorityTest(SharedSnubaTest):
             weights: PrioritySortWeights = {
                 "log_level": 0,
                 "has_stacktrace": 0,
+                "relative_volume": 1,
                 "event_halflife_hours": 4,
                 "issue_halflife_hours": 24 * 7,
                 "v2": False,
@@ -2156,6 +2158,7 @@ class EventsBetterPriorityTest(SharedSnubaTest):
             weights: PrioritySortWeights = {
                 "log_level": 0,
                 "has_stacktrace": 0,
+                "relative_volume": 1,
                 "event_halflife_hours": 4,
                 "issue_halflife_hours": 24 * 7,
                 "v2": True,
@@ -2204,6 +2207,7 @@ class EventsBetterPriorityTest(SharedSnubaTest):
             "better_priority": {
                 "log_level": 0,
                 "has_stacktrace": 0,
+                "relative_volume": 1,
                 "event_halflife_hours": 4,
                 "issue_halflife_hours": 24 * 7,
                 "v2": False,
@@ -2252,6 +2256,7 @@ class EventsBetterPriorityTest(SharedSnubaTest):
             "better_priority": {
                 "log_level": 0,
                 "has_stacktrace": 0,
+                "relative_volume": 1,
                 "event_halflife_hours": 4,
                 "issue_halflife_hours": 24 * 7,
                 "v2": False,
@@ -2360,6 +2365,7 @@ class EventsBetterPriorityTest(SharedSnubaTest):
             "better_priority": {
                 "log_level": 0,
                 "has_stacktrace": 0,
+                "relative_volume": 1,
                 "event_halflife_hours": 4,
                 "issue_halflife_hours": 24 * 7,
                 "v2": False,


### PR DESCRIPTION
Optionally allow weighing the score for 'relative volume' of events from the last hour versus the last 7 days. 