### PR TITLE
ref(crons): Use less verbose human readable cron text

### DIFF
--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -11,7 +11,7 @@ export function crontabAsText(crontabInput: string | null): string | null {
   let parsedSchedule: string;
   try {
     parsedSchedule = cronstrue.toString(crontabInput, {
-      verbose: true,
+      verbose: false,
       use24HourTimeFormat: shouldUse24Hours(),
     });
   } catch (_e) {


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="545" src="https://i.imgur.com/DrM9Zej.png" />

After

<img alt="clipboard.png" width="580" src="https://i.imgur.com/HhmfO9U.png" />