### PR TITLE
feat(HC): Adds organization_mapping service upsert method

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -39,10 +39,6 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.services.hybrid_cloud import IDEMPOTENCY_KEY_LENGTH
-from sentry.services.hybrid_cloud.organization_mapping import (
-    RpcOrganizationMappingUpdate,
-    organization_mapping_service,
-)
 from sentry.utils.cache import memoize
 
 ERR_DEFAULT_ORG = "You cannot remove the default organization."
@@ -519,11 +515,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 with transaction.atomic():
                     organization, changed_data = serializer.save()
 
-                    if "name" in changed_data:
-                        organization_mapping_service.update(
-                            organization_id=organization.id,
-                            update=RpcOrganizationMappingUpdate(name=organization.name),
-                        )
             # TODO(hybrid-cloud): This will need to be a more generic error
             # when the internal RPC is implemented.
             except IntegrityError:

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -240,6 +240,10 @@ class Organization(Model, SnowflakeIdMixin):
 
     snowflake_redis_key = "organization_snowflake_key"
 
+    def save_with_update_outbox(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        Organization.outbox_for_update(self.id).save()
+
     def save(self, *args, **kwargs):
         slugify_target = None
         if not self.slug:
@@ -252,12 +256,16 @@ class Organization(Model, SnowflakeIdMixin):
                 slugify_target = slugify_target.lower().replace("_", "-").strip("-")
                 slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
 
+        # Run the save + outbox queueing in a transaction to ensure the control-silo is notified
+        # when a change is made to the organization model.
         if SENTRY_USE_SNOWFLAKE:
             self.save_with_snowflake_id(
-                self.snowflake_redis_key, lambda: super(Organization, self).save(*args, **kwargs)
+                self.snowflake_redis_key,
+                lambda: self.save_with_update_outbox(*args, **kwargs),
             )
         else:
-            super().save(*args, **kwargs)
+            with transaction.atomic():
+                self.save_with_update_outbox(*args, **kwargs)
 
     @classmethod
     def reserve_snowflake_id(cls):

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -109,7 +109,7 @@ def process_organization_updates(object_identifier: int, **kwds: Any):
         return
 
     update = update_organization_mapping_from_instance(org)
-    organization_mapping_service.update(organization_id=org.id, update=update)
+    organization_mapping_service.upsert(organization_id=org.id, update=update)
 
 
 @receiver(process_region_outbox, sender=OutboxCategory.PROJECT_UPDATE)

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -56,6 +56,15 @@ class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
                 .update(**update)
             )
 
+    def upsert(
+        self, organization_id: int, update: RpcOrganizationMappingUpdate
+    ) -> OrganizationMapping:
+        org_mapping, _created = OrganizationMapping.objects.update_or_create(
+            organization_id=organization_id, defaults=update
+        )
+
+        return org_mapping
+
     def verify_mappings(self, organization_id: int, slug: str) -> None:
         try:
             mapping = OrganizationMapping.objects.get(organization_id=organization_id, slug=slug)

--- a/src/sentry/services/hybrid_cloud/organization_mapping/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/model.py
@@ -21,7 +21,7 @@ class RpcOrganizationMapping(RpcModel):
     region_name: str = ""
     date_created: datetime = Field(default_factory=timezone.now)
     verified: bool = False
-    customer_id: str = None
+    customer_id: Optional[str] = None
     status: Optional[OrganizationStatus] = None
 
 

--- a/src/sentry/services/hybrid_cloud/organization_mapping/model.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/model.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from pydantic.fields import Field
 from typing_extensions import TypedDict
 
+from sentry.models import OrganizationStatus
 from sentry.services.hybrid_cloud import RpcModel
 
 
@@ -20,7 +21,8 @@ class RpcOrganizationMapping(RpcModel):
     region_name: str = ""
     date_created: datetime = Field(default_factory=timezone.now)
     verified: bool = False
-    customer_id: Optional[str] = None
+    customer_id: str = None
+    status: Optional[OrganizationStatus] = None
 
 
 class RpcOrganizationMappingUpdate(TypedDict):
@@ -33,3 +35,5 @@ class RpcOrganizationMappingUpdate(TypedDict):
 
     name: str
     customer_id: Optional[str]
+    status: OrganizationStatus
+    slug: str

