### PR TITLE
fix(functions): Ensure selected functions projects are returned

### DIFF
--- a/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
@@ -71,6 +71,7 @@ describe('SlowestFunctionsWidget', function () {
           dataset: 'profileFunctions',
           query: 'is_application:1',
           field: ['project.id', 'sum()'],
+          project: [1],
         }),
       ],
     });

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -15,12 +15,15 @@ import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {IconChevron, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 import {EventsResultsDataRow} from 'sentry/utils/profiling/hooks/types';
 import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFunctions';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+
+const MAX_FUNCTIONS = 3;
 
 export function SlowestFunctionsWidget() {
   const [expandedIndex, setExpandedIndex] = useState(0);
@@ -39,7 +42,7 @@ export function SlowestFunctionsWidget() {
       order: 'desc',
     },
     query,
-    limit: 3,
+    limit: MAX_FUNCTIONS,
   });
 
   const totalsQuery = useProfileFunctions<TotalsField>({
@@ -50,7 +53,16 @@ export function SlowestFunctionsWidget() {
       order: 'desc',
     },
     query,
-    limit: 1,
+    limit: MAX_FUNCTIONS,
+    // make sure to query for the projects from the top functions
+    projects: functionsQuery.isFetched
+      ? [
+          ...new Set(
+            (functionsQuery.data?.data ?? []).map(func => func['project.id'] as number)
+          ),
+        ]
+      : [],
+    enabled: functionsQuery.isFetched && defined(functionsQuery.data?.data),
   });
 
   return (


### PR DESCRIPTION
Currently only returning a single project result. We need to ensure the project for each function is in the result.