### PR TITLE
fix(starfish): query failing

### DIFF
--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -93,7 +93,9 @@ function getQuery(
     ${transaction ? `AND transaction = '${transaction}'` : ''}
     ${dateFilters}
     GROUP BY group_id, span_operation, domain, description
-    ORDER BY ${(orderBy && !orderBy.includes('time_spent_percentage')) ?? 'count'} desc
+    ORDER BY ${
+      orderBy && !orderBy.includes('time_spent_percentage') ? orderBy : 'count'
+    } desc
     ${limit ? `LIMIT ${limit}` : ''}`;
 }
 

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -93,7 +93,7 @@ function getQuery(
     ${transaction ? `AND transaction = '${transaction}'` : ''}
     ${dateFilters}
     GROUP BY group_id, span_operation, domain, description
-    ORDER BY ${(orderBy && orderBy !== '-time_spent_percentage') ?? 'count'} desc
+    ORDER BY ${(orderBy && !orderBy.includes('time_spent_percentage')) ?? 'count'} desc
     ${limit ? `LIMIT ${limit}` : ''}`;
 }
 

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -81,7 +81,7 @@ function getQuery(
     span_operation as "span.operation",
     description as "span.description",
     domain as "span.domain",
-    sum(exclusive_time) as "sum(span.duration)"
+    sum(exclusive_time) as "sum(span.duration)",
     quantile(0.95)(exclusive_time) as "p95(span.duration)",
     divide(count(), ${
       moment(endTime ?? undefined).unix() - moment(startTime).unix()
@@ -93,7 +93,7 @@ function getQuery(
     ${transaction ? `AND transaction = '${transaction}'` : ''}
     ${dateFilters}
     GROUP BY group_id, span_operation, domain, description
-    ORDER BY ${orderBy ?? 'count'} desc
+    ORDER BY ${(orderBy && orderBy !== '-time_spent_percentage') ?? 'count'} desc
     ${limit ? `LIMIT ${limit}` : ''}`;
 }
 

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -47,7 +47,6 @@ export const useSpanList = (
     endTime,
     dateFilters,
     transaction,
-    orderBy,
     limit
   );
   const eventView = getEventView(moduleName, location, transaction, orderBy);
@@ -71,7 +70,6 @@ function getQuery(
   endTime: Moment,
   dateFilters: string,
   transaction?: string,
-  orderBy?: string,
   limit?: number
 ) {
   const conditions = buildQueryConditions(moduleName, location).filter(Boolean);
@@ -93,9 +91,7 @@ function getQuery(
     ${transaction ? `AND transaction = '${transaction}'` : ''}
     ${dateFilters}
     GROUP BY group_id, span_operation, domain, description
-    ORDER BY ${
-      orderBy && !orderBy.includes('time_spent_percentage') ? orderBy : 'count'
-    } desc
+    ORDER BY count() desc
     ${limit ? `LIMIT ${limit}` : ''}`;
 }
 


### PR DESCRIPTION
Quick fix for failing query in module page.
Orderby doesn't work in the hacked data well, just defaulting back to count as were moving away from this data anyways.