### PR TITLE
feat(org-tokens): Implement initial org token overview UI

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -940,9 +940,16 @@ function buildRoutes() {
         />
         <Route
           path="new-token/"
-          name={t('Create New Token')}
+          name={t('Create New Auth Token')}
           component={make(
             () => import('sentry/views/settings/organizationAuthTokens/newAuthToken')
+          )}
+        />
+        <Route
+          path=":tokenId/"
+          name={t('Edit Auth Token')}
+          component={make(
+            () => import('sentry/views/settings/organizationAuthTokens/authTokenDetails')
           )}
         />
       </Route>

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -1,0 +1,198 @@
+import {useCallback, useEffect, useState} from 'react';
+import {browserHistory} from 'react-router';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import Alert from 'sentry/components/alert';
+import {Form, TextField} from 'sentry/components/forms';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t, tct} from 'sentry/locale';
+import {Organization, Project} from 'sentry/types';
+import {setDateToTime} from 'sentry/utils/dates';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import withOrganization from 'sentry/utils/withOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+import {tokenPreview, TokenWip} from 'sentry/views/settings/organizationAuthTokens';
+
+function generateMockToken({
+  id,
+  name,
+  scopes,
+  dateCreated = new Date(),
+  dateLastUsed,
+  projectLastUsed,
+}: {
+  id: string;
+  name: string;
+  scopes: string[];
+  dateCreated?: Date;
+  dateLastUsed?: Date;
+  projectLastUsed?: Project;
+}): TokenWip {
+  return {
+    id,
+    name,
+    tokenLastCharacters: crypto.randomUUID().slice(0, 4),
+    scopes,
+    dateCreated,
+    dateLastUsed,
+    projectLastUsed,
+  };
+}
+
+type Props = {
+  organization: Organization;
+  params: {tokenId: string};
+};
+
+function AuthTokenDetailsForm({
+  token,
+  organization,
+}: {
+  organization: Organization;
+  token: TokenWip;
+}) {
+  const initialData = {
+    name: token.name,
+    tokenPreview: tokenPreview(token.tokenLastCharacters || '****'),
+  };
+
+  return (
+    <Form
+      apiMethod="PUT"
+      initialData={initialData}
+      apiEndpoint={`/organizations/${organization.slug}/auth-tokens/${token.id}/`}
+      onSubmit={() => {
+        // TODO FN: Actually submit data
+
+        try {
+          const message = t('Successfully updated the auth token.');
+          addSuccessMessage(message);
+        } catch (error) {
+          const message = t('Failed to update the auth token.');
+          handleXhrErrorResponse(message, error);
+          addErrorMessage(message);
+        }
+      }}
+      onCancel={() =>
+        browserHistory.push(normalizeUrl(`/settings/${organization.slug}/auth-tokens/`))
+      }
+    >
+      <TextField
+        name="name"
+        label={t('Name')}
+        value={token.dateLastUsed}
+        required
+        help={t('A name to help you identify this token.')}
+      />
+
+      <TextField
+        name="tokenPreview"
+        label={t('Token')}
+        value={tokenPreview(
+          token.tokenLastCharacters
+            ? getDynamicText({
+                value: token.tokenLastCharacters,
+                fixed: 'ABCD',
+              })
+            : '****'
+        )}
+        disabled
+        help={t('You can only view the token once after creation.')}
+      />
+
+      <FieldGroup
+        label={t('Scopes')}
+        inline={false}
+        help={t(
+          'You cannot change the scopes of an existing token. If you need different scopes, please create a new token.'
+        )}
+      >
+        <div>{token.scopes.slice().sort().join(', ')}</div>
+      </FieldGroup>
+    </Form>
+  );
+}
+
+export function OrganizationAuthTokensDetails({params, organization}: Props) {
+  const [token, setToken] = useState<TokenWip | null>(null);
+  const [hasLoadingError, setHasLoadingError] = useState(false);
+
+  const {tokenId} = params;
+
+  const fetchToken = useCallback(async () => {
+    try {
+      // TODO FN: Actually do something here
+      await new Promise(resolve => setTimeout(resolve, 500));
+      setToken(
+        generateMockToken({
+          id: tokenId,
+          name: 'custom token',
+          scopes: ['org:ci'],
+          dateLastUsed: setDateToTime(new Date(), '00:05:00'),
+          projectLastUsed: {slug: 'my-project', name: 'My Project'} as Project,
+          dateCreated: setDateToTime(new Date(), '00:01:00'),
+        })
+      );
+      setHasLoadingError(false);
+    } catch (error) {
+      const message = t('Failed to load auth token.');
+      handleXhrErrorResponse(message, error);
+      setHasLoadingError(error);
+    }
+  }, [tokenId]);
+
+  useEffect(() => {
+    fetchToken();
+  }, [fetchToken]);
+
+  return (
+    <div>
+      <SentryDocumentTitle title={t('Edit Auth Token')} />
+      <SettingsPageHeader title={t('Edit Auth Token')} />
+
+      <Alert>Note: This page is WIP and currently only shows mocked data.</Alert>
+
+      <TextBlock>
+        {t(
+          "Authentication tokens allow you to perform actions against the Sentry API on behalf of your organization. They're the easiest way to get started using the API."
+        )}
+      </TextBlock>
+      <TextBlock>
+        {tct(
+          'For more information on how to use the web API, see our [link:documentation].',
+          {
+            link: <ExternalLink href="https://docs.sentry.io/api/" />,
+          }
+        )}
+      </TextBlock>
+      <Panel>
+        <PanelHeader>{t('Auth Token Details')}</PanelHeader>
+
+        <PanelBody>
+          {hasLoadingError && (
+            <LoadingError
+              message={t('Failed to load auth token.')}
+              onRetry={fetchToken}
+            />
+          )}
+
+          {!hasLoadingError && !token && <LoadingIndicator />}
+
+          {!hasLoadingError && token && (
+            <AuthTokenDetailsForm token={token} organization={organization} />
+          )}
+        </PanelBody>
+      </Panel>
+    </div>
+  );
+}
+
+export default withOrganization(OrganizationAuthTokensDetails);

--- a/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenRow.tsx
@@ -1,0 +1,193 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import Confirm from 'sentry/components/confirm';
+import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {PanelItem} from 'sentry/components/panels';
+import TimeSince from 'sentry/components/timeSince';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconSubtract} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Organization, Project} from 'sentry/types';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {tokenPreview, TokenWip} from 'sentry/views/settings/organizationAuthTokens';
+
+function LastUsed({
+  organization,
+  dateLastUsed,
+  projectLastUsed,
+}: {
+  organization: Organization;
+  dateLastUsed?: Date;
+  projectLastUsed?: Project;
+}) {
+  if (dateLastUsed && projectLastUsed) {
+    return (
+      <Fragment>
+        {tct('Last used [date] in [project]', {
+          date: (
+            <TimeSince
+              date={getDynamicText({
+                value: dateLastUsed,
+                fixed: new Date(1508208080000), // National Pasta Day
+              })}
+            />
+          ),
+          project: (
+            <Link to={`/settings/${organization.slug}/${projectLastUsed.slug}/`}>
+              {projectLastUsed.name}
+            </Link>
+          ),
+        })}
+      </Fragment>
+    );
+  }
+
+  if (dateLastUsed) {
+    return (
+      <Fragment>
+        {tct('Last used [date]', {
+          date: (
+            <TimeSince
+              date={getDynamicText({
+                value: dateLastUsed,
+                fixed: new Date(1508208080000), // National Pasta Day
+              })}
+            />
+          ),
+        })}
+      </Fragment>
+    );
+  }
+
+  if (projectLastUsed) {
+    return (
+      <Fragment>
+        {tct('Last used in [project]', {
+          project: (
+            <Link to={`/settings/${organization.slug}/${projectLastUsed.slug}/`}>
+              {projectLastUsed.name}
+            </Link>
+          ),
+        })}
+      </Fragment>
+    );
+  }
+
+  return <Fragment>{t('Never used')}</Fragment>;
+}
+
+export function OrganizationAuthTokensAuthTokenRow({
+  organization,
+  isRevoking,
+  token,
+  revokeToken,
+  canRevoke,
+}: {
+  canRevoke: boolean;
+  isRevoking: boolean;
+  organization: Organization;
+  revokeToken: (token: TokenWip) => void;
+  token: TokenWip;
+}) {
+  return (
+    <StyledPanelItem>
+      <StyledPanelHeader>
+        <Label>
+          <Link to={`/settings/${organization.slug}/auth-tokens/${token.id}/`}>
+            {token.name}
+          </Link>
+        </Label>
+
+        <Actions>
+          <Tooltip
+            title={t(
+              'You must be an organization owner, manager or admin to revoke a token.'
+            )}
+            disabled={canRevoke}
+          >
+            <Confirm
+              disabled={!canRevoke || isRevoking}
+              onConfirm={() => revokeToken(token)}
+              message={t(
+                'Are you sure you want to revoke this token? The token will not be usable anymore, and this cannot be undone.'
+              )}
+            >
+              <Button
+                size="sm"
+                onClick={() => revokeToken(token)}
+                disabled={isRevoking || !canRevoke}
+                icon={
+                  isRevoking ? (
+                    <LoadingIndicator mini />
+                  ) : (
+                    <IconSubtract isCircled size="xs" />
+                  )
+                }
+              >
+                {t('Revoke')}
+              </Button>
+            </Confirm>
+          </Tooltip>
+        </Actions>
+      </StyledPanelHeader>
+
+      <StyledPanelBody>
+        {token.tokenLastCharacters && (
+          <TokenPreview>
+            {tokenPreview(
+              getDynamicText({
+                value: token.tokenLastCharacters,
+                fixed: 'ABCD',
+              })
+            )}
+          </TokenPreview>
+        )}
+
+        <LastUsedDate>
+          <LastUsed
+            dateLastUsed={token.dateLastUsed}
+            projectLastUsed={token.projectLastUsed}
+            organization={organization}
+          />
+        </LastUsedDate>
+      </StyledPanelBody>
+    </StyledPanelItem>
+  );
+}
+
+const StyledPanelItem = styled(PanelItem)`
+  flex-direction: column;
+  padding: ${space(2)};
+  gap: ${space(1)};
+`;
+
+const StyledPanelHeader = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: ${space(0.25)} ${space(1)};
+`;
+
+const Label = styled('div')``;
+
+const Actions = styled('div')`
+  margin-left: auto;
+`;
+
+const StyledPanelBody = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const LastUsedDate = styled('div')`
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+  margin-left: auto;
+`;
+
+const TokenPreview = styled('div')`
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+`;

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -1,21 +1,116 @@
+import {Fragment, useCallback, useEffect, useState} from 'react';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import Access from 'sentry/components/acl/access';
+import Alert from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {Organization} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
+import {setDateToTime} from 'sentry/utils/dates';
+import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import withOrganization from 'sentry/utils/withOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
+import {OrganizationAuthTokensAuthTokenRow} from 'sentry/views/settings/organizationAuthTokens/authTokenRow';
+
+export type TokenWip = {
+  dateCreated: Date;
+  id: string;
+  name: string;
+  scopes: string[];
+  dateLastUsed?: Date;
+  projectLastUsed?: Project;
+  tokenLastCharacters?: string;
+};
+
+function generateMockToken({
+  name,
+  scopes,
+  dateCreated = new Date(),
+  dateLastUsed,
+  projectLastUsed,
+}: {
+  name: string;
+  scopes: string[];
+  dateCreated?: Date;
+  dateLastUsed?: Date;
+  projectLastUsed?: Project;
+}): TokenWip {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    tokenLastCharacters: crypto.randomUUID().slice(0, 4),
+    scopes,
+    dateCreated,
+    dateLastUsed,
+    projectLastUsed,
+  };
+}
 
 export function OrganizationAuthTokensIndex({
   organization,
 }: {
   organization: Organization;
 }) {
-  const isEmpty = true;
-  const tokenList = [];
+  const [tokenList, setTokenList] = useState<TokenWip[] | null>(null);
+  const [hasLoadingError, setHasLoadingError] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const fetchTokenList = useCallback(async () => {
+    try {
+      // TODO FN: Actually do something here
+      await new Promise(resolve => setTimeout(resolve, 500));
+      setTokenList([
+        generateMockToken({
+          name: 'custom token',
+          scopes: ['org:ci'],
+          dateLastUsed: setDateToTime(new Date(), '00:05:00'),
+          projectLastUsed: {slug: 'my-project', name: 'My Project'} as Project,
+          dateCreated: setDateToTime(new Date(), '00:01:00'),
+        }),
+        generateMockToken({
+          name: 'my-project CI token',
+          scopes: ['org:ci'],
+          dateLastUsed: new Date('2023-06-09'),
+        }),
+        generateMockToken({name: 'my-pro2 CI token', scopes: ['org:ci']}),
+      ]);
+      setHasLoadingError(false);
+    } catch (error) {
+      const message = t('Failed to load auth tokens for the organization.');
+      handleXhrErrorResponse(message, error);
+      setHasLoadingError(error);
+    }
+  }, []);
+
+  const handleRevokeToken = useCallback(
+    async (token: TokenWip) => {
+      try {
+        setIsRevoking(true);
+        // TODO FN: Actually do something here
+        await new Promise(resolve => setTimeout(resolve, 500));
+        const newTokens = (tokenList || []).filter(
+          tokenCompare => tokenCompare !== token
+        );
+        setTokenList(newTokens);
+
+        addSuccessMessage(t('Revoked auth token for the organization.'));
+      } catch (error) {
+        const message = t('Failed to revoke the auth token for the organization.');
+        handleXhrErrorResponse(message, error);
+        addErrorMessage(message);
+      } finally {
+        setIsRevoking(false);
+      }
+    },
+    [tokenList]
+  );
 
   const createNewToken = (
     <Button
@@ -28,41 +123,74 @@ export function OrganizationAuthTokensIndex({
     </Button>
   );
 
+  useEffect(() => {
+    fetchTokenList();
+  }, [fetchTokenList]);
+
   return (
-    <div>
-      <SentryDocumentTitle title={t('Auth Tokens')} />
-      <SettingsPageHeader title={t('Auth Tokens')} action={createNewToken} />
+    <Access access={['org:write']}>
+      {({hasAccess}) => (
+        <Fragment>
+          <SentryDocumentTitle title={t('Auth Tokens')} />
+          <SettingsPageHeader title={t('Auth Tokens')} action={createNewToken} />
 
-      <TextBlock>
-        {t(
-          "Authentication tokens allow you to perform actions against the Sentry API on behalf of your organization. They're the easiest way to get started using the API."
-        )}
-      </TextBlock>
-      <TextBlock>
-        {tct(
-          'For more information on how to use the web API, see our [link:documentation].',
-          {
-            link: <ExternalLink href="https://docs.sentry.io/api/" />,
-          }
-        )}
-      </TextBlock>
-      <Panel>
-        <PanelHeader>{t('Auth Token')}</PanelHeader>
+          <Alert>Note: This page is WIP and currently only shows mocked data.</Alert>
 
-        <PanelBody>
-          {isEmpty && (
-            <EmptyMessage>
-              {t("You haven't created any authentication tokens yet.")}
-            </EmptyMessage>
-          )}
+          <TextBlock>
+            {t(
+              "Authentication tokens allow you to perform actions against the Sentry API on behalf of your organization. They're the easiest way to get started using the API."
+            )}
+          </TextBlock>
+          <TextBlock>
+            {tct(
+              'For more information on how to use the web API, see our [link:documentation].',
+              {
+                link: <ExternalLink href="https://docs.sentry.io/api/" />,
+              }
+            )}
+          </TextBlock>
+          <Panel>
+            <PanelHeader>{t('Auth Token')}</PanelHeader>
 
-          {tokenList?.map(token => (
-            <div key={token}>{token}</div>
-          ))}
-        </PanelBody>
-      </Panel>
-    </div>
+            <PanelBody>
+              {hasLoadingError && (
+                <LoadingError
+                  message={t('Failed to load auth tokens for the organization.')}
+                  onRetry={fetchTokenList}
+                />
+              )}
+
+              {!hasLoadingError && !tokenList && <LoadingIndicator />}
+
+              {!hasLoadingError && tokenList && tokenList.length === 0 && (
+                <EmptyMessage>
+                  {t("You haven't created any authentication tokens yet.")}
+                </EmptyMessage>
+              )}
+
+              {!hasLoadingError &&
+                tokenList &&
+                tokenList.length > 0 &&
+                tokenList.map(token => (
+                  <OrganizationAuthTokensAuthTokenRow
+                    key={token.id}
+                    organization={organization}
+                    token={token}
+                    isRevoking={isRevoking}
+                    revokeToken={hasAccess ? handleRevokeToken : () => {}}
+                    canRevoke={hasAccess}
+                  />
+                ))}
+            </PanelBody>
+          </Panel>
+        </Fragment>
+      )}
+    </Access>
   );
+}
+
+export function tokenPreview(tokenLastCharacters: string) {
+  return `sntrys_************${tokenLastCharacters}`;
 }
 
 export default withOrganization(OrganizationAuthTokensIndex);


### PR DESCRIPTION
This updates the org token overview page UI for an initial version.
This shows only mocked data for now, as the data model is WIP.

![image](https://github.com/getsentry/sentry/assets/2411343/825f657f-770f-4076-836e-6e2421c321c4)
