### PR TITLE
feat(starfish): add units to duration charts

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -236,12 +236,16 @@ function Chart({
         return element.classList.contains('echarts-for-react');
       }
     );
+
     if (hoveredEchartElement === chartRef?.current?.ele) {
       // Return undefined to use default formatter
       return getFormatter({
         isGroupedByDate: true,
         showTimeInTooltip: true,
         utc,
+        valueFormatter: (value, seriesName) => {
+          return tooltipFormatter(value, aggregateOutputType(seriesName));
+        },
         ...tooltipFormatterOptions,
       })(params, asyncTicket);
     }

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -244,7 +244,10 @@ function Chart({
         showTimeInTooltip: true,
         utc,
         valueFormatter: (value, seriesName) => {
-          return tooltipFormatter(value, aggregateOutputType(seriesName));
+          return tooltipFormatter(
+            value,
+            aggregateOutputFormat ?? aggregateOutputType(seriesName)
+          );
         },
         ...tooltipFormatterOptions,
       })(params, asyncTicket);

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -126,7 +126,6 @@ export function SpanTimeCharts({moduleName, appliedFilters}: Props) {
       <ChartsContainerItem>
         <ChartPanel title={DataTitles.p95}>
           <Chart
-            aggregateOutputFormat="duration"
             statsPeriod="24h"
             height={100}
             data={[...p95Series]}

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -126,6 +126,7 @@ export function SpanTimeCharts({moduleName, appliedFilters}: Props) {
       <ChartsContainerItem>
         <ChartPanel title={DataTitles.p95}>
           <Chart
+            aggregateOutputFormat="duration"
             statsPeriod="24h"
             height={100}
             data={[...p95Series]}


### PR DESCRIPTION
This PR uses the generic tooltip formatter to set the units in the tooltip based on the series name.
This ensures that all p95() charts include a duration in the tooltip
Before
<img width="621" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/2c5b05df-b1a2-42e1-abf5-b270b0f82188">

After
<img width="649" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/2162db91-d33b-47d5-acca-5abb9894ce06">
