### PR TITLE
feat(crons): Add grid lines to the timeline table

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import {Fragment, useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -10,6 +10,10 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
+import {
+  GridLineOverlay,
+  GridLineTimeLabels,
+} from 'sentry/views/monitors/components/overviewTimeline/timelineScrubber';
 
 import {Monitor} from '../../types';
 import {scheduleAsText} from '../../utils';
@@ -23,6 +27,7 @@ export function OverviewTimeline({monitorList}: Props) {
   const {replace, location} = useRouter();
 
   const resolution = location.query?.resolution ?? '24h';
+  const nowRef = useRef<Date>(new Date());
 
   const handleResolutionChange = useCallback(
     (value: string) => {
@@ -47,7 +52,8 @@ export function OverviewTimeline({monitorList}: Props) {
           <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
         </SegmentedControl>
       </ListFilters>
-      <TimelineScrubber />
+      <GridLineTimeLabels resolution={resolution} end={nowRef.current} />
+      <GridLineOverlay resolution={resolution} end={nowRef.current} />
 
       {monitorList.map(monitor => (
         <Fragment key={monitor.id}>
@@ -105,9 +111,5 @@ const ListFilters = styled('div')`
   display: flex;
   gap: ${space(1)};
   padding: ${space(1.5)} ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.border};
-`;
-
-const TimelineScrubber = styled('div')`
   border-bottom: 1px solid ${p => p.theme.border};
 `;

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -52,8 +52,8 @@ export function OverviewTimeline({monitorList}: Props) {
           <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
         </SegmentedControl>
       </ListFilters>
-      <GridLineTimeLabels resolution={resolution} end={nowRef.current} />
-      <GridLineOverlay resolution={resolution} end={nowRef.current} />
+      <GridLineTimeLabels timeWindow={resolution} end={nowRef.current} />
+      <GridLineOverlay timeWindow={resolution} end={nowRef.current} />
 
       {monitorList.map(monitor => (
         <Fragment key={monitor.id}>

--- a/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
@@ -4,8 +4,7 @@ import moment from 'moment';
 import DateTime from 'sentry/components/dateTime';
 import {space} from 'sentry/styles/space';
 import {useDimensions} from 'sentry/utils/useDimensions';
-
-type ResolutionValue = '1h' | '24h' | '7d' | '30d';
+import {ResolutionValue} from 'sentry/views/monitors/components/overviewTimeline/types';
 
 interface Props {
   end: Date;
@@ -13,11 +12,17 @@ interface Props {
 }
 
 interface ResolutionOptions {
-  // Props to pass to <DateTime> when displaying a time marker
+  /**
+   * Props to pass to <DateTime> when displaying a time marker
+   */
   dateTimeProps: {dateOnly?: boolean; timeOnly?: boolean};
-  // The elapsed minutes based on the selected resolution
+  /**
+   * The elapsed minutes based on the selected resolution
+   */
   elapsedMinutes: number;
-  // The interval between each grid line and time label in minutes
+  /**
+   * The interval between each grid line and time label in minutes
+   */
   timeMarkerInterval: number;
 }
 
@@ -71,7 +76,7 @@ function getTimeMarkers(end: Date, resolution: string, width: number): TimeMarke
 }
 
 export function GridLineTimeLabels({end, resolution}: Props) {
-  const {elementRef, width} = useDimensions();
+  const {elementRef, width} = useDimensions<HTMLDivElement>();
   return (
     <LabelsContainer ref={elementRef}>
       {getTimeMarkers(end, resolution, width).map(({date, position}) => (
@@ -84,7 +89,7 @@ export function GridLineTimeLabels({end, resolution}: Props) {
 }
 
 export function GridLineOverlay({end, resolution}: Props) {
-  const {elementRef, width} = useDimensions();
+  const {elementRef, width} = useDimensions<HTMLDivElement>();
   return (
     <Overlay ref={elementRef}>
       <GridLineContainer>

--- a/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
@@ -1,0 +1,136 @@
+import styled from '@emotion/styled';
+import moment from 'moment';
+
+import DateTime from 'sentry/components/dateTime';
+import {space} from 'sentry/styles/space';
+import {useDimensions} from 'sentry/utils/useDimensions';
+
+type ResolutionValue = '1h' | '24h' | '7d' | '30d';
+
+interface Props {
+  end: Date;
+  resolution: ResolutionValue;
+}
+
+interface ResolutionOptions {
+  // Props to pass to <DateTime> when displaying a time marker
+  dateTimeProps: {dateOnly?: boolean; timeOnly?: boolean};
+  // The elapsed minutes based on the selected resolution
+  elapsedMinutes: number;
+  // The interval between each grid line and time label in minutes
+  timeMarkerInterval: number;
+}
+
+// Stores options and data which correspond to each selectable resolution
+const resolutionData: Record<ResolutionValue, ResolutionOptions> = {
+  '1h': {elapsedMinutes: 60, timeMarkerInterval: 10, dateTimeProps: {timeOnly: true}},
+  '24h': {
+    elapsedMinutes: 60 * 24,
+    timeMarkerInterval: 60 * 4,
+    dateTimeProps: {timeOnly: true},
+  },
+  '7d': {elapsedMinutes: 60 * 24 * 7, timeMarkerInterval: 60 * 24, dateTimeProps: {}},
+  '30d': {
+    elapsedMinutes: 60 * 24 * 30,
+    timeMarkerInterval: 60 * 24 * 5,
+    dateTimeProps: {dateOnly: true},
+  },
+};
+
+function clampTimeBasedOnResolution(date: moment.Moment, resolution: string) {
+  if (resolution === '1h') {
+    date.minute(date.minutes() - (date.minutes() % 10));
+  } else if (resolution === '30d') {
+    date.startOf('day');
+  } else {
+    date.startOf('hour');
+  }
+}
+
+interface TimeMarker {
+  date: Date;
+  position: number;
+}
+
+function getTimeMarkers(end: Date, resolution: string, width: number): TimeMarker[] {
+  const {elapsedMinutes, timeMarkerInterval} = resolutionData[resolution];
+  const msPerPixel = (elapsedMinutes * 60 * 1000) / width;
+
+  const times: TimeMarker[] = [];
+  const start = moment(end).subtract(elapsedMinutes, 'minute');
+
+  // Iterate and generate time markers which represent location of grid lines/time labels
+  for (let i = 1; i < elapsedMinutes / timeMarkerInterval; i++) {
+    const timeMark = moment(start).add(i * timeMarkerInterval, 'minute');
+    clampTimeBasedOnResolution(timeMark, resolution);
+    const position = (timeMark.valueOf() - start.valueOf()) / msPerPixel;
+    times.push({date: timeMark.toDate(), position});
+  }
+
+  return times;
+}
+
+export function GridLineTimeLabels({end, resolution}: Props) {
+  const {elementRef, width} = useDimensions();
+  return (
+    <LabelsContainer ref={elementRef}>
+      {getTimeMarkers(end, resolution, width).map(({date, position}) => (
+        <TimeLabelContainer key={date.getTime()} left={position}>
+          <TimeLabel date={date} {...resolutionData[resolution].dateTimeProps} />
+        </TimeLabelContainer>
+      ))}
+    </LabelsContainer>
+  );
+}
+
+export function GridLineOverlay({end, resolution}: Props) {
+  const {elementRef, width} = useDimensions();
+  return (
+    <Overlay ref={elementRef}>
+      <GridLineContainer>
+        {getTimeMarkers(end, resolution, width).map(({date, position}) => (
+          <Gridline key={date.getTime()} left={position} />
+        ))}
+      </GridLineContainer>
+    </Overlay>
+  );
+}
+
+const Overlay = styled('div')`
+  grid-row: 1;
+  grid-column: 2;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+`;
+
+const GridLineContainer = styled('div')`
+  position: relative;
+  height: 100%;
+`;
+
+const LabelsContainer = styled('div')`
+  position: relative;
+  align-self: stretch;
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const Gridline = styled('div')<{left: number}>`
+  position: absolute;
+  left: ${p => p.left}px;
+  border-left: 1px solid ${p => p.theme.innerBorder};
+  height: 100%;
+`;
+
+const TimeLabelContainer = styled(Gridline)`
+  display: flex;
+  height: 100%;
+  align-items: center;
+`;
+
+const TimeLabel = styled(DateTime)`
+  font-variant-numeric: tabular-nums;
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  margin-left: ${space(1)};
+`;

--- a/static/app/views/monitors/components/overviewTimeline/types.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/types.tsx
@@ -1,1 +1,18 @@
-export type ResolutionValue = '1h' | '24h' | '7d' | '30d';
+export type TimeWindow = '1h' | '24h' | '7d' | '30d';
+
+export interface TimeWindowOptions {
+  /**
+   * Props to pass to <DateTime> when displaying a time marker
+   */
+  dateTimeProps: {dateOnly?: boolean; timeOnly?: boolean};
+  /**
+   * The elapsed minutes based on the selected resolution
+   */
+  elapsedMinutes: number;
+  /**
+   * The interval between each grid line and time label in minutes
+   */
+  timeMarkerInterval: number;
+}
+
+export type TimeWindowData = Record<TimeWindow, TimeWindowOptions>;

--- a/static/app/views/monitors/components/overviewTimeline/types.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/types.tsx
@@ -1,0 +1,1 @@
+export type ResolutionValue = '1h' | '24h' | '7d' | '30d';

--- a/static/app/views/monitors/components/overviewTimeline/utils.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/utils.tsx
@@ -1,9 +1,6 @@
 import moment from 'moment';
 
-import {
-  TimeWindow,
-  TimeWindowData,
-} from 'sentry/views/monitors/components/overviewTimeline/types';
+import {TimeWindow, TimeWindowData} from './types';
 
 // Stores options and data which correspond to each selectable time window
 export const timeWindowData: TimeWindowData = {

--- a/static/app/views/monitors/components/overviewTimeline/utils.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/utils.tsx
@@ -1,0 +1,29 @@
+import moment from 'moment';
+
+import {
+  TimeWindow,
+  TimeWindowData,
+} from 'sentry/views/monitors/components/overviewTimeline/types';
+
+// Stores options and data which correspond to each selectable time window
+export const timeWindowData: TimeWindowData = {
+  '1h': {elapsedMinutes: 60, timeMarkerInterval: 10, dateTimeProps: {timeOnly: true}},
+  '24h': {
+    elapsedMinutes: 60 * 24,
+    timeMarkerInterval: 60 * 4,
+    dateTimeProps: {timeOnly: true},
+  },
+  '7d': {elapsedMinutes: 60 * 24 * 7, timeMarkerInterval: 60 * 24, dateTimeProps: {}},
+  '30d': {
+    elapsedMinutes: 60 * 24 * 30,
+    timeMarkerInterval: 60 * 24 * 5,
+    dateTimeProps: {dateOnly: true},
+  },
+};
+
+export function getStartFromTimeWindow(end: Date, timeWindow: TimeWindow): Date {
+  const {elapsedMinutes} = timeWindowData[timeWindow];
+  const start = moment(end).subtract(elapsedMinutes, 'minute');
+
+  return start.toDate();
+}


### PR DESCRIPTION

Modifies `<TimelineScrubber> --> <GridLineTimeLabels>` to show the timeline labels (2pm, 3pm, etc...)
And adds an overlay element which draws the grid lines across all the rows of the grid view

<img width="1253" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/8473d589-e8e4-46c6-8a8f-69a1c93abb6d">
