### PR TITLE
feat(crons): Add environment support to monitor alert rules

### DIFF
--- a/src/sentry/monitors/utils.py
+++ b/src/sentry/monitors/utils.py
@@ -100,7 +100,7 @@ def create_alert_rule_data(project: Project, user: User, monitor: Monitor, alert
             "name": user.email,
         },
         "dateCreated": timezone.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-        "environment": None,
+        "environment": alert_rule.get("environment", None),
         "filterMatch": "all",
         "filters": [
             {

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -50,6 +50,9 @@ class MonitorAlertRuleTargetValidator(serializers.Serializer):
 
 
 class MonitorAlertRuleValidator(serializers.Serializer):
+    environment = serializers.CharField(
+        max_length=64, required=False, allow_null=True, help_text="Name of the environment"
+    )
     targets = MonitorAlertRuleTargetValidator(
         many=True,
         help_text="Array of dictionaries with information of the user or team to be notified",


### PR DESCRIPTION
Adds the ability to specify environments in monitor alert rules

Initial work for https://github.com/getsentry/sentry/issues/49209