### PR TITLE
feat(event): Add api_target to http interface

### DIFF
--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -113,6 +113,7 @@ class Http(Interface):
     def to_python(cls, data, **kwargs):
         data.setdefault("query_string", [])
         for key in (
+            "api_target",
             "method",
             "url",
             "fragment",
@@ -129,6 +130,7 @@ class Http(Interface):
     def to_json(self):
         return prune_empty_keys(
             {
+                "apiTarget": self.api_target,
                 "method": self.method,
                 "url": self.url,
                 "query_string": self.query_string or None,
@@ -180,6 +182,7 @@ class Http(Interface):
             headers = sorted(self.headers.items())
 
         data = {
+            "apiTarget": self.api_target,
             "method": self.method,
             "url": self.url,
             "query": self.query_string,
@@ -198,6 +201,7 @@ class Http(Interface):
 
         return {
             "": meta.get(""),
+            "apiTarget": meta.get("api_target"),
             "method": meta.get("method"),
             "url": meta.get("url"),
             "query": meta.get("query_string"),

--- a/tests/sentry/event_manager/interfaces/test_http.py
+++ b/tests/sentry/event_manager/interfaces/test_http.py
@@ -25,6 +25,7 @@ def test_basic(make_http_snapshot):
 def test_full(make_http_snapshot):
     make_http_snapshot(
         dict(
+            api_target="foo",
             method="GET",
             url="http://example.com",
             query_string="foo=bar",


### PR DESCRIPTION
`api_target` was added in https://github.com/getsentry/relay/pull/2141, this ensures that it gets picked up by the event serializer.