### PR TITLE
feat(roles): Team-roles for Metric Alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -7,6 +7,7 @@ import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import SearchBar from 'sentry/components/events/searchBar';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import SelectField from 'sentry/components/forms/fields/selectField';
@@ -256,10 +257,14 @@ class RuleConditionsForm extends PureComponent<Props, State> {
       organization,
       disableProjectSelector,
     } = this.props;
+    const hasOrgWrite = hasEveryAccess(['org:write'], {organization});
     const hasOpenMembership = organization.features.includes('open-membership');
-    const myProjects = projects.filter(project => project.hasAccess && project.isMember);
+
+    const myProjects = projects.filter(
+      project => project.isMember && project.access.includes('alerts:write')
+    );
     const allProjects = projects.filter(
-      project => project.hasAccess && !project.isMember
+      project => !project.isMember && project.access.includes('alerts:write')
     );
 
     const myProjectOptions = myProjects.map(myProject => ({
@@ -284,7 +289,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
     ];
 
     const projectOptions =
-      hasOpenMembership || isActiveSuperuser()
+      hasOpenMembership || hasOrgWrite || isActiveSuperuser()
         ? openMembershipProjects
         : myProjectOptions;
 
@@ -555,6 +560,14 @@ const SearchContainer = styled('div')`
 
 const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
+
+  ${p =>
+    p.disabled &&
+    `
+    background: ${p.theme.backgroundSecondary};
+    color: ${p.theme.disabled};
+    cursor: not-allowed;
+  `}
 `;
 
 const StyledListItem = styled(ListItem)`

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -260,12 +260,13 @@ class RuleConditionsForm extends PureComponent<Props, State> {
     const hasOrgWrite = hasEveryAccess(['org:write'], {organization});
     const hasOpenMembership = organization.features.includes('open-membership');
 
-    const myProjects = projects.filter(
-      project => project.isMember && project.access.includes('alerts:write')
-    );
-    const allProjects = projects.filter(
-      project => !project.isMember && project.access.includes('alerts:write')
-    );
+    // If form is enabled, we want to limit to the subset of projects which the
+    // user can create/edit alerts.
+    const targetProjects = disabled
+      ? projects
+      : projects.filter(project => project.access.includes('alerts:write'));
+    const myProjects = targetProjects.filter(project => project.isMember);
+    const allProjects = targetProjects.filter(project => !project.isMember);
 
     const myProjectOptions = myProjects.map(myProject => ({
       value: myProject.id,

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.jsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.jsx
@@ -80,12 +80,16 @@ describe('Incident Rules Form', () => {
 
   describe('Viewing the rule', () => {
     const rule = TestStubs.MetricRule();
+    const permissionAlertText =
+      'These settings can only be edited by users with the organization-level owner, manager, or team-level admin roles.';
+
     it('is enabled without org-level alerts:write', () => {
       organization.access = [];
       project.access = [];
       createWrapper({rule});
 
-      expect(screen.getByLabelText('Save Rule')).toBeDisabled();
+      expect(screen.queryByText(permissionAlertText)).toBeInTheDocument();
+      expect(screen.queryByLabelText('Save Rule')).toBeDisabled();
     });
 
     it('is enabled with org-level alerts:write', () => {
@@ -93,7 +97,8 @@ describe('Incident Rules Form', () => {
       project.access = [];
       createWrapper({rule});
 
-      expect(screen.getByLabelText('Save Rule')).toBeEnabled();
+      expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Save Rule')).toBeEnabled();
     });
 
     it('is enabled with project-level alerts:write', () => {
@@ -101,7 +106,8 @@ describe('Incident Rules Form', () => {
       project.access = ['alerts:write'];
       createWrapper({rule});
 
-      expect(screen.getByLabelText('Save Rule')).toBeEnabled();
+      expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Save Rule')).toBeEnabled();
     });
   });
 

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.jsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.jsx
@@ -78,6 +78,33 @@ describe('Incident Rules Form', () => {
     jest.clearAllMocks();
   });
 
+  describe('Viewing the rule', () => {
+    const rule = TestStubs.MetricRule();
+    it('is enabled without org-level alerts:write', () => {
+      organization.access = [];
+      project.access = [];
+      createWrapper({rule});
+
+      expect(screen.getByLabelText('Save Rule')).toBeDisabled();
+    });
+
+    it('is enabled with org-level alerts:write', () => {
+      organization.access = ['alerts:write'];
+      project.access = [];
+      createWrapper({rule});
+
+      expect(screen.getByLabelText('Save Rule')).toBeEnabled();
+    });
+
+    it('is enabled with project-level alerts:write', () => {
+      organization.access = [];
+      project.access = ['alerts:write'];
+      createWrapper({rule});
+
+      expect(screen.getByLabelText('Save Rule')).toBeEnabled();
+    });
+  });
+
   describe('Creating a new rule', () => {
     let createRule;
     beforeEach(() => {

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -9,7 +9,7 @@ import {
   Indicator,
 } from 'sentry/actionCreators/indicator';
 import {fetchOrganizationTags} from 'sentry/actionCreators/tags';
-import Access from 'sentry/components/acl/access';
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {Button} from 'sentry/components/button';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
@@ -27,7 +27,6 @@ import {EventsStats, MultiSeriesEventsStats, Organization, Project} from 'sentry
 import {defined} from 'sentry/utils';
 import {metric, trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
-import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withProjects from 'sentry/utils/withProjects';
 import {IncompatibleAlertQuery} from 'sentry/views/alerts/rules/metric/incompatibleAlertQuery';
@@ -861,96 +860,86 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       />
     );
 
-    return (
-      <Access access={['alerts:write']}>
-        {({hasAccess}) => {
-          const formDisabled = loading || !(isActiveSuperuser() || hasAccess);
-          const submitDisabled = formDisabled || !this.state.isQueryValid;
+    const hasAlertWrite = hasEveryAccess(['alerts:write'], {organization, project});
+    const formDisabled = loading || !hasAlertWrite;
+    const submitDisabled = formDisabled || !this.state.isQueryValid;
 
-          return (
-            <Fragment>
-              <Main fullWidth>
-                {eventView && (
-                  <IncompatibleAlertQuery
-                    orgSlug={organization.slug}
-                    eventView={eventView}
-                  />
-                )}
-                <Form
-                  model={this.form}
-                  apiMethod={ruleId ? 'PUT' : 'POST'}
-                  apiEndpoint={`/organizations/${organization.slug}/alert-rules/${
-                    ruleId ? `${ruleId}/` : ''
-                  }`}
-                  submitDisabled={submitDisabled}
-                  initialData={{
-                    name,
-                    dataset,
-                    eventTypes,
-                    aggregate,
-                    query,
-                    timeWindow: rule.timeWindow,
-                    environment: rule.environment || null,
-                    owner: rule.owner,
-                    projectId: project.id,
-                    alertType,
-                  }}
-                  saveOnBlur={false}
-                  onSubmit={this.handleSubmit}
-                  onSubmitSuccess={onSubmitSuccess}
-                  onCancel={this.handleCancel}
-                  onFieldChange={this.handleFieldChange}
-                  extraButton={
-                    rule.id ? (
-                      <Confirm
-                        disabled={formDisabled}
-                        message={t('Are you sure you want to delete this alert rule?')}
-                        header={t('Delete Alert Rule?')}
-                        priority="danger"
-                        confirmText={t('Delete Rule')}
-                        onConfirm={this.handleDeleteRule}
-                      >
-                        <Button priority="danger">{t('Delete Rule')}</Button>
-                      </Confirm>
-                    ) : null
-                  }
-                  submitLabel={t('Save Rule')}
+    return (
+      <Fragment>
+        <Main fullWidth>
+          {eventView && (
+            <IncompatibleAlertQuery orgSlug={organization.slug} eventView={eventView} />
+          )}
+          <Form
+            model={this.form}
+            apiMethod={ruleId ? 'PUT' : 'POST'}
+            apiEndpoint={`/organizations/${organization.slug}/alert-rules/${
+              ruleId ? `${ruleId}/` : ''
+            }`}
+            submitDisabled={submitDisabled}
+            initialData={{
+              name,
+              dataset,
+              eventTypes,
+              aggregate,
+              query,
+              timeWindow: rule.timeWindow,
+              environment: rule.environment || null,
+              owner: rule.owner,
+              projectId: project.id,
+              alertType,
+            }}
+            saveOnBlur={false}
+            onSubmit={this.handleSubmit}
+            onSubmitSuccess={onSubmitSuccess}
+            onCancel={this.handleCancel}
+            onFieldChange={this.handleFieldChange}
+            extraButton={
+              rule.id ? (
+                <Confirm
+                  disabled={formDisabled}
+                  message={t('Are you sure you want to delete this alert rule?')}
+                  header={t('Delete Alert Rule?')}
+                  priority="danger"
+                  confirmText={t('Delete Rule')}
+                  onConfirm={this.handleDeleteRule}
                 >
-                  <List symbol="colored-numeric">
-                    <RuleConditionsForm
-                      project={project}
-                      organization={organization}
-                      router={router}
-                      disabled={formDisabled}
-                      thresholdChart={wizardBuilderChart}
-                      onFilterSearch={this.handleFilterUpdate}
-                      allowChangeEventTypes={
-                        alertType === 'custom' || dataset === Dataset.ERRORS
-                      }
-                      alertType={alertType}
-                      dataset={dataset}
-                      timeWindow={timeWindow}
-                      comparisonType={comparisonType}
-                      comparisonDelta={comparisonDelta}
-                      onComparisonDeltaChange={value =>
-                        this.handleFieldChange('comparisonDelta', value)
-                      }
-                      onTimeWindowChange={value =>
-                        this.handleFieldChange('timeWindow', value)
-                      }
-                      disableProjectSelector={disableProjectSelector}
-                    />
-                    <AlertListItem>{t('Set thresholds')}</AlertListItem>
-                    {thresholdTypeForm(formDisabled)}
-                    {triggerForm(formDisabled)}
-                    {ruleNameOwnerForm(formDisabled)}
-                  </List>
-                </Form>
-              </Main>
-            </Fragment>
-          );
-        }}
-      </Access>
+                  <Button priority="danger">{t('Delete Rule')}</Button>
+                </Confirm>
+              ) : null
+            }
+            submitLabel={t('Save Rule')}
+          >
+            <List symbol="colored-numeric">
+              <RuleConditionsForm
+                project={project}
+                organization={organization}
+                router={router}
+                disabled={formDisabled}
+                thresholdChart={wizardBuilderChart}
+                onFilterSearch={this.handleFilterUpdate}
+                allowChangeEventTypes={
+                  alertType === 'custom' || dataset === Dataset.ERRORS
+                }
+                alertType={alertType}
+                dataset={dataset}
+                timeWindow={timeWindow}
+                comparisonType={comparisonType}
+                comparisonDelta={comparisonDelta}
+                onComparisonDeltaChange={value =>
+                  this.handleFieldChange('comparisonDelta', value)
+                }
+                onTimeWindowChange={value => this.handleFieldChange('timeWindow', value)}
+                disableProjectSelector={disableProjectSelector}
+              />
+              <AlertListItem>{t('Set thresholds')}</AlertListItem>
+              {thresholdTypeForm(formDisabled)}
+              {triggerForm(formDisabled)}
+              {ruleNameOwnerForm(formDisabled)}
+            </List>
+          </Form>
+        </Main>
+      </Fragment>
     );
   }
 }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1,4 +1,4 @@
-import {Fragment, ReactNode} from 'react';
+import {ReactNode} from 'react';
 import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -865,81 +865,77 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const submitDisabled = formDisabled || !this.state.isQueryValid;
 
     return (
-      <Fragment>
-        <Main fullWidth>
-          {eventView && (
-            <IncompatibleAlertQuery orgSlug={organization.slug} eventView={eventView} />
-          )}
-          <Form
-            model={this.form}
-            apiMethod={ruleId ? 'PUT' : 'POST'}
-            apiEndpoint={`/organizations/${organization.slug}/alert-rules/${
-              ruleId ? `${ruleId}/` : ''
-            }`}
-            submitDisabled={submitDisabled}
-            initialData={{
-              name,
-              dataset,
-              eventTypes,
-              aggregate,
-              query,
-              timeWindow: rule.timeWindow,
-              environment: rule.environment || null,
-              owner: rule.owner,
-              projectId: project.id,
-              alertType,
-            }}
-            saveOnBlur={false}
-            onSubmit={this.handleSubmit}
-            onSubmitSuccess={onSubmitSuccess}
-            onCancel={this.handleCancel}
-            onFieldChange={this.handleFieldChange}
-            extraButton={
-              rule.id ? (
-                <Confirm
-                  disabled={formDisabled}
-                  message={t('Are you sure you want to delete this alert rule?')}
-                  header={t('Delete Alert Rule?')}
-                  priority="danger"
-                  confirmText={t('Delete Rule')}
-                  onConfirm={this.handleDeleteRule}
-                >
-                  <Button priority="danger">{t('Delete Rule')}</Button>
-                </Confirm>
-              ) : null
-            }
-            submitLabel={t('Save Rule')}
-          >
-            <List symbol="colored-numeric">
-              <RuleConditionsForm
-                project={project}
-                organization={organization}
-                router={router}
+      <Main fullWidth>
+        {eventView && (
+          <IncompatibleAlertQuery orgSlug={organization.slug} eventView={eventView} />
+        )}
+        <Form
+          model={this.form}
+          apiMethod={ruleId ? 'PUT' : 'POST'}
+          apiEndpoint={`/organizations/${organization.slug}/alert-rules/${
+            ruleId ? `${ruleId}/` : ''
+          }`}
+          submitDisabled={submitDisabled}
+          initialData={{
+            name,
+            dataset,
+            eventTypes,
+            aggregate,
+            query,
+            timeWindow: rule.timeWindow,
+            environment: rule.environment || null,
+            owner: rule.owner,
+            projectId: project.id,
+            alertType,
+          }}
+          saveOnBlur={false}
+          onSubmit={this.handleSubmit}
+          onSubmitSuccess={onSubmitSuccess}
+          onCancel={this.handleCancel}
+          onFieldChange={this.handleFieldChange}
+          extraButton={
+            rule.id ? (
+              <Confirm
                 disabled={formDisabled}
-                thresholdChart={wizardBuilderChart}
-                onFilterSearch={this.handleFilterUpdate}
-                allowChangeEventTypes={
-                  alertType === 'custom' || dataset === Dataset.ERRORS
-                }
-                alertType={alertType}
-                dataset={dataset}
-                timeWindow={timeWindow}
-                comparisonType={comparisonType}
-                comparisonDelta={comparisonDelta}
-                onComparisonDeltaChange={value =>
-                  this.handleFieldChange('comparisonDelta', value)
-                }
-                onTimeWindowChange={value => this.handleFieldChange('timeWindow', value)}
-                disableProjectSelector={disableProjectSelector}
-              />
-              <AlertListItem>{t('Set thresholds')}</AlertListItem>
-              {thresholdTypeForm(formDisabled)}
-              {triggerForm(formDisabled)}
-              {ruleNameOwnerForm(formDisabled)}
-            </List>
-          </Form>
-        </Main>
-      </Fragment>
+                message={t('Are you sure you want to delete this alert rule?')}
+                header={t('Delete Alert Rule?')}
+                priority="danger"
+                confirmText={t('Delete Rule')}
+                onConfirm={this.handleDeleteRule}
+              >
+                <Button priority="danger">{t('Delete Rule')}</Button>
+              </Confirm>
+            ) : null
+          }
+          submitLabel={t('Save Rule')}
+        >
+          <List symbol="colored-numeric">
+            <RuleConditionsForm
+              project={project}
+              organization={organization}
+              router={router}
+              disabled={formDisabled}
+              thresholdChart={wizardBuilderChart}
+              onFilterSearch={this.handleFilterUpdate}
+              allowChangeEventTypes={alertType === 'custom' || dataset === Dataset.ERRORS}
+              alertType={alertType}
+              dataset={dataset}
+              timeWindow={timeWindow}
+              comparisonType={comparisonType}
+              comparisonDelta={comparisonDelta}
+              onComparisonDeltaChange={value =>
+                this.handleFieldChange('comparisonDelta', value)
+              }
+              onTimeWindowChange={value => this.handleFieldChange('timeWindow', value)}
+              disableProjectSelector={disableProjectSelector}
+            />
+            <AlertListItem>{t('Set thresholds')}</AlertListItem>
+            {thresholdTypeForm(formDisabled)}
+            {triggerForm(formDisabled)}
+            {ruleNameOwnerForm(formDisabled)}
+          </List>
+        </Form>
+      </Main>
     );
   }
 }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -43,6 +43,7 @@ import {
   MetricAlertType,
 } from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
+import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
 import {addOrUpdateRule} from './actions';
@@ -866,6 +867,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
     return (
       <Main fullWidth>
+        <PermissionAlert access={['alerts:write']} project={project} />
+
         {eventView && (
           <IncompatibleAlertQuery orgSlug={organization.slug} eventView={eventView} />
         )}


### PR DESCRIPTION
- Allow team-admins to set up Metric Alerts for projects where they have admin scopes.
- Allow org-members to see the form in disabled state, with an alert to indicate that they need more permissions.

<img width="1018" alt="Screenshot 2023-06-07 at 2 16 05 PM" src="https://github.com/getsentry/sentry/assets/1748388/2b5758c4-e6c8-4194-9f33-a439d1a157c2">

