### PR TITLE
ref(sort): Change default better priority values

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -225,9 +225,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 assert "environment" not in extra_query_kwargs
                 query_kwargs.update(extra_query_kwargs)
 
-            if query_kwargs["sort_by"] == "betterPriority":
-                query_kwargs["aggregate_kwargs"] = self.build_better_priority_sort_kwargs(request)
-
             query_kwargs["environments"] = environments if environments else None
 
             query_kwargs["actor"] = request.user

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -40,7 +40,6 @@ from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import (
     DEFAULT_PRIORITY_WEIGHTS,
-    V2_DEFAULT_PRIORITY_WEIGHTS,
     PrioritySortWeights,
     get_search_filter,
 )
@@ -185,56 +184,35 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
             return func(val) if val is not None else default
 
-        if _coerce(request.GET.get("v2"), bool, False):
-            return {
-                "better_priority": {
-                    "log_level": _coerce(
-                        request.GET.get("logLevel"), int, V2_DEFAULT_PRIORITY_WEIGHTS["log_level"]
-                    ),
-                    "has_stacktrace": _coerce(
-                        request.GET.get("hasStacktrace"),
-                        int,
-                        V2_DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
-                    ),
-                    "relative_volume": _coerce(
-                        request.GET.get("relativeVolume"),
-                        int,
-                        V2_DEFAULT_PRIORITY_WEIGHTS["relative_volume"],
-                    ),
-                    "event_halflife_hours": _coerce(
-                        request.GET.get("eventHalflifeHours"),
-                        int,
-                        V2_DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"],
-                    ),
-                    "issue_halflife_hours": _coerce(
-                        request.GET.get("issueHalflifeHours"),
-                        int,
-                        V2_DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"],
-                    ),
-                    "v2": True,
-                    "norm": _coerce(
-                        request.GET.get("norm"), bool, V2_DEFAULT_PRIORITY_WEIGHTS["norm"]
-                    ),
-                }
+        return {
+            "better_priority": {
+                "log_level": _coerce(
+                    request.GET.get("logLevel"), int, DEFAULT_PRIORITY_WEIGHTS["log_level"]
+                ),
+                "has_stacktrace": _coerce(
+                    request.GET.get("hasStacktrace"),
+                    int,
+                    DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
+                ),
+                "relative_volume": _coerce(
+                    request.GET.get("relativeVolume"),
+                    int,
+                    DEFAULT_PRIORITY_WEIGHTS["relative_volume"],
+                ),
+                "event_halflife_hours": _coerce(
+                    request.GET.get("eventHalflifeHours"),
+                    int,
+                    DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"],
+                ),
+                "issue_halflife_hours": _coerce(
+                    request.GET.get("issueHalflifeHours"),
+                    int,
+                    DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"],
+                ),
+                "v2": _coerce(request.GET.get("v2"), bool, DEFAULT_PRIORITY_WEIGHTS["v2"]),
+                "norm": _coerce(request.GET.get("norm"), bool, DEFAULT_PRIORITY_WEIGHTS["norm"]),
             }
-        else:
-            return {
-                "better_priority": {
-                    "log_level": _coerce(
-                        request.GET.get("logLevel"), int, DEFAULT_PRIORITY_WEIGHTS["log_level"]
-                    ),
-                    "has_stacktrace": _coerce(
-                        request.GET.get("hasStacktrace"),
-                        int,
-                        DEFAULT_PRIORITY_WEIGHTS["has_stacktrace"],
-                    ),
-                    "relative_volume": DEFAULT_PRIORITY_WEIGHTS["relative_volume"],
-                    "event_halflife_hours": DEFAULT_PRIORITY_WEIGHTS["event_halflife_hours"],
-                    "issue_halflife_hours": DEFAULT_PRIORITY_WEIGHTS["issue_halflife_hours"],
-                    "v2": False,
-                    "norm": False,
-                }
-            }
+        }
 
     def _search(
         self, request: Request, organization, projects, environments, extra_query_kwargs=None

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -225,6 +225,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 assert "environment" not in extra_query_kwargs
                 query_kwargs.update(extra_query_kwargs)
 
+            if query_kwargs["sort_by"] == "betterPriority":
+                query_kwargs["aggregate_kwargs"] = self.build_better_priority_sort_kwargs(request)
+
             query_kwargs["environments"] = environments if environments else None
 
             query_kwargs["actor"] = request.user

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -66,7 +66,7 @@ class PrioritySortWeights(TypedDict):
 DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
     "log_level": 0,
     "has_stacktrace": 0,
-    "relative_volume": 0,
+    "relative_volume": 1,
     "event_halflife_hours": 4,
     "issue_halflife_hours": 72,
     "v2": True,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -68,18 +68,8 @@ DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
     "has_stacktrace": 0,
     "relative_volume": 0,
     "event_halflife_hours": 4,
-    "issue_halflife_hours": 24 * 7,
-    "v2": False,
-    "norm": False,
-}
-
-V2_DEFAULT_PRIORITY_WEIGHTS: PrioritySortWeights = {
-    "log_level": 0,
-    "has_stacktrace": 0,
-    "relative_volume": 1,
-    "event_halflife_hours": 12,
-    "issue_halflife_hours": 4,
-    "v2": False,
+    "issue_halflife_hours": 72,
+    "v2": True,
     "norm": False,
 }
 


### PR DESCRIPTION
Change the default values so that when I merge [the PR to set the default sort to better priority for EA orgs](https://github.com/getsentry/sentry/pull/50541) we're using values that more closely match what we're testing.