### PR TITLE
fix(indexer): Add join timeout for indexer parallel consumer

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -599,6 +599,7 @@ def occurrences_ingest_consumer(**options):
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--ingest-profile", required=True)
 @click.option("--indexer-db", default="postgres")
+@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=5)
 @click.option("max_msg_batch_size", "--max-msg-batch-size", type=int, default=50)
 @click.option("max_msg_batch_time", "--max-msg-batch-time-ms", type=int, default=10000)
 @click.option("max_parallel_batch_size", "--max-parallel-batch-size", type=int, default=50)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -599,7 +599,7 @@ def occurrences_ingest_consumer(**options):
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--ingest-profile", required=True)
 @click.option("--indexer-db", default="postgres")
-@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=5)
+@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=60)
 @click.option("max_msg_batch_size", "--max-msg-batch-size", type=int, default=50)
 @click.option("max_msg_batch_time", "--max-msg-batch-time-ms", type=int, default=10000)
 @click.option("max_parallel_batch_size", "--max-parallel-batch-size", type=int, default=50)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -599,7 +599,7 @@ def occurrences_ingest_consumer(**options):
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--ingest-profile", required=True)
 @click.option("--indexer-db", default="postgres")
-@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=60)
+@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=10)
 @click.option("max_msg_batch_size", "--max-msg-batch-size", type=int, default=50)
 @click.option("max_msg_batch_time", "--max-msg-batch-time-ms", type=int, default=10000)
 @click.option("max_parallel_batch_size", "--max-parallel-batch-size", type=int, default=50)

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -182,6 +182,7 @@ def get_parallel_metrics_consumer(
     group_id: str,
     auto_offset_reset: str,
     strict_offset_reset: bool,
+    join_timeout: int,
     indexer_profile: MetricsIngestConfiguration,
     slicing_router: Optional[SlicingRouter],
 ) -> StreamProcessor[KafkaPayload]:
@@ -209,4 +210,5 @@ def get_parallel_metrics_consumer(
         Topic(indexer_profile.input_topic),
         processing_factory,
         ONCE_PER_SECOND,
+        join_timeout=join_timeout,
     )


### PR DESCRIPTION
In order to limit the time a consumer can spend during a join, add a parameter to control the join timeout. This is similar to what was done on the snuba consumers in https://github.com/getsentry/snuba/pull/4222