### PR TITLE
perf(crons): Handle check-in aggregation in pg query

### DIFF
--- a/tests/sentry/monitors/endpoints/test_organization_monitor_stats.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_stats.py
@@ -34,6 +34,14 @@ class ListMonitorCheckInsTest(MonitorTestCase):
         )
         MonitorCheckIn.objects.create(
             monitor=self.monitor,
+            monitor_environment=monitor_environment_production,
+            project_id=self.project.id,
+            duration=None,
+            date_added=self.monitor.date_added + timedelta(minutes=1),
+            status=CheckInStatus.IN_PROGRESS,
+        )
+        MonitorCheckIn.objects.create(
+            monitor=self.monitor,
             monitor_environment=monitor_environment_debug,
             project_id=self.project.id,
             duration=2000,
@@ -90,6 +98,7 @@ class ListMonitorCheckInsTest(MonitorTestCase):
         assert hour_one["missed"] == 0
         assert hour_one["error"] == 0
         assert hour_one["timeout"] == 0
+        assert "in_progress" not in hour_one
 
         assert hour_two["duration"] == 2500
         assert hour_two["ok"] == 0


### PR DESCRIPTION
Refactors the monitor details stats endpoint to do check-in bucketing and avg duration computation in postgres instead of in memory. This should significantly improve performance on monitors that have thousands of check-ins.