### PR TITLE
feat(replays): Add page containing click target to the issue event tags payload

### DIFF
--- a/src/sentry/replays/usecases/ingest/dead_click.py
+++ b/src/sentry/replays/usecases/ingest/dead_click.py
@@ -31,7 +31,7 @@ def report_dead_click_issue(project_id: int, replay_id: str, event: SentryEvent)
         extra_event_data={
             "contexts": {"replay": {"replay_id": replay_id}},
             "level": "warning",
-            "tags": {"replayId": replay_id},
+            "tags": {"replayId": replay_id, "url": payload["data"]["url"]},
             "user": {
                 "id": "1",
                 "username": "Test User",

--- a/src/sentry/replays/usecases/ingest/dead_click.py
+++ b/src/sentry/replays/usecases/ingest/dead_click.py
@@ -13,9 +13,9 @@ def report_dead_click_issue(project_id: int, replay_id: str, event: SentryEvent)
     payload = event["data"]["payload"]
 
     # Only timeout reasons on <a> and <button> tags are accepted.
-    if payload["data"]["node"]["tagName"] not in ("a", "button"):
+    if payload["data"]["endReason"] != "timeout":
         return False
-    elif payload["data"]["endReason"] != "timeout":
+    elif payload["data"]["node"]["tagName"] not in ("a", "button"):
         return False
 
     # Seconds since epoch is UTC.

--- a/tests/sentry/replays/unit/test_dead_click_issue.py
+++ b/tests/sentry/replays/unit/test_dead_click_issue.py
@@ -10,7 +10,11 @@ def test_report_dead_click_issue_a_tag():
     event = {
         "data": {
             "payload": {
-                "data": {"node": {"tagName": "a"}, "endReason": "timeout"},
+                "data": {
+                    "node": {"tagName": "a"},
+                    "endReason": "timeout",
+                    "url": "https://www.sentry.io",
+                },
                 "message": "div.xyz > a",
                 "timestamp": time.time(),
             }


### PR DESCRIPTION
This will be useful for codeowners assignment.  Also moved the timeout conditional check above the tagName conditional check.