### PR TITLE
feat(sdk-crash-detection): Event data allowlist

### DIFF
--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -1,26 +1,64 @@
-from typing import Any, Mapping, Sequence, Tuple
+from enum import Enum, auto
+from typing import Any, Mapping, Optional, Sequence
 
 from sentry.eventstore.models import Event
 from sentry.utils.safe import get_path
 from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector
 
-ALLOWED_EVENT_KEYS = {
-    "type",
-    "datetime",
-    "timestamp",
-    "platform",
-    "sdk",
-    "level",
-    "logger",
-    "exception",
-    "debug_meta",
-    "contexts",
+
+class Allow(Enum):
+    def __init__(self, explanation: str = "") -> None:
+        self.explanation = explanation
+
+    """Keeps the event data if it is of type str, int, float, bool."""
+    SIMPLE_TYPE = auto()
+
+    """Keeps the event data no matter the type."""
+    ALL = auto()
+
+    """
+    Doesn't keep the event data no matter the type. This can be used to explicitly
+    specify that data should be removed with an explanation.
+    """
+    NEVER = auto()
+
+    def with_explanation(self, explanation: str) -> "Allow":
+        self.explanation = explanation
+        return self
+
+
+EVENT_DATA_ALLOWLIST = {
+    "type": Allow.SIMPLE_TYPE,
+    "datetime": Allow.SIMPLE_TYPE,
+    "timestamp": Allow.SIMPLE_TYPE,
+    "platform": Allow.SIMPLE_TYPE,
+    "sdk": {
+        "name": Allow.SIMPLE_TYPE,
+        "version": Allow.SIMPLE_TYPE,
+        "integrations": Allow.NEVER.with_explanation("Users can add their own integrations."),
+    },
+    "exception": Allow.ALL.with_explanation("We strip the exception data separately."),
+    "debug_meta": Allow.ALL,
+    "contexts": {
+        "device": {
+            "family": Allow.SIMPLE_TYPE,
+            "model": Allow.SIMPLE_TYPE,
+            "arch": Allow.SIMPLE_TYPE,
+        },
+        "os": {
+            "name": Allow.SIMPLE_TYPE,
+            "version": Allow.SIMPLE_TYPE,
+            "build": Allow.SIMPLE_TYPE,
+        },
+    },
 }
 
 
 def strip_event_data(event: Event, sdk_crash_detector: SDKCrashDetector) -> Event:
-    new_event_data = {key: value for key, value in event.data.items() if key in ALLOWED_EVENT_KEYS}
-    new_event_data["contexts"] = dict(filter(_filter_contexts, new_event_data["contexts"].items()))
+    new_event_data = _strip_event_data_with_allowlist(event.data, EVENT_DATA_ALLOWLIST)
+
+    if (new_event_data is None) or (new_event_data == {}):
+        return
 
     stripped_frames: Sequence[Mapping[str, Any]] = []
     frames = get_path(new_event_data, "exception", "values", -1, "stacktrace", "frames")
@@ -37,11 +75,37 @@ def strip_event_data(event: Event, sdk_crash_detector: SDKCrashDetector) -> Even
     return new_event_data
 
 
-def _filter_contexts(pair: Tuple[str, Any]) -> bool:
-    key, _ = pair
-    if key in {"os", "device"}:
-        return True
-    return False
+def _strip_event_data_with_allowlist(
+    data: Mapping[str, Any], allowlist: Optional[Mapping[str, Any]]
+) -> Optional[Mapping[str, Any]]:
+    """
+    Recursively traverses the data and only keeps values based on the allowlist.
+    """
+    if allowlist is None:
+        return None
+
+    stripped_data = {}
+    for data_key, data_value in data.items():
+        allowlist_for_data = allowlist.get(data_key)
+        if allowlist_for_data is None:
+            continue
+
+        if isinstance(allowlist_for_data, Allow):
+            allowed = allowlist_for_data
+
+            if allowed is Allow.SIMPLE_TYPE and isinstance(data_value, (str, int, float, bool)):
+                stripped_data[data_key] = data_value
+            elif allowed is Allow.ALL:
+                stripped_data[data_key] = data_value
+            else:
+                continue
+
+        elif isinstance(data_value, Mapping):
+            stripped_data[data_key] = _strip_event_data_with_allowlist(
+                data_value, allowlist_for_data
+            )
+
+    return stripped_data
 
 
 def _strip_debug_meta(

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 from sentry.eventstore.models import Event
 from sentry.utils.safe import get_path
@@ -84,7 +84,7 @@ def _strip_event_data_with_allowlist(
     if allowlist is None:
         return None
 
-    stripped_data = {}
+    stripped_data: Dict[str, Any] = {}
     for data_key, data_value in data.items():
         allowlist_for_data = allowlist.get(data_key)
         if allowlist_for_data is None:

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -58,7 +58,7 @@ class SDKCrashDetection:
             return None
 
         if self.cocoa_sdk_crash_detector.is_sdk_crash(frames):
-            sdk_crash_event_data = strip_event_data(event, self.cocoa_sdk_crash_detector)
+            sdk_crash_event_data = strip_event_data(event.data, self.cocoa_sdk_crash_detector)
 
             set_path(
                 sdk_crash_event_data, "contexts", "sdk_crash_detection", value={"detected": True}

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -72,20 +72,18 @@ class EventStripperTestMixin(BaseEventStripperMixin):
 
         stripped_event_data = strip_event_data(event, CocoaSDKCrashDetector())
 
-        contexts = stripped_event_data.get("contexts")
-        assert len(contexts) == 2
-
-        assert contexts.get("os") == {
-            "name": "iOS",
-            "version": "16.3",
-            "build": "20D47",
+        assert stripped_event_data.get("contexts") == {
+            "os": {
+                "name": "iOS",
+                "version": "16.3",
+                "build": "20D47",
+            },
+            "device": {
+                "family": "iOS",
+                "model": "iPhone14,8",
+                "arch": "arm64e",
+            },
         }
-
-        device_context = contexts.get("device")
-        assert len(device_context) == 3
-        assert device_context.get("family") == "iOS"
-        assert device_context.get("model") == "iPhone14,8"
-        assert device_context.get("arch") == "arm64e"
 
     def test_strip_event_data_strips_sdk(self):
         event = self.create_event(
@@ -95,11 +93,10 @@ class EventStripperTestMixin(BaseEventStripperMixin):
 
         stripped_event_data = strip_event_data(event, CocoaSDKCrashDetector())
 
-        sdk = stripped_event_data.get("sdk")
-
-        assert len(sdk) == 2
-        assert sdk.get("name") == "sentry.cocoa"
-        assert sdk.get("version") == "8.1.0"
+        assert stripped_event_data.get("sdk") == {
+            "name": "sentry.cocoa",
+            "version": "8.1.0",
+        }
 
     def test_strip_event_data_strips_value_if_not_simple_type(self):
         event = self.create_event(

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -76,9 +76,9 @@ class EventStripperTestMixin(BaseEventStripperMixin):
         assert len(contexts) == 2
 
         assert contexts.get("os") == {
-          "name": "iOS",
-          "version": "16.3",
-          "build": "20D47",
+            "name": "iOS",
+            "version": "16.3",
+            "build": "20D47",
         }
 
         device_context = contexts.get("device")

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -75,11 +75,11 @@ class EventStripperTestMixin(BaseEventStripperMixin):
         contexts = stripped_event_data.get("contexts")
         assert len(contexts) == 2
 
-        os_context = contexts.get("os")
-        assert len(os_context) == 3
-        assert os_context.get("name") == "iOS"
-        assert os_context.get("version") == "16.3"
-        assert os_context.get("build") == "20D47"
+        assert contexts.get("os") == {
+          "name": "iOS",
+          "version": "16.3",
+          "build": "20D47",
+        }
 
         device_context = contexts.get("device")
         assert len(device_context) == 3


### PR DESCRIPTION
Specify an allowlist for the event data to ensure only keeping essential data doesn't contain PII.

Fixes GH-49935

This PR is based on https://github.com/getsentry/sentry/pull/49928.
