### PR TITLE
ref(timeRangeSelector): Accept `relativeOptions` prop as a function

### DIFF
--- a/static/app/components/timeRangeSelector.tsx
+++ b/static/app/components/timeRangeSelector.tsx
@@ -15,10 +15,11 @@ import DateRange from 'sentry/components/organizations/timeRangeSelector/dateRan
 import SelectorItems from 'sentry/components/organizations/timeRangeSelector/selectorItems';
 import {
   getAbsoluteSummary,
-  getDefaultRelativePeriods,
+  getArbitraryRelativePeriod,
+  getSortedRelativePeriods,
   timeRangeAutoCompleteFilter,
 } from 'sentry/components/organizations/timeRangeSelector/utils';
-import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {IconArrow, IconCalendar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -92,9 +93,16 @@ export interface TimeRangeSelectorProps
    */
   relative?: string | null;
   /**
-   * Override defaults from DEFAULT_RELATIVE_PERIODS
+   * Override defaults. Accepts a function where defaultRelativeOptions =
+   * DEFAULT_RELATIVE_PERIODS, and arbitraryRelativeOptions contains the custom
+   * user-created periods (via the search box).
    */
-  relativeOptions?: Record<string, React.ReactNode>;
+  relativeOptions?:
+    | Record<string, React.ReactNode>
+    | ((props: {
+        arbitraryOptions: Record<string, React.ReactNode>;
+        defaultOptions: Record<string, React.ReactNode>;
+      }) => Record<string, React.ReactNode>);
   /**
    * Show absolute date selectors
    */
@@ -249,11 +257,23 @@ export function TimeRangeSelector({
     [defaultAbsolute, defaultPeriod, relative, onChange]
   );
 
+  const arbitraryRelativePeriods = getArbitraryRelativePeriod(relative);
+  const defaultRelativePeriods = {
+    ...DEFAULT_RELATIVE_PERIODS,
+    ...arbitraryRelativePeriods,
+  };
   return (
     <SelectorItemsHook
       shouldShowAbsolute={showAbsolute}
       shouldShowRelative={showRelative}
-      relativePeriods={relativeOptions ?? getDefaultRelativePeriods(relative)}
+      relativePeriods={getSortedRelativePeriods(
+        typeof relativeOptions === 'function'
+          ? relativeOptions({
+              defaultOptions: DEFAULT_RELATIVE_PERIODS,
+              arbitraryOptions: arbitraryRelativePeriods,
+            })
+          : relativeOptions ?? defaultRelativePeriods
+      )}
       handleSelectRelative={value => handleChange({value})}
     >
       {items => (


### PR DESCRIPTION
The `relativeOptions` prop in `TimeRangeSelector` lets us override the default list of relative time ranges:
<img width="276" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/0c0e2832-3160-4701-bd12-540f35a209ea">

However, if arbitrary relative ranges are allowed (i.e. `disallowArbitraryRelativeRanges` is `false`/`undefined`), then selecting a custom range (e.g. `2h`) that's outside of those specified in `relativeOptions` will result in an invalid period warning:
<img width="186" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/de51c686-ed36-446e-afc2-16ffe413a891">

That's because `relativeOptions` forcefully overrides the list of selectable ranges. `TimeRangeSelector` does not add the user-created ranges (`2h`) to the final list if `relativeOptions` is specified.

**Solution:** accept a functional version of `relativeOptions` of the type 
```typescript
(props: {
  arbitraryOptions: Record<string, React.ReactNode>;
  defaultOptions: Record<string, React.ReactNode>;
}) => Record<string, React.ReactNode>)
```
This way, we can include user-created options (`arbitraryOptions`) in the return value. For example:
<img width="597" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/e7632454-5113-4a43-b5f4-3e6711b407ec">
<img width="274" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/0639c1e9-234b-4a53-a3f2-c22d5c8ab226">


