### PR TITLE
fix(perf): Fully fallback transaction summary based on cardinality

### DIFF
--- a/static/app/utils/discover/discoverQuery.tsx
+++ b/static/app/utils/discover/discoverQuery.tsx
@@ -1,4 +1,3 @@
-import {defined} from 'sentry/utils';
 import {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {TransactionThresholdMetric} from 'sentry/views/performance/transactionSummary/transactionThresholdModal';
 

--- a/static/app/utils/discover/discoverQuery.tsx
+++ b/static/app/utils/discover/discoverQuery.tsx
@@ -1,3 +1,4 @@
+import {defined} from 'sentry/utils';
 import {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {TransactionThresholdMetric} from 'sentry/views/performance/transactionSummary/transactionThresholdModal';
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -13,6 +13,7 @@ import {t} from 'sentry/locale';
 import {Organization, Project, SelectValue} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
+import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -153,7 +154,12 @@ function TransactionSummaryCharts({
   };
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, organization);
+  const mepCardinalityContext = useMetricsCardinalityContext();
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    mepCardinalityContext,
+    organization
+  );
 
   return (
     <Panel>

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -14,6 +14,7 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {Project} from 'sentry/types';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {
   MEPSetting,
   MEPState,
@@ -72,10 +73,19 @@ function TestComponent({
 }) {
   const client = new QueryClient();
 
+  if (!props.organization) {
+    throw new Error('Missing organization');
+  }
+
   return (
     <QueryClientProvider client={client}>
       <RouteContext.Provider value={{router, ...router}}>
-        <TransactionSummary {...props} />
+        <MetricsCardinalityProvider
+          organization={props.organization}
+          location={props.location}
+        >
+          <TransactionSummary {...props} />
+        </MetricsCardinalityProvider>
       </RouteContext.Provider>
     </QueryClientProvider>
   );
@@ -427,6 +437,26 @@ describe('Performance > TransactionSummary', function () {
       url: `/projects/org-slug/project-slug/profiling/functions/`,
       body: {functions: []},
     });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/metrics-compatibility/`,
+      body: {
+        compatible_projects: [],
+        incompatible_projecs: [],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/metrics-compatibility-sums/`,
+      body: {
+        sum: {
+          metrics: 100,
+          metrics_null: 0,
+          metrics_unparam: 0,
+        },
+      },
+    });
 
     jest.spyOn(MEPSetting, 'get').mockImplementation(() => MEPState.auto);
   });
@@ -442,10 +472,17 @@ describe('Performance > TransactionSummary', function () {
     it('renders basic UI elements', async function () {
       const {organization, router, routerContext} = initializeData();
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       //  It shows the header
       await screen.findByText('Transaction Summary');
@@ -487,10 +524,17 @@ describe('Performance > TransactionSummary', function () {
         features: ['incidents'],
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       // Ensure create alert from discover is shown with metric alerts
       expect(screen.getByRole('button', {name: 'Create Alert'})).toBeInTheDocument();
@@ -505,10 +549,17 @@ describe('Performance > TransactionSummary', function () {
         },
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       // It renders the web vitals widget
       await screen.findByRole('heading', {name: 'Web Vitals'});
@@ -524,10 +575,17 @@ describe('Performance > TransactionSummary', function () {
     it('renders sidebar widgets', async function () {
       const {organization, router, routerContext} = initializeData({});
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       // Renders Apdex widget
       await screen.findByRole('heading', {name: 'Apdex'});
@@ -595,11 +653,18 @@ describe('Performance > TransactionSummary', function () {
       // Ensure project id is not in path
       delete router.location.query.project;
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-        projects,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+          projects,
+        }
+      );
 
       renderGlobalModal();
 
@@ -635,10 +700,17 @@ describe('Performance > TransactionSummary', function () {
         },
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       expect(getTransactionThresholdMock).toHaveBeenCalledTimes(1);
       expect(getProjectThresholdMock).not.toHaveBeenCalled();
@@ -662,10 +734,17 @@ describe('Performance > TransactionSummary', function () {
         },
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
 
@@ -676,10 +755,17 @@ describe('Performance > TransactionSummary', function () {
     it('triggers a navigation on search', async function () {
       const {organization, router, routerContext} = initializeData();
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       // Fill out the search box, and submit it.
       await userEvent.type(
@@ -704,10 +790,17 @@ describe('Performance > TransactionSummary', function () {
     it('can mark a transaction as key', async function () {
       const {organization, router, routerContext} = initializeData();
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       const mockUpdate = MockApiClient.addMockResponse({
         url: `/organizations/org-slug/key-transactions/`,
@@ -729,10 +822,17 @@ describe('Performance > TransactionSummary', function () {
     it('triggers a navigation on transaction filter', async function () {
       const {organization, router, routerContext} = initializeData();
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
       await waitFor(() => {
@@ -761,10 +861,17 @@ describe('Performance > TransactionSummary', function () {
     it('renders pagination buttons', async function () {
       const {organization, router, routerContext} = initializeData();
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
 
@@ -794,10 +901,17 @@ describe('Performance > TransactionSummary', function () {
         query: {query: 'tag:value'},
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
 
@@ -820,10 +934,17 @@ describe('Performance > TransactionSummary', function () {
         query: {query: 'tag:value event.type:transaction'},
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
 
@@ -840,10 +961,17 @@ describe('Performance > TransactionSummary', function () {
         features: ['performance-suspect-spans-view'],
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       expect(await screen.findByText('Suspect Spans')).toBeInTheDocument();
     });
@@ -851,10 +979,17 @@ describe('Performance > TransactionSummary', function () {
     it('adds search condition on transaction status when clicking on status breakdown', async function () {
       const {organization, router, routerContext} = initializeData();
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByTestId('status-ok');
 
@@ -873,10 +1008,17 @@ describe('Performance > TransactionSummary', function () {
     it('appends tag value to existing query when clicked', async function () {
       const {organization, router, routerContext} = initializeData();
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Tag Summary');
 
@@ -918,10 +1060,17 @@ describe('Performance > TransactionSummary', function () {
         features: [''], // No 'dynamic-sampling' feature to indicate it can use metrics dataset or metrics enhanced.
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
 
@@ -953,10 +1102,17 @@ describe('Performance > TransactionSummary', function () {
         features: ['dynamic-sampling', 'mep-rollout-flag'],
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
 
@@ -991,6 +1147,61 @@ describe('Performance > TransactionSummary', function () {
       expect(
         screen.queryByTestId('search-metrics-fallback-warning')
       ).not.toBeInTheDocument();
+    });
+
+    it('does not use MEP dataset for stats query if cardinality fallback fails', async function () {
+      MockApiClient.addMockResponse({
+        method: 'GET',
+        url: `/organizations/org-slug/metrics-compatibility-sums/`,
+        body: {
+          sum: {
+            metrics: 100,
+            metrics_null: 100,
+            metrics_unparam: 0,
+          },
+        },
+      });
+      const {organization, router, routerContext} = initializeData({
+        query: {query: 'transaction.op:pageload'}, // transaction.op is covered by the metrics dataset
+        features: ['dynamic-sampling', 'mep-rollout-flag'],
+      });
+
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
+
+      await screen.findByText('Transaction Summary');
+
+      // Renders Apdex widget
+      await screen.findByRole('heading', {name: 'Apdex'});
+      expect(await screen.findByTestId('apdex-summary-value')).toHaveTextContent('0.6');
+
+      expect(eventStatsMock).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query:
+              'transaction.op:pageload event.type:transaction transaction:/performance',
+          }),
+        })
+      );
+
+      // Renders TPM widget
+      expect(
+        screen.getByRole('heading', {name: 'Percentage of Total Transactions'})
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('count-percentage-summary-value')).toHaveTextContent(
+        '100%'
+      );
     });
 
     it('uses MEP dataset for stats query and shows fallback warning', async function () {
@@ -1046,10 +1257,17 @@ describe('Performance > TransactionSummary', function () {
         features: ['dynamic-sampling', 'mep-rollout-flag'],
       });
 
-      render(<TestComponent router={router} location={router.location} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <TestComponent
+          organization={organization}
+          router={router}
+          location={router.location}
+        />,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       await screen.findByText('Transaction Summary');
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 import {Location} from 'history';
 
 import {loadOrganizationTags} from 'sentry/actionCreators/tags';
+import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Project} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -80,10 +81,20 @@ function TransactionOverview(props: Props) {
         tab={Tab.TransactionSummary}
         getDocumentTitle={getDocumentTitle}
         generateEventView={generateEventView}
-        childComponent={OverviewContentWrapper}
+        childComponent={CardinalityLoadingWrapper}
       />
     </MEPSettingProvider>
   );
+}
+
+function CardinalityLoadingWrapper(props: ChildProps) {
+  const mepCardinalityContext = useMetricsCardinalityContext();
+
+  if (mepCardinalityContext.isLoading) {
+    return <LoadingContainer isLoading />;
+  }
+
+  return <OverviewContentWrapper {...props} />;
 }
 
 function OverviewContentWrapper(props: ChildProps) {
@@ -97,9 +108,9 @@ function OverviewContentWrapper(props: ChildProps) {
     transactionThresholdMetric,
   } = props;
 
+  const mepContext = useMEPDataContext();
   const mepSetting = useMEPSettingContext();
   const mepCardinalityContext = useMetricsCardinalityContext();
-  const mepContext = useMEPDataContext();
   const queryExtras = getTransactionMEPParamsIfApplicable(
     mepSetting,
     mepCardinalityContext,

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -10,6 +10,7 @@ import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {Column, isAggregateField, QueryFieldValue} from 'sentry/utils/discover/fields';
 import {WebVital} from 'sentry/utils/fields';
+import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {
   getIsMetricsDataFromResults,
   useMEPDataContext,
@@ -97,8 +98,13 @@ function OverviewContentWrapper(props: ChildProps) {
   } = props;
 
   const mepSetting = useMEPSettingContext();
+  const mepCardinalityContext = useMetricsCardinalityContext();
   const mepContext = useMEPDataContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, organization);
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    mepCardinalityContext,
+    organization
+  );
 
   const queryData = useDiscoverQuery({
     eventView: getTotalsEventView(organization, eventView),

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -26,6 +26,7 @@ import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import AnomaliesQuery from 'sentry/utils/performance/anomalies/anomaliesQuery';
+import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
@@ -222,7 +223,12 @@ function SidebarChartsContainer({
   const utc = normalizeDateTimeParams(location.query).utc === 'true';
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, organization);
+  const mepCardinalityContext = useMetricsCardinalityContext();
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    mepCardinalityContext,
+    organization
+  );
 
   const axisLineConfig = {
     scale: true,

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -14,6 +14,7 @@ import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {WebVital} from 'sentry/utils/fields';
+import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
@@ -74,7 +75,12 @@ function UserStats({
   });
 
   const mepSetting = useMEPSettingContext();
-  const queryExtras = getTransactionMEPParamsIfApplicable(mepSetting, organization);
+  const mepCardinalityContext = useMetricsCardinalityContext();
+  const queryExtras = getTransactionMEPParamsIfApplicable(
+    mepSetting,
+    mepCardinalityContext,
+    organization
+  );
 
   return (
     <Fragment>

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -3,6 +3,7 @@ import {Location} from 'history';
 import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {AggregationKeyWithAlias, QueryFieldValue} from 'sentry/utils/discover/fields';
+import {MetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsEnhancedPerformanceDataContext} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {
   canUseMetricsData,
@@ -30,14 +31,19 @@ export function canUseTransactionMetricsData(
 }
 
 export function getTransactionMEPParamsIfApplicable(
-  mepContext: MetricsEnhancedSettingContext,
+  mepSetting: MetricsEnhancedSettingContext,
+  mepCardinality: MetricsCardinalityContext,
   organization: Organization
 ) {
   if (!canUseMetricsData(organization)) {
     return undefined;
   }
 
-  return getMEPQueryParams(mepContext, true);
+  if (mepCardinality.outcome?.forceTransactionsOnly) {
+    return undefined;
+  }
+
+  return getMEPQueryParams(mepSetting, false);
 }
 
 export function getUnfilteredTotalsEventView(

--- a/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/utils.tsx
@@ -43,7 +43,7 @@ export function getTransactionMEPParamsIfApplicable(
     return undefined;
   }
 
-  return getMEPQueryParams(mepSetting, false);
+  return getMEPQueryParams(mepSetting, true);
 }
 
 export function getUnfilteredTotalsEventView(


### PR DESCRIPTION
### Summary
Previously we were using the 'setting' for metrics fallback decision which could be propagated from the landing page. There are too many cases where this doesn't happen and we still have flows from entirely 'null' transactions that currently don't work with the clusterer whatsoever, this means **showing the transaction summary based on metrics data will not work.** This does a full fallback similarly to how the landing page does. We can remove it in the future when we're closer to 100% ingestion and landing no longer needs the fallback either.

This should fix the cases of "no transactions" appearing in either the graph or the transaction list _due to transaction.source:unknown_

![Screenshot 2023-06-01 at 12 40 43 PM](https://github.com/getsentry/sentry/assets/6111995/fcd7fa6c-09ec-401b-8909-fba313f39795)

