### PR TITLE
ref(button): Remove `onClick` prop rewrite

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -84,10 +84,6 @@ interface BaseButtonProps
    */
   name?: string;
   /**
-   * Callback for when the button is clicked.
-   */
-  onClick?: (e: React.MouseEvent) => void;
-  /**
    * The semantic "priority" of the button. Use `primary` when the action is
    * contextually the primary action, `danger` if the button will do something
    * destructive, `link` for visual similarity to a link.


### PR DESCRIPTION
Remove the custom `onClick` prop type in `Button` in favor of the one already provided in `ButtonHTMLAttributes`. Removing it doesn't result in any new error, and helps resolve a type conflict that has prevented us from upgrading `@react-aria/button` to a newer version.