### PR TITLE
feat(crons): Support empty check_in_id in consumer

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import uuid
 from typing import Dict, Mapping, Optional
 
 import msgpack
@@ -165,10 +166,25 @@ def _process_message(wrapper: Dict) -> None:
                 else None
             )
 
+            # Invalid UUIDs will raise ValueError
+            check_in_id = uuid.UUID(params["check_in_id"])
+
+            # When the UUID is empty we will default to looking for the most
+            # recent check-in which is not in a terminal state.
+            use_latest_checkin = check_in_id.int == 0
+
             try:
-                check_in = MonitorCheckIn.objects.select_for_update().get(
-                    guid=params["check_in_id"],
-                )
+                if use_latest_checkin:
+                    check_in = (
+                        MonitorCheckIn.objects.select_for_update()
+                        .exclude(status__in=CheckInStatus.FINISHED_VALUES)
+                        .order_by("-date_added")[:1]
+                        .get()
+                    )
+                else:
+                    check_in = MonitorCheckIn.objects.select_for_update().get(
+                        guid=check_in_id,
+                    )
 
                 if (
                     check_in.project_id != project_id
@@ -181,7 +197,7 @@ def _process_message(wrapper: Dict) -> None:
                     )
                     logger.debug(
                         "check-in guid %s already associated with %s not payload %s",
-                        params["check_in_id"],
+                        check_in_id,
                         check_in.monitor_id,
                         monitor.id,
                     )
@@ -233,11 +249,17 @@ def _process_message(wrapper: Dict) -> None:
                         monitor_environment.last_checkin
                     )
 
+                # If the UUID is unset (zero value) generate a new UUID
+                if check_in_id.int == 0:
+                    guid = uuid.uuid4()
+                else:
+                    guid = check_in_id
+
                 check_in = MonitorCheckIn.objects.create(
                     project_id=project_id,
                     monitor=monitor,
                     monitor_environment=monitor_environment,
-                    guid=params["check_in_id"],
+                    guid=guid,
                     duration=duration,
                     status=status,
                     date_added=date_added,


### PR DESCRIPTION
This is to support https://github.com/getsentry/relay/pull/2153

Provdes a means to creating check-ins without giving a check_in_id in the consumer payload.

Documentation for this is here https://github.com/getsentry/develop/pull/950

Fixes: https://github.com/getsentry/sentry/issues/49664