### PR TITLE
feat(github-comments): PR comment workflow

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -125,7 +125,7 @@ def comment_workflow():
             continue
 
         top_5_issues = get_top_5_issues_by_count(issue_list, project)
-        issue_comment_contents = get_comment_contents(top_5_issues)
+        issue_comment_contents = get_comment_contents([issue["group_id"] for issue in top_5_issues])
 
         try:
             repo = Repository.objects.get(id=gh_repo_id)

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -1,10 +1,13 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import responses
+from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models import Commit, Group, GroupOwner, GroupOwnerType, PullRequest
 from sentry.models.repository import Repository
+from sentry.snuba.sessions_v2 import isoformat_z
 from sentry.tasks.integrations.github import pr_comment
 from sentry.tasks.integrations.github.pr_comment import (
     PullRequestIssue,
@@ -316,7 +319,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         self.user_id = "user_1"
         self.app_id = "app_1"
         self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        self.expires_at = "3000-01-01T00:00:00Z"
+        self.expires_at = isoformat_z(timezone.now() + timedelta(days=365))
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -1,11 +1,18 @@
+from unittest.mock import patch
+
+import responses
+
+from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models import Commit, GroupOwner, GroupOwnerType, PullRequest
+from sentry.models.repository import Repository
 from sentry.tasks.integrations.github import pr_comment
 from sentry.tasks.integrations.github.pr_comment import (
     PullRequestIssue,
     get_comment_contents,
     get_top_5_issues_by_count,
 )
-from sentry.testutils import SnubaTestCase, TestCase
+from sentry.testutils import IntegrationTestCase, SnubaTestCase, TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
@@ -90,7 +97,11 @@ class GithubCommentTestCase(TestCase):
 
     def add_groupowner_to_commit(self, commit: Commit, project, user):
         event = self.store_event(
-            data={"fingerprint": [f"issue{self.fingerprint}"]}, project_id=project.id
+            data={
+                "message": f"issue{self.fingerprint}",
+                "fingerprint": [f"issue{self.fingerprint}"],
+            },
+            project_id=project.id,
         )
         self.fingerprint += 1
         groupowner = GroupOwner.objects.create(
@@ -292,3 +303,104 @@ class TestFormatComment(TestCase):
         formatted_comment = pr_comment.format_comment(issues)
         expected_comment = "## Suspect Issues\nThis pull request has been deployed and Sentry has observed the following issues:\n\n- ‼️ **TypeError** `sentry.tasks.derive_code_mappings.derive_code_m...` [View Issue](https://sentry.sentry.io/issues/)\n- ‼️ **KafkaException** `query_subscription_consumer_process_message` [View Issue](https://sentry.sentry.io/stats/)\n\n<sub>Did you find this useful? React with a 👍 or 👎</sub>"
         assert formatted_comment == expected_comment
+
+
+class TestCommentWorkflow(GithubCommentTestCase, IntegrationTestCase):
+    provider = GitHubIntegrationProvider
+    base_url = "https://api.github.com"
+
+    def setUp(self):
+        super().setUp()
+        self.installation_id = "github:1"
+        self.user_id = "user_1"
+        self.app_id = "app_1"
+        self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        self.expires_at = "3000-01-01T00:00:00Z"
+
+    @patch(
+        "sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count",
+        return_value=[23, 24],
+    )
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @with_feature("organizations:pr-comment-bot")
+    @responses.activate
+    def test_comment_workflow(self, get_jwt, mock_issues):
+        # this test will fail if you run it on its own due to self.fingerprint
+        commit_1 = self.add_commit_to_repo(self.gh_repo, self.user, self.project)
+        self.add_pr_to_commit(commit_1)
+        self.add_groupowner_to_commit(commit_1, self.project, self.user)
+        self.add_groupowner_to_commit(commit_1, self.another_org_project, self.another_org_user)
+
+        responses.add(
+            responses.POST,
+            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
+            json={"token": self.access_token, "expires_at": self.expires_at},
+        )
+        responses.add(
+            responses.POST,
+            self.base_url + "/repos/getsentry/sentry/issues/1/comments",
+            json={},
+        )
+
+        pr_comment.comment_workflow()
+
+        assert (
+            responses.calls[1].request.body
+            == b'{"body": "## Suspect Issues\\nThis pull request has been deployed and Sentry has observed the following issues:\\n\\n- \\u203c\\ufe0f **issue1** `issue1` [View Issue](http://testserver/organizations/foo/issues/23/)\\n- \\u203c\\ufe0f **issue2** `issue2` [View Issue](http://testserver/organizations/foobar/issues/24/)\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"}'
+        )
+
+    @patch(
+        "sentry.tasks.integrations.github.pr_comment.pr_to_issue_query",
+        return_value=[(0, 0, 0, [])],
+    )
+    @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
+    def test_comment_workflow_missing_org(self, mock_issues, mock_issue_query):
+        pr_comment.comment_workflow()
+
+        assert not mock_issues.called
+
+    @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
+    def test_comment_workflow_missing_feature_flag(self, mock_issues):
+        pr_comment.comment_workflow()
+
+        assert not mock_issues.called
+
+    @patch(
+        "sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count",
+        return_value=[23, 24],
+    )
+    @patch("sentry.models.Repository.objects")
+    @patch("sentry.tasks.integrations.github.pr_comment.format_comment")
+    @with_feature("organizations:pr-comment-bot")
+    def test_comment_workflow_missing_repo(self, mock_format_comment, mock_repository, mock_issues):
+        commit_1 = self.add_commit_to_repo(self.gh_repo, self.user, self.project)
+        self.add_pr_to_commit(commit_1)
+        self.add_groupowner_to_commit(commit_1, self.project, self.user)
+        self.add_groupowner_to_commit(commit_1, self.another_org_project, self.another_org_user)
+
+        mock_repository.get.side_effect = Repository.DoesNotExist
+        pr_comment.comment_workflow()
+
+        assert mock_issues.called
+        assert not mock_format_comment.called
+
+    @patch(
+        "sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count",
+        return_value=[23, 24],
+    )
+    @patch("sentry.tasks.integrations.github.pr_comment.format_comment")
+    @with_feature("organizations:pr-comment-bot")
+    def test_comment_workflow_missing_integration(self, mock_format_comment, mock_issues):
+        commit_1 = self.add_commit_to_repo(self.gh_repo, self.user, self.project)
+        self.add_pr_to_commit(commit_1)
+        self.add_groupowner_to_commit(commit_1, self.project, self.user)
+        self.add_groupowner_to_commit(commit_1, self.another_org_project, self.another_org_user)
+
+        # invalid integration id
+        self.gh_repo.integration_id = 0
+        self.gh_repo.save()
+
+        pr_comment.comment_workflow()
+
+        assert mock_issues.called
+        assert not mock_format_comment.called

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -322,7 +322,6 @@ class TestCommentWorkflow(GithubCommentTestCase, IntegrationTestCase):
     @with_feature("organizations:pr-comment-bot")
     @responses.activate
     def test_comment_workflow(self, get_jwt, mock_issues):
-        # this test will fail if you run it on its own due to self.fingerprint
         commit_1 = self.add_commit_to_repo(self.gh_repo, self.user, self.project)
         self.add_pr_to_commit(commit_1)
         self.add_groupowner_to_commit(commit_1, self.project, self.user)


### PR DESCRIPTION
PR comment workflow that only creates comments in this iteration. This will later be refactored to run for 1 PR at a time since we are no longer having this be a periodic task.

- Check the feature flag
- Get the top 5 issues by count for the PR
- Format the issues into the comment template
- Fetch the Github integration and create the comment

For ER-1574