### PR TITLE
fix(alerts): Filter metric alert incidents with no activities

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricHistory.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.spec.tsx
@@ -26,4 +26,10 @@ describe('MetricHistory', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Show 7 Hidden Alerts'}));
     expect(screen.getAllByRole('link').length).toBe(incidents.length);
   });
+
+  it('filters incidents with no activities (unexpected behavior)', () => {
+    const incidents = [TestStubs.Incident({activities: []})];
+    render(<MetricHistory incidents={incidents} />);
+    expect(screen.getByText('No alerts triggered during this time.')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -110,7 +110,10 @@ type Props = {
 
 function MetricHistory({incidents}: Props) {
   const organization = useOrganization();
-  const numOfIncidents = incidents?.length ?? 0;
+  const filteredIncidents = (incidents ?? []).filter(
+    incident => incident.activities?.length
+  );
+  const numOfIncidents = filteredIncidents.length;
 
   return (
     <CollapsePanel
@@ -127,7 +130,7 @@ function MetricHistory({incidents}: Props) {
             emptyMessage={t('No alerts triggered during this time.')}
             expanded={numOfIncidents <= COLLAPSE_COUNT || isExpanded}
           >
-            {incidents?.map((incident, idx) => {
+            {filteredIncidents.map((incident, idx) => {
               if (idx >= COLLAPSE_COUNT && !isExpanded) {
                 return null;
               }


### PR DESCRIPTION
I think this is a race condition when editing the alert. It has only happened once.

activities are normally created as soon as the incident starts

fixes JAVASCRIPT-2MKV