### PR TITLE
ref(routes): Avoid named exports for routes for now

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -508,63 +508,28 @@ function buildRoutes() {
       />
       <Route path="source-maps/" name={t('Source Maps')}>
         <IndexRoute
-          component={make(async () => {
-            const {ProjectSourceMapsContainer} = await import(
-              'sentry/views/settings/projectSourceMaps'
-            );
-            return {
-              default: ProjectSourceMapsContainer,
-            };
-          })}
+          component={make(() => import('sentry/views/settings/projectSourceMaps'))}
         />
         <Route
           path="artifact-bundles/"
           name={t('Artifact Bundles')}
-          component={make(async () => {
-            const {ProjectSourceMapsContainer} = await import(
-              'sentry/views/settings/projectSourceMaps'
-            );
-            return {
-              default: ProjectSourceMapsContainer,
-            };
-          })}
+          component={make(() => import('sentry/views/settings/projectSourceMaps'))}
         >
           <Route
             name={t('Artifact Bundle')}
             path=":bundleId/"
-            component={make(async () => {
-              const {ProjectSourceMapsContainer} = await import(
-                'sentry/views/settings/projectSourceMaps'
-              );
-              return {
-                default: ProjectSourceMapsContainer,
-              };
-            })}
+            component={make(() => import('sentry/views/settings/projectSourceMaps'))}
           />
         </Route>
         <Route
           path="release-bundles/"
           name={t('Release Bundles')}
-          component={make(async () => {
-            const {ProjectSourceMapsContainer} = await import(
-              'sentry/views/settings/projectSourceMaps'
-            );
-            return {
-              default: ProjectSourceMapsContainer,
-            };
-          })}
+          component={make(() => import('sentry/views/settings/projectSourceMaps'))}
         >
           <Route
             name={t('Release Bundle')}
             path=":bundleId/"
-            component={make(async () => {
-              const {ProjectSourceMapsContainer} = await import(
-                'sentry/views/settings/projectSourceMaps'
-              );
-              return {
-                default: ProjectSourceMapsContainer,
-              };
-            })}
+            component={make(() => import('sentry/views/settings/projectSourceMaps'))}
           />
         </Route>
         <Route
@@ -1041,12 +1006,7 @@ function buildRoutes() {
       {usingCustomerDomain && (
         <Route
           path="/projects/"
-          component={make(async () => {
-            const {Projects} = await import('sentry/views/projects/');
-            return {
-              default: Projects,
-            };
-          })}
+          component={make(() => import('sentry/views/projects/'))}
           key="orgless-projects-route"
         >
           {projectsChildRoutes}
@@ -1054,12 +1014,7 @@ function buildRoutes() {
       )}
       <Route
         path="/organizations/:orgId/projects/"
-        component={make(async () => {
-          const {Projects} = await import('sentry/views/projects/');
-          return {
-            default: Projects,
-          };
-        })}
+        component={make(() => import('sentry/views/projects/'))}
         key="org-projects"
       >
         {projectsChildRoutes}

--- a/static/app/views/projects/index.tsx
+++ b/static/app/views/projects/index.tsx
@@ -4,7 +4,7 @@ type Props = {
   children: React.ReactNode;
 };
 
-export function Projects({children}: Props) {
+export default function Projects({children}: Props) {
   return (
     <GettingStartedWithProjectContextProvider>
       {children}

--- a/static/app/views/settings/projectSourceMaps/index.tsx
+++ b/static/app/views/settings/projectSourceMaps/index.tsx
@@ -16,7 +16,7 @@ type Props = RouteComponentProps<
   project: Project;
 };
 
-export function ProjectSourceMapsContainer({params, location, ...props}: Props) {
+export default function ProjectSourceMapsContainer({params, location, ...props}: Props) {
   const organization = useOrganization();
   const sourceMapsDebugIds = organization.features.includes('source-maps-debug-ids');
 


### PR DESCRIPTION
While we are slowly trying to remove more default exports, for routes we have a consistent pattern of using default exports. Until we work out a solution to have all views have a standard convention for named exports we should just keep using default exports.