### PR TITLE
feat(replays): Soften dead click issue title language to reflect the uncertainty in the detection

### DIFF
--- a/src/sentry/replays/usecases/ingest/dead_click.py
+++ b/src/sentry/replays/usecases/ingest/dead_click.py
@@ -57,6 +57,6 @@ def _report_dead_click_issue(
         project_id=project_id,
         subtitle=subtitle,
         timestamp=timestamp,
-        title="[TEST] Dead Click Detected",
+        title="Possible Dead Click Detected",
         extra_event_data=extra_event_data,
     )

--- a/src/sentry/replays/usecases/ingest/dead_click.py
+++ b/src/sentry/replays/usecases/ingest/dead_click.py
@@ -57,6 +57,6 @@ def _report_dead_click_issue(
         project_id=project_id,
         subtitle=subtitle,
         timestamp=timestamp,
-        title="Possible Dead Click Detected",
+        title="Suspected Dead Click",
         extra_event_data=extra_event_data,
     )


### PR DESCRIPTION
Currently we say "we've definitively found a dead click" but that may not be the case.  This is a heuristic and that uncertainty should be conveyed to the user so this feature is not mentally discarded.  We should convey a "warning" log not an "error" log.