### PR TITLE
ref(dropdownMenu): Update `trigger` prop type

### DIFF
--- a/static/app/components/alerts/snoozeAlert.tsx
+++ b/static/app/components/alerts/snoozeAlert.tsx
@@ -172,6 +172,7 @@ function SnoozeAlert({
           trigger={triggerProps => (
             <DropdownTrigger
               {...triggerProps}
+              size="sm"
               aria-label={t('Mute alert options')}
               icon={<IconChevron direction="down" size="xs" />}
             />

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -2,7 +2,7 @@ import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
 import {useMenuTrigger} from '@react-aria/menu';
-import {useResizeObserver} from '@react-aria/utils';
+import {mergeProps, useResizeObserver} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
 
 import DropdownButton, {DropdownButtonProps} from 'sentry/components/dropdownButton';
@@ -103,9 +103,8 @@ interface DropdownMenuProps
    * features won't work correctly.
    */
   trigger?: (
-    props: Omit<React.HTMLAttributes<Element>, 'children'> & {
-      onClick?: (e: MouseEvent) => void;
-    }
+    props: Omit<React.HTMLAttributes<HTMLElement>, 'children'>,
+    isOpen: boolean
   ) => React.ReactNode;
   /**
    * By default, the menu trigger will be rendered as a button, with
@@ -210,13 +209,7 @@ function DropdownMenu({
 
   function renderTrigger() {
     if (trigger) {
-      return trigger({
-        size,
-        isOpen,
-        ...triggerProps,
-        ...overlayTriggerProps,
-        ...buttonProps,
-      });
+      return trigger({...mergeProps(overlayTriggerProps, buttonProps)}, isOpen);
     }
     return (
       <DropdownButton

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -2,7 +2,7 @@ import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
 import {useMenuTrigger} from '@react-aria/menu';
-import {mergeProps, useResizeObserver} from '@react-aria/utils';
+import {useResizeObserver} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
 
 import DropdownButton, {DropdownButtonProps} from 'sentry/components/dropdownButton';

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -209,7 +209,7 @@ function DropdownMenu({
 
   function renderTrigger() {
     if (trigger) {
-      return trigger({...mergeProps(overlayTriggerProps, buttonProps)}, isOpen);
+      return trigger({...overlayTriggerProps, ...buttonProps}, isOpen);
     }
     return (
       <DropdownButton

--- a/static/app/components/notificationActions/forms/pagerdutyForm.tsx
+++ b/static/app/components/notificationActions/forms/pagerdutyForm.tsx
@@ -86,9 +86,10 @@ function PagerdutyForm({
         <div>{t('Send a notification to the')}</div>
         <DropdownMenu
           items={accountOptions}
-          trigger={triggerProps => (
+          trigger={(triggerProps, isOpen) => (
             <DropdownButton
               {...triggerProps}
+              isOpen={isOpen}
               aria-label={t('Select Account')}
               size="xs"
               data-test-id="pagerduty-account-dropdown"

--- a/static/app/components/notificationActions/forms/slackForm.tsx
+++ b/static/app/components/notificationActions/forms/slackForm.tsx
@@ -72,9 +72,10 @@ function SlackForm({
         <div>{t('Send a notification to the')}</div>
         <DropdownMenu
           items={workspaceOptions}
-          trigger={triggerProps => (
+          trigger={(triggerProps, isOpen) => (
             <DropdownButton
               {...triggerProps}
+              isOpen={isOpen}
               size="xs"
               aria-label={t('Select Workspace')}
               data-test-id="slack-workspace-dropdown"

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -195,9 +195,10 @@ function NotificationActionManager({
     >
       <DropdownMenu
         items={getMenuItems()}
-        trigger={triggerProps => (
+        trigger={(triggerProps, isOpen) => (
           <DropdownButton
             {...triggerProps}
+            isOpen={isOpen}
             aria-label={t('Add Action')}
             size="xs"
             icon={<IconAdd isCircled color="gray300" />}

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1906,6 +1906,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
               trigger={props => (
                 <ActionButton
                   {...props}
+                  size="sm"
                   aria-label={t('Show more')}
                   icon={<VerticalEllipsisIcon size="xs" />}
                 />


### PR DESCRIPTION
Update `DropdownMenu`'s `trigger` prop type from
```tsx
  trigger?: (
    props: Omit<React.HTMLAttributes<Element>, 'children'> & {
      onClick?: (e: MouseEvent) => void;
    }
  ) => React.ReactNode;
```
to
```tsx
  trigger?: (
    props: Omit<React.HTMLAttributes<HTMLElement>, 'children'>,
    isOpen: boolean
  ) => React.ReactNode;
```
The main change here is in the `isOpen` prop: it's been moved outside the `props` parameter and is now it's own standalone parameter in the render function. Doing this helps prevent typing conflicts in the future (and paves the way for an upcoming `@react-aria/button` package upgrade). `isOpen` is obviously not a native HTML prop — it's only being used by `DropdownButton`. Isolating `isOpen` from the `props` parameter means we can pass `props` to other components (e.g. a plain `Button`) that don't accept `isOpen` as a prop.