### PR TITLE
fix(hybridcloud) Route migrations by table instead of model

### DIFF
--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -116,7 +116,7 @@ class SiloRouter:
 
     def allow_migrate(self, db, app_label, model=None, **hints):
         if model:
-            return self._db_for_model(model) == db
+            return self._db_for_table(model._meta.db_table, app_label) == db
 
         # We use this hint in our RunSql/RunPython migrations to help resolve databases.
         if "tables" in hints:


### PR DESCRIPTION
Because migrations use generated 'fake' models we can't reliably access the concrete models we've defined. Without those concrete models we cannot access decorators and silo_limit attributes.

Routing by table allows us to locate the concrete model and access its meta data.

This will resolve the build failures in getsentry/getsentry#10717
