### PR TITLE
feat(replay): Create a Replay Details>Errors tab to replace Issues

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -5,11 +5,16 @@ import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 jest.mock('react-router');
 jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useOrganization');
 
 const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+const mockUseOrganization = useOrganization as jest.MockedFunction<
+  typeof useOrganization
+>;
 const mockPush = browserHistory.push as jest.MockedFunction<typeof browserHistory.push>;
 
 function mockLocation(query: string = '') {
@@ -24,9 +29,19 @@ function mockLocation(query: string = '') {
   } as Location);
 }
 
+function mockOrganiation(props?: {features: string[]}) {
+  const features = props?.features ?? [];
+  mockUseOrganization.mockReturnValue(
+    TestStubs.Organization({
+      features,
+    })
+  );
+}
+
 describe('useActiveReplayTab', () => {
   beforeEach(() => {
     mockLocation();
+    mockOrganiation();
     mockPush.mockReset();
   });
 
@@ -55,11 +70,55 @@ describe('useActiveReplayTab', () => {
     });
   });
 
-  it('should not change the tab if the name is invalid', () => {
+  it('should set the default tab if the name is invalid', () => {
     const {result} = reactHooks.renderHook(useActiveReplayTab);
     expect(result.current.getActiveTab()).toBe(TabKey.CONSOLE);
 
     result.current.setActiveTab('foo bar');
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '',
+      query: {t_main: TabKey.CONSOLE},
+    });
+  });
+
+  it('should allow ISSUES if session-replay-errors-tab is disabled', () => {
+    mockOrganiation({
+      features: [],
+    });
+    const {result} = reactHooks.renderHook(useActiveReplayTab);
+    expect(result.current.getActiveTab()).toBe(TabKey.CONSOLE);
+
+    // ISSUES is allowed:
+    result.current.setActiveTab(TabKey.ISSUES);
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '',
+      query: {t_main: TabKey.ISSUES},
+    });
+
+    // ERRORS is not enabled, reset to default:
+    result.current.setActiveTab(TabKey.ERRORS);
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '',
+      query: {t_main: TabKey.CONSOLE},
+    });
+  });
+
+  it('should allow ERRORS if session-replay-errors-tab is enabled', () => {
+    mockOrganiation({
+      features: ['session-replay-errors-tab'],
+    });
+    const {result} = reactHooks.renderHook(useActiveReplayTab);
+    expect(result.current.getActiveTab()).toBe(TabKey.CONSOLE);
+
+    // ERRORS is enabled:
+    result.current.setActiveTab(TabKey.ERRORS);
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '',
+      query: {t_main: TabKey.ERRORS},
+    });
+
+    // ISSUES is not allowed, it's been replaced by ERRORS, reset to default:
+    result.current.setActiveTab(TabKey.ISSUES);
     expect(mockPush).toHaveBeenLastCalledWith({
       pathname: '',
       query: {t_main: TabKey.CONSOLE},

--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -29,7 +29,7 @@ function mockLocation(query: string = '') {
   } as Location);
 }
 
