### PR TITLE
ref(crons): Allow custom resolution on monitor stats

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -494,12 +494,20 @@ class EnvironmentMixin:
 
 
 class StatsMixin:
-    def _parse_args(self, request: Request, environment_id=None):
+    def _parse_args(self, request: Request, environment_id=None, restrict_rollups=True):
+        """
+        Parse common stats parameters from the query string. This includes
+        `since`, `until`, and `resolution`.
+
+        :param boolean restrict_rollups: When False allows any rollup value to
+        be specified. Be careful using this as this allows for fine grain
+        rollups that may put strain on the system.
+        """
         try:
             resolution = request.GET.get("resolution")
             if resolution:
                 resolution = self._parse_resolution(resolution)
-                if resolution not in tsdb.get_rollups():
+                if restrict_rollups and resolution not in tsdb.get_rollups():
                     raise ValueError
         except ValueError:
             raise ParseError(detail="Invalid resolution")

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -31,7 +31,10 @@ def normalize_to_epoch(timestamp: datetime, seconds: int):
 class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
     # TODO(epurkhiser): probably convert to snuba
     def get(self, request: Request, organization) -> Response:
-        args = self._parse_args(request)
+        # Do not restirct rollups allowing us to define custom resolutions.
+        # Important for this endpoint since we want our buckets to align with
+        # the UI's time scale markers.
+        args = self._parse_args(request, restrict_rollups=False)
 
         start = normalize_to_epoch(args["start"], args["rollup"])
         end = normalize_to_epoch(args["end"], args["rollup"])
@@ -66,7 +69,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
         bucket = Func(
             timedelta(seconds=args["rollup"]),
             "date_added",
-            datetime.fromtimestamp(end),
+            datetime.fromtimestamp(start),
             function="date_bin",
             output_field=DateTimeField(),
         )

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
@@ -129,3 +129,36 @@ class OrganizationMonitorIndexStatsTest(MonitorTestCase):
                 "production": {"ok": 2, "error": 0, "missed": 0, "timeout": 0},
             },
         ]
+
+    def test_custom_resolution(self):
+        two_min_later = self.since + timedelta(minutes=2)
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            **{
+                "monitor": [self.monitor1.slug],
+                "since": self.since.timestamp(),
+                "until": two_min_later.timestamp(),
+                "resolution": "1m",
+            },
+        )
+
+        min_0, min_1, min_2 = resp.data[self.monitor1.slug]
+
+        assert min_0 == [
+            1647849420,
+            {},
+        ]
+
+        assert min_1 == [
+            1647849480,
+            {
+                "production": {"ok": 1, "error": 0, "missed": 0, "timeout": 0},
+            },
+        ]
+        assert min_2 == [
+            1647849540,
+            {
+                "debug": {"ok": 1, "error": 0, "missed": 0, "timeout": 0},
+            },
+        ]


### PR DESCRIPTION
This also fixes a small boundary issue where items were falling into previous buckets due to the orgin of the date_bin being set as the 'until' timestamp.

Before

```
time range 1647849420 1647849540
checin1 time 1647849480.0
checin2 time 1647849540.0
{
    "a536b24376a8": [
        [1647849420, {"production": {"ok": 1, "error": 0, "missed": 0, "timeout": 0}}],
        [1647849480, {}],
        [1647849540, {"debug": {"ok": 1, "error": 0, "missed": 0, "timeout": 0}}],
    ]
}
````

After

```
time range 1647849420 1647849540
checin1 time 1647849480.0
checin2 time 1647849540.0
{
    "1cd5f18e2ba0": [
        [1647849420, {}],
        [1647849480, {"production": {"ok": 1, "error": 0, "missed": 0, "timeout": 0}}],
        [1647849540, {"debug": {"ok": 1, "error": 0, "missed": 0, "timeout": 0}}],
    ]
}
```