### PR TITLE
fix(sort): special aggregation for sorted issue platform issues

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -237,7 +237,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             aggregation = self.aggregation_defs[alias]
             # TODO: remove this hack once we can properly support better_priority sort on issue platform dataset
             if replace_better_priority_aggregation and alias == "better_priority":
-                aggregation = self.aggregation_defs["force_last"]
+                aggregation = self.aggregation_defs["force_last"]  # type:ignore[call-overload]
             if callable(aggregation):
                 if aggregate_kwargs:
                     aggregation = aggregation(start, end, aggregate_kwargs.get(alias, {}))

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2469,7 +2469,6 @@ class EventsBetterPriorityTest(SharedSnubaTest, OccurrenceTestMixin):
             )[0]
         error_group_score = results[0][1]
         profile_group_score = results[1][1]
-        # initially group 2's score is higher since it has a more recent event
         assert error_group_score > 0
         assert profile_group_score == 0
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2068,7 +2068,7 @@ class EventsSnubaSearchTest(SharedSnubaTest):
         assert len(results) == 0
 
 
-class EventsBetterPriorityTest(SharedSnubaTest):
+class EventsBetterPriorityTest(SharedSnubaTest, OccurrenceTestMixin):
     @property
     def backend(self):
         return EventsDatasetSnubaSearchBackend()
@@ -2404,6 +2404,74 @@ class EventsBetterPriorityTest(SharedSnubaTest):
         group1_score_after = results[0][1]
         group2_score_after = results[1][1]
         assert group1_score_after < group2_score_after
+
+    def test_better_priority_mixed_group_types(self):
+        base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=pytz.utc)
+
+        error_event = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group1"],
+                "event_id": "a" * 32,
+                "timestamp": iso_format(base_datetime - timedelta(hours=1)),
+                "message": "foo",
+                "stacktrace": {"frames": [{"module": "group1"}]},
+                "environment": "staging",
+                "level": "fatal",
+            },
+            project_id=self.project.id,
+        )
+        error_group = error_event.group
+
+        profile_event_id = uuid.uuid4().hex
+        _, group_info = process_event_and_issue_occurrence(
+            self.build_occurrence_data(event_id=profile_event_id),
+            {
+                "event_id": profile_event_id,
+                "project_id": self.project.id,
+                "title": "some problem",
+                "platform": "python",
+                "tags": {"my_tag": "1"},
+                "timestamp": before_now(minutes=1).isoformat(),
+                "received": before_now(minutes=1).isoformat(),
+            },
+        )
+        profile_group_1 = group_info.group
+
+        agg_kwargs = {
+            "better_priority": {
+                "log_level": 0,
+                "has_stacktrace": 0,
+                "relative_volume": 1,
+                "event_halflife_hours": 4,
+                "issue_halflife_hours": 24 * 7,
+                "v2": False,
+                "norm": False,
+            }
+        }
+        query_executor = self.backend._get_query_executor()
+        with self.feature(
+            [
+                "organizations:issue-platform",
+                ProfileFileIOGroupType.build_visible_feature_name(),
+                "organizations:issue-list-better-priority-sort",
+            ]
+        ):
+            results = query_executor.snuba_search(
+                start=None,
+                end=None,
+                project_ids=[self.project.id],
+                environment_ids=[],
+                sort_field="better_priority",
+                organization=self.organization,
+                group_ids=[profile_group_1.id, error_group.id],
+                limit=150,
+                aggregate_kwargs=agg_kwargs,
+            )[0]
+        error_group_score = results[0][1]
+        profile_group_score = results[1][1]
+        # initially group 2's score is higher since it has a more recent event
+        assert error_group_score > 0
+        assert profile_group_score == 0
 
 
 class EventsTransactionsSnubaSearchTest(SharedSnubaTest):


### PR DESCRIPTION
Workaround to 'support' betterPriority sort for issue platform backed issues. 

This basically sets Performance and Profiling issue scores to zero so they end up at the very last in issue search sort order.

Resolves SENTRY-11SS