### PR TITLE
fix(profiling): Pagination on suspect functions table

### DIFF
--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -98,11 +98,7 @@ export function SuspectFunctionsTable({
           onChange={({value}) => setFunctionType(value)}
         />
         <StyledPagination
-          pageLinks={
-            functionsQuery.isFetched
-              ? functionsQuery.data?.[2]?.getResponseHeader('Link') ?? null
-              : null
-          }
+          pageLinks={functionsQuery.getResponseHeader?.('Link')}
           onCursor={handleFunctionsCursor}
           size="xs"
         />


### PR DESCRIPTION
There was a change to how we can get the request headers and this component was not updated.