### PR TITLE
chore: Increase avatar migration rate

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3424,7 +3424,7 @@ MAX_ENVIRONMENTS_PER_MONITOR = 1000
 # tests)
 SENTRY_METRICS_INDEXER_RAISE_VALIDATION_ERRORS = False
 
-SENTRY_FILE_COPY_ROLLOUT_RATE = 0.01
+SENTRY_FILE_COPY_ROLLOUT_RATE = 0.1
 
 # The Redis cluster to use for monitoring the health of
 # Celery queues.


### PR DESCRIPTION
Increase the rate we move avatars from region bucket to the control one. At the current rate it will take several months to move all the avatars over.