### PR TITLE
feat(api): Add team_slug global param

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -18,6 +18,13 @@ class GLOBAL_PARAMS:
         type=str,
         location="path",
     )
+    TEAM_SLUG = OpenApiParameter(
+        name="team_slug",
+        description="The slug of the team the resource belongs to.",
+        required=True,
+        type=str,
+        location="path",
+    )
     STATS_PERIOD = OpenApiParameter(
         name="statsPeriod",
         location="query",


### PR DESCRIPTION
Add team_slug global param in order to document team related endpoints using drf spectacular and open api.