### PR TITLE
ref(ui): Fix text for Sentry App uninstallation

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
@@ -243,7 +243,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
       return (
         <Confirm
           disabled={!userHasAccess}
-          message={tct('Are you sure you want to remove the [slug] installation?', {
+          message={tct('Are you sure you want to uninstall the [slug] installation?', {
             slug: capitalizedSlug,
           })}
           onConfirm={() => this.handleUninstall(install)} // called when the user confirms the action


### PR DESCRIPTION
Changes the text from `remove` to `uninstall` when uninstalling a Sentry App.

Fixes GH-49986




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
