### PR TITLE
chore(grouping): Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -415,10 +415,12 @@ yarn.lock                                                @getsentry/owners-js-de
 
 ## Issues
 /src/sentry/event_manager.py                        @getsentry/issues
+/src/sentry/grouping/                               @getsentry/issues
 /src/sentry/issues/                                 @getsentry/issues
 /src/sentry/tasks/post_process.py                   @getsentry/issues
 /src/sentry/types/issues.py                         @getsentry/issues
 /tests/sentry/event_manager/test_event_manager.py   @getsentry/issues
+/tests/sentry/grouping/                             @getsentry/issues
 /tests/sentry/issues/                               @getsentry/issues
 /tests/sentry/search/                               @getsentry/issues
 /tests/sentry/tasks/test_post_process.py            @getsentry/issues


### PR DESCRIPTION
The Issues team is going to own grouping from a users' perspective and work with other teams as need be.