### PR TITLE
feat(ui): Let users navigate to project stats thru main list (ER-1600) 

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -353,6 +353,23 @@ describe('OrganizationStats', function () {
     );
   });
 
+  it('renders a project when its graph icon is clicked (starting from global-views)', async () => {
+    // First initialize a default view w/no projects selected.
+    const newOrg = initializeOrg();
+    newOrg.organization.features = [
+      'global-views',
+      'team-insights',
+      // TODO(Leander): Remove the following check once the project-stats flag is GA
+      'project-stats',
+    ];
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
+      context: newOrg.routerContext,
+    });
+    await userEvent.click(screen.getByTestId('proj-1'));
+    expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
+    expect(screen.getAllByText('proj-1').length).toBe(2);
+  });
+
   /**
    * Feature Flagging
    */

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -353,8 +353,7 @@ describe('OrganizationStats', function () {
     );
   });
 
-  it('renders a project when its graph icon is clicked (starting from global-views)', async () => {
-    // First initialize a default view w/no projects selected.
+  it('renders a project when its graph icon is clicked', async () => {
     const newOrg = initializeOrg();
     newOrg.organization.features = [
       'global-views',

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -396,6 +396,7 @@ export class OrganizationStats extends Component<Props> {
               </div>
               <ErrorBoundary mini>
                 <UsageStatsProjects
+                  router={this.props.router}
                   organization={organization}
                   dataCategory={this.dataCategory}
                   dataCategoryName={this.dataCategoryName}

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -396,7 +396,6 @@ export class OrganizationStats extends Component<Props> {
               </div>
               <ErrorBoundary mini>
                 <UsageStatsProjects
-                  router={this.props.router}
                   organization={organization}
                   dataCategory={this.dataCategory}
                   dataCategoryName={this.dataCategoryName}

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {LocationDescriptorObject} from 'history';
@@ -19,6 +20,8 @@ import withProjects from 'sentry/utils/withProjects';
 import {UsageSeries} from './types';
 import UsageTable, {CellProject, CellStat, TableStat} from './usageTable';
 
+type Router = InjectedRouter | null | undefined;
+
 type Props = {
   dataCategory: DataCategoryInfo['plural'];
   dataCategoryName: string;
@@ -37,6 +40,7 @@ type Props = {
   organization: Organization;
   projectIds: number[];
   projects: Project[];
+  router: Router;
   tableCursor?: string;
   tableQuery?: string;
   tableSort?: string;
@@ -450,6 +454,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
             headers={headers}
             dataCategory={dataCategory}
             usageStats={tableStats}
+            router={this.props.router}
           />
           <Pagination pageLinks={this.pageLink} />
         </Container>

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -120,6 +120,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
 
   get tableData() {
     const {projectStats} = this.state;
+
     return {
       headers: this.tableHeader,
       ...this.mapSeriesToTable(projectStats),
@@ -218,7 +219,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
       return direction > 0 ? 'desc' : 'asc';
     };
 
-    const columnHeaders = [
+    return [
       {
         key: SortBy.PROJECT,
         title: t('Project'),
@@ -254,24 +255,23 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
         direction: getArrowDirection(SortBy.DROPPED),
         onClick: () => this.handleChangeSort(SortBy.DROPPED),
       },
-    ].map(h => {
-      const Cell = h.key === SortBy.PROJECT ? CellProject : CellStat;
+    ]
+      .map(h => {
+        const Cell = h.key === SortBy.PROJECT ? CellProject : CellStat;
 
-      return (
-        <Cell key={h.key}>
-          <SortLink
-            canSort
-            title={h.title}
-            align={h.align as Alignments}
-            direction={h.direction}
-            generateSortLink={h.onClick}
-          />
-        </Cell>
-      );
-    });
-    const emptyColumn = <CellStat key="extra" />; // For displaying extra buttons
-    columnHeaders.push(emptyColumn);
-    return columnHeaders;
+        return (
+          <Cell key={h.key}>
+            <SortLink
+              canSort
+              title={h.title}
+              align={h.align as Alignments}
+              direction={h.direction}
+              generateSortLink={h.onClick}
+            />
+          </Cell>
+        );
+      })
+      .concat([<CellStat key="empty" />]); // Extra column for displaying buttons etc.
   }
 
   getProjectLink(project: Project) {

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -124,7 +124,6 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
 
   get tableData() {
     const {projectStats} = this.state;
-
     return {
       headers: this.tableHeader,
       ...this.mapSeriesToTable(projectStats),
@@ -223,7 +222,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
       return direction > 0 ? 'desc' : 'asc';
     };
 
-    return [
+    const columnHeaders = [
       {
         key: SortBy.PROJECT,
         title: t('Project'),
@@ -274,6 +273,9 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
         </Cell>
       );
     });
+    const emptyColumn = <CellStat key="extra" />;
+    columnHeaders.push(emptyColumn);
+    return columnHeaders;
   }
 
   getProjectLink(project: Project) {
@@ -427,7 +429,6 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
     const {error, errors, loading} = this.state;
     const {dataCategory, loadingProjects, tableQuery, isSingleProject} = this.props;
     const {headers, tableStats} = this.tableData;
-
     return (
       <Fragment>
         {isSingleProject && (

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {LocationDescriptorObject} from 'history';
@@ -20,8 +19,6 @@ import withProjects from 'sentry/utils/withProjects';
 import {UsageSeries} from './types';
 import UsageTable, {CellProject, CellStat, TableStat} from './usageTable';
 
-type Router = InjectedRouter | null | undefined;
-
 type Props = {
   dataCategory: DataCategoryInfo['plural'];
   dataCategoryName: string;
@@ -40,7 +37,6 @@ type Props = {
   organization: Organization;
   projectIds: number[];
   projects: Project[];
-  router: Router;
   tableCursor?: string;
   tableQuery?: string;
   tableSort?: string;
@@ -455,7 +451,6 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
             headers={headers}
             dataCategory={dataCategory}
             usageStats={tableStats}
-            router={this.props.router}
           />
           <Pagination pageLinks={this.pageLink} />
         </Container>

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -273,7 +273,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
         </Cell>
       );
     });
-    const emptyColumn = <CellStat key="extra" />;
+    const emptyColumn = <CellStat key="extra" />; // For displaying extra buttons
     columnHeaders.push(emptyColumn);
     return columnHeaders;
   }

--- a/static/app/views/organizationStats/usageTable/index.tsx
+++ b/static/app/views/organizationStats/usageTable/index.tsx
@@ -1,5 +1,5 @@
 import {Component} from 'react';
-import {InjectedRouter} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
@@ -15,23 +15,21 @@ import {IconGraph, IconSettings, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategoryInfo, Project} from 'sentry/types';
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import {formatUsageWithUnits, getFormatUsageOptions} from '../utils';
 
 const DOCS_URL = 'https://docs.sentry.io/product/accounts/membership/#restricting-access';
 
-type Router = InjectedRouter | null | undefined;
-
 type Props = {
   dataCategory: DataCategoryInfo['plural'];
   headers: React.ReactNode[];
-  router: Router;
   usageStats: TableStat[];
   errors?: Record<string, Error>;
   isEmpty?: boolean;
   isError?: boolean;
   isLoading?: boolean;
-};
+} & WithRouterProps<{}, {}>;
 
 export type TableStat = {
   accepted: number;
@@ -144,7 +142,7 @@ class UsageTable extends Component<Props> {
   }
 }
 
-export default UsageTable;
+export default withSentryRouter(UsageTable);
 
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: repeat(6, auto);

--- a/static/app/views/organizationStats/usageTable/index.tsx
+++ b/static/app/views/organizationStats/usageTable/index.tsx
@@ -3,6 +3,7 @@ import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 
 import {updateProjects} from 'sentry/actionCreators/pageFilters';
+import {Button} from 'sentry/components/button';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import IdBadge from 'sentry/components/idBadge';
@@ -83,16 +84,6 @@ class UsageTable extends Component<Props> {
             displayName={project.slug}
           />
         </Link>
-        <SettingsIconLink to={stat.projectSettingsLink}>
-          <IconSettings size="sm" />
-        </SettingsIconLink>
-        <StyledIconGraph
-          data-test-id={project.slug}
-          size="sm"
-          onClick={() => {
-            this.loadProject(parseInt(stat.project.id, 10));
-          }}
-        />
       </CellProject>,
       <CellStat key={1}>
         {formatUsageWithUnits(total, dataCategory, getFormatUsageOptions(dataCategory))}
@@ -113,6 +104,23 @@ class UsageTable extends Component<Props> {
       </CellStat>,
       <CellStat key={4}>
         {formatUsageWithUnits(dropped, dataCategory, getFormatUsageOptions(dataCategory))}
+      </CellStat>,
+      <CellStat key={5}>
+        <Button
+          data-test-id={project.slug}
+          size="sm"
+          onClick={() => {
+            this.loadProject(parseInt(stat.project.id, 10));
+          }}
+        >
+          <StyledIconGraph type="bar" size="sm" />
+          <span>View Stats</span>
+        </Button>
+        <Link to={stat.projectSettingsLink}>
+          <StyledSettingsButton size="sm">
+            <SettingsIcon size="sm" />
+          </StyledSettingsButton>
+        </Link>
       </CellStat>,
     ];
   }
@@ -139,23 +147,22 @@ class UsageTable extends Component<Props> {
 export default UsageTable;
 
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: repeat(5, auto);
+  grid-template-columns: repeat(6, auto);
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 1fr repeat(4, minmax(0, auto));
+    grid-template-columns: 1fr repeat(5, minmax(0, auto));
   }
 `;
 
 export const CellStat = styled('div')`
-  flex-shrink: 1;
-  text-align: right;
+  display: flex;
+  align-items: center;
   font-variant-numeric: tabular-nums;
+  justify-content: right;
 `;
 
 export const CellProject = styled(CellStat)`
-  display: flex;
-  align-items: center;
-  text-align: left;
+  justify-content: left;
 `;
 
 const StyledIdBadge = styled(IdBadge)`
@@ -164,12 +171,12 @@ const StyledIdBadge = styled(IdBadge)`
   flex-shrink: 1;
 `;
 
-const SettingsIconLink = styled(Link)`
+const SettingsIcon = styled(IconSettings)`
   color: ${p => p.theme.gray300};
   align-items: center;
   display: inline-flex;
   justify-content: space-between;
-  margin-right: ${space(1.5)};
+  margin-right: ${space(1.0)};
   margin-left: ${space(1.0)};
   transition: 0.5s opacity ease-out;
 
@@ -180,8 +187,14 @@ const SettingsIconLink = styled(Link)`
 
 const StyledIconGraph = styled(IconGraph)`
   color: ${p => p.theme.gray300};
+  margin-right: 5px;
   &:hover {
     color: ${p => p.theme.textColor};
     cursor: pointer;
   }
+`;
+
+const StyledSettingsButton = styled(Button)`
+  padding: 0px;
+  margin-left: 7px;
 `;


### PR DESCRIPTION
[ER-1600](https://getsentry.atlassian.net/jira/software/c/projects/ER/boards/90?modal=detail&selectedIssue=ER-1600&assignee=712020%3A45bb2666-a66d-424e-94cd-55c5c73bdc57) describes a UX problem in which users have to go through a 3-click process to access individual project statistics.

This PR adds a button to the end of each row that when clicked, takes you to that projects statistics, it also moves the settings link into a button at the end of each row.

It looks like this:
<img width="1145" alt="Screenshot 2023-06-06 at 10 48 28 AM" src="https://github.com/getsentry/sentry/assets/26236981/f2530c21-21f6-4c9c-b76e-415e3a0695f6">


https://github.com/getsentry/sentry/assets/26236981/6f1c4420-37d0-417b-92b4-ccbaa76cead5



[ER-1600]: https://getsentry.atlassian.net/browse/ER-1600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