### PR TITLE
feat(spans): Add span metrics in new namespace

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -150,9 +150,14 @@ SHARED_TAG_STRINGS = {
 
 # 400-499
 SPAN_METRICS_NAMES = {
+    # Deprecated -- transactions namespace
     "s:transactions/span.user@none": PREFIX + 400,
     "d:transactions/span.duration@millisecond": PREFIX + 401,
     "d:transactions/span.exclusive_time@millisecond": PREFIX + 402,
+    # Spans namespace
+    "s:spans/user@none": PREFIX + 403,
+    "d:spans/duration@millisecond": PREFIX + 404,
+    "d:spans/exclusive_time@millisecond": PREFIX + 405,
 }
 
 SHARED_STRINGS = {


### PR DESCRIPTION
Now that the new spans namespace is available, we're moving the span metrics from the transactions namespace to the spans namespace.

The namespace is registered [here](https://github.com/getsentry/sentry/blob/28505c0a1d8139d53e6a00749b1da109b519cf74/src/sentry/sentry_metrics/use_case_id_registry.py#L10).