### PR TITLE
fix(azure): redirect to control silo

### DIFF
--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -337,6 +337,5 @@ export function escapeDoubleQuotes(str: string) {
 }
 
 export function generateBaseControlSiloUrl() {
-  const baseUrl = ConfigStore.get('links').sentryUrl || '';
-  return baseUrl + '/api/0';
+  return ConfigStore.get('links').sentryUrl || '';
 }

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -149,8 +149,9 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
     this.trackInstallationStart();
     // need to send to control silo to finish the installation
     window.location.assign(
-      controlSiloUrl +
-        `/extensions/${this.integrationSlug}/configure/?${urlEncode(query)}`
+      `${controlSiloUrl}/extensions/${this.integrationSlug}/configure/?${urlEncode(
+        query
+      )}`
     );
   };
 

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -34,9 +34,11 @@ type State = AsyncView['state'] & {
   selectedOrgSlug?: string;
 };
 
+const controlSiloUrl = generateBaseControlSiloUrl();
+
 export default class IntegrationOrganizationLink extends AsyncView<Props, State> {
   disableErrorReport = false;
-  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl()});
+  controlSiloApi = new Client({baseUrl: controlSiloUrl + '/api/0'});
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     return [['organizations', '/organizations/']];
@@ -145,8 +147,10 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
     const {selectedOrgSlug} = this.state;
     const query = {orgSlug: selectedOrgSlug, ...this.queryParams};
     this.trackInstallationStart();
+    // need to send to control silo to finish the installation
     window.location.assign(
-      `/extensions/${this.integrationSlug}/configure/?${urlEncode(query)}`
+      controlSiloUrl +
+        `/extensions/${this.integrationSlug}/configure/?${urlEncode(query)}`
     );
   };
 

--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -31,7 +31,7 @@ type State = AsyncView['state'] & {
 
 export default class SentryAppExternalInstallation extends AsyncView<Props, State> {
   disableErrorReport = false;
-  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl()});
+  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl() + '/api/0'});
 
   getDefaultState() {
     const state = super.getDefaultState();


### PR DESCRIPTION
I think installation isn't working properly because we are using the region silo and we might need to access a different organization. As a result, we should redirect to the control silo.