### PR TITLE
fix(proj-creation): Change default team name to '[parsed-email]-team'

### DIFF
--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import string
+from email.headerregistry import Address
 
 from django.db import IntegrityError, transaction
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
@@ -27,9 +28,13 @@ CONFLICTING_TEAM_SLUG_ERROR = "A team with this slug already exists."
 MISSING_PERMISSION_ERROR_STRING = "You do not have permission to join a new team as a Team Admin."
 
 
-def _generate_suffix():
+def _generate_suffix() -> str:
     letters = string.ascii_lowercase
     return "".join(random.choice(letters) for _ in range(3))
+
+
+def fetch_email_local_part(email: str) -> str:
+    return Address(addr_spec=email).username
 
 
 # This endpoint is intended to be available to all members of an
@@ -86,8 +91,11 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
         ):
             raise ResourceDoesNotExist(detail=MISSING_PERMISSION_ERROR_STRING)
 
+        # parse the email to retrieve the username before the "@"
+        parsed_email = fetch_email_local_part(request.user.email)
+
         project_name = result["name"]
-        default_team_slug = f"default-team-{request.user.username}"
+        default_team_slug = f"{parsed_email}-team"
         suffixed_team_slug = default_team_slug
 
         # attempt to a maximum of 5 times to add a suffix to team slug until it is unique

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -95,7 +95,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
         parsed_email = fetch_email_username(request.user.email)
 
         project_name = result["name"]
-        default_team_slug = f"{parsed_email}-team"
+        default_team_slug = f"team-{parsed_email}"
         suffixed_team_slug = default_team_slug
 
         # attempt to a maximum of 5 times to add a suffix to team slug until it is unique

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -33,7 +33,7 @@ def _generate_suffix() -> str:
     return "".join(random.choice(letters) for _ in range(3))
 
 
-def fetch_email_local_part(email: str) -> str:
+def fetch_email_username(email: str) -> str:
     return Address(addr_spec=email).username
 
 
@@ -92,7 +92,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
             raise ResourceDoesNotExist(detail=MISSING_PERMISSION_ERROR_STRING)
 
         # parse the email to retrieve the username before the "@"
-        parsed_email = fetch_email_local_part(request.user.email)
+        parsed_email = fetch_email_username(request.user.email)
 
         project_name = result["name"]
         default_team_slug = f"{parsed_email}-team"

--- a/tests/sentry/api/endpoints/test_organization_projects_experiment.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_experiment.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
+    fetch_email_local_part,
 )
 from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 from sentry.models.project import Project
@@ -25,7 +26,8 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.t1 = f"default-team-{self.user}"
+        self.email_local = fetch_email_local_part(self.user.email)
+        self.t1 = f"{self.email_local}-team"
         self.mock_experiment_get = patch("sentry.experiments.manager.get", return_value=1).start()
 
     @cached_property
@@ -135,7 +137,7 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
     def test_consecutive_reqs_adds_team_suffix(self):
         resp1 = self.get_success_response(self.organization.slug, name=self.p1, status_code=201)
         resp2 = self.get_success_response(self.organization.slug, name=self.p2, status_code=201)
-        teams = Team.objects.filter(slug__icontains=self.t1)
+        teams = Team.objects.filter(slug__icontains=self.email_local)
         assert len(teams) == 2
 
         if teams[0].slug == self.t1:

--- a/tests/sentry/api/endpoints/test_organization_projects_experiment.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_experiment.py
@@ -27,7 +27,7 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
         self.email_username = fetch_email_username(self.user.email)
-        self.t1 = f"{self.email_username}-team"
+        self.t1 = f"team-{self.email_username}"
         self.mock_experiment_get = patch("sentry.experiments.manager.get", return_value=1).start()
 
     @cached_property

--- a/tests/sentry/api/endpoints/test_organization_projects_experiment.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_experiment.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
-    fetch_email_local_part,
+    fetch_email_username,
 )
 from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 from sentry.models.project import Project
@@ -26,8 +26,8 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.email_local = fetch_email_local_part(self.user.email)
-        self.t1 = f"{self.email_local}-team"
+        self.email_username = fetch_email_username(self.user.email)
+        self.t1 = f"{self.email_username}-team"
         self.mock_experiment_get = patch("sentry.experiments.manager.get", return_value=1).start()
 
     @cached_property
@@ -137,7 +137,7 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
     def test_consecutive_reqs_adds_team_suffix(self):
         resp1 = self.get_success_response(self.organization.slug, name=self.p1, status_code=201)
         resp2 = self.get_success_response(self.organization.slug, name=self.p2, status_code=201)
-        teams = Team.objects.filter(slug__icontains=self.email_local)
+        teams = Team.objects.filter(slug__icontains=self.email_username)
         assert len(teams) == 2
 
         if teams[0].slug == self.t1:


### PR DESCRIPTION
Previously, the default team name was `default-team-[username]`. This had to problem of including the default 32 letter string as the username if the user never changed their sentry username. We instead parse the email username (everything before the @) and use `[email_username]-team` for shortness and clarity, eg: `seiji.chew-team`