### PR TITLE
ref(group-preview-tooltip): Remove broken event previews

### DIFF
--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -25,7 +25,7 @@ function EventOrGroupTitle({
   grouping = false,
   className,
 }: EventOrGroupTitleProps) {
-  const {id, eventID, groupID, projectID} = data as Event;
+  const {id, groupID} = data as Event;
 
   const {title, subtitle, treeLabel} = getTitle(data, organization?.features, grouping);
   const titleLabel = treeLabel ? (
@@ -41,8 +41,6 @@ function EventOrGroupTitle({
           groupId={groupID ? groupID : id}
           issueCategory={data.issueCategory}
           groupingCurrentLevel={data.metadata?.current_level}
-          eventId={eventID}
-          projectId={projectID}
         >
           {titleLabel}
         </GroupPreviewTooltip>

--- a/static/app/components/groupPreviewTooltip/evidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/evidencePreview.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as useApi from 'sentry/utils/useApi';
 
@@ -19,49 +19,11 @@ describe('EvidencePreview', () => {
     jest.spyOn(useApi, 'default').mockReturnValue(api);
     const spy = jest.spyOn(api, 'requestPromise');
 
-    render(
-      <EvidencePreview eventId="event-id" projectSlug="project-slug" groupId="group-id">
-        Hover me
-      </EvidencePreview>
-    );
+    render(<EvidencePreview groupId="group-id">Hover me</EvidencePreview>);
 
     jest.runAllTimers();
 
     expect(spy).not.toHaveBeenCalled();
-  });
-
-  it('fetches from event URL when event and project are provided', async () => {
-    const mock = MockApiClient.addMockResponse({
-      url: `/projects/org-slug/project-slug/events/event-id/`,
-      body: null,
-    });
-
-    render(
-      <EvidencePreview eventId="event-id" projectSlug="project-slug" groupId="group-id">
-        Hover me
-      </EvidencePreview>
-    );
-
-    await userEvent.hover(screen.getByText('Hover me'), {delay: null});
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalled();
-    });
-  });
-
-  it('fetches from group URL when only group ID is provided', async () => {
-    const mock = MockApiClient.addMockResponse({
-      url: `/issues/group-id/events/latest/`,
-      body: null,
-    });
-
-    render(<EvidencePreview groupId="group-id">Hover me</EvidencePreview>);
-
-    await userEvent.hover(screen.getByText('Hover me'), {delay: null});
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalled();
-    });
   });
 
   it('shows error when request fails', async () => {

--- a/static/app/components/groupPreviewTooltip/evidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/evidencePreview.tsx
@@ -14,8 +14,6 @@ import {space} from 'sentry/styles/space';
 type SpanEvidencePreviewProps = {
   children: ReactChild;
   groupId: string;
-  eventId?: string;
-  projectSlug?: string;
 };
 
 type SpanEvidencePreviewBodyProps = {
@@ -23,8 +21,6 @@ type SpanEvidencePreviewBodyProps = {
   onRequestBegin: () => void;
   onRequestEnd: () => void;
   onUnmount: () => void;
-  eventId?: string;
-  projectSlug?: string;
 };
 
 function SpanEvidencePreviewBody({
@@ -32,10 +28,8 @@ function SpanEvidencePreviewBody({
   onRequestEnd,
   onUnmount,
   groupId,
-  eventId,
-  projectSlug,
 }: SpanEvidencePreviewBodyProps) {
-  const {data, isLoading, isError} = usePreviewEvent({groupId, eventId, projectSlug});
+  const {data, isLoading, isError} = usePreviewEvent({groupId});
 
   useEffect(() => {
     if (isLoading) {
@@ -81,12 +75,7 @@ function SpanEvidencePreviewBody({
   );
 }
 
-export function EvidencePreview({
-  children,
-  groupId,
-  eventId,
-  projectSlug,
-}: SpanEvidencePreviewProps) {
+export function EvidencePreview({children, groupId}: SpanEvidencePreviewProps) {
   const {shouldShowLoadingState, onRequestBegin, onRequestEnd, reset} =
     useDelayedLoadingState();
 
@@ -99,8 +88,6 @@ export function EvidencePreview({
           onRequestEnd={onRequestEnd}
           onUnmount={reset}
           groupId={groupId}
-          eventId={eventId}
-          projectSlug={projectSlug}
         />
       }
     >

--- a/static/app/components/groupPreviewTooltip/index.tsx
+++ b/static/app/components/groupPreviewTooltip/index.tsx
@@ -1,7 +1,6 @@
 import {ReactChild} from 'react';
 
 import {EvidencePreview} from 'sentry/components/groupPreviewTooltip/evidencePreview';
-import ProjectsStore from 'sentry/stores/projectsStore';
 import {IssueCategory} from 'sentry/types';
 
 import {SpanEvidencePreview} from './spanEvidencePreview';
@@ -10,9 +9,6 @@ import {StackTracePreview} from './stackTracePreview';
 type GroupPreviewTooltipProps = {
   children: ReactChild;
   groupId: string;
-  // we need eventId only when hovering over Event, not Group
-  // (different API call is made to get the stack trace then)
-  eventId?: string;
   groupingCurrentLevel?: number;
   issueCategory?: IssueCategory;
   projectId?: string;
@@ -20,42 +16,25 @@ type GroupPreviewTooltipProps = {
 
 function GroupPreviewTooltip({
   children,
-  eventId,
   groupId,
   groupingCurrentLevel,
   issueCategory,
-  projectId,
 }: GroupPreviewTooltipProps) {
-  const projectSlug = eventId ? ProjectsStore.getById(projectId)?.slug : undefined;
+  if (!issueCategory) {
+    return null;
+  }
 
   switch (issueCategory) {
     case IssueCategory.ERROR:
       return (
-        <StackTracePreview
-          groupId={groupId}
-          groupingCurrentLevel={groupingCurrentLevel}
-          eventId={eventId}
-          projectSlug={projectSlug}
-        >
+        <StackTracePreview groupId={groupId} groupingCurrentLevel={groupingCurrentLevel}>
           {children}
         </StackTracePreview>
       );
     case IssueCategory.PERFORMANCE:
-      return (
-        <SpanEvidencePreview
-          groupId={groupId}
-          eventId={eventId}
-          projectSlug={projectSlug}
-        >
-          {children}
-        </SpanEvidencePreview>
-      );
+      return <SpanEvidencePreview groupId={groupId}>{children}</SpanEvidencePreview>;
     default:
-      return (
-        <EvidencePreview groupId={groupId} eventId={eventId} projectSlug={projectSlug}>
-          {children}
-        </EvidencePreview>
-      );
+      return <EvidencePreview groupId={groupId}>{children}</EvidencePreview>;
   }
 }
 

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
@@ -3,7 +3,7 @@ import {
   ProblemSpan,
   TransactionEventBuilder,
 } from 'sentry-test/performance/utils';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as useApi from 'sentry/utils/useApi';
 
@@ -25,57 +25,11 @@ describe('SpanEvidencePreview', () => {
     jest.spyOn(useApi, 'default').mockReturnValue(api);
     const spy = jest.spyOn(api, 'requestPromise');
 
-    render(
-      <SpanEvidencePreview
-        eventId="event-id"
-        projectSlug="project-slug"
-        groupId="group-id"
-      >
-        Hover me
-      </SpanEvidencePreview>
-    );
+    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
 
     jest.runAllTimers();
 
     expect(spy).not.toHaveBeenCalled();
-  });
-
-  it('fetches from event URL when event and project are provided', async () => {
-    const mock = MockApiClient.addMockResponse({
-      url: `/projects/org-slug/project-slug/events/event-id/`,
-      body: null,
-    });
-
-    render(
-      <SpanEvidencePreview
-        eventId="event-id"
-        projectSlug="project-slug"
-        groupId="group-id"
-      >
-        Hover me
-      </SpanEvidencePreview>
-    );
-
-    await userEvent.hover(screen.getByText('Hover me'), {delay: null});
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalled();
-    });
-  });
-
-  it('fetches from group URL when only group ID is provided', async () => {
-    const mock = MockApiClient.addMockResponse({
-      url: `/issues/group-id/events/latest/`,
-      body: null,
-    });
-
-    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
-
-    await userEvent.hover(screen.getByText('Hover me'), {delay: null});
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalled();
-    });
   });
 
   it('shows error when request fails', async () => {

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.tsx
@@ -1,4 +1,4 @@
-import {Fragment, ReactChild, useEffect} from 'react';
+import {ReactChild, useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {SpanEvidenceKeyValueList} from 'sentry/components/events/interfaces/performance/spanEvidenceKeyValueList';
@@ -11,13 +11,10 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {EventTransaction} from 'sentry/types';
-import useOrganization from 'sentry/utils/useOrganization';
 
 type SpanEvidencePreviewProps = {
   children: ReactChild;
   groupId: string;
-  eventId?: string;
-  projectSlug?: string;
 };
 
 type SpanEvidencePreviewBodyProps = {
@@ -25,44 +22,16 @@ type SpanEvidencePreviewBodyProps = {
   onRequestBegin: () => void;
   onRequestEnd: () => void;
   onUnmount: () => void;
-  eventId?: string;
-  projectSlug?: string;
-};
-
-const makeGroupPreviewRequestUrl = ({
-  orgSlug,
-  eventId,
-  groupId,
-  projectSlug,
-}: {
-  orgSlug: string;
-  eventId?: string;
-  groupId?: string;
-  projectSlug?: string;
-}) => {
-  if (eventId && projectSlug) {
-    return `/projects/${orgSlug}/${projectSlug}/events/${eventId}/`;
-  }
-
-  if (groupId) {
-    return `/issues/${groupId}/events/latest/`;
-  }
-
-  return null;
 };
 
 function SpanEvidencePreviewBody({
   groupId,
-  eventId,
   onRequestBegin,
   onRequestEnd,
   onUnmount,
-  projectSlug,
 }: SpanEvidencePreviewBodyProps) {
   const {data, isLoading, isError} = usePreviewEvent<EventTransaction>({
     groupId,
-    eventId,
-    projectSlug,
   });
 
   useEffect(() => {
@@ -90,7 +59,7 @@ function SpanEvidencePreviewBody({
   if (data) {
     return (
       <SpanEvidencePreviewWrapper data-test-id="span-evidence-preview-body">
-        <SpanEvidenceKeyValueList event={data} projectSlug={projectSlug} />
+        <SpanEvidenceKeyValueList event={data} />
       </SpanEvidencePreviewWrapper>
     );
   }
@@ -102,25 +71,9 @@ function SpanEvidencePreviewBody({
   );
 }
 
-export function SpanEvidencePreview({
-  children,
-  groupId,
-  eventId,
-  projectSlug,
-}: SpanEvidencePreviewProps) {
-  const organization = useOrganization();
-  const endpointUrl = makeGroupPreviewRequestUrl({
-    groupId,
-    eventId,
-    projectSlug,
-    orgSlug: organization.slug,
-  });
+export function SpanEvidencePreview({children, groupId}: SpanEvidencePreviewProps) {
   const {shouldShowLoadingState, onRequestBegin, onRequestEnd, reset} =
     useDelayedLoadingState();
-
-  if (!endpointUrl) {
-    return <Fragment>{children}</Fragment>;
-  }
 
   return (
     <GroupPreviewHovercard
@@ -130,8 +83,6 @@ export function SpanEvidencePreview({
           onRequestBegin={onRequestBegin}
           onRequestEnd={onRequestEnd}
           onUnmount={reset}
-          projectSlug={projectSlug}
-          eventId={eventId}
           groupId={groupId}
         />
       }

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {EventError} from 'sentry/types';
 import {EntryType, Event, ExceptionType, ExceptionValue, Frame} from 'sentry/types/event';
@@ -22,40 +22,6 @@ beforeEach(() => {
 });
 
 describe('StackTracePreview', () => {
-  it('fetches from projects when eventId and projectSlug are provided', async () => {
-    const mockGet = MockApiClient.addMockResponse({
-      url: `/projects/org-slug/project_slug/events/456/`,
-      body: makeEvent({id: '456', entries: []}),
-    });
-
-    render(
-      <StackTracePreview groupId="123" eventId="456" projectSlug="project_slug">
-        Preview Trigger
-      </StackTracePreview>
-    );
-
-    await userEvent.hover(screen.getByText(/Preview Trigger/));
-
-    await waitFor(() => {
-      expect(mockGet).toHaveBeenCalled();
-    });
-  });
-
-  it('fetches from issues when eventId and projectSlug are not provided', async () => {
-    const mockGet = MockApiClient.addMockResponse({
-      url: `/issues/123/events/latest/`,
-      body: makeEvent({id: '456', entries: []}),
-    });
-
-    render(<StackTracePreview groupId="123">Preview Trigger</StackTracePreview>);
-
-    await userEvent.hover(screen.getByText(/Preview Trigger/));
-
-    await waitFor(() => {
-      expect(mockGet).toHaveBeenCalled();
-    });
-  });
-
   it('renders error message', async () => {
     MockApiClient.addMockResponse({
       url: `/issues/123/events/latest/`,

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.tsx
@@ -119,16 +119,14 @@ interface StackTracePreviewBodyProps
 
 function StackTracePreviewBody({
   groupId,
-  eventId,
   groupingCurrentLevel,
-  projectSlug,
   onRequestBegin,
   onRequestEnd,
   onUnmount,
 }: StackTracePreviewBodyProps) {
   const organization = useOrganization();
 
-  const {data, isLoading, isError} = usePreviewEvent({groupId, eventId, projectSlug});
+  const {data, isLoading, isError} = usePreviewEvent({groupId});
 
   useEffect(() => {
     if (isLoading) {

--- a/static/app/components/groupPreviewTooltip/utils.tsx
+++ b/static/app/components/groupPreviewTooltip/utils.tsx
@@ -37,15 +37,7 @@ export function useDelayedLoadingState() {
   };
 }
 
-export function usePreviewEvent<T = Event>({
-  groupId,
-  projectSlug,
-  eventId,
-}: {
-  groupId: string;
-  eventId?: string;
-  projectSlug?: string;
-}) {
+export function usePreviewEvent<T = Event>({groupId}: {groupId: string}) {
   const organization = useOrganization();
   const hasPrefetchIssueFeature = organization.features.includes(
     'issue-list-prefetch-issue-on-hover'
@@ -55,9 +47,7 @@ export function usePreviewEvent<T = Event>({
   // be fully loaded already if you preview then click.
   const eventQuery = useApiQuery<T>(
     [
-      eventId && projectSlug
-        ? `/projects/${organization.slug}/${projectSlug}/events/${eventId}/`
-        : `/issues/${groupId}/events/latest/`,
+      `/issues/${groupId}/events/latest/`,
       {query: getGroupEventDetailsQueryData({stacktraceOnly: !hasPrefetchIssueFeature})},
     ],
     {staleTime: 30000, cacheTime: 30000}


### PR DESCRIPTION
The group preview tooltip previously accepted either a group ID or an event ID + project slug. The idea was that you could also preview specific events without a corresponding group. However, since the addition of performance issues we require the issue category to know what kind of preview to display. Ever since that addition, we can't know how to display an event preview and the event previews have been broken.

This just formalizes the need for an issue category and removes all the code paths that use event ID + project slug.