### PR TITLE
feat(starfish): Make chart titles consistent

### DIFF
--- a/static/app/views/starfish/components/samplesTable/useSlowMedianFastSamplesQuery.tsx
+++ b/static/app/views/starfish/components/samplesTable/useSlowMedianFastSamplesQuery.tsx
@@ -5,7 +5,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-const LIMIT_PER_POPULATION = 5;
+const LIMIT_PER_POPULATION = 2;
 
 /**
  * This hook will fetch transaction events from 3 different types of populations and combine them in one set, then return them:

--- a/static/app/views/starfish/utils/generatePerformanceEventView.tsx
+++ b/static/app/views/starfish/utils/generatePerformanceEventView.tsx
@@ -124,7 +124,7 @@ export function generateWebServiceEventView(
   const fields = [
     'transaction',
     'http.method',
-    'tpm()',
+    'tps()',
     'p95(transaction.duration)',
     'http_error_count()',
     'time_spent_percentage()',

--- a/static/app/views/starfish/views/webServiceView/endpointList.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointList.tsx
@@ -29,14 +29,15 @@ import {formatPercentage} from 'sentry/utils/formatters';
 import {TableColumn} from 'sentry/views/discover/table/types';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TIME_SPENT_IN_SERVICE} from 'sentry/views/starfish/utils/generatePerformanceEventView';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/endpointDetails';
 
 const COLUMN_TITLES = [
   'Endpoint',
-  'Throughput',
-  'Duration (P95)',
-  '5XX Responses',
-  'Time Spent',
+  DataTitles.throughput,
+  DataTitles.p95,
+  DataTitles.errorCount,
+  DataTitles.timeSpent,
 ];
 
 type Props = {
@@ -121,8 +122,12 @@ function EndpointList({eventView, location, organization, setError}: Props) {
       );
     }
 
-    if (field === 'tpm()') {
-      return <ThroughputCell throughputPerSecond={(dataRow[field] as number) / 60} />;
+    if (field === 'tps()') {
+      return (
+        <NumberContainer>
+          <ThroughputCell throughputPerSecond={dataRow[field] as number} />
+        </NumberContainer>
+      );
     }
 
     if (

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -23,7 +23,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import withApi from 'sentry/utils/withApi';
 import Chart from 'sentry/views/starfish/components/chart';
-import {FacetInsights} from 'sentry/views/starfish/components/facetInsights';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {TransactionSamplesTable} from 'sentry/views/starfish/components/samplesTable/transactionSamplesTable';
 import {ModuleName} from 'sentry/views/starfish/types';
@@ -37,6 +36,7 @@ import SpansTable, {
   SpanTrendDataRow,
 } from 'sentry/views/starfish/views/spans/spansTable';
 import {buildQueryConditions} from 'sentry/views/starfish/views/spans/spansView';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {SpanGroupBreakdownContainer} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const SPANS_TABLE_LIMIT = 5;
@@ -201,7 +201,6 @@ export default function EndpointOverview() {
                               loading={loading}
                               utc={false}
                               stacked
-                              isLineChart
                               disableXAxis
                               definedAxisTicks={2}
                               chartColors={[theme.charts.getColorPalette(0)[0]]}
@@ -211,13 +210,16 @@ export default function EndpointOverview() {
                                 top: '8px',
                                 bottom: '16px',
                               }}
+                              tooltipFormatterOptions={{
+                                valueFormatter: value => t('%s/sec', value.toFixed(2)),
+                              }}
                             />
                           </MiniChartPanel>
                         </Fragment>
                       );
                     }}
                   </EventsRequest>
-                  <MiniChartPanel title={t('Errors (5XXs)')}>
+                  <MiniChartPanel title={DataTitles.errorCount}>
                     {renderFailureRateChart()}
                   </MiniChartPanel>
                 </ChartsContainerItem2>
@@ -238,7 +240,6 @@ export default function EndpointOverview() {
               </SegmentedControl>
             </SegmentedControlContainer>
             <SpanMetricsTable filter={state.spansFilter} transaction={transaction} />
-            <FacetInsights eventView={eventView} />
           </Layout.Main>
         </Layout.Body>
       </Layout.Page>

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -132,7 +132,6 @@ export default function EndpointOverview() {
                 definedAxisTicks={2}
                 isLineChart
                 chartColors={[CHART_PALETTE[5][3]]}
-                disableXAxis
               />
             </Fragment>
           );
@@ -201,7 +200,6 @@ export default function EndpointOverview() {
                               loading={loading}
                               utc={false}
                               stacked
-                              disableXAxis
                               definedAxisTicks={2}
                               chartColors={[theme.charts.getColorPalette(0)[0]]}
                               grid={{

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -181,7 +181,7 @@ export default function EndpointOverview() {
                     start={pageFilter.selection.datetime.start}
                     end={pageFilter.selection.datetime.end}
                     organization={organization}
-                    yAxis={['tpm()']}
+                    yAxis={['tps()']}
                     dataset={DiscoverDatasets.METRICS}
                   >
                     {({loading, timeseriesData}) => {
@@ -206,7 +206,7 @@ export default function EndpointOverview() {
                                 left: '0',
                                 right: '0',
                                 top: '8px',
-                                bottom: '16px',
+                                bottom: '0',
                               }}
                               tooltipFormatterOptions={{
                                 valueFormatter: value => t('%s/sec', value.toFixed(2)),

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -48,7 +48,9 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
     eventView: getEventView(
       selection,
       // TODO: Fix has:span.category in the backend
-      `has:span.category ${transaction ? `transaction:${transaction}` : ''}`,
+      `transaction.op:http.server has:span.category ${
+        transaction ? `transaction:${transaction}` : ''
+      }`,
       ['span.category']
     ),
     orgSlug: organization.slug,
@@ -59,7 +61,7 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
   const {data: cumulativeTime} = useDiscoverQuery({
     eventView: getEventView(
       selection,
-      `${transaction ? `transaction:${transaction}` : ''}`,
+      `transaction.op:http.server ${transaction ? `transaction:${transaction}` : ''}`,
       []
     ),
     orgSlug: organization.slug,
@@ -69,7 +71,9 @@ export function SpanGroupBreakdownContainer({transaction: maybeTransaction}: Pro
   const {isLoading: isTopDataLoading, data: topData} = useWrappedDiscoverTimeseriesQuery({
     eventView: getEventView(
       selection,
-      `has:span.category  ${transaction ? `transaction:${transaction}` : ''}`,
+      `transaction.op:http.server has:span.category ${
+        transaction ? `transaction:${transaction}` : ''
+      }`,
       ['span.category'],
       true
     ),

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -126,7 +126,6 @@ export function StarfishView(props: BasePerformanceViewProps) {
                 definedAxisTicks={2}
                 isLineChart
                 chartColors={theme.charts.getColorPalette(2)}
-                disableXAxis
                 onClick={e => {
                   if (e.componentType === 'markArea') {
                     setSelectedSpike({
@@ -191,7 +190,6 @@ export function StarfishView(props: BasePerformanceViewProps) {
               definedAxisTicks={2}
               stacked
               chartColors={theme.charts.getColorPalette(2)}
-              disableXAxis
               tooltipFormatterOptions={{
                 valueFormatter: value => t('%s/sec', value.toFixed(2)),
               }}

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -24,6 +24,7 @@ import withApi from 'sentry/utils/withApi';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {insertClickableAreasIntoSeries} from 'sentry/views/starfish/utils/insertClickableAreasIntoSeries';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {EndpointDataRow} from 'sentry/views/starfish/views/webServiceView/endpointDetails';
 import FailureDetailPanel from 'sentry/views/starfish/views/webServiceView/failureDetailPanel';
 import {SpanGroupBreakdownContainer} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
@@ -164,7 +165,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
         start={eventView.start}
         end={eventView.end}
         organization={organization}
-        yAxis="tpm()"
+        yAxis="tps()"
         queryExtras={{dataset: 'metrics'}}
       >
         {({loading, timeseriesData}) => {
@@ -191,6 +192,9 @@ export function StarfishView(props: BasePerformanceViewProps) {
               stacked
               chartColors={theme.charts.getColorPalette(2)}
               disableXAxis
+              tooltipFormatterOptions={{
+                valueFormatter: value => t('%s/sec', value.toFixed(2)),
+              }}
             />
           );
         }}
@@ -211,7 +215,7 @@ export function StarfishView(props: BasePerformanceViewProps) {
             <MiniChartPanel title={t('Throughput Per Second')}>
               {renderThroughputChart()}
             </MiniChartPanel>
-            <MiniChartPanel title={t('5XX Responses')}>
+            <MiniChartPanel title={DataTitles.errorCount}>
               {renderFailureRateChart()}
             </MiniChartPanel>
           </ChartsContainerItem2>


### PR DESCRIPTION
- Use DataTitles wherever possible
- Remove the facet insights component because we're not sure what is happening there
- Use tps everywhere
- Make the endpoint overview sample table a bit smaller