### PR TITLE
feat(profiling): Add regex, core data and view issue types

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -313,6 +313,30 @@ class ProfileJSONDecodeType(GroupType):
     category = GroupCategory.PROFILE.value
 
 
+@dataclass(frozen=True)
+class ProfileCoreDataType(GroupType):
+    type_id = 2004
+    slug = "profile_core_data_main_thread"
+    description = "Core Data on Main Thread"
+    category = GroupCategory.PERFORMANCE.value
+
+
+@dataclass(frozen=True)
+class ProfileRegexType(GroupType):
+    type_id = 2005
+    slug = "profile_regex_main_thread"
+    description = "Regex on Main Thread"
+    category = GroupCategory.PERFORMANCE.value
+
+
+@dataclass(frozen=True)
+class ProfileViewIsSlowType(GroupType):
+    type_id = 2006
+    slug = "profile_view_is_slow"
+    description = "View Render/Layout/Update is slow"
+    category = GroupCategory.PERFORMANCE.value
+
+
 @metrics.wraps("noise_reduction.should_create_group", sample_rate=1.0)
 def should_create_group(
     grouptype: Type[GroupType],

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -315,25 +315,25 @@ class ProfileJSONDecodeType(GroupType):
 
 
 @dataclass(frozen=True)
-class ProfileCoreDataType(GroupType):
+class ProfileCoreDataExperimentalType(GroupType):
     type_id = 2004
-    slug = "profile_core_data_main_thread"
+    slug = "profile_core_data_main_thread_experimental"
     description = "Core Data on Main Thread"
     category = GroupCategory.PERFORMANCE.value
 
 
 @dataclass(frozen=True)
-class ProfileRegexType(GroupType):
+class ProfileRegexExperimentalType(GroupType):
     type_id = 2005
-    slug = "profile_regex_main_thread"
+    slug = "profile_regex_main_thread_experimental"
     description = "Regex on Main Thread"
     category = GroupCategory.PERFORMANCE.value
 
 
 @dataclass(frozen=True)
-class ProfileViewIsSlowType(GroupType):
+class ProfileViewIsSlowExperimentalType(GroupType):
     type_id = 2006
-    slug = "profile_view_is_slow"
+    slug = "profile_view_is_slow_experimental"
     description = "View Render/Layout/Update is slow"
     category = GroupCategory.PERFORMANCE.value
 


### PR DESCRIPTION
Adding new types of issues to be detected.

As we need to look at the data from customers, we're going to have those types hidden from them and when we're ready to release the detectors, we'll change issue type so we don't run into the caveat of having to surface old issues detected and not having notifications.