### PR TITLE
feat(functions): Properly support time column for functions timeseries

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1600,7 +1600,7 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
         self.groupby = [self.time_column]
 
     @property
-    def time_column(self):
+    def time_column(self) -> SelectType:
         return Column("time")
 
     def resolve_query(

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1592,6 +1592,7 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
             skip_tag_resolution=skip_tag_resolution,
         )
 
+        self.interval = interval
         self.granularity = Granularity(interval)
 
         self.limit = None if limit is None else Limit(limit)

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1566,8 +1566,6 @@ class UnresolvedQuery(QueryBuilder):
 
 
 class TimeseriesQueryBuilder(UnresolvedQuery):
-    time_column = Column("time")
-
     def __init__(
         self,
         dataset: Dataset,
@@ -1600,6 +1598,10 @@ class TimeseriesQueryBuilder(UnresolvedQuery):
 
         # This is a timeseries, the groupby will always be time
         self.groupby = [self.time_column]
+
+    @property
+    def time_column(self):
+        return Column("time")
 
     def resolve_query(
         self,

--- a/src/sentry/search/events/builder/issue_platform.py
+++ b/src/sentry/search/events/builder/issue_platform.py
@@ -33,5 +33,8 @@ class IssuePlatformTimeseriesQueryBuilder(TimeseriesQueryBuilder):
             has_metrics=has_metrics,
             skip_tag_resolution=skip_tag_resolution,
         )
-        self.time_column = manual_group_on_time_aggregation(interval, "time")
         self.groupby = [self.time_column]
+
+    @property
+    def time_column(self):
+        return manual_group_on_time_aggregation(self.granularity.granularity)

--- a/src/sentry/search/events/builder/issue_platform.py
+++ b/src/sentry/search/events/builder/issue_platform.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from sentry.issues.query import manual_group_on_time_aggregation
 from sentry.search.events.builder import TimeseriesQueryBuilder
-from sentry.search.events.types import ParamsType
+from sentry.search.events.types import ParamsType, SelectType
 from sentry.utils.snuba import Dataset
 
 
@@ -36,5 +36,5 @@ class IssuePlatformTimeseriesQueryBuilder(TimeseriesQueryBuilder):
         self.groupby = [self.time_column]
 
     @property
-    def time_column(self):
-        return manual_group_on_time_aggregation(self.granularity.granularity)
+    def time_column(self) -> SelectType:
+        return manual_group_on_time_aggregation(self.granularity.granularity, "time")

--- a/src/sentry/search/events/builder/issue_platform.py
+++ b/src/sentry/search/events/builder/issue_platform.py
@@ -37,4 +37,4 @@ class IssuePlatformTimeseriesQueryBuilder(TimeseriesQueryBuilder):
 
     @property
     def time_column(self) -> SelectType:
-        return manual_group_on_time_aggregation(self.granularity.granularity, "time")
+        return manual_group_on_time_aggregation(self.interval, "time")

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -925,7 +925,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
             self.groupby.insert(0, groupby)
 
     @property
-    def time_column(self):
+    def time_column(self) -> SelectType:
         return self.resolve_time_column(self.granularity.granularity)
 
     def resolve_time_column(self, interval: int) -> Function:

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -915,7 +915,6 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
                     self.granularity = Granularity(granularity)
                     break
 
-        self.time_column = self.resolve_time_column(interval)
         self.limit = None if limit is None else Limit(limit)
 
         # This is a timeseries, the implied groupby will always be time
@@ -924,6 +923,10 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         # If additional groupby is provided it will be used first before time
         if groupby is not None:
             self.groupby.insert(0, groupby)
+
+    @property
+    def time_column(self):
+        return self.resolve_time_column(self.granularity.granularity)
 
     def resolve_time_column(self, interval: int) -> Function:
         """Need to round the timestamp to the interval requested

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -915,6 +915,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
                     self.granularity = Granularity(granularity)
                     break
 
+        self.time_column = self.resolve_time_column(interval)
         self.limit = None if limit is None else Limit(limit)
 
         # This is a timeseries, the implied groupby will always be time
@@ -923,10 +924,6 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         # If additional groupby is provided it will be used first before time
         if groupby is not None:
             self.groupby.insert(0, groupby)
-
-    @property
-    def time_column(self) -> SelectType:
-        return self.resolve_time_column(self.interval)
 
     def resolve_time_column(self, interval: int) -> Function:
         """Need to round the timestamp to the interval requested

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -926,7 +926,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
 
     @property
     def time_column(self) -> SelectType:
-        return self.resolve_time_column(self.granularity.granularity)
+        return self.resolve_time_column(self.interval)
 
     def resolve_time_column(self, interval: int) -> Function:
         """Need to round the timestamp to the interval requested

--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -5,7 +5,7 @@ from snuba_sdk.function import Function
 
 from sentry.search.events.builder import QueryBuilder, TimeseriesQueryBuilder
 from sentry.search.events.datasets.profile_functions import ProfileFunctionsDatasetConfig
-from sentry.search.events.types import SnubaParams
+from sentry.search.events.types import SelectType, SnubaParams
 
 
 class ProfileFunctionsQueryBuilderProtocol(Protocol):
@@ -41,7 +41,7 @@ class ProfileFunctionsTimeseriesQueryBuilder(
     ProfileFunctionsQueryBuilderMixin, TimeseriesQueryBuilder
 ):
     @property
-    def time_column(self):
+    def time_column(self) -> SelectType:
         return Function(
             "toDateTime",
             [

--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -52,10 +52,10 @@ class ProfileFunctionsTimeseriesQueryBuilder(
                             "intDiv",
                             [
                                 Function("toUInt32", [Column("timestamp")]),
-                                self.granularity.granularity,
+                                self.interval,
                             ],
                         ),
-                        self.granularity.granularity,
+                        self.interval,
                     ],
                 ),
             ],

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -18,8 +18,12 @@ class SpansIndexedQueryBuilder(QueryBuilder):
 
 
 class TimeseriesSpanIndexedQueryBuilder(TimeseriesQueryBuilder):
-    time_column = Function("toStartOfHour", [Column("end_timestamp")], "time")
+    @property
+    def time_column(self):
+        return Function("toStartOfHour", [Column("end_timestamp")], "time")
 
 
 class TopEventsSpanIndexedQueryBuilder(TopEventsQueryBuilder):
-    time_column = Function("toStartOfHour", [Column("timestamp")], "time")
+    @property
+    def time_column(self):
+        return Function("toStartOfHour", [Column("timestamp")], "time")

--- a/src/sentry/search/events/builder/spans_indexed.py
+++ b/src/sentry/search/events/builder/spans_indexed.py
@@ -3,6 +3,7 @@ from typing import Optional
 from snuba_sdk import Column, Function
 
 from sentry.search.events.builder import QueryBuilder, TimeseriesQueryBuilder, TopEventsQueryBuilder
+from sentry.search.events.types import SelectType
 
 
 class SpansIndexedQueryBuilder(QueryBuilder):
@@ -19,11 +20,11 @@ class SpansIndexedQueryBuilder(QueryBuilder):
 
 class TimeseriesSpanIndexedQueryBuilder(TimeseriesQueryBuilder):
     @property
-    def time_column(self):
+    def time_column(self) -> SelectType:
         return Function("toStartOfHour", [Column("end_timestamp")], "time")
 
 
 class TopEventsSpanIndexedQueryBuilder(TopEventsQueryBuilder):
     @property
-    def time_column(self):
+    def time_column(self) -> SelectType:
         return Function("toStartOfHour", [Column("timestamp")], "time")

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -67,7 +67,7 @@ def timeseries_query(
     use_metrics_layer: bool = False,
 ) -> Any:
     builder = ProfileFunctionsTimeseriesQueryBuilder(
-        dataset=Dataset.Profiles,
+        dataset=Dataset.Functions,
         params=params,
         query=query,
         interval=rollup,


### PR DESCRIPTION
The TimeseriesProcessor in snuba is deprecated (see getsentry/snuba#4280), so handle the granularity in the query builder.