### PR TITLE
feat(dropdownMenu): Add option to render in React portal

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
 import {useMenuTrigger} from '@react-aria/menu';
@@ -118,6 +119,13 @@ interface DropdownMenuProps
    * component.
    */
   triggerProps?: DropdownButtonProps;
+  /**
+   * Whether to render the menu inside a React portal (false by default). This should
+   * only be enabled if necessary, e.g. when the dropdown menu is inside a small,
+   * scrollable container that messes with the menu's position. Some features, namely
+   * submenus, will not work correctly inside portals.
+   */
+  usePortal?: boolean;
 }
 
 /**
@@ -139,6 +147,7 @@ function DropdownMenu({
   className,
 
   // Overlay props
+  usePortal = false,
   offset = 8,
   position = 'bottom-start',
   isDismissable = true,
@@ -235,7 +244,7 @@ function DropdownMenu({
       return null;
     }
 
-    return (
+    const menu = (
       <DropdownMenuList
         {...props}
         {...menuProps}
@@ -266,6 +275,8 @@ function DropdownMenu({
         }}
       </DropdownMenuList>
     );
+
+    return usePortal ? createPortal(menu, document.body) : menu;
   }
 
   return (


### PR DESCRIPTION
**Without `usePortal`**, the menu gets cropped off if it's inside scrollable containers that are too small (it can't flip because there's not enough space on the other side). In many cases we can remove some unnecessary `overflow: auto` and fix the issue. In some cases, however, we really need auto scroll, like here with `PanelTable`:
<img width="219" alt="Screenshot 2023-06-09 at 10 09 16 AM" src="https://github.com/getsentry/sentry/assets/44172267/3b150a4e-5f08-4be9-9a54-a870088ac1d7">

**With `usePortal`** we don't need to worry about overflow issues anymore
<img width="219" alt="Screenshot 2023-06-09 at 10 08 23 AM" src="https://github.com/getsentry/sentry/assets/44172267/ddb9c05f-06a8-4b4d-987b-50ec3b8df17e">


Keyboard navigation and accessibility attributes (e.g. `aria-controls`) still work great inside portals. Nested submenus break, which is why `usePortal` is disabled by default and should only be used if necessary.