### PR TITLE
feat(crons): Add timeline component

### DIFF
--- a/static/app/views/monitors/components/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/checkInTimeline.tsx
@@ -1,0 +1,73 @@
+import {Theme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Resizeable} from 'sentry/components/replays/resizeable';
+import {space} from 'sentry/styles/space';
+import {CheckIn, CheckInStatus} from 'sentry/views/monitors/types';
+
+interface Props {
+  checkins: CheckIn[];
+  end: Date;
+  start: Date;
+  width?: number;
+}
+
+function getColorFromStatus(status: CheckInStatus, theme: Theme) {
+  const statusToColor: Record<CheckInStatus, string> = {
+    [CheckInStatus.ERROR]: theme.red200,
+    [CheckInStatus.TIMEOUT]: theme.red200,
+    [CheckInStatus.OK]: theme.green200,
+    [CheckInStatus.MISSED]: theme.yellow200,
+    [CheckInStatus.IN_PROGRESS]: theme.disabled,
+  };
+  return statusToColor[status];
+}
+
+function getCheckInPosition(checkDate: string, timelineStart: Date, msPerPixel: number) {
+  const elapsedSinceStart = new Date(checkDate).getTime() - timelineStart.getTime();
+  return elapsedSinceStart / msPerPixel;
+}
+
+export function CheckInTimeline(props: Props) {
+  const {checkins, start, end} = props;
+
+  function renderTimelineWithWidth(width: number) {
+    const timeWindow = end.getTime() - start.getTime();
+    const msPerPixel = timeWindow / width;
+
+    return (
+      <TimelineContainer>
+        {checkins.map(({id, dateCreated, status}) => {
+          const left = getCheckInPosition(dateCreated, start, msPerPixel);
+          if (left < 0) {
+            return null;
+          }
+
+          return <JobTick key={id} left={left} status={status} />;
+        })}
+      </TimelineContainer>
+    );
+  }
+
+  if (props.width) {
+    return renderTimelineWithWidth(props.width);
+  }
+
+  return <Resizeable>{({width}) => renderTimelineWithWidth(width)}</Resizeable>;
+}
+
+const TimelineContainer = styled('div')`
+  position: relative;
+  height: 14px;
+  margin: ${space(4)} 0;
+`;
+
+const JobTick = styled('div')<{left: number; status: CheckInStatus}>`
+  position: absolute;
+  width: 4px;
+  height: 14px;
+  border-radius: 6px;
+  left: ${p => p.left}px;
+
+  background: ${p => getColorFromStatus(p.status, p.theme)};
+`;


### PR DESCRIPTION
Adding this timeline component, which takes a start and end time as well as a list of check-ins and renders them as tick marks inside of the view.

 first step in creating the new timeline view on the monitors listing page
<img width="887" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/9320270f-6813-4e17-8483-6eacc93a8d72">

Eventually will look more like this (with gridlines and time values):
<img width="1232" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/472cf1ed-ad67-425c-94f0-4a4499c228c9">



Will follow up with the gridlines overlay shortly
