### PR TITLE
feat(sort): Add better priority to saved searches

### DIFF
--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -19,6 +19,7 @@ class SortOptions:
     USER = "user"
     TREND = "trend"
     INBOX = "inbox"
+    BETTER_PRIORITY = "betterPriority"
 
     @classmethod
     def as_choices(cls):
@@ -30,6 +31,7 @@ class SortOptions:
             (cls.USER, _("Users")),
             (cls.TREND, _("Relative Change")),
             (cls.INBOX, _("Date Added")),
+            (cls.BETTER_PRIORITY, _("Better Priority")),
         )
 
 


### PR DESCRIPTION
Add better priority to the saved searches - without this you can't click "Set as Default" or save a search that is using the better priority sort. 