### PR TITLE
fix(starfish) Use local time spent in span summary

### DIFF
--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -15,7 +15,7 @@ export type SpanTransactionMetrics = {
   'p95(span.duration)': number;
   'spm()': number;
   'sum(span.self_time)': number;
-  'time_spent_percentage()': number;
+  'time_spent_percentage(local)': number;
   transaction: string;
 };
 
@@ -82,9 +82,9 @@ function getEventView(span: {group: string}, location: Location, transactions: s
         'spm()',
         'sum(span.duration)',
         'p95(span.duration)',
-        'time_spent_percentage()',
+        'time_spent_percentage(local)',
       ],
-      orderby: '-time_spent_percentage()',
+      orderby: '-time_spent_percentage_local',
       dataset: DiscoverDatasets.SPANS_METRICS,
       projects: [1],
       version: 2,

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -33,7 +33,7 @@ type Props = {
 export type Keys =
   | 'transaction'
   | 'p95(transaction.duration)'
-  | 'time_spent_percentage()'
+  | 'time_spent_percentage(local)'
   | 'spm()';
 export type TableColumnHeader = GridColumnHeader<Keys>;
 
@@ -109,10 +109,12 @@ function BodyCell({span, column, row, openSidebar, onClickTransactionName}: Cell
     return <ThroughputCell throughputPerSecond={row.metrics?.['spm()']} />;
   }
 
-  if (column.key === 'time_spent_percentage()') {
+  if (column.key === 'time_spent_percentage(local)') {
     return (
       <TimeSpentCell
-        formattedTimeSpent={formatPercentage(row.metrics?.['time_spent_percentage()'])}
+        formattedTimeSpent={formatPercentage(
+          row.metrics?.['time_spent_percentage(local)']
+        )}
         totalSpanTime={row.metrics?.['sum(span.duration)']}
       />
     );
@@ -152,7 +154,7 @@ const COLUMN_ORDER: TableColumnHeader[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'time_spent_percentage()',
+    key: 'time_spent_percentage(local)',
     name: DataTitles.timeSpent,
     width: COL_WIDTH_UNDEFINED,
   },


### PR DESCRIPTION
Small fix to the span table. Ensures that the time spent is relative to the span, not to the app, so the totals in the time spent column sum up to 100%.