-function mockOrganiation(props?: {features: string[]}) {
+function mockOrganization(props?: {features: string[]}) {
   const features = props?.features ?? [];
   mockUseOrganization.mockReturnValue(
     TestStubs.Organization({
@@ -41,7 +41,7 @@ function mockOrganiation(props?: {features: string[]}) {
 describe('useActiveReplayTab', () => {
   beforeEach(() => {
     mockLocation();
-    mockOrganiation();
+    mockOrganization();
     mockPush.mockReset();
   });
 
@@ -82,7 +82,7 @@ describe('useActiveReplayTab', () => {
   });
 
   it('should allow ISSUES if session-replay-errors-tab is disabled', () => {
-    mockOrganiation({
+    mockOrganization({
       features: [],
     });
     const {result} = reactHooks.renderHook(useActiveReplayTab);
@@ -104,7 +104,7 @@ describe('useActiveReplayTab', () => {
   });
 
   it('should allow ERRORS if session-replay-errors-tab is enabled', () => {
-    mockOrganiation({
+    mockOrganization({
       features: ['session-replay-errors-tab'],
     });
     const {result} = reactHooks.renderHook(useActiveReplayTab);

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -1,8 +1,10 @@
 import {useCallback, useMemo} from 'react';
 
 import {parseSearch} from 'sentry/components/searchSyntax/parser';
+import type {Organization} from 'sentry/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import useUrlParams from 'sentry/utils/useUrlParams';
 
 export enum TabKey {
@@ -15,7 +17,16 @@ export enum TabKey {
   TRACE = 'trace',
 }
 
-function isReplayTab(tab: string): tab is TabKey {
+function isReplayTab(tab: string, organization: Organization): tab is TabKey {
+  const hasErrorTab = organization.features.includes('session-replay-errors-tab');
+  if (tab === TabKey.ERRORS) {
+    // If the errors tab feature is enabled, then TabKey.ERRORS is valid.
+    return hasErrorTab;
+  }
+  if (tab === TabKey.ISSUES) {
+    // If the errors tab is enabled, then then Issues tab is invalid
+    return !hasErrorTab;
+  }
   return Object.values<string>(TabKey).includes(tab);
 }
 
@@ -38,22 +49,25 @@ function useDefaultTab() {
 
 function useActiveReplayTab() {
   const defaultTab = useDefaultTab();
+  const organization = useOrganization();
   const {getParamValue, setParamValue} = useUrlParams('t_main', defaultTab);
 
   const paramValue = getParamValue()?.toLowerCase() ?? '';
 
   return {
     getActiveTab: useCallback(
-      () => (isReplayTab(paramValue) ? (paramValue as TabKey) : defaultTab),
-      [paramValue, defaultTab]
+      () => (isReplayTab(paramValue, organization) ? (paramValue as TabKey) : defaultTab),
+      [organization, paramValue, defaultTab]
     ),
     setActiveTab: useCallback(
       (value: string) => {
         setParamValue(
-          isReplayTab(value.toLowerCase()) ? value.toLowerCase() : defaultTab
+          isReplayTab(value.toLowerCase(), organization)
+            ? value.toLowerCase()
+            : defaultTab
         );
       },
-      [setParamValue, defaultTab]
+      [organization, setParamValue, defaultTab]
     ),
   };
 }

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -8,10 +8,11 @@ import useUrlParams from 'sentry/utils/useUrlParams';
 export enum TabKey {
   CONSOLE = 'console',
   DOM = 'dom',
-  NETWORK = 'network',
-  TRACE = 'trace',
+  ERRORS = 'errors',
   ISSUES = 'issues',
   MEMORY = 'memory',
+  NETWORK = 'network',
+  TRACE = 'trace',
 }
 
 function isReplayTab(tab: string): tab is TabKey {

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -151,6 +151,10 @@ export default class ReplayReader {
 
   getRawErrors = memoize(() => this.rawErrors);
 
+  getErrorCrumbs = memoize(() =>
+    this.breadcrumbs.filter(crumb => crumb.type === BreadcrumbType.ERROR)
+  );
+
   getNonConsoleCrumbs = memoize(() =>
     this.breadcrumbs.filter(crumb => crumb.category !== 'console')
   );

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -146,13 +146,13 @@ export default class ReplayReader {
   });
 
   getConsoleCrumbs = memoize(() =>
-    this.breadcrumbs.filter(crumb => ['console', 'issue'].includes(crumb.category || ''))
+    this.breadcrumbs.filter(crumb => crumb.category === 'console')
   );
 
   getRawErrors = memoize(() => this.rawErrors);
 
-  getErrorCrumbs = memoize(() =>
-    this.breadcrumbs.filter(crumb => crumb.type === BreadcrumbType.ERROR)
+  getIssueCrumbs = memoize(() =>
+    this.breadcrumbs.filter(crumb => crumb.category === 'issue')
   );
 
   getNonConsoleCrumbs = memoize(() =>

--- a/static/app/views/replays/detail/console/viewIssueLink.tsx
+++ b/static/app/views/replays/detail/console/viewIssueLink.tsx
@@ -1,6 +1,7 @@
 import ShortId from 'sentry/components/shortId';
 import {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
 import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {breadcrumbHasIssue} from 'sentry/views/replays/detail/console/utils';
 
 type Props = {
@@ -16,7 +17,9 @@ function ViewIssueLink({breadcrumb}: Props) {
   const {groupId, groupShortId, eventId} = breadcrumb.data || {};
 
   const to = {
-    pathname: `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/?referrer=replay-console`,
+    pathname: normalizeUrl(
+      `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/?referrer=replay-console`
+    ),
   };
   return <ShortId to={to} shortId={groupShortId} />;
 }

--- a/static/app/views/replays/detail/errorList/errorFilters.tsx
+++ b/static/app/views/replays/detail/errorList/errorFilters.tsx
@@ -1,0 +1,45 @@
+import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
+import SearchBar from 'sentry/components/searchBar';
+import {t} from 'sentry/locale';
+import type {Crumb} from 'sentry/types/breadcrumbs';
+import useErrorFilters from 'sentry/views/replays/detail/errorList/useErrorFilters';
+import FiltersGrid from 'sentry/views/replays/detail/filtersGrid';
+
+type Props = {
+  errorCrumbs: undefined | Crumb[];
+} & ReturnType<typeof useErrorFilters>;
+
+function ErrorFilters({
+  getProjectOptions,
+  errorCrumbs,
+  searchTerm,
+  selectValue,
+  setFilters,
+  setSearchTerm,
+}: Props) {
+  const projectOptions = getProjectOptions();
+
+  return (
+    <FiltersGrid>
+      <CompactSelect
+        disabled={!projectOptions.length}
+        multiple
+        onChange={setFilters as (selection: SelectOption<string>[]) => void}
+        options={projectOptions}
+        size="sm"
+        triggerLabel={selectValue?.length === 0 ? t('Any') : null}
+        triggerProps={{prefix: t('Project')}}
+        value={selectValue}
+      />
+      <SearchBar
+        size="sm"
+        onChange={setSearchTerm}
+        placeholder={t('Search Errors')}
+        query={searchTerm}
+        disabled={!errorCrumbs || !errorCrumbs.length}
+      />
+    </FiltersGrid>
+  );
+}
+
+export default ErrorFilters;

--- a/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
@@ -1,0 +1,85 @@
+import {ComponentProps, CSSProperties, forwardRef, ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconArrow, IconInfo} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useSortErrors from 'sentry/views/replays/detail/errorList/useSortErrors';
+
+type SortConfig = ReturnType<typeof useSortErrors>['sortConfig'];
+type Props = {
+  handleSort: ReturnType<typeof useSortErrors>['handleSort'];
+  index: number;
+  sortConfig: SortConfig;
+  style: CSSProperties;
+};
+
+const SizeInfoIcon = styled(IconInfo)`
+  display: block;
+`;
+
+const COLUMNS: {
+  field: SortConfig['by'];
+  label: string;
+  tooltipTitle?: ComponentProps<typeof Tooltip>['title'];
+}[] = [
+  {field: 'id', label: t('Event ID')},
+  {field: 'title', label: t('Title')},
+  {field: 'project', label: t('Issue')},
+  {field: 'timestamp', label: t('Timestamp')},
+];
+
+export const COLUMN_COUNT = COLUMNS.length;
+
+function CatchClicks({children}: {children: ReactNode}) {
+  return <div onClick={e => e.stopPropagation()}>{children}</div>;
+}
+
+const ErrorHeaderCell = forwardRef<HTMLButtonElement, Props>(
+  ({handleSort, index, sortConfig, style}: Props, ref) => {
+    const {field, label, tooltipTitle} = COLUMNS[index];
+    return (
+      <HeaderButton style={style} onClick={() => handleSort(field)} ref={ref}>
+        {label}
+        {tooltipTitle ? (
+          <Tooltip isHoverable title={<CatchClicks>{tooltipTitle}</CatchClicks>}>
+            <SizeInfoIcon size="xs" />
+          </Tooltip>
+        ) : null}
+        <IconArrow
+          color="gray300"
+          size="xs"
+          direction={sortConfig.by === field && !sortConfig.asc ? 'down' : 'up'}
+          style={{visibility: sortConfig.by === field ? 'visible' : 'hidden'}}
+        />
+      </HeaderButton>
+    );
+  }
+);
+
+const HeaderButton = styled('button')`
+  border: 0;
+  border-bottom: 1px solid ${p => p.theme.border};
+  background: ${p => p.theme.backgroundSecondary};
+  color: ${p => p.theme.subText};
+
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: 600;
+  line-height: 16px;
+  text-align: unset;
+  text-transform: uppercase;
+  white-space: nowrap;
+
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${space(0.5)} ${space(1)} ${space(0.5)} ${space(1.5)};
+
+  svg {
+    margin-left: ${space(0.25)};
+  }
+`;
+
+export default ErrorHeaderCell;

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import Avatar from 'sentry/components/avatar';
 import Link from 'sentry/components/links/link';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
-import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import {getShortEventId} from 'sentry/utils/events';
@@ -126,6 +125,17 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
     const renderFns = [
       () => (
         <Cell {...columnProps} numeric align="flex-start">
+          {issueUrl ? (
+            <Link to={issueUrl}>
+              <Text>{getShortEventId(eventId || '')}</Text>
+            </Link>
+          ) : (
+            <Text>{getShortEventId(eventId || '')}</Text>
+          )}
+        </Cell>
+      ),
+      () => (
+        <Cell {...columnProps}>
           <QuickContextHoverWrapper
             dataRow={{
               id: eventId,
@@ -134,21 +144,8 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
             contextType={ContextType.EVENT}
             organization={organization}
           >
-            {issueUrl ? (
-              <Link to={issueUrl}>
-                <Text>{getShortEventId(eventId || '')}</Text>
-              </Link>
-            ) : (
-              <Text>{getShortEventId(eventId || '')}</Text>
-            )}
-          </QuickContextHoverWrapper>
-        </Cell>
-      ),
-      () => (
-        <Cell {...columnProps}>
-          <Tooltip isHoverable title={title}>
             <Text>{title ?? EMPTY_CELL}</Text>
-          </Tooltip>
+          </QuickContextHoverWrapper>
         </Cell>
       ),
       () => (

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -1,0 +1,239 @@
+import {CSSProperties, forwardRef, useMemo} from 'react';
+import styled from '@emotion/styled';
+import classNames from 'classnames';
+
+import Avatar from 'sentry/components/avatar';
+import Link from 'sentry/components/links/link';
+import {relativeTimeInMs} from 'sentry/components/replays/utils';
+import {Tooltip} from 'sentry/components/tooltip';
+import {space} from 'sentry/styles/space';
+import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
+import {getShortEventId} from 'sentry/utils/events';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
+import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
+import ViewIssueLink from 'sentry/views/replays/detail/console/viewIssueLink';
+import useSortErrors from 'sentry/views/replays/detail/errorList/useSortErrors';
+import TimestampButton from 'sentry/views/replays/detail/timestampButton';
+
+const EMPTY_CELL = '--';
+
+type Props = {
+  columnIndex: number;
+  crumb: Crumb;
+  currentHoverTime: number | undefined;
+  currentTime: number;
+  handleMouseEnter: (crumb: Crumb) => void;
+  handleMouseLeave: (crumb: Crumb) => void;
+  onClickCell: (props: {dataIndex: number; rowIndex: number}) => void;
+  onClickTimestamp: (crumb: Crumb) => void;
+  rowIndex: number;
+  sortConfig: ReturnType<typeof useSortErrors>['sortConfig'];
+  startTimestampMs: number;
+  style: CSSProperties;
+};
+
+type CellProps = {
+  hasOccurred: boolean | undefined;
+  align?: 'flex-start' | 'flex-end';
+  className?: string;
+  gap?: Parameters<typeof space>[0];
+  numeric?: boolean;
+  onClick?: undefined | (() => void);
+};
+
+const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
+  (
+    {
+      columnIndex,
+      currentHoverTime,
+      currentTime,
+      handleMouseEnter,
+      handleMouseLeave,
+      onClickCell,
+      onClickTimestamp,
+      rowIndex,
+      sortConfig,
+      crumb,
+      startTimestampMs,
+      style,
+    }: Props,
+    ref
+  ) => {
+    // Rows include the sortable header, the dataIndex does not
+    const dataIndex = rowIndex - 1;
+
+    const organization = useOrganization();
+
+    // @ts-expect-error
+    const {eventId, groupId, groupShortId, project: projectSlug} = crumb.data;
+    const title = crumb.message;
+    const {projects} = useProjects();
+    const project = useMemo(
+      () => projects.find(p => p.slug === projectSlug),
+      [projects, projectSlug]
+    );
+
+    // const eventUrl = {
+    //   pathname: `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/?referrer=replay-errors`,
+    // };
+
+    const crumbTime = useMemo(
+      // @ts-expect-error
+      () => relativeTimeInMs(crumb.timestamp * 1000, startTimestampMs),
+      [crumb.timestamp, startTimestampMs]
+    );
+    const hasOccurred = currentTime >= crumbTime;
+    const isBeforeHover = currentHoverTime === undefined || currentHoverTime >= crumbTime;
+
+    const isByTimestamp = sortConfig.by === 'startTimestamp';
+    const isAsc = isByTimestamp ? sortConfig.asc : undefined;
+    const columnProps = {
+      className: classNames({
+        beforeCurrentTime: isByTimestamp
+          ? isAsc
+            ? hasOccurred
+            : !hasOccurred
+          : undefined,
+        afterCurrentTime: isByTimestamp
+          ? isAsc
+            ? !hasOccurred
+            : hasOccurred
+          : undefined,
+        beforeHoverTime:
+          isByTimestamp && currentHoverTime !== undefined
+            ? isAsc
+              ? isBeforeHover
+              : !isBeforeHover
+            : undefined,
+        afterHoverTime:
+          isByTimestamp && currentHoverTime !== undefined
+            ? isAsc
+              ? !isBeforeHover
+              : isBeforeHover
+            : undefined,
+      }),
+      hasOccurred: isByTimestamp ? hasOccurred : undefined,
+      onClick: () => onClickCell({dataIndex, rowIndex}),
+      onMouseEnter: () => handleMouseEnter(crumb),
+      onMouseLeave: () => handleMouseLeave(crumb),
+      ref,
+      style,
+    } as CellProps;
+
+    const renderFns = [
+      () => (
+        <Cell {...columnProps} numeric align="flex-start">
+          <QuickContextHoverWrapper
+            dataRow={{
+              id: eventId,
+              'project.name': projectSlug,
+            }}
+            contextType={ContextType.EVENT}
+            organization={organization}
+          >
+            <Link
+              to={{
+                pathname: normalizeUrl(
+                  `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/`
+                ),
+                query: {
+                  referrer: 'replay-errors',
+                },
+              }}
+            >
+              <Text>{getShortEventId(eventId || '')}</Text>
+            </Link>
+          </QuickContextHoverWrapper>
+        </Cell>
+      ),
+      () => (
+        <Cell {...columnProps}>
+          <Tooltip isHoverable title={title}>
+            <Text>{title ?? EMPTY_CELL}</Text>
+          </Tooltip>
+        </Cell>
+      ),
+      () => (
+        <Cell {...columnProps} gap={0.5}>
+          <AvatarWrapper>
+            <Avatar project={project} size={16} />
+          </AvatarWrapper>
+          <QuickContextHoverWrapper
+            dataRow={{
+              'issue.id': groupId,
+              issue: groupShortId,
+            }}
+            contextType={ContextType.ISSUE}
+            organization={organization}
+          >
+            <ViewIssueLink breadcrumb={crumb as Extract<Crumb, BreadcrumbTypeDefault>} />
+          </QuickContextHoverWrapper>
+        </Cell>
+      ),
+      () => (
+        <Cell {...columnProps} numeric>
+          <StyledTimestampButton
+            format="mm:ss.SSS"
+            onClick={() => {
+              onClickTimestamp(crumb);
+            }}
+            startTimestampMs={startTimestampMs}
+            timestampMs={crumb.timestamp || ''}
+          />
+        </Cell>
+      ),
+    ];
+
+    return renderFns[columnIndex]();
+  }
+);
+
+const cellBackground = p => {
+  if (p.hasOccurred === undefined && !p.isStatusError) {
+    const color = p.isHovered ? p.theme.hover : 'inherit';
+    return `background-color: ${color};`;
+  }
+  return `background-color: inherit;`;
+};
+
+const cellColor = p => {
+  return `color: ${p.hasOccurred !== false ? 'inherit' : p.theme.gray300};`;
+};
+
+const Cell = styled('div')<CellProps>`
+  display: flex;
+  gap: ${p => space(p.gap ?? 0)};
+  align-items: center;
+  font-size: ${p => p.theme.fontSizeSmall};
+  cursor: ${p => (p.onClick ? 'pointer' : 'inherit')};
+
+  ${cellBackground}
+  ${cellColor}
+
+  ${p =>
+    p.numeric &&
+    `
+    font-variant-numeric: tabular-nums;
+    justify-content: ${p.align ?? 'flex-end'};
+  `};
+`;
+
+const Text = styled('div')`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  padding: ${space(0.75)} ${space(1.5)};
+`;
+
+const AvatarWrapper = styled('div')`
+  align-self: center;
+`;
+
+const StyledTimestampButton = styled(TimestampButton)`
+  padding-inline: ${space(1.5)};
+`;
+
+export default ErrorTableCell;

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -76,19 +76,15 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
       [projects, projectSlug]
     );
 
-    // const eventUrl = {
-    //   pathname: `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/?referrer=replay-errors`,
-    // };
-
     const crumbTime = useMemo(
       // @ts-expect-error
-      () => relativeTimeInMs(crumb.timestamp * 1000, startTimestampMs),
+      () => relativeTimeInMs(new Date(crumb.timestamp).getTime(), startTimestampMs),
       [crumb.timestamp, startTimestampMs]
     );
     const hasOccurred = currentTime >= crumbTime;
     const isBeforeHover = currentHoverTime === undefined || currentHoverTime >= crumbTime;
 
-    const isByTimestamp = sortConfig.by === 'startTimestamp';
+    const isByTimestamp = sortConfig.by === 'timestamp';
     const isAsc = isByTimestamp ? sortConfig.asc : undefined;
     const columnProps = {
       className: classNames({

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -26,7 +26,6 @@ type Props = {
   currentTime: number;
   handleMouseEnter: (crumb: Crumb) => void;
   handleMouseLeave: (crumb: Crumb) => void;
-  onClickCell: (props: {dataIndex: number; rowIndex: number}) => void;
   onClickTimestamp: (crumb: Crumb) => void;
   rowIndex: number;
   sortConfig: ReturnType<typeof useSortErrors>['sortConfig'];
@@ -51,9 +50,7 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
       currentTime,
       handleMouseEnter,
       handleMouseLeave,
-      onClickCell,
       onClickTimestamp,
-      rowIndex,
       sortConfig,
       crumb,
       startTimestampMs,
@@ -61,9 +58,6 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
     }: Props,
     ref
   ) => {
-    // Rows include the sortable header, the dataIndex does not
-    const dataIndex = rowIndex - 1;
-
     const organization = useOrganization();
 
     // @ts-expect-error
@@ -123,7 +117,6 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
             : undefined,
       }),
       hasOccurred: isByTimestamp ? hasOccurred : undefined,
-      onClick: () => onClickCell({dataIndex, rowIndex}),
       onMouseEnter: () => handleMouseEnter(crumb),
       onMouseLeave: () => handleMouseLeave(crumb),
       ref,

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -7,14 +7,13 @@ import Link from 'sentry/components/links/link';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
-import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
+import type {Crumb} from 'sentry/types/breadcrumbs';
 import {getShortEventId} from 'sentry/utils/events';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
-import ViewIssueLink from 'sentry/views/replays/detail/console/viewIssueLink';
 import useSortErrors from 'sentry/views/replays/detail/errorList/useSortErrors';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
@@ -76,6 +75,18 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
       [projects, projectSlug]
     );
 
+    const issueUrl =
+      groupId && eventId
+        ? {
+            pathname: normalizeUrl(
+              `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/`
+            ),
+            query: {
+              referrer: 'replay-errors',
+            },
+          }
+        : null;
+
     const crumbTime = useMemo(
       // @ts-expect-error
       () => relativeTimeInMs(new Date(crumb.timestamp).getTime(), startTimestampMs),
@@ -130,18 +141,13 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
             contextType={ContextType.EVENT}
             organization={organization}
           >
-            <Link
-              to={{
-                pathname: normalizeUrl(
-                  `/organizations/${organization.slug}/issues/${groupId}/events/${eventId}/`
-                ),
-                query: {
-                  referrer: 'replay-errors',
-                },
-              }}
-            >
+            {issueUrl ? (
+              <Link to={issueUrl}>
+                <Text>{getShortEventId(eventId || '')}</Text>
+              </Link>
+            ) : (
               <Text>{getShortEventId(eventId || '')}</Text>
-            </Link>
+            )}
           </QuickContextHoverWrapper>
         </Cell>
       ),
@@ -165,7 +171,11 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
             contextType={ContextType.ISSUE}
             organization={organization}
           >
-            <ViewIssueLink breadcrumb={crumb as Extract<Crumb, BreadcrumbTypeDefault>} />
+            {issueUrl ? (
+              <Link to={issueUrl}>{groupShortId}</Link>
+            ) : (
+              <span>{groupShortId}</span>
+            )}
           </QuickContextHoverWrapper>
         </Cell>
       ),

--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useMemo, useRef} from 'react';
 import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
@@ -35,8 +35,6 @@ const cellMeasurer = {
 function ErrorList({errorCrumbs, startTimestampMs}: Props) {
   const {currentTime, currentHoverTime} = useReplayContext();
 
-  const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
-
   const filterProps = useErrorFilters({errorCrumbs: errorCrumbs || []});
   const {items: filteredItems, searchTerm, setSearchTerm} = filterProps;
   const clearSearchTerm = () => setSearchTerm('');
@@ -55,10 +53,6 @@ function ErrorList({errorCrumbs, startTimestampMs}: Props) {
       dynamicColumnIndex: 1,
       deps,
     });
-
-  const onClickCell = useCallback(({rowIndex}: {dataIndex: number; rowIndex: number}) => {
-    setScrollToRow(rowIndex);
-  }, []);
 
   const cellRenderer = ({columnIndex, rowIndex, key, style, parent}: GridCellProps) => {
     const error = items[rowIndex - 1];
@@ -94,7 +88,6 @@ function ErrorList({errorCrumbs, startTimestampMs}: Props) {
               handleMouseEnter={handleMouseEnter}
               handleMouseLeave={handleMouseLeave}
               onClickTimestamp={handleClick}
-              onClickCell={onClickCell}
               ref={e => e && registerChild?.(e)}
               rowIndex={rowIndex}
               sortConfig={sortConfig}
@@ -135,12 +128,6 @@ function ErrorList({errorCrumbs, startTimestampMs}: Props) {
                     </NoRowRenderer>
                   )}
                   onScrollbarPresenceChange={onScrollbarPresenceChange}
-                  onScroll={() => {
-                    if (scrollToRow !== undefined) {
-                      setScrollToRow(undefined);
-                    }
-                  }}
-                  scrollToRow={scrollToRow}
                   overscanColumnCount={COLUMN_COUNT}
                   overscanRowCount={5}
                   rowCount={items.length + 1}

--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -1,0 +1,208 @@
+import {useCallback, useMemo, useRef, useState} from 'react';
+import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
+import styled from '@emotion/styled';
+
+import Placeholder from 'sentry/components/placeholder';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {t} from 'sentry/locale';
+import type {Crumb} from 'sentry/types/breadcrumbs';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
+import ErrorFilters from 'sentry/views/replays/detail/errorList/errorFilters';
+import ErrorHeaderCell, {
+  COLUMN_COUNT,
+} from 'sentry/views/replays/detail/errorList/errorHeaderCell';
+import ErrorTableCell from 'sentry/views/replays/detail/errorList/errorTableCell';
+import useErrorFilters from 'sentry/views/replays/detail/errorList/useErrorFilters';
+import useSortErrors from 'sentry/views/replays/detail/errorList/useSortErrors';
+import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
+import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
+import useVirtualizedGrid from 'sentry/views/replays/detail/useVirtualizedGrid';
+
+const HEADER_HEIGHT = 25;
+const BODY_HEIGHT = 28;
+
+type Props = {
+  errorCrumbs: undefined | Crumb[];
+  startTimestampMs: number;
+};
+
+const cellMeasurer = {
+  defaultHeight: BODY_HEIGHT,
+  defaultWidth: 100,
+  fixedHeight: true,
+};
+
+function ErrorList({errorCrumbs, startTimestampMs}: Props) {
+  const {currentTime, currentHoverTime} = useReplayContext();
+
+  const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
+
+  const filterProps = useErrorFilters({errorCrumbs: errorCrumbs || []});
+  const {items: filteredItems, searchTerm, setSearchTerm} = filterProps;
+  const clearSearchTerm = () => setSearchTerm('');
+  const {handleSort, items, sortConfig} = useSortErrors({items: filteredItems});
+
+  const {handleMouseEnter, handleMouseLeave, handleClick} =
+    useCrumbHandlers(startTimestampMs);
+
+  const gridRef = useRef<MultiGrid>(null);
+  const deps = useMemo(() => [items, searchTerm], [items, searchTerm]);
+  const {cache, getColumnWidth, onScrollbarPresenceChange, onWrapperResize} =
+    useVirtualizedGrid({
+      cellMeasurer,
+      gridRef,
+      columnCount: COLUMN_COUNT,
+      dynamicColumnIndex: 1,
+      deps,
+    });
+
+  const onClickCell = useCallback(({rowIndex}: {dataIndex: number; rowIndex: number}) => {
+    setScrollToRow(rowIndex);
+  }, []);
+
+  const cellRenderer = ({columnIndex, rowIndex, key, style, parent}: GridCellProps) => {
+    const error = items[rowIndex - 1];
+
+    return (
+      <CellMeasurer
+        cache={cache}
+        columnIndex={columnIndex}
+        key={key}
+        parent={parent}
+        rowIndex={rowIndex}
+      >
+        {({
+          measure: _,
+          registerChild,
+        }: {
+          measure: () => void;
+          registerChild?: (element?: Element) => void;
+        }) =>
+          rowIndex === 0 ? (
+            <ErrorHeaderCell
+              ref={e => e && registerChild?.(e)}
+              handleSort={handleSort}
+              index={columnIndex}
+              sortConfig={sortConfig}
+              style={{...style, height: HEADER_HEIGHT}}
+            />
+          ) : (
+            <ErrorTableCell
+              columnIndex={columnIndex}
+              currentHoverTime={currentHoverTime}
+              currentTime={currentTime}
+              handleMouseEnter={handleMouseEnter}
+              handleMouseLeave={handleMouseLeave}
+              onClickTimestamp={handleClick}
+              onClickCell={onClickCell}
+              ref={e => e && registerChild?.(e)}
+              rowIndex={rowIndex}
+              sortConfig={sortConfig}
+              crumb={error}
+              startTimestampMs={startTimestampMs}
+              style={{...style, height: BODY_HEIGHT}}
+            />
+          )
+        }
+      </CellMeasurer>
+    );
+  };
+
+  return (
+    <FluidHeight>
+      <ErrorFilters errorCrumbs={errorCrumbs} {...filterProps} />
+      <ErrorTable>
+        {errorCrumbs ? (
+          <OverflowHidden>
+            <AutoSizer onResize={onWrapperResize}>
+              {({height, width}) => (
+                <MultiGrid
+                  ref={gridRef}
+                  cellRenderer={cellRenderer}
+                  columnCount={COLUMN_COUNT}
+                  columnWidth={getColumnWidth(width)}
+                  deferredMeasurementCache={cache}
+                  estimatedColumnSize={100}
+                  estimatedRowSize={BODY_HEIGHT}
+                  fixedRowCount={1}
+                  height={height}
+                  noContentRenderer={() => (
+                    <NoRowRenderer
+                      unfilteredItems={errorCrumbs}
+                      clearSearchTerm={clearSearchTerm}
+                    >
+                      {t('No errors! Go make some.')}
+                    </NoRowRenderer>
+                  )}
+                  onScrollbarPresenceChange={onScrollbarPresenceChange}
+                  onScroll={() => {
+                    if (scrollToRow !== undefined) {
+                      setScrollToRow(undefined);
+                    }
+                  }}
+                  scrollToRow={scrollToRow}
+                  overscanColumnCount={COLUMN_COUNT}
+                  overscanRowCount={5}
+                  rowCount={items.length + 1}
+                  rowHeight={({index}) => (index === 0 ? HEADER_HEIGHT : BODY_HEIGHT)}
+                  width={width}
+                />
+              )}
+            </AutoSizer>
+          </OverflowHidden>
+        ) : (
+          <Placeholder height="100%" />
+        )}
+      </ErrorTable>
+    </FluidHeight>
+  );
+}
+
+const OverflowHidden = styled('div')`
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const ErrorTable = styled(FluidHeight)`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+
+  .beforeHoverTime + .afterHoverTime:before {
+    border-top: 1px solid ${p => p.theme.purple200};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeHoverTime:last-child:before {
+    border-bottom: 1px solid ${p => p.theme.purple200};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime + .afterCurrentTime:before {
+    border-top: 1px solid ${p => p.theme.purple300};
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 999999999%;
+  }
+
+  .beforeCurrentTime:last-child:before {
+    border-bottom: 1px solid ${p => p.theme.purple300};
+    content: '';
+    right: 0;
+    position: absolute;
+    bottom: 0;
+    width: 999999999%;
+  }
+`;
+
+export default ErrorList;

--- a/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
+++ b/static/app/views/replays/detail/errorList/useErrorFilters.spec.tsx
@@ -1,0 +1,209 @@
+import {browserHistory} from 'react-router';
+import type {Location} from 'history';
+
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
+import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
+import type {Color} from 'sentry/utils/theme';
+import {useLocation} from 'sentry/utils/useLocation';
+
+import useNetworkFilters, {ErrorSelectOption, FilterFields} from './useErrorFilters';
+
+jest.mock('react-router');
+jest.mock('sentry/utils/useLocation');
+
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+const mockBrowserHistoryPush = browserHistory.push as jest.MockedFunction<
+  typeof browserHistory.push
+>;
+
+type DefaultCrumb = Extract<Crumb, BreadcrumbTypeDefault>;
+
+const ERROR_1_JS_RANGEERROR = {
+  type: BreadcrumbType.ERROR as const,
+  level: BreadcrumbLevelType.ERROR,
+  category: 'issue',
+  message: 'Invalid time value',
+  data: {
+    label: 'RangeError',
+    eventId: '415ecb5c85ac43b19f1886bb41ddab96',
+    groupId: 11,
+    groupShortId: 'JAVASCRIPT-RANGE',
+    project: 'javascript',
+  },
+  timestamp: '2023-06-09T12:00:00+00:00',
+  id: 360,
+  color: 'red300' as Color,
+  description: 'Error',
+};
+
+const ERROR_2_NEXTJS_TYPEERROR = {
+  type: BreadcrumbType.ERROR as const,
+  level: BreadcrumbLevelType.ERROR,
+  category: 'issue',
+  message: `undefined is not an object (evaluating 'e.apply').`,
+  data: {
+    label: 'TypeError',
+    eventId: 'ac43b19f1886bb41ddab96415ecb5c85',
+    groupId: 22,
+    groupShortId: 'NEXTJS-TYPE',
+    project: 'next-js',
+  },
+  timestamp: '2023-06-09T12:10:00+00:00',
+  id: 360,
+  color: 'red300' as Color,
+  description: 'Error',
+};
+
+const ERROR_3_JS_UNDEFINED = {
+  type: BreadcrumbType.ERROR as const,
+  level: BreadcrumbLevelType.ERROR,
+  category: 'issue',
+  message: 'Maximum update depth exceeded.',
+  data: {
+    label: 'Error',
+    eventId: '9f1886bb41ddab96415ecb5c85ac43b1',
+    groupId: 22,
+    groupShortId: 'JAVASCRIPT-UNDEF',
+    project: 'javascript',
+  },
+  timestamp: '2023-06-09T12:20:00+00:00',
+  id: 360,
+  color: 'red300' as Color,
+  description: 'Error',
+};
+
+describe('useErrorFilters', () => {
+  const errorCrumbs: DefaultCrumb[] = [
+    ERROR_1_JS_RANGEERROR,
+    ERROR_2_NEXTJS_TYPEERROR,
+    ERROR_3_JS_UNDEFINED,
+  ];
+
+  beforeEach(() => {
+    mockBrowserHistoryPush.mockReset();
+  });
+
+  it('should update the url when setters are called', () => {
+    const PROJECT_OPTION = {
+      value: 'resource.fetch',
+      label: 'resource.fetch',
+      qs: 'f_e_project',
+    } as ErrorSelectOption;
+    const SEARCH_FILTER = 'BadRequestError';
+
+    mockUseLocation
+      .mockReturnValueOnce({
+        pathname: '/',
+        query: {},
+      } as Location<FilterFields>)
+      .mockReturnValueOnce({
+        pathname: '/',
+        query: {f_e_project: [PROJECT_OPTION.value]},
+      } as Location<FilterFields>);
+
+    const {result, rerender} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {errorCrumbs},
+    });
+
+    result.current.setFilters([PROJECT_OPTION]);
+    expect(browserHistory.push).toHaveBeenLastCalledWith({
+      pathname: '/',
+      query: {
+        f_e_project: [PROJECT_OPTION.value],
+      },
+    });
+
+    rerender();
+
+    result.current.setSearchTerm(SEARCH_FILTER);
+    expect(browserHistory.push).toHaveBeenLastCalledWith({
+      pathname: '/',
+      query: {
+        f_e_project: [PROJECT_OPTION.value],
+        f_e_search: SEARCH_FILTER,
+      },
+    });
+  });
+
+  it('should not filter anything when no values are set', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/',
+      query: {},
+    } as Location<FilterFields>);
+
+    const {result} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {errorCrumbs},
+    });
+    expect(result.current.items).toHaveLength(3);
+  });
+
+  it('should filter by project', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/',
+      query: {
+        f_e_project: ['javascript'],
+      },
+    } as Location<FilterFields>);
+
+    const {result} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {errorCrumbs},
+    });
+    expect(result.current.items).toStrictEqual([
+      ERROR_1_JS_RANGEERROR,
+      ERROR_3_JS_UNDEFINED,
+    ]);
+  });
+
+  it('should filter by searchTerm', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/',
+      query: {
+        f_e_search: 'Maximum update depth',
+      },
+    } as Location<FilterFields>);
+
+    const {result} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {errorCrumbs},
+    });
+    expect(result.current.items).toHaveLength(1);
+  });
+});
+
+describe('getProjectOptions', () => {
+  it('should default to having nothing in the list of method types', () => {
+    const errorCrumbs = [];
+
+    const {result} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {errorCrumbs},
+    });
+
+    expect(result.current.getProjectOptions()).toStrictEqual([]);
+  });
+
+  it('should return a sorted list of project slugs', () => {
+    const errorCrumbs = [ERROR_2_NEXTJS_TYPEERROR, ERROR_3_JS_UNDEFINED];
+
+    const {result} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {errorCrumbs},
+    });
+
+    expect(result.current.getProjectOptions()).toStrictEqual([
+      {label: 'javascript', value: 'javascript', qs: 'f_e_project'},
+      {label: 'next-js', value: 'next-js', qs: 'f_e_project'},
+    ]);
+  });
+
+  it('should deduplicate BreadcrumbType', () => {
+    const errorCrumbs = [ERROR_1_JS_RANGEERROR, ERROR_3_JS_UNDEFINED];
+
+    const {result} = reactHooks.renderHook(useNetworkFilters, {
+      initialProps: {errorCrumbs},
+    });
+
+    expect(result.current.getProjectOptions()).toStrictEqual([
+      {label: 'javascript', value: 'javascript', qs: 'f_e_project'},
+    ]);
+  });
+});

--- a/static/app/views/replays/detail/errorList/useErrorFilters.tsx
+++ b/static/app/views/replays/detail/errorList/useErrorFilters.tsx
@@ -1,0 +1,108 @@
+import {useCallback, useMemo} from 'react';
+
+import type {SelectOption} from 'sentry/components/compactSelect';
+import type {Crumb} from 'sentry/types/breadcrumbs';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
+import {filterItems} from 'sentry/views/replays/detail/utils';
+
+export interface ErrorSelectOption extends SelectOption<string> {
+  qs: 'f_e_project';
+}
+
+const DEFAULT_FILTERS = {f_e_project: []} as Record<ErrorSelectOption['qs'], string[]>;
+
+export type FilterFields = {
+  f_e_project: string[];
+  f_e_search: string;
+};
+
+type Options = {
+  errorCrumbs: Crumb[];
+};
+
+type Return = {
+  getProjectOptions: () => ErrorSelectOption[];
+  items: Crumb[];
+  searchTerm: string;
+  selectValue: string[];
+  setFilters: (val: ErrorSelectOption[]) => void;
+  setSearchTerm: (searchTerm: string) => void;
+};
+
+const FILTERS = {
+  project: (item: Crumb, projects: string[]) =>
+    // @ts-expect-error
+    projects.length === 0 || projects.includes(item.data.project || ''),
+
+  searchTerm: (item: Crumb, searchTerm: string) =>
+    JSON.stringify([item.message, item.description]).toLowerCase().includes(searchTerm),
+};
+
+function useErrorFilters({errorCrumbs}: Options): Return {
+  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+
+  const project = decodeList(query.f_e_project);
+  const searchTerm = decodeScalar(query.f_e_search, '').toLowerCase();
+
+  const items = useMemo(
+    () =>
+      filterItems({
+        items: errorCrumbs,
+        filterFns: FILTERS,
+        filterVals: {project, searchTerm},
+      }),
+    [errorCrumbs, project, searchTerm]
+  );
+
+  const getProjectOptions = useCallback(
+    () =>
+      Array.from(
+        new Set(
+          errorCrumbs
+            // @ts-expect-error
+            .map(crumb => crumb.data.project)
+            .concat(project)
+        )
+      )
+        .filter(Boolean)
+        .sort()
+        .map(
+          (value): ErrorSelectOption => ({
+            value,
+            label: value,
+            qs: 'f_e_project',
+          })
+        ),
+    [errorCrumbs, project]
+  );
+
+  const setSearchTerm = useCallback(
+    (f_e_search: string) => setFilter({f_e_search: f_e_search || undefined}),
+    [setFilter]
+  );
+
+  const setFilters = useCallback(
+    (value: ErrorSelectOption[]) => {
+      const groupedValues = value.reduce((state, selection) => {
+        return {
+          ...state,
+          [selection.qs]: [...state[selection.qs], selection.value],
+        };
+      }, DEFAULT_FILTERS);
+      setFilter(groupedValues);
+    },
+    [setFilter]
+  );
+
+  return {
+    getProjectOptions,
+    items,
+    searchTerm,
+    selectValue: project,
+    setFilters,
+    setSearchTerm,
+  };
+}
+
+export default useErrorFilters;

--- a/static/app/views/replays/detail/errorList/useSortErrors.spec.tsx
+++ b/static/app/views/replays/detail/errorList/useSortErrors.spec.tsx
@@ -1,0 +1,197 @@
+import {act} from 'react-test-renderer';
+
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
+import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
+import type {Color} from 'sentry/utils/theme';
+
+import useSortErrors from './useSortErrors';
+
+jest.mock('react-router');
+jest.mock('sentry/utils/useUrlParams', () => {
+  const map = new Map();
+  return (name, dflt) => {
+    if (!map.has(name)) {
+      map.set(name, dflt);
+    }
+    return {
+      getParamValue: () => map.get(name),
+      setParamValue: value => {
+        map.set(name, value);
+      },
+    };
+  };
+});
+
+type DefaultCrumb = Extract<Crumb, BreadcrumbTypeDefault>;
+
+const ERROR_1_JS_RANGEERROR = {
+  type: BreadcrumbType.ERROR as const,
+  level: BreadcrumbLevelType.ERROR,
+  category: 'issue',
+  message: 'Invalid time value',
+  data: {
+    label: 'RangeError',
+    eventId: '415ecb5c85ac43b19f1886bb41ddab96',
+    groupId: 11,
+    groupShortId: 'JAVASCRIPT-RANGE',
+    project: 'javascript',
+  },
+  timestamp: '2023-06-09T12:00:00+00:00',
+  id: 360,
+  color: 'red300' as Color,
+  description: 'Error',
+};
+
+const ERROR_2_NEXTJS_TYPEERROR = {
+  type: BreadcrumbType.ERROR as const,
+  level: BreadcrumbLevelType.ERROR,
+  category: 'issue',
+  message: `undefined is not an object (evaluating 'e.apply').`,
+  data: {
+    label: 'TypeError',
+    eventId: 'ac43b19f1886bb41ddab96415ecb5c85',
+    groupId: 22,
+    groupShortId: 'NEXTJS-TYPE',
+    project: 'next-js',
+  },
+  timestamp: '2023-06-09T12:10:00+00:00',
+  id: 360,
+  color: 'red300' as Color,
+  description: 'Error',
+};
+
+const ERROR_3_JS_UNDEFINED = {
+  type: BreadcrumbType.ERROR as const,
+  level: BreadcrumbLevelType.ERROR,
+  category: 'issue',
+  message: 'Maximum update depth exceeded.',
+  data: {
+    label: 'Error',
+    eventId: '9f1886bb41ddab96415ecb5c85ac43b1',
+    groupId: 22,
+    groupShortId: 'JAVASCRIPT-UNDEF',
+    project: 'javascript',
+  },
+  timestamp: '2023-06-09T12:20:00+00:00',
+  id: 360,
+  color: 'red300' as Color,
+  description: 'Error',
+};
+
+describe('useSortErrors', () => {
+  const items: DefaultCrumb[] = [
+    ERROR_1_JS_RANGEERROR,
+    ERROR_3_JS_UNDEFINED,
+    ERROR_2_NEXTJS_TYPEERROR,
+  ];
+
+  it('should the list by timestamp by default', () => {
+    const {result} = reactHooks.renderHook(useSortErrors, {
+      initialProps: {items},
+    });
+
+    expect(result.current.sortConfig).toStrictEqual({
+      by: 'timestamp',
+      asc: true,
+      getValue: expect.any(Function),
+    });
+    expect(result.current.items).toStrictEqual([
+      ERROR_1_JS_RANGEERROR,
+      ERROR_2_NEXTJS_TYPEERROR,
+      ERROR_3_JS_UNDEFINED,
+    ]);
+  });
+
+  it('should reverse the sort order', () => {
+    const {result, rerender} = reactHooks.renderHook(useSortErrors, {
+      initialProps: {items},
+    });
+
+    act(() => {
+      result.current.handleSort('timestamp');
+    });
+
+    rerender({items});
+
+    expect(result.current.sortConfig).toStrictEqual({
+      by: 'timestamp',
+      asc: false,
+      getValue: expect.any(Function),
+    });
+    expect(result.current.items).toStrictEqual([
+      ERROR_3_JS_UNDEFINED,
+      ERROR_2_NEXTJS_TYPEERROR,
+      ERROR_1_JS_RANGEERROR,
+    ]);
+  });
+
+  it('should sort by the title field', () => {
+    const {result, rerender} = reactHooks.renderHook(useSortErrors, {
+      initialProps: {items},
+    });
+
+    act(() => {
+      result.current.handleSort('title');
+    });
+
+    rerender({items});
+
+    expect(result.current.sortConfig).toStrictEqual({
+      by: 'title',
+      asc: true,
+      getValue: expect.any(Function),
+    });
+    expect(result.current.items).toStrictEqual([
+      ERROR_1_JS_RANGEERROR,
+      ERROR_3_JS_UNDEFINED,
+      ERROR_2_NEXTJS_TYPEERROR,
+    ]);
+  });
+
+  it('should sort by project', () => {
+    const mixedItems = [
+      ERROR_3_JS_UNDEFINED,
+      ERROR_2_NEXTJS_TYPEERROR,
+      ERROR_1_JS_RANGEERROR,
+    ];
+    const {result, rerender} = reactHooks.renderHook(useSortErrors, {
+      initialProps: {items: mixedItems},
+    });
+
+    act(() => {
+      result.current.handleSort('project');
+    });
+
+    rerender({items: mixedItems});
+
+    expect(result.current.sortConfig).toStrictEqual({
+      by: 'project',
+      asc: true,
+      getValue: expect.any(Function),
+    });
+    expect(result.current.items).toStrictEqual([
+      ERROR_3_JS_UNDEFINED,
+      ERROR_1_JS_RANGEERROR,
+      ERROR_2_NEXTJS_TYPEERROR,
+    ]);
+
+    act(() => {
+      result.current.handleSort('project');
+    });
+
+    rerender({items: mixedItems});
+
+    expect(result.current.sortConfig).toStrictEqual({
+      by: 'project',
+      asc: false,
+      getValue: expect.any(Function),
+    });
+    expect(result.current.items).toStrictEqual([
+      ERROR_2_NEXTJS_TYPEERROR,
+      ERROR_3_JS_UNDEFINED,
+      ERROR_1_JS_RANGEERROR,
+    ]);
+  });
+});

--- a/static/app/views/replays/detail/errorList/useSortErrors.tsx
+++ b/static/app/views/replays/detail/errorList/useSortErrors.tsx
@@ -1,0 +1,98 @@
+import {useCallback, useMemo} from 'react';
+
+import type {Crumb} from 'sentry/types/breadcrumbs';
+import useUrlParams from 'sentry/utils/useUrlParams';
+
+interface SortConfig {
+  asc: boolean;
+  by: keyof Crumb | string;
+  getValue: (row: Crumb) => any;
+}
+
+const SortStrategies: Record<string, (row: Crumb) => any> = {
+  id: row => row.id,
+  title: row => row.description,
+  // @ts-expect-error
+  project: row => row.data?.project,
+  timestamp: row => row.timestamp,
+};
+
+const DEFAULT_ASC = 'true';
+const DEFAULT_BY = 'timestamp';
+
+type Opts = {items: Crumb[]};
+
+function useSortErrors({items}: Opts) {
+  const {getParamValue: getSortAsc, setParamValue: setSortAsc} = useUrlParams(
+    's_e_asc',
+    DEFAULT_ASC
+  );
+  const {getParamValue: getSortBy, setParamValue: setSortBy} = useUrlParams(
+    's_e_by',
+    DEFAULT_BY
+  );
+
+  const sortAsc = getSortAsc();
+  const sortBy = getSortBy();
+
+  const sortConfig = useMemo(
+    () =>
+      ({
+        asc: sortAsc === 'true',
+        by: sortBy,
+        getValue: SortStrategies[sortBy],
+      } as SortConfig),
+    [sortAsc, sortBy]
+  );
+
+  const sortedItems = useMemo(() => sortErrors(items, sortConfig), [items, sortConfig]);
+
+  const handleSort = useCallback(
+    (fieldName: keyof typeof SortStrategies) => {
+      if (sortConfig.by === fieldName) {
+        setSortAsc(sortConfig.asc ? 'false' : 'true');
+      } else {
+        setSortAsc('true');
+        setSortBy(fieldName);
+      }
+    },
+    [sortConfig, setSortAsc, setSortBy]
+  );
+
+  return {
+    handleSort,
+    items: sortedItems,
+    sortConfig,
+  };
+}
+
+function sortErrors(crumbs: Crumb[], sortConfig: SortConfig): Crumb[] {
+  return [...crumbs].sort((a, b) => {
+    let valueA = sortConfig.getValue(a);
+    let valueB = sortConfig.getValue(b);
+
+    valueA = typeof valueA === 'string' ? valueA.toUpperCase() : valueA;
+    valueB = typeof valueB === 'string' ? valueB.toUpperCase() : valueB;
+
+    // if the values are not defined, we want to push them to the bottom of the list
+    if (valueA === undefined) {
+      return 1;
+    }
+
+    if (valueB === undefined) {
+      return -1;
+    }
+
+    if (valueA === valueB) {
+      return 0;
+    }
+
+    if (sortConfig.asc) {
+      return valueA > valueB ? 1 : -1;
+    }
+
+    return valueB > valueA ? 1 : -1;
+  });
+}
+
+export default useSortErrors;

--- a/static/app/views/replays/detail/layout/focusArea.tsx
+++ b/static/app/views/replays/detail/layout/focusArea.tsx
@@ -4,6 +4,7 @@ import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveRe
 import useOrganization from 'sentry/utils/useOrganization';
 import Console from 'sentry/views/replays/detail/console';
 import DomMutations from 'sentry/views/replays/detail/domMutations';
+import ErrorList from 'sentry/views/replays/detail/errorList/index';
 import IssueList from 'sentry/views/replays/detail/issueList';
 import MemoryChart from 'sentry/views/replays/detail/memoryChart';
 import NetworkList from 'sentry/views/replays/detail/network';
@@ -37,6 +38,13 @@ function FocusArea({}: Props) {
         <IssueList
           replayId={replay.getReplay()?.id}
           projectId={replay.getReplay()?.project_id}
+        />
+      );
+    case TabKey.ERRORS:
+      return (
+        <ErrorList
+          errorCrumbs={replay?.getErrorCrumbs()}
+          startTimestampMs={replay?.getReplay()?.started_at?.getTime() || 0}
         />
       );
     case TabKey.DOM:

--- a/static/app/views/replays/detail/layout/focusArea.tsx
+++ b/static/app/views/replays/detail/layout/focusArea.tsx
@@ -73,18 +73,18 @@ function FocusArea({}: Props) {
         return (
           <Console
             breadcrumbs={replay?.getConsoleCrumbs()}
-            startTimestampMs={replay?.getReplay()?.started_at?.getTime() || 0}
+            startTimestampMs={replay?.getReplay().started_at.getTime() || 0}
           />
         );
       }
 
-      const breadcrumbs = !replay
-        ? undefined
-        : [...replay.getConsoleCrumbs(), ...replay.getIssueCrumbs()];
+      const breadcrumbs = replay
+        ? [...replay.getConsoleCrumbs(), ...replay.getIssueCrumbs()]
+        : undefined;
       return (
         <Console
           breadcrumbs={breadcrumbs}
-          startTimestampMs={replay?.getReplay()?.started_at?.getTime() || 0}
+          startTimestampMs={replay?.getReplay().started_at.getTime() || 0}
         />
       );
     }

--- a/static/app/views/replays/detail/layout/focusArea.tsx
+++ b/static/app/views/replays/detail/layout/focusArea.tsx
@@ -43,7 +43,7 @@ function FocusArea({}: Props) {
     case TabKey.ERRORS:
       return (
         <ErrorList
-          errorCrumbs={replay?.getErrorCrumbs()}
+          errorCrumbs={replay?.getIssueCrumbs()}
           startTimestampMs={replay?.getReplay()?.started_at?.getTime() || 0}
         />
       );
@@ -66,13 +66,28 @@ function FocusArea({}: Props) {
         />
       );
     case TabKey.CONSOLE:
-    default:
+    default: {
+      const hasErrorTab = organization.features.includes('session-replay-errors-tab');
+
+      if (hasErrorTab) {
+        return (
+          <Console
+            breadcrumbs={replay?.getConsoleCrumbs()}
+            startTimestampMs={replay?.getReplay()?.started_at?.getTime() || 0}
+          />
+        );
+      }
+
+      const breadcrumbs = !replay
+        ? undefined
+        : [...replay.getConsoleCrumbs(), ...replay.getIssueCrumbs()];
       return (
         <Console
-          breadcrumbs={replay?.getConsoleCrumbs()}
+          breadcrumbs={breadcrumbs}
           startTimestampMs={replay?.getReplay()?.started_at?.getTime() || 0}
         />
       );
+    }
   }
 }
 

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -15,20 +15,31 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
   const hasReplayNetworkDetails = organization.features.includes(
     'session-replay-network-details'
   );
+  const hasErrorTab = true || organization.features.includes('session-replay-errors-tab');
 
-  const networkLabel = hasReplayNetworkDetails ? (
+  const networkLabel =
+    !hasErrorTab && hasReplayNetworkDetails ? (
+      <Fragment>
+        {t('Network')} <FeatureBadge type="new" />
+      </Fragment>
+    ) : (
+      t('Network')
+    );
+
+  const errorLabel = hasErrorTab ? (
     <Fragment>
-      {t('Network')} <FeatureBadge type="new" />
+      {t('Errors')} <FeatureBadge type="new" />
     </Fragment>
   ) : (
-    t('Network')
+    t('Errors')
   );
 
   return {
     [TabKey.CONSOLE]: t('Console'),
     [TabKey.NETWORK]: networkLabel,
     [TabKey.DOM]: t('DOM Events'),
-    [TabKey.ISSUES]: t('Issues'),
+    [TabKey.ERRORS]: hasErrorTab ? errorLabel : null,
+    [TabKey.ISSUES]: hasErrorTab ? null : t('Issues'),
     [TabKey.MEMORY]: t('Memory'),
     [TabKey.TRACE]: t('Trace'),
   };
@@ -46,24 +57,26 @@ function FocusTabs({className}: Props) {
 
   return (
     <ScrollableTabs className={className} underlined>
-      {Object.entries(getReplayTabs(organization)).map(([tab, label]) => (
-        <ListLink
-          key={tab}
-          isActive={() => tab === activeTab}
-          to={`${pathname}?${queryString.stringify({...query, t_main: tab})}`}
-          onClick={e => {
-            e.preventDefault();
-            setActiveTab(tab);
+      {Object.entries(getReplayTabs(organization)).map(([tab, label]) =>
+        label ? (
+          <ListLink
+            key={tab}
+            isActive={() => tab === activeTab}
+            to={`${pathname}?${queryString.stringify({...query, t_main: tab})}`}
+            onClick={e => {
+              e.preventDefault();
+              setActiveTab(tab);
 
-            trackAnalytics('replay.details-tab-changed', {
-              tab,
-              organization,
-            });
-          }}
-        >
-          {label}
-        </ListLink>
-      ))}
+              trackAnalytics('replay.details-tab-changed', {
+                tab,
+                organization,
+              });
+            }}
+          >
+            {label}
+          </ListLink>
+        ) : null
+      )}
     </ScrollableTabs>
   );
 }

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -15,7 +15,7 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
   const hasReplayNetworkDetails = organization.features.includes(
     'session-replay-network-details'
   );
-  const hasErrorTab = true || organization.features.includes('session-replay-errors-tab');
+  const hasErrorTab = organization.features.includes('session-replay-errors-tab');
 
   const networkLabel =
     !hasErrorTab && hasReplayNetworkDetails ? (

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -14,6 +14,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import type {ReplayError, ReplayRecord} from 'sentry/views/replays/types';
 
@@ -24,17 +25,28 @@ type Props = {
 
 function ReplayMetaData({replayRecord, replayErrors}: Props) {
   const {pathname, query} = useLocation();
+  const organization = useOrganization();
   const {projects} = useProjects();
 
-  const errorsTabHref = {
-    pathname,
-    query: {
-      ...query,
-      t_main: 'console',
-      f_c_logLevel: 'issue',
-      f_c_search: undefined,
-    },
-  };
+  const hasErrorTab = organization.features.includes('session-replay-errors-tab');
+
+  const errorsTabHref = hasErrorTab
+    ? {
+        pathname,
+        query: {
+          ...query,
+          t_main: 'errors',
+        },
+      }
+    : {
+        pathname,
+        query: {
+          ...query,
+          t_main: 'console',
+          f_c_logLevel: 'issue',
+          f_c_search: undefined,
+        },
+      };
 
   const errorCountByProject = useMemo(
     () =>


### PR DESCRIPTION
New Errors tab, replaces Issues

<img width="736" alt="SCR-20230609-oakw" src="https://github.com/getsentry/sentry/assets/187460/9faf76f5-8c44-495b-9321-2a7231467565">

Per figma design: https://www.figma.com/file/VJffxPWvRaaRJ1gywzuUre/Specs%3A-Connecting-Backend-Errors?type=design&node-id=422-25593&t=ItjQdTp713gEnnYn-0

There are tooltips as well:
| Title | Issue Id | 
| --- | --- |
| <img width="645" alt="SCR-20230613-hwez" src="https://github.com/getsentry/sentry/assets/187460/bc41c9e9-f946-47d2-ab56-798e2e755a99"> | <img width="741" alt="SCR-20230609-oaql" src="https://github.com/getsentry/sentry/assets/187460/48f6cbb0-3b1a-4949-8ad5-7cf8659858c0"> |


Fixes https://github.com/getsentry/sentry/issues/50306