### PR TITLE
feat(replays): Send replay_event data on issue creation request

### DIFF
--- a/src/sentry/replays/usecases/ingest/dead_click.py
+++ b/src/sentry/replays/usecases/ingest/dead_click.py
@@ -6,7 +6,12 @@ from sentry.replays.usecases.ingest.events import SentryEvent
 from sentry.replays.usecases.issue import new_issue_occurrence
 
 
-def report_dead_click_issue(project_id: int, replay_id: str, event: SentryEvent) -> bool:
+def report_dead_click_issue(
+    project_id: int,
+    replay_id: str,
+    event: SentryEvent,
+    replay_event: Dict[str, Any],
+) -> bool:
     payload = event["data"]["payload"]
 
     # Only timeout reasons on <a> and <button> tags are accepted.
@@ -19,21 +24,36 @@ def report_dead_click_issue(project_id: int, replay_id: str, event: SentryEvent)
     timestamp = datetime.datetime.fromtimestamp(payload["timestamp"])
     timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
 
+    # Deserialized replay_event payload key.
+    replay_event_payload = replay_event.get("payload", {})
+
+    # Modify the contexts object to ensure the replay_id key is included.
+    contexts_data = replay_event_payload.get("contexts", {})
+    if "replay" in contexts_data:
+        contexts_data["replay"]["replay_id"] = replay_id
+    else:
+        contexts_data["replay"] = {"replay_id": replay_id}
+
+    # Modify the tags object to ensure the replayId key is included.
+    tags_data = replay_event_payload.get("tags", {})
+    tags_data.update({"replayId": replay_id})
+
     _report_dead_click_issue(
-        environment="prod",
+        environment=replay_event_payload.get("platform", "javascript"),
         fingerprint=payload["message"],
         project_id=project_id,
         subtitle=payload["message"],
         timestamp=timestamp,
         extra_event_data={
-            "contexts": {"replay": {"replay_id": replay_id}},
+            "contexts": contexts_data,
+            "dist": replay_event_payload.get("dist", None),
+            "environment": replay_event_payload.get("environment", None),
             "level": "warning",
-            "tags": {"replayId": replay_id},
-            "user": {
-                "id": "1",
-                "username": "Test User",
-                "email": "test.user@sentry.io",
-            },
+            "release": replay_event_payload.get("release", None),
+            "request": replay_event_payload.get("request", {}),
+            "sdk": replay_event_payload.get("sdk", {}),
+            "tags": tags_data,
+            "user": replay_event_payload.get("user", {}),
         },
     )
 

--- a/tests/sentry/replays/unit/test_dead_click_issue.py
+++ b/tests/sentry/replays/unit/test_dead_click_issue.py
@@ -17,7 +17,7 @@ def test_report_dead_click_issue_a_tag():
         }
     }
 
-    reported = report_dead_click_issue(project_id=1, replay_id="", event=event)
+    reported = report_dead_click_issue(project_id=1, replay_id="", event=event, replay_event={})
     assert reported is True
 
 
@@ -33,7 +33,7 @@ def test_report_dead_click_issue_other_tag():
         }
     }
 
-    reported = report_dead_click_issue(project_id=1, replay_id="", event=event)
+    reported = report_dead_click_issue(project_id=1, replay_id="", event=event, replay_event={})
     assert reported is False
 
 
@@ -49,5 +49,5 @@ def test_report_dead_click_issue_mutation_reason():
         }
     }
 
-    reported = report_dead_click_issue(project_id=1, replay_id="", event=event)
+    reported = report_dead_click_issue(project_id=1, replay_id="", event=event, replay_event={})
     assert reported is False

--- a/tests/sentry/replays/unit/test_ingest_dom_index.py
+++ b/tests/sentry/replays/unit/test_ingest_dom_index.py
@@ -45,7 +45,7 @@ def test_get_user_actions():
         }
     ]
 
-    user_actions = get_user_actions(1, uuid.uuid4().hex, events)
+    user_actions = get_user_actions(1, uuid.uuid4().hex, events, {})
     assert len(user_actions) == 1
     assert user_actions[0]["node_id"] == 1
     assert user_actions[0]["tag"] == "div"
@@ -79,7 +79,7 @@ def test_get_user_actions_missing_node():
         }
     ]
 
-    user_actions = get_user_actions(1, uuid.uuid4().hex, events)
+    user_actions = get_user_actions(1, uuid.uuid4().hex, events, {})
     assert len(user_actions) == 0
 
 
@@ -116,7 +116,7 @@ def test_parse_replay_actions():
             },
         }
     ]
-    replay_actions = parse_replay_actions(1, "1", 30, events)
+    replay_actions = parse_replay_actions(1, "1", 30, events, {})
 
     assert replay_actions["type"] == "replay_event"
     assert isinstance(replay_actions["start_time"], float)
@@ -190,7 +190,7 @@ def test_parse_request_response_latest():
         }
     ]
     with mock.patch("sentry.utils.metrics.timing") as timing:
-        parse_replay_actions(1, "1", 30, events)
+        parse_replay_actions(1, "1", 30, events, {})
         assert timing.call_args_list == [
             mock.call("replays.usecases.ingest.request_body_size", 2949),
             mock.call("replays.usecases.ingest.response_body_size", 94),
@@ -217,7 +217,7 @@ def test_parse_request_response_no_info():
             },
         },
     ]
-    parse_replay_actions(1, "1", 30, events)
+    parse_replay_actions(1, "1", 30, events, {})
     # just make sure we don't raise
 
 
@@ -243,7 +243,7 @@ def test_parse_request_response_old_format_request_only():
         },
     ]
     with mock.patch("sentry.utils.metrics.timing") as timing:
-        parse_replay_actions(1, "1", 30, events)
+        parse_replay_actions(1, "1", 30, events, {})
         assert timing.call_args_list == [
             mock.call("replays.usecases.ingest.request_body_size", 1002),
         ]
@@ -271,7 +271,7 @@ def test_parse_request_response_old_format_response_only():
         },
     ]
     with mock.patch("sentry.utils.metrics.timing") as timing:
-        parse_replay_actions(1, "1", 30, events)
+        parse_replay_actions(1, "1", 30, events, {})
         assert timing.call_args_list == [
             mock.call("replays.usecases.ingest.response_body_size", 1002),
         ]
@@ -300,7 +300,7 @@ def test_parse_request_response_old_format_request_and_response():
         },
     ]
     with mock.patch("sentry.utils.metrics.timing") as timing:
-        parse_replay_actions(1, "1", 30, events)
+        parse_replay_actions(1, "1", 30, events, {})
         assert timing.call_args_list == [
             mock.call("replays.usecases.ingest.request_body_size", 1002),
             mock.call("replays.usecases.ingest.response_body_size", 8001),
@@ -338,7 +338,7 @@ def test_log_sdk_options():
         "random.randint"
     ) as randint:
         randint.return_value = 0
-        parse_replay_actions(1, "1", 30, events)
+        parse_replay_actions(1, "1", 30, events, {})
         assert logger.info.call_args_list == [mock.call("SDK Options:", extra=log)]
 
 
@@ -367,7 +367,7 @@ def test_log_large_dom_mutations():
         "random.randint"
     ) as randint:
         randint.return_value = 0
-        parse_replay_actions(1, "1", 30, events)
+        parse_replay_actions(1, "1", 30, events, {})
         assert logger.info.call_args_list == [mock.call("Large DOM Mutations List:", extra=log)]
 
 


### PR DESCRIPTION
TODO: When the replay_event becomes available update the test coverage and call sites.

Sends replay_event metadata to the issue platform for display on the issues page.