### PR TITLE
feat(scim): Create datadog metrics for scim

### DIFF
--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -208,9 +208,7 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
                 "idp_provisioned": True,
             }
         )
-        metrics.incr(
-            "sentry.scim.team.provision", sample_rate=1.0, tags={"organization": organization}
-        )
+        metrics.incr("sentry.scim.team.provision", tags={"organization": organization})
         return super().post(request, organization)
 
 
@@ -450,9 +448,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             sentry_sdk.capture_exception(e)
             return Response(SCIM_400_INTEGRITY_ERROR, status=400)
 
-        metrics.incr(
-            "sentry.scim.team.update", sample_rate=1.0, tags={"organization": organization}
-        )
+        metrics.incr("sentry.scim.team.update", tags={"organization": organization})
         return self.respond(status=204)
 
     @extend_schema(
@@ -470,9 +466,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         """
         Delete a team with a SCIM Group DELETE Request.
         """
-        metrics.incr(
-            "sentry.scim.team.delete", sample_rate=1.0, tags={"organization": organization}
-        )
+        metrics.incr("sentry.scim.team.delete", tags={"organization": organization})
         return super().delete(request, team)
 
     def put(self, request: Request, organization, team) -> Response:

--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.models import OrganizationMemberTeam, Team, TeamStatus
@@ -73,7 +75,8 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         )
         assert response.status_code == 400, response.content
 
-    def test_scim_team_details_patch_replace_rename_team(self):
+    @patch("sentry.scim.endpoints.teams.metrics")
+    def test_scim_team_details_patch_replace_rename_team(self, mock_metrics):
         team = self.create_team(organization=self.organization)
         url = reverse(
             "sentry-api-0-organization-scim-team-details", args=[self.organization.slug, team.id]
@@ -97,6 +100,9 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert Team.objects.get(id=team.id).slug == "newname"
         assert Team.objects.get(id=team.id).name == "newName"
         assert Team.objects.get(id=team.id).idp_provisioned
+        mock_metrics.incr.assert_called_with(
+            "sentry.scim.team.update", sample_rate=1.0, tags={"organization": self.organization}
+        )
 
     def test_scim_team_details_patch_add(self):
         team = self.create_team(organization=self.organization)
@@ -309,7 +315,8 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert Team.objects.get(id=self.team.id).slug == "thenewname"
         assert Team.objects.get(id=self.team.id).idp_provisioned
 
-    def test_delete_team(self):
+    @patch("sentry.scim.endpoints.teams.metrics")
+    def test_delete_team(self, mock_metrics):
         team = self.create_team(organization=self.organization)
         url = reverse(
             "sentry-api-0-organization-scim-team-details", args=[self.organization.slug, team.id]
@@ -318,6 +325,9 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert response.status_code == 204, response.content
 
         assert Team.objects.get(id=team.id).status == TeamStatus.PENDING_DELETION
+        mock_metrics.incr.assert_called_with(
+            "sentry.scim.team.delete", sample_rate=1.0, tags={"organization": self.organization}
+        )
 
     def test_remove_member_azure(self):
         member1 = self.create_member(

--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -101,7 +101,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert Team.objects.get(id=team.id).name == "newName"
         assert Team.objects.get(id=team.id).idp_provisioned
         mock_metrics.incr.assert_called_with(
-            "sentry.scim.team.update", sample_rate=1.0, tags={"organization": self.organization}
+            "sentry.scim.team.update", tags={"organization": self.organization}
         )
 
     def test_scim_team_details_patch_add(self):
@@ -326,7 +326,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
 
         assert Team.objects.get(id=team.id).status == TeamStatus.PENDING_DELETION
         mock_metrics.incr.assert_called_with(
-            "sentry.scim.team.delete", sample_rate=1.0, tags={"organization": self.organization}
+            "sentry.scim.team.delete", tags={"organization": self.organization}
         )
 
     def test_remove_member_azure(self):

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -228,7 +228,3 @@ class SCIMGroupIndexTests(SCIMTestCase):
         )
         response = self.client.post(url, CREATE_TEAM_POST_DATA)
         assert response.status_code == 409, response.content
-        assert response.status_code == 409, response.content
-        assert response.status_code == 409, response.content
-        assert response.status_code == 409, response.content
-        assert response.status_code == 409, response.content

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -52,7 +52,6 @@ class SCIMGroupIndexTests(SCIMTestCase):
         assert len(Team.objects.get(id=team_id).member_set) == 0
         mock_metrics.incr.assert_called_with(
             "sentry.scim.team.provision",
-            sample_rate=1.0,
             tags={"organization": self.organization},
         )
 

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.models import Team
@@ -26,7 +28,8 @@ class SCIMGroupIndexTests(SCIMTestCase):
         assert response.status_code == 200, response.content
         assert response.data == correct_get_data
 
-    def test_scim_team_index_create(self):
+    @patch("sentry.scim.endpoints.teams.metrics")
+    def test_scim_team_index_create(self, mock_metrics):
         url = reverse(
             "sentry-api-0-organization-scim-team-index",
             args=[self.organization.slug],
@@ -47,6 +50,11 @@ class SCIMGroupIndexTests(SCIMTestCase):
         assert Team.objects.get(id=team_id).name == "Test SCIMv2"
         assert Team.objects.get(id=team_id).idp_provisioned
         assert len(Team.objects.get(id=team_id).member_set) == 0
+        mock_metrics.incr.assert_called_with(
+            "sentry.scim.team.provision",
+            sample_rate=1.0,
+            tags={"organization": self.organization},
+        )
 
     def test_scim_team_index_populated(self):
         team = self.create_team(organization=self.organization)
@@ -219,4 +227,8 @@ class SCIMGroupIndexTests(SCIMTestCase):
             args=[self.organization.slug],
         )
         response = self.client.post(url, CREATE_TEAM_POST_DATA)
+        assert response.status_code == 409, response.content
+        assert response.status_code == 409, response.content
+        assert response.status_code == 409, response.content
+        assert response.status_code == 409, response.content
         assert response.status_code == 409, response.content

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
@@ -129,6 +130,25 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
             method="put",
             status_code=400,
             **generate_put_data(self.restricted_custom_role_member, role="owner"),
+        )
+
+    @patch("sentry.scim.endpoints.members.metrics")
+    def test_metrics(self, mock_metrics):
+        # current restricted default role + blank sentryOrgRole -> unrestricted default role
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.restricted_default_role_member.id,
+            method="put",
+            **generate_put_data(self.restricted_default_role_member),
+        )
+        self.restricted_default_role_member.refresh_from_db()
+        assert resp.data["sentryOrgRole"] == self.organization.default_role
+        assert self.restricted_default_role_member.role == self.organization.default_role
+        assert not self.restricted_default_role_member.flags["idp:role-restricted"]
+        mock_metrics.incr.assert_called_with(
+            "sentry.scim.member.update_role",
+            sample_rate=1.0,
+            tags={"organization": self.organization},
         )
 
     def test_set_to_blank(self):
