### PR TITLE
fix(datascrubbing): Limit sensitiveFields for organization

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -12,6 +12,7 @@ from sentry import audit_log, roles
 from sentry.api.base import ONE_DAY, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.decorators import sudo_required
+from sentry.api.endpoints.project_details import MAX_SENSITIVE_FIELD_CHARS
 from sentry.api.fields import AvatarField
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import serialize
@@ -189,6 +190,8 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     def validate_sensitiveFields(self, value):
         if value and not all(value):
             raise serializers.ValidationError("Empty values are not allowed.")
+        if sum(map(len, value)) > MAX_SENSITIVE_FIELD_CHARS:
+            raise serializers.ValidationError("List of sensitive fields is too long.")
         return value
 
     def validate_safeFields(self, value):

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -269,6 +269,11 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             response = self.get_success_response(org.slug)
             assert not response.data["isDynamicallySampled"]
 
+    def test_sensitive_fields_too_long(self):
+        value = 1000 * ["0123456789"] + ["1"]
+        resp = self.get_response(self.organization.slug, method="put", sensitiveFields=value)
+        assert resp.status_code == 400
+
 
 @region_silo_test
 class OrganizationUpdateTest(OrganizationDetailsTestBase):


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/38803 restricted the number of sensitive fields in _project_ details, but the same field exists in _organization_ details. Add same validation to the org level.

S4S issue: https://sentry.my.sentry.io/organizations/sentry/issues/395735