### PR TITLE
chore(replay): Remove render-issues-detail-count metric collection

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -60,11 +60,6 @@ export type ReplayEventParameters = {
     play: boolean;
     user_email: string;
   };
-  'replay.render-issues-detail-count': {
-    count: number;
-    platform: string;
-    project_id: string;
-  };
   'replay.render-issues-group-list': {
     platform: string | undefined;
     project_id: string | undefined;
@@ -106,7 +101,6 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.list-time-spent': 'Time Spent Viewing Replay List',
   'replay.list-view-setup-sidebar': 'Views Set Up Replays Sidebar',
   'replay.play-pause': 'Played/Paused Replay',
-  'replay.render-issues-detail-count': 'Render Issues Detail Replay Count',
   'replay.render-issues-group-list': 'Render Issues Detail Replay List',
   'replay.render-player': 'Rendered ReplayPlayer',
   'replay.search': 'Searched Replay',

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 import omit from 'lodash/omit';
@@ -26,7 +26,6 @@ import {IconChat} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event, Group, Organization, Project} from 'sentry/types';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {getMessage} from 'sentry/utils/events';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -74,19 +73,6 @@ function GroupHeaderTabs({
   const hasReplaySupport = organizationFeatures.has('session-replay');
 
   const issueTypeConfig = getConfigForIssueType(group);
-
-  useEffect(() => {
-    if (!hasReplaySupport || typeof replaysCount === 'undefined') {
-      return;
-    }
-
-    trackAnalytics('replay.render-issues-detail-count', {
-      platform: project.platform!,
-      project_id: project.id,
-      count: replaysCount,
-      organization,
-    });
-  }, [hasReplaySupport, replaysCount, project, organization]);
 
   useRouteAnalyticsParams({
     group_has_replay: (replaysCount ?? 0) > 0,


### PR DESCRIPTION
These metrics are coming in as much as the page-view stuff, it could be combined with that pageview.

But after reviewing the analyrtics were' doing with it, it's some low-value information, so we're going to remove this specific event for now. 

Fixes https://github.com/getsentry/sentry/issues/50348