### PR TITLE
ref(calendar): Update hover effects

### DIFF
--- a/static/app/components/calendar/calendarStylesWrapper.tsx
+++ b/static/app/components/calendar/calendarStylesWrapper.tsx
@@ -99,7 +99,8 @@ const CalendarStylesWrapper = styled('div')`
   .rdrDayEndPreview,
   .rdrDayInPreview {
     border: 0;
-    background: rgba(200, 200, 200, 0.3);
+    background: ${p => p.theme.headingColor};
+    opacity: 0.08;
     z-index: -1;
   }
 
@@ -200,6 +201,28 @@ const CalendarStylesWrapper = styled('div')`
     height: auto;
     background-color: transparent;
     border: none;
+  }
+
+  .rdrNextPrevButton:hover,
+  .rdrMonthPicker:hover,
+  .rdrYearPicker:hover {
+    position: relative;
+    background-color: transparent;
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: ${p => p.theme.borderRadius};
+      background: ${p => p.theme.headingColor};
+      opacity: 0.08;
+      z-index: -1;
+    }
+  }
+
+  .rdrMonthPicker select:hover,
+  .rdrYearPicker select:hover {
+    background-color: transparent;
   }
 
   .rdrPprevButton {


### PR DESCRIPTION
**Before ——**
<img width="326" alt="Screenshot 2023-06-05 at 3 35 45 PM" src="https://github.com/getsentry/sentry/assets/44172267/7df30aae-ba9c-4bf5-bfc6-30c13dd5794d">
<img width="326" alt="Screenshot 2023-06-05 at 3 35 36 PM" src="https://github.com/getsentry/sentry/assets/44172267/f4969506-9770-42e3-9723-b9fab9e4b6a8">
<img width="326" alt="Screenshot 2023-06-05 at 3 35 23 PM" src="https://github.com/getsentry/sentry/assets/44172267/de40b7d5-e594-4024-8946-122b18b58c17">

**After ——**
<img width="326" alt="Screenshot 2023-06-05 at 3 34 25 PM" src="https://github.com/getsentry/sentry/assets/44172267/19e4a2e9-244c-4b37-a0c8-df9f3c6b3770">
<img width="326" alt="Screenshot 2023-06-05 at 3 34 40 PM" src="https://github.com/getsentry/sentry/assets/44172267/3a41d4c2-1db4-490e-ae5f-5172ce2ba00b">
<img width="326" alt="Screenshot 2023-06-05 at 3 34 52 PM" src="https://github.com/getsentry/sentry/assets/44172267/1cdba4c4-96fa-41a1-b599-714863ed7787">
