### PR TITLE
ref(Options): Add spans cardinality rate limit option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1043,6 +1043,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "sentry-metrics.cardinality-limiter.limits.spans.per-org",
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org",
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/sentry_metrics/use_case_id_registry.py
+++ b/src/sentry/sentry_metrics/use_case_id_registry.py
@@ -30,6 +30,7 @@ REVERSE_METRIC_PATH_MAPPING: Mapping[UseCaseKey, UseCaseID] = {
 USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS = {
     UseCaseID.TRANSACTIONS: "sentry-metrics.cardinality-limiter.limits.performance.per-org",
     UseCaseID.SESSIONS: "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
+    UseCaseID.SPANS: "sentry-metrics.cardinality-limiter.limits.spans.per-org",
 }
 
 USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS = {


### PR DESCRIPTION
Add `sentry-metrics.cardinality-limiter.limits.spans.per-org` as the cardinality rate limit option for spans