### PR TITLE
feat(starfish): Add percentile range

### DIFF
--- a/src/sentry/search/events/datasets/function_aliases.py
+++ b/src/sentry/search/events/datasets/function_aliases.py
@@ -1,4 +1,4 @@
-from typing import Callable, Mapping, Optional, Sequence, Union
+from typing import Callable, List, Mapping, Optional, Sequence, Union
 
 from snuba_sdk import Column, Function
 
@@ -177,17 +177,31 @@ def resolve_metrics_percentile(
     args: Mapping[str, Union[str, Column, SelectType, int, float]],
     alias: str,
     fixed_percentile: Optional[float] = None,
+    extra_conditions: Optional[List[Function]] = None,
 ) -> SelectType:
     if fixed_percentile is None:
         fixed_percentile = args["percentile"]
     if fixed_percentile not in constants.METRIC_PERCENTILES:
         raise IncompatibleMetricsQuery("Custom quantile incompatible with metrics")
+
+    conditions = [Function("equals", [Column("metric_id"), args["metric_id"]])]
+    if extra_conditions is not None:
+        conditions.extend(extra_conditions)
+
+    if len(conditions) == 2:
+        condition = Function("and", conditions)
+    elif len(conditions) != 1:
+        # Need to chain multiple and functions here to allow more than 2 conditions (ie. and(and(a, b), c))
+        raise InvalidSearchQuery("Only 1 additional condition is currently available")
+    else:
+        condition = conditions[0]
+
     return (
         Function(
             "maxIf",
             [
                 Column("value"),
-                Function("equals", [Column("metric_id"), args["metric_id"]]),
+                condition,
             ],
             alias,
         )
@@ -197,10 +211,7 @@ def resolve_metrics_percentile(
             [
                 Function(
                     f"quantilesIf({fixed_percentile})",
-                    [
-                        Column("value"),
-                        Function("equals", [Column("metric_id"), args["metric_id"]]),
-                    ],
+                    [Column("value"), condition],
                 ),
                 1,
             ],

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -249,6 +249,35 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     snql_distribution=self._resolve_http_error_count,
                     default_result_type="integer",
                 ),
+                fields.MetricsFunction(
+                    "percentile_range",
+                    required_args=[
+                        fields.MetricArg(
+                            "column",
+                            allowed_columns=["span.duration"],
+                            allow_custom_measurements=False,
+                        ),
+                        fields.NumberRange("percentile", 0, 1),
+                        fields.ConditionArg("condition"),
+                        fields.SnQLDateArg("middle"),
+                    ],
+                    calculated_args=[resolve_metric_id],
+                    snql_distribution=lambda args, alias: function_aliases.resolve_metrics_percentile(
+                        args=args,
+                        alias=alias,
+                        fixed_percentile=args["percentile"],
+                        extra_conditions=[
+                            Function(
+                                args["condition"],
+                                [
+                                    Function("toDateTime", [args["middle"]]),
+                                    self.builder.column("timestamp"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    default_result_type="duration",
+                ),
             ]
         }
 


### PR DESCRIPTION
- This adds a percentile range function so that we can do relative changes in percentiles
- Modified the resolve_metrics_percentile function so it can accept one additional conditions that way its just inserted into the existing if, and we still use max vs quantile with the same logic
  - mentioned in a comment but `Function('and', [a bunch of conditions])` doesn't work so its currently restricted to just two since that's the only use case right now