### PR TITLE
fix(issue-details): Display culprit for all issue types generated by the issue platform

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -178,19 +178,11 @@ export function getTitle(
         treeLabel: undefined,
       };
     case EventOrGroupType.TRANSACTION:
-      const isPerfIssue =
-        !isTombstone(event) && event.issueCategory === IssueCategory.PERFORMANCE;
-      return {
-        title: isPerfIssue ? metadata.title : customTitle ?? title,
-        subtitle: isPerfIssue ? culprit : '',
-        treeLabel: undefined,
-      };
     case EventOrGroupType.GENERIC:
-      const isProfilingIssue =
-        !isTombstone(event) && event.issueCategory === IssueCategory.PROFILE;
+      const isIssue = !isTombstone(event) && defined(event.issueCategory);
       return {
-        title: isProfilingIssue ? metadata.title : customTitle ?? title,
-        subtitle: isProfilingIssue ? culprit : '',
+        title: customTitle ?? title,
+        subtitle: isIssue ? culprit : '',
         treeLabel: undefined,
       };
     default:


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/50423

There was a specific case for profiling issues, but we'd like to do the same thing for all issue types.

Since the logic was similar for transactions, I combined the two cases. 