### PR TITLE
feat: Unify naming to 'User Auth Tokens'

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -158,7 +158,7 @@ function SidebarDropdown({
                         {t('User settings')}
                       </SidebarMenuItem>
                       <SidebarMenuItem to="/settings/account/api/">
-                        {t('API keys')}
+                        {t('User auth tokens')}
                       </SidebarMenuItem>
                       {hasOrganization && (
                         <Hook

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -370,7 +370,7 @@ function buildRoutes() {
       />
       <Route path="api/" name={t('API')}>
         <IndexRedirect to="auth-tokens/" />
-        <Route path="auth-tokens/" name={t('Auth Tokens')}>
+        <Route path="auth-tokens/" name={t('User Auth Tokens')}>
           <IndexRoute
             component={make(() => import('sentry/views/settings/account/apiTokens'))}
           />

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -26,7 +26,7 @@ type State = {
 
 export class ApiTokens extends AsyncView<Props, State> {
   getTitle() {
-    return t('Auth Tokens');
+    return t('User Auth Tokens');
   }
 
   getDefaultState() {

--- a/static/app/views/settings/account/navigationConfiguration.tsx
+++ b/static/app/views/settings/account/navigationConfiguration.tsx
@@ -76,7 +76,7 @@ function getConfiguration({organization}: ConfigParams): NavigationSection[] {
         },
         {
           path: `${pathPrefix}/api/auth-tokens/`,
-          title: t('Auth Tokens'),
+          title: t('User Auth Tokens'),
           description: t(
             "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
           ),

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -79,7 +79,7 @@ function OrganizationApiKeysList({
 
       <AlertLink to="/settings/account/api/auth-tokens/" priority="info">
         {tct(
-          'Until Sentry supports OAuth, you might want to switch to using [tokens:Auth Tokens] instead.',
+          'Until Sentry supports OAuth, you might want to switch to using [tokens:User Auth Tokens] instead.',
           {
             tokens: <u />,
           }


### PR DESCRIPTION
This unifies the naming to "User Auth Tokens" everywhere. Previously, we were using `API keys` in the user dropdown, and `Auth Tokens` in the account settings page. Renaming this makes this more explicit and also prepares us for having more types of access tokens (e.g. org based) in the future.

![Screenshot 2023-06-01 at 15 36 27](https://github.com/getsentry/sentry/assets/2411343/ef6dd54a-821d-46cb-8c7c-41322a7c74fe)

As far as I can tell (based on a search) we only reference this by URL in the docs (e.g. see: https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/webpack/), so should be fine from that perspective.