### PR TITLE
fix(timeRangeSelector): Use `start` & `date` prop when opening absolute range selector

### DIFF
--- a/static/app/components/timeRangeSelector.tsx
+++ b/static/app/components/timeRangeSelector.tsx
@@ -236,17 +236,21 @@ export function TimeRangeSelector({
     option => {
       // The absolute option was selected -> open absolute selector
       if (option.value === ABSOLUTE_OPTION_VALUE) {
-        setInternalValue(current => ({
-          ...current,
-          // Update default values for absolute selector
-          start: defaultAbsolute?.start
+        setInternalValue(current => {
+          const defaultStart = defaultAbsolute?.start
             ? defaultAbsolute.start
             : getPeriodAgo(
                 'hours',
                 parsePeriodToHours(relative || defaultPeriod || DEFAULT_STATS_PERIOD)
-              ).toDate(),
-          end: defaultAbsolute?.end ? defaultAbsolute.end : new Date(),
-        }));
+              ).toDate();
+          const defaultEnd = defaultAbsolute?.end ? defaultAbsolute.end : new Date();
+          return {
+            ...current,
+            // Update default values for absolute selector
+            start: start ? getInternalDate(start, utc) : defaultStart,
+            end: end ? getInternalDate(end, utc) : defaultEnd,
+          };
+        });
         setShowAbsoluteSelector(true);
         return;
       }
@@ -254,7 +258,7 @@ export function TimeRangeSelector({
       setInternalValue(current => ({...current, relative: option.value}));
       onChange?.({relative: option.value, start: undefined, end: undefined});
     },
-    [defaultAbsolute, defaultPeriod, relative, onChange]
+    [start, end, utc, defaultAbsolute, defaultPeriod, relative, onChange]
   );
 
   const arbitraryRelativePeriods = getArbitraryRelativePeriod(relative);


### PR DESCRIPTION
**Before ——** select an absolute date range —> trigger button is updated with new value (May 30 — May 31) —> open menu again & go to absolute date picker —> the highlighted range doesn't match the newly selected value

https://github.com/getsentry/sentry/assets/44172267/5a4f9527-4547-4dc3-a66a-6dec224470a1



**After ——** same actions… —> the highlighted range matches the newly selected value

https://github.com/getsentry/sentry/assets/44172267/23656f59-d35a-4eb3-861e-3e737bd45232

