### PR TITLE
ref(calendar): De-emphasize disabled/passive days

### DIFF
--- a/static/app/components/calendar/calendarStylesWrapper.tsx
+++ b/static/app/components/calendar/calendarStylesWrapper.tsx
@@ -43,8 +43,10 @@ const CalendarStylesWrapper = styled('div')`
     background: none;
   }
 
-  .rdrDayDisabled span {
+  .rdrDayDisabled .rdrDayNumber span,
+  .rdrDayPassive .rdrDayNumber span {
     color: ${p => p.theme.subText};
+    opacity: 0.5;
   }
 
   .rdrDayToday .rdrDayNumber span {


### PR DESCRIPTION
**Before ——**
<img width="322" alt="Screenshot 2023-06-07 at 4 26 02 PM" src="https://github.com/getsentry/sentry/assets/44172267/5324e799-f1b0-49d9-990d-716b7f2242a9">
<img width="322" alt="Screenshot 2023-06-07 at 4 26 11 PM" src="https://github.com/getsentry/sentry/assets/44172267/6bc9288c-9c2d-4583-97a7-e7b38ac7f5ae">

**After ——**
<img width="322" alt="Screenshot 2023-06-07 at 4 25 30 PM" src="https://github.com/getsentry/sentry/assets/44172267/63a53d3e-1fc1-4f15-9f79-bf308533d9ab">
<img width="322" alt="Screenshot 2023-06-07 at 4 25 41 PM" src="https://github.com/getsentry/sentry/assets/44172267/d9f801ff-989b-4981-935b-d23ced23b91b">
