### PR TITLE
chore(starfish): Remove references to starfish endpoint

### DIFF
--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -56,7 +56,6 @@ type State = {
   dashboards: DashboardListItem[] | null;
   dashboardsPageLinks: string;
   showTemplates: boolean;
-  starfishResult?: null;
 } & AsyncView['state'];
 
 class ManageDashboards extends AsyncView<Props, State> {
@@ -82,13 +81,6 @@ class ManageDashboards extends AsyncView<Props, State> {
         },
       ],
     ];
-    if (organization.features.includes('starfish-test-endpoint')) {
-      endpoints.push([
-        'starfishResult',
-        `/organizations/${organization.slug}/events-starfish/`,
-        {query: {statsPeriod: '7d'}},
-      ]);
-    }
     return endpoints;
   }
 

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -6,7 +6,6 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {
   getDatetimeFromState,
-  normalizeDateTimeParams,
   normalizeDateTimeString,
 } from 'sentry/components/organizations/pageFilters/parse';
 import {getPageFilterStorage} from 'sentry/components/organizations/pageFilters/persistence';
@@ -83,25 +82,13 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
   }
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization, selection} = this.props;
-    const {projects, environments, datetime} = selection;
-    const commonQuery = {
-      environment: environments,
-      project: projects.map(proj => String(proj)),
-    };
+    const {organization} = this.props;
 
     const endpoints: ReturnType<AsyncComponent['getEndpoints']> = [];
     if (organization.features.includes('discover-query')) {
       endpoints.push([
         'savedQuery',
         `/organizations/${organization.slug}/discover/homepage/`,
-      ]);
-    }
-    if (organization.features.includes('starfish-test-endpoint')) {
-      endpoints.push([
-        'starfishResult',
-        `/organizations/${organization.slug}/events-starfish/`,
-        {query: {...commonQuery, ...normalizeDateTimeParams(datetime)}},
       ]);
     }
     return endpoints;

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -18,9 +18,7 @@ import {useTheme} from '@emotion/react';
 
 import {t} from 'sentry/locale';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import withApi from 'sentry/utils/withApi';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
@@ -47,26 +45,6 @@ export function StarfishView(props: BasePerformanceViewProps) {
   const theme = useTheme();
   const [selectedSpike, setSelectedSpike] = useState<FailureSpike>(null);
   const router = useRouter();
-
-  const pageFilters = usePageFilters();
-  const {selection} = pageFilters;
-  const {projects, environments} = selection;
-
-  useApiQuery<null>(
-    [
-      `/organizations/${organization.slug}/events-starfish/`,
-      {
-        query: {
-          environment: environments,
-          project: projects.map(proj => String(proj)),
-          statsPeriod: '7d',
-        },
-      },
-    ],
-    {
-      staleTime: 10,
-    }
-  );
 
   function renderFailureRateChart() {
     const query = new MutableSearch(['event.type:transaction']);


### PR DESCRIPTION
We've switched over to prod data and don't need this anymore