### PR TITLE
fix(ui) Send CSRF token when doing requests between subdomains

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -439,10 +439,10 @@ export class Client {
     });
 
     // Do not set the X-CSRFToken header when making a request outside of the
-    // current domain
+    // current domain. Because we use subdomains we loosely compare origins
     const absoluteUrl = new URL(fullUrl, window.location.origin);
-    const isSameOrigin = window.location.origin === absoluteUrl.origin;
-
+    const originUrl = new URL(window.location.origin);
+    const isSameOrigin = originUrl.hostname.endsWith(absoluteUrl.hostname);
     if (!csrfSafeMethod(method) && isSameOrigin) {
       headers.set('X-CSRFToken', getCsrfToken());
     }


### PR DESCRIPTION
When doing a request to sentry.io from acme.sentry.io we should include the CSRF token or else mutation requests will be rejected. We need this in the present for integration installation, and in the future most customer API calls will be across subdomains.
