### PR TITLE
feat(starfish): fix formatting time spent cell

### DIFF
--- a/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/starfish/components/tableCells/timeSpentCell.tsx
@@ -1,18 +1,20 @@
 import {Tooltip} from 'sentry/components/tooltip';
+import {formatPercentage} from 'sentry/utils/formatters';
 import {getTooltip} from 'sentry/views/starfish/views/spans/types';
 
 export function TimeSpentCell({
-  formattedTimeSpent,
+  timeSpentPercentage,
   totalSpanTime,
 }: {
-  formattedTimeSpent: string;
+  timeSpentPercentage: number;
   totalSpanTime: number;
 }) {
   const toolTip = getTooltip('timeSpent', totalSpanTime);
+  const percentage = timeSpentPercentage > 1 ? 1 : timeSpentPercentage;
   return (
     <span>
       <Tooltip isHoverable title={toolTip}>
-        {formattedTimeSpent}
+        {formatPercentage(percentage)}
       </Tooltip>
     </span>
   );

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -8,7 +8,6 @@ import {Panel, PanelBody} from 'sentry/components/panels';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {formatPercentage} from 'sentry/utils/formatters';
 import {
   PageErrorAlert,
   PageErrorProvider,
@@ -98,9 +97,7 @@ function SpanSummaryPage({params, location}: Props) {
                   )}
                 >
                   <TimeSpentCell
-                    formattedTimeSpent={formatPercentage(
-                      spanMetrics?.['time_spent_percentage()']
-                    )}
+                    timeSpentPercentage={spanMetrics?.['time_spent_percentage()']}
                     totalSpanTime={spanMetrics?.['sum(span.duration)']}
                   />
                 </Block>

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -1,4 +1,3 @@
-import {formatPercentage} from 'sentry/utils/formatters';
 import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
@@ -31,9 +30,7 @@ function SampleInfo(props: Props) {
       </Block>
       <Block title={DataTitles.timeSpent}>
         <TimeSpentCell
-          formattedTimeSpent={formatPercentage(
-            spanMetrics?.['time_spent_percentage(local)']
-          )}
+          timeSpentPercentage={spanMetrics?.['time_spent_percentage(local)']}
           totalSpanTime={spanMetrics?.['sum(span.duration)']}
         />
       </Block>

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -7,7 +7,6 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import Truncate from 'sentry/components/truncate';
-import {formatPercentage} from 'sentry/utils/formatters';
 import {useLocation} from 'sentry/utils/useLocation';
 import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
 import ThroughputCell from 'sentry/views/starfish/components/tableCells/throughputCell';
@@ -112,9 +111,7 @@ function BodyCell({span, column, row, openSidebar, onClickTransactionName}: Cell
   if (column.key === 'time_spent_percentage(local)') {
     return (
       <TimeSpentCell
-        formattedTimeSpent={formatPercentage(
-          row.metrics?.['time_spent_percentage(local)']
-        )}
+        timeSpentPercentage={row.metrics?.['time_spent_percentage(local)']}
         totalSpanTime={row.metrics?.['sum(span.duration)']}
       />
     );

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -6,7 +6,6 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
-import {formatPercentage} from 'sentry/utils/formatters';
 import {useLocation} from 'sentry/utils/useLocation';
 import {TableColumnSort} from 'sentry/views/discover/table/types';
 import DurationCell from 'sentry/views/starfish/components/tableCells/durationCell';
@@ -116,7 +115,7 @@ function renderBodyCell(column: TableColumnHeader, row: SpanDataRow): React.Reac
   if (column.key === 'time_spent_percentage()') {
     return (
       <TimeSpentCell
-        formattedTimeSpent={formatPercentage(row['time_spent_percentage()'])}
+        timeSpentPercentage={row['time_spent_percentage()']}
         totalSpanTime={row['sum(span.duration)']}
       />
     );


### PR DESCRIPTION
Two changes made to help provide consistency.
1. This PR ensure time spent is always <=100%. There's some weird rounding error where time spent can be >100%.
2. This PR moves the percentage formatting into the time spent component, so that its consistently formatted.
