### PR TITLE
feat(hybrid-cloud): Add Gitlab request parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1594,6 +1594,7 @@ module = [
     "tests.sentry.mediators.token_exchange.test_refresher",
     "tests.sentry.mediators.token_exchange.test_validator",
     "tests.sentry.middleware.integrations.parsers.test_github",
+    "tests.sentry.middleware.integrations.parsers.test_gitlab",
     "tests.sentry.middleware.integrations.parsers.test_slack",
     "tests.sentry.middleware.test_auth",
     "tests.sentry.middleware.test_customer_domain",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1594,7 +1594,6 @@ module = [
     "tests.sentry.mediators.token_exchange.test_refresher",
     "tests.sentry.mediators.token_exchange.test_validator",
     "tests.sentry.middleware.integrations.parsers.test_github",
-    "tests.sentry.middleware.integrations.parsers.test_gitlab",
     "tests.sentry.middleware.integrations.parsers.test_slack",
     "tests.sentry.middleware.test_auth",
     "tests.sentry.middleware.test_customer_domain",

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Mapping
+from typing import Any, Mapping, Tuple
 
 from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
@@ -197,8 +199,37 @@ class PushEventWebhook(Webhook):
 handlers = {"Push Hook": PushEventWebhook, "Merge Request Hook": MergeEventWebhook}
 
 
+class GitlabWebhookMixin:
+    def _get_external_id(self, request, extra) -> Tuple[str, str] | HttpResponse:
+        token = "<unknown>"
+        try:
+            # Munge the token to extract the integration external_id.
+            # gitlab hook payloads don't give us enough unique context
+            # to find data on our side so we embed one in the token.
+            token = request.META["HTTP_X_GITLAB_TOKEN"]
+            # e.g. "example.gitlab.com:group-x:webhook_secret_from_sentry_integration_table"
+            instance, group_path, secret = token.split(":")
+            external_id = f"{instance}:{group_path}"
+            return (external_id, secret)
+        except KeyError:
+            logger.info("gitlab.webhook.missing-gitlab-token")
+            extra["reason"] = "The customer needs to set a Secret Token in their webhook."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+        except ValueError:
+            logger.info("gitlab.webhook.malformed-gitlab-token", extra=extra)
+            extra["reason"] = "The customer's Secret Token is malformed."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+        except Exception:
+            logger.info("gitlab.webhook.invalid-token", extra=extra)
+            extra["reason"] = "Generic catch-all error."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+
+
 @region_silo_endpoint
-class GitlabWebhookEndpoint(Endpoint):
+class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
     authentication_classes = ()
     permission_classes = ()
     provider = "gitlab"
@@ -221,30 +252,10 @@ class GitlabWebhookEndpoint(Endpoint):
             # AppPlatformEvents also hit this API
             "event-type": request.META.get("HTTP_X_GITLAB_EVENT"),
         }
-        token = "<unknown>"
-        try:
-            # Munge the token to extract the integration external_id.
-            # gitlab hook payloads don't give us enough unique context
-            # to find data on our side so we embed one in the token.
-            token = request.META["HTTP_X_GITLAB_TOKEN"]
-            # e.g. "example.gitlab.com:group-x:webhook_secret_from_sentry_integration_table"
-            instance, group_path, secret = token.split(":")
-            external_id = f"{instance}:{group_path}"
-        except KeyError:
-            logger.info("gitlab.webhook.missing-gitlab-token")
-            extra["reason"] = "The customer needs to set a Secret Token in their webhook."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-        except ValueError:
-            logger.info("gitlab.webhook.malformed-gitlab-token", extra=extra)
-            extra["reason"] = "The customer's Secret Token is malformed."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-        except Exception:
-            logger.info("gitlab.webhook.invalid-token", extra=extra)
-            extra["reason"] = "Generic catch-all error."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
+        result = self._get_external_id(request=request, extra=extra)
+        if isinstance(result, HttpResponse):
+            return result
+        (external_id, secret) = result
 
         integration, installs = integration_service.get_organization_contexts(
             provider=self.provider, external_id=external_id

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -194,13 +194,16 @@ class PushEventWebhook(Webhook):
                 pass
 
 
+handlers = {"Push Hook": PushEventWebhook, "Merge Request Hook": MergeEventWebhook}
+
+
 @region_silo_endpoint
 class GitlabWebhookEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
     provider = "gitlab"
 
-    _handlers = {"Push Hook": PushEventWebhook, "Merge Request Hook": MergeEventWebhook}
+    _handlers = handlers
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request: Request, *args, **kwargs) -> Response:

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -6,12 +6,17 @@ from typing import Mapping, Type
 
 from sentry.silo import SiloMode
 
-from .parsers import GithubRequestParser, JiraRequestParser, SlackRequestParser
+from .parsers import GithubRequestParser, GitlabRequestParser, JiraRequestParser, SlackRequestParser
 from .parsers.base import BaseRequestParser
 
 logger = logging.getLogger(__name__)
 
-ACTIVE_PARSERS = [GithubRequestParser, JiraRequestParser, SlackRequestParser]
+ACTIVE_PARSERS = [
+    GithubRequestParser,
+    GitlabRequestParser,
+    JiraRequestParser,
+    SlackRequestParser,
+]
 
 
 class IntegrationControlMiddleware:

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -1,4 +1,5 @@
 from .github import GithubRequestParser
+from .gitlab import GitlabRequestParser
 from .jira import JiraRequestParser
 from .slack import SlackRequestParser
 
@@ -6,4 +7,5 @@ __all__ = (
     "GithubRequestParser",
     "JiraRequestParser",
     "SlackRequestParser",
+    "GitlabRequestParser",
 )

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -123,7 +123,7 @@ class BaseRequestParser(abc.ABC):
 
     # Required Overrides
 
-    def get_response(self):
+    def get_response(self) -> HttpResponse:
         """
         Used to surface a response as part of the middleware.
         Should be overwritten by implementation.

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -22,7 +22,7 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
     webhook_identifier = WebhookProviderIdentifier.GITLAB
     _integration: Integration = None
 
-    def _get_external_id(self) -> Tuple[str, str] | HttpResponse:
+    def _resolve_external_id(self) -> Tuple[str, str] | HttpResponse:
         clear_tags_and_context()
         extra = {
             # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
@@ -50,7 +50,7 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
                 return self._integration
 
             # Webhook endpoints
-            result = self._get_external_id()
+            result = self._resolve_external_id()
             if isinstance(result, tuple):
                 (external_id, _secret) = result
                 self._integration = Integration.objects.filter(
@@ -64,7 +64,7 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
     def get_response(self) -> HttpResponse:
         result = resolve(self.request.path)
         if result.url_name == "sentry-extensions-gitlab-webhook":
-            maybe_http_response = self._get_external_id()
+            maybe_http_response = self._resolve_external_id()
             if isinstance(maybe_http_response, HttpResponse):
                 return maybe_http_response
 

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
     provider = EXTERNAL_PROVIDERS[ExternalProviders.GITLAB]
     webhook_identifier = WebhookProviderIdentifier.GITLAB
-    _integration: Integration = None
+    _integration: Integration | None = None
 
     def _resolve_external_id(self) -> Tuple[str, str] | HttpResponse:
         clear_tags_and_context()

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -6,6 +6,7 @@ from typing import Tuple
 from django.http import HttpResponse
 from django.urls import resolve
 
+from sentry.integrations.gitlab.webhooks import GitlabWebhookMixin
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.integrations.integration import Integration
@@ -16,7 +17,7 @@ from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 logger = logging.getLogger(__name__)
 
 
-class GitlabRequestParser(BaseRequestParser):
+class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
     provider = EXTERNAL_PROVIDERS[ExternalProviders.GITLAB]
     webhook_identifier = WebhookProviderIdentifier.GITLAB
     _integration: Integration = None
@@ -30,31 +31,7 @@ class GitlabRequestParser(BaseRequestParser):
             # AppPlatformEvents also hit this API
             "event-type": self.request.META.get("HTTP_X_GITLAB_EVENT"),
         }
-        token = "<unknown>"
-        try:
-            # Munge the token to extract the integration external_id.
-            # gitlab hook payloads don't give us enough unique context
-            # to find data on our side so we embed one in the token.
-            token = self.request.META["HTTP_X_GITLAB_TOKEN"]
-            # e.g. "example.gitlab.com:group-x:webhook_secret_from_sentry_integration_table"
-            instance, group_path, secret = token.split(":")
-            external_id = f"{instance}:{group_path}"
-            return (external_id, secret)
-        except KeyError:
-            logger.info("gitlab.webhook.missing-gitlab-token")
-            extra["reason"] = "The customer needs to set a Secret Token in their webhook."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-        except ValueError:
-            logger.info("gitlab.webhook.malformed-gitlab-token", extra=extra)
-            extra["reason"] = "The customer's Secret Token is malformed."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-        except Exception:
-            logger.info("gitlab.webhook.invalid-token", extra=extra)
-            extra["reason"] = "Generic catch-all error."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
+        return super()._get_external_id(request=self.request, extra=extra)
 
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -4,16 +4,14 @@ import logging
 from typing import Tuple
 
 from django.http import HttpResponse
-from django.utils.crypto import constant_time_compare
+from django.urls import resolve
 
-from sentry.integrations.gitlab.webhooks import handlers
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.integrations.integration import Integration
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -58,47 +56,6 @@ class GitlabRequestParser(BaseRequestParser):
             logger.exception(extra["reason"])
             return HttpResponse(status=400, reason=extra["reason"])
 
-    def _validate_webhook_secret(self, secret: str) -> HttpResponse | None:
-        clear_tags_and_context()
-        extra = {
-            # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
-            "user-agent": self.request.META.get("HTTP_USER_AGENT"),
-            # Gitlab does not seem to be the only host sending events
-            # AppPlatformEvents also hit this API
-            "event-type": self.request.META.get("HTTP_X_GITLAB_EVENT"),
-        }
-        integration = self.get_integration_from_request()
-        try:
-            if not constant_time_compare(secret, integration.metadata["webhook_secret"]):
-                # Summary and potential workaround mentioned here:
-                # https://github.com/getsentry/sentry/issues/34903#issuecomment-1262754478
-                # This forces a stack trace to be produced
-                raise Exception("The webhook secrets do not match.")
-        except Exception:
-            logger.info("gitlab.webhook.invalid-token-secret", extra=extra)
-            extra[
-                "reason"
-            ] = "Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/product/integrations/integration-platform/public-integration/#refreshing-tokens."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-
-    def _validate_json(self) -> HttpResponse | None:
-        clear_tags_and_context()
-        extra = {
-            # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
-            "user-agent": self.request.META.get("HTTP_USER_AGENT"),
-            # Gitlab does not seem to be the only host sending events
-            # AppPlatformEvents also hit this API
-            "event-type": self.request.META.get("HTTP_X_GITLAB_EVENT"),
-        }
-        try:
-            json.loads(self.request.body.decode("utf-8"))
-        except json.JSONDecodeError:
-            logger.info("gitlab.webhook.invalid-json", extra=extra)
-            extra["reason"] = "Data received is not JSON."
-            logger.exception(extra["reason"])
-            return HttpResponse(status=400, reason=extra["reason"])
-
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:
         if self._integration:
@@ -106,38 +63,33 @@ class GitlabRequestParser(BaseRequestParser):
         if not self.is_json_request():
             return None
         try:
+            _view, _args, kwargs = resolve(self.request.path)
+            # Non-webhook endpoints
+            if "integration_id" in kwargs and "organization_slug" in kwargs:
+                self._integration = Integration.objects.filter(
+                    id=kwargs["integration_id"],
+                    organization_slug=kwargs["organization_slug"],
+                ).first()
+                return self._integration
+
+            # Webhook endpoints
             result = self._get_external_id()
-            if not isinstance(result, tuple):
-                return None
-            (external_id, _secret) = result
-            self._integration = Integration.objects.filter(
-                external_id=external_id, provider=self.provider
-            ).first()
-            return self._integration
+            if isinstance(result, tuple):
+                (external_id, _secret) = result
+                self._integration = Integration.objects.filter(
+                    external_id=external_id, provider=self.provider
+                ).first()
+                return self._integration
         except Exception:
-            return None
+            pass
+        return None
 
     def get_response(self) -> HttpResponse:
-        if self.request.method != "POST":
-            return HttpResponse(status=405, reason="HTTP method not supported.")
-        maybe_http_response = self._get_external_id()
-        if isinstance(maybe_http_response, HttpResponse):
-            return maybe_http_response
-        (_external_id, secret) = maybe_http_response
-
-        if self.request.META["HTTP_X_GITLAB_EVENT"] not in handlers:
-            return HttpResponse(
-                status=400,
-                reason="Webhook event type not supported.",
-            )
-
-        response = self._validate_webhook_secret(secret)
-        if response:
-            return response
-
-        response = self._validate_json()
-        if response:
-            return response
+        result = resolve(self.request.path)
+        if result.url_name == "sentry-extensions-gitlab-webhook":
+            maybe_http_response = self._get_external_id()
+            if isinstance(maybe_http_response, HttpResponse):
+                return maybe_http_response
 
         # All Gitlab webhooks will be sent to region silos
         regions = self.get_regions_from_organizations()

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class GitlabRequestParser(BaseRequestParser):
     provider = EXTERNAL_PROVIDERS[ExternalProviders.GITLAB]
     webhook_identifier = WebhookProviderIdentifier.GITLAB
-    _integration = None
+    _integration: Integration = None
 
     def _get_external_id(self) -> Tuple[str, str] | HttpResponse:
         clear_tags_and_context()

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import logging
+from typing import Tuple
+
+from django.http import HttpResponse
+from django.utils.crypto import constant_time_compare
+
+from sentry.integrations.gitlab.webhooks import handlers
+from sentry.integrations.utils.scope import clear_tags_and_context
+from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.models.integrations.integration import Integration
+from sentry.models.outbox import WebhookProviderIdentifier
+from sentry.services.hybrid_cloud.util import control_silo_function
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+from sentry.utils import json
+
+logger = logging.getLogger(__name__)
+
+
+class GitlabRequestParser(BaseRequestParser):
+    provider = EXTERNAL_PROVIDERS[ExternalProviders.GITLAB]
+    webhook_identifier = WebhookProviderIdentifier.GITLAB
+    _integration = None
+
+    def _get_external_id(self) -> Tuple[str, str] | HttpResponse:
+        clear_tags_and_context()
+        extra = {
+            # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
+            "user-agent": self.request.META.get("HTTP_USER_AGENT"),
+            # Gitlab does not seem to be the only host sending events
+            # AppPlatformEvents also hit this API
+            "event-type": self.request.META.get("HTTP_X_GITLAB_EVENT"),
+        }
+        token = "<unknown>"
+        try:
+            # Munge the token to extract the integration external_id.
+            # gitlab hook payloads don't give us enough unique context
+            # to find data on our side so we embed one in the token.
+            token = self.request.META["HTTP_X_GITLAB_TOKEN"]
+            # e.g. "example.gitlab.com:group-x:webhook_secret_from_sentry_integration_table"
+            instance, group_path, secret = token.split(":")
+            external_id = f"{instance}:{group_path}"
+            return (external_id, secret)
+        except KeyError:
+            logger.info("gitlab.webhook.missing-gitlab-token")
+            extra["reason"] = "The customer needs to set a Secret Token in their webhook."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+        except ValueError:
+            logger.info("gitlab.webhook.malformed-gitlab-token", extra=extra)
+            extra["reason"] = "The customer's Secret Token is malformed."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+        except Exception:
+            logger.info("gitlab.webhook.invalid-token", extra=extra)
+            extra["reason"] = "Generic catch-all error."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+
+    def _validate_webhook_secret(self, secret: str) -> HttpResponse | None:
+        clear_tags_and_context()
+        extra = {
+            # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
+            "user-agent": self.request.META.get("HTTP_USER_AGENT"),
+            # Gitlab does not seem to be the only host sending events
+            # AppPlatformEvents also hit this API
+            "event-type": self.request.META.get("HTTP_X_GITLAB_EVENT"),
+        }
+        integration = self.get_integration_from_request()
+        try:
+            if not constant_time_compare(secret, integration.metadata["webhook_secret"]):
+                # Summary and potential workaround mentioned here:
+                # https://github.com/getsentry/sentry/issues/34903#issuecomment-1262754478
+                # This forces a stack trace to be produced
+                raise Exception("The webhook secrets do not match.")
+        except Exception:
+            logger.info("gitlab.webhook.invalid-token-secret", extra=extra)
+            extra[
+                "reason"
+            ] = "Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/product/integrations/integration-platform/public-integration/#refreshing-tokens."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+
+    def _validate_json(self) -> HttpResponse | None:
+        clear_tags_and_context()
+        extra = {
+            # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
+            "user-agent": self.request.META.get("HTTP_USER_AGENT"),
+            # Gitlab does not seem to be the only host sending events
+            # AppPlatformEvents also hit this API
+            "event-type": self.request.META.get("HTTP_X_GITLAB_EVENT"),
+        }
+        try:
+            json.loads(self.request.body.decode("utf-8"))
+        except json.JSONDecodeError:
+            logger.info("gitlab.webhook.invalid-json", extra=extra)
+            extra["reason"] = "Data received is not JSON."
+            logger.exception(extra["reason"])
+            return HttpResponse(status=400, reason=extra["reason"])
+
+    @control_silo_function
+    def get_integration_from_request(self) -> Integration | None:
+        if self._integration:
+            return self._integration
+        if not self.is_json_request():
+            return None
+        try:
+            result = self._get_external_id()
+            if not isinstance(result, tuple):
+                return None
+            (external_id, _secret) = result
+            self._integration = Integration.objects.filter(
+                external_id=external_id, provider=self.provider
+            ).first()
+            return self._integration
+        except Exception:
+            return None
+
+    def get_response(self) -> HttpResponse:
+        if self.request.method != "POST":
+            return HttpResponse(status=405, reason="HTTP method not supported.")
+        maybe_http_response = self._get_external_id()
+        if isinstance(maybe_http_response, HttpResponse):
+            return maybe_http_response
+        (_external_id, secret) = maybe_http_response
+
+        if self.request.META["HTTP_X_GITLAB_EVENT"] not in handlers:
+            return HttpResponse(
+                status=400,
+                reason="Webhook event type not supported.",
+            )
+
+        response = self._validate_webhook_secret(secret)
+        if response:
+            return response
+
+        response = self._validate_json()
+        if response:
+            return response
+
+        # All Gitlab webhooks will be sent to region silos
+        regions = self.get_regions_from_organizations()
+        if len(regions) == 0:
+            logger.error("no_regions", extra={"path": self.request.path})
+            return self.get_response_from_control_silo()
+
+        return self.get_response_from_outbox_creation(regions=regions)

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -83,6 +83,7 @@ class WebhookProviderIdentifier(IntEnum):
     SLACK = 0
     GITHUB = 1
     JIRA = 2
+    GITLAB = 3
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -9,7 +9,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class GitlabSearchTest(GitLabTestCase):
     provider = "gitlab"
 

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -33,6 +33,7 @@ class GithubRequestParserTest(TestCase):
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
         response = parser.get_response()
+        assert response.status_code == 200
         assert response.content == b"no-error"
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -9,13 +9,12 @@ from sentry.middleware.integrations.integration_control import IntegrationContro
 from sentry.middleware.integrations.parsers.gitlab import GitlabRequestParser
 from sentry.silo.base import SiloMode
 from sentry.testutils import TestCase
-from sentry.testutils.cases import BaseTestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
 
 
 @control_silo_test(stable=True)
-class GitlabRequestParserTest(TestCase, BaseTestCase):
+class GitlabRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     middleware = IntegrationControlMiddleware(get_response)
     factory = RequestFactory()

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -22,8 +22,8 @@ class GitlabRequestParserTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.integration = self.create_integration(
-            organization=self.organization,
+        self.integration = self.create_integration(  # type: ignore
+            organization=self.organization,  # type: ignore
             provider="gitlab",
             name="Example Gitlab",
             external_id=EXTERNAL_ID,
@@ -78,16 +78,16 @@ class GitlabRequestParserTest(TestCase):
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         parser = GitlabRequestParser(request=request, response_handler=self.get_response)
-        parser.get_response_from_control_silo = MagicMock()
-        parser.get_response_from_outbox_creation = MagicMock()
+        parser.get_response_from_control_silo = MagicMock()  # type: ignore
+        parser.get_response_from_outbox_creation = MagicMock()  # type: ignore
 
         # No regions identified
-        parser.get_regions_from_organizations = MagicMock(return_value=[])
+        parser.get_regions_from_organizations = MagicMock(return_value=[])  # type: ignore
         parser.get_response()
         assert parser.get_response_from_control_silo.called
 
         # Regions found
-        parser.get_regions_from_organizations = MagicMock(return_value=[self.region])
+        parser.get_regions_from_organizations = MagicMock(return_value=[self.region])  # type: ignore
         parser.get_response()
         assert parser.get_response_from_outbox_creation.called
 

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -1,0 +1,156 @@
+from unittest.mock import MagicMock
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+from fixtures.gitlab import EXTERNAL_ID, PUSH_EVENT, WEBHOOK_SECRET, WEBHOOK_TOKEN
+from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
+from sentry.middleware.integrations.parsers.gitlab import GitlabRequestParser
+from sentry.silo.base import SiloMode
+from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.types.region import Region, RegionCategory
+
+
+@control_silo_test(stable=True)
+class GitlabRequestParserTest(TestCase):
+    get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
+    middleware = IntegrationControlMiddleware(get_response)
+    factory = RequestFactory()
+    path = f"{IntegrationControlMiddleware.webhook_prefix}gitlab/webhook/"
+    region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
+
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="gitlab",
+            name="Example Gitlab",
+            external_id=EXTERNAL_ID,
+            metadata={
+                "instance": "example.gitlab.com",
+                "base_url": "https://example.gitlab.com",
+                "domain_name": "example.gitlab.com/group-x",
+                "verify_ssl": False,
+                "webhook_secret": WEBHOOK_SECRET,
+                "group_id": 1,
+            },
+        )
+
+    def run_parser(self, request):
+        parser = GitlabRequestParser(request=request, response_handler=self.get_response)
+        return parser.get_response()
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_get(self):
+        request = self.factory.get(self.path)
+        response = self.run_parser(request)
+        assert response.status_code == 405
+        assert response.reason_phrase == "HTTP method not supported."
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_missing_x_gitlab_token(self):
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_EVENT="lol",
+        )
+        response = self.run_parser(request)
+        assert response.status_code == 400
+        assert (
+            response.reason_phrase == "The customer needs to set a Secret Token in their webhook."
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_unknown_event(self):
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="lol",
+        )
+        response = self.run_parser(request)
+        assert response.status_code == 400
+        assert response.reason_phrase == "Webhook event type not supported."
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_invalid_token(self):
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN="wrong",
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        response = self.run_parser(request)
+        assert response.status_code == 400
+        assert response.reason_phrase == "The customer's Secret Token is malformed."
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_valid_id_invalid_secret(self):
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=f"{EXTERNAL_ID}:wrong",
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        parser = GitlabRequestParser(request=request, response_handler=self.get_response)
+        parser.get_regions_from_organizations = MagicMock(return_value=[self.region])
+        response = parser.get_response()
+        assert response.status_code == 400
+        assert (
+            response.reason_phrase
+            == "Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/product/integrations/integration-platform/public-integration/#refreshing-tokens."
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_invalid_payload(self):
+        request = self.factory.post(
+            self.path,
+            data="lol not json",
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        response = self.run_parser(request)
+        assert response.status_code == 400
+        assert response.reason_phrase == "Data received is not JSON."
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_routing_properly(self):
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        parser = GitlabRequestParser(request=request, response_handler=self.get_response)
+        parser.get_response_from_control_silo = MagicMock()
+        parser.get_response_from_outbox_creation = MagicMock()
+
+        # No regions identified
+        parser.get_regions_from_organizations = MagicMock(return_value=[])
+        parser.get_response()
+        assert parser.get_response_from_control_silo.called
+
+        # Regions found
+        parser.get_regions_from_organizations = MagicMock(return_value=[self.region])
+        parser.get_response()
+        assert parser.get_response_from_outbox_creation.called
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_get_integration_from_request(self):
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        parser = GitlabRequestParser(request=request, response_handler=self.get_response)
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -19,7 +19,7 @@ class GitlabRequestParserTest(TestCase, BaseTestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     middleware = IntegrationControlMiddleware(get_response)
     factory = RequestFactory()
-    path = f"{IntegrationControlMiddleware.webhook_prefix}gitlab/webhook/"
+    path = f"{IntegrationControlMiddleware.integration_prefix}gitlab/webhook/"
     region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):


### PR DESCRIPTION
Add Gitlab request parser for intercepting webhook requests at the control silo.