### PR TITLE
chore(ts): Consistent enum casing

### DIFF
--- a/static/app/components/discover/performanceCardTable.tsx
+++ b/static/app/components/discover/performanceCardTable.tsx
@@ -21,7 +21,7 @@ import {
   MOBILE_VITAL_DETAILS,
   WEB_VITAL_DETAILS,
 } from 'sentry/utils/performance/vitals/constants';
-import {PROJECT_PERFORMANCE_TYPE} from 'sentry/views/performance/utils';
+import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
 type PerformanceCardTableProps = {
   allReleasesEventView: EventView;
@@ -612,25 +612,25 @@ function PerformanceCardTable({
   const loader = <StyledLoadingIndicator />;
 
   const platformPerformanceRender = {
-    [PROJECT_PERFORMANCE_TYPE.FRONTEND]: {
+    [ProjectPerformanceType.FRONTEND]: {
       title: t('Frontend Performance'),
       section: renderFrontendPerformance(),
     },
-    [PROJECT_PERFORMANCE_TYPE.BACKEND]: {
+    [ProjectPerformanceType.BACKEND]: {
       title: t('Backend Performance'),
       section: renderBackendPerformance(),
     },
-    [PROJECT_PERFORMANCE_TYPE.MOBILE]: {
+    [ProjectPerformanceType.MOBILE]: {
       title: t('Mobile Performance'),
       section: renderMobilePerformance(),
     },
-    [PROJECT_PERFORMANCE_TYPE.ANY]: {
+    [ProjectPerformanceType.ANY]: {
       title: t('[Unknown] Performance'),
       section: renderUnknownPerformance(),
     },
   };
 
-  const isUnknownPlatform = performanceType === PROJECT_PERFORMANCE_TYPE.ANY;
+  const isUnknownPlatform = performanceType === ProjectPerformanceType.ANY;
 
   return (
     <Fragment>

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -5,7 +5,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Content} from 'sentry/components/events/interfaces/crashContent/exception/content';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {EntryType} from 'sentry/types';
-import {STACK_TYPE, STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 
 describe('Exception Content', function () {
   it('display redacted values from exception entry', async function () {
@@ -103,12 +103,12 @@ describe('Exception Content', function () {
 
     render(
       <Content
-        type={STACK_TYPE.ORIGINAL}
+        type={StackType.ORIGINAL}
         groupingCurrentLevel={0}
         hasHierarchicalGrouping
         newestFirst
         platform="python"
-        stackView={STACK_VIEW.APP}
+        stackView={StackView.APP}
         event={event}
         values={event.entries[0].data.values}
         meta={event._meta.entries[0].data.values}
@@ -149,11 +149,11 @@ describe('Exception Content', function () {
     const project = TestStubs.Project();
 
     const defaultProps = {
-      type: STACK_TYPE.ORIGINAL,
+      type: StackType.ORIGINAL,
       hasHierarchicalGrouping: false,
       newestFirst: true,
       platform: 'python' as const,
-      stackView: STACK_VIEW.APP,
+      stackView: StackView.APP,
       event,
       values: event.entries[0].data.values,
       projectSlug: project.slug,

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -9,7 +9,7 @@ import {tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {ExceptionType, Project} from 'sentry/types';
 import {Event, ExceptionValue} from 'sentry/types/event';
-import {STACK_TYPE} from 'sentry/types/stacktrace';
+import {StackType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -25,7 +25,7 @@ type Props = {
   event: Event;
   platform: StackTraceProps['platform'];
   projectSlug: Project['slug'];
-  type: STACK_TYPE;
+  type: StackType;
   meta?: Record<any, any>;
   newestFirst?: boolean;
   stackView?: StackTraceProps['stackView'];
@@ -201,7 +201,7 @@ export function Content({
         </ErrorBoundary>
         <StackTrace
           data={
-            type === STACK_TYPE.ORIGINAL
+            type === StackType.ORIGINAL
               ? exc.stacktrace
               : exc.rawStacktrace || exc.stacktrace
           }

--- a/static/app/components/events/interfaces/crashContent/exception/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/index.tsx
@@ -1,7 +1,7 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {ExceptionType, Group, PlatformType, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {STACK_TYPE, STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 
 import {Content} from './content';
 import RawContent from './rawContent';
@@ -12,10 +12,10 @@ type Props = {
   newestFirst: boolean;
   platform: PlatformType;
   projectSlug: Project['slug'];
-  stackType: STACK_TYPE;
+  stackType: StackType;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   meta?: Record<any, any>;
-  stackView?: STACK_VIEW;
+  stackView?: StackView;
 } & Pick<ExceptionType, 'values'>;
 
 export function ExceptionContent({
@@ -32,7 +32,7 @@ export function ExceptionContent({
 }: Props) {
   return (
     <ErrorBoundary mini>
-      {stackView === STACK_VIEW.RAW ? (
+      {stackView === StackView.RAW ? (
         <RawContent
           eventId={event.id}
           projectSlug={projectSlug}

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
@@ -2,7 +2,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ExceptionStacktraceContent from 'sentry/components/events/interfaces/crashContent/exception/stackTrace';
-import {STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackView} from 'sentry/types/stacktrace';
 
 const frames = [
   {
@@ -109,7 +109,7 @@ describe('ExceptionStacktraceContent', function () {
     render(
       <ExceptionStacktraceContent
         {...props}
-        stackView={STACK_VIEW.APP}
+        stackView={StackView.APP}
         chainedException={false}
         stacktrace={{...stacktrace, frames: []}}
       />
@@ -136,7 +136,7 @@ describe('ExceptionStacktraceContent', function () {
     render(
       <ExceptionStacktraceContent
         {...props}
-        stackView={STACK_VIEW.APP}
+        stackView={StackView.APP}
         chainedException
       />
     );

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
@@ -134,11 +134,7 @@ describe('ExceptionStacktraceContent', function () {
 
   it('should render system frames if "stackView: app" and there are no inApp frames and is a chained exceptions', function () {
     render(
-      <ExceptionStacktraceContent
-        {...props}
-        stackView={StackView.APP}
-        chainedException
-      />
+      <ExceptionStacktraceContent {...props} stackView={StackView.APP} chainedException />
     );
 
     for (const frame of frames) {

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -5,7 +5,7 @@ import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ExceptionValue, Group, PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {isNativePlatform} from 'sentry/utils/platform';
 
@@ -25,7 +25,7 @@ type Props = {
   groupingCurrentLevel?: Group['metadata']['current_level'];
   meta?: Record<any, any>;
   newestFirst?: boolean;
-  stackView?: STACK_VIEW;
+  stackView?: StackView;
 };
 
 function StackTrace({
@@ -47,7 +47,7 @@ function StackTrace({
   }
 
   if (
-    stackView === STACK_VIEW.APP &&
+    stackView === StackView.APP &&
     (stacktrace.frames ?? []).filter(frame => frame.inApp).length === 0 &&
     !chainedException
   ) {
@@ -70,7 +70,7 @@ function StackTrace({
   }
 
   const includeSystemFrames =
-    stackView === STACK_VIEW.FULL ||
+    stackView === StackView.FULL ||
     (chainedException && data.frames?.every(frame => !frame.inApp));
 
   /**

--- a/static/app/components/events/interfaces/crashContent/index.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/index.spec.tsx
@@ -2,7 +2,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 
 import {CrashContent} from 'sentry/components/events/interfaces/crashContent';
 import {withMeta} from 'sentry/components/events/meta/metaProxy';
-import {STACK_TYPE, STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 
 describe('CrashContent', function () {
   const exc = TestStubs.ExceptionWithMeta();
@@ -11,8 +11,8 @@ describe('CrashContent', function () {
   it('renders with meta data', function () {
     const wrapper = render(
       <CrashContent
-        stackView={STACK_VIEW.FULL}
-        stackType={STACK_TYPE.ORIGINAL}
+        stackView={StackView.FULL}
+        stackType={StackType.ORIGINAL}
         event={TestStubs.Event()}
         newestFirst
         exception={(proxiedExc as any).exception}

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {StackView, StacktraceType} from 'sentry/types/stacktrace';
+import {StacktraceType, StackView} from 'sentry/types/stacktrace';
 import {isNativePlatform} from 'sentry/utils/platform';
 
 import Content from './content';

--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {STACK_VIEW, StacktraceType} from 'sentry/types/stacktrace';
+import {StackView, StacktraceType} from 'sentry/types/stacktrace';
 import {isNativePlatform} from 'sentry/utils/platform';
 
 import Content from './content';
@@ -23,7 +23,7 @@ type Props = Pick<
   inlined?: boolean;
   maxDepth?: number;
   meta?: Record<any, any>;
-  stackView?: STACK_VIEW;
+  stackView?: StackView;
 };
 
 export function StackTraceContent({
@@ -38,7 +38,7 @@ export function StackTraceContent({
   meta,
   inlined,
 }: Props) {
-  if (stackView === STACK_VIEW.RAW) {
+  if (stackView === StackView.RAW) {
     return (
       <ErrorBoundary mini>
         <pre className="traceback plain">
@@ -53,7 +53,7 @@ export function StackTraceContent({
       <ErrorBoundary mini>
         <StyledNativeContent
           data={stacktrace}
-          includeSystemFrames={stackView === STACK_VIEW.FULL}
+          includeSystemFrames={stackView === StackView.FULL}
           platform={platform}
           event={event}
           newestFirst={newestFirst}
@@ -72,7 +72,7 @@ export function StackTraceContent({
         <StyledHierarchicalGroupingContent
           data={stacktrace}
           className="no-exception"
-          includeSystemFrames={stackView === STACK_VIEW.FULL}
+          includeSystemFrames={stackView === StackView.FULL}
           platform={platform}
           event={event}
           newestFirst={newestFirst}
@@ -91,7 +91,7 @@ export function StackTraceContent({
       <StyledContent
         data={stacktrace}
         className="no-exception"
-        includeSystemFrames={stackView === STACK_VIEW.FULL}
+        includeSystemFrames={stackView === StackView.FULL}
         platform={platform}
         event={event}
         newestFirst={newestFirst}

--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import {ExceptionType, Group, PlatformType, Project} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
-import {STACK_TYPE, STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 
 import {PermalinkTitle, TraceEventDataSection} from '../traceEventDataSection';
 
@@ -63,7 +63,7 @@ export function Exception({
     <TraceEventDataSection
       title={<PermalinkTitle>{t('Stack Trace')}</PermalinkTitle>}
       type={EntryType.EXCEPTION}
-      stackType={STACK_TYPE.ORIGINAL}
+      stackType={StackType.ORIGINAL}
       projectSlug={projectSlug}
       eventId={event.id}
       recentFirst={isStacktraceNewestFirst()}
@@ -108,14 +108,14 @@ export function Exception({
         ) : (
           <ExceptionContent
             stackType={
-              display.includes('minified') ? STACK_TYPE.MINIFIED : STACK_TYPE.ORIGINAL
+              display.includes('minified') ? StackType.MINIFIED : StackType.ORIGINAL
             }
             stackView={
               display.includes('raw-stack-trace')
-                ? STACK_VIEW.RAW
+                ? StackView.RAW
                 : fullStackTrace
-                ? STACK_VIEW.FULL
-                : STACK_VIEW.APP
+                ? StackView.FULL
+                : StackView.APP
             }
             projectSlug={projectSlug}
             newestFirst={recentFirst}

--- a/static/app/components/events/interfaces/exceptionV2.tsx
+++ b/static/app/components/events/interfaces/exceptionV2.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import {ExceptionType, Group, PlatformType, Project} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
-import {STACK_TYPE, STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 
 import {PermalinkTitle, TraceEventDataSection} from '../traceEventDataSection';
 
@@ -63,7 +63,7 @@ export function ExceptionV2({
     <TraceEventDataSection
       title={<PermalinkTitle>{t('Stack Trace')}</PermalinkTitle>}
       type={EntryType.EXCEPTION}
-      stackType={STACK_TYPE.ORIGINAL}
+      stackType={StackType.ORIGINAL}
       projectSlug={projectSlug}
       eventId={event.id}
       recentFirst={isStacktraceNewestFirst()}
@@ -108,14 +108,14 @@ export function ExceptionV2({
         ) : (
           <ExceptionContent
             stackType={
-              display.includes('minified') ? STACK_TYPE.MINIFIED : STACK_TYPE.ORIGINAL
+              display.includes('minified') ? StackType.MINIFIED : StackType.ORIGINAL
             }
             stackView={
               display.includes('raw-stack-trace')
-                ? STACK_VIEW.RAW
+                ? StackView.RAW
                 : fullStackTrace
-                ? STACK_VIEW.FULL
-                : STACK_VIEW.APP
+                ? StackView.FULL
+                : StackView.APP
             }
             projectSlug={projectSlug}
             newestFirst={recentFirst}

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -10,7 +10,7 @@ import {IconChevron, IconProfiling} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {EntryType, EventTransaction, Frame, PlatformType} from 'sentry/types/event';
-import {STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackView} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 import {formatPercentage} from 'sentry/utils/formatters';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
@@ -208,7 +208,7 @@ export function SpanProfileDetails({
           registers: null,
           frames,
         }}
-        stackView={STACK_VIEW.APP}
+        stackView={StackView.APP}
         inlined
         maxDepth={MAX_STACK_DEPTH}
       />

--- a/static/app/components/events/interfaces/stackTrace.tsx
+++ b/static/app/components/events/interfaces/stackTrace.tsx
@@ -2,7 +2,7 @@ import {CrashContent} from 'sentry/components/events/interfaces/crashContent';
 import {t} from 'sentry/locale';
 import {Group, PlatformType, Project} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
-import {STACK_TYPE, STACK_VIEW} from 'sentry/types/stacktrace';
+import {StackType, StackView} from 'sentry/types/stacktrace';
 
 import {PermalinkTitle, TraceEventDataSection} from '../traceEventDataSection';
 
@@ -47,7 +47,7 @@ export function StackTrace({
   return (
     <TraceEventDataSection
       type={EntryType.STACKTRACE}
-      stackType={STACK_TYPE.ORIGINAL}
+      stackType={StackType.ORIGINAL}
       projectSlug={projectSlug}
       eventId={event.id}
       platform={platform}
@@ -80,10 +80,10 @@ export function StackTrace({
             platform={platform}
             stackView={
               display.includes('raw-stack-trace')
-                ? STACK_VIEW.RAW
+                ? StackView.RAW
                 : fullStackTrace
-                ? STACK_VIEW.FULL
-                : STACK_VIEW.APP
+                ? StackView.FULL
+                : StackView.APP
             }
             newestFirst={recentFirst}
             stacktrace={data}

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -22,8 +22,8 @@ import {
   Organization,
   PlatformType,
   Project,
-  STACK_TYPE,
-  STACK_VIEW,
+  StackType,
+  StackView,
   Thread,
 } from 'sentry/types';
 
@@ -56,16 +56,16 @@ type State = {
 function getIntendedStackView(
   thread: Thread,
   exception: ReturnType<typeof getThreadException>
-): STACK_VIEW {
+): StackView {
   if (exception) {
     return exception.values.find(value => !!value.stacktrace?.hasSystemFrames)
-      ? STACK_VIEW.APP
-      : STACK_VIEW.FULL;
+      ? StackView.APP
+      : StackView.FULL;
   }
 
   const stacktrace = getThreadStacktrace(false, thread);
 
-  return stacktrace?.hasSystemFrames ? STACK_VIEW.APP : STACK_VIEW.FULL;
+  return stacktrace?.hasSystemFrames ? StackView.APP : StackView.FULL;
 }
 
 export function getThreadStateIcon(state: ThreadStates | undefined) {
@@ -183,8 +183,8 @@ export function Threads({
     fullStackTrace,
   }: Parameters<React.ComponentProps<typeof TraceEventDataSection>['children']>[0]) {
     const stackType = display.includes('minified')
-      ? STACK_TYPE.MINIFIED
-      : STACK_TYPE.ORIGINAL;
+      ? StackType.MINIFIED
+      : StackType.ORIGINAL;
 
     if (exception) {
       return (
@@ -192,10 +192,10 @@ export function Threads({
           stackType={stackType}
           stackView={
             display.includes('raw-stack-trace')
-              ? STACK_VIEW.RAW
+              ? StackView.RAW
               : fullStackTrace
-              ? STACK_VIEW.FULL
-              : STACK_VIEW.APP
+              ? StackView.FULL
+              : StackView.APP
           }
           projectSlug={projectSlug}
           newestFirst={recentFirst}
@@ -210,7 +210,7 @@ export function Threads({
     }
 
     const stackTrace = getThreadStacktrace(
-      stackType !== STACK_TYPE.ORIGINAL,
+      stackType !== StackType.ORIGINAL,
       activeThread
     );
 
@@ -220,10 +220,10 @@ export function Threads({
           stacktrace={stackTrace}
           stackView={
             display.includes('raw-stack-trace')
-              ? STACK_VIEW.RAW
+              ? StackView.RAW
               : fullStackTrace
-              ? STACK_VIEW.FULL
-              : STACK_VIEW.APP
+              ? StackView.FULL
+              : StackView.APP
           }
           newestFirst={recentFirst}
           event={event}
@@ -298,11 +298,11 @@ export function Threads({
       )}
       <TraceEventDataSection
         type={EntryType.THREADS}
-        stackType={STACK_TYPE.ORIGINAL}
+        stackType={StackType.ORIGINAL}
         projectSlug={projectSlug}
         eventId={event.id}
         recentFirst={isStacktraceNewestFirst()}
-        fullStackTrace={stackView === STACK_VIEW.FULL}
+        fullStackTrace={stackView === StackView.FULL}
         title={
           hasMoreThanOneThread &&
           activeThread &&

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -17,7 +17,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PlatformType, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {STACK_TYPE} from 'sentry/types/stacktrace';
+import {StackType} from 'sentry/types/stacktrace';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
 import useApi from 'sentry/utils/useApi';
@@ -60,7 +60,7 @@ type Props = {
   projectSlug: Project['slug'];
   recentFirst: boolean;
   stackTraceNotFound: boolean;
-  stackType: STACK_TYPE;
+  stackType: StackType;
   title: React.ReactElement<any, any>;
   type: string;
   wrapTitle?: boolean;
@@ -340,7 +340,7 @@ export function TraceEventDataSection({
   }
 
   const nativePlatform = isNativePlatform(platform);
-  const minified = stackType === STACK_TYPE.MINIFIED;
+  const minified = stackType === StackType.MINIFIED;
 
   // Apple crash report endpoint
   const appleCrashEndpoint = `/projects/${organization.slug}/${projectSlug}/events/${eventId}/apple-crash-report?minified=${minified}`;

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -24,7 +24,7 @@ import {OnboardingSelectedSDK, Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-export enum SUPPORTED_LANGUAGES {
+export enum SupportedLanguages {
   JAVASCRIPT = 'javascript',
   PYTHON = 'python',
   NODE = 'node',
@@ -57,19 +57,19 @@ const topNodeFrameworks = [
 ];
 
 export const languageDetails = {
-  [SUPPORTED_LANGUAGES.JAVASCRIPT]: {
+  [SupportedLanguages.JAVASCRIPT]: {
     description: t(
       'Our JavaScript framework SDK’s include all the features of our Browser Javascript SDK with additional features specific to that framework'
     ),
     topFrameworksImage: onboardingFrameworkSelectionJavascript,
   },
-  [SUPPORTED_LANGUAGES.NODE]: {
+  [SupportedLanguages.NODE]: {
     description: t(
       'Our Node framework SDK’s include all the features of our Node SDK with instructions specific to that framework'
     ),
     topFrameworksImage: onboardingFrameworkSelectionNode,
   },
-  [SUPPORTED_LANGUAGES.PYTHON]: {
+  [SupportedLanguages.PYTHON]: {
     description: t(
       'Our Python framework SDK’s include all the features of our Python SDK with instructions specific to that framework'
     ),
@@ -106,10 +106,10 @@ export function FrameworkSuggestionModal({
   );
 
   const [topFrameworks, otherFrameworks] = partition(frameworks, framework => {
-    if (selectedPlatform.key === SUPPORTED_LANGUAGES.NODE) {
+    if (selectedPlatform.key === SupportedLanguages.NODE) {
       return topNodeFrameworks.includes(framework.id);
     }
-    if (selectedPlatform.key === SUPPORTED_LANGUAGES.PYTHON) {
+    if (selectedPlatform.key === SupportedLanguages.PYTHON) {
       return topPythonFrameworks.includes(framework.id);
     }
     return topJavascriptFrameworks.includes(framework.id);
@@ -117,10 +117,10 @@ export function FrameworkSuggestionModal({
 
   const otherFrameworksSortedAlphabetically = sortBy(otherFrameworks);
   const topFrameworksOrdered = sortBy(topFrameworks, framework => {
-    if (selectedPlatform.key === SUPPORTED_LANGUAGES.NODE) {
+    if (selectedPlatform.key === SupportedLanguages.NODE) {
       return topNodeFrameworks.indexOf(framework.id);
     }
-    if (selectedPlatform.key === SUPPORTED_LANGUAGES.PYTHON) {
+    if (selectedPlatform.key === SupportedLanguages.PYTHON) {
       return topPythonFrameworks.indexOf(framework.id);
     }
     return topJavascriptFrameworks.indexOf(framework.id);

--- a/static/app/types/stacktrace.tsx
+++ b/static/app/types/stacktrace.tsx
@@ -1,12 +1,12 @@
 import type {Frame} from './event';
 
-export enum STACK_VIEW {
+export enum StackView {
   RAW = 'raw',
   FULL = 'full',
   APP = 'app',
 }
 
-export enum STACK_TYPE {
+export enum StackType {
   ORIGINAL = 'original',
   MINIFIED = 'minified',
 }

--- a/static/app/utils/performance/contexts/performanceDisplayContext.tsx
+++ b/static/app/utils/performance/contexts/performanceDisplayContext.tsx
@@ -1,9 +1,9 @@
-import {PROJECT_PERFORMANCE_TYPE} from 'sentry/views/performance/utils';
+import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
 import {createDefinedContext} from './utils';
 
 type useCurrentPerformanceView = {
-  performanceType: PROJECT_PERFORMANCE_TYPE;
+  performanceType: ProjectPerformanceType;
 };
 
 const [PerformanceDisplayProvider, _usePerformanceDisplayType] =
@@ -13,6 +13,6 @@ const [PerformanceDisplayProvider, _usePerformanceDisplayType] =
 
 export {PerformanceDisplayProvider};
 
-export function usePerformanceDisplayType(): PROJECT_PERFORMANCE_TYPE {
+export function usePerformanceDisplayType(): ProjectPerformanceType {
   return _usePerformanceDisplayType().performanceType;
 }

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -179,13 +179,12 @@ export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
     [ids, storeIds]
   );
 
-  const shouldLoadSlugs = slugsToLoad.length > 0;
-  const shouldLoadIds = idsToLoad.length > 0;
-  const shouldLoadTeams = provideUserTeams && !store.loadedUserTeams;
+  const shouldLoadByQuery = slugsToLoad.length > 0 || idsToLoad.length > 0;
+  const shouldLoadUserTeams = provideUserTeams && !store.loadedUserTeams;
 
   // If we don't need to make a request either for slugs or user teams, set
   // initiallyLoaded to true
-  const initiallyLoaded = !shouldLoadSlugs && !shouldLoadTeams && !shouldLoadIds;
+  const initiallyLoaded = !shouldLoadUserTeams && !shouldLoadByQuery;
 
   const [state, setState] = useState<State>({
     initiallyLoaded,
@@ -221,7 +220,7 @@ export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
     [api, orgId]
   );
 
-  const loadTeamsBySlugOrId = useCallback(
+  const loadTeamsByQuery = useCallback(
     async function () {
       if (orgId === undefined) {
         return;
@@ -349,16 +348,16 @@ export function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
 
   // Load specified team slugs
   useEffect(() => {
-    if (shouldLoadSlugs || shouldLoadIds) {
-      loadTeamsBySlugOrId();
+    if (shouldLoadByQuery) {
+      loadTeamsByQuery();
     }
-  }, [shouldLoadSlugs, shouldLoadIds, loadTeamsBySlugOrId]);
+  }, [shouldLoadByQuery, loadTeamsByQuery]);
 
   useEffect(() => {
-    if (shouldLoadTeams) {
+    if (shouldLoadUserTeams) {
       loadUserTeams();
     }
-  }, [shouldLoadTeams, loadUserTeams]);
+  }, [shouldLoadUserTeams, loadUserTeams]);
 
   const isSuperuser = isActiveSuperuser();
 

--- a/static/app/views/onboarding/components/createProjectsFooter.tsx
+++ b/static/app/views/onboarding/components/createProjectsFooter.tsx
@@ -12,7 +12,7 @@ import {
 import {openModal} from 'sentry/actionCreators/modal';
 import {createProject} from 'sentry/actionCreators/projects';
 import {Button} from 'sentry/components/button';
-import {SUPPORTED_LANGUAGES} from 'sentry/components/onboarding/frameworkSuggestionModal';
+import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -150,8 +150,8 @@ export function CreateProjectsFooter({
 
     if (
       selectedPlatform.type !== 'language' ||
-      !Object.values(SUPPORTED_LANGUAGES).includes(
-        selectedPlatform.language as SUPPORTED_LANGUAGES
+      !Object.values(SupportedLanguages).includes(
+        selectedPlatform.language as SupportedLanguages
       )
     ) {
       createPlatformProject();

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -43,7 +43,7 @@ export const getDefaultStatsPeriod = (organization: Organization) => {
   return DEFAULT_STATS_PERIOD;
 };
 
-export enum PERFORMANCE_TERM {
+export enum PerformanceTerm {
   TPM = 'tpm',
   THROUGHPUT = 'throughput',
   FAILURE_RATE = 'failureRate',
@@ -78,32 +78,32 @@ export type TooltipOption = SelectValue<string> & {
 export function getAxisOptions(organization: Organization): TooltipOption[] {
   return [
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APDEX),
+      tooltip: getTermHelp(organization, PerformanceTerm.APDEX),
       value: 'apdex()',
       label: t('Apdex'),
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.TPM),
+      tooltip: getTermHelp(organization, PerformanceTerm.TPM),
       value: 'tpm()',
       label: t('Transactions Per Minute'),
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE),
+      tooltip: getTermHelp(organization, PerformanceTerm.FAILURE_RATE),
       value: 'failure_rate()',
       label: t('Failure Rate'),
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P50),
+      tooltip: getTermHelp(organization, PerformanceTerm.P50),
       value: 'p50()',
       label: t('p50 Duration'),
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P95),
+      tooltip: getTermHelp(organization, PerformanceTerm.P95),
       value: 'p95()',
       label: t('p95 Duration'),
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P99),
+      tooltip: getTermHelp(organization, PerformanceTerm.P99),
       value: 'p99()',
       label: t('p99 Duration'),
     },
@@ -122,27 +122,27 @@ export type AxisOption = TooltipOption & {
 export function getFrontendAxisOptions(organization: Organization): AxisOption[] {
   return [
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.LCP),
+      tooltip: getTermHelp(organization, PerformanceTerm.LCP),
       value: `p75(lcp)`,
       label: t('LCP p75'),
       field: 'p75(measurements.lcp)',
       isLeftDefault: true,
       backupOption: {
-        tooltip: getTermHelp(organization, PERFORMANCE_TERM.FCP),
+        tooltip: getTermHelp(organization, PerformanceTerm.FCP),
         value: `p75(fcp)`,
         label: t('FCP p75'),
         field: 'p75(measurements.fcp)',
       },
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+      tooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
       value: 'lcp_distribution',
       label: t('LCP Distribution'),
       field: 'measurements.lcp',
       isDistribution: true,
       isRightDefault: true,
       backupOption: {
-        tooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+        tooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
         value: 'fcp_distribution',
         label: t('FCP Distribution'),
         field: 'measurements.fcp',
@@ -150,7 +150,7 @@ export function getFrontendAxisOptions(organization: Organization): AxisOption[]
       },
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.TPM),
+      tooltip: getTermHelp(organization, PerformanceTerm.TPM),
       value: 'tpm()',
       label: t('Transactions Per Minute'),
       field: 'tpm()',
@@ -161,26 +161,26 @@ export function getFrontendAxisOptions(organization: Organization): AxisOption[]
 export function getFrontendOtherAxisOptions(organization: Organization): AxisOption[] {
   return [
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P50),
+      tooltip: getTermHelp(organization, PerformanceTerm.P50),
       value: `p50()`,
       label: t('Duration p50'),
       field: 'p50(transaction.duration)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
+      tooltip: getTermHelp(organization, PerformanceTerm.P75),
       value: `p75()`,
       label: t('Duration p75'),
       field: 'p75(transaction.duration)',
       isLeftDefault: true,
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P95),
+      tooltip: getTermHelp(organization, PerformanceTerm.P95),
       value: `p95()`,
       label: t('Duration p95'),
       field: 'p95(transaction.duration)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+      tooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
       value: 'duration_distribution',
       label: t('Duration Distribution'),
       field: 'transaction.duration',
@@ -193,44 +193,44 @@ export function getFrontendOtherAxisOptions(organization: Organization): AxisOpt
 export function getBackendAxisOptions(organization: Organization): AxisOption[] {
   return [
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P50),
+      tooltip: getTermHelp(organization, PerformanceTerm.P50),
       value: `p50()`,
       label: t('Duration p50'),
       field: 'p50(transaction.duration)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
+      tooltip: getTermHelp(organization, PerformanceTerm.P75),
       value: `p75()`,
       label: t('Duration p75'),
       field: 'p75(transaction.duration)',
       isLeftDefault: true,
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P95),
+      tooltip: getTermHelp(organization, PerformanceTerm.P95),
       value: `p95()`,
       label: t('Duration p95'),
       field: 'p95(transaction.duration)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P99),
+      tooltip: getTermHelp(organization, PerformanceTerm.P99),
       value: `p99()`,
       label: t('Duration p99'),
       field: 'p99(transaction.duration)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.TPM),
+      tooltip: getTermHelp(organization, PerformanceTerm.TPM),
       value: 'tpm()',
       label: t('Transactions Per Minute'),
       field: 'tpm()',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE),
+      tooltip: getTermHelp(organization, PerformanceTerm.FAILURE_RATE),
       value: 'failure_rate()',
       label: t('Failure Rate'),
       field: 'failure_rate()',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+      tooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
       value: 'duration_distribution',
       label: t('Duration Distribution'),
       field: 'transaction.duration',
@@ -238,7 +238,7 @@ export function getBackendAxisOptions(organization: Organization): AxisOption[] 
       isRightDefault: true,
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APDEX),
+      tooltip: getTermHelp(organization, PerformanceTerm.APDEX),
       value: 'apdex()',
       label: t('Apdex'),
       field: 'apdex()',
@@ -249,32 +249,32 @@ export function getBackendAxisOptions(organization: Organization): AxisOption[] 
 export function getMobileAxisOptions(organization: Organization): AxisOption[] {
   return [
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_COLD),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_COLD),
       value: `p50(measurements.app_start_cold)`,
       label: t('Cold Start Duration p50'),
       field: 'p50(measurements.app_start_cold)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_COLD),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_COLD),
       value: `p75(measurements.app_start_cold)`,
       label: t('Cold Start Duration p75'),
       field: 'p75(measurements.app_start_cold)',
       isLeftDefault: true,
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_COLD),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_COLD),
       value: `p95(measurements.app_start_cold)`,
       label: t('Cold Start Duration p95'),
       field: 'p95(measurements.app_start_cold)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_COLD),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_COLD),
       value: `p99(measurements.app_start_cold)`,
       label: t('Cold Start Duration p99'),
       field: 'p99(measurements.app_start_cold)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+      tooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
       value: 'app_start_cold_distribution',
       label: t('Cold Start Distribution'),
       field: 'measurements.app_start_cold',
@@ -282,44 +282,44 @@ export function getMobileAxisOptions(organization: Organization): AxisOption[] {
       isRightDefault: true,
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_WARM),
       value: `p50(measurements.app_start_warm)`,
       label: t('Warm Start Duration p50'),
       field: 'p50(measurements.app_start_warm)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_WARM),
       value: `p75(measurements.app_start_warm)`,
       label: t('Warm Start Duration p75'),
       field: 'p75(measurements.app_start_warm)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_WARM),
       value: `p95(measurements.app_start_warm)`,
       label: t('Warm Start Duration p95'),
       field: 'p95(measurements.app_start_warm)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_WARM),
       value: `p99(measurements.app_start_warm)`,
       label: t('Warm Start Duration p99'),
       field: 'p99(measurements.app_start_warm)',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+      tooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
       value: 'app_start_warm_distribution',
       label: t('Warm Start Distribution'),
       field: 'measurements.app_start_warm',
       isDistribution: true,
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.TPM),
+      tooltip: getTermHelp(organization, PerformanceTerm.TPM),
       value: 'tpm()',
       label: t('Transactions Per Minute'),
       field: 'tpm()',
     },
     {
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE),
+      tooltip: getTermHelp(organization, PerformanceTerm.FAILURE_RATE),
       value: 'failure_rate()',
       label: t('Failure Rate'),
       field: 'failure_rate()',
@@ -329,7 +329,7 @@ export function getMobileAxisOptions(organization: Organization): AxisOption[] {
 
 type TermFormatter = (organization: Organization) => string;
 
-export const PERFORMANCE_TERMS: Record<PERFORMANCE_TERM, TermFormatter> = {
+export const PERFORMANCE_TERMS: Record<PerformanceTerm, TermFormatter> = {
   tpm: () => t('TPM is the number of recorded transaction events per minute.'),
   throughput: () =>
     t('Throughput is the number of recorded transaction events per minute.'),

--- a/static/app/views/performance/landing/queryBatcher.spec.tsx
+++ b/static/app/views/performance/landing/queryBatcher.spec.tsx
@@ -32,9 +32,7 @@ function WrappedComponent({data, ...rest}) {
   return (
     <OrganizationContext.Provider value={data.organization}>
       <MEPSettingProvider>
-        <PerformanceDisplayProvider
-          value={{performanceType: ProjectPerformanceType.ANY}}
-        >
+        <PerformanceDisplayProvider value={{performanceType: ProjectPerformanceType.ANY}}>
           <WidgetContainer
             allowedCharts={[
               PerformanceWidgetSetting.TPM_AREA,

--- a/static/app/views/performance/landing/queryBatcher.spec.tsx
+++ b/static/app/views/performance/landing/queryBatcher.spec.tsx
@@ -9,7 +9,7 @@ import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/perf
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import WidgetContainer from 'sentry/views/performance/landing/widgets/components/widgetContainer';
 import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
-import {PROJECT_PERFORMANCE_TYPE} from 'sentry/views/performance/utils';
+import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
 const initializeData = () => {
   const data = _initializeData({
@@ -33,7 +33,7 @@ function WrappedComponent({data, ...rest}) {
     <OrganizationContext.Provider value={data.organization}>
       <MEPSettingProvider>
         <PerformanceDisplayProvider
-          value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}
+          value={{performanceType: ProjectPerformanceType.ANY}}
         >
           <WidgetContainer
             allowedCharts={[

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -16,9 +16,9 @@ import {HistogramData} from 'sentry/utils/performance/histogram/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
-import {AxisOption, getTermHelp, PERFORMANCE_TERM} from '../data';
+import {AxisOption, getTermHelp, PerformanceTerm} from '../data';
 import {Rectangle} from '../transactionSummary/transactionVitals/types';
-import {platformToPerformanceType, PROJECT_PERFORMANCE_TYPE} from '../utils';
+import {platformToPerformanceType, ProjectPerformanceType} from '../utils';
 
 export const LEFT_AXIS_QUERY_KEY = 'left';
 export const RIGHT_AXIS_QUERY_KEY = 'right';
@@ -168,10 +168,10 @@ export function getDefaultDisplayFieldForPlatform(
   const projectIds = eventView.project;
 
   const performanceTypeToDisplay = {
-    [PROJECT_PERFORMANCE_TYPE.ANY]: LandingDisplayField.ALL,
-    [PROJECT_PERFORMANCE_TYPE.FRONTEND]: LandingDisplayField.FRONTEND_PAGELOAD,
-    [PROJECT_PERFORMANCE_TYPE.BACKEND]: LandingDisplayField.BACKEND,
-    [PROJECT_PERFORMANCE_TYPE.MOBILE]: LandingDisplayField.MOBILE,
+    [ProjectPerformanceType.ANY]: LandingDisplayField.ALL,
+    [ProjectPerformanceType.FRONTEND]: LandingDisplayField.FRONTEND_PAGELOAD,
+    [ProjectPerformanceType.BACKEND]: LandingDisplayField.BACKEND,
+    [ProjectPerformanceType.MOBILE]: LandingDisplayField.MOBILE,
   };
   const performanceType = platformToPerformanceType(projects, projectIds);
   const landingField =
@@ -191,47 +191,47 @@ export const vitalCardDetails = (
   return {
     'p75(transaction.duration)': {
       title: t('Duration (p75)'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
+      tooltip: getTermHelp(organization, PerformanceTerm.P75),
       formatter: value => getDuration(value / 1000, value >= 1000 ? 3 : 0, true),
     },
     'tpm()': {
       title: t('Throughput'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.THROUGHPUT),
+      tooltip: getTermHelp(organization, PerformanceTerm.THROUGHPUT),
       formatter: formatAbbreviatedNumber,
     },
     'failure_rate()': {
       title: t('Failure Rate'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE),
+      tooltip: getTermHelp(organization, PerformanceTerm.FAILURE_RATE),
       formatter: value => formatPercentage(value, 2),
     },
     'apdex()': {
       title: t('Apdex'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APDEX),
+      tooltip: getTermHelp(organization, PerformanceTerm.APDEX),
       formatter: value => formatFloat(value, 4),
     },
     'p75(measurements.frames_slow_rate)': {
       title: t('Slow Frames (p75)'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_FRAMES),
+      tooltip: getTermHelp(organization, PerformanceTerm.SLOW_FRAMES),
       formatter: value => formatPercentage(value, 2),
     },
     'p75(measurements.frames_frozen_rate)': {
       title: t('Frozen Frames (p75)'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.FROZEN_FRAMES),
+      tooltip: getTermHelp(organization, PerformanceTerm.FROZEN_FRAMES),
       formatter: value => formatPercentage(value, 2),
     },
     'p75(measurements.app_start_cold)': {
       title: t('Cold Start (p75)'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_COLD),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_COLD),
       formatter: value => getDuration(value / 1000, value >= 1000 ? 3 : 0, true),
     },
     'p75(measurements.app_start_warm)': {
       title: t('Warm Start (p75)'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
+      tooltip: getTermHelp(organization, PerformanceTerm.APP_START_WARM),
       formatter: value => getDuration(value / 1000, value >= 1000 ? 3 : 0, true),
     },
     'p75(measurements.stall_percentage)': {
       title: t('Stall Percentage (p75)'),
-      tooltip: getTermHelp(organization, PERFORMANCE_TERM.STALL_PERCENTAGE),
+      tooltip: getTermHelp(organization, PerformanceTerm.STALL_PERCENTAGE),
       formatter: value => formatPercentage(value, 2),
     },
   };

--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -3,7 +3,7 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
 
 import Table from '../../table';
-import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
+import {ProjectPerformanceType} from '../../utils';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
 import {PerformanceWidgetSetting} from '../widgets/widgetDefinitions';
 
@@ -25,7 +25,7 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
   }
 
   return (
-    <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
+    <PerformanceDisplayProvider value={{performanceType: ProjectPerformanceType.ANY}}>
       <div data-test-id="all-transactions-view">
         <DoubleChartRow {...props} allowedCharts={doubleChartRowCharts} />
         <TripleChartRow

--- a/static/app/views/performance/landing/views/backendView.tsx
+++ b/static/app/views/performance/landing/views/backendView.tsx
@@ -7,7 +7,7 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
 
 import Table from '../../table';
-import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
+import {ProjectPerformanceType} from '../../utils';
 import {BACKEND_COLUMN_TITLES} from '../data';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
 import {filterAllowedChartsMetrics} from '../widgets/utils';
@@ -51,7 +51,7 @@ export function BackendView(props: BasePerformanceViewProps) {
     doubleChartRowCharts.unshift(PerformanceWidgetSetting.SPAN_OPERATIONS);
   }
   return (
-    <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
+    <PerformanceDisplayProvider value={{performanceType: ProjectPerformanceType.ANY}}>
       <div>
         <DoubleChartRow {...props} allowedCharts={doubleChartRowCharts} />
         <TripleChartRow

--- a/static/app/views/performance/landing/views/frontendOtherView.tsx
+++ b/static/app/views/performance/landing/views/frontendOtherView.tsx
@@ -7,7 +7,7 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
 
 import Table from '../../table';
-import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
+import {ProjectPerformanceType} from '../../utils';
 import {FRONTEND_OTHER_COLUMN_TITLES} from '../data';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
 import {filterAllowedChartsMetrics} from '../widgets/utils';
@@ -49,7 +49,7 @@ export function FrontendOtherView(props: BasePerformanceViewProps) {
 
   return (
     <PerformanceDisplayProvider
-      value={{performanceType: PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER}}
+      value={{performanceType: ProjectPerformanceType.FRONTEND_OTHER}}
     >
       <div>
         <DoubleChartRow {...props} allowedCharts={doubleChartRowCharts} />

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -7,7 +7,7 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
 
 import Table from '../../table';
-import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
+import {ProjectPerformanceType} from '../../utils';
 import {FRONTEND_PAGELOAD_COLUMN_TITLES} from '../data';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
 import {filterAllowedChartsMetrics} from '../widgets/utils';
@@ -51,7 +51,7 @@ export function FrontendPageloadView(props: BasePerformanceViewProps) {
   }
   return (
     <PerformanceDisplayProvider
-      value={{performanceType: PROJECT_PERFORMANCE_TYPE.FRONTEND}}
+      value={{performanceType: ProjectPerformanceType.FRONTEND}}
     >
       <div data-test-id="frontend-pageload-view">
         <DoubleChartRow {...props} allowedCharts={doubleChartRowCharts} />

--- a/static/app/views/performance/landing/views/mobileView.tsx
+++ b/static/app/views/performance/landing/views/mobileView.tsx
@@ -2,7 +2,7 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
 
 import Table from '../../table';
-import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
+import {ProjectPerformanceType} from '../../utils';
 import {MOBILE_COLUMN_TITLES, REACT_NATIVE_COLUMN_TITLES} from '../data';
 import {checkIsReactNative} from '../utils';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
@@ -33,7 +33,7 @@ export function MobileView(props: BasePerformanceViewProps) {
     );
   }
   return (
-    <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
+    <PerformanceDisplayProvider value={{performanceType: ProjectPerformanceType.ANY}}>
       <div>
         <DoubleChartRow
           {...props}

--- a/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
@@ -7,7 +7,7 @@ import {PerformanceLayoutBodyRow} from 'sentry/components/performance/layouts';
 import {space} from 'sentry/styles/space';
 import EventView from 'sentry/utils/discover/eventView';
 import {usePerformanceDisplayType} from 'sentry/utils/performance/contexts/performanceDisplayContext';
-import {PROJECT_PERFORMANCE_TYPE} from 'sentry/views/performance/utils';
+import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
 import {getChartSetting} from '../utils';
 import {PerformanceWidgetSetting} from '../widgetDefinitions';
@@ -26,7 +26,7 @@ export interface ChartRowProps {
 function getInitialChartSettings(
   chartCount: number,
   chartHeight: number,
-  performanceType: PROJECT_PERFORMANCE_TYPE,
+  performanceType: ProjectPerformanceType,
   allowedCharts: PerformanceWidgetSetting[]
 ) {
   return new Array(chartCount)

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -30,9 +30,7 @@ function WrappedComponent({data, withStaticFilters = false, ...rest}) {
   return (
     <OrganizationContext.Provider value={data.organization}>
       <MEPSettingProvider>
-        <PerformanceDisplayProvider
-          value={{performanceType: ProjectPerformanceType.ANY}}
-        >
+        <PerformanceDisplayProvider value={{performanceType: ProjectPerformanceType.ANY}}>
           <WidgetContainer
             allowedCharts={[
               PerformanceWidgetSetting.TPM_AREA,

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -13,7 +13,7 @@ import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/perf
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import WidgetContainer from 'sentry/views/performance/landing/widgets/components/widgetContainer';
 import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
-import {PROJECT_PERFORMANCE_TYPE} from 'sentry/views/performance/utils';
+import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
 const initializeData = (query = {}, rest: initializeDataSettings = {}) => {
   const data = _initializeData({
@@ -31,7 +31,7 @@ function WrappedComponent({data, withStaticFilters = false, ...rest}) {
     <OrganizationContext.Provider value={data.organization}>
       <MEPSettingProvider>
         <PerformanceDisplayProvider
-          value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}
+          value={{performanceType: ProjectPerformanceType.ANY}}
         >
           <WidgetContainer
             allowedCharts={[

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -7,7 +7,7 @@ import {
   MetricsEnhancedSettingContext,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 
-import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
+import {ProjectPerformanceType} from '../../utils';
 
 import {PerformanceWidgetSetting} from './widgetDefinitions';
 
@@ -81,7 +81,7 @@ export function getMEPParamsIfApplicable(
 const getContainerLocalStorageObjectKey = 'landing-chart-container';
 const getContainerKey = (
   index: number,
-  performanceType: PROJECT_PERFORMANCE_TYPE,
+  performanceType: ProjectPerformanceType,
   height: number
 ) => `landing-chart-container#${performanceType}#${height}#${index}`;
 
@@ -95,7 +95,7 @@ function getWidgetStorageObject() {
 export const getChartSetting = (
   index: number,
   height: number,
-  performanceType: PROJECT_PERFORMANCE_TYPE,
+  performanceType: ProjectPerformanceType,
   defaultType: PerformanceWidgetSetting,
   forceDefaultChartSetting?: boolean // Used for testing.
 ): PerformanceWidgetSetting => {
@@ -118,7 +118,7 @@ export const getChartSetting = (
 export const _setChartSetting = (
   index: number,
   height: number,
-  performanceType: PROJECT_PERFORMANCE_TYPE,
+  performanceType: ProjectPerformanceType,
   setting: PerformanceWidgetSetting
 ) => {
   const key = getContainerKey(index, performanceType, height);

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -3,7 +3,7 @@ import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/discover/fields';
 
-import {getTermHelp, PERFORMANCE_TERM} from '../../data';
+import {getTermHelp, PerformanceTerm} from '../../data';
 
 import {GenericPerformanceWidgetDataType} from './types';
 
@@ -72,35 +72,35 @@ export const WIDGET_DEFINITIONS: ({
 }) => ({
   [PerformanceWidgetSetting.DURATION_HISTOGRAM]: {
     title: t('Duration Distribution'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
     fields: ['transaction.duration'],
     dataType: GenericPerformanceWidgetDataType.HISTOGRAM,
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.LCP_HISTOGRAM]: {
     title: t('LCP Distribution'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
     fields: ['measurements.lcp'],
     dataType: GenericPerformanceWidgetDataType.HISTOGRAM,
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.FCP_HISTOGRAM]: {
     title: t('FCP Distribution'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
     fields: ['measurements.fcp'],
     dataType: GenericPerformanceWidgetDataType.HISTOGRAM,
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.FID_HISTOGRAM]: {
     title: t('FID Distribution'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.DURATION_DISTRIBUTION),
     fields: ['measurements.fid'],
     dataType: GenericPerformanceWidgetDataType.HISTOGRAM,
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.WORST_LCP_VITALS]: {
     title: t('Worst LCP Web Vitals'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.LCP),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.LCP),
     fields: ['measurements.lcp'],
     vitalStops: {
       poor: 4000,
@@ -110,7 +110,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.WORST_FCP_VITALS]: {
     title: t('Worst FCP Web Vitals'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FCP),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.FCP),
     fields: ['measurements.fcp'],
     vitalStops: {
       poor: 3000,
@@ -120,7 +120,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.WORST_FID_VITALS]: {
     title: t('Worst FID Web Vitals'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FID),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.FID),
     fields: ['measurements.fid'],
     vitalStops: {
       poor: 300,
@@ -130,7 +130,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.WORST_CLS_VITALS]: {
     title: t('Worst CLS Web Vitals'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.CLS),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.CLS),
     fields: ['measurements.cls'],
     vitalStops: {
       poor: 0.25,
@@ -140,7 +140,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.TPM_AREA]: {
     title: t('Transactions Per Minute'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.TPM),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.TPM),
     fields: ['tpm()'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[1],
@@ -148,7 +148,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.APDEX_AREA]: {
     title: t('Apdex'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.APDEX),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.APDEX),
     fields: ['apdex()'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[4],
@@ -156,7 +156,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.P50_DURATION_AREA]: {
     title: t('p50 Duration'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P50),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.P50),
     fields: ['p50(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[3],
@@ -164,7 +164,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.P75_DURATION_AREA]: {
     title: t('p75 Duration'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.P75),
     fields: ['p75(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[3],
@@ -172,7 +172,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.P95_DURATION_AREA]: {
     title: t('p95 Duration'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P95),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.P95),
     fields: ['p95(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[3],
@@ -180,7 +180,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.P99_DURATION_AREA]: {
     title: t('p99 Duration'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P99),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.P99),
     fields: ['p99(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[3],
@@ -188,7 +188,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.P75_LCP_AREA]: {
     title: t('p75 LCP'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.P75),
     fields: ['p75(measurements.lcp)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[1],
@@ -196,7 +196,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.FAILURE_RATE_AREA]: {
     title: t('Failure Rate'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.FAILURE_RATE),
     fields: ['failure_rate()'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[2],
@@ -204,7 +204,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.USER_MISERY_AREA]: {
     title: t('User Misery'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.USER_MISERY),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.USER_MISERY),
     fields: [`user_misery()`],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[0],
@@ -212,7 +212,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.COLD_STARTUP_AREA]: {
     title: t('Cold Startup Time'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_COLD),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.APP_START_COLD),
     fields: ['p75(measurements.app_start_cold)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[4],
@@ -220,7 +220,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.WARM_STARTUP_AREA]: {
     title: t('Warm Startup Time'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.APP_START_WARM),
     fields: ['p75(measurements.app_start_warm)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[3],
@@ -228,7 +228,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.SLOW_FRAMES_AREA]: {
     title: t('Slow Frames'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_FRAMES),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.SLOW_FRAMES),
     fields: ['p75(measurements.frames_slow_rate)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[0],
@@ -236,7 +236,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.FROZEN_FRAMES_AREA]: {
     title: t('Frozen Frames'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FROZEN_FRAMES),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.FROZEN_FRAMES),
     fields: ['p75(measurements.frames_frozen_rate)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[5],
@@ -244,49 +244,49 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.MOST_RELATED_ERRORS]: {
     title: t('Most Related Errors'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.MOST_ERRORS),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.MOST_ERRORS),
     fields: [`failure_count()`],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.MOST_RELATED_ISSUES]: {
     title: t('Most Related Issues'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.MOST_ISSUES),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.MOST_ISSUES),
     fields: [`count()`],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_HTTP_OPS]: {
     title: t('Slow HTTP Ops'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.SLOW_HTTP_SPANS),
     fields: [`p75(spans.http)`],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_BROWSER_OPS]: {
     title: t('Slow Browser Ops'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.SLOW_HTTP_SPANS),
     fields: [`p75(spans.browser)`],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_RESOURCE_OPS]: {
     title: t('Slow Resource Ops'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.SLOW_HTTP_SPANS),
     fields: [`p75(spans.resource)`],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_DB_OPS]: {
     title: t('Slow DB Ops'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.SLOW_HTTP_SPANS),
     fields: [`p75(spans.db)`],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.TIME_TO_INITIAL_DISPLAY]: {
     title: t('Time to Initial Display'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.TIME_TO_INITIAL_DISPLAY),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.TIME_TO_INITIAL_DISPLAY),
     fields: ['p75(measurements.time_to_initial_display)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[4],
@@ -294,7 +294,7 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.TIME_TO_FULL_DISPLAY]: {
     title: t('Time to Full Display'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.TIME_TO_FULL_DISPLAY),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.TIME_TO_FULL_DISPLAY),
     fields: ['p75(measurements.time_to_full_display)'],
     dataType: GenericPerformanceWidgetDataType.AREA,
     chartColor: WIDGET_PALETTE[4],
@@ -302,14 +302,14 @@ export const WIDGET_DEFINITIONS: ({
   },
   [PerformanceWidgetSetting.MOST_SLOW_FRAMES]: {
     title: t('Most Slow Frames'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_FRAMES),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.SLOW_FRAMES),
     fields: ['avg(measurements.frames_slow)'],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.MOST_FROZEN_FRAMES]: {
     title: t('Most Frozen Frames'),
-    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FROZEN_FRAMES),
+    titleTooltip: getTermHelp(organization, PerformanceTerm.FROZEN_FRAMES),
     fields: ['avg(measurements.frames_frozen)'],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -22,7 +22,7 @@ import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {
   platformToPerformanceType,
-  PROJECT_PERFORMANCE_TYPE,
+  ProjectPerformanceType,
 } from 'sentry/views/performance/utils';
 
 import Filter, {filterToSearchConditions, SpanOperationBreakdownFilter} from '../filter';
@@ -90,7 +90,7 @@ function EventsContent(props: Props) {
   }
 
   const platform = platformToPerformanceType(projects, eventView.project);
-  if (platform === PROJECT_PERFORMANCE_TYPE.BACKEND) {
+  if (platform === ProjectPerformanceType.BACKEND) {
     const userIndex = transactionsListTitles.indexOf('user');
     if (userIndex > 0) {
       transactionsListTitles.splice(userIndex + 1, 0, 'http.method');

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -33,7 +33,7 @@ import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
 import {
@@ -91,7 +91,7 @@ function SidebarCharts({
           {t('Apdex')}
           <QuestionTooltip
             position="top"
-            title={getTermHelp(organization, PERFORMANCE_TERM.APDEX)}
+            title={getTermHelp(organization, PerformanceTerm.APDEX)}
             size="sm"
           />
         </ChartTitle>
@@ -108,7 +108,7 @@ function SidebarCharts({
           {t('Failure Rate')}
           <QuestionTooltip
             position="top"
-            title={getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE)}
+            title={getTermHelp(organization, PerformanceTerm.FAILURE_RATE)}
             size="sm"
           />
         </ChartTitle>

--- a/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
@@ -16,7 +16,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 
 type Props = {
   eventView: EventView;
@@ -38,7 +38,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
         {t('Status Breakdown')}
         <QuestionTooltip
           position="top"
-          title={getTermHelp(organization, PERFORMANCE_TERM.STATUS_BREAKDOWN)}
+          title={getTermHelp(organization, PerformanceTerm.STATUS_BREAKDOWN)}
           size="sm"
         />
       </SectionHeading>

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -33,7 +33,7 @@ import {TableColumn} from 'sentry/views/discover/table/types';
 
 import {
   platformAndConditionsToPerformanceType,
-  PROJECT_PERFORMANCE_TYPE,
+  ProjectPerformanceType,
 } from '../../utils';
 import {
   SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD,
@@ -130,7 +130,7 @@ export const getTransactionField = (
   }
 
   const performanceType = platformAndConditionsToPerformanceType(projects, eventView);
-  if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
+  if (performanceType === ProjectPerformanceType.FRONTEND) {
     return 'measurements.lcp';
   }
 
@@ -156,7 +156,7 @@ const getColumnsWithReplacedDuration = (
   }
 
   const performanceType = platformAndConditionsToPerformanceType(projects, eventView);
-  if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
+  if (performanceType === ProjectPerformanceType.FRONTEND) {
     durationColumn.name = 'Avg LCP';
     return columns;
   }

--- a/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
@@ -14,7 +14,7 @@ import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnh
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import DurationChart from 'sentry/views/performance/charts/chart';
-import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 import {ViewProps} from 'sentry/views/performance/types';
 
@@ -65,7 +65,7 @@ function UserMiseryChart({
       <QuestionTooltip
         size="sm"
         position="top"
-        title={getTermHelp(organization as Organization, PERFORMANCE_TERM.USER_MISERY)}
+        title={getTermHelp(organization as Organization, PerformanceTerm.USER_MISERY)}
       />
     </HeaderTitleLegend>
   );

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -17,7 +17,7 @@ import {WebVital} from 'sentry/utils/fields';
 import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 import {getTransactionMEPParamsIfApplicable} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 import {vitalsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionVitals/utils';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
@@ -122,7 +122,7 @@ function UserStats({
           {t('User Misery')}
           <QuestionTooltip
             position="top"
-            title={getTermHelp(organization, PERFORMANCE_TERM.USER_MISERY)}
+            title={getTermHelp(organization, PerformanceTerm.USER_MISERY)}
             size="sm"
           />
         </SectionHeading>

--- a/static/app/views/performance/trends/utils.spec.tsx
+++ b/static/app/views/performance/trends/utils.spec.tsx
@@ -6,7 +6,7 @@ import {
   getCurrentTrendParameter,
   performanceTypeToTrendParameterLabel,
 } from 'sentry/views/performance/trends/utils';
-import {PROJECT_PERFORMANCE_TYPE} from 'sentry/views/performance/utils';
+import {ProjectPerformanceType} from 'sentry/views/performance/utils';
 
 describe('Trend parameter utils', function () {
   describe('performanceTypeToTrendParameterLabel', function () {
@@ -22,27 +22,27 @@ describe('Trend parameter utils', function () {
       };
 
       const frontendProjectOutput = performanceTypeToTrendParameterLabel(
-        PROJECT_PERFORMANCE_TYPE.FRONTEND
+        ProjectPerformanceType.FRONTEND
       );
       expect(frontendProjectOutput).toEqual(lcp);
 
       const anyProjectOutput = performanceTypeToTrendParameterLabel(
-        PROJECT_PERFORMANCE_TYPE.ANY
+        ProjectPerformanceType.ANY
       );
       expect(anyProjectOutput).toEqual(duration);
 
       const backendProjectOutput = performanceTypeToTrendParameterLabel(
-        PROJECT_PERFORMANCE_TYPE.BACKEND
+        ProjectPerformanceType.BACKEND
       );
       expect(backendProjectOutput).toEqual(duration);
 
       const frontendOtherProjectOutput = performanceTypeToTrendParameterLabel(
-        PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER
+        ProjectPerformanceType.FRONTEND_OTHER
       );
       expect(frontendOtherProjectOutput).toEqual(duration);
 
       const mobileProjectOutput = performanceTypeToTrendParameterLabel(
-        PROJECT_PERFORMANCE_TYPE.MOBILE
+        ProjectPerformanceType.MOBILE
       );
       expect(mobileProjectOutput).toEqual(duration);
     });

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -17,7 +17,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import theme from 'sentry/utils/theme';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
-import {platformToPerformanceType, PROJECT_PERFORMANCE_TYPE} from '../utils';
+import {platformToPerformanceType, ProjectPerformanceType} from '../utils';
 
 import {
   NormalizedTrendsTransaction,
@@ -177,17 +177,17 @@ export function getCurrentTrendParameter(
 }
 
 export function performanceTypeToTrendParameterLabel(
-  performanceType: PROJECT_PERFORMANCE_TYPE
+  performanceType: ProjectPerformanceType
 ): TrendParameter {
   switch (performanceType) {
-    case PROJECT_PERFORMANCE_TYPE.FRONTEND:
+    case ProjectPerformanceType.FRONTEND:
       return {
         label: TrendParameterLabel.LCP,
         column: TrendParameterColumn.LCP,
       };
-    case PROJECT_PERFORMANCE_TYPE.ANY:
-    case PROJECT_PERFORMANCE_TYPE.BACKEND:
-    case PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER:
+    case ProjectPerformanceType.ANY:
+    case ProjectPerformanceType.BACKEND:
+    case ProjectPerformanceType.FRONTEND_OTHER:
     default:
       return {
         label: TrendParameterLabel.DURATION,

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -87,7 +87,7 @@ export function createUnnamedTransactionsDiscoverTarget(props: {
  * Performance type can used to determine a default view or which specific field should be used by default on pages
  * where we don't want to wait for transaction data to return to determine how to display aspects of a page.
  */
-export enum PROJECT_PERFORMANCE_TYPE {
+export enum ProjectPerformanceType {
   ANY = 'any', // Fallback to transaction duration
   FRONTEND = 'frontend',
   BACKEND = 'backend',
@@ -110,7 +110,7 @@ export function platformToPerformanceType(
   projectIds: readonly number[]
 ) {
   if (projectIds.length === 0 || projectIds[0] === ALL_ACCESS_PROJECTS) {
-    return PROJECT_PERFORMANCE_TYPE.ANY;
+    return ProjectPerformanceType.ANY;
   }
 
   const selectedProjects = projects.filter(p =>
@@ -118,27 +118,27 @@ export function platformToPerformanceType(
   );
 
   if (selectedProjects.length === 0 || selectedProjects.some(p => !p.platform)) {
-    return PROJECT_PERFORMANCE_TYPE.ANY;
+    return ProjectPerformanceType.ANY;
   }
 
-  const projectPerformanceTypes = new Set<PROJECT_PERFORMANCE_TYPE>();
+  const projectPerformanceTypes = new Set<ProjectPerformanceType>();
 
   selectedProjects.forEach(project => {
     if (FRONTEND_PLATFORMS.includes(project.platform ?? '')) {
-      projectPerformanceTypes.add(PROJECT_PERFORMANCE_TYPE.FRONTEND);
+      projectPerformanceTypes.add(ProjectPerformanceType.FRONTEND);
     }
     if (BACKEND_PLATFORMS.includes(project.platform ?? '')) {
-      projectPerformanceTypes.add(PROJECT_PERFORMANCE_TYPE.BACKEND);
+      projectPerformanceTypes.add(ProjectPerformanceType.BACKEND);
     }
     if (MOBILE_PLATFORMS.includes(project.platform ?? '')) {
-      projectPerformanceTypes.add(PROJECT_PERFORMANCE_TYPE.MOBILE);
+      projectPerformanceTypes.add(ProjectPerformanceType.MOBILE);
     }
   });
 
   const uniquePerformanceTypeCount = projectPerformanceTypes.size;
 
   if (!uniquePerformanceTypeCount || uniquePerformanceTypeCount > 1) {
-    return PROJECT_PERFORMANCE_TYPE.ANY;
+    return ProjectPerformanceType.ANY;
   }
   const [platformType] = projectPerformanceTypes;
   return platformType;
@@ -152,11 +152,11 @@ export function platformAndConditionsToPerformanceType(
   eventView: EventView
 ) {
   const performanceType = platformToPerformanceType(projects, eventView.project);
-  if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
+  if (performanceType === ProjectPerformanceType.FRONTEND) {
     const conditions = new MutableSearch(eventView.query);
     const ops = conditions.getFilterValues('!transaction.op');
     if (ops.some(op => op === 'pageload')) {
-      return PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER;
+      return ProjectPerformanceType.FRONTEND_OTHER;
     }
   }
 
@@ -169,16 +169,16 @@ export function platformAndConditionsToPerformanceType(
 export function isSummaryViewFrontendPageLoad(eventView: EventView, projects: Project[]) {
   return (
     platformAndConditionsToPerformanceType(projects, eventView) ===
-    PROJECT_PERFORMANCE_TYPE.FRONTEND
+    ProjectPerformanceType.FRONTEND
   );
 }
 
 export function isSummaryViewFrontend(eventView: EventView, projects: Project[]) {
   return (
     platformAndConditionsToPerformanceType(projects, eventView) ===
-      PROJECT_PERFORMANCE_TYPE.FRONTEND ||
+      ProjectPerformanceType.FRONTEND ||
     platformAndConditionsToPerformanceType(projects, eventView) ===
-      PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER
+      ProjectPerformanceType.FRONTEND_OTHER
   );
 }
 

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -37,7 +37,7 @@ import {
   SessionTerm,
 } from 'sentry/views/releases/utils/sessionTerm';
 
-import {getTermHelp, PERFORMANCE_TERM} from '../performance/data';
+import {getTermHelp, PerformanceTerm} from '../performance/data';
 
 import ProjectBaseEventsChart from './charts/projectBaseEventsChart';
 import ProjectBaseSessionsChart from './charts/projectBaseSessionsChart';
@@ -162,7 +162,7 @@ class ProjectCharts extends Component<Props, State> {
           !hasTransactions,
         tooltip:
           hasPerformance && hasTransactions
-            ? getTermHelp(organization, PERFORMANCE_TERM.APDEX)
+            ? getTermHelp(organization, PerformanceTerm.APDEX)
             : noPerformanceTooltip,
       },
       {
@@ -174,7 +174,7 @@ class ProjectCharts extends Component<Props, State> {
           !hasTransactions,
         tooltip:
           hasPerformance && hasTransactions
-            ? getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE)
+            ? getTermHelp(organization, PerformanceTerm.FAILURE_RATE)
             : noPerformanceTooltip,
       },
       {
@@ -186,7 +186,7 @@ class ProjectCharts extends Component<Props, State> {
           !hasTransactions,
         tooltip:
           hasPerformance && hasTransactions
-            ? getTermHelp(organization, PERFORMANCE_TERM.TPM)
+            ? getTermHelp(organization, PerformanceTerm.TPM)
             : noPerformanceTooltip,
       },
       {
@@ -335,7 +335,7 @@ class ProjectCharts extends Component<Props, State> {
               {displayMode === DisplayModes.APDEX && (
                 <ProjectBaseEventsChart
                   title={t('Apdex')}
-                  help={getTermHelp(organization, PERFORMANCE_TERM.APDEX)}
+                  help={getTermHelp(organization, PerformanceTerm.APDEX)}
                   query={new MutableSearch([
                     'event.type:transaction',
                     query ?? '',
@@ -352,7 +352,7 @@ class ProjectCharts extends Component<Props, State> {
               {displayMode === DisplayModes.FAILURE_RATE && (
                 <ProjectBaseEventsChart
                   title={t('Failure Rate')}
-                  help={getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE)}
+                  help={getTermHelp(organization, PerformanceTerm.FAILURE_RATE)}
                   query={new MutableSearch([
                     'event.type:transaction',
                     query ?? '',
@@ -369,7 +369,7 @@ class ProjectCharts extends Component<Props, State> {
               {displayMode === DisplayModes.TPM && (
                 <ProjectBaseEventsChart
                   title={t('Transactions Per Minute')}
-                  help={getTermHelp(organization, PERFORMANCE_TERM.TPM)}
+                  help={getTermHelp(organization, PerformanceTerm.TPM)}
                   query={new MutableSearch([
                     'event.type:transaction',
                     query ?? '',

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -13,7 +13,7 @@ import {Organization, PageFilters} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getPeriod} from 'sentry/utils/getPeriod';
-import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 
 import MissingPerformanceButtons from '../missingFeatureButtons/missingPerformanceButtons';
 
@@ -115,7 +115,7 @@ class ProjectApdexScoreCard extends AsyncComponent<Props, State> {
 
   get cardHelp() {
     const {organization} = this.props;
-    const baseHelp = getTermHelp(organization, PERFORMANCE_TERM.APDEX);
+    const baseHelp = getTermHelp(organization, PerformanceTerm.APDEX);
 
     if (this.trend) {
       return baseHelp + t(' This shows how it has changed since the last period.');

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -14,7 +14,7 @@ import {Button} from 'sentry/components/button';
 import Input from 'sentry/components/input';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {SUPPORTED_LANGUAGES} from 'sentry/components/onboarding/frameworkSuggestionModal';
+import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import PlatformPicker, {Platform} from 'sentry/components/platformPicker';
 import {useProjectCreationAccess} from 'sentry/components/projects/useProjectCreationAccess';
 import TeamSelector from 'sentry/components/teamSelector';
@@ -200,8 +200,8 @@ function CreateProject() {
 
     if (
       selectedPlatform.type !== 'language' ||
-      !Object.values(SUPPORTED_LANGUAGES).includes(
-        selectedPlatform.language as SUPPORTED_LANGUAGES
+      !Object.values(SupportedLanguages).includes(
+        selectedPlatform.language as SupportedLanguages
       )
     ) {
       createProject();

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -46,7 +46,7 @@ import {
 import {TrendChangeType, TrendView} from 'sentry/views/performance/trends/types';
 import {
   platformToPerformanceType,
-  PROJECT_PERFORMANCE_TYPE,
+  ProjectPerformanceType,
 } from 'sentry/views/performance/utils';
 
 import {
@@ -201,7 +201,7 @@ class ReleaseOverview extends AsyncView<Props> {
     baseQuery: NewQuery
   ): EventView {
     const eventView =
-      performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND
+      performanceType === ProjectPerformanceType.FRONTEND
         ? (EventView.fromSavedQuery({
             ...baseQuery,
             fields: [
@@ -215,12 +215,12 @@ class ReleaseOverview extends AsyncView<Props> {
               `p75(${SpanOpBreakdown.SPANS_RESOURCE})`,
             ],
           }) as EventView)
-        : performanceType === PROJECT_PERFORMANCE_TYPE.BACKEND
+        : performanceType === ProjectPerformanceType.BACKEND
         ? (EventView.fromSavedQuery({
             ...baseQuery,
             fields: [...baseQuery.fields, 'apdex()', 'p75(spans.http)', 'p75(spans.db)'],
           }) as EventView)
-        : performanceType === PROJECT_PERFORMANCE_TYPE.MOBILE
+        : performanceType === ProjectPerformanceType.MOBILE
         ? (EventView.fromSavedQuery({
             ...baseQuery,
             fields: [

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -23,7 +23,7 @@ import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import useRouter from 'sentry/utils/useRouter';
 import withOrganization from 'sentry/utils/withOrganization';
-import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
+import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 
 import {
   generateReleaseMarkLines,
@@ -125,7 +125,7 @@ function ReleaseEventsChart({
   function getHelp() {
     switch (chartType) {
       case ReleaseComparisonChartType.FAILURE_RATE:
-        return getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE);
+        return getTermHelp(organization, PerformanceTerm.FAILURE_RATE);
       default:
         return null;
     }

--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -34,7 +34,7 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {DebugIdBundlesTags} from 'sentry/views/settings/projectSourceMaps/debugIdBundlesTags';
 
-enum SORT_BY {
+enum SortBy {
   ASC = 'date_added',
   DESC = '-date_added',
 }
@@ -134,7 +134,7 @@ export function ProjectSourceMaps({location, router, project}: Props) {
 
   // query params
   const query = decodeScalar(location.query.query);
-  const sortBy = location.query.sort ?? SORT_BY.DESC;
+  const sortBy = location.query.sort ?? SortBy.DESC;
   const cursor = location.query.cursor ?? '';
 
   // endpoints
@@ -215,7 +215,7 @@ export function ProjectSourceMaps({location, router, project}: Props) {
       query: {
         ...location.query,
         cursor: undefined,
-        sort: sortBy === SORT_BY.ASC ? SORT_BY.DESC : SORT_BY.ASC,
+        sort: sortBy === SortBy.ASC ? SortBy.DESC : SortBy.ASC,
       },
     });
   }, [location, router, sortBy]);
@@ -304,13 +304,13 @@ export function ProjectSourceMaps({location, router, project}: Props) {
             <Tooltip
               containerDisplayMode="inline-flex"
               title={
-                sortBy === SORT_BY.DESC
+                sortBy === SortBy.DESC
                   ? t('Switch to ascending order')
                   : t('Switch to descending order')
               }
             >
               <IconArrow
-                direction={sortBy === SORT_BY.DESC ? 'down' : 'up'}
+                direction={sortBy === SortBy.DESC ? 'down' : 'up'}
                 data-test-id="icon-arrow"
               />
             </Tooltip>


### PR DESCRIPTION
All enums should be in pascal case

The following were the offenders

```
/Users/evan/Coding/sentry/static/app/components/onboarding/frameworkSuggestionModal.tsx
  27:13  error  Enum name `SUPPORTED_LANGUAGES` must match one of the following formats: PascalCase  @typescript-eslint/naming-convention

/Users/evan/Coding/sentry/static/app/types/stacktrace.tsx
  3:13  error  Enum name `STACK_VIEW` must match one of the following formats: PascalCase  @typescript-eslint/naming-convention
  9:13  error  Enum name `STACK_TYPE` must match one of the following formats: PascalCase  @typescript-eslint/naming-convention

/Users/evan/Coding/sentry/static/app/views/performance/data.tsx
  46:13  error  Enum name `PERFORMANCE_TERM` must match one of the following formats: PascalCase  @typescript-eslint/naming-convention

/Users/evan/Coding/sentry/static/app/views/performance/utils.tsx
  90:13  error  Enum name `PROJECT_PERFORMANCE_TYPE` must match one of the following formats: PascalCase  @typescript-eslint/naming-convention

/Users/evan/Coding/sentry/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
  37:6  error  Enum name `SORT_BY` must match one of the following formats: PascalCase  @typescript-eslint/naming-convention
```