### PR TITLE
fix(post-process-group): retry retrieving events from eventstore up to 3 times

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -13,7 +13,6 @@ from sentry import features
 from sentry.exceptions import PluginError
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.occurrence_consumer import EventLookupError
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
@@ -395,6 +394,8 @@ MAX_FETCH_ATTEMPTS = 3
 
 
 def should_retry_fetch(attempt: int, e: Exception) -> bool:
+    from sentry.issues.occurrence_consumer import EventLookupError
+
     return not attempt > MAX_FETCH_ATTEMPTS and (
         isinstance(e, ServiceUnavailable) or isinstance(e, EventLookupError)
     )
@@ -433,6 +434,7 @@ def post_process_group(
         from sentry.ingest.transaction_clusterer.datasource.redis import (
             record_transaction_name as record_transaction_name_for_clustering,
         )
+        from sentry.issues.occurrence_consumer import EventLookupError
         from sentry.models import Organization, Project
         from sentry.reprocessing2 import is_reprocessed_event
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -400,7 +400,7 @@ def should_retry_fetch(attempt: int, e: Exception) -> bool:
     )
 
 
-fetch_retry_policy = ConditionalRetryPolicy(should_retry_fetch, exponential_delay(0.00))
+fetch_retry_policy = ConditionalRetryPolicy(should_retry_fetch, exponential_delay(1.00))
 
 
 @instrumented_task(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -494,7 +494,7 @@ def post_process_group(
                 return event_or_none
 
             event = get_event_with_retry(
-                lambda _: eventstore.get_event_by_id(
+                lambda: eventstore.get_event_by_id(
                     project_id,
                     occurrence.event_id,
                     group_id=group_id,


### PR DESCRIPTION
Eventstore is occasionally returning None events. Not totally sure whether its a timing issue or whether eventstore actually doesn't have the event. This PR retries retrieving the event with an exponential backoff delay and returns early in post_process_group if event is None.

Also retries on `ServiceUnavailable` exception when Bigtable is temporarily unavailable.

Resolves SENTRY-ZEB, SENTRY-11G0