### PR TITLE
CI: Update peter-evans actions

### DIFF
--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -36,7 +36,7 @@ jobs:
           labels: 'Scope: Backend'
 
       - name: Find previous frontend/backend warning comment
-        uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -47,7 +47,7 @@ jobs:
           result-encoding: string
 
       - name: Find previous dry-run comment
-        uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
         if: github.event_name == 'pull_request'
         id: fc
         with:


### PR DESCRIPTION
Updating to v2 of [peter-evans/find-comment](https://github.com/peter-evans/find-comment) in order to address some lingering deprecation warnings.