### PR TITLE
styles(functions): Handle function name overflow in suspect functions

### DIFF
--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -286,7 +286,7 @@ const AccordionItem = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-const FunctionName = styled('div')`
+const FunctionName = styled(TextOverflow)`
   flex: 1 1 auto;
 `;
 


### PR DESCRIPTION
The function name can be long, especially on android.