### PR TITLE
fix(alerts): Add missing slash to the preview route

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2104,7 +2104,7 @@ PROJECT_URLS = [
         name="sentry-api-0-metric-rule-snooze",
     ),
     url(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/preview$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/preview/$",
         ProjectRulePreviewEndpoint.as_view(),
         name="sentry-api-0-project-rule-preview",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2089,7 +2089,7 @@ PROJECT_URLS = [
         name="sentry-api-0-project-rules-configuration",
     ),
     url(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>\d+)/$",
         ProjectRuleDetailsEndpoint.as_view(),
         name="sentry-api-0-project-rule-details",
     ),

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -462,7 +462,7 @@ describe('ProjectAlertsCreate', function () {
         groups[i].lastTriggered = date;
       }
       const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/preview',
+        url: '/projects/org-slug/project-slug/rules/preview/',
         method: 'POST',
         body: groups,
         headers: {
@@ -513,7 +513,7 @@ describe('ProjectAlertsCreate', function () {
 
     it('invalid preview alert', async () => {
       const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/preview',
+        url: '/projects/org-slug/project-slug/rules/preview/',
         method: 'POST',
         statusCode: 400,
       });
@@ -535,7 +535,7 @@ describe('ProjectAlertsCreate', function () {
 
     it('empty preview table', async () => {
       const mock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/rules/preview',
+        url: '/projects/org-slug/project-slug/rules/preview/',
         method: 'POST',
         body: [],
         headers: {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -391,7 +391,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     }
     // we currently don't have a way to parse objects from query params, so this method is POST for now
     this.api
-      .requestPromise(`/projects/${organization.slug}/${project.slug}/rules/preview`, {
+      .requestPromise(`/projects/${organization.slug}/${project.slug}/rules/preview/`, {
         method: 'POST',
         includeAllArgs: true,
         query: {


### PR DESCRIPTION
I'm going to just disable the feature flag until it deploys because requests will fail until both are deployed
