### PR TITLE
fix(breadcrumbs) : Add transaction title and remove deadlink 

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
@@ -105,7 +105,7 @@ function FormatMessage({
     const projectSlug = maybeProject.slug;
     const eventSlug = generateEventSlug({project: projectSlug, id: message});
 
-    const newContent =
+    const description =
       queryData && queryData.data.length > 0 ? (
         <Link to={getTransactionDetailsUrl(orgSlug, eventSlug)}>
           <Highlight text={searchTerm}>{queryData.data[0].title}</Highlight>
@@ -114,7 +114,7 @@ function FormatMessage({
         content
       );
 
-    return newContent;
+    return description;
   }
   switch (breadcrumb.messageFormat) {
     case 'sql':

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
@@ -1,3 +1,4 @@
+import type {BreadcrumbTransactionEvent} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {BreadcrumbMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {Organization} from 'sentry/types';
 import {BreadcrumbType, RawCrumb} from 'sentry/types/breadcrumbs';
@@ -13,9 +14,17 @@ type Props = {
   organization: Organization;
   searchTerm: string;
   meta?: BreadcrumbMeta;
+  transactionEvents?: BreadcrumbTransactionEvent[];
 };
 
-export function Data({breadcrumb, event, organization, searchTerm, meta}: Props) {
+export function Data({
+  breadcrumb,
+  event,
+  organization,
+  searchTerm,
+  meta,
+  transactionEvents,
+}: Props) {
   const orgSlug = organization.slug;
 
   if (breadcrumb.type === BreadcrumbType.HTTP) {
@@ -36,6 +45,7 @@ export function Data({breadcrumb, event, organization, searchTerm, meta}: Props)
       breadcrumb={breadcrumb}
       searchTerm={searchTerm}
       meta={meta}
+      transactionEvents={transactionEvents}
     />
   );
 }

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
@@ -3,6 +3,7 @@ import {CellMeasurerCache} from 'react-virtualized';
 import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
 
+import type {BreadcrumbTransactionEvent} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {BreadcrumbType, Crumb} from 'sentry/types/breadcrumbs';
@@ -28,6 +29,7 @@ type Props = {
   searchTerm: string;
   style: React.CSSProperties;
   meta?: Record<any, any>;
+  transactionEvents?: BreadcrumbTransactionEvent[];
 };
 
 export const Breadcrumb = memo(function Breadcrumb({
@@ -43,6 +45,7 @@ export const Breadcrumb = memo(function Breadcrumb({
   meta,
   isLastItem,
   cache,
+  transactionEvents,
 }: Props) {
   const sizingRef = useRef<HTMLDivElement | null>(null);
   const {type, description, color, level, category, timestamp} = breadcrumb;
@@ -79,6 +82,7 @@ export const Breadcrumb = memo(function Breadcrumb({
         breadcrumb={breadcrumb}
         searchTerm={searchTerm}
         meta={meta}
+        transactionEvents={transactionEvents}
       />
       <div>
         <Level level={level} searchTerm={searchTerm} />

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -128,6 +128,11 @@ describe('Breadcrumbs', () => {
         ],
       },
     };
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${props.organization.slug}/events/`,
+      method: 'GET',
+    });
   });
 
   describe('filterCrumbs', function () {

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -263,9 +263,12 @@ describe('Breadcrumbs', () => {
       );
 
       // Transaction in response should show as clickable title
-      expect(await screen.findByText('/settings/')).toBeInTheDocument();
+      expect(await screen.findByRole('link', {name: '/settings/'})).toBeInTheDocument();
 
-      expect(screen.getByText('/settings/')).toHaveAttribute('href');
+      expect(screen.getByText('/settings/')).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/project-slug:abcdabcdabcdabcdabcdabcdabcdabcd/?referrer=breadcrumbs'
+      );
     });
   });
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -4,7 +4,6 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {Breadcrumbs} from 'sentry/components/events/interfaces/breadcrumbs';
-import {Project} from 'sentry/types';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 import {
   useHasOrganizationSentAnyReplayEvents,
@@ -59,6 +58,8 @@ describe('Breadcrumbs', () => {
     >;
 
   beforeEach(() => {
+    const project = TestStubs.Project({platform: 'javascript'});
+
     MockUseProjects.mockReturnValue({
       fetchError: null,
       fetching: false,
@@ -66,7 +67,7 @@ describe('Breadcrumbs', () => {
       initiallyLoaded: false,
       onSearch: () => Promise.resolve(),
       placeholders: [],
-      projects: [TestStubs.Project({platform: 'javascript'}) as Project],
+      projects: [project],
     });
     MockUseHasOrganizationSentAnyReplayEvents.mockReturnValue({
       hasOrgSentReplays: false,
@@ -80,7 +81,7 @@ describe('Breadcrumbs', () => {
       organization: TestStubs.Organization(),
       projectSlug: 'project-slug',
       isShare: false,
-      event: TestStubs.Event({entries: []}),
+      event: TestStubs.Event({entries: [], projectID: project.id}),
       data: {
         values: [
           {
@@ -132,6 +133,16 @@ describe('Breadcrumbs', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${props.organization.slug}/events/`,
       method: 'GET',
+      body: {
+        data: [
+          {
+            title: '/settings/',
+            'project.name': 'javascript',
+            id: 'abcdabcdabcdabcdabcdabcdabcdabcd',
+          },
+        ],
+        meta: {},
+      },
     });
   });
 
@@ -222,6 +233,39 @@ describe('Breadcrumbs', () => {
       expect(screen.getByTestId('crumb')).toBeInTheDocument();
 
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
+    });
+
+    it('should render Sentry Transactions crumb', async function () {
+      props.data.values = [
+        {
+          message: '12345678123456781234567812345678',
+          category: 'sentry.transaction',
+          level: BreadcrumbLevelType.INFO,
+          type: BreadcrumbType.TRANSACTION,
+        },
+        {
+          message: 'abcdabcdabcdabcdabcdabcdabcdabcd',
+          category: 'sentry.transaction',
+          level: BreadcrumbLevelType.INFO,
+          type: BreadcrumbType.TRANSACTION,
+        },
+      ];
+
+      render(<Breadcrumbs {...props} />);
+
+      // Transaction not in response should show as non-clickable id
+      expect(
+        await screen.findByText('12345678123456781234567812345678')
+      ).toBeInTheDocument();
+
+      expect(screen.getByText('12345678123456781234567812345678')).not.toHaveAttribute(
+        'href'
+      );
+
+      // Transaction in response should show as clickable title
+      expect(await screen.findByText('/settings/')).toBeInTheDocument();
+
+      expect(screen.getByText('/settings/')).toHaveAttribute('href');
     });
   });
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -96,6 +96,7 @@ function Breadcrumbs({
     ],
     {
       staleTime: Infinity,
+      enabled: sentryTransactionIds.length > 0 && defined(maybeProject),
     }
   );
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -9,15 +9,22 @@ import {
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {BreadcrumbWithMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
+import {
+  BreadcrumbTransactionEvent,
+  BreadcrumbWithMeta,
+} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {PanelTable} from 'sentry/components/panels';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {BreadcrumbType} from 'sentry/types/breadcrumbs';
+import {defined} from 'sentry/utils';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useProjects from 'sentry/utils/useProjects';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
+import {isEventId} from './breadcrumb/data/default';
 import {Breadcrumb} from './breadcrumb';
 
 const PANEL_MIN_HEIGHT = 200;
@@ -51,9 +58,46 @@ function Breadcrumbs({
   emptyMessage,
 }: Props) {
   const [scrollbarSize, setScrollbarSize] = useState(0);
+  const {projects, fetching: loadingProjects} = useProjects();
+
+  const maybeProject = !loadingProjects
+    ? projects.find(project => {
+        return event && project.id === event.projectID;
+      })
+    : null;
 
   const listRef = useRef<List>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const sentryTransaction = breadcrumbs.filter(
+    crumb =>
+      crumb.breadcrumb.category === 'sentry.transaction' &&
+      defined(crumb.breadcrumb.message) &&
+      isEventId(crumb.breadcrumb.message)
+  );
+
+  const sentryTransactionIds = sentryTransaction
+    .map(crumb => crumb.breadcrumb.message)
+    .filter(defined);
+
+  const {data: transactionEvents} = useApiQuery<{
+    data: BreadcrumbTransactionEvent[];
+    meta: any;
+  }>(
+    [
+      `/organizations/${organization.slug}/events/`,
+      {
+        query: {
+          query: `id:[${sentryTransactionIds}]`,
+          field: ['title'],
+          project: [maybeProject?.id],
+        },
+      },
+    ],
+    {
+      staleTime: Infinity,
+    }
+  );
 
   const updateGrid = useCallback(() => {
     if (listRef.current) {
@@ -110,6 +154,7 @@ function Breadcrumbs({
                   ? scrollbarSize
                   : 0
               }
+              transactionEvents={transactionEvents?.data}
             />
           </BreadcrumbRow>
         )}

--- a/static/app/components/events/interfaces/breadcrumbs/types.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/types.tsx
@@ -6,3 +6,10 @@ export type BreadcrumbWithMeta = {
   breadcrumb: Crumb;
   meta: BreadcrumbMeta;
 };
+
+// Used when looking up transaction title from breadcrumb transactions
+export type BreadcrumbTransactionEvent = {
+  id: string;
+  'project.name': string;
+  title: string;
+};


### PR DESCRIPTION
this pr makes 2 changes. first, it removes the link from transaction that don't exist in Sentry. This can be caused by a number of things, but the current experience is a not found page if the transaction doesn't exist. second, if the transaction does exist, we will now show the transaction title instead of the id in the breadcrumbs. clicking this link will still bring you to the transaction page, but will now show more useful information about the transaction while just looking at the breadcrumbs. 

![Screenshot 2023-06-06 at 10 31 27 AM](https://github.com/getsentry/sentry/assets/46740234/3523a5c1-64c4-4c4a-90e9-c74abddf344c)

Closes https://github.com/getsentry/sentry/issues/49599 and https://github.com/getsentry/sentry/issues/49600