--- a/src/sentry/services/hybrid_cloud/organization_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/service.py
@@ -65,6 +65,11 @@ class OrganizationMappingService(RpcService):
 
     @rpc_method
     @abstractmethod
+    def upsert(self, *, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
+        pass
+
+    @rpc_method
+    @abstractmethod
     def verify_mappings(self, *, organization_id: int, slug: str) -> None:
         pass
 

--- a/src/sentry/services/hybrid_cloud/organization_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/service.py
@@ -6,6 +6,7 @@
 from abc import abstractmethod
 from typing import Optional, cast
 
+from sentry.models import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMapping,
     RpcOrganizationMappingUpdate,
@@ -65,7 +66,9 @@ class OrganizationMappingService(RpcService):
 
     @rpc_method
     @abstractmethod
-    def upsert(self, *, organization_id: int, update: RpcOrganizationMappingUpdate) -> None:
+    def upsert(
+        self, *, organization_id: int, update: RpcOrganizationMappingUpdate
+    ) -> OrganizationMapping:
         pass
 
     @rpc_method

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -267,13 +267,13 @@ class Factories:
         if not name:
             name = petname.Generate(2, " ", letters=10).title()
 
-        create_mapping = not kwargs.pop("no_mapping", False)
         org = Organization.objects.create(name=name, **kwargs)
-        if create_mapping:
-            Factories.create_org_mapping(org)
 
         if owner:
             Factories.create_member(organization=org, user_id=owner.id, role="owner")
+
+        region_outbox = Organization.outbox_for_update(org_id=org.id)
+        region_outbox.drain_shard()
         return org
 
     @staticmethod

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import responses
 from dateutil.parser import parse as parse_date
 from django.core import mail
+from django.db import IntegrityError
 from django.utils import timezone
 from pytz import UTC
 from rest_framework import status
@@ -772,6 +773,61 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             assert OrganizationMapping.objects.filter(
                 organization_id=organization_id, name="SaNtRy"
             ).exists()
+
+    def test_update_slug(self):
+        organization_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        assert organization_mapping.slug == self.organization.slug
+
+        desired_slug = "new-santry"
+        self.get_success_response(self.organization.slug, slug=desired_slug)
+        self.organization.refresh_from_db()
+        assert self.organization.slug == desired_slug
+
+        # Ensure that the organization update has been flushed
+        with outbox_runner():
+            pass
+
+        organization_mapping.refresh_from_db()
+        assert organization_mapping.slug == desired_slug
+
+    def test_update_slug_with_temporary_rename_collision(self):
+        desired_slug = "taken"
+        previous_slug = self.organization.slug
+        org_with_colliding_slug = self.create_organization(
+            slug=desired_slug, name="collision-imminent"
+        )
+
+        # Drain the initial slug creation to ensure a mapping exists for the new org
+        Organization.outbox_for_update(org_id=org_with_colliding_slug.id).drain_shard()
+        colliding_org_mapping = OrganizationMapping.objects.get(
+            organization_id=org_with_colliding_slug.id
+        )
+        assert colliding_org_mapping.slug == desired_slug
+
+        # Queue a slug update but don't drain the shard yet to ensure a temporary collision happens
+        org_with_colliding_slug.slug = "unique-slug"
+        org_with_colliding_slug.save()
+
+        self.get_success_response(self.organization.slug, slug=desired_slug)
+        self.organization.refresh_from_db()
+        assert self.organization.slug == desired_slug
+
+        # Ensure that the organization update has been flushed, but it collides when attempting an upsert
+        with pytest.raises(IntegrityError):
+            Organization.outbox_for_update(org_id=self.organization.id).drain_shard()
+
+        organization_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        assert organization_mapping.slug == previous_slug
+
+        # Flush the colliding org slug change
+        Organization.outbox_for_update(org_id=org_with_colliding_slug.id).drain_shard()
+        colliding_org_mapping.refresh_from_db()
+        assert colliding_org_mapping.slug == "unique-slug"
+
+        # Flush the desired slug change and assert the correct slug was resolved
+        Organization.outbox_for_update(org_id=self.organization.id).drain_shard()
+        organization_mapping.refresh_from_db()
+        assert organization_mapping.slug == desired_slug
 
     def test_org_mapping_already_taken(self):
         self.create_organization(slug="taken")

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -30,6 +30,7 @@ from sentry.models import (
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.signals import project_created
 from sentry.testutils import APITestCase, TwoFactorAPITestCase, pytest
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils import json
 
@@ -763,6 +764,9 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         organization_id = response.data["id"]
         org = Organization.objects.get(id=organization_id)
         assert org.name == "SaNtRy"
+
+        with outbox_runner():
+            pass
 
         with exempt_from_silo_limits():
             assert OrganizationMapping.objects.filter(

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -38,15 +38,14 @@ from sentry.testutils.silo import region_silo_test
 class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):
     def test_simple(self):
         org_owner = self.create_user()
-        org = self.create_organization(name="test", owner=org_owner, no_mapping=True)
+        org = self.create_organization(name="test", owner=org_owner)
+        org_mapping = OrganizationMapping.objects.get(organization_id=org.id)
         org_member = OrganizationMember.objects.get(organization_id=org.id, user_id=org_owner.id)
         self.assert_org_member_mapping(org_member=org_member)
 
         org_owner2 = self.create_user()
-        org2 = self.create_organization(name="test2", owner=org_owner2, no_mapping=True)
-
-        org_mapping = self.create_organization_mapping(org)
-        org_mapping2 = self.create_organization_mapping(org2)
+        org2 = self.create_organization(name="test2", owner=org_owner2)
+        org_mapping2 = OrganizationMapping.objects.get(organization_id=org2.id)
 
         self.create_team(organization=org, name="test1")
         self.create_team(organization=org, name="test2")

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -33,7 +33,7 @@ class OrganizationMappingTest(TransactionTestCase):
 
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         assert org_mapping.idempotency_key == ""
-        assert self.organization.id == self.organization.id
+        assert self.organization.id == org_mapping.organization_id
         assert org_mapping.verified is False
         assert self.organization.slug == org_mapping.slug
         assert self.organization.name == org_mapping.name
@@ -76,7 +76,7 @@ class OrganizationMappingTest(TransactionTestCase):
         fixture_org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         fixture_org_mapping.delete()
 
-        assert len(OrganizationMapping.objects.filter(organization_id=self.organization.id)) == 0
+        assert not OrganizationMapping.objects.filter(organization_id=self.organization.id).exists()
 
         organization_mapping_service.upsert(
             organization_id=self.organization.id,

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -1,6 +1,8 @@
 import pytest
 from django.db import IntegrityError
 
+from sentry.models import Organization
+from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMappingUpdate,
@@ -8,86 +10,39 @@ from sentry.services.hybrid_cloud.organization_mapping import (
 )
 from sentry.testutils import TransactionTestCase
 from sentry.testutils.factories import Factories
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits
 
 
-@pytest.mark.skip(reason="Disabling these tests until we finalize the organization mapping logic")
 @control_silo_test(stable=True)
 class OrganizationMappingTest(TransactionTestCase):
-    def test_create(self):
-        self.organization = Factories.create_organization(no_mapping=True)
-        fields = {
-            "organization_id": self.organization.id,
-            "slug": self.organization.slug,
-            "name": "test name",
-            "region_name": "us",
-        }
-        rpc_org_mapping = organization_mapping_service.create(**fields)
+    def test_create_on_organization_save(self):
+        with exempt_from_silo_limits():
+            self.organization = Organization(
+                name="test name",
+            )
+            self.organization.save()
+
+        # Validate that organization mapping has not been created
+        with pytest.raises(OrganizationMapping.DoesNotExist):
+            OrganizationMapping.objects.get(organization_id=self.organization.id)
+
+        # Drain outbox to ensure mapping is created
+        with outbox_runner():
+            pass
+
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         assert org_mapping.idempotency_key == ""
-        assert (
-            rpc_org_mapping.organization_id == org_mapping.organization_id == self.organization.id
-        )
-        assert rpc_org_mapping.verified is org_mapping.verified is False
-        assert rpc_org_mapping.slug == org_mapping.slug == fields["slug"]
-        assert rpc_org_mapping.region_name == org_mapping.region_name == fields["region_name"]
-        assert rpc_org_mapping.date_created == org_mapping.date_created
-        assert rpc_org_mapping.name == org_mapping.name == fields["name"]
-
-    def test_idempotency_key(self):
-        self.organization = Factories.create_organization(no_mapping=True)
-        data = {
-            "slug": self.organization.slug,
-            "name": "test name",
-            "region_name": "us",
-            "idempotency_key": "test",
-        }
-        self.create_organization_mapping(self.organization, **data)
-        next_organization_id = 7654321
-        rpc_org_mapping = organization_mapping_service.create(
-            **{**data, "organization_id": next_organization_id}
-        )
-
-        assert not OrganizationMapping.objects.filter(organization_id=self.organization.id).exists()
-        org_mapping = OrganizationMapping.objects.filter(organization_id=next_organization_id)
-        assert org_mapping
-        org_mapping = org_mapping.first()
-        assert org_mapping.idempotency_key == data["idempotency_key"]
-
-        assert rpc_org_mapping.organization_id == next_organization_id
-        assert rpc_org_mapping.region_name == "us"
-        assert rpc_org_mapping.name == data["name"]
-
-    def test_duplicate_slug(self):
-        self.organization = Factories.create_organization(no_mapping=True)
-        data = {
-            "slug": self.organization.slug,
-            "name": "test name",
-            "region_name": "us",
-            "idempotency_key": "test",
-        }
-        self.create_organization_mapping(self.organization, **data)
-
-        with pytest.raises(IntegrityError):
-            organization_mapping_service.create(
-                **{
-                    **data,
-                    "organization_id": 7654321,
-                    "region_name": "de",
-                    "idempotency_key": "test2",
-                }
-            )
+        assert self.organization.id == self.organization.id
+        assert org_mapping.verified is False
+        assert self.organization.slug == org_mapping.slug
+        assert self.organization.name == org_mapping.name
 
     def test_update(self):
-        self.organization = Factories.create_organization(no_mapping=True)
-        fields = {
-            "name": "test name",
-            "organization_id": self.organization.id,
-            "slug": self.organization.slug,
-            "region_name": "us",
-        }
-        rpc_org_mapping = organization_mapping_service.create(**fields)
-        assert rpc_org_mapping.customer_id is None
+        self.organization = Factories.create_organization(name="test name")
+
+        organization_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        assert not organization_mapping.customer_id
 
         organization_mapping_service.update(
             organization_id=self.organization.id,
@@ -103,9 +58,72 @@ class OrganizationMappingTest(TransactionTestCase):
         org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
         assert org_mapping.customer_id == "test"
         assert org_mapping.name == "new name!"
+        assert org_mapping.slug == self.organization.slug
+        assert org_mapping.status == self.organization.status
 
         organization_mapping_service.update(
             organization_id=self.organization.id, update=RpcOrganizationMappingUpdate()
         )
         # Does not overwrite with empty value.
         assert org_mapping.name == "new name!"
+
+    def test_upsert__create_if_not_found(self):
+        self.organization = self.create_organization(
+            name="test name",
+            slug="foobar",
+        )
+
+        fixture_org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        fixture_org_mapping.delete()
+
+        assert len(OrganizationMapping.objects.filter(organization_id=self.organization.id)) == 0
+
+        organization_mapping_service.upsert(
+            organization_id=self.organization.id,
+            update=RpcOrganizationMappingUpdate(
+                name=self.organization.name,
+                slug=self.organization.slug,
+                status=self.organization.status,
+            ),
+        )
+
+        new_org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        assert new_org_mapping.name == self.organization.name
+        assert not new_org_mapping.customer_id
+        assert new_org_mapping.slug == self.organization.slug
+        assert new_org_mapping.status == self.organization.status
+
+    def test_upsert__update_if_found(self):
+        with exempt_from_silo_limits():
+            self.organization = Organization(
+                name="test name",
+                slug="foobar",
+            )
+
+            self.organization.save()
+
+        with outbox_runner():
+            pass
+
+        fixture_org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+
+        organization_mapping_service.upsert(
+            organization_id=self.organization.id,
+            update=RpcOrganizationMappingUpdate(
+                name="santry_org", slug="santryslug", status=OrganizationStatus.PENDING_DELETION
+            ),
+        )
+
+        fixture_org_mapping.refresh_from_db()
+        assert fixture_org_mapping.name == "santry_org"
+        assert fixture_org_mapping.slug == "santryslug"
+        assert fixture_org_mapping.status == OrganizationStatus.PENDING_DELETION
+
+    def test_upsert__duplicate_slug(self):
+        self.organization = Factories.create_organization(slug="alreadytaken")
+
+        with pytest.raises(IntegrityError):
+            organization_mapping_service.upsert(
+                organization_id=7654321,
+                update=RpcOrganizationMappingUpdate(slug=self.organization.slug),
+            )

--- a/tests/sentry/hybrid_cloud/test_region.py
+++ b/tests/sentry/hybrid_cloud/test_region.py
@@ -24,13 +24,10 @@ class RegionResolutionTest(TestCase):
             Region("europe", 2, "eu.sentry.io", RegionCategory.MULTI_TENANT),
         ]
         self.target_region = self.regions[0]
-        self.organization = self.create_organization(no_mapping=True)
-        OrganizationMapping.objects.create(
-            organization_id=self.organization.id,
-            slug=self.organization.slug,
-            name=self.organization.name,
-            region_name=self.target_region.name,
-        )
+        self.organization = self.create_organization()
+        org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        org_mapping.region_name = self.target_region.name
+        org_mapping.save()
 
     def test_by_organization_object(self):
         with override_regions(self.regions):

--- a/tests/sentry/hybrid_cloud/test_rpc.py
+++ b/tests/sentry/hybrid_cloud/test_rpc.py
@@ -38,12 +38,14 @@ class RpcServiceTest(TestCase):
         target_region = _REGIONS[0]
 
         user = self.create_user()
-        organization = self.create_organization(no_mapping=True)
-        OrganizationMapping.objects.create(
+        organization = self.create_organization()
+        OrganizationMapping.objects.update_or_create(
             organization_id=organization.id,
-            slug=organization.slug,
-            name=organization.name,
-            region_name=target_region.name,
+            defaults={
+                "slug": organization.slug,
+                "name": organization.name,
+                "region_name": target_region.name,
+            },
         )
 
         serial_user = RpcUser(id=user.id)

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import ContextManager
 from unittest.mock import call, patch
 
+import pytest
 import responses
 from django.test import RequestFactory, override_settings
 from freezegun import freeze_time
@@ -12,6 +13,7 @@ from rest_framework import status
 from sentry.models import (
     ControlOutbox,
     Organization,
+    OrganizationMapping,
     OrganizationMember,
     OutboxCategory,
     OutboxScope,
@@ -30,6 +32,13 @@ from sentry.testutils.silo import control_silo_test, exempt_from_silo_limits, re
 from sentry.types.region import MONOLITH_REGION_NAME, Region, RegionCategory
 
 
+@pytest.fixture(autouse=True, scope="function")
+@pytest.mark.django_db(transaction=True)
+def setup_clear_fixture_outbox_messages():
+    with outbox_runner():
+        pass
+
+
 @control_silo_test(stable=True)
 class ControlOutboxTest(TestCase):
     webhook_request = RequestFactory().post(
@@ -43,8 +52,18 @@ class ControlOutboxTest(TestCase):
 
     def test_creating_user_outboxes(self):
         with exempt_from_silo_limits():
-            org = Factories.create_organization(no_mapping=True)
-            Factories.create_org_mapping(org, region_name="a")
+            org = Factories.create_organization()
+
+            org_mapping = OrganizationMapping.objects.get(organization_id=org.id)
+            org_mapping.region_name = "a"
+            org_mapping.save()
+
+            org2 = Factories.create_organization()
+
+            org_mapping2 = OrganizationMapping.objects.get(organization_id=org2.id)
+            org_mapping2.region_name = "b"
+            org_mapping2.save()
+
             user1 = Factories.create_user()
             organization_service.add_organization_member(
                 organization_id=org.id,
@@ -52,8 +71,6 @@ class ControlOutboxTest(TestCase):
                 user_id=user1.id,
             )
 
-            org2 = Factories.create_organization(no_mapping=True)
-            Factories.create_org_mapping(org2, region_name="b")
             organization_service.add_organization_member(
                 organization_id=org2.id,
                 default_org_role=org2.default_role,
@@ -69,8 +86,12 @@ class ControlOutboxTest(TestCase):
     def test_control_sharding_keys(self):
         request = RequestFactory().get("/extensions/slack/webhook/")
         with exempt_from_silo_limits():
-            org = Factories.create_organization(no_mapping=True)
-            Factories.create_org_mapping(org, region_name=MONOLITH_REGION_NAME)
+            org = Factories.create_organization()
+
+            org_mapping = OrganizationMapping.objects.get(organization_id=org.id)
+            org_mapping.region_name = MONOLITH_REGION_NAME
+            org_mapping.save()
+
             user1 = Factories.create_user()
             user2 = Factories.create_user()
             organization_service.add_organization_member(
@@ -343,8 +364,8 @@ class RegionOutboxTest(TestCase):
             assert last_call_count == 2
 
     def test_region_sharding_keys(self):
-        org1 = Factories.create_organization(no_mapping=True)
-        org2 = Factories.create_organization(no_mapping=True)
+        org1 = Factories.create_organization()
+        org2 = Factories.create_organization()
 
         Organization.outbox_for_update(org1.id).save()
         Organization.outbox_for_update(org2.id).save()

--- a/tests/sentry/tasks/test_organization_mapping.py
+++ b/tests/sentry/tasks/test_organization_mapping.py
@@ -11,11 +11,12 @@ from sentry.testutils.factories import Factories
 
 class OrganizationMappingRepairTest(TestCase):
     def test_removes_expired_unverified(self):
-        self.organization = Factories.create_organization(no_mapping=True)
+        self.organization = Factories.create_organization()
         expired_time = datetime.now() - ORGANIZATION_MAPPING_EXPIRY
-        mapping = self.create_organization_mapping(
-            self.organization, verified=False, date_created=expired_time
-        )
+        mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        mapping.verified = False
+        mapping.date_created = expired_time
+        mapping.save()
         phantom_mapping = self.create_organization_mapping(
             Organization(id=123, slug="fake-slug"), date_created=expired_time, verified=False
         )
@@ -28,11 +29,14 @@ class OrganizationMappingRepairTest(TestCase):
         assert mapping.verified
 
     def test_set_verified(self):
-        self.organization = Factories.create_organization(no_mapping=True)
+        self.organization = Factories.create_organization()
         expired_time = datetime.now() - ORGANIZATION_MAPPING_EXPIRY
-        mapping = self.create_organization_mapping(
-            self.organization, verified=False, date_created=expired_time, idempotency_key="1234"
-        )
+
+        mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        mapping.verified = False
+        mapping.date_created = expired_time
+        mapping.idempotency_key = "1234"
+        mapping.save()
 
         repair_mappings()
 

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -1,6 +1,7 @@
 import pytest
 from django.test import override_settings
 
+from sentry.models import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.silo import SiloMode
 from sentry.testutils import TestCase
@@ -78,15 +79,12 @@ class RegionMappingTest(TestCase):
         from sentry.types.region import find_regions_for_user
 
         organization = self.create_organization(name="test name")
-        self.create_organization_mapping(
-            organization,
-            **{
-                "slug": organization.slug,
-                "name": "test name",
-                "region_name": "na",
-                "idempotency_key": "test",
-            },
-        )
+        organization_mapping = OrganizationMapping.objects.get(organization_id=organization.id)
+        organization_mapping.name = "test name"
+        organization_mapping.region_name = "na"
+        organization_mapping.idempotency_key = "test"
+        organization_mapping.save()
+
         region_config = [
             {
                 "name": "na",

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -77,7 +77,7 @@ class RegionMappingTest(TestCase):
     def test_find_regions_for_user(self):
         from sentry.types.region import find_regions_for_user
 
-        organization = self.create_organization(name="test name", no_mapping=True)
+        organization = self.create_organization(name="test name")
         self.create_organization_mapping(
             organization,
             **{


### PR DESCRIPTION
Additionally:
- Adds `status`, `slug` to `RpcOrganizationMappingUpdate`
- Defaults organization update outbox to upsert an org mapping
- Removes the `no_mapping` kwarg from organization factory due to the outbox update changes
- Updates testing to always create an organization mapping by default by draining the outbox shard post save
- Updates tests to clear out old organization mappings if one has not been created

<!-- Describe your PR here. -->
In preparation for a full backfill of the OrganizationMapping table we are planning to:
- Remove all verification outbox + slug reservation logic
    - (PR #49993)
    - (PR #50015)
- Delete all OrganizationMapping rows from the table
    - (PR #50002)
- Migrate the OrganizationMapping schema to ensure org ID is unique in the table
    - (PR #50082)
- Add logic to upsert OrganizationMapping objects via the Org Update outbox (this PR)
- Backfill the entire OrganizationMapping table with the current org data, which should now be a 1:1 relationship
    - This will ensure that the system is eventually consistent, and that region continues to be the source of truth until we come up with a definitive plan for our distributed Organization creation process

