### PR TITLE
ref(kafka): Generic consumer CLI for ingest-monitors consumer

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -13,7 +13,11 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "ingest-profiles": {
         "topic": settings.KAFKA_PROFILES,
         "strategy_factory": "sentry.profiles.consumers.process.factory.ProcessProfileStrategyFactory",
-    }
+    },
+    "ingest-monitors": {
+        "topic": settings.KAFKA_INGEST_MONITORS,
+        "strategy_factory": "sentry.monitors.consumers.monitor_consumer.StoreMonitorCheckInStrategyFactory",
+    },
 }
 
 for consumer in KAFKA_CONSUMERS:


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/50364 for context.

`sentry run ingest-monitors` will be removed once we cut over to the new
CLI.
