### PR TITLE
fix(azure): check unregistered features

### DIFF
--- a/src/sentry/web/frontend/integration_extension_configuration.py
+++ b/src/sentry/web/frontend/integration_extension_configuration.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.core.signing import SignatureExpired
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -8,7 +9,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features, integrations
-from sentry.features.exceptions import FeatureNotRegistered
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.models import Organization, OrganizationMember
 from sentry.web.frontend.base import BaseView
@@ -124,20 +124,20 @@ class IntegrationExtensionConfigurationView(BaseView):
                 "organization_id": org.id,
                 "provider": self.provider,
             }
-            logger.info(
-                "integration-extension-config.check-feature",
-                extra=log_params,
-            )
-            try:
-                result = features.has(flag_name, org, actor=user)
-                logger.info(
-                    "integration-extension-config.feature-result",
-                    extra={"result": result, **log_params},
-                )
-                if result:
-                    return True
             # we have some integration features that are not actually
             # registered. Those features are unrestricted.
-            except FeatureNotRegistered:
+            if flag_name not in settings.SENTRY_FEATURES:
+                logger.info(
+                    "integration-extension-config.missing-feature",
+                    extra=log_params,
+                )
                 return True
+            result = features.has(flag_name, org, actor=user)
+            logger.info(
+                "integration-extension-config.feature-result",
+                extra={"result": result, **log_params},
+            )
+            if result:
+                return True
+        # no features enabled for this provider
         return False

--- a/tests/sentry/web/frontend/test_vsts_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vsts_extension_configuration.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qsl, urlparse
 
+from django.test import override_settings
 from django.urls import reverse
 
 from sentry.models import OrganizationMember
@@ -59,3 +60,12 @@ class VstsExtensionConfigurationTest(TestCase):
 
         assert next_parts.path == "/extensions/vsts/configure/"
         assert dict(parse_qsl(next_parts.query)) == query
+
+    @override_settings(SENTRY_FEATURES={})
+    def test_goes_to_setup_unregisted_feature(self):
+        self.login_as(self.user)
+
+        resp = self.client.get(self.path, {"targetId": "1", "targetName": "foo"})
+
+        assert resp.status_code == 302
+        assert resp.url.startswith("https://app.vssps.visualstudio.com/oauth2/authorize")


### PR DESCRIPTION
It seems that the check for unregistered features has changed which is preventing organizations from installing it. This change make it so that if a feature is unregistered, we automatically enable the integration for the organization which was intended.