### PR TITLE
fix(roles): Unable to assign Org-admins to new teams

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -77,10 +77,6 @@ class OrganizationMemberSerializer(serializers.Serializer):
         return self.validate_orgRole(role)
 
     def validate_orgRole(self, role):
-        if features.has("organizations:team-roles", self.context["organization"]):
-            if role in {r.id for r in organization_roles.get_all() if r.is_retired}:
-                raise serializers.ValidationError("This org-level role has been deprecated")
-
         if role not in {r.id for r in self.context["allowed_roles"]}:
             raise serializers.ValidationError(
                 "You do not have permission to set that org-level role"

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -100,9 +100,7 @@ class OrganizationMemberSerializerTest(TestCase):
         data = {"email": "eric@localhost", "orgRole": "admin", "teamRoles": []}
 
         serializer = OrganizationMemberSerializer(context=context, data=data)
-
-        assert not serializer.is_valid()
-        assert serializer.errors == {"orgRole": ["This org-level role has been deprecated"]}
+        assert serializer.is_valid()
 
     def test_invalid_team_role(self):
         context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}


### PR DESCRIPTION
We don't have firm plans to deprecate org-admins, so it's fine to remove it from the serializer.