### PR TITLE
fix(integrations): hit control silo for external installation flow

### DIFF
--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -3,6 +3,7 @@ import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
 
+import ConfigStore from 'sentry/stores/configStore';
 import {Project} from 'sentry/types';
 import {EventTag} from 'sentry/types/event';
 import {appendTagCondition} from 'sentry/utils/queryString';
@@ -333,4 +334,9 @@ export const isFunction = (value: any): value is Function => typeof value === 'f
 // NOTE: only escapes a " if it's not already escaped
 export function escapeDoubleQuotes(str: string) {
   return str.replace(/\\([\s\S])|(")/g, '\\$1$2');
+}
+
+export function generateBaseControlSiloUrl() {
+  const baseUrl = ConfigStore.get('links').sentryUrl || '';
+  return baseUrl + '/api/0';
 }

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {urlEncode} from '@sentry/utils';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
@@ -13,6 +14,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NarrowLayout from 'sentry/components/narrowLayout';
 import {t, tct} from 'sentry/locale';
 import {Integration, IntegrationProvider, Organization} from 'sentry/types';
+import {generateBaseControlSiloUrl} from 'sentry/utils';
 import {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
 import {
   getIntegrationFeatureGate,
@@ -34,6 +36,7 @@ type State = AsyncView['state'] & {
 
 export default class IntegrationOrganizationLink extends AsyncView<Props, State> {
   disableErrorReport = false;
+  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl()});
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     return [['organizations', '/organizations/']];
@@ -103,8 +106,8 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
         Organization,
         {providers: IntegrationProvider[]}
       ] = await Promise.all([
-        this.api.requestPromise(`/organizations/${orgSlug}/`),
-        this.api.requestPromise(
+        this.controlSiloApi.requestPromise(`/organizations/${orgSlug}/`),
+        this.controlSiloApi.requestPromise(
           `/organizations/${orgSlug}/config/integrations/?provider_key=${this.integrationSlug}`
         ),
       ]);

--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -11,18 +11,13 @@ import FieldGroup from 'sentry/components/forms/fieldGroup';
 import SentryAppDetailsModal from 'sentry/components/modals/sentryAppDetailsModal';
 import NarrowLayout from 'sentry/components/narrowLayout';
 import {t, tct} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
 import {Organization, SentryApp, SentryAppInstallation} from 'sentry/types';
+import {generateBaseControlSiloUrl} from 'sentry/utils';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
 import AsyncView from 'sentry/views/asyncView';
 
 import {OrganizationContext} from '../organizationContext';
-
-function generateBaseUrl() {
-  const baseUrl = ConfigStore.get('links').sentryUrl || '';
-  return baseUrl + '/api/0';
-}
 
 type Props = RouteComponentProps<{sentryAppSlug: string}, {}>;
 
@@ -36,7 +31,7 @@ type State = AsyncView['state'] & {
 
 export default class SentryAppExternalInstallation extends AsyncView<Props, State> {
   disableErrorReport = false;
-  controlSiloApi = new Client({baseUrl: generateBaseUrl()});
+  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl()});
 
   getDefaultState() {
     const state = super.getDefaultState();


### PR DESCRIPTION
We need to hit the control silo when loading cross-organization details