### PR TITLE
ref(sort): Remove trend sort from saved searches

### DIFF
--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -17,7 +17,6 @@ class SortOptions:
     PRIORITY = "priority"
     FREQ = "freq"
     USER = "user"
-    TREND = "trend"
     INBOX = "inbox"
     BETTER_PRIORITY = "betterPriority"
 
@@ -29,7 +28,6 @@ class SortOptions:
             (cls.PRIORITY, _("Priority")),
             (cls.FREQ, _("Events")),
             (cls.USER, _("Users")),
-            (cls.TREND, _("Relative Change")),
             (cls.INBOX, _("Date Added")),
             (cls.BETTER_PRIORITY, _("Better Priority")),
         )


### PR DESCRIPTION
This didn't actually show up anywhere, I just forgot to delete it when I cleaned up all the rest of the references to trend sort.