### PR TITLE
fix(alert-details): Prevent environments call from being cancelled

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -20,6 +20,7 @@ import {space} from 'sentry/styles/space';
 import {Environment, Organization, Project, SelectValue} from 'sentry/types';
 import {getDisplayName} from 'sentry/utils/environment';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
 import WizardField from 'sentry/views/alerts/rules/metric/wizardField';
 import {
@@ -576,4 +577,4 @@ const FormRow = styled('div')<{columns?: number; noMargin?: boolean}>`
     `}
 `;
 
-export default withProjects(RuleConditionsForm);
+export default withApi(withProjects(RuleConditionsForm));

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -918,7 +918,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                 >
                   <List symbol="colored-numeric">
                     <RuleConditionsForm
-                      api={this.api}
                       project={project}
                       organization={organization}
                       router={router}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/50268

For whatever reason, the environments call was being cancelled in some circumstances, which resulted in a disabled dropdown. Using a new api client here fixes the issue.