### PR TITLE
ref: Rename feature to org-auth-tokens to align with naming

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1535,8 +1535,8 @@ SENTRY_FEATURES = {
     "organizations:js-sdk-dynamic-loader": False,
     # If true certain Slack messages will be escaped to prevent rendering markdown
     "organizations:slack-escape-messages": False,
-    # If true, allow to create/use org access tokens
-    "organizations:org-access-tokens": False,
+    # If true, allow to create/use org auth tokens
+    "organizations:org-auth-tokens": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -106,7 +106,7 @@ default_manager.add("organizations:metrics-extraction", OrganizationFeature, Fea
 default_manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:mobile-vitals", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:mobile-cpu-memory-in-transactions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:org-access-tokens", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:org-auth-tokens", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:anr-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:anr-analyze-frames", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
Started out with `org-access-tokens` but since we are using `auth token` everywhere now, makes sense to align this before we actually use it!

Need to update https://github.com/getsentry/sentry/pull/50145/files accordingly then.