### PR TITLE
feat(settings): Group all api source errors

### DIFF
--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -393,14 +393,16 @@ class ApiSource extends Component<Props, State> {
   }, 150);
 
   handleRequestError = (err: ResponseMeta, {url, orgId}) => {
-    Sentry.withScope(scope => {
-      scope.setExtra(
-        'url',
-        url.replace(`/organizations/${orgId}/`, '/organizations/:orgId/')
-      );
-      scope.setFingerprint(['api-source-failed']);
-      Sentry.captureException(err);
-    });
+    if (err && err.status !== 401 && err.status !== 403) {
+      Sentry.withScope(scope => {
+        scope.setExtra(
+          'url',
+          url.replace(`/organizations/${orgId}/`, '/organizations/:orgId/')
+        );
+        scope.setFingerprint(['api-source-failed']);
+        Sentry.captureException(err);
+      });
+    }
   };
 
   // Handles a list of search request promises, and then updates state with response objects

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -398,9 +398,8 @@ class ApiSource extends Component<Props, State> {
         'url',
         url.replace(`/organizations/${orgId}/`, '/organizations/:orgId/')
       );
-      Sentry.captureException(
-        new Error(`API Source Failed: ${err?.responseJSON?.detail}`)
-      );
+      scope.setFingerprint(['api-source-failed']);
+      Sentry.captureException(err);
     });
   };
 


### PR DESCRIPTION
These are currently poorly grouped because we're setting a different error message. Just force them into one group since we aren't doing much with these errors.

Filter out 401 and 403 errors
