### PR TITLE
fix(functions): Handle cross projects global suspect functions

### DIFF
--- a/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.spec.tsx
@@ -33,6 +33,31 @@ describe('SlowestFunctionsWidget', function () {
     expect(await screen.findByTestId('error-indicator')).toBeInTheDocument();
   });
 
+  it('renders no functions', async function () {
+    // for the slowest functions query
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [],
+      },
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'profileFunctions',
+          query: 'is_application:1',
+          field: ['project.id', 'package', 'function', 'count()', 'sum()'],
+        }),
+      ],
+    });
+
+    render(<SlowestFunctionsWidget />);
+
+    // starts by rendering loading
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+
+    // switches to the no functions view
+    expect(await screen.findByText('No functions found')).toBeInTheDocument();
+  });
+
   it('renders example transactions', async function () {
     // for the slowest functions query
     MockApiClient.addMockResponse({


### PR DESCRIPTION
When the global-views feature is off, we need to correctly handle the totals query in the global suspect functions and make sure we don't query for my projects when the first slowest functions queries returns no results.