### PR TITLE
feat(sort): Add priority sort experiment

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -30,6 +30,12 @@ export const experimentList = [
     parameter: 'exposed',
     assignments: [0, 1],
   },
+  {
+    key: 'PrioritySortExperiment',
+    type: ExperimentType.USER,
+    parameter: 'variant',
+    assignments: ['baseline', 'variant1', 'variant2'],
+  },
 ] as const;
 
 export const experimentConfig = experimentList.reduce(

--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -32,7 +32,7 @@ export const experimentList = [
   },
   {
     key: 'PrioritySortExperiment',
-    type: ExperimentType.USER,
+    type: ExperimentType.ORGANIZATION,
     parameter: 'variant',
     assignments: ['baseline', 'variant1', 'variant2'],
   },

--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -32,7 +32,7 @@ export const experimentList = [
   },
   {
     key: 'PrioritySortExperiment',
-    type: ExperimentType.ORGANIZATION,
+    type: ExperimentType.USER,
     parameter: 'variant',
     assignments: ['baseline', 'variant1', 'variant2'],
   },

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -36,6 +36,7 @@ import {
   SavedSearch,
   TagCollection,
 } from 'sentry/types';
+import {ExperimentAssignment} from 'sentry/types/experiments';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import CursorPoller from 'sentry/utils/cursorPoller';
@@ -50,6 +51,7 @@ import withRouteAnalytics, {
 } from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import withApi from 'sentry/utils/withApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import withExperiment from 'sentry/utils/withExperiment';
 import withIssueTags from 'sentry/utils/withIssueTags';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -84,6 +86,7 @@ type Params = {
 
 type Props = {
   api: Client;
+  experimentAssignment: ExperimentAssignment['PrioritySortExperiment'];
   location: Location;
   organization: Organization;
   params: Params;
@@ -333,6 +336,8 @@ class IssueListOverview extends Component<Props, State> {
   }
 
   getBetterPriorityParams(): BetterPriorityEndpointParams {
+    console.log(this.props.experimentAssignment);
+    console.log(this.props.organization?.experiments);
     const query = this.props.location.query ?? {};
     const {
       eventHalflifeHours,
@@ -1281,7 +1286,15 @@ class IssueListOverview extends Component<Props, State> {
 export default withRouteAnalytics(
   withApi(
     withPageFilters(
-      withSavedSearches(withOrganization(withIssueTags(withProfiler(IssueListOverview))))
+      withSavedSearches(
+        withOrganization(
+          withIssueTags(
+            withProfiler(
+              withExperiment(IssueListOverview, {experiment: 'PrioritySortExperiment'})
+            )
+          )
+        )
+      )
     )
   )
 );

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -337,7 +337,7 @@ class IssueListOverview extends Component<Props, State> {
 
   getBetterPriorityParams(): BetterPriorityEndpointParams {
     console.log(this.props.experimentAssignment);
-    console.log(this.props.organization?.experiments);
+    console.log(this.props.organization?.experiments?.PrioritySortExperiment);
     const query = this.props.location.query ?? {};
     const {
       eventHalflifeHours,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -152,6 +152,7 @@ type BetterPriorityEndpointParams = Partial<EndpointParams> & {
   norm?: boolean;
   relativeVolume?: number;
   v2?: boolean;
+  variant?: string;
 };
 
 class IssueListOverview extends Component<Props, State> {
@@ -338,10 +339,9 @@ class IssueListOverview extends Component<Props, State> {
 
   getBetterPriorityParams(): BetterPriorityEndpointParams {
     const user = ConfigStore.get('user');
-    const hasBetterPrioritySort = this.props.organization.isEarlyAdopter;
-    const variant = user.experiments?.PrioritySortExperiment;
+    const variant = user.experiments?.PrioritySortExperiment || 'baseline';
     const query = this.props.location.query ?? {};
-    let {
+    const {
       eventHalflifeHours,
       hasStacktrace,
       issueHalflifeHours,
@@ -349,22 +349,7 @@ class IssueListOverview extends Component<Props, State> {
       norm,
       v2,
       relativeVolume,
-      sort,
     } = query;
-    if (variant === 'variant1' && hasBetterPrioritySort) {
-      v2 = true;
-      issueHalflifeHours = 12;
-    } else if (variant === 'variant2' && hasBetterPrioritySort) {
-      v2 = true;
-      issueHalflifeHours = 12;
-      relativeVolume = 0;
-    } else {
-      sort = 'date';
-      eventHalflifeHours = null;
-      hasStacktrace = null;
-      logLevel = null;
-      norm = null;
-    }
 
     return {
       eventHalflifeHours,
@@ -374,7 +359,7 @@ class IssueListOverview extends Component<Props, State> {
       norm,
       v2,
       relativeVolume,
-      sort,
+      variant,
     };
   }
 


### PR DESCRIPTION
Add a user level priority sort experiment that'll show different variants to users with a baseline of "last seen". This just passes the variant name to the backend so we can take advantage of the automatic Amplitude logging, and another PR will read it and hard code the values.

[getsentry PR](https://github.com/getsentry/getsentry/pull/10796)