### PR TITLE
CI: Switch to fork to support node 16

### DIFF
--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -24,13 +24,13 @@ jobs:
           filters: .github/file-filters.yml
 
       - name: Add frontend label
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
+        uses: getsentry/action-add-labels@54d0cba498c1eaf8bd34985d715504d1b6e2935f
         if: steps.changes.outputs.frontend_src == 'true'
         with:
           labels: 'Scope: Frontend'
 
       - name: Add backend label
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
+        uses: getsentry/action-add-labels@54d0cba498c1eaf8bd34985d715504d1b6e2935f
         if: steps.changes.outputs.backend_src == 'true'
         with:
           labels: 'Scope: Backend'


### PR DESCRIPTION
Switching to a [forked version](https://github.com/getsentry/action-add-labels/commit/54d0cba498c1eaf8bd34985d715504d1b6e2935f) of the action-add-labels as the author of the upstream project doesn't seem responsive on updating to Node 16. This is important as Node 12 is deprecated and the use of Node 16 will be enforced as of June 14th (https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/)
