### PR TITLE
feat(api): Return 404 from internal Relay endpoint

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -36,3 +36,8 @@ def crossdomain_xml(request, project_id):
     response["Content-Type"] = "application/xml"
 
     return response
+
+
+@cache_control(max_age=3600, public=True)
+def not_found(request):
+    return HttpResponse(status=404)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -101,6 +101,12 @@ urlpatterns += [
         api.ClientConfigView.as_view(),
         name="sentry-api-client-config",
     ),
+    # Forbidden Relay endpoint
+    url(
+        r"^api/relay/.*$",
+        api.not_found,
+        name="sentry-api-internal-relay",
+    ),
     # We do not want to have webpack assets served under a versioned URL, as these assets have
     # a filecontent-based hash in its filenames so that it can be cached long term
     url(


### PR DESCRIPTION
Sentry routes a number of endpoints to Relay. This does not include an internal
endpoint at `/api/relay/*`, which is meant to inspect Relay itself. Such an
endpoint is useful for operating Relay, but does not belong to the public API of
Sentry.

In Sentry's web API, this path falls back to a catch-all endpoint, which
redirects to a login view. This is undesirable for the Relay endpoint,
especially if someone tries to access `/api/relay/healthcheck/live/` and
receives a redirect response.

This PR ensures we respond with 404 on all paths that are assigned to Relay.

