### PR TITLE
fix(functions): Typo use functions dataset for timeseries

### DIFF
--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -67,7 +67,7 @@ def timeseries_query(
     use_metrics_layer: bool = False,
 ) -> Any:
     builder = ProfileFunctionsTimeseriesQueryBuilder(
-        dataset=Dataset.Profiles,
+        dataset=Dataset.Functions,
         params=params,
         query=query,
         interval=rollup,


### PR DESCRIPTION
This was a typo as it should use the functions dataset and not profiles.