### PR TITLE
fix(source-maps): Fix partial match bug and update test

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug.py
+++ b/src/sentry/api/endpoints/source_map_debug.py
@@ -197,12 +197,14 @@ class SourceMapDebugEndpoint(ProjectEndpoint):
 
     def _find_partial_matches(self, unified_path, artifacts):
         filename = unified_path.split("/")[-1]
-        filename_matches = [artifact for artifact in artifacts if artifact.name.endswith(filename)]
+        filename_matches = [
+            artifact for artifact in artifacts if artifact.name.split("/")[-1] == filename
+        ]
         artifact_names = [artifact.name.split("/") for artifact in filename_matches]
         while any(artifact_names):
             for i in range(len(artifact_names)):
                 if unified_path.endswith("/".join(artifact_names[i])):
-                    return [artifacts[i]]
+                    return [filename_matches[i]]
                 artifact_names[i] = artifact_names[i][1:]
         return []
 

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -364,8 +364,22 @@ class SourceMapDebugEndpointTestCase(APITestCase):
         ReleaseFile.objects.create(
             organization_id=self.project.organization_id,
             release_id=release.id,
+            file=File.objects.create(name="incorrect_application.js", type="release.file"),
+            name="~/dist/static/js/incorrect_application.js",
+        )
+
+        ReleaseFile.objects.create(
+            organization_id=self.project.organization_id,
+            release_id=release.id,
             file=File.objects.create(name="application.js", type="release.file"),
             name="~/dist/static/js/application.js",
+        )
+
+        ReleaseFile.objects.create(
+            organization_id=self.project.organization_id,
+            release_id=release.id,
+            file=File.objects.create(name="also_incorrect_application.js", type="release.file"),
+            name="~/dist/static/js/also_incorrect_application.js",
         )
 
         resp = self.get_success_response(
@@ -385,7 +399,11 @@ class SourceMapDebugEndpointTestCase(APITestCase):
             "filename": "/static/js/application.js",
             "unifiedPath": "~/static/js/application.js",
             "urlPrefix": "~/dist",
-            "artifactNames": ["~/dist/static/js/application.js"],
+            "artifactNames": [
+                "~/dist/static/js/also_incorrect_application.js",
+                "~/dist/static/js/application.js",
+                "~/dist/static/js/incorrect_application.js",
+            ],
         }
 
     def test_no_url_match(self):


### PR DESCRIPTION
this pr fixes a bug with finding partial matches where it looked up the index in the wrong array, potentially giving the incorrect result. The actual result of the endpoint wasn't affected (it worked as expected), but the message we gave could've been incorrect. The tests have been updated to test the bug and confirm the fix works. 