### PR TITLE
fix: Add all archives to previous status for escalating GroupHistory 

### DIFF
--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -122,6 +122,7 @@ PREVIOUS_STATUSES = {
     GroupHistoryStatus.REGRESSED: RESOLVED_STATUSES,
     GroupHistoryStatus.ESCALATING: (
         GroupHistoryStatus.ARCHIVED_UNTIL_ESCALATING,
+        GroupHistoryStatus.ARCHIVED_UNTIL_CONDITION_MET,
         GroupHistoryStatus.IGNORED,
     ),
 }

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -120,7 +120,10 @@ PREVIOUS_STATUSES = {
     GroupHistoryStatus.ASSIGNED: (GroupHistoryStatus.UNASSIGNED,),
     GroupHistoryStatus.UNASSIGNED: (GroupHistoryStatus.ASSIGNED,),
     GroupHistoryStatus.REGRESSED: RESOLVED_STATUSES,
-    GroupHistoryStatus.ESCALATING: (GroupHistoryStatus.ARCHIVED_UNTIL_ESCALATING,),
+    GroupHistoryStatus.ESCALATING: (
+        GroupHistoryStatus.ARCHIVED_UNTIL_ESCALATING,
+        GroupHistoryStatus.IGNORED,
+    ),
 }
 
 ACTIVITY_STATUS_TO_GROUP_HISTORY_STATUS = {


### PR DESCRIPTION
Add `GroupHistoryStatus.IGNORED` and `GroupHistoryStatus.ARCHIVED_UNTIL_CONDITION_MET` as a possible previous status for `GroupHistoryStatus.ESCALATING`

This is needed as `GroupHistoryStatus.ESCALATING` now can refer to any ignored/archived (any type of ignore/archived) -> escalating/unignored group