### PR TITLE
fix(crons): Properly update config when schedule type changes

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -286,8 +286,12 @@ class Monitor(Model):
 
     def update_config(self, config_payload, validated_config):
         monitor_config = self.config
-        # Only update keys that were specified in the payload
-        for key in config_payload.keys():
+        keys = set(config_payload.keys())
+
+        # Always update schedule and schedule_type
+        keys.update({"schedule", "schedule_type"})
+        # Otherwise, only update keys that were specified in the payload
+        for key in keys:
             if key in validated_config:
                 monitor_config[key] = validated_config[key]
         self.save()

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -541,8 +541,10 @@ class MonitorEnvironmentTestCase(TestCase):
         )
 
         new_config = {
-            "schedule": [2, "month"],
-            "schedule_type": "interval",
+            "schedule": {
+                "type": "crontab",
+                "value": "0 0 1 2 *",
+            },
             "max_runtime": 10,
             "garbage": "data",
         }
@@ -552,8 +554,8 @@ class MonitorEnvironmentTestCase(TestCase):
         monitor.update_config(new_config, validated_config)
 
         assert monitor.config == {
-            "schedule": [2, "month"],
-            "schedule_type": ScheduleType.INTERVAL,
+            "schedule": "0 0 1 2 *",
+            "schedule_type": ScheduleType.CRONTAB,
             "max_runtime": 10,
             "alert_rule_id": 1,
         }


### PR DESCRIPTION
Always updates monitor config with `schedule` and `schedule_type` from the validator, as type may be nested in the actual schedule payload. Both values are guaranteed to exist on a valid monitor config

Fixes SENTRY-11XX
Fixes SENTRY-11XK
Fixes SENTRY-11XZ