### PR TITLE
feat(slack): move logic for escaping slack text

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -6,7 +6,6 @@ from typing import Any, Mapping, MutableMapping, Sequence
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.message_builder import AbstractMessageBuilder
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackBody
-from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.issues.grouptype import GroupCategory
 from sentry.models import Group
 from sentry.notifications.utils.actions import MessageAction
@@ -63,7 +62,6 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         footer: str | None = None,
         color: str | None = None,
         actions: Sequence[MessageAction] | None = None,
-        is_unfurl: bool = False,
         **kwargs: Any,
     ) -> SlackBody:
         """
@@ -92,18 +90,9 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         if actions is not None:
             kwargs["actions"] = [get_slack_button(action) for action in actions]
 
-        markdown_in = ["text"]
-        if self.escape_text:
-            text = escape_slack_text(text)
-            # XXX(scefali): Not sure why we actually need to do this just for unfurled messages.
-            # If we figure out why this is required we should note it here because it's quite strange
-            if is_unfurl:
-                text = escape_slack_text(text)
-            markdown_in = []
-
         return {
             "text": text,
-            "mrkdwn_in": markdown_in,
+            "mrkdwn_in": ["text"],
             "color": LEVEL_TO_COLOR[color or "info"],
             **kwargs,
         }

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -9,8 +9,7 @@ from django.urls import reverse
 from sentry.eventstore.models import Event
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.incidents.models import IncidentStatus
-from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackBody
-from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
+from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.message_builder.issues import (
     SlackIssuesMessageBuilder,
@@ -27,20 +26,6 @@ from sentry.testutils.silo import region_silo_test
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
-
-
-class DummySlackNotification(SlackMessageBuilder):
-    def __init__(self, text, escape_text=False) -> None:
-        super().__init__()
-        self.text = text
-        self._escape_text = escape_text
-
-    @property
-    def escape_text(self) -> bool:
-        return self._escape_text
-
-    def build(self) -> SlackBody:
-        return self._build(text=self.text)
 
 
 def build_test_message(
@@ -538,22 +523,4 @@ class BuildMetricAlertAttachmentTest(TestCase):
                 },
                 {"alt_text": "Metric Alert Chart", "image_url": "chart_url", "type": "image"},
             ],
-        }
-
-
-class DummySlackNotificationTest(TestCase):
-    def test_no_escape(self):
-        raw_text = "<https://example.com/|*Click Here*>"
-        assert DummySlackNotification(raw_text).build() == {
-            "text": raw_text,
-            "mrkdwn_in": ["text"],
-            "color": "#2788CE",
-        }
-
-    def test_with_escape(self):
-        raw_text = "<https://example.com/|*Click Here*>"
-        assert DummySlackNotification(raw_text, True).build() == {
-            "text": "&lt;https://example.com/|*Click Here*&gt;",
-            "mrkdwn_in": [],
-            "color": "#2788CE",
         }


### PR DESCRIPTION
Moving the logic for escaping Slack messages to just the untrusted text (the title of the issue).