### PR TITLE
ref(discoverTable): Use `DropdownMenu` to display cell actions

### DIFF
--- a/static/app/views/discover/table/cellAction.spec.jsx
+++ b/static/app/views/discover/table/cellAction.spec.jsx
@@ -68,33 +68,14 @@ describe('Discover -> CellAction', function () {
   };
   const view = EventView.fromLocation(location);
 
-  async function hoverContainer() {
-    await userEvent.hover(screen.getByText('some content'));
-  }
-
-  async function unhoverContainer() {
-    await userEvent.unhover(screen.getByText('some content'));
-  }
-
   async function openMenu() {
-    await hoverContainer();
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button', {name: 'Actions'}));
   }
 
   describe('hover menu button', function () {
     it('shows no menu by default', function () {
       renderComponent(view);
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    });
-
-    it('shows a menu on hover, and hides again', async function () {
-      renderComponent(view);
-
-      await hoverContainer();
-      expect(screen.getByRole('button')).toBeInTheDocument();
-
-      await unhoverContainer();
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Actions'})).toBeInTheDocument();
     });
   });
 
@@ -102,7 +83,9 @@ describe('Discover -> CellAction', function () {
     it('toggles the menu on click', async function () {
       renderComponent(view);
       await openMenu();
-      expect(screen.getByRole('button', {name: 'Add to filter'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Add to filter'})
+      ).toBeInTheDocument();
     });
   });
 
@@ -116,7 +99,7 @@ describe('Discover -> CellAction', function () {
     it('add button appends condition', async function () {
       renderComponent(view, handleCellAction);
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
       expect(handleCellAction).toHaveBeenCalledWith('add', 'best-transaction');
     });
@@ -124,7 +107,9 @@ describe('Discover -> CellAction', function () {
     it('exclude button adds condition', async function () {
       renderComponent(view, handleCellAction);
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Exclude from filter'}));
+      await userEvent.click(
+        screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+      );
 
       expect(handleCellAction).toHaveBeenCalledWith('exclude', 'best-transaction');
     });
@@ -135,7 +120,9 @@ describe('Discover -> CellAction', function () {
       });
       renderComponent(excludeView, handleCellAction);
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Exclude from filter'}));
+      await userEvent.click(
+        screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+      );
 
       expect(handleCellAction).toHaveBeenCalledWith('exclude', 'best-transaction');
     });
@@ -143,7 +130,7 @@ describe('Discover -> CellAction', function () {
     it('go to release button goes to release health page', async function () {
       renderComponent(view, handleCellAction, 3);
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Go to release'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Go to release'}));
 
       expect(handleCellAction).toHaveBeenCalledWith(
         'release',
@@ -155,7 +142,7 @@ describe('Discover -> CellAction', function () {
       renderComponent(view, handleCellAction, 2);
       await openMenu();
       await userEvent.click(
-        screen.getByRole('button', {name: 'Show values greater than'})
+        screen.getByRole('menuitemradio', {name: 'Show values greater than'})
       );
 
       expect(handleCellAction).toHaveBeenCalledWith(
@@ -167,7 +154,9 @@ describe('Discover -> CellAction', function () {
     it('less than button adds condition', async function () {
       renderComponent(view, handleCellAction, 2);
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Show values less than'}));
+      await userEvent.click(
+        screen.getByRole('menuitemradio', {name: 'Show values less than'})
+      );
 
       expect(handleCellAction).toHaveBeenCalledWith(
         'show_less_than',
@@ -178,7 +167,7 @@ describe('Discover -> CellAction', function () {
     it('error.handled with null adds condition', async function () {
       renderComponent(view, handleCellAction, 7, defaultData);
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
       expect(handleCellAction).toHaveBeenCalledWith('add', 1);
     });
@@ -186,7 +175,7 @@ describe('Discover -> CellAction', function () {
     it('error.type with array values adds condition', async function () {
       renderComponent(view, handleCellAction, 8, defaultData);
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
       expect(handleCellAction).toHaveBeenCalledWith('add', [
         'ServerException',
@@ -202,7 +191,7 @@ describe('Discover -> CellAction', function () {
         'error.handled': [0],
       });
       await openMenu();
-      await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
       expect(handleCellAction).toHaveBeenCalledWith('add', [0]);
     });
@@ -211,15 +200,17 @@ describe('Discover -> CellAction', function () {
       renderComponent(view, handleCellAction, 0);
       await openMenu();
 
-      expect(screen.getByRole('button', {name: 'Add to filter'})).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Exclude from filter'})
+        screen.getByRole('menuitemradio', {name: 'Add to filter'})
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Show values greater than'})
+        screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Show values greater than'})
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Show values less than'})
+        screen.queryByRole('menuitemradio', {name: 'Show values less than'})
       ).not.toBeInTheDocument();
     });
 
@@ -227,9 +218,11 @@ describe('Discover -> CellAction', function () {
       renderComponent(view, handleCellAction, 4);
       await openMenu();
 
-      expect(screen.getByRole('button', {name: 'Add to filter'})).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Exclude from filter'})
+        screen.getByRole('menuitemradio', {name: 'Add to filter'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
       ).toBeInTheDocument();
     });
 
@@ -238,16 +231,16 @@ describe('Discover -> CellAction', function () {
       await openMenu();
 
       expect(
-        screen.queryByRole('button', {name: 'Add to filter'})
+        screen.queryByRole('menuitemradio', {name: 'Add to filter'})
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Exclude from filter'})
+        screen.queryByRole('menuitemradio', {name: 'Exclude from filter'})
       ).not.toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Show values greater than'})
+        screen.getByRole('menuitemradio', {name: 'Show values greater than'})
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Show values less than'})
+        screen.getByRole('menuitemradio', {name: 'Show values less than'})
       ).toBeInTheDocument();
     });
 
@@ -255,15 +248,17 @@ describe('Discover -> CellAction', function () {
       renderComponent(view, handleCellAction, 2);
       await openMenu();
 
-      expect(screen.getByRole('button', {name: 'Add to filter'})).toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Exclude from filter'})
-      ).not.toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {name: 'Show values greater than'})
+        screen.getByRole('menuitemradio', {name: 'Add to filter'})
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Show values less than'})
+        screen.queryByRole('menuitemradio', {name: 'Exclude from filter'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Show values greater than'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Show values less than'})
       ).toBeInTheDocument();
     });
 
@@ -271,7 +266,9 @@ describe('Discover -> CellAction', function () {
       renderComponent(view, handleCellAction, 3);
       await openMenu();
 
-      expect(screen.getByRole('button', {name: 'Go to release'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Go to release'})
+      ).toBeInTheDocument();
     });
 
     it('show appropriate actions for empty release cells', async function () {
@@ -279,7 +276,7 @@ describe('Discover -> CellAction', function () {
       await openMenu();
 
       expect(
-        screen.queryByRole('button', {name: 'Go to release'})
+        screen.queryByRole('menuitemradio', {name: 'Go to release'})
       ).not.toBeInTheDocument();
     });
 
@@ -288,16 +285,16 @@ describe('Discover -> CellAction', function () {
       await openMenu();
 
       expect(
-        screen.queryByRole('button', {name: 'Add to filter'})
+        screen.queryByRole('menuitemradio', {name: 'Add to filter'})
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Exclude from filter'})
+        screen.queryByRole('menuitemradio', {name: 'Exclude from filter'})
       ).not.toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Show values greater than'})
+        screen.getByRole('menuitemradio', {name: 'Show values greater than'})
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Show values less than'})
+        screen.getByRole('menuitemradio', {name: 'Show values less than'})
       ).toBeInTheDocument();
     });
 
@@ -308,15 +305,17 @@ describe('Discover -> CellAction', function () {
       });
       await openMenu();
 
-      expect(screen.getByRole('button', {name: 'Add to filter'})).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Exclude from filter'})
+        screen.getByRole('menuitemradio', {name: 'Add to filter'})
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Show values greater than'})
+        screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitemradio', {name: 'Show values greater than'})
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: 'Show values less than'})
+        screen.queryByRole('menuitemradio', {name: 'Show values less than'})
       ).not.toBeInTheDocument();
     });
 
@@ -325,20 +324,19 @@ describe('Discover -> CellAction', function () {
       await openMenu();
 
       expect(
-        screen.getByRole('button', {name: 'Show values greater than'})
+        screen.getByRole('menuitemradio', {name: 'Show values greater than'})
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', {name: 'Show values less than'})
+        screen.getByRole('menuitemradio', {name: 'Show values less than'})
       ).toBeInTheDocument();
     });
 
-    it('show appropriate actions for empty numeric function cells', async function () {
+    it('show appropriate actions for empty numeric function cells', function () {
       renderComponent(view, handleCellAction, 6, {
         ...defaultData,
         'percentile(measurements.fcp, 0.5)': null,
       });
-      await hoverContainer();
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Actions'})).not.toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/discover/table/tableView.spec.jsx
+++ b/static/app/views/discover/table/tableView.spec.jsx
@@ -53,8 +53,7 @@ describe('TableView > CellActions', function () {
     const firstRow = screen.getAllByRole('row')[1];
     const emptyValueCell = within(firstRow).getAllByRole('cell')[cellIndex];
 
-    await userEvent.hover(within(emptyValueCell).getByTestId('cell-action-container'));
-    await userEvent.click(within(emptyValueCell).getByRole('button'));
+    await userEvent.click(within(emptyValueCell).getByRole('button', {name: 'Actions'}));
   }
 
   beforeEach(function () {
@@ -139,7 +138,7 @@ describe('TableView > CellActions', function () {
 
     renderComponent(initialData, rows, eventView);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -156,7 +155,7 @@ describe('TableView > CellActions', function () {
 
     renderComponent(initialData, rows, view);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -172,7 +171,7 @@ describe('TableView > CellActions', function () {
 
     renderComponent(initialData, rows, view);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -187,7 +186,7 @@ describe('TableView > CellActions', function () {
 
     renderComponent(initialData, rows, eventView);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Add to filter'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -201,7 +200,9 @@ describe('TableView > CellActions', function () {
   it('handles exclude cell action on string value', async function () {
     renderComponent(initialData, rows, eventView);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Exclude from filter'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+    );
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -217,7 +218,9 @@ describe('TableView > CellActions', function () {
 
     renderComponent(initialData, rows, view);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Exclude from filter'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+    );
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -232,7 +235,9 @@ describe('TableView > CellActions', function () {
 
     renderComponent(initialData, rows, eventView);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Exclude from filter'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+    );
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -249,7 +254,9 @@ describe('TableView > CellActions', function () {
 
     renderComponent(initialData, rows, view);
     await openContextMenu(1);
-    await userEvent.click(screen.getByRole('button', {name: 'Exclude from filter'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+    );
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -262,7 +269,9 @@ describe('TableView > CellActions', function () {
   it('handles greater than cell action on number value', async function () {
     renderComponent(initialData, rows, eventView);
     await openContextMenu(3);
-    await userEvent.click(screen.getByRole('button', {name: 'Show values greater than'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Show values greater than'})
+    );
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -275,7 +284,9 @@ describe('TableView > CellActions', function () {
   it('handles less than cell action on number value', async function () {
     renderComponent(initialData, rows, eventView);
     await openContextMenu(3);
-    await userEvent.click(screen.getByRole('button', {name: 'Show values less than'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Show values less than'})
+    );
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: location.pathname,
@@ -306,7 +317,7 @@ describe('TableView > CellActions', function () {
   it('handles go to release', async function () {
     renderComponent(initialData, rows, eventView);
     await openContextMenu(5);
-    await userEvent.click(screen.getByRole('button', {name: 'Go to release'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Go to release'}));
 
     expect(browserHistory.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/releases/v1.0.2/',

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -200,21 +200,25 @@ describe('Performance > Table', function () {
 
       const cellActionContainers = screen.getAllByTestId('cell-action-container');
       expect(cellActionContainers).toHaveLength(18); // 9 cols x 2 rows
-      await userEvent.hover(cellActionContainers[8]);
-      const cellActions = await screen.findByTestId('cell-action');
-      expect(cellActions).toBeInTheDocument();
-      await userEvent.click(cellActions);
+      const cellActionTriggers = screen.getAllByRole('button', {name: 'Actions'});
+      expect(cellActionTriggers[8]).toBeInTheDocument();
+      await userEvent.click(cellActionTriggers[8]);
 
-      expect(await screen.findByTestId('add-to-filter')).toBeInTheDocument();
-      expect(screen.getByTestId('exclude-from-filter')).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Add to filter'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Exclude from filter'})
+      ).toBeInTheDocument();
 
-      await userEvent.hover(cellActionContainers[0]); // Transaction name
-      const transactionCellActions = await screen.findAllByTestId('cell-action');
-      expect(transactionCellActions[0]).toBeInTheDocument();
-      await userEvent.click(transactionCellActions[0]);
+      await userEvent.keyboard('{Escape}'); // Close actions menu
+
+      const transactionCellTrigger = cellActionTriggers[0]; // Transaction name
+      expect(transactionCellTrigger).toBeInTheDocument();
+      await userEvent.click(transactionCellTrigger);
 
       expect(browserHistory.push).toHaveBeenCalledTimes(0);
-      await userEvent.click(screen.getByTestId('add-to-filter'));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
       expect(browserHistory.push).toHaveBeenCalledTimes(1);
       expect(browserHistory.push).toHaveBeenNthCalledWith(1, {


### PR DESCRIPTION
**Before ——**
<img width="173" alt="Screenshot 2023-06-09 at 11 27 12 AM" src="https://github.com/getsentry/sentry/assets/44172267/db26e1bb-f7a5-4497-8337-304a8537b7db">

**After ——**
<img width="173" alt="Screenshot 2023-06-09 at 11 26 29 AM" src="https://github.com/getsentry/sentry/assets/44172267/ab4a99ad-262d-4fb2-98fa-dba50899ac29">
