### PR TITLE
fix(starfish): incorrect units used in span summary duration

### DIFF
--- a/static/app/views/starfish/components/tableCells/durationCell.tsx
+++ b/static/app/views/starfish/components/tableCells/durationCell.tsx
@@ -1,9 +1,9 @@
 import Duration from 'sentry/components/duration';
 
 type Props = {
-  seconds: number;
+  milliseconds: number;
 };
 
-export default function DurationCell({seconds}: Props) {
-  return <Duration seconds={seconds} fixedDigits={2} abbreviation />;
+export default function DurationCell({milliseconds}: Props) {
+  return <Duration seconds={milliseconds / 1000} fixedDigits={2} abbreviation />;
 }

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -30,7 +30,7 @@ function SampleInfo(props: Props) {
         <ThroughputCell throughputPerSecond={spansPerSecond} />
       </Block>
       <Block title={DataTitles.p95}>
-        <DurationCell seconds={p95} />
+        <DurationCell milliseconds={p95} />
       </Block>
       <Block title={DataTitles.timeSpent}>
         <TimeSpentCell

--- a/static/app/views/starfish/views/spanSummaryPage/spanBaselineTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanBaselineTable.tsx
@@ -98,7 +98,7 @@ function BodyCell({
   }
 
   if (column.key === 'p95(span.self_time)') {
-    return <DurationCell seconds={row.metrics.p95} />;
+    return <DurationCell milliseconds={row.metrics.p95} />;
   }
 
   if (column.key === 'spans_per_second') {

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -122,7 +122,7 @@ function BodyCell({span, column, row, openSidebar, onClickTransactionName}: Cell
   }
 
   if (column.key === 'p95(transaction.duration)') {
-    return <DurationCell seconds={row.metrics?.p95} />;
+    return <DurationCell milliseconds={row.metrics?.p95} />;
   }
 
   if (column.key === 'spans_per_second') {


### PR DESCRIPTION
Updates the durationCell component to accept milliseconds as a unit (because this is what typically is returned from the BE), this also fixes a bug where we passed in milliseconds, but the component expected seconds