### PR TITLE
feat(replay): Render an unstyled Replay Preview for Replay Issues

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -17,6 +17,7 @@ import {Exception} from './interfaces/exception';
 import {Generic} from './interfaces/generic';
 import {Message} from './interfaces/message';
 import {SpanEvidenceSection} from './interfaces/performance/spanEvidence';
+import {Replay} from './interfaces/replay';
 import {Request} from './interfaces/request';
 import {Spans} from './interfaces/spans';
 import {StackTrace} from './interfaces/stackTrace';
@@ -101,6 +102,24 @@ function EventEntryContent({
           projectSlug={projectSlug}
         />
       );
+
+    case EntryType.REPLAY:
+      const showReplay = !isShare && organization.features?.includes('session-replay');
+      const showReplayContainer = organization.features?.includes(
+        'issue-details-replay-event'
+      );
+      if (showReplay && showReplayContainer) {
+        return (
+          <Replay
+            data={entry.data}
+            organization={organization as Organization}
+            event={event}
+            isShare={isShare}
+            projectSlug={projectSlug}
+          />
+        );
+      }
+      return null;
 
     case EntryType.THREADS:
       return (

--- a/static/app/components/events/interfaces/replay/index.tsx
+++ b/static/app/components/events/interfaces/replay/index.tsx
@@ -1,0 +1,3 @@
+import Loader from 'sentry/components/events/interfaces/replay/loader';
+
+export {Loader as Replay};

--- a/static/app/components/events/interfaces/replay/loader.tsx
+++ b/static/app/components/events/interfaces/replay/loader.tsx
@@ -1,0 +1,34 @@
+import {useCallback} from 'react';
+
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import LazyLoad from 'sentry/components/lazyLoad';
+import type {Organization} from 'sentry/types';
+import type {Entry, EntryType, Event} from 'sentry/types/event';
+
+interface Props {
+  data: Extract<Entry, {type: EntryType.REPLAY}>['data'];
+  event: Event;
+  organization: Organization;
+  projectSlug: string;
+  isShare?: boolean;
+}
+
+function Loader({data, event, organization}: Props) {
+  const replayPreview = useCallback(
+    () => import('sentry/components/events/eventReplay/replayPreview'),
+    []
+  );
+
+  return (
+    <ErrorBoundary mini>
+      <LazyLoad
+        component={replayPreview}
+        event={event}
+        orgSlug={organization.slug}
+        replaySlug={data.replayId}
+      />
+    </ErrorBoundary>
+  );
+}
+
+export default Loader;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -270,6 +270,7 @@ export enum EntryType {
   THREAD_TAGS = 'thread-tags',
   DEBUGMETA = 'debugmeta',
   SPANS = 'spans',
+  REPLAY = 'replay',
   RESOURCES = 'resources',
 }
 
@@ -351,6 +352,14 @@ type EntryGeneric = {
   type: EntryType.EXPECTCT | EntryType.EXPECTSTAPLE | EntryType.HPKP;
 };
 
+// TODO(replay): Sync with @cmanallen for this shape
+type EntryReplay = {
+  data: {
+    replayId: string;
+  };
+  type: EntryType.REPLAY;
+};
+
 type EntryResources = {
   data: any; // Data is unused here
   type: EntryType.RESOURCES;
@@ -368,6 +377,7 @@ export type Entry =
   | EntryTemplate
   | EntryCsp
   | EntryGeneric
+  | EntryReplay
   | EntryResources;
 
 // Contexts: https://develop.sentry.dev/sdk/event-payloads/contexts/

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -45,6 +45,27 @@ function GroupEventEntry({event, entryType, group, project}: GroupEventEntryProp
   const organization = useOrganization();
   const matchingEntry = event.entries.find(entry => entry.type === entryType);
 
+  if (entryType === EntryType.REPLAY) {
+    const replayId = event?.tags?.find(({key}) => key === 'replayId')?.value;
+    if (!replayId) {
+      return null;
+    }
+
+    return (
+      <EventEntry
+        projectSlug={project.slug}
+        group={group}
+        entry={{
+          data: {
+            replayId,
+          },
+          type: EntryType.REPLAY,
+        }}
+        {...{organization, event}}
+      />
+    );
+  }
+
   if (!matchingEntry) {
     return null;
   }
@@ -126,6 +147,7 @@ function GroupEventDetailsContent({
       <GroupEventEntry entryType={EntryType.EXPECTSTAPLE} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.TEMPLATE} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.BREADCRUMBS} {...eventEntryProps} />
+      <GroupEventEntry entryType={EntryType.REPLAY} {...eventEntryProps} />
       <ResourcesAndMaybeSolutions
         event={event}
         projectSlug={project.slug}


### PR DESCRIPTION
The purpose of this PR is to implement some feature checks so we can work inside them. 

When `organizations:issue-details-replay-event` is deployed & enabled you'll see an unstyled `<ReplayPreview>`:

<img width="1207" alt="SCR-20230607-oolg" src="https://github.com/getsentry/sentry/assets/187460/38d4b288-2149-4308-9997-ac2af5dd21e6">


`[groupEventDetailsContent.tsx](https://github.com/getsentry/sentry/pull/50360/files#diff-62bb4e4467c7adb45b2e826efbed8320da7e614e233e1e2237ca870d202e278c)` contains a mocked out a `EntryReplay` value which gets passed directly into `eventEntry.tsx` where we do feature checks. 

Relates to https://github.com/getsentry/team-replay/issues/91