### PR TITLE
feat(starfish): Span group chart fixes

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -73,10 +73,10 @@ function computeMax(data: Series[]) {
 }
 
 // adapted from https://stackoverflow.com/questions/11397239/rounding-up-for-a-graph-maximum
-function computeAxisMax(data: Series[]) {
+function computeAxisMax(data: Series[], stacked?: boolean) {
   // assumes min is 0
   let maxValue = 0;
-  if (data.length > 2) {
+  if (data.length > 1 && stacked) {
     for (let i = 0; i < data.length; i++) {
       maxValue += max(data[i].data.map(point => point.value)) as number;
     }
@@ -160,7 +160,10 @@ function Chart({
     data.every(value => aggregateOutputType(value.seriesName) === 'percentage');
 
   let dataMax = durationOnly
-    ? computeAxisMax([...data, ...(scatterPlot?.[0]?.data?.length ? scatterPlot : [])])
+    ? computeAxisMax(
+        [...data, ...(scatterPlot?.[0]?.data?.length ? scatterPlot : [])],
+        stacked
+      )
     : percentOnly
     ? computeMax(data)
     : undefined;

--- a/static/app/views/starfish/views/webServiceView/queries.js
+++ b/static/app/views/starfish/views/webServiceView/queries.js
@@ -27,7 +27,7 @@ export const getTopModules = ({transaction, datetime}) => {
 export const getTopModulesTimeseries = ({transaction, topConditions, datetime}) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `SELECT
- quantile(0.50)(exclusive_time) as "p50(span.duration)", module as "span.module",
+ quantile(0.95)(exclusive_time) as "p95(span.duration)", module as "span.module",
  toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
@@ -42,7 +42,7 @@ export const getTopModulesTimeseries = ({transaction, topConditions, datetime}) 
 export const getOtherModulesTimeseries = ({transaction, topConditions, datetime}) => {
   const {start_timestamp, end_timestamp} = datetimeToClickhouseFilterTimestamps(datetime);
   return `SELECT
- quantile(0.50)(exclusive_time) as "p50(span.duration)",
+ quantile(0.95)(exclusive_time) as "p95(span.duration)",
  toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE greaterOrEquals(start_timestamp, '${start_timestamp}')
@@ -88,7 +88,7 @@ export const getTopDomainsAndMethods = ({transaction}) => {
 
 export const getTopHttpDomains = ({transaction}) => {
   return `SELECT
- quantile(0.50)(exclusive_time) as "p50(span.duration)", domain,
+ quantile(0.95)(exclusive_time) as "p95(span.duration)", domain,
  toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
  FROM default.spans_experimental_starfish
  WHERE domain IN (
@@ -108,7 +108,7 @@ export const getTopHttpDomains = ({transaction}) => {
 
 export const getOtherDomains = ({transaction}) => {
   return `SELECT
-  quantile(0.50)(exclusive_time) as "p50(span.duration)",
+  quantile(0.95)(exclusive_time) as "p95(span.duration)",
   toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
   FROM default.spans_experimental_starfish
   WHERE domain NOT IN (
@@ -128,7 +128,7 @@ export const getOtherDomains = ({transaction}) => {
 
 export const getDatabaseTimeSpent = ({transaction}) => {
   return `SELECT
-  quantile(0.50)(exclusive_time) as "p50(span.duration)",
+  quantile(0.95)(exclusive_time) as "p95(span.duration)",
   toStartOfInterval(start_timestamp, INTERVAL 12 HOUR) as interval
   FROM default.spans_experimental_starfish
   WHERE startsWith(span_operation, 'db') and span_operation != 'db.redis'

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -118,8 +118,9 @@ export function SpanGroupBreakdown({
                 <RightAlignedCell>
                   <Tooltip
                     title={t(
-                      'This group of spans account for %s of the cumulative time on your web service',
-                      formatPercentage(row.cumulativeTime / totalValues, 1)
+                      '%s time spent on %s',
+                      formatPercentage(row.cumulativeTime / totalValues, 1),
+                      group['span.module']
                     )}
                     containerDisplayMode="block"
                     position="top"

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -11,6 +11,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Series} from 'sentry/types/echarts';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage} from 'sentry/utils/formatters';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -54,7 +55,7 @@ export function SpanGroupBreakdown({
     <Fragment>
       <ChartPadding>
         <Header>
-          <ChartLabel>{'App Time Breakdown'}</ChartLabel>
+          <ChartLabel>{t('App Time Breakdown (p95)')}</ChartLabel>
         </Header>
         <Chart
           statsPeriod="24h"
@@ -73,6 +74,10 @@ export function SpanGroupBreakdown({
           definedAxisTicks={6}
           stacked
           aggregateOutputFormat="duration"
+          tooltipFormatterOptions={{
+            valueFormatter: value =>
+              tooltipFormatterUsingAggregateOutputType(value, 'duration'),
+          }}
         />
       </ChartPadding>
       <ListContainer>

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -53,7 +53,11 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
       transaction,
       datetime: selection.datetime,
     })}`,
-    eventView: getEventView(selection, 'span.module:[db,http]', ['span.module']),
+    eventView: getEventView(
+      selection,
+      `span.module:[db,http] ${transaction ? `transaction:${transaction}` : ''}`,
+      ['span.module']
+    ),
     initialData: [],
     forceUseDiscover: FORCE_USE_DISCOVER,
   });
@@ -63,7 +67,11 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
       transaction,
       datetime: selection.datetime,
     })}`,
-    eventView: getEventView(selection, '', []),
+    eventView: getEventView(
+      selection,
+      `${transaction ? `transaction:${transaction}` : ''}`,
+      []
+    ),
     initialData: [],
     forceUseDiscover: FORCE_USE_DISCOVER,
   });
@@ -114,7 +122,12 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
       topConditions,
       datetime: selection.datetime,
     })}`,
-    eventView: getEventView(selection, 'span.module:[db,http]', ['span.module'], true),
+    eventView: getEventView(
+      selection,
+      `span.module:[db,http] ${transaction ? `transaction:${transaction}` : ''}`,
+      ['span.module'],
+      true
+    ),
     initialData: [],
     forceUseDiscover: FORCE_USE_DISCOVER,
   });
@@ -125,7 +138,12 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
       topConditions,
       datetime: selection.datetime,
     })}`,
-    eventView: getEventView(selection, '!span.module:[db,http]', [], true),
+    eventView: getEventView(
+      selection,
+      `!span.module:[db,http] ${transaction ? `transaction:${transaction}` : ''}`,
+      [],
+      true
+    ),
     initialData: [],
     forceUseDiscover: FORCE_USE_DISCOVER,
   });

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -33,7 +33,7 @@ type Group = {
 };
 
 export type Segment = Group & {
-  'p50(span.duration)': number;
+  'p95(span.duration)': number;
   'sum(span.duration)': number;
 };
 
@@ -175,7 +175,7 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
 
     topData.forEach(value => {
       seriesByDomain[value['span.module'] ?? value.group].data.push({
-        value: value['p50(span.duration)'],
+        value: value['p95(span.duration)'],
         name: value.interval,
       });
     });
@@ -188,7 +188,7 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
 
     otherData.forEach(value => {
       seriesByDomain.Other.data.push({
-        value: value['p50(span.duration)'],
+        value: value['p95(span.duration)'],
         name: value.interval,
       });
     });
@@ -229,8 +229,8 @@ const getEventView = (
 ) => {
   return EventView.fromSavedQuery({
     name: '',
-    fields: ['sum(span.duration)', 'p50(span.duration)', ...groups],
-    yAxis: getTimeseries ? ['sum(span.duration)', 'p50(span.duration)'] : [],
+    fields: ['sum(span.duration)', 'p95(span.duration)', ...groups],
+    yAxis: getTimeseries ? ['sum(span.duration)', 'p95(span.duration)'] : [],
     query,
     dataset: DiscoverDatasets.SPANS_METRICS,
     start: pageFilters.datetime.start ?? undefined,


### PR DESCRIPTION
- Uses p95 on the breakdown chart,
- accounts for transaction on endpoint overview
- fixes a bug where the chart was being clipped because the max y-axis wasn't taking into account stacked charts
- adds units to the tooltip for span group breakdown chart