### PR TITLE
fix(analytics): Add org id to slack status analytic

### DIFF
--- a/src/sentry/integrations/slack/analytics.py
+++ b/src/sentry/integrations/slack/analytics.py
@@ -11,6 +11,7 @@ class SlackIntegrationStatus(analytics.Event):
     type = "integrations.slack.status"
 
     attributes = (
+        analytics.Attribute("organization_id"),
         analytics.Attribute("status"),
         analytics.Attribute("resolve_type", required=False),
         analytics.Attribute("user_id", required=False),

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -241,6 +241,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
 
         analytics.record(
             "integrations.slack.status",
+            organization_id=group.project.organization.id,
             status=status["status"],
             resolve_type=resolve_type,
             user_id=user.id,


### PR DESCRIPTION
Lack of organization_id was preventing this metric from showing up on amplitude