### PR TITLE
fix: Metrics indexer drops any inflight messages on join

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -599,7 +599,6 @@ def occurrences_ingest_consumer(**options):
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--ingest-profile", required=True)
 @click.option("--indexer-db", default="postgres")
-@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=10)
 @click.option("max_msg_batch_size", "--max-msg-batch-size", type=int, default=50)
 @click.option("max_msg_batch_time", "--max-msg-batch-time-ms", type=int, default=10000)
 @click.option("max_parallel_batch_size", "--max-parallel-batch-size", type=int, default=50)

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -182,7 +182,6 @@ def get_parallel_metrics_consumer(
     group_id: str,
     auto_offset_reset: str,
     strict_offset_reset: bool,
-    join_timeout: int,
     indexer_profile: MetricsIngestConfiguration,
     slicing_router: Optional[SlicingRouter],
 ) -> StreamProcessor[KafkaPayload]:
@@ -210,5 +209,7 @@ def get_parallel_metrics_consumer(
         Topic(indexer_profile.input_topic),
         processing_factory,
         ONCE_PER_SECOND,
-        join_timeout=join_timeout,
+        # We drop any in flight messages in processing step prior to produce.
+        # The SimpleProduceStep has a hardcoded join timeout of 5 seconds.
+        join_timeout=0.0,
     )


### PR DESCRIPTION
Any messages in the processing pipeline prior to the produce step should be dropped.

Previously this timeout applied to the ParallelTransform step, which would wait 10 seconds for join to complete. However, since the subsequent step (Unbatch) drops all messages on join anyway, it is pointless to wait up to 10 seconds to parallel transform messages that will later be dropped anyway.

