### PR TITLE
fix(hybridcloud) Clear lookup state during initialization

### DIFF
--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -39,6 +39,7 @@ class SiloRouter:
     """Whether or not we're operating in a simulated silo environment"""
 
     def __init__(self):
+        self.__table_to_silo = {}
         try:
             # By accessing the connections Django will raise
             # Use `assert` to appease linters

--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -90,7 +90,9 @@ class SiloRouter:
                 # have to scan through models more than once.
                 self.__table_to_silo[table] = self._db_for_model(model)
 
-        return self.__table_to_silo[table]
+        # All actively used tables should be in this map, but we also
+        # need to handle tables in migrations that no longer exist.
+        return self.__table_to_silo.get(table, "default")
 
     def db_for_read(self, model, **hints):
         return self._db_for_model(model)

--- a/tests/sentry/db/test_router.py
+++ b/tests/sentry/db/test_router.py
@@ -24,6 +24,11 @@ class SiloRouterSimulatedTest(TestCase):
         assert router.allow_migrate("control", "sentry", User)
         assert not router.allow_migrate("region", "sentry", User)
 
+        # Ensure tables that no longer exist don't fail
+        assert router.allow_migrate(
+            "default", "sentry", model=None, hints={"tables": ["jira_ac_tenant"]}
+        )
+
     @override_settings(SILO_MODE="REGION")
     def test_for_region(self):
         router = SiloRouter()


### PR DESCRIPTION
This avoids leaking state between instances of the SiloRouter which was impacting getsentry tests.
