### PR TITLE
fix(issue-stream): Clear selected issues after navigating away from stream

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -26,6 +26,7 @@ import ProcessingIssueList from 'sentry/components/stream/processingIssueList';
 import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
+import SelectedGroupStore from 'sentry/stores/selectedGroupStore';
 import {space} from 'sentry/styles/space';
 import {
   BaseGroup,
@@ -263,6 +264,7 @@ class IssueListOverview extends Component<Props, State> {
 
   componentWillUnmount() {
     this._poller.disable();
+    SelectedGroupStore.reset();
     GroupStore.reset();
     this.props.api.clear();
     this.listener?.();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/50617

This fixes a bug where, sometimes, the issue stream would select all the issues for you:

https://github.com/getsentry/sentry/assets/10888943/24147730-2634-4c78-bd2d-d331d027a794

