### PR TITLE
chore(hybridcloud) Bump control file migration rate

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3439,7 +3439,7 @@ MAX_ENVIRONMENTS_PER_MONITOR = 1000
 # tests)
 SENTRY_METRICS_INDEXER_RAISE_VALIDATION_ERRORS = False
 
-SENTRY_FILE_COPY_ROLLOUT_RATE = 0.1
+SENTRY_FILE_COPY_ROLLOUT_RATE = 0.3
 
 # The Redis cluster to use for monitoring the health of
 # Celery queues.


### PR DESCRIPTION
At 10% we're making progress but it is slow. 3x rate should help speed up the migration process without creating noticeable load.
