### PR TITLE
feat: Add pages for org auth tokens

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -64,6 +64,7 @@ function SidebarDropdown({
   const hasMemberRead = org?.access?.includes('member:read');
   const hasTeamRead = org?.access?.includes('team:read');
   const canCreateOrg = ConfigStore.get('features').has('organizations:create');
+  const hasOrgAuthTokens = org?.features.includes('org-auth-tokens');
 
   // Avatar to use: Organization --> user --> Sentry
   const avatar =
@@ -112,9 +113,16 @@ function SidebarDropdown({
                   {!hideOrgLinks && (
                     <Fragment>
                       {hasOrgRead && (
-                        <SidebarMenuItem to={`/settings/${org.slug}/`}>
-                          {t('Organization settings')}
-                        </SidebarMenuItem>
+                        <Fragment>
+                          <SidebarMenuItem to={`/settings/${org.slug}/`}>
+                            {t('Organization settings')}
+                          </SidebarMenuItem>
+                          {hasOrgAuthTokens && (
+                            <SidebarMenuItem to={`/settings/${org.slug}/auth-tokens/`}>
+                              {t('Auth tokens')}
+                            </SidebarMenuItem>
+                          )}
+                        </Fragment>
                       )}
                       {hasMemberRead && (
                         <SidebarMenuItem to={`/settings/${org.slug}/members/`}>

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -64,7 +64,6 @@ function SidebarDropdown({
   const hasMemberRead = org?.access?.includes('member:read');
   const hasTeamRead = org?.access?.includes('team:read');
   const canCreateOrg = ConfigStore.get('features').has('organizations:create');
-  const hasOrgAuthTokens = org?.features.includes('org-auth-tokens');
 
   // Avatar to use: Organization --> user --> Sentry
   const avatar =
@@ -113,16 +112,9 @@ function SidebarDropdown({
                   {!hideOrgLinks && (
                     <Fragment>
                       {hasOrgRead && (
-                        <Fragment>
-                          <SidebarMenuItem to={`/settings/${org.slug}/`}>
-                            {t('Organization settings')}
-                          </SidebarMenuItem>
-                          {hasOrgAuthTokens && (
-                            <SidebarMenuItem to={`/settings/${org.slug}/auth-tokens/`}>
-                              {t('Auth tokens')}
-                            </SidebarMenuItem>
-                          )}
-                        </Fragment>
+                        <SidebarMenuItem to={`/settings/${org.slug}/`}>
+                          {t('Organization settings')}
+                        </SidebarMenuItem>
                       )}
                       {hasMemberRead && (
                         <SidebarMenuItem to={`/settings/${org.slug}/members/`}>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -969,6 +969,18 @@ function buildRoutes() {
           />
         </Route>
       </Route>
+      <Route path="auth-tokens/" name={t('Auth Tokens')}>
+        <IndexRoute
+          component={make(() => import('sentry/views/settings/organizationAuthTokens'))}
+        />
+        <Route
+          path="new-token/"
+          name={t('Create New Token')}
+          component={make(
+            () => import('sentry/views/settings/organizationAuthTokens/newAuthToken')
+          )}
+        />
+      </Route>
     </Route>
   );
 

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -27,9 +27,9 @@ export default class ApiNewToken extends Component {
 
   render() {
     return (
-      <SentryDocumentTitle title={t('Create API Token')}>
+      <SentryDocumentTitle title={t('Create User Auth Token')}>
         <div>
-          <SettingsPageHeader title={t('Create New Token')} />
+          <SettingsPageHeader title={t('Create New User Auth Token')} />
           <TextBlock>
             {t(
               "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
@@ -44,7 +44,7 @@ export default class ApiNewToken extends Component {
             )}
           </TextBlock>
           <Panel>
-            <PanelHeader>{t('Create New Token')}</PanelHeader>
+            <PanelHeader>{t('Create New User Auth Token')}</PanelHeader>
             <ApiForm
               apiMethod="POST"
               apiEndpoint="/api-tokens/"

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -100,4 +100,112 @@ const organizationNavigation: NavigationSection[] = [
   },
 ];
 
+export const organizationNavigationWithAuthTokens: NavigationSection[] = [
+  {
+    name: t('Organization'),
+    items: [
+      {
+        path: `${pathPrefix}/`,
+        title: t('General Settings'),
+        index: true,
+        description: t('Configure general settings for an organization'),
+        id: 'general',
+      },
+      {
+        path: `${pathPrefix}/projects/`,
+        title: t('Projects'),
+        description: t("View and manage an organization's projects"),
+        id: 'projects',
+      },
+      {
+        path: `${pathPrefix}/teams/`,
+        title: t('Teams'),
+        description: t("Manage an organization's teams"),
+        id: 'teams',
+      },
+      {
+        path: `${pathPrefix}/members/`,
+        title: t('Members'),
+        show: ({access}) => access!.has('member:read'),
+        description: t('Manage user membership for an organization'),
+        id: 'members',
+      },
+      {
+        path: `${pathPrefix}/security-and-privacy/`,
+        title: t('Security & Privacy'),
+        description: t(
+          'Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'
+        ),
+        id: 'security-and-privacy',
+      },
+      {
+        path: `${pathPrefix}/auth/`,
+        title: t('Auth'),
+        description: t('Configure single sign-on'),
+        id: 'sso',
+      },
+      {
+        path: `${pathPrefix}/api-keys/`,
+        title: t('API Keys'),
+        show: ({access, features}) =>
+          features!.has('api-keys') && access!.has('org:admin'),
+        id: 'api-keys',
+      },
+      {
+        path: `${pathPrefix}/audit-log/`,
+        title: t('Audit Log'),
+        show: ({access}) => access!.has('org:write'),
+        description: t('View the audit log for an organization'),
+        id: 'audit-log',
+      },
+      {
+        path: `${pathPrefix}/rate-limits/`,
+        title: t('Rate Limits'),
+        show: ({access, features}) =>
+          features!.has('legacy-rate-limits') && access!.has('org:write'),
+        description: t('Configure rate limits for all projects in the organization'),
+        id: 'rate-limits',
+      },
+      {
+        path: `${pathPrefix}/relay/`,
+        title: t('Relay'),
+        description: t('Manage relays connected to the organization'),
+        id: 'relay',
+      },
+      {
+        path: `${pathPrefix}/repos/`,
+        title: t('Repositories'),
+        description: t('Manage repositories connected to the organization'),
+        id: 'repos',
+      },
+      {
+        path: `${pathPrefix}/integrations/`,
+        title: t('Integrations'),
+        description: t(
+          'Manage organization-level integrations, including: Slack, Github, Bitbucket, Jira, and Azure DevOps'
+        ),
+        id: 'integrations',
+        recordAnalytics: true,
+      },
+    ],
+  },
+  {
+    name: t('Developer Settings'),
+    items: [
+      {
+        path: `${pathPrefix}/auth-tokens/`,
+        title: t('Auth Tokens'),
+        description: t('Manage organization auth tokens'),
+        id: 'auth-tokens',
+      },
+      {
+        path: `${pathPrefix}/developer-settings/`,
+        title: t('Custom Integrations'),
+        description: t('Manage custom integrations'),
+        id: 'developer-settings',
+      },
+    ],
+  },
+];
+
 export default organizationNavigation;

--- a/static/app/views/settings/organization/organizationSettingsNavigation.tsx
+++ b/static/app/views/settings/organization/organizationSettingsNavigation.tsx
@@ -5,7 +5,9 @@ import {Organization} from 'sentry/types';
 import {HookName, Hooks} from 'sentry/types/hooks';
 import withOrganization from 'sentry/utils/withOrganization';
 import SettingsNavigation from 'sentry/views/settings/components/settingsNavigation';
-import navigationConfiguration from 'sentry/views/settings/organization/navigationConfiguration';
+import navigationConfiguration, {
+  organizationNavigationWithAuthTokens,
+} from 'sentry/views/settings/organization/navigationConfiguration';
 import {NavigationSection} from 'sentry/views/settings/types';
 
 type Props = {
@@ -72,9 +74,13 @@ class OrganizationSettingsNavigation extends Component<Props, State> {
     const access = new Set(organization.access);
     const features = new Set(organization.features);
 
+    const navigationObjects = features.has('org-auth-tokens')
+      ? organizationNavigationWithAuthTokens
+      : navigationConfiguration;
+
     return (
       <SettingsNavigation
-        navigationObjects={navigationConfiguration}
+        navigationObjects={navigationObjects}
         access={access}
         features={features}
         organization={organization}

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -1,0 +1,68 @@
+import {Button} from 'sentry/components/button';
+import EmptyMessage from 'sentry/components/emptyMessage';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import withOrganization from 'sentry/utils/withOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+export function OrganizationAuthTokensIndex({
+  organization,
+}: {
+  organization: Organization;
+}) {
+  const isEmpty = true;
+  const tokenList = [];
+
+  const createNewToken = (
+    <Button
+      priority="primary"
+      size="sm"
+      to={`/settings/${organization.slug}/auth-tokens/new-token/`}
+      data-test-id="create-token"
+    >
+      {t('Create New Token')}
+    </Button>
+  );
+
+  return (
+    <div>
+      <SentryDocumentTitle title={t('Auth Tokens')} />
+      <SettingsPageHeader title={t('Auth Tokens')} action={createNewToken} />
+
+      <TextBlock>
+        {t(
+          "Authentication tokens allow you to perform actions against the Sentry API on behalf of your organization. They're the easiest way to get started using the API."
+        )}
+      </TextBlock>
+      <TextBlock>
+        {tct(
+          'For more information on how to use the web API, see our [link:documentation].',
+          {
+            link: <ExternalLink href="https://docs.sentry.io/api/" />,
+          }
+        )}
+      </TextBlock>
+      <Panel>
+        <PanelHeader>{t('Auth Token')}</PanelHeader>
+
+        <PanelBody>
+          {isEmpty && (
+            <EmptyMessage>
+              {t("You haven't created any authentication tokens yet.")}
+            </EmptyMessage>
+          )}
+
+          {tokenList?.map(token => (
+            <div key={token}>{token}</div>
+          ))}
+        </PanelBody>
+      </Panel>
+    </div>
+  );
+}
+
+export default withOrganization(OrganizationAuthTokensIndex);

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -1,0 +1,41 @@
+import EmptyMessage from 'sentry/components/emptyMessage';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import {Organization} from 'sentry/types';
+import withOrganization from 'sentry/utils/withOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+export function OrganizationAuthTokensNewAuthToken(_props: {organization: Organization}) {
+  return (
+    <div>
+      <SentryDocumentTitle title={t('Create New Auth Token')} />
+      <SettingsPageHeader title={t('Create New Auth Token')} />
+
+      <TextBlock>
+        {t(
+          "Authentication tokens allow you to perform actions against the Sentry API on behalf of your organization. They're the easiest way to get started using the API."
+        )}
+      </TextBlock>
+      <TextBlock>
+        {tct(
+          'For more information on how to use the web API, see our [link:documentation].',
+          {
+            link: <ExternalLink href="https://docs.sentry.io/api/" />,
+          }
+        )}
+      </TextBlock>
+      <Panel>
+        <PanelHeader>{t('Create New Auth Token')}</PanelHeader>
+
+        <PanelBody>
+          <EmptyMessage>Coming soon</EmptyMessage>
+        </PanelBody>
+      </Panel>
+    </div>
+  );
+}
+
+export default withOrganization(OrganizationAuthTokensNewAuthToken);

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -213,10 +213,12 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
       tabs.push(['sentryfx', t('Sentry Function')]);
     }
 
+    const hasAuthTokens = organization.features.includes('org-auth-tokens');
+
     return (
       <div>
         <SettingsPageHeader
-          title={t('Developer Settings')}
+          title={hasAuthTokens ? t('Custom Integrations') : t('Developer Settings')}
           body={
             <Fragment>
               {t(

--- a/static/app/views/settings/settingsIndex.spec.tsx
+++ b/static/app/views/settings/settingsIndex.spec.tsx
@@ -55,7 +55,8 @@ describe('SettingsIndex', function () {
       id: '44',
       name: 'Org Index',
       slug: 'org-index',
-    } as Organization;
+      features: [],
+    } as unknown as Organization;
 
     const spy = jest.spyOn(OrgActions, 'fetchOrganizationDetails');
     const api = MockApiClient.addMockResponse({

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -66,6 +66,8 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
     organizationSettingsUrl,
   };
 
+  const hasOrgAuthTokens = organization?.features.includes('org-auth-tokens');
+
   const myAccount = (
     <GridPanel>
       <HomePanelHeader>
@@ -215,12 +217,19 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
       <HomePanelBody>
         <h3>{t('Quick links')}:</h3>
         <ul>
+          {hasOrgAuthTokens && (
+            <li>
+              <HomeLink to={`${organizationSettingsUrl}auth-tokens/`}>
+                {t('Organization Auth Tokens')}
+              </HomeLink>
+            </li>
+          )}
           <li>
-            <HomeLink to={LINKS.API}>{t('Auth Tokens')}</HomeLink>
+            <HomeLink to={LINKS.API}>{t('User Auth Tokens')}</HomeLink>
           </li>
           <li>
             <HomeLink to={`${organizationSettingsUrl}developer-settings/`}>
-              {t('Your Integrations')}
+              {t('Custom Integrations')}
             </HomeLink>
           </li>
           <li>


### PR DESCRIPTION
For now these pages do nothing, but it sets up the base UI behind feature flags where we can start filling in the actual functionality in follow up PRs.

For users with the `org-auth-tokens` feature, we rename the `Developer Settings` page under org settings to `Custom Integrations`, move it to a new section` Developer Settings` & add another subpage `Auth Tokens` there. 

![Screenshot 2023-06-02 at 10 22 43](https://github.com/getsentry/sentry/assets/2411343/6a3e1341-963b-405e-80f8-362826a12083)

~~We also add a direct link there in the account dropdown navigation:~~

I also referenced @priscilawebdev to maybe look over this from a react perspective, that I am not doing something stupid on that front xD feel free to re-assign this to another reviewer instead!

I haven't added any tests yet, will do this in the following steps when actually adding functionality.

