### PR TITLE
fix: Fix issue stream archive analytics to match issue details

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -141,7 +141,10 @@ export type IssueEventParameters = {
     search_source: string;
     search_type: string;
   };
-  'issues_stream.archived': {status_details?: string; substatus?: string};
+  'issues_stream.archived': {
+    action_status_details?: string;
+    action_substatus?: string;
+  };
   'issues_stream.issue_assigned': IssueStream & {
     assigned_type: string;
     did_assign_suggestion: boolean;

--- a/static/app/views/issueList/actions/index.spec.jsx
+++ b/static/app/views/issueList/actions/index.spec.jsx
@@ -239,10 +239,7 @@ describe('IssueListActions', function () {
         expect(analyticsSpy).toHaveBeenCalledWith(
           'issues_stream.archived',
           expect.objectContaining({
-            status_details: {
-              ignoreUserCount: 300,
-              ignoreUserWindow: 10080,
-            },
+            action_status_details: 'ignoreUserCount',
           })
         );
       });
@@ -280,8 +277,7 @@ describe('IssueListActions', function () {
     expect(analyticsSpy).toHaveBeenCalledWith(
       'issues_stream.archived',
       expect.objectContaining({
-        status_details: {},
-        substatus: 'archived_until_escalating',
+        action_substatus: 'archived_until_escalating',
       })
     );
   });

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -133,9 +133,16 @@ function IssueListActions({
 
   function handleUpdate(data?: any) {
     if (data.status === 'ignored') {
+      const statusDetails = data.statusDetails.ignoreCount
+        ? 'ignoreCount'
+        : data.statusDetails.ignoreDuration
+        ? 'ignoreDuration'
+        : data.statusDetails.ignoreUserCount
+        ? 'ignoreUserCount'
+        : undefined;
       trackAnalytics('issues_stream.archived', {
-        status_details: data.statusDetails,
-        substatus: data.substatus,
+        action_status_details: statusDetails,
+        action_substatus: data.substatus,
         organization,
       });
     }


### PR DESCRIPTION
Fix the `issues_stream.archive` analytics to match the fields in [issue_details.action_clicked](https://github.com/getsentry/sentry/blob/97f4174c28041357aa190f27012dc33c1c7bafc7/static/app/utils/analytics/workflowAnalyticsEvents.tsx#L68) so that they can be shown in one [Amplitude table](https://analytics.amplitude.com/sentry/chart/wbuhbj9s/edit/pfhwb1eq)
