### PR TITLE
fix(starfish): Fix db and http drilldown from wsv

### DIFF
--- a/static/app/views/starfish/views/spans/index.tsx
+++ b/static/app/views/starfish/views/spans/index.tsx
@@ -11,16 +11,17 @@ import {ModuleName} from 'sentry/views/starfish/types';
 import SpansView from './spansView';
 
 type Query = {
-  moduleName?: string;
+  'span.module'?: string;
 };
 
 export default function Spans() {
   const location = useLocation<Query>();
 
-  const moduleName =
-    (location.query.moduleName ?? '') in ModuleName
-      ? (location.query.moduleName as ModuleName)
-      : ModuleName.ALL;
+  const moduleName = Object.values(ModuleName).includes(
+    (location.query['span.module'] ?? '') as ModuleName
+  )
+    ? (location.query['span.module'] as ModuleName)
+    : ModuleName.ALL;
 
   return (
     <Layout.Page>


### PR DESCRIPTION
Fix the span module drill down for db and http
Follow up: filter to correct spans when drilling
down from other categories