### PR TITLE
feat(starfish): Use metrics data in WSV table

### DIFF
--- a/static/app/views/starfish/utils/generatePerformanceEventView.tsx
+++ b/static/app/views/starfish/utils/generatePerformanceEventView.tsx
@@ -1,22 +1,20 @@
 import {Location} from 'history';
-import trimStart from 'lodash/trimStart';
 
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import {wrapQueryInWildcards} from 'sentry/components/performance/searchBar';
 import {t} from 'sentry/locale';
 import {NewQuery, Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {getCurrentTrendParameter} from 'sentry/views/performance/trends/utils';
-import {getMiddleTimestamp} from 'sentry/views/starfish/utils/dates';
 
 const DEFAULT_STATS_PERIOD = '7d';
 
 const TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH = ['transaction'];
-export const TIME_SPENT_IN_SERVICE =
-  'equation|sum(transaction.duration) / total.transaction_duration';
+export const TIME_SPENT_IN_SERVICE = 'time_spent_percentage()';
 
 export const getDefaultStatsPeriod = (organization: Organization) => {
   if (organization?.features?.includes('performance-landing-page-stats-period')) {
@@ -120,41 +118,17 @@ export function generateWebServiceEventView(
   organization: Organization
 ) {
   const {query} = location;
-  const percentile = '0.95';
   const hasStartAndEnd = query.start && query.end;
-  const middleTimestamp = getMiddleTimestamp({
-    start: decodeScalar(query.start),
-    end: decodeScalar(query.end),
-    statsPeriod:
-      !query.statsPeriod && !hasStartAndEnd
-        ? getDefaultStatsPeriod(organization)
-        : decodeScalar(query.statsPeriod),
-  });
-
-  const deltaColName = `equation|(percentile_range(transaction.duration,${percentile},lessOrEquals,${middleTimestamp})-percentile_range(transaction.duration,0.95,greater,${middleTimestamp}))/percentile_range(transaction.duration,${percentile},lessOrEquals,${middleTimestamp})`;
-  let orderby = decodeScalar(query.sort, `-${TIME_SPENT_IN_SERVICE}`);
-  const isDescending = orderby.startsWith('-');
-  const rawOrderby = trimStart(orderby, '-');
-  if (
-    rawOrderby.startsWith(
-      `equation|(percentile_range(transaction.duration,${percentile},lessOrEquals,`
-    )
-  ) {
-    orderby = isDescending ? `-${deltaColName}` : deltaColName;
-  }
+  const orderby = decodeScalar(query.sort, `-time_spent_percentage`);
 
   const fields = [
     'transaction',
     'http.method',
     'tpm()',
-    'p95()',
-    deltaColName,
-    'count_if(http.status_code,greaterOrEquals,500)',
-    TIME_SPENT_IN_SERVICE,
-    'total.transaction_duration',
+    'p95(transaction.duration)',
+    'http_error_count()',
+    'time_spent_percentage()',
     'sum(transaction.duration)',
-    `percentile_range(transaction.duration,${percentile},lessOrEquals,${middleTimestamp})`,
-    `percentile_range(transaction.duration,${percentile},greater,${middleTimestamp})`,
   ];
 
   const savedQuery: NewQuery = {
@@ -164,6 +138,7 @@ export function generateWebServiceEventView(
     projects: [],
     fields,
     version: 2,
+    dataset: DiscoverDatasets.METRICS,
   };
 
   const widths = Array(savedQuery.fields.length).fill(COL_WIDTH_UNDEFINED);

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -1,8 +1,10 @@
 import {Fragment, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
 import {Location, LocationDescriptorObject} from 'history';
 import * as qs from 'query-string';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
+import Duration from 'sentry/components/duration';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumn,
@@ -10,7 +12,10 @@ import GridEditable, {
 import SortLink, {Alignments} from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
+import BaseSearchBar from 'sentry/components/searchBar';
 import {Tooltip} from 'sentry/components/tooltip';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import DiscoverQuery, {
   TableData,
@@ -18,32 +23,20 @@ import DiscoverQuery, {
 } from 'sentry/utils/discover/discoverQuery';
 import EventView, {isFieldSortable, MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import {
-  ColumnType,
-  fieldAlignment,
-  getAggregateAlias,
-} from 'sentry/utils/discover/fields';
-import {TableColumn} from 'sentry/views/discover/table/types';
-
-const COLUMN_TITLES = ['endpoint', 'tpm', 'p95(duration)'];
-
-import styled from '@emotion/styled';
-
-import Duration from 'sentry/components/duration';
-import BaseSearchBar from 'sentry/components/searchBar';
-import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
+import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatPercentage} from 'sentry/utils/formatters';
+import {TableColumn} from 'sentry/views/discover/table/types';
 import {TIME_SPENT_IN_SERVICE} from 'sentry/views/starfish/utils/generatePerformanceEventView';
 import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/endpointDetails';
 
-// HACK: Overrides ColumnType for TIME_SPENT_IN_SERVICE which is
-// returned as a number because it's an equation, but we
-// want formatted as a percentage
-const TABLE_META_OVERRIDES: Record<string, ColumnType> = {
-  [TIME_SPENT_IN_SERVICE]: 'percentage',
-};
+const COLUMN_TITLES = [
+  'Endpoint',
+  'Throughput',
+  'Duration (P95)',
+  '5XX Responses',
+  'Time Spent',
+];
 
 type Props = {
   eventView: EventView;
@@ -52,18 +45,9 @@ type Props = {
   organization: Organization;
   projects: Project[];
   setError: (msg: string | undefined) => void;
-  columnTitles?: string[];
-  dataset?: 'discover' | 'metrics';
 };
 
-function EndpointList({
-  eventView,
-  location,
-  organization,
-  setError,
-  columnTitles,
-  dataset,
-}: Props) {
+function EndpointList({eventView, location, organization, setError}: Props) {
   const [widths, setWidths] = useState<number[]>([]);
   const [_eventView, setEventView] = useState<EventView>(eventView);
 
@@ -86,7 +70,7 @@ function EndpointList({
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
     }
-    const tableMeta = {...tableData.meta, ...TABLE_META_OVERRIDES};
+    const tableMeta = tableData.meta;
 
     const field = String(column.key);
     const fieldRenderer = getFieldRenderer(field, tableMeta, false);
@@ -123,21 +107,15 @@ function EndpointList({
       const cumulativeTimePercentage = Number(dataRow[TIME_SPENT_IN_SERVICE]);
       return (
         <Tooltip
-          title={t(
-            'This endpoint accounts for %s of the cumulative time on your web service',
-            formatPercentage(cumulativeTimePercentage)
-          )}
+          title={tct('Total time spent by endpoint is [cumulativeTime])', {
+            cumulativeTime: (
+              <Duration seconds={cumulativeTime / 1000} fixedDigits={2} abbreviation />
+            ),
+          })}
           containerDisplayMode="block"
           position="top"
         >
-          <NumberContainer>
-            {tct('[cumulativeTime] ([cumulativeTimePercentage])', {
-              cumulativeTime: (
-                <Duration seconds={cumulativeTime / 1000} fixedDigits={2} abbreviation />
-              ),
-              cumulativeTimePercentage: formatPercentage(cumulativeTimePercentage),
-            })}
-          </NumberContainer>
+          <NumberContainer>{formatPercentage(cumulativeTimePercentage)}</NumberContainer>
         </Tooltip>
       );
     }
@@ -208,15 +186,9 @@ function EndpointList({
     column: TableColumn<keyof TableDataRow>,
     title: React.ReactNode
   ): React.ReactNode {
-    // Hack to get equations to align and sort properly because
-    // some of the functions called below aren't set up to handle
-    // equations. Fudging code here to keep minimal footprint of
-    // code changes.
-    let align: Alignments = 'left';
-    if (column.column.kind === 'equation') {
-      align = 'right';
-    } else {
-      align = fieldAlignment(column.name, column.type, tableMeta);
+    let align: Alignments = 'right';
+    if (title === 'Endpoint') {
+      align = 'left';
     }
     const field = {
       field: column.column.kind === 'equation' ? (column.key as string) : column.name,
@@ -262,7 +234,7 @@ function EndpointList({
   }
 
   function renderHeadCellWithMeta(tableMeta: TableData['meta']) {
-    const newColumnTitles = columnTitles ?? COLUMN_TITLES;
+    const newColumnTitles = COLUMN_TITLES;
     return (column: TableColumn<keyof TableDataRow>, index: number): React.ReactNode =>
       renderHeadCell(tableMeta, column, newColumnTitles[index]);
   }
@@ -287,9 +259,6 @@ function EndpointList({
     .getColumns()
     .filter(
       (col: TableColumn<React.ReactText>) =>
-        !col.name.startsWith('count_miserable') &&
-        !col.name.startsWith('percentile_range') &&
-        col.name !== 'project_threshold_config' &&
         col.name !== 'project' &&
         col.name !== 'http.method' &&
         col.name !== 'total.transaction_duration' &&
@@ -313,7 +282,7 @@ function EndpointList({
         location={location}
         setError={error => setError(error?.message)}
         referrer="api.starfish.endpoint-list"
-        queryExtras={{dataset: dataset ?? 'metrics'}}
+        queryExtras={{dataset: 'metrics'}}
       >
         {({pageLinks, isLoading, tableData}) => (
           <Fragment>

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -292,16 +292,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
       <EndpointList
         {...props}
         setError={usePageError().setPageError}
-        dataset="discover" // Metrics dataset can't do total.transaction_duration yet
         onSelect={onSelect}
-        columnTitles={[
-          'endpoint',
-          'tpm',
-          DataTitles.p95,
-          'p95 change',
-          'failure count',
-          'cumulative time',
-        ]}
       />
     </div>
   );


### PR DESCRIPTION
The table now queries metrics data since we've
exposed time spent and http error count functions