### PR TITLE
feat(starish): format time spent tooltip using duration formatter

### DIFF
--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
+import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
 
 export type DataKey =
   | 'timeSpent'
@@ -25,10 +26,11 @@ export const getTooltip = (
   ...options: (string | number)[]
 ): React.ReactNode => {
   if (key === 'timeSpent') {
-    const spanTime = `${(Number(options[0]) / 1000).toFixed(2)}s`;
     return (
       <Fragment>
-        <div>{spanTime}</div>
+        <div>
+          <DurationCell milliseconds={options[0] as number} />
+        </div>
         <Link to="/starfish/definitions/">How was this calculated?</Link>
       </Fragment>
     );


### PR DESCRIPTION
Uses the duration formatter for the time spent tooltip, that way we don't get hard to read time spent like 1231241241s.