### PR TITLE
feat(starfish): update unit label for throughput tables

### DIFF
--- a/static/app/views/starfish/components/tableCells/throughputCell.tsx
+++ b/static/app/views/starfish/components/tableCells/throughputCell.tsx
@@ -6,5 +6,5 @@ type Props = {
 
 export default function ThroughputCell({throughputPerSecond}: Props) {
   const throughput = throughputPerSecond ? throughputPerSecond.toFixed(2) : '--';
-  return <span>{`${throughput}/${t('sec')}`}</span>;
+  return <span>{`${throughput}/${t('s')}`}</span>;
 }


### PR DESCRIPTION
Use `XYZ / s` for throughput instead of `XYZ / sec` to be consistent