### PR TITLE
ref(ui): Fix text for Sentry App uninstallation

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
@@ -243,7 +243,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
       return (
         <Confirm
           disabled={!userHasAccess}
-          message={tct('Are you sure you want to remove the [slug] installation?', {
+          message={tct('Are you sure you want to uninstall the [slug] installation?', {
             slug: capitalizedSlug,
           })}
           onConfirm={() => this.handleUninstall(install)} // called when the user confirms the action


### PR DESCRIPTION
Changes the text from `remove` to `uninstall` when uninstalling a Sentry App.

Fixes GH-49986