### PR TITLE
fix(crons): Set cacheTime:0 on edit monitor request

### DIFF
--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -40,6 +40,7 @@ export default function EditMonitor() {
     data: monitor,
     refetch,
   } = useApiQuery<Monitor>(queryKey, {
+    cacheTime: 0,
     staleTime: 0,
   });
 


### PR DESCRIPTION
Without this we'll return the previous value of the monitor form without
the alert rule, so we need to invalidate the cache