### PR TITLE
fix(dropdownMenu): Consistently show item dividers

### DIFF
--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -135,20 +135,20 @@ function DropdownMenuList({
   const showDividers = stateCollection.some(item => !!item.props.details);
 
   // Render a single menu item
-  const renderItem = (node: Node<MenuItemProps>, isLastNode: boolean) => {
+  const renderItem = (node: Node<MenuItemProps>) => {
     return (
       <DropdownMenuItem
         node={node}
         state={state}
         onClose={onClose}
         closeOnSelect={closeOnSelect}
-        showDivider={showDividers && !isLastNode}
+        showDivider={showDividers}
       />
     );
   };
 
   // Render a submenu whose trigger button is a menu item
-  const renderItemWithSubmenu = (node: Node<MenuItemProps>, isLastNode: boolean) => {
+  const renderItemWithSubmenu = (node: Node<MenuItemProps>) => {
     if (!node.value?.children) {
       return null;
     }
@@ -158,7 +158,7 @@ function DropdownMenuList({
         renderAs="div"
         node={node}
         state={state}
-        showDivider={showDividers && !isLastNode}
+        showDivider={showDividers}
         closeOnSelect={false}
         {...omit(triggerProps, [
           'onClick',
@@ -210,8 +210,8 @@ function DropdownMenuList({
         );
       } else {
         itemToRender = node.value?.isSubmenu
-          ? renderItemWithSubmenu(node, isLastNode)
-          : renderItem(node, isLastNode);
+          ? renderItemWithSubmenu(node)
+          : renderItem(node);
       }
 
       return (

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -323,7 +323,7 @@ const ContentWrap = styled('div')<{
     p.showDivider &&
     !p.isFocused &&
     `
-      ${MenuItemWrap}:not(:last-child) &::after {
+      li:not(:last-child) &::after {
         content: '';
         position: absolute;
         left: 0;


### PR DESCRIPTION
**Before ——**
<img width="287" alt="Screenshot 2023-06-08 at 4 54 59 PM" src="https://github.com/getsentry/sentry/assets/44172267/9697319b-6b2a-400b-b511-f788a6ec58ed">

**After ——**
<img width="287" alt="Screenshot 2023-06-08 at 4 54 37 PM" src="https://github.com/getsentry/sentry/assets/44172267/641b9169-85ee-470b-99fe-cfd8f922fd67">
