### PR TITLE
fix(backpressure): Fix wrong logic

### DIFF
--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -135,6 +135,8 @@ def is_queue_healthy(queue_name: str) -> bool:
         return True
     # check if queue is healthy by pinging Redis
     try:
+        # We set the key if the queue is unhealthy. If the key exists,
+        # the queue is unhealthy and we need to return False.
         healthy = not queue_monitoring_cluster.exists(_unhealthy_queue_key(queue_name))
     except Exception as e:
         sentry_sdk.capture_exception(e)

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -140,7 +140,8 @@ def is_queue_healthy(queue_name: str) -> bool:
         healthy = not queue_monitoring_cluster.exists(_unhealthy_queue_key(queue_name))
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        healthy = False
+        # By default it's considered healthy
+        healthy = True
     return healthy
 
 

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -135,8 +135,9 @@ def is_queue_healthy(queue_name: str) -> bool:
         return True
     # check if queue is healthy by pinging Redis
     try:
-        healthy = queue_monitoring_cluster.exists(_unhealthy_queue_key(queue_name))
-    except Exception:
+        healthy = not queue_monitoring_cluster.exists(_unhealthy_queue_key(queue_name))
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
         healthy = False
     return healthy
 


### PR DESCRIPTION
We set the key if the queue is unhealthy. If the key exists, the queue is unhealthy and we need to return `False`.