### PR TITLE
ref(releases): Use new time range selector

### DIFF
--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -18,8 +18,7 @@ import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
-import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
-import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
@@ -437,6 +436,13 @@ class ReleaseOverview extends AsyncView<Props> {
             shouldFilterSessionsInTimeWindow: true,
           };
 
+          const defaultDateTimeSelected = !period && !start && !end;
+
+          const releaseBoundsLabel =
+            releaseBounds.type === 'clamped'
+              ? t('Clamped Release Period')
+              : t('Entire Release Period');
+
           return (
             <SessionsRequest {...sessionsRequestProps}>
               {({
@@ -468,31 +474,38 @@ class ReleaseOverview extends AsyncView<Props> {
                           )}
                           <ReleaseDetailsPageFilters>
                             <EnvironmentPageFilter />
-                            <PageTimeRangeSelector
-                              organization={organization}
-                              relative={period ?? ''}
+                            <TimeRangeSelector
+                              relative={
+                                period ??
+                                (defaultDateTimeSelected ? RELEASE_PERIOD_KEY : null)
+                              }
                               start={start ?? null}
                               end={end ?? null}
                               utc={utc ?? null}
-                              onUpdate={this.handleDateChange}
-                              relativeOptions={
+                              onChange={this.handleDateChange}
+                              menuTitle={t('Filter Time Range')}
+                              triggerLabel={
+                                defaultDateTimeSelected ? releaseBoundsLabel : null
+                              }
+                              relativeOptions={({defaultOptions, arbitraryOptions}) =>
                                 releaseBounds.type !== 'ancient'
                                   ? {
                                       [RELEASE_PERIOD_KEY]: (
                                         <Fragment>
-                                          {releaseBounds.type === 'clamped'
-                                            ? t('Clamped Release Period')
-                                            : t('Entire Release Period')}{' '}
-                                          (
-                                          <DateTime
-                                            date={releaseBounds.releaseStart}
-                                          /> -{' '}
-                                          <DateTime date={releaseBounds.releaseEnd} />)
+                                          {releaseBoundsLabel}
+                                          <br />
+                                          <ReleaseBoundsDescription
+                                            primary={defaultDateTimeSelected}
+                                          >
+                                            <DateTime date={releaseBounds.releaseStart} />
+                                            –<DateTime date={releaseBounds.releaseEnd} />
+                                          </ReleaseBoundsDescription>
                                         </Fragment>
                                       ),
-                                      ...DEFAULT_RELATIVE_PERIODS,
+                                      ...defaultOptions,
+                                      ...arbitraryOptions,
                                     }
-                                  : DEFAULT_RELATIVE_PERIODS
+                                  : {...defaultOptions, ...arbitraryOptions}
                               }
                               defaultPeriod={
                                 releaseBounds.type !== 'ancient'
@@ -730,6 +743,11 @@ const ReleaseDetailsPageFilters = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: auto;
   }
+`;
+
+const ReleaseBoundsDescription = styled('span')<{primary: boolean}>`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => (p.primary ? p.theme.activeText : p.theme.subText)};
 `;
 
 export default withApi(withPageFilters(withOrganization(ReleaseOverview)));


### PR DESCRIPTION
**Before ——**
<img width="840" alt="Screenshot 2023-06-02 at 3 06 29 PM" src="https://github.com/getsentry/sentry/assets/44172267/c49a2266-4d5e-4c64-abbc-cd6b693e08a2">


**After ——**
<img width="840" alt="Screenshot 2023-06-02 at 3 05 56 PM" src="https://github.com/getsentry/sentry/assets/44172267/81581df6-05bd-4e88-bd29-01a08f60e593">
