### PR TITLE
fix(tsc): audit slowest types

### DIFF
--- a/static/app/components/calendar/datePicker.tsx
+++ b/static/app/components/calendar/datePicker.tsx
@@ -2,7 +2,7 @@ import {Calendar, CalendarProps} from 'react-date-range';
 
 import CalendarStylesWrapper from './calendarStylesWrapper';
 
-export type DatePickerProps = CalendarProps;
+export interface DatePickerProps extends CalendarProps {}
 
 function DatePicker(props: DatePickerProps) {
   return (

--- a/static/app/components/calendar/dateRangePicker.tsx
+++ b/static/app/components/calendar/dateRangePicker.tsx
@@ -3,11 +3,12 @@ import {DateRange, DateRangeProps, Range, RangeKeyDict} from 'react-date-range';
 
 import CalendarStylesWrapper from './calendarStylesWrapper';
 
-export type DateRangePickerProps = Omit<DateRangeProps, 'ranges' | 'onChange'> & {
+export interface DateRangePickerProps
+  extends Omit<DateRangeProps, 'ranges' | 'onChange'> {
   onChange: (range: Range) => void;
   endDate?: Date;
   startDate?: Date;
-};
+}
 
 type RangeSelection = {primary: Range};
 

--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -105,10 +105,8 @@ function Menu(props: React.ComponentProps<typeof selectComponents.Menu>) {
   );
 }
 
-export type ControlProps<OptionType extends OptionTypeBase = GeneralSelectValue> = Omit<
-  ReactSelectProps<OptionType>,
-  'onChange' | 'value'
-> & {
+export interface ControlProps<OptionType extends OptionTypeBase = GeneralSelectValue>
+  extends Omit<ReactSelectProps<OptionType>, 'onChange' | 'value'> {
   /**
    * Backwards compatible shim to work with select2 style choice type.
    */
@@ -142,18 +140,19 @@ export type ControlProps<OptionType extends OptionTypeBase = GeneralSelectValue>
    * can't have a good type here.
    */
   value?: any;
-};
+}
 
 /**
  * Additional props provided by forwardRef
  */
-type WrappedControlProps<OptionType extends OptionTypeBase> = ControlProps<OptionType> & {
+interface WrappedControlProps<OptionType extends OptionTypeBase>
+  extends ControlProps<OptionType> {
   /**
    * Ref forwarded into ReactSelect component.
    * The any is inherited from react-select.
    */
   forwardedRef: React.Ref<ReactSelect>;
-};
+}
 
 // TODO(ts) The exported component uses forwardRef.
 // This means we cannot fill the SelectValue generic
@@ -472,7 +471,8 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   );
 }
 
-type PickerProps<OptionType extends OptionTypeBase> = ControlProps<OptionType> & {
+export interface PickerProps<OptionType extends OptionTypeBase>
+  extends ControlProps<OptionType> {
   /**
    * Enable async option loading.
    */
@@ -485,7 +485,7 @@ type PickerProps<OptionType extends OptionTypeBase> = ControlProps<OptionType> &
    * Enable 'create' mode which allows values to be created inline.
    */
   creatable?: boolean;
-};
+}
 
 function SelectPicker<OptionType extends OptionTypeBase>({
   async,

--- a/static/app/components/overlayArrow.tsx
+++ b/static/app/components/overlayArrow.tsx
@@ -5,13 +5,13 @@ import styled from '@emotion/styled';
 import domId from 'sentry/utils/domId';
 import {ColorOrAlias} from 'sentry/utils/theme';
 
-type Props = React.HTMLAttributes<HTMLDivElement> & {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   background?: ColorOrAlias;
   border?: ColorOrAlias;
   placement?: PopperProps<any>['placement'];
   size?: number;
   strokeWidth?: number;
-};
+}
 
 function BaseOverlayArrow(
   {

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -68,26 +68,28 @@ import {
   workflowEventMap,
 } from './analytics/workflowAnalyticsEvents';
 
-type EventParameters = GrowthEventParameters &
-  CoreUIEventParameters &
-  DashboardsEventParameters &
-  DiscoverEventParameters &
-  IssueEventParameters &
-  MonitorsEventParameters &
-  PerformanceEventParameters &
-  ProfilingEventParameters &
-  ReleasesEventParameters &
-  ReplayEventParameters &
-  SearchEventParameters &
-  SettingsEventParameters &
-  TeamInsightsEventParameters &
-  DynamicSamplingEventParameters &
-  OnboardingEventParameters &
-  StackTraceEventParameters &
-  AiSuggestedSolutionEventParameters &
-  EcosystemEventParameters &
-  IntegrationEventParameters &
-  ProjectCreationEventParameters;
+interface EventParameters
+  extends GrowthEventParameters,
+    CoreUIEventParameters,
+    DashboardsEventParameters,
+    DiscoverEventParameters,
+    IssueEventParameters,
+    MonitorsEventParameters,
+    PerformanceEventParameters,
+    ProfilingEventParameters,
+    ReleasesEventParameters,
+    ReplayEventParameters,
+    SearchEventParameters,
+    SettingsEventParameters,
+    TeamInsightsEventParameters,
+    DynamicSamplingEventParameters,
+    OnboardingEventParameters,
+    StackTraceEventParameters,
+    AiSuggestedSolutionEventParameters,
+    EcosystemEventParameters,
+    IntegrationEventParameters,
+    ProjectCreationEventParameters,
+    Record<string, Record<string, any>> {}
 
 const allEventMap: Record<string, string | null> = {
   ...coreUIEventMap,

--- a/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
@@ -14,14 +14,14 @@ import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 import WidgetContainer from './widgetContainer';
 
-export type ChartRowProps = {
+export interface ChartRowProps {
   allowedCharts: PerformanceWidgetSetting[];
   chartCount: number;
   chartHeight: number;
   eventView: EventView;
   location: Location;
   withStaticFilters: boolean;
-};
+}
 
 function getInitialChartSettings(
   chartCount: number,

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -38,7 +38,7 @@ import {VitalWidget} from '../widgets/vitalWidget';
 
 import {ChartRowProps} from './widgetChartRow';
 
-type Props = {
+interface Props extends ChartRowProps {
   allowedCharts: PerformanceWidgetSetting[];
   chartHeight: number;
   defaultChartSetting: PerformanceWidgetSetting;
@@ -50,7 +50,7 @@ type Props = {
   withStaticFilters: boolean;
   chartColor?: string;
   forceDefaultChartSetting?: boolean;
-} & ChartRowProps;
+}
 
 function trackChartSettingChange(
   previousChartSetting: PerformanceWidgetSetting,


### PR DESCRIPTION
Quick audit on slowest types as per the use interface vs type doc changes. Good news is that we haven't seem to have regressed much at all, just a couple of occurrences here and there (but these might have been there before anyways).

The changes seem to shave ~3s or about 10% of time on my machine.