### PR TITLE
fix(crons): No events for disabled Monitors

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -270,7 +270,7 @@ def _process_message(wrapper: Dict) -> None:
 
                 signal_first_checkin(project, monitor)
 
-            if check_in.status == CheckInStatus.ERROR and monitor.status != ObjectStatus.DISABLED:
+            if check_in.status == CheckInStatus.ERROR:
                 monitor_environment.mark_failed(start_time)
             else:
                 monitor_environment.mark_ok(check_in, start_time)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -203,7 +203,7 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
 
             signal_first_checkin(project, monitor)
 
-            if checkin.status == CheckInStatus.ERROR and monitor.status != ObjectStatus.DISABLED:
+            if checkin.status == CheckInStatus.ERROR:
                 monitor_failed = monitor_environment.mark_failed(last_checkin=checkin.date_added)
                 if not monitor_failed:
                     if isinstance(request.auth, ProjectKey):

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -488,6 +488,10 @@ class MonitorEnvironment(Model):
         if not affected:
             return False
 
+        # Do not create event if monitor is disabled
+        if self.monitor.status == ObjectStatus.DISABLED:
+            return True
+
         group_type, level = get_group_type_and_level(reason)
         current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
 

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -133,9 +133,9 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
             monitor_environment = MonitorEnvironment.objects.get(id=checkin.monitor_environment.id)
 
-            # The created monitor environment is active, but the parent monitor
+            # The created monitor environment is in line with the check-in, but the parent monitor
             # is disabled
-            assert monitor_environment.status == MonitorStatus.ACTIVE
+            assert monitor_environment.status == MonitorStatus.ERROR
             assert monitor_environment.last_checkin == checkin.date_added
             assert monitor_environment.next_checkin == monitor.get_next_scheduled_checkin(
                 checkin.date_added

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -180,9 +180,9 @@ class MonitorConsumerTest(TestCase):
 
         monitor_environment = MonitorEnvironment.objects.get(id=checkin.monitor_environment.id)
 
-        # The created monitor environment is active, but the parent monitor is
-        # disabled
-        assert monitor_environment.status == MonitorStatus.ACTIVE
+        # The created monitor environment is in line with the check-in, but the parent monitor
+        # is disabled
+        assert monitor_environment.status == MonitorStatus.ERROR
         assert monitor_environment.last_checkin == checkin.date_added
         assert monitor_environment.next_checkin == monitor.get_next_scheduled_checkin(
             checkin.date_added


### PR DESCRIPTION
Move disabled monitor check to the `mark_failed` function, correctly updating monitor environment status in the background (but not emitting events).

Fixes SENTRY-11WP