### PR TITLE
track(perf): Add >30d to unparam table analytics

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -40,7 +40,8 @@ export type PerformanceEventParameters = {
   };
   'performance_views.landing.table.seen': {};
   'performance_views.landing.table.unparameterized': {
-    first_event: 'none' | '14d' | '30d';
+    first_event: 'none' | '14d' | '30d' | '>30d';
+    hit_multi_project_cap: boolean;
     sent_transaction: boolean;
     single_project: boolean;
     stats_period: string;


### PR DESCRIPTION
We had a case of 'none' which covered single projects, and we also want to cover multi projects since they make up some of the new accounts as well. Put a cap on # of iterated projects here so outliers don't have bad performance.