### PR TITLE
fix(issues): Prevent 414 URI too long in recent searches

### DIFF
--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -54,6 +54,16 @@ export function fetchRecentSearches(
   query?: string
 ): Promise<RecentSearch[]> {
   const url = getRecentSearchUrl(orgSlug);
+
+  // Prevent requests that are too long
+  // 8k is the default max size for a URL in nginx
+  // Docs - http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
+  // 5000 saves us room for other query params and url
+  // Recent searches stops being useful at a certain point
+  if (query && query.length > 5000) {
+    query = query.substring(0, 5000);
+  }
+
   const promise = api.requestPromise(url, {
     query: {
       query,


### PR DESCRIPTION
You can paste a search query of any size, but url's have a max length. Recent searches probably aren't useful after something like 5000 characters which i have chosen at random

fixes JAVASCRIPT-2MH0