### PR TITLE
ref: fix typing error in sentry.auth.access

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -884,6 +884,7 @@ class SystemAccess(OrganizationlessAccess):
             ),
         )
 
+    @property
     def has_global_access(self) -> bool:
         return True
 


### PR DESCRIPTION
latest mypy flags this, current mypy misses it for some reason


the code "works" as is because the function object returned is always truthy -- we're getting lucky :)


<!-- Describe your PR here. -->