### PR TITLE
fix(starfish): span sample duration chart yAxis max incorrect

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -165,7 +165,7 @@ function Chart({
         stacked
       )
     : percentOnly
-    ? computeMax(data)
+    ? computeMax([...data, ...(scatterPlot?.[0]?.data?.length ? scatterPlot : [])])
     : undefined;
   // Fix an issue where max == 1 for duration charts would look funky cause we round
   if (dataMax === 1 && durationOnly) {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -65,7 +65,6 @@ function DurationChart({groupId, transactionName, spanDescription}: Props) {
       scatterPlot={isSamplesLoading ? undefined : sampledSpanDataSeries}
       utc={false}
       chartColors={[P95_COLOR]}
-      stacked
       isLineChart
       definedAxisTicks={4}
     />


### PR DESCRIPTION
yAxis scale was messed with the span samples plotted because the yAxis max was incorrectly calculated.

Before
![image](https://github.com/getsentry/sentry/assets/44422760/bb5c1908-cb19-4194-bc1e-03dad9ab92f9)

After
![image](https://github.com/getsentry/sentry/assets/44422760/9da1088a-1c96-459e-b62d-429beb24db0d)

