### PR TITLE
feat(starfish) Add production data support to span view table

### DIFF
--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -26,6 +26,7 @@ export type SpanMetrics = {
 
 export const useSpanList = (
   moduleName: ModuleName,
+  transaction?: string,
   orderBy?: string,
   limit?: number,
   _referrer = 'span-metrics'
@@ -41,6 +42,7 @@ export const useSpanList = (
     startTime,
     endTime,
     dateFilters,
+    transaction,
     orderBy,
     limit
   );
@@ -63,6 +65,7 @@ const getQuery = (
   startTime: Moment,
   endTime: Moment,
   dateFilters: string,
+  transaction?: string,
   orderBy?: string,
   limit?: number
 ) => {
@@ -83,6 +86,7 @@ const getQuery = (
     WHERE 1 = 1
     ${conditions.length > 0 ? 'AND' : ''}
     ${conditions.join(' AND ')}
+    ${transaction ? `AND transaction = '${transaction}'` : ''}
     ${dateFilters}
     GROUP BY group_id, span_operation, domain, description
     ORDER BY ${orderBy ?? 'count'} desc

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -1,0 +1,106 @@
+import {Location} from 'history';
+import moment, {Moment} from 'moment';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {ModuleName} from 'sentry/views/starfish/types';
+import {getDateFilters} from 'sentry/views/starfish/utils/dates';
+import {getDateQueryFilter} from 'sentry/views/starfish/utils/getDateQueryFilter';
+import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+
+const SPAN_FILTER_KEYS = ['span_operation', 'domain', 'action'];
+
+export type SpanMetrics = {
+  count: number;
+  description: string;
+  domain: string;
+  epm: number;
+  formatted_desc: string;
+  group_id: string;
+  p50: number;
+  p95: number;
+  span_operation: string;
+  spans_per_second: number;
+  total_exclusive_time: number;
+};
+
+export const useSpanList = (
+  moduleName: ModuleName,
+  orderBy?: string,
+  limit?: number,
+  _referrer = 'span-metrics'
+) => {
+  const location = useLocation();
+  const pageFilters = usePageFilters();
+  const {startTime, endTime} = getDateFilters(pageFilters);
+  const dateFilters = getDateQueryFilter(startTime, endTime);
+
+  const query = getQuery(
+    moduleName,
+    location,
+    startTime,
+    endTime,
+    dateFilters,
+    orderBy,
+    limit
+  );
+  const eventView = undefined;
+
+  // TODO: Add referrer
+  const {isLoading, data} = useSpansQuery<SpanMetrics[]>({
+    eventView,
+    queryString: query,
+    initialData: [],
+    enabled: Boolean(query),
+  });
+
+  return {isLoading, data};
+};
+
+const getQuery = (
+  moduleName: ModuleName,
+  location: Location,
+  startTime: Moment,
+  endTime: Moment,
+  dateFilters: string,
+  orderBy?: string,
+  limit?: number
+) => {
+  const conditions = buildQueryConditions(moduleName, location).filter(Boolean);
+
+  return `SELECT
+    group_id, span_operation, description, domain,
+    sum(exclusive_time) as total_exclusive_time,
+    uniq(transaction) as transactions,
+    quantile(0.95)(exclusive_time) as p95,
+    quantile(0.75)(exclusive_time) as p75,
+    quantile(0.50)(exclusive_time) as p50,
+    count() as count,
+    divide(count(), ${
+      moment(endTime ?? undefined).unix() - moment(startTime).unix()
+    }) as spans_per_second
+    FROM spans_experimental_starfish
+    WHERE 1 = 1
+    ${conditions.length > 0 ? 'AND' : ''}
+    ${conditions.join(' AND ')}
+    ${dateFilters}
+    GROUP BY group_id, span_operation, domain, description
+    ORDER BY ${orderBy ?? 'count'} desc
+    ${limit ? `LIMIT ${limit}` : ''}`;
+};
+
+const buildQueryConditions = (moduleName: ModuleName, location: Location) => {
+  const {query} = location;
+  const result = Object.keys(query)
+    .filter(key => SPAN_FILTER_KEYS.includes(key))
+    .filter(key => Boolean(query[key]))
+    .map(key => {
+      return `${key} = '${query[key]}'`;
+    });
+
+  if (moduleName !== ModuleName.ALL) {
+    result.push(`module = '${moduleName}'`);
+  }
+
+  return result;
+};

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -56,7 +56,7 @@ export function ActionSelector({value = '', moduleName = ModuleName.ALL}: Props)
           ...location,
           query: {
             ...location.query,
-            action: newValue.value,
+            'span.action': newValue.value,
           },
         });
       }}

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -52,7 +52,7 @@ export function DomainSelector({value = '', moduleName = ModuleName.ALL}: Props)
           ...location,
           query: {
             ...location.query,
-            domain: newValue.value,
+            'span.domain': newValue.value,
           },
         });
       }}

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -49,7 +49,7 @@ export function SpanOperationSelector({value = '', moduleName = ModuleName.ALL}:
           ...location,
           query: {
             ...location.query,
-            span_operation: newValue.value,
+            'span.op': newValue.value,
           },
         });
       }}

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -31,10 +31,10 @@ type Props = {
 };
 
 type AppliedFilters = {
-  action: string;
-  domain: string;
-  group_id: string;
-  span_operation: string;
+  'span.action': string;
+  'span.domain': string;
+  'span.group': string;
+  'span.op': string;
 };
 
 type ChartProps = {
@@ -94,9 +94,12 @@ function ThroughputChart({moduleName, filters}: ChartProps): JSX.Element {
   const query = getQuery(moduleName, pageFilters.selection, filters);
   const eventView = getEventView(moduleName, location, pageFilters.selection, filters);
   const {startTime, endTime} = getDateFilters(pageFilters);
-  const {span_operation, action, domain} = location.query;
 
-  const label = getSegmentLabel(span_operation, action, domain);
+  const label = getSegmentLabel(
+    location.query['span.op'],
+    location.query['span.action'],
+    location.query['span.domain']
+  );
   const {isLoading, data} = useSpansQuery({
     eventView,
     queryString: `${query}&referrer=span-time-charts`,
@@ -153,9 +156,12 @@ function DurationChart({moduleName, filters}: ChartProps): JSX.Element {
   const query = getQuery(moduleName, pageFilters.selection, filters);
   const eventView = getEventView(moduleName, location, pageFilters.selection, filters);
   const {startTime, endTime} = getDateFilters(pageFilters);
-  const {span_operation, action, domain} = location.query;
 
-  const label = getSegmentLabel(span_operation, action, domain);
+  const label = getSegmentLabel(
+    location.query['span.op'],
+    location.query['span.action'],
+    location.query['span.domain']
+  );
 
   const {isLoading, data} = useSpansQuery({
     eventView,

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -47,6 +47,7 @@ export default function SpansView(props: Props) {
 
   const {isLoading: areSpansLoading, data: spansData} = useSpanList(
     props.moduleName ?? ModuleName.ALL,
+    undefined,
     orderBy,
     LIMIT
   );

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -8,6 +8,7 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {HOST} from 'sentry/views/starfish/utils/constants';
 import {ActionSelector} from 'sentry/views/starfish/views/spans/selectors/actionSelector';
@@ -15,8 +16,8 @@ import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domain
 import {SpanOperationSelector} from 'sentry/views/starfish/views/spans/selectors/spanOperationSelector';
 import {SpanTimeCharts} from 'sentry/views/starfish/views/spans/spanTimeCharts';
 
-import {getSpanListQuery, getSpansTrendsQuery} from './queries';
-import type {SpanDataRow, SpanTrendDataRow} from './spansTable';
+import {getSpansTrendsQuery} from './queries';
+import type {SpanTrendDataRow} from './spansTable';
 import SpansTable from './spansTable';
 
 const LIMIT: number = 25;
@@ -44,24 +45,11 @@ export default function SpansView(props: Props) {
 
   const {orderBy} = state;
 
-  const queryConditions = buildQueryConditions(
-    props.moduleName || ModuleName.ALL,
-    location
-  );
-  const query = getSpanListQuery(
-    pageFilter.selection.datetime,
-    queryConditions,
+  const {isLoading: areSpansLoading, data: spansData} = useSpanList(
+    props.moduleName ?? ModuleName.ALL,
     orderBy,
     LIMIT
   );
-
-  const {isLoading: areSpansLoading, data: spansData} = useQuery<SpanDataRow[]>({
-    queryKey: ['spans', query],
-    queryFn: () => fetch(`${HOST}/?query=${query}&format=sql`).then(res => res.json()),
-    retry: false,
-    refetchOnWindowFocus: false,
-    initialData: [],
-  });
 
   const groupIDs = spansData.map(({group_id}) => group_id);
 

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
 import {space} from 'sentry/styles/space';
@@ -25,16 +24,16 @@ type State = {
 };
 
 type Query = {
-  action: string;
-  domain: string;
-  group_id: string;
-  span_operation: string;
+  'span.action': string;
+  'span.domain': string;
+  'span.group': string;
+  'span.op': string;
 };
 
 export default function SpansView(props: Props) {
   const location = useLocation<Query>();
   const appliedFilters = location.query;
-  const [state, setState] = useState<State>({orderBy: 'total_exclusive_time'});
+  const [state, setState] = useState<State>({orderBy: '-time_spent_percentage'});
 
   const {orderBy} = state;
 
@@ -52,17 +51,17 @@ export default function SpansView(props: Props) {
 
         <SpanOperationSelector
           moduleName={props.moduleName}
-          value={appliedFilters.span_operation || ''}
+          value={appliedFilters['span.op'] || ''}
         />
 
         <DomainSelector
           moduleName={props.moduleName}
-          value={appliedFilters.domain || ''}
+          value={appliedFilters['span.domain'] || ''}
         />
 
         <ActionSelector
           moduleName={props.moduleName}
-          value={appliedFilters.action || ''}
+          value={appliedFilters['span.action'] || ''}
         />
       </FilterOptionsContainer>
 
@@ -96,21 +95,3 @@ const FilterOptionsContainer = styled(PaddedContainer)`
   gap: ${space(1)};
   margin-bottom: ${space(2)};
 `;
-
-const SPAN_FILTER_KEYS = ['span_operation', 'domain', 'action'];
-
-export const buildQueryConditions = (moduleName: ModuleName, location: Location) => {
-  const {query} = location;
-  const result = Object.keys(query)
-    .filter(key => SPAN_FILTER_KEYS.includes(key))
-    .filter(key => Boolean(query[key]))
-    .map(key => {
-      return `${key} = '${query[key]}'`;
-    });
-
-  if (moduleName !== ModuleName.ALL) {
-    result.push(`module = '${moduleName}'`);
-  }
-
-  return result;
-};

--- a/static/app/views/starfish/views/spans/spansView.tsx
+++ b/static/app/views/starfish/views/spans/spansView.tsx
@@ -1,23 +1,17 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
-import {useQuery} from '@tanstack/react-query';
 import {Location} from 'history';
-import _orderBy from 'lodash/orderBy';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName} from 'sentry/views/starfish/types';
-import {HOST} from 'sentry/views/starfish/utils/constants';
 import {ActionSelector} from 'sentry/views/starfish/views/spans/selectors/actionSelector';
 import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domainSelector';
 import {SpanOperationSelector} from 'sentry/views/starfish/views/spans/selectors/spanOperationSelector';
 import {SpanTimeCharts} from 'sentry/views/starfish/views/spans/spanTimeCharts';
 
-import {getSpansTrendsQuery} from './queries';
-import type {SpanTrendDataRow} from './spansTable';
 import SpansTable from './spansTable';
 
 const LIMIT: number = 25;
@@ -40,7 +34,6 @@ type Query = {
 export default function SpansView(props: Props) {
   const location = useLocation<Query>();
   const appliedFilters = location.query;
-  const pageFilter = usePageFilters();
   const [state, setState] = useState<State>({orderBy: 'total_exclusive_time'});
 
   const {orderBy} = state;
@@ -51,22 +44,6 @@ export default function SpansView(props: Props) {
     orderBy,
     LIMIT
   );
-
-  const groupIDs = spansData.map(({group_id}) => group_id);
-
-  const {isLoading: areSpansTrendsLoading, data: spansTrendsData} = useQuery<
-    SpanTrendDataRow[]
-  >({
-    queryKey: ['spansTrends'],
-    queryFn: () =>
-      fetch(
-        `${HOST}/?query=${getSpansTrendsQuery(pageFilter.selection.datetime, groupIDs)}`
-      ).then(res => res.json()),
-    retry: false,
-    refetchOnWindowFocus: false,
-    initialData: [],
-    enabled: groupIDs.length > 0,
-  });
 
   return (
     <Fragment>
@@ -99,11 +76,10 @@ export default function SpansView(props: Props) {
       <PaddedContainer>
         <SpansTable
           moduleName={props.moduleName || ModuleName.ALL}
-          isLoading={areSpansLoading || areSpansTrendsLoading}
+          isLoading={areSpansLoading}
           spansData={spansData}
           orderBy={orderBy}
           onSetOrderBy={newOrderBy => setState({orderBy: newOrderBy})}
-          spansTrendsData={spansTrendsData}
         />
       </PaddedContainer>
     </Fragment>

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -28,17 +28,11 @@ import Tags from 'sentry/views/discover/tags';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 import Chart from 'sentry/views/starfish/components/chart';
 import {TransactionSamplesTable} from 'sentry/views/starfish/components/samplesTable/transactionSamplesTable';
+import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {HOST} from 'sentry/views/starfish/utils/constants';
-import {
-  getSpanListQuery,
-  getSpansTrendsQuery,
-} from 'sentry/views/starfish/views/spans/queries';
-import SpansTable, {
-  SpanDataRow,
-  SpanTrendDataRow,
-} from 'sentry/views/starfish/views/spans/spansTable';
-import {buildQueryConditions} from 'sentry/views/starfish/views/spans/spansView';
+import {getSpansTrendsQuery} from 'sentry/views/starfish/views/spans/queries';
+import SpansTable, {SpanTrendDataRow} from 'sentry/views/starfish/views/spans/spansTable';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {SpanGroupBreakdownContainer} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
@@ -278,29 +272,15 @@ function SpanMetricsTable({
   filter: ModuleName;
   transaction: string | undefined;
 }) {
-  const location = useLocation();
   const pageFilter = usePageFilters();
 
   // TODO: Add transaction http method to query conditions as well, since transaction name alone is not unique
-  const queryConditions = buildQueryConditions(filter || ModuleName.ALL, location);
-  if (transaction) {
-    queryConditions.push(`transaction = '${transaction}'`);
-  }
-
-  const query = getSpanListQuery(
-    pageFilter.selection.datetime,
-    queryConditions,
+  const {isLoading: areSpansLoading, data: spansData} = useSpanList(
+    filter ?? ModuleName.ALL,
+    transaction,
     'count',
     SPANS_TABLE_LIMIT
   );
-
-  const {isLoading: areSpansLoading, data: spansData} = useQuery<SpanDataRow[]>({
-    queryKey: ['spans', query],
-    queryFn: () => fetch(`${HOST}/?query=${query}&format=sql`).then(res => res.json()),
-    retry: false,
-    refetchOnWindowFocus: false,
-    initialData: [],
-  });
 
   const groupIDs = spansData.map(({group_id}) => group_id);
 

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -273,7 +273,7 @@ function SpanMetricsTable({
   const {isLoading: areSpansLoading, data: spansData} = useSpanList(
     filter ?? ModuleName.ALL,
     transaction,
-    'count',
+    '-time_spent_percentage',
     SPANS_TABLE_LIMIT
   );
 

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -282,7 +282,7 @@ function SpanMetricsTable({
       moduleName={ModuleName.ALL}
       isLoading={areSpansLoading}
       spansData={spansData}
-      orderBy="count"
+      orderBy="-time_spent_percentage"
       onSetOrderBy={() => undefined}
     />
   );

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -18,7 +18,6 @@ import {generateQueryWithTag} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import {formatTagKey} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {useQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -30,9 +29,7 @@ import Chart from 'sentry/views/starfish/components/chart';
 import {TransactionSamplesTable} from 'sentry/views/starfish/components/samplesTable/transactionSamplesTable';
 import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
 import {ModuleName} from 'sentry/views/starfish/types';
-import {HOST} from 'sentry/views/starfish/utils/constants';
-import {getSpansTrendsQuery} from 'sentry/views/starfish/views/spans/queries';
-import SpansTable, {SpanTrendDataRow} from 'sentry/views/starfish/views/spans/spansTable';
+import SpansTable from 'sentry/views/starfish/views/spans/spansTable';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {SpanGroupBreakdownContainer} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
@@ -272,8 +269,6 @@ function SpanMetricsTable({
   filter: ModuleName;
   transaction: string | undefined;
 }) {
-  const pageFilter = usePageFilters();
-
   // TODO: Add transaction http method to query conditions as well, since transaction name alone is not unique
   const {isLoading: areSpansLoading, data: spansData} = useSpanList(
     filter ?? ModuleName.ALL,
@@ -282,30 +277,13 @@ function SpanMetricsTable({
     SPANS_TABLE_LIMIT
   );
 
-  const groupIDs = spansData.map(({group_id}) => group_id);
-
-  const {isLoading: areSpansTrendsLoading, data: spansTrendsData} = useQuery<
-    SpanTrendDataRow[]
-  >({
-    queryKey: ['spansTrends'],
-    queryFn: () =>
-      fetch(
-        `${HOST}/?query=${getSpansTrendsQuery(pageFilter.selection.datetime, groupIDs)}`
-      ).then(res => res.json()),
-    retry: false,
-    refetchOnWindowFocus: false,
-    initialData: [],
-    enabled: groupIDs.length > 0,
-  });
-
   return (
     <SpansTable
       moduleName={ModuleName.ALL}
-      isLoading={areSpansLoading || areSpansTrendsLoading}
+      isLoading={areSpansLoading}
       spansData={spansData}
       orderBy="count"
       onSetOrderBy={() => undefined}
-      spansTrendsData={spansTrendsData}
     />
   );
 }


### PR DESCRIPTION
Pain. Converts both the span view span table to use production data, as well as the little span tables in the endpoint overview. The good news is that with this change, the span view is fully production-compatible.

- Extract span list query into hook
- Allow filtering by transaction
- Use data hook on endpoint overview
- Add EventView support
- Remove span trends nonsense
- Pull span table from production data
