### PR TITLE
fix(hybrid-cloud): Add API Gateway to middleware stack

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -323,6 +323,7 @@ MIDDLEWARE = (
     "django.middleware.csrf.CsrfViewMiddleware",
     "sentry.middleware.auth.AuthenticationMiddleware",
     "sentry.middleware.integrations.IntegrationControlMiddleware",
+    "sentry.middleware.api_gateway.ApiGatewayMiddleware",
     "sentry.middleware.customer_domain.CustomerDomainMiddleware",
     "sentry.middleware.user.UserActiveMiddleware",
     "sentry.middleware.sudo.SudoMiddleware",

--- a/src/sentry/silo/util.py
+++ b/src/sentry/silo/util.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hmac
 from hashlib import sha256
-from typing import Mapping, Set
+from typing import Iterable, Mapping
 from wsgiref.util import is_hop_by_hop
 
 from django.conf import settings
@@ -11,7 +11,7 @@ PROXY_BASE_PATH = "/api/0/internal/integration-proxy"
 PROXY_OI_HEADER = "X-Sentry-Subnet-Organization-Integration"
 PROXY_SIGNATURE_HEADER = "X-Sentry-Subnet-Signature"
 
-INVALID_PROXY_HEADERS = {"host", "content-length", "content-encoding"}
+INVALID_PROXY_HEADERS = {"Host", "Content-Length", "Content-Encoding"}
 INVALID_OUTBOUND_HEADERS = INVALID_PROXY_HEADERS | {PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER}
 
 DEFAULT_REQUEST_BODY = b""
@@ -24,14 +24,15 @@ def trim_leading_slashes(path: str) -> str:
 
 
 def clean_headers(
-    headers: Mapping[str, str] | None, invalid_headers: Set[str]
+    headers: Mapping[str, str] | None, invalid_headers: Iterable[str]
 ) -> Mapping[str, str]:
     if not headers:
         headers = {}
+    normalized_invalid = {h.lower() for h in invalid_headers}
     modified_headers = {
         h: v
         for h, v in headers.items()
-        if h.lower() not in invalid_headers and not is_hop_by_hop(h)
+        if h.lower() not in normalized_invalid and not is_hop_by_hop(h)
     }
     return modified_headers
 

--- a/tests/sentry/api_gateway/test_proxy.py
+++ b/tests/sentry/api_gateway/test_proxy.py
@@ -7,7 +7,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
 from rest_framework.exceptions import NotFound
 
-from sentry.api_gateway.proxy import HEADER_STRIKE_LIST, proxy_request
+from sentry.api_gateway.proxy import proxy_request
+from sentry.silo.util import INVALID_OUTBOUND_HEADERS
 from sentry.testutils.helpers.api_gateway import (
     SENTRY_REGION_CONFIG,
     ApiGatewayTestCase,
@@ -222,8 +223,8 @@ class ProxyTestCase(ApiGatewayTestCase):
             "http://sentry.io/post",
             data=request_body,
             content_type="application/json",
-            headers={header: "1" for header in HEADER_STRIKE_LIST},
+            headers={header: "1" for header in INVALID_OUTBOUND_HEADERS},
         )
 
         resp = proxy_request(request, self.organization.slug)
-        assert not any([header in resp for header in HEADER_STRIKE_LIST])
+        assert not any([header in resp for header in INVALID_OUTBOUND_HEADERS])


### PR DESCRIPTION
This PR adds the API Gateway to the middleware stack and makes some small changes to it that threw a few errors when I was testing it out.

This was sort of another attempt at https://github.com/getsentry/sentry/pull/50128 without as much code deletion, I will adapt that PR into a refactor of the integration proxy work, but since this works for the gateway, I'd rather not delete it.

> Now with the gateway running, some pages even load!

<img width="1654" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/d833f5ce-e696-460b-a659-14acf3d3a41c">
<img width="1703" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/b27ea54b-175a-47b3-9179-ee17ac48e0f9">

> and partial failures are to be expected as we don't have 100% coverage on siloing endpoints

<img width="1712" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/9bae1414-9b19-4246-b683-6297759865c3">
