### PR TITLE
feat(dashboard-widget-description-frontend): Added functionality and …

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -227,6 +227,15 @@ describe('Modals -> WidgetViewerModal', function () {
         expect(screen.getByText('echarts mock')).toBeInTheDocument();
       });
 
+      it('renders description', async function () {
+        mockEvents();
+        await renderModal({
+          initialData,
+          widget: {...mockWidget, description: 'This is a description'},
+        });
+        expect(screen.getByText('This is a description')).toBeInTheDocument();
+      });
+
       it('renders Discover area chart widget viewer', async function () {
         mockEvents();
         const {container} = await renderModal({initialData, widget: mockWidget});

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -62,7 +62,10 @@ import {
   getWidgetIssueUrl,
   getWidgetReleasesUrl,
 } from 'sentry/views/dashboards/utils';
-import {SESSION_DURATION_ALERT} from 'sentry/views/dashboards/widgetCard';
+import {
+  SESSION_DURATION_ALERT,
+  WidgetDescription,
+} from 'sentry/views/dashboards/widgetCard';
 import WidgetCardChart, {
   AugmentedEChartDataZoomHandler,
   SLIDER_HEIGHT,
@@ -994,6 +997,9 @@ function WidgetViewerModal(props: Props) {
                   <Header closeButton>
                     <WidgetTitle>
                       <h3>{widget.title}</h3>
+                      {widget.description && (
+                        <WidgetDescription>{widget.description}</WidgetDescription>
+                      )}
                       <DashboardsMEPConsumer>
                         {({}) => {
                           // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
@@ -1194,8 +1200,8 @@ const EmptyQueryContainer = styled('span')`
 
 const WidgetTitle = styled('div')`
   display: flex;
+  flex-direction: column;
   gap: ${space(1)};
-  align-items: center;
 `;
 
 export default withPageFilters(WidgetViewerModal);

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -46,6 +46,7 @@ export type Widget = {
   interval: string;
   queries: WidgetQuery[];
   title: string;
+  description?: string;
   id?: string;
   layout?: WidgetLayout | null;
   // Used to define 'topEvents' when fetching time-series data for a widget

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1337,7 +1337,7 @@ describe('WidgetBuilder', function () {
     expect(screen.getByText('Limit to 2 results')).toBeInTheDocument();
   });
 
-  it('alerts the user if there are unsaved changes', async function () {
+  it('alerts the user if there are unsaved title changes', async function () {
     const {router} = renderTestComponent();
 
     const alertMock = jest.fn();
@@ -1351,9 +1351,40 @@ describe('WidgetBuilder', function () {
     expect(customWidgetLabels).toBeInTheDocument();
 
     // Change title text
-    await await userEvent.clear(screen.getByRole('textbox', {name: 'Widget title'}));
+    await userEvent.clear(screen.getByRole('textbox', {name: 'Widget title'}));
     await userEvent.click(screen.getByRole('textbox', {name: 'Widget title'}));
     await userEvent.paste('Unique Users');
+    await userEvent.keyboard('{Enter}');
+
+    // Click Cancel
+    await userEvent.click(screen.getByText('Cancel'));
+
+    // Assert an alert was triggered
+    expect(alertMock).toHaveBeenCalled();
+  });
+
+  it('alerts the user if there are unsaved description changes', async function () {
+    const {router} = renderTestComponent();
+
+    const alertMock = jest.fn();
+    const setRouteLeaveHookMock = jest.spyOn(router, 'setRouteLeaveHook');
+    setRouteLeaveHookMock.mockImplementationOnce((_route, _callback) => {
+      alertMock();
+    });
+
+    const descriptionTextArea = await screen.findByRole('textbox', {
+      name: 'Widget Description',
+    });
+    expect(descriptionTextArea).toBeInTheDocument();
+    expect(descriptionTextArea).toHaveAttribute(
+      'placeholder',
+      'Enter description (Optional)'
+    );
+
+    // Change description text
+    await userEvent.clear(descriptionTextArea);
+    await userEvent.click(descriptionTextArea);
+    await userEvent.paste('This is a description');
     await userEvent.keyboard('{Enter}');
 
     // Click Cancel

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -166,7 +166,7 @@ describe('Dashboards > WidgetCard', function () {
       />
     );
 
-    expect(await screen.findByText('Valid widget description123')).toBeInTheDocument();
+    expect(await screen.findByText('Valid widget description')).toBeInTheDocument();
   });
 
   it('Opens in Discover with World Map', async function () {

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -37,6 +37,7 @@ describe('Dashboards > WidgetCard', function () {
 
   const multipleQueryWidget: Widget = {
     title: 'Errors',
+    description: 'Valid widget description',
     interval: '5m',
     displayType: DisplayType.LINE,
     widgetType: WidgetType.DISCOVER,
@@ -146,6 +147,26 @@ describe('Dashboards > WidgetCard', function () {
     expect(router.push).toHaveBeenCalledWith(
       '/organizations/org-slug/discover/results/?environment=prod&field=count%28%29&field=failure_count%28%29&name=Errors&project=1&query=event.type%3Aerror&statsPeriod=14d&yAxis=count%28%29&yAxis=failure_count%28%29'
     );
+  });
+
+  it('renders widget description in dashboard', async function () {
+    renderWithProviders(
+      <WidgetCard
+        api={api}
+        organization={organization}
+        widget={multipleQueryWidget}
+        selection={selection}
+        isEditing={false}
+        onDelete={() => undefined}
+        onEdit={() => undefined}
+        onDuplicate={() => undefined}
+        renderErrorMessage={() => undefined}
+        showContextMenu
+        widgetLimitReached={false}
+      />
+    );
+
+    expect(await screen.findByText('Valid widget description123')).toBeInTheDocument();
   });
 
   it('Opens in Discover with World Map', async function () {

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -305,6 +305,15 @@ class WidgetCard extends Component<Props, State> {
                     >
                       <WidgetTitle>{widget.title}</WidgetTitle>
                     </Tooltip>
+                    {widget.description && (
+                      <Tooltip
+                        title={widget.description}
+                        containerDisplayMode="grid"
+                        showOnlyOnOverflow
+                      >
+                        <WidgetDescription>{widget.description}</WidgetDescription>
+                      </Tooltip>
+                    )}
                     <DashboardsMEPConsumer>
                       {({}) => {
                         // TODO(Tele-Team): Re-enable this when we have a better way to determine if the data is transaction only
@@ -495,6 +504,11 @@ const StyledErrorPanel = styled(ErrorPanel)`
 
 const WidgetHeaderDescription = styled('div')`
   display: flex;
-  gap: ${space(1)};
-  align-items: center;
+  flex-direction: column;
+  gap: ${space(0.5)};
+`;
+
+export const WidgetDescription = styled('small')`
+  ${p => p.theme.overflowEllipsis}
+  color: ${p => p.theme.gray300};
 `;


### PR DESCRIPTION
Linked Issue: https://github.com/getsentry/sentry/issues/34420

1. Added description textarea in widget builder: 
<img width="786" alt="Screenshot 2023-06-01 at 11 39 50 AM" src="https://github.com/getsentry/sentry/assets/60121741/46aa00f6-727a-4031-b71c-943e92b96676">


2. Added description to widget previews:
<img width="833" alt="Screenshot 2023-06-01 at 11 40 38 AM" src="https://github.com/getsentry/sentry/assets/60121741/c15e60b3-75b7-4690-947e-09fd5c5d3d10">


3.Added description to widget viewer modal: 
<img width="595" alt="Screenshot 2023-06-01 at 11 41 09 AM" src="https://github.com/getsentry/sentry/assets/60121741/18ac7b76-cfaf-43cc-abd7-ed00c1398ff1">


4. Added tests. 

