### PR TITLE
fix(js): Do not capture RouteError TypeError

### DIFF
--- a/static/app/views/routeError.tsx
+++ b/static/app/views/routeError.tsx
@@ -61,7 +61,7 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
       } catch (e) {
         Sentry.withScope(scope => {
           enrichScopeContext(scope);
-          Sentry.captureException(e);
+          scope.setExtra('cannotSetMessage', true);
         });
       }
     }


### PR DESCRIPTION
This is a follow up from https://github.com/getsentry/sentry/pull/16327

We explicitly captured this here https://github.com/getsentry/sentry/pull/16327#discussion_r364386102, but the actual error we're capturing is ostensible in-actionable.

Fixes: JAVASCRIPT-2MFW