### PR TITLE
ref(gridEditable): Remove unnecessary overflow: hidden

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -51,7 +51,6 @@ export const Body = styled(({children, ...props}) => (
     <PanelBody>{children}</PanelBody>
   </Panel>
 ))`
-  overflow: hidden;
   z-index: ${Z_INDEX_PANEL};
 `;
 
@@ -79,8 +78,12 @@ export const Grid = styled('table')<{height?: string | number; scrollable?: bool
   margin: 0;
 
   z-index: ${Z_INDEX_GRID};
-  overflow-x: auto;
-  overflow-y: ${p => (p.scrollable ? 'scroll' : 'hidden')};
+  ${p =>
+    p.scrollable &&
+    `
+    overflow-x: auto;
+    overflow-y: scroll;
+    `}
   ${p =>
     p.height
       ? `


### PR DESCRIPTION
Remove unnecessary `overflow: hidden` declarations in `GridEditable`, to fix an overflow issue with dropdown menus inside these grids:

**Before ——**
<img width="613" alt="Screenshot 2023-06-07 at 1 36 49 PM" src="https://github.com/getsentry/sentry/assets/44172267/16501374-4bf9-42d3-92e5-8dbf4178675a">

**After ——**
<img width="613" alt="Screenshot 2023-06-07 at 1 36 22 PM" src="https://github.com/getsentry/sentry/assets/44172267/af11ddb2-cd48-446c-8642-b9984c290a8f">