@@ -337,7 +357,8 @@ class SCIMMemberDetailsTests(SCIMTestCase):
             "sentryOrgRole": self.organization.default_role,
         }
 
-    def test_user_details_set_inactive(self):
+    @patch("sentry.scim.endpoints.members.metrics")
+    def test_user_details_set_inactive(self, mock_metrics):
         member = self.create_member(
             user=self.create_user(email="test.user@okta.local"), organization=self.organization
         )
@@ -355,6 +376,9 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         response = self.client.patch(url, patch_req)
 
         assert response.status_code == 204, response.content
+        mock_metrics.incr.assert_called_with(
+            "sentry.scim.member.update", sample_rate=1.0, tags={"organization": self.organization}
+        )
 
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
@@ -380,7 +404,6 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         response = self.client.patch(url, patch_req)
 
         assert response.status_code == 204, response.content
-
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
 
@@ -495,7 +518,8 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         response = self.client.patch(url, patch_req)
         assert response.status_code == 404, response.content
 
-    def test_delete_route(self):
+    @patch("sentry.scim.endpoints.members.metrics")
+    def test_delete_route(self, mock_metrics):
         member = self.create_member(user=self.create_user(), organization=self.organization)
         AuthIdentity.objects.create(
             user=member.user, auth_provider=self.auth_provider, ident="test_ident"
@@ -506,6 +530,9 @@ class SCIMMemberDetailsTests(SCIMTestCase):
         )
         response = self.client.delete(url)
         assert response.status_code == 204, response.content
+        mock_metrics.incr.assert_called_with(
+            "sentry.scim.member.delete", sample_rate=1.0, tags={"organization": self.organization}
+        )
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(organization=self.organization, id=member.id)
         with pytest.raises(AuthIdentity.DoesNotExist):

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from django.urls import reverse
 from django.utils import timezone
@@ -21,6 +21,10 @@ CREATE_USER_POST_DATA = {
     "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
     "active": True,
 }
+
+
+def merge_dictionaries(dict1, dict2):
+    return {**dict1, **dict2}
 
 
 @control_silo_test
@@ -73,8 +77,51 @@ class SCIMMemberIndexTests(SCIMTestCase, HybridCloudTestMixin):
         assert member.role == self.organization.default_role
         mock_metrics.incr.assert_called_with(
             "sentry.scim.member.provision",
-            sample_rate=1.0,
             tags={"organization": self.organization},
+        )
+
+    @patch("sentry.scim.endpoints.members.metrics")
+    def test_update_role_metric_called_when_role_specified(self, mock_metrics):
+        url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
+        with outbox_runner():
+            response = self.client.post(
+                url, merge_dictionaries(CREATE_USER_POST_DATA, {"sentryOrgRole": "member"})
+            )
+        assert response.status_code == 201, response.content
+        member = OrganizationMember.objects.get(
+            organization=self.organization, email="test.user@okta.local"
+        )
+        self.assert_org_member_mapping(org_member=member)
+        correct_post_data = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            "id": str(member.id),
+            "userName": "test.user@okta.local",
+            "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
+            "active": True,
+            "name": {"familyName": "N/A", "givenName": "N/A"},
+            "meta": {"resourceType": "User"},
+            "sentryOrgRole": "member",
+        }
+
+        assert AuditLogEntry.objects.filter(
+            target_object=member.id, event=audit_log.get_event_id("MEMBER_INVITE")
+        ).exists()
+        assert correct_post_data == response.data
+        assert member.email == "test.user@okta.local"
+        assert member.flags["idp:provisioned"]
+        assert member.flags["idp:role-restricted"]
+        assert member.role == self.organization.default_role
+        mock_metrics.incr.assert_has_calls(
+            [
+                call(
+                    "sentry.scim.member.provision",
+                    tags={"organization": self.organization},
+                ),
+                call(
+                    "sentry.scim.member.update_role",
+                    tags={"organization": self.organization},
+                ),
+            ],
         )
 
     def test_post_users_successful_existing_invite(self):


### PR DESCRIPTION
Create datadog metrics for the following SCIM actions:

Team related
- Provisioning a new team
- Updating a team
- Deleting a team

Member related
- Provisioning a new member
- Updating a member (uses same metric as delete b/c limited to only deleting members at the moment)
- Deleting a member
- Changing a member's role