### PR TITLE
ref(txnames): Increase sample size

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -20,7 +20,7 @@ from sentry.utils.safe import safe_execute
 
 #: Maximum number of transaction names per project that we want
 #: to store in redis.
-MAX_SET_SIZE = 2000
+MAX_SET_SIZE = 4000
 
 #: Retention of a set.
 #: Remove the set if it has not received any updates for 24 hours.


### PR DESCRIPTION
The larger the sample size, the better the chances of discovering rules (see [docs](https://develop.sentry.dev/transaction-clustering/#:~:text=The%20sample%20size%20of%20observed%20transactions%2C%20is%20currently%20set%20to%202000%20(10x%20the%20merge%20threshold).%20A%20larger%20set%20increases%20the%20probability%20of%20discovering%20a%20rule.)).

We initially chose a sample size of 10x the merge threshold because we wanted to be defensive in the amount of storage space needed. However, it seems that our redis instance has plenty of space left, so we can safely increase the sample size.