### PR TITLE
fix(sdk): Patch DSC public_key in relay_transport envelope

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -395,8 +395,12 @@ def configure_sdk():
                     args_list = list(args)
                     envelope = args_list[0]
                     relay_envelope = copy.copy(envelope)
+
                     # fix DSC public_key since SDK assumes everything is upstream_dsn
-                    relay_envelope.headers["trace"]["public_key"] = relay_transport.parsed_dsn.public_key
+                    dsc = relay_envelope.headers.get("trace")
+                    if dsc and relay_transport.parsed_dsn:
+                        dsc["public_key"] = relay_transport.parsed_dsn.public_key
+
                     relay_envelope.items = envelope.items.copy()
                     args = [relay_envelope, *args_list[1:]]
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -395,6 +395,8 @@ def configure_sdk():
                     args_list = list(args)
                     envelope = args_list[0]
                     relay_envelope = copy.copy(envelope)
+                    # fix DSC public_key since SDK assumes everything is upstream_dsn
+                    relay_envelope.headers["trace"]["public_key"] = relay_transport.parsed_dsn.public_key
                     relay_envelope.items = envelope.items.copy()
                     args = [relay_envelope, *args_list[1:]]
 


### PR DESCRIPTION
The SDK assumes one DSN, the `upstream_dsn` and thus the DSC will have the wrong `public_key` which will cause relay to fail its check and drop stuff

fixes https://github.com/getsentry/sentry/issues/50289