### PR TITLE
fix(query-subscription-consumer): Fix multi processing usage in prod try 2

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -465,7 +465,7 @@ def post_process_forwarder(**options):
     "query-subscription-consumer",
     include_batching_options=True,
     allow_force_cluster=False,
-    default_max_batch_size=1000,
+    default_max_batch_size=100,
 )
 @click.option(
     "--processes",

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -491,6 +491,7 @@ def query_subscription_consumer(**options):
         processes=options["processes"],
         input_block_size=options["input_block_size"],
         output_block_size=options["output_block_size"],
+        multi_proc=True,
     )
     run_processor_with_signals(subscriber)
 

--- a/src/sentry/snuba/query_subscriptions/run.py
+++ b/src/sentry/snuba/query_subscriptions/run.py
@@ -127,7 +127,7 @@ def get_query_subscription_consumer(
     cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
     cluster_options = kafka_config.get_kafka_consumer_cluster_options(cluster_name)
 
-    initialize_metrics()
+    initialize_metrics(group_id=group_id)
 
     consumer = KafkaConsumer(
         build_kafka_consumer_configuration(
@@ -153,9 +153,11 @@ def get_query_subscription_consumer(
     )
 
 
-def initialize_metrics() -> None:
+def initialize_metrics(group_id: str) -> None:
     from sentry.utils import metrics
     from sentry.utils.arroyo import MetricsWrapper
 
-    metrics_wrapper = MetricsWrapper(metrics.backend, name="query_subscription_consumer")
+    metrics_wrapper = MetricsWrapper(
+        metrics.backend, name="query_subscription_consumer", tags={"consumer_group": group_id}
+    )
     configure_metrics(metrics_wrapper)


### PR DESCRIPTION
Trying this again. We've lowered the number of processes to 2, and also are dropping the max batch size to help reduce memory usage. https://github.com/getsentry/ops/pull/6989 needs to be merged before we merge this.