### PR TITLE
feat(issue-platform): add support for replay_id and profile_id values from dataset

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -725,5 +725,15 @@ class Columns(Enum):
         event_name=None,
         transaction_name="profile_id",
         discover_name="profile_id",
+        issue_platform_name="profile_id",
         alias="profile.id",
+    )
+
+    REPLAY_ID = Column(
+        group_name=None,
+        event_name="replay_id",
+        transaction_name="replay_id",
+        discover_name="replay_id",
+        issue_platform_name="replay_id",
+        alias="replayId",
     )

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -731,9 +731,9 @@ class Columns(Enum):
 
     REPLAY_ID = Column(
         group_name=None,
-        event_name="replay_id",
-        transaction_name="replay_id",
-        discover_name="replay_id",
+        event_name=None,
+        transaction_name=None,
+        discover_name=None,
         issue_platform_name="replay_id",
         alias="replayId",
     )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -503,6 +503,7 @@ class PerformanceIssueTestCase(BaseTestCase):
         noise_limit=0,
         project_id=None,
         detector_option="performance.issues.n_plus_one_db.problem-creation",
+        user_data=None,
     ):
         if issue_type is None:
             issue_type = PerformanceNPlusOneGroupType
@@ -519,6 +520,8 @@ class PerformanceIssueTestCase(BaseTestCase):
             event_data["transaction"] = transaction
         if project_id is None:
             project_id = self.project.id
+        if user_data:
+            event_data["user"] = user_data
 
         perf_event_manager = EventManager(event_data)
         perf_event_manager.normalize()

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -1,4 +1,5 @@
 import math
+import uuid
 from base64 import b64encode
 from datetime import timedelta
 from unittest import mock
@@ -6158,3 +6159,66 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
         assert len(data) == 1
         result = {r["user.display"] for r in data}
         assert result == {user_data["email"]}
+
+    def test_all_events_fields(self):
+        # user_data = {
+        #     "id": self.user.id,
+        #     "username": "user",
+        #     "email": "hellboy@bar.com",
+        #     "ip_address": "127.0.0.1",
+        # }
+        event = self.create_performance_issue(
+            # tags={},
+            contexts={
+                "trace": {
+                    "trace_id": str(uuid.uuid4().hex),
+                    "span_id": "933e5c9a8e464da9",
+                    "type": "trace",
+                }
+            },
+        )
+
+        query = {
+            "field": [
+                "id",
+                "transaction",
+                "title",
+                "release",
+                "environment",
+                "user.display",
+                "device",
+                "os",
+                "url",
+                "runtime",
+                # "replayId",
+                # "profile.id",
+                "transaction.duration",
+                "timestamp",
+            ],
+            # "field": ["count()"],
+            "statsPeriod": "1h",
+            "query": f"project:{event.group.project.slug} issue:{event.group.qualified_short_id}",
+            # "query": f"issue:{event.group.qualified_short_id}",
+            "dataset": "issuePlatform",
+        }
+
+        with self.options({"performance.issues.create_issues_through_platform": True}):
+            response = self.do_request(query)
+        assert response.status_code == 200, response.content
+
+        assert response.data["data"][0] == {
+            "id": event.event_id,
+            "transaction": event.transaction,
+            "title": event.group.title,
+            "release": event.release,
+            "environment": event.get_environment().name,
+            "user.display": "",
+            "device": "Mac",
+            "os": "",
+            "url": "",
+            "runtime": event.get_raw_data()[0]["tags"]["runtime"],
+            "replayId": "",
+            "profile.id": "",
+            "transaction.duration": 3000,
+            "timestamp": event.datetime.replace(microsecond=0).isoformat(),
+        }

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6161,21 +6161,25 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
         assert result == {user_data["email"]}
 
     def test_all_events_fields(self):
-        # user_data = {
-        #     "id": self.user.id,
-        #     "username": "user",
-        #     "email": "hellboy@bar.com",
-        #     "ip_address": "127.0.0.1",
-        # }
+        user_data = {
+            "id": self.user.id,
+            "username": "user",
+            "email": "hellboy@bar.com",
+            "ip_address": "127.0.0.1",
+        }
+        replay_id = str(uuid.uuid4())
+        profile_id = str(uuid.uuid4())
         event = self.create_performance_issue(
-            # tags={},
             contexts={
                 "trace": {
                     "trace_id": str(uuid.uuid4().hex),
                     "span_id": "933e5c9a8e464da9",
                     "type": "trace",
-                }
+                },
+                "replay": {"replay_id": replay_id},
+                "profile": {"profile_id": profile_id},
             },
+            user_data=user_data,
         )
 
         query = {
@@ -6190,35 +6194,35 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
                 "os",
                 "url",
                 "runtime",
-                # "replayId",
-                # "profile.id",
+                "replayId",
+                "profile.id",
                 "transaction.duration",
                 "timestamp",
             ],
-            # "field": ["count()"],
             "statsPeriod": "1h",
             "query": f"project:{event.group.project.slug} issue:{event.group.qualified_short_id}",
-            # "query": f"issue:{event.group.qualified_short_id}",
             "dataset": "issuePlatform",
         }
 
-        with self.options({"performance.issues.create_issues_through_platform": True}):
-            response = self.do_request(query)
+        response = self.do_request(query)
         assert response.status_code == 200, response.content
 
-        assert response.data["data"][0] == {
+        data = response.data["data"][0]
+
+        assert data == {
             "id": event.event_id,
             "transaction": event.transaction,
+            "project.name": event.project.name.lower(),
             "title": event.group.title,
             "release": event.release,
             "environment": event.get_environment().name,
-            "user.display": "",
+            "user.display": user_data["email"],
             "device": "Mac",
             "os": "",
-            "url": "",
-            "runtime": event.get_raw_data()[0]["tags"]["runtime"],
-            "replayId": "",
-            "profile.id": "",
+            "url": event.interfaces.data["request"].full_url,
+            "runtime": dict(event.get_raw_data()["tags"])["runtime"],
+            "replayId": replay_id.replace("-", ""),
+            "profile.id": profile_id.replace("-", ""),
             "transaction.duration": 3000,
             "timestamp": event.datetime.replace(microsecond=0).isoformat(),
         }


### PR DESCRIPTION
Maps `replayId` and `profile.id` dataset query used in the 'All Events' tab to the search_issues dataset used for generic issues.

The additional test will fail until this https://github.com/getsentry/snuba/pull/4281 is merged in.