### PR TITLE
ref(perf): Track indexed vs. processed drift

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -6,7 +6,7 @@ from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.search.events.fields import get_function_alias
-from sentry.snuba import metrics_performance, discover
+from sentry.snuba import discover, metrics_performance
 
 COUNT_UNPARAM = "count_unparameterized_transactions()"
 COUNT_HAS_TXN = "count_has_transaction_name()"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1450,6 +1450,8 @@ SENTRY_FEATURES = {
     "organizations:performance-issues-render-blocking-assets-detector": False,
     # Enable MN+1 DB performance issue type
     "organizations:performance-issues-m-n-plus-one-db-detector": False,
+    # Enable metrics for indexed vs. process drift
+    "organizations:performance-indexed-processed-compat-drift": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -145,6 +145,7 @@ default_manager.add("organizations:performance-new-trends", OrganizationFeature,
 default_manager.add("organizations:performance-trendsv2-dev-only", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-metrics-backed-transaction-summary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-slow-db-issue", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:performance-indexed-processed-compat-drift", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:profiling-ui-frames", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:profiling-using-transactions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
### Summary
This will track whether there are periods of drift between processed and indexed events when the compatibility checks are being called. 

This is behind a feature flag to mitigate extra queries when we don't need to capture drift.


