### PR TITLE
feat(alerts): Remove incompatible-rules feature flag

### DIFF
--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -558,7 +558,7 @@ describe('ProjectAlertsCreate', function () {
       'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.';
 
     it('shows error for incompatible conditions', async () => {
-      createWrapper({organization});
+      createWrapper();
       await selectEvent.select(screen.getByText('Add optional trigger...'), [
         'A new issue is created',
       ]);
@@ -577,7 +577,7 @@ describe('ProjectAlertsCreate', function () {
     });
 
     it('test any filterMatch', async () => {
-      createWrapper({organization});
+      createWrapper();
       const allDropdowns = screen.getAllByText('all');
       await selectEvent.select(screen.getByText('Add optional trigger...'), [
         'A new issue is created',

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -554,9 +554,6 @@ describe('ProjectAlertsCreate', function () {
   });
 
   describe('test incompatible conditions', () => {
-    const organization = TestStubs.Organization({
-      features: ['issue-alert-incompatible-rules'],
-    });
     const errorText =
       'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.';
 

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -10,7 +10,7 @@ import AlertRuleDetails from './ruleDetails';
 
 describe('AlertRuleDetails', () => {
   const context = initializeOrg({
-    organization: {features: ['issue-alert-incompatible-rules', 'mute-alerts']},
+    organization: {features: ['mute-alerts']},
   });
   const organization = context.organization;
   const project = TestStubs.Project();
@@ -218,7 +218,7 @@ describe('AlertRuleDetails', () => {
       method: 'POST',
     });
     const contextWithQueryParam = initializeOrg({
-      organization: {features: ['issue-alert-incompatible-rules', 'mute-alerts']},
+      organization: {features: ['mute-alerts']},
       router: {
         location: {query: {mute: '1'}},
       },
@@ -237,7 +237,7 @@ describe('AlertRuleDetails', () => {
 
   it('mute button is disabled if no alerts:write permission', async () => {
     const orgWithoutAccess = {
-      features: ['issue-alert-incompatible-rules', 'mute-alerts'],
+      features: ['mute-alerts'],
       access: [],
     };
 

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -246,10 +246,7 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
   };
   function renderIncompatibleAlert() {
     const incompatibleRule = findIncompatibleRules(rule);
-    if (
-      (incompatibleRule.conditionIndices || incompatibleRule.filterIndices) &&
-      organization.features.includes('issue-alert-incompatible-rules')
-    ) {
+    if (incompatibleRule.conditionIndices || incompatibleRule.filterIndices) {
       return (
         <Alert type="error" showIcon>
           {tct(

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -446,22 +446,20 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
   // As more incompatible combinations are added, we will need a more generic way to check for incompatibility.
   checkIncompatibleRuleDebounced = debounce(() => {
-    if (this.props.organization.features.includes('issue-alert-incompatible-rules')) {
-      const {conditionIndices, filterIndices} = findIncompatibleRules(this.state.rule);
-      if (
-        !this.trackIncompatibleAnalytics &&
-        (conditionIndices !== null || filterIndices !== null)
-      ) {
-        this.trackIncompatibleAnalytics = true;
-        trackAnalytics('edit_alert_rule.incompatible_rule', {
-          organization: this.props.organization,
-        });
-      }
-      this.setState({
-        incompatibleConditions: conditionIndices,
-        incompatibleFilters: filterIndices,
+    const {conditionIndices, filterIndices} = findIncompatibleRules(this.state.rule);
+    if (
+      !this.trackIncompatibleAnalytics &&
+      (conditionIndices !== null || filterIndices !== null)
+    ) {
+      this.trackIncompatibleAnalytics = true;
+      trackAnalytics('edit_alert_rule.incompatible_rule', {
+        organization: this.props.organization,
       });
     }
+    this.setState({
+      incompatibleConditions: conditionIndices,
+      incompatibleFilters: filterIndices,
+    });
   }, 500);
 
   onPreviewCursor: CursorHandler = (cursor, _1, _2, direction) => {


### PR DESCRIPTION
Feature has been GA forever, removing the feature flag. This shows a few errors when you made an impossible issue alert. This was an intern project.

looks like this
![image](https://github.com/getsentry/sentry/assets/1400464/920d37f6-e7e4-46b1-9870-c7720b76663c)
