### PR TITLE
ref(dropdownMenu): Add `textValue` to `MenuItemProps`

### DIFF
--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -43,6 +43,11 @@ export interface MenuItemProps extends MenuListItemProps {
    */
   isSubmenu?: boolean;
   /**
+   * Menu item label. Should preferably be a string. If not, provide a `textValue` prop
+   * to enable search & keyboard select.
+   */
+  label?: MenuListItemProps['label'];
+  /**
    * Function to call when user selects/clicks/taps on the menu item. The
    * item's key is passed as an argument.
    */
@@ -52,6 +57,11 @@ export interface MenuItemProps extends MenuListItemProps {
    * if `children` is defined and `isSubmenu` is true)
    */
   submenuTitle?: string;
+  /**
+   * A plain text version of the `label` prop if the label is not a string. Used for
+   * filtering and keyboard select (quick-focusing on options by typing the first letter).
+   */
+  textValue?: string;
   /**
    * Destination if this menu item is a link.
    */


### PR DESCRIPTION
In `DropdownMenu`, if a menu item's `label` is not a string, then `react-aria` requires an additional `textValue` prop, which will be used for search & quick keyboard select. We should add an optional `textValue` prop to the `MenuItemProps` interface to account for such cases.