### PR TITLE
chore(hybridcloud) Disable beacon tasks in multi-region mode

### DIFF
--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -12,6 +12,7 @@ from sentry import tsdb
 from sentry.debug.utils.packages import get_all_package_versions
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.locks import locks
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
 
@@ -39,6 +40,9 @@ def should_skip_beacon(install_id):
 
     if settings.DEBUG:
         logger.info("beacon.skipped", extra={"install_id": install_id, "reason": "debug"})
+        return True
+
+    if SiloMode.get_current_mode() != SiloMode.MONOLITH:
         return True
 
     return False

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -9,9 +9,11 @@ from sentry import options
 from sentry.models import Broadcast
 from sentry.tasks.beacon import BEACON_URL, send_beacon, send_beacon_metric
 from sentry.testutils import TestCase
+from sentry.testutils.silo import no_silo_test
 from sentry.utils import json
 
 
+@no_silo_test(stable=True)
 class SendBeaconTest(TestCase):
     @patch("sentry.tasks.beacon.get_all_package_versions")
     @patch("sentry.tasks.beacon.safe_urlopen")


### PR DESCRIPTION
Disable beacon data collection in multi-region deployments. We have no plans to support multi-region deployments with self-hosted, so we don't need to collect beacon data unless we're in monolith mode.

Not collecting beacon data in multi-region mode means that we don't have to introduce and maintain more RPC methods.

Refs HC-774
