### PR TITLE
feat(github-comments): comment bot org option toggle frontend

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -17,6 +17,7 @@ export interface OrganizationSummary {
   codecovAccess: boolean;
   dateCreated: string;
   features: string[];
+  githubPRBot: boolean;
   id: string;
   isEarlyAdopter: boolean;
   links: {

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -38,6 +38,13 @@ describe('OrganizationGeneralSettings', function () {
       url: `/organizations/${organization.slug}/auth-provider/`,
       method: 'GET',
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/?provider_key=github`,
+      method: 'GET',
+      body: {
+        providers: [{canAdd: true}],
+      },
+    });
   });
 
   it('can enable "early adopter"', async function () {

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.jsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.jsx
@@ -17,6 +17,13 @@ describe('OrganizationSettingsForm', function () {
       url: `/organizations/${organization.slug}/auth-provider/`,
       method: 'GET',
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/?provider_key=github`,
+      method: 'GET',
+      body: {
+        providers: [{canAdd: true}],
+      },
+    });
     onSave.mockReset();
   });
 
@@ -160,5 +167,27 @@ describe('OrganizationSettingsForm', function () {
         },
       })
     );
+  });
+
+  it('enable PR bot is disabled without GitHub integration', function () {
+    render(
+      <OrganizationSettingsForm
+        location={TestStubs.location()}
+        orgId={organization.slug}
+        access={new Set(['org:write'])}
+        initialData={TestStubs.Organization()}
+        onSave={onSave}
+      />,
+      {
+        organization: {
+          ...organization,
+          features: ['pr-comment-bot'],
+        },
+      }
+    );
+
+    expect(
+      screen.getByRole('checkbox', {name: /Enable Pull Request Bot/})
+    ).toBeDisabled();
   });
 });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -100,6 +100,15 @@ class OrganizationSettingsForm extends AsyncComponent<Props, State> {
           </PoweredByCodecov>
         ),
       },
+      {
+        name: 'githubPRBot',
+        type: 'boolean',
+        label: t('Github Pull Request Bot'),
+        visible: ({features}) => features.has('pr-comment-bot'),
+        help: t(
+          "Allow Sentry to comment on pull requests about relevant issues impacting your app's performance."
+        ),
+      },
     ];
 
     return (

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -125,7 +125,7 @@ class OrganizationSettingsForm extends AsyncComponent<Props, State> {
             </Link>
           </Fragment>
         ),
-        disabled: hasGithubIntegration,
+        disabled: !hasGithubIntegration,
         disabledReason: (
           <Fragment>
             {t('You must have a GitHub integration to enable this feature.')}

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -13,12 +14,13 @@ import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {Hovercard} from 'sentry/components/hovercard';
+import Link from 'sentry/components/links/link';
 import Tag from 'sentry/components/tag';
 import organizationSettingsFields from 'sentry/data/forms/organizationGeneralSettings';
 import {IconCodecov, IconLock} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Organization, Scope} from 'sentry/types';
+import {IntegrationProvider, Organization, Scope} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
 
 const HookCodecovSettingsLink = HookOrDefault({
@@ -35,18 +37,26 @@ type Props = {
 
 type State = AsyncComponent['state'] & {
   authProvider: object;
+  githubIntegration: {providers: IntegrationProvider[]};
 };
 
 class OrganizationSettingsForm extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {organization} = this.props;
-    return [['authProvider', `/organizations/${organization.slug}/auth-provider/`]];
+    return [
+      ['authProvider', `/organizations/${organization.slug}/auth-provider/`],
+      [
+        'githubIntegration',
+        `/organizations/${organization.slug}/config/integrations/?provider_key=github`,
+      ],
+    ];
   }
 
   render() {
     const {initialData, organization, onSave, access} = this.props;
-    const {authProvider} = this.state;
+    const {authProvider, githubIntegration} = this.state;
     const endpoint = `/organizations/${organization.slug}/`;
+    const hasGithubIntegration = !githubIntegration?.providers[0].canAdd;
 
     const jsonFormSettings = {
       additionalFieldProps: {hasSsoEnabled: !!authProvider},
@@ -103,10 +113,23 @@ class OrganizationSettingsForm extends AsyncComponent<Props, State> {
       {
         name: 'githubPRBot',
         type: 'boolean',
-        label: t('Github Pull Request Bot'),
+        label: t('Enable Pull Request Bot'),
         visible: ({features}) => features.has('pr-comment-bot'),
-        help: t(
-          "Allow Sentry to comment on pull requests about relevant issues impacting your app's performance."
+        help: (
+          <Fragment>
+            {t(
+              "Allow Sentry to comment on pull requests about relevant issues impacting your app's performance."
+            )}{' '}
+            <Link to={`/settings/${organization.slug}/integrations/github`}>
+              {t('Configure GitHub integration')}
+            </Link>
+          </Fragment>
+        ),
+        disabled: hasGithubIntegration,
+        disabledReason: (
+          <Fragment>
+            {t('You must have a GitHub integration to enable this feature.')}
+          </Fragment>
         ),
       },
     ];


### PR DESCRIPTION
Disabled for orgs without GitHub integration
<img width="583" alt="Screenshot 2023-06-28 at 16 00 38" src="https://github.com/getsentry/sentry/assets/70817427/3a2b115e-07d0-4f71-83cc-52773a68a6e2">

Enable-able for orgs with GitHub integration
<img width="583" alt="Screenshot 2023-06-28 at 16 00 52" src="https://github.com/getsentry/sentry/assets/70817427/2ffc1539-7588-4f21-be1b-cf0a192df5e9">


For ER-1589