### PR TITLE
feat(starfish): Update Endpoint Overview sidebar

### DIFF
--- a/static/app/views/starfish/colours.tsx
+++ b/static/app/views/starfish/colours.tsx
@@ -1,6 +1,6 @@
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 
 export const THROUGHPUT_COLOR = CHART_PALETTE[0][0];
-export const P50_COLOR = CHART_PALETTE[2][2];
-export const P95_COLOR = CHART_PALETTE[2][1];
-export const ERRORS_COLOR = CHART_PALETTE[2][2];
+export const P50_COLOR = CHART_PALETTE[3][1];
+export const P95_COLOR = CHART_PALETTE[3][3];
+export const ERRORS_COLOR = CHART_PALETTE[5][3];

--- a/static/app/views/starfish/components/samplesTable/transactionSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/transactionSamplesTable.tsx
@@ -1,8 +1,11 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import DateTime from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import {DurationComparisonCell} from 'sentry/views/starfish/components/samplesTable/common';
 import useSlowMedianFastSamplesQuery from 'sentry/views/starfish/components/samplesTable/useSlowMedianFastSamplesQuery';
@@ -54,8 +57,10 @@ type DataRow = {
   'transaction.duration': number;
 };
 
-export function TransactionSamplesTable({eventView}: Props) {
+export function TransactionSamplesTable({eventView: metricEventView}: Props) {
   const location = useLocation();
+  const eventView = cloneDeep(metricEventView);
+  eventView.dataset = DiscoverDatasets.DISCOVER;
   const {isLoading, data, aggregatesData} = useSlowMedianFastSamplesQuery(eventView);
 
   function renderHeadCell(column: GridColumnHeader): React.ReactNode {

--- a/static/app/views/starfish/components/samplesTable/transactionSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/transactionSamplesTable.tsx
@@ -1,11 +1,11 @@
-import cloneDeep from 'lodash/cloneDeep';
-
 import DateTime from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
 import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
+import {NewQuery} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {DurationComparisonCell} from 'sentry/views/starfish/components/samplesTable/common';
 import useSlowMedianFastSamplesQuery from 'sentry/views/starfish/components/samplesTable/useSlowMedianFastSamplesQuery';
@@ -47,7 +47,7 @@ const COLUMN_ORDER: TableColumnHeader[] = [
 ];
 
 type Props = {
-  eventView: EventView;
+  queryConditions: string[];
 };
 
 type DataRow = {
@@ -57,10 +57,21 @@ type DataRow = {
   'transaction.duration': number;
 };
 
-export function TransactionSamplesTable({eventView: metricEventView}: Props) {
+export function TransactionSamplesTable({queryConditions}: Props) {
   const location = useLocation();
-  const eventView = cloneDeep(metricEventView);
-  eventView.dataset = DiscoverDatasets.DISCOVER;
+  const query = new MutableSearch(queryConditions);
+
+  const savedQuery: NewQuery = {
+    id: undefined,
+    name: 'Endpoint Overview Samples',
+    query: query.formatString(),
+    projects: [1],
+    fields: [],
+    dataset: DiscoverDatasets.DISCOVER,
+    version: 2,
+  };
+
+  const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   const {isLoading, data, aggregatesData} = useSlowMedianFastSamplesQuery(eventView);
 
   function renderHeadCell(column: GridColumnHeader): React.ReactNode {

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -264,7 +264,7 @@ export default function EndpointOverview() {
             {/* TODO: Add transaction method to filter */}
             <SpanMetricsTable filter={state.spansFilter} transaction={transaction} />
             <SubHeader>{t('Sample Events')}</SubHeader>
-            <TransactionSamplesTable eventView={eventView} />
+            <TransactionSamplesTable queryConditions={queryConditions} />
           </Layout.Main>
           <Layout.Side>
             {renderSidebarCharts()}

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -10,6 +10,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Series} from 'sentry/types/echarts';
+import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
 import {NumberContainer} from 'sentry/utils/discover/styles';
@@ -98,6 +99,8 @@ export function SpanGroupBreakdown({
               : {statsPeriod: period};
           if (['db', 'http'].includes(group['span.category'])) {
             spansLinkQueryParams['span.module'] = group['span.category'];
+          } else {
+            spansLinkQueryParams['span.category'] = group['span.category'];
           }
 
           const spansLink =
@@ -119,9 +122,13 @@ export function SpanGroupBreakdown({
                   }}
                 />
                 <TextAlignLeft>
-                  <Link to={spansLink}>
+                  {defined(transaction) ? (
                     <TextOverflow>{group['span.category']}</TextOverflow>
-                  </Link>
+                  ) : (
+                    <Link to={spansLink}>
+                      <TextOverflow>{group['span.category']}</TextOverflow>
+                    </Link>
+                  )}
                 </TextAlignLeft>
                 <RightAlignedCell>
                   <Tooltip

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -83,7 +83,7 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
   });
 
   if (!segments?.data || !cumulativeTime?.data || topData.length === 0) {
-    return <Placeholder height="200px" />;
+    return <Placeholder height="285px" />;
   }
 
   const totalValues = cumulativeTime.data[0]['sum(span.duration)']


### PR DESCRIPTION
Removes tag breakdown from sidebar
Updates the charts to include p95
Adds totals to the sidebar charts
Removes the span category breakdown links in WSV

