### PR TITLE
fix(mep): Granularity was going to the wrong bucket size

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -195,6 +195,8 @@ class MetricsQueryBuilder(QueryBuilder):
             # precisely going hour to hour
             self.start.minute
             == self.end.minute
+            == self.start.second
+            == self.end.second
             == duration % 3600
             == 0
         ):

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -494,6 +494,16 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         end = datetime.datetime(2015, 5, 28, 1, 57, 0, tzinfo=timezone.utc)
         assert get_granularity(start, end) == 3600, "On the hour, long period"
 
+        # Hour to hour should only happen at the precise hour
+        start = datetime.datetime(2015, 5, 18, 10, 0, 0, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 18, 18, 0, 0, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 3600, "precisely hour to hour"
+
+        # Even a few seconds means we need to switch back to minutes since the latter bucket may not be filled
+        start = datetime.datetime(2015, 5, 18, 10, 0, 1, tzinfo=timezone.utc)
+        end = datetime.datetime(2015, 5, 18, 18, 0, 1, tzinfo=timezone.utc)
+        assert get_granularity(start, end) == 60, "hour to hour but with seconds"
+
         # Even though this is >24h of data, because its a random hour in the middle of the day to the next we use minute
         # granularity
         start = datetime.datetime(2015, 5, 18, 10, 15, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
- This fixes a bug where we'd pick the wrong granularity for statsPeriod=1h queries
  - What would happen is that the start and end would be 16:00:37 to 17:00:37, which would mean we'd pick the 17:00 bucket, which wouldn't have any data yet.