### PR TITLE
fix(notifications): Adjust copy on claim unassigned issues

### DIFF
--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -112,12 +112,12 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, Field> = {
   selfAssignOnResolve: {
     name: 'selfAssignOnResolve',
     type: 'select',
-    label: t('Claim Unassigned Issues I’ve Resolved'),
+    label: t('Resolve and Auto-Assign'),
     choices: [
       [true as any, t('On')],
       [false as any, t('Off')],
     ],
-    help: t('You’ll be assigned unassigned issues you resolve.'),
+    help: t("When you resolve an unassigned issue, we'll auto-assign it to you."),
   },
 };
 

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -117,7 +117,7 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, Field> = {
       [true as any, t('On')],
       [false as any, t('Off')],
     ],
-    help: t('You’ll receive notifications about any changes that happen afterwards.'),
+    help: t('You’ll be assigned unassigned issues you resolve.'),
   },
 };
 


### PR DESCRIPTION
This was confusing to me

what it looked like before
![image](https://github.com/getsentry/sentry/assets/1400464/19fe8cdc-b7d7-4dc0-8006-a887cafb20e4)
