### PR TITLE
fix(hc): sentry_app.api_application_id can be None, outboxes should work

### DIFF
--- a/src/sentry/models/integrations/sentry_app_installation.py
+++ b/src/sentry/models/integrations/sentry_app_installation.py
@@ -175,20 +175,20 @@ class SentryAppInstallation(ParanoidModel):
             for outbox in self.outboxes_for_update(
                 identifier=self.id,
                 org_id=self.organization_id,
-                api_application_id=self.api_application_id,
+                # In the case of a bad relation, it's ok to just replicate this in a special ordering.
+                api_application_id=self.api_application_id or 0,
             ):
                 outbox.save()
             return super().delete(**kwargs)
 
     @property
-    def api_application_id(self) -> int:
+    def api_application_id(self) -> int | None:
         from sentry.models import SentryApp
 
         try:
             return self.sentry_app.application_id
         except SentryApp.DoesNotExist:
-            # In the case of a bad relation, it's ok to just replicate this in a special ordering.
-            return 0
+            return None
 
     @classmethod
     def outboxes_for_update(


### PR DESCRIPTION
SentryApp's relation to ApiApplication can be set null on cascaded deletion.  I suppose also it's possible for the api application underlying SentryApp to change in some cases (which seems weird!)

That said, we order sentry app's outboxes based on the api application to ensure application level consistency.  In the case that we do have a null here, though, it is correct and fine to order then by `0` which will never be a real identifier.