### PR TITLE
feat(crons): Add timeline component into listing page

### DIFF
--- a/static/app/views/monitors/components/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/checkInTimeline.tsx
@@ -48,8 +48,12 @@ function getColorFromStatus(status: CheckInStatus, theme: Theme) {
   return statusToColor[status];
 }
 
-function getCheckInPosition(checkDate: number, timelineStart: Date, msPerPixel: number) {
-  const elapsedSinceStart = new Date(checkDate).getTime() - timelineStart.getTime();
+function getBucketedCheckInsPosition(
+  timestamp: number,
+  timelineStart: Date,
+  msPerPixel: number
+) {
+  const elapsedSinceStart = new Date(timestamp).getTime() - timelineStart.getTime();
   return elapsedSinceStart / msPerPixel;
 }
 
@@ -68,7 +72,7 @@ export function CheckInTimeline(props: Props) {
             return null;
           }
 
-          const left = getCheckInPosition(timestampMs, start, msPerPixel);
+          const left = getBucketedCheckInsPosition(timestampMs, start, msPerPixel);
           if (left < 0) {
             return null;
           }

--- a/static/app/views/monitors/components/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/checkInTimeline.tsx
@@ -5,7 +5,10 @@ import DateTime from 'sentry/components/dateTime';
 import {Resizeable} from 'sentry/components/replays/resizeable';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
-import {MonitorBucketData} from 'sentry/views/monitors/components/overviewTimeline/types';
+import {
+  MonitorBucketData,
+  MonitorBucketEnvMapping,
+} from 'sentry/views/monitors/components/overviewTimeline/types';
 import {CheckInStatus} from 'sentry/views/monitors/types';
 
 interface Props {
@@ -15,7 +18,7 @@ interface Props {
   width?: number;
 }
 
-function getAggregateStatus(envData: MonitorBucketData[number][1]) {
+function getAggregateStatus(envData: MonitorBucketEnvMapping) {
   // Orders the status in terms of precedence for showing to the user
   const statusOrdering = [
     CheckInStatus.OK,

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -18,14 +18,12 @@ import {
   GridLineOverlay,
   GridLineTimeLabels,
 } from 'sentry/views/monitors/components/overviewTimeline/timelineScrubber';
-import {MonitorBucketData} from 'sentry/views/monitors/components/overviewTimeline/types';
-import {
-  getStartFromTimeWindow,
-  timeWindowData,
-} from 'sentry/views/monitors/components/overviewTimeline/utils';
 
 import {Monitor} from '../../types';
 import {scheduleAsText} from '../../utils';
+
+import {MonitorBucketData} from './types';
+import {getStartFromTimeWindow, timeWindowData} from './utils';
 
 interface Props {
   monitorList: Monitor[];

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -4,16 +4,25 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import Link from 'sentry/components/links/link';
 import Panel from 'sentry/components/panels/panel';
+import Placeholder from 'sentry/components/placeholder';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDimensions} from 'sentry/utils/useDimensions';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
+import {CheckInTimeline} from 'sentry/views/monitors/components/checkInTimeline';
 import {
   GridLineOverlay,
   GridLineTimeLabels,
 } from 'sentry/views/monitors/components/overviewTimeline/timelineScrubber';
+import {MonitorBucketData} from 'sentry/views/monitors/components/overviewTimeline/types';
+import {
+  getStartFromTimeWindow,
+  timeWindowData,
+} from 'sentry/views/monitors/components/overviewTimeline/utils';
 
 import {Monitor} from '../../types';
 import {scheduleAsText} from '../../utils';
@@ -23,17 +32,44 @@ interface Props {
   monitorListPageLinks?: string | null;
 }
 
+const DEFAULT_WIDTH = 800;
+
 export function OverviewTimeline({monitorList}: Props) {
   const {replace, location} = useRouter();
+  const organization = useOrganization();
 
   const resolution = location.query?.resolution ?? '24h';
   const nowRef = useRef<Date>(new Date());
+  const start = getStartFromTimeWindow(nowRef.current, resolution);
+  const {elementRef, width} = useDimensions<HTMLDivElement>();
 
   const handleResolutionChange = useCallback(
     (value: string) => {
       replace({...location, query: {...location.query, resolution: value}});
     },
     [location, replace]
+  );
+
+  const rollup = Math.floor(
+    (timeWindowData[resolution].elapsedMinutes * 60) / (width > 0 ? width : DEFAULT_WIDTH)
+  );
+  const monitorStatsQueryKey = `/organizations/${organization.slug}/monitors-stats/`;
+  const {data: monitorStats, isLoading} = useApiQuery<Record<string, MonitorBucketData>>(
+    [
+      monitorStatsQueryKey,
+      {
+        query: {
+          until: Math.floor(nowRef.current.getTime() / 1000),
+          since: Math.floor(start.getTime() / 1000),
+          monitor: monitorList.map(m => m.slug),
+          resolution: `${rollup}s`,
+          ...location.query,
+        },
+      },
+    ],
+    {
+      staleTime: 0,
+    }
   );
 
   return (
@@ -52,13 +88,27 @@ export function OverviewTimeline({monitorList}: Props) {
           <SegmentedControl.Item key="30d">{t('Month')}</SegmentedControl.Item>
         </SegmentedControl>
       </ListFilters>
-      <GridLineTimeLabels timeWindow={resolution} end={nowRef.current} />
-      <GridLineOverlay timeWindow={resolution} end={nowRef.current} />
+      <GridLineTimeLabels
+        timeWindow={resolution}
+        end={nowRef.current}
+        width={width}
+        ref={elementRef}
+      />
+      <GridLineOverlay timeWindow={resolution} end={nowRef.current} width={width} />
 
       {monitorList.map(monitor => (
         <Fragment key={monitor.id}>
           <MonitorDetails monitor={monitor} />
-          <TimelineContainer />
+          {isLoading || !monitorStats ? (
+            <Placeholder />
+          ) : (
+            <CheckInTimeline
+              bucketedData={monitorStats[monitor.slug]}
+              end={nowRef.current}
+              start={start}
+              width={width}
+            />
+          )}
         </Fragment>
       ))}
     </MonitorListPanel>
@@ -83,8 +133,6 @@ const MonitorListPanel = styled(Panel)`
   display: grid;
   grid-template-columns: 350px 1fr;
 `;
-
-const TimelineContainer = styled('div')``;
 
 const DetailsContainer = styled(Link)`
   color: ${p => p.theme.textColor};

--- a/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
@@ -1,9 +1,9 @@
+import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
 import DateTime from 'sentry/components/dateTime';
 import {space} from 'sentry/styles/space';
-import {useDimensions} from 'sentry/utils/useDimensions';
 import {TimeWindow} from 'sentry/views/monitors/components/overviewTimeline/types';
 import {
   getStartFromTimeWindow,
@@ -13,6 +13,7 @@ import {
 interface Props {
   end: Date;
   timeWindow: TimeWindow;
+  width: number;
 }
 
 function clampTimeBasedOnResolution(date: moment.Moment, resolution: string) {
@@ -48,23 +49,23 @@ function getTimeMarkers(end: Date, timeWindow: TimeWindow, width: number): TimeM
   return times;
 }
 
-export function GridLineTimeLabels({end, timeWindow}: Props) {
-  const {elementRef, width} = useDimensions<HTMLDivElement>();
-  return (
-    <LabelsContainer ref={elementRef}>
-      {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
-        <TimeLabelContainer key={date.getTime()} left={position}>
-          <TimeLabel date={date} {...timeWindowData[timeWindow].dateTimeProps} />
-        </TimeLabelContainer>
-      ))}
-    </LabelsContainer>
-  );
-}
+export const GridLineTimeLabels = forwardRef<HTMLDivElement, Props>(
+  ({end, timeWindow, width}: Props, ref) => {
+    return (
+      <LabelsContainer ref={ref}>
+        {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
+          <TimeLabelContainer key={date.getTime()} left={position}>
+            <TimeLabel date={date} {...timeWindowData[timeWindow].dateTimeProps} />
+          </TimeLabelContainer>
+        ))}
+      </LabelsContainer>
+    );
+  }
+);
 
-export function GridLineOverlay({end, timeWindow}: Props) {
-  const {elementRef, width} = useDimensions<HTMLDivElement>();
+export function GridLineOverlay({end, timeWindow, width}: Props) {
   return (
-    <Overlay ref={elementRef}>
+    <Overlay>
       <GridLineContainer>
         {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
           <Gridline key={date.getTime()} left={position} />

--- a/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineScrubber.tsx
@@ -1,4 +1,3 @@
-import {forwardRef} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
@@ -49,19 +48,17 @@ function getTimeMarkers(end: Date, timeWindow: TimeWindow, width: number): TimeM
   return times;
 }
 
-export const GridLineTimeLabels = forwardRef<HTMLDivElement, Props>(
-  ({end, timeWindow, width}: Props, ref) => {
-    return (
-      <LabelsContainer ref={ref}>
-        {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
-          <TimeLabelContainer key={date.getTime()} left={position}>
-            <TimeLabel date={date} {...timeWindowData[timeWindow].dateTimeProps} />
-          </TimeLabelContainer>
-        ))}
-      </LabelsContainer>
-    );
-  }
-);
+export function GridLineTimeLabels({end, timeWindow, width}: Props) {
+  return (
+    <LabelsContainer>
+      {getTimeMarkers(end, timeWindow, width).map(({date, position}) => (
+        <TimeLabelContainer key={date.getTime()} left={position}>
+          <TimeLabel date={date} {...timeWindowData[timeWindow].dateTimeProps} />
+        </TimeLabelContainer>
+      ))}
+    </LabelsContainer>
+  );
+}
 
 export function GridLineOverlay({end, timeWindow, width}: Props) {
   return (

--- a/static/app/views/monitors/components/overviewTimeline/types.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/types.tsx
@@ -21,6 +21,4 @@ export type TimeWindowData = Record<TimeWindow, TimeWindowOptions>;
 
 export type MonitorBucketData = [timestamp: number, envData: MonitorBucketEnvMapping][];
 
-export type MonitorBucketEnvMapping = {
-  string: Record<CheckInStatus, number>;
-};
+export type MonitorBucketEnvMapping = Record<string, Record<CheckInStatus, number>>;

--- a/static/app/views/monitors/components/overviewTimeline/types.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/types.tsx
@@ -1,3 +1,5 @@
+import {CheckInStatus} from 'sentry/views/monitors/types';
+
 export type TimeWindow = '1h' | '24h' | '7d' | '30d';
 
 export interface TimeWindowOptions {
@@ -16,3 +18,9 @@ export interface TimeWindowOptions {
 }
 
 export type TimeWindowData = Record<TimeWindow, TimeWindowOptions>;
+
+export type MonitorBucketData = [timestamp: number, envData: MonitorBucketEnvMapping][];
+
+export type MonitorBucketEnvMapping = {
+  string: Record<CheckInStatus, number>;
+};


### PR DESCRIPTION
Adds in the timeline component to display a set of ticks for each monitor in the listing page with a placeholder tooltip on each job tick for now

<img width="1250" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/95bec116-616b-4a9a-bcfe-6aa154aaba2b">


Loading state looks like:
<img width="1258" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/0fcd95b0-34fb-4609-a5be-fecb89db442c">
