### PR TITLE
chore(hybrid-cloud): Clean up webhook_prefix

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -98,7 +98,7 @@ class GitHubIssueBasic(IssueBasicMixin):
 
         org = group.organization
         autocomplete_url = reverse(
-            "sentry-extensions-github-search", args=[org.slug, self.model.id]
+            "sentry-integration-github-search", args=[org.slug, self.model.id]
         )
 
         return [
@@ -156,7 +156,7 @@ class GitHubIssueBasic(IssueBasicMixin):
 
         org = group.organization
         autocomplete_url = reverse(
-            "sentry-extensions-github-search", args=[org.slug, self.model.id]
+            "sentry-integration-github-search", args=[org.slug, self.model.id]
         )
 
         return [

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     url(
         r"^webhook/$",
         GitHubIntegrationsWebhookEndpoint.as_view(),
+        name="sentry-extensions-github-webhook",
     ),
     url(
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -7,11 +7,11 @@ urlpatterns = [
     url(
         r"^webhook/$",
         GitHubIntegrationsWebhookEndpoint.as_view(),
-        name="sentry-extensions-github-webhook",
+        name="sentry-integration-github-webhook",
     ),
     url(
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitHubSearchEndpoint.as_view(),
-        name="sentry-extensions-github-search",
+        name="sentry-integration-github-search",
     ),
 ]

--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     url(
         r"^action/$",
         SlackActionEndpoint.as_view(),
+        name="sentry-integration-slack-action",
     ),
     url(
         r"^commands/$",
@@ -21,6 +22,7 @@ urlpatterns = [
     url(
         r"^event/$",
         SlackEventEndpoint.as_view(),
+        name="sentry-integration-slack-event",
     ),
     url(
         r"^link-identity/(?P<signed_params>[^\/]+)/$",

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -15,7 +15,7 @@ ACTIVE_PARSERS = [GithubRequestParser, JiraRequestParser, SlackRequestParser]
 
 
 class IntegrationControlMiddleware:
-    webhook_prefix: str = "/extensions/"
+    integration_prefix: str = "/extensions/"
     """Prefix for all integration requests. See `src/sentry/web/urls.py`"""
     setup_suffix: str = "/setup/"
     """Suffix for PipelineAdvancerView on installation. See `src/sentry/web/urls.py`"""
@@ -32,8 +32,8 @@ class IntegrationControlMiddleware:
         Parses the provider out of the request path
             e.g. `/extensions/slack/commands/` -> `slack`
         """
-        webhook_prefix_regex = re.escape(self.webhook_prefix)
-        provider_regex = rf"^{webhook_prefix_regex}(\w+)"
+        integration_prefix_regex = re.escape(self.integration_prefix)
+        provider_regex = rf"^{integration_prefix_regex}(\w+)"
         result = re.search(provider_regex, request.path)
         if not result:
             logger.error(
@@ -48,7 +48,7 @@ class IntegrationControlMiddleware:
         Determines whether this middleware will operate or just pass the request along.
         """
         is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
-        is_integration = request.path.startswith(self.webhook_prefix)
+        is_integration = request.path.startswith(self.integration_prefix)
         is_not_setup = not request.path.endswith(self.setup_suffix)
         return is_correct_silo and is_integration and is_not_setup
 

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -43,7 +43,7 @@ class GithubSearchTest(APITestCase):
 
         self.login_as(self.user)
         self.url = reverse(
-            "sentry-extensions-github-search",
+            "sentry-integration-github-search",
             kwargs={
                 "organization_slug": self.organization.slug,
                 "integration_id": self.installation.model.id,
@@ -194,7 +194,7 @@ class GithubSearchTest(APITestCase):
     # Missing Resources
     def test_missing_integration(self):
         url = reverse(
-            "sentry-extensions-github-search",
+            "sentry-integration-github-search",
             kwargs={"organization_slug": self.organization.slug, "integration_id": "1234567890"},
         )
         resp = self.client.get(

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -17,7 +17,7 @@ class GithubRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     middleware = IntegrationControlMiddleware(get_response)
     factory = RequestFactory()
-    path = reverse("sentry-extensions-github-webhook")
+    path = reverse("sentry-integration-github-webhook")
     region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
+from django.urls import reverse
 
 from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
 from sentry.middleware.integrations.parsers.github import GithubRequestParser
@@ -16,7 +17,7 @@ class GithubRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     middleware = IntegrationControlMiddleware(get_response)
     factory = RequestFactory()
-    path = f"{IntegrationControlMiddleware.webhook_prefix}github/webhook/"
+    path = reverse("sentry-extensions-github-webhook")
     region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):

--- a/tests/sentry/middleware/integrations/parsers/test_jira.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira.py
@@ -15,7 +15,7 @@ class JiraRequestParserTest(TestCase, BaseTestCase):
     get_response = MagicMock()
     middleware = IntegrationControlMiddleware(get_response)
     factory = RequestFactory()
-    path_base = f"{IntegrationControlMiddleware.webhook_prefix}jira"
+    path_base = f"{IntegrationControlMiddleware.integration_prefix}jira"
     region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import RequestFactory
+from django.urls import reverse
 
 from sentry.integrations.slack.requests.command import SlackCommandRequest
 from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
@@ -19,7 +20,6 @@ class SlackRequestParserTest(TestCase):
     get_response = MagicMock()
     middleware = IntegrationControlMiddleware(get_response)
     factory = RequestFactory()
-    path_base = f"{IntegrationControlMiddleware.webhook_prefix}slack"
     region = Region("na", 1, "https://na.testserver", RegionCategory.MULTI_TENANT)
 
     def setUp(self):
@@ -29,8 +29,8 @@ class SlackRequestParserTest(TestCase):
             organization=self.organization, external_id="TXXXXXXX1", provider="slack"
         )
 
-    def get_parser(self, path):
-        self.request = self.factory.post(f"{self.path_base}{path}")
+    def get_parser(self, path: str):
+        self.request = self.factory.post(path)
         parser = SlackRequestParser(self.request, self.get_response)
         parser.get_regions_from_organizations = MagicMock(return_value=[self.region])
         return parser
@@ -45,7 +45,7 @@ class SlackRequestParserTest(TestCase):
     def test_webhook(self, mock_authorize, mock_validate_integration, mock_integration):
         # Retrieve the correct integration
         mock_integration.id = self.integration.id
-        parser = self.get_parser("/commands/")
+        parser = self.get_parser(reverse("sentry-integration-slack-commands"))
         integration = parser.get_integration_from_request()
         assert mock_authorize.called
         assert mock_validate_integration.called
@@ -72,7 +72,12 @@ class SlackRequestParserTest(TestCase):
 
     def test_django_view(self):
         # Retrieve the correct integration
-        parser = self.get_parser(f"/link-identity/{sign(integration_id=self.integration.id)}/")
+        parser = self.get_parser(
+            reverse(
+                "sentry-integration-slack-link-identity",
+                kwargs={"signed_params": sign(integration_id=self.integration.id)},
+            )
+        )
         parser_integration = parser.get_integration_from_request()
         assert parser_integration.id == self.integration.id
 

--- a/tests/sentry/middleware/integrations/test_integration_control.py
+++ b/tests/sentry/middleware/integrations/test_integration_control.py
@@ -11,7 +11,7 @@ from sentry.testutils import TestCase
 class IntegrationControlMiddlewareTest(TestCase):
     get_response = MagicMock()
     middleware = IntegrationControlMiddleware(get_response)
-    prefix = IntegrationControlMiddleware.webhook_prefix
+    prefix = IntegrationControlMiddleware.integration_prefix
 
     def setUp(self):
         self.factory = RequestFactory()


### PR DESCRIPTION
`webhook_prefix` is misleading since not all endpoints under `/extensions/provider/*` are not webhook endpoints.

I've renamed  `webhook_prefix` to `integration_prefix_regex`, and cleaned up some tests.