### PR TITLE
CI: Update enforce license compliance action

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Enforce License Compliance'
-        uses: getsentry/action-enforce-license-compliance@6599a041195852debba3417e069829060d671e76  # main
+        uses: getsentry/action-enforce-license-compliance@520fb640b532c27b4da9644116d102b579ef84f5  # main
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Updating the SHA of the compliance action to a version the uses checkout v3 (rather than v2) in order to move away from node 12 prior to [GitHub's enforcement on June 14th](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/).
https://github.com/getsentry/action-enforce-license-compliance/pull/18