### PR TITLE
feat(crons): Add aggregate multi-monitor stats endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -74,6 +74,9 @@ from sentry.monitors.endpoints.organization_monitor_details import (
     OrganizationMonitorDetailsEndpoint,
 )
 from sentry.monitors.endpoints.organization_monitor_index import OrganizationMonitorIndexEndpoint
+from sentry.monitors.endpoints.organization_monitor_index_stats import (
+    OrganizationMonitorIndexStatsEndpoint,
+)
 from sentry.monitors.endpoints.organization_monitor_stats import OrganizationMonitorStatsEndpoint
 from sentry.replays.endpoints.organization_replay_count import OrganizationReplayCountEndpoint
 from sentry.replays.endpoints.organization_replay_details import OrganizationReplayDetailsEndpoint
@@ -1373,6 +1376,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/monitors/$",
         OrganizationMonitorIndexEndpoint.as_view(),
         name="sentry-api-0-organization-monitor-index",
+    ),
+    url(
+        r"^(?P<organization_slug>[^\/]+)/monitors-stats/$",
+        OrganizationMonitorIndexStatsEndpoint.as_view(),
+        name="sentry-api-0-organization-monitor-index-stats",
     ),
     url(
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/$",

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections import OrderedDict, defaultdict
+from datetime import datetime, timedelta
+from typing import List, MutableMapping
+
+from django.db.models import Count, DateTimeField, Func
+from django.db.models.functions import Extract
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import StatsMixin, region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.helpers.environments import get_environments
+from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn
+from sentry.utils.dates import to_timestamp
+
+
+def normalize_to_epoch(timestamp: datetime, seconds: int):
+    """
+    Given a ``timestamp`` (datetime object) normalize to an epoch timestamp.
+
+    i.e. if the rollup is minutes, the resulting timestamp would have
+    the seconds and microseconds rounded down.
+    """
+    epoch = int(to_timestamp(timestamp))
+    return epoch - (epoch % seconds)
+
+
+@region_silo_endpoint
+class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
+    # TODO(epurkhiser): probably convert to snuba
+    def get(self, request: Request, organization) -> Response:
+        args = self._parse_args(request)
+
+        start = normalize_to_epoch(args["start"], args["rollup"])
+        end = normalize_to_epoch(args["end"], args["rollup"])
+
+        monitor_slugs: List[str] = request.GET.getlist("monitor")
+
+        tracked_statuses = [
+            CheckInStatus.OK,
+            CheckInStatus.ERROR,
+            CheckInStatus.MISSED,
+            CheckInStatus.TIMEOUT,
+        ]
+
+        monitor_ids = Monitor.objects.filter(
+            organization_id=organization.id,
+            slug__in=monitor_slugs,
+        ).values("id")
+
+        check_ins = MonitorCheckIn.objects.filter(
+            monitor_id__in=monitor_ids,
+            status__in=tracked_statuses,
+            date_added__gt=args["start"],
+            date_added__lte=args["end"],
+        )
+
+        environments = get_environments(request, organization)
+
+        if environments:
+            check_ins = check_ins.filter(monitor_environment__environment__in=environments)
+
+        # Use postgres' `date_bin` to bucket rounded to our rolllups
+        bucket = Func(
+            timedelta(seconds=args["rollup"]),
+            "date_added",
+            datetime.fromtimestamp(end),
+            function="date_bin",
+            output_field=DateTimeField(),
+        )
+        # Save space on date allocation and return buckets as unix timestamps
+        bucket = Extract(bucket, "epoch")
+
+        # retrieve the list of checkins in the time range and count each by
+        # status. Bucketing is done at the postgres level for performance
+        history = (
+            check_ins.all()
+            .annotate(bucket=bucket)
+            .values(
+                "bucket",
+                "monitor__slug",
+                "monitor_environment__environment",
+                "status",
+            )
+            .order_by("monitor__slug", "bucket")
+            .annotate(count=Count("*"))
+            .values_list(
+                "monitor__slug",
+                "bucket",
+                "monitor_environment__environment__name",
+                "status",
+                "count",
+            )
+        )
+
+        status_to_name = dict(CheckInStatus.as_choices())
+
+        StatusStats = MutableMapping[str, int]
+
+        def status_obj_factory() -> StatusStats:
+            return {status_to_name[status]: 0 for status in tracked_statuses}
+
+        # Mapping chain of monitor_id -> timestamp[] -> monitor_env_names -> StatusStats
+        EnvToStatusMapping = MutableMapping[int, StatusStats]
+        TsToEnvsMapping = MutableMapping[int, EnvToStatusMapping]
+        MonitorToTimestampsMapping = MutableMapping[str, TsToEnvsMapping]
+
+        # Use ordered dict for timestamp -> envs mapping since we want to
+        # maintain the ordering of the timestamps
+        stats: MonitorToTimestampsMapping = defaultdict(OrderedDict)
+
+        # initialize mappings
+        for slug in monitor_slugs:
+            ts = start
+            while ts <= end:
+                stats[slug][ts] = defaultdict(status_obj_factory)
+                ts += args["rollup"]
+
+        for slug, ts, env_name, status, count in history.iterator():
+            named_status = status_to_name[status]
+            stats[slug][ts][env_name][named_status] = count
+
+        # Flatten the timestamp to env mapping dict into a tuple list, this
+        # maintains the ordering
+        stats_list = {
+            slug: [[ts, env_mapping] for ts, env_mapping in ts_to_envs.items()]
+            for slug, ts_to_envs in stats.items()
+        }
+
+        return Response(stats_list)

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+from freezegun import freeze_time
+
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn
+from sentry.testutils import MonitorTestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+@freeze_time(datetime(2022, 3, 21, 7, 57, tzinfo=timezone.utc))
+class OrganizationMonitorIndexStatsTest(MonitorTestCase):
+    endpoint = "sentry-api-0-organization-monitor-index-stats"
+
+    def add_checkin(self, monitor, offset, env=None, status=None):
+        if status is None:
+            status = CheckInStatus.OK
+        if env is None:
+            env = self.env_prod
+
+        MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=env,
+            project_id=self.project.id,
+            date_added=self.monitor1.date_added + timedelta(**offset),
+            status=status,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.monitor1 = self._create_monitor()
+        self.monitor2 = self._create_monitor()
+        self.env_prod = self._create_monitor_environment(monitor=self.monitor1)
+        self.env_debug = self._create_monitor_environment(monitor=self.monitor1, name="debug")
+
+        # Be sure to note the freeze time above
+        self.since = self.monitor1.date_added
+        self.until = self.monitor1.date_added + timedelta(hours=2)
+
+        self.add_checkin(self.monitor1, offset={"minutes": 1})
+        self.add_checkin(self.monitor1, offset={"minutes": 1}, status=CheckInStatus.IN_PROGRESS)
+        self.add_checkin(self.monitor1, offset={"minutes": 2}, env=self.env_debug)
+
+        self.add_checkin(
+            self.monitor1,
+            offset={"hours": 1, "minutes": 1},
+            status=CheckInStatus.MISSED,
+        )
+        self.add_checkin(
+            self.monitor1,
+            offset={"hours": 1, "minutes": 2},
+            env=self.env_debug,
+            status=CheckInStatus.ERROR,
+        )
+        self.add_checkin(
+            self.monitor1,
+            offset={"hours": 1, "minutes": 1},
+            status=CheckInStatus.TIMEOUT,
+        )
+        self.add_checkin(
+            self.monitor1,
+            offset={"hours": 1, "minutes": 2},
+            env=self.env_debug,
+            status=CheckInStatus.TIMEOUT,
+        )
+
+        self.add_checkin(self.monitor2, offset={"minutes": 1})
+        self.add_checkin(self.monitor2, offset={"minutes": 2})
+
+    def test_simple(self):
+        resp = self.get_success_response(
+            self.organization.slug,
+            **{
+                "monitor": [self.monitor1.slug, self.monitor2.slug],
+                "since": self.since.timestamp(),
+                "until": self.until.timestamp(),
+                "resolution": "1h",
+            },
+        )
+
+        assert list(resp.data.keys()) == [self.monitor1.slug, self.monitor2.slug]
+
+        # Check monitor1's stats
+        hour_one, hour_two, *extra = resp.data[self.monitor1.slug]
+        assert hour_one == [
+            1647846000,
+            {
+                "production": {"ok": 1, "error": 0, "missed": 0, "timeout": 0},
+                "debug": {"ok": 1, "error": 0, "missed": 0, "timeout": 0},
+            },
+        ]
+        assert hour_two == [
+            1647849600,
+            {
+                "production": {"ok": 0, "error": 0, "missed": 1, "timeout": 1},
+                "debug": {"ok": 0, "error": 1, "missed": 0, "timeout": 1},
+            },
+        ]
+
+        # Check monitor2's stats
+        hour_one, *extra = resp.data[self.monitor2.slug]
+        assert hour_one == [
+            1647846000,
+            {
+                "production": {"ok": 2, "error": 0, "missed": 0, "timeout": 0},
+            },
+        ]
+
+    def test_filtered(self):
+        resp = self.get_success_response(
+            self.organization.slug,
+            **{
+                "monitor": [self.monitor2.slug],
+                "since": self.since.timestamp(),
+                "until": self.until.timestamp(),
+                "resolution": "1h",
+            },
+        )
+
+        assert list(resp.data.keys()) == [self.monitor2.slug]
+
+        # Check monitor2's stats
+        hour_one, *extra = resp.data[self.monitor2.slug]
+        assert hour_one == [
+            1647846000,
+            {
+                "production": {"ok": 2, "error": 0, "missed": 0, "timeout": 0},
+            },
+        ]


### PR DESCRIPTION
Adds a new endpoint `/organizations/{}/monitors-stats/` that can be used
to query stats for a list of monitor_ids via the `monitor` query
parameter (multiple may be provided)