### PR TITLE
bug(replays): Fix loading Replay Details at a specific timestamp

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -243,8 +243,7 @@ export function Provider({
   const [fastForwardSpeed, setFFSpeed] = useState(0);
   const [buffer, setBufferTime] = useState({target: -1, previous: -1});
   const playTimer = useRef<number | undefined>(undefined);
-
-  const didUseInitialOffset = useRef(false);
+  const didApplyInitialOffset = useRef(false);
 
   const isFinished = replayerRef.current?.getCurrentTime() === finishedAtMS;
 
@@ -345,7 +344,7 @@ export function Provider({
 
   const applyInitialOffset = useCallback(() => {
     if (
-      !didUseInitialOffset.current &&
+      !didApplyInitialOffset.current &&
       initialTimeOffsetMs &&
       events &&
       replayerRef.current
@@ -361,7 +360,7 @@ export function Provider({
           highlight(highlightArgs);
         });
       }
-      didUseInitialOffset.current = true;
+      didApplyInitialOffset.current = true;
     }
   }, [
     clearAllHighlightsCallback,

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -350,7 +350,7 @@ export function Provider({
       replayerRef.current
     ) {
       const {highlight: highlightArgs, offsetMs} = initialTimeOffsetMs;
-      if (offsetMs) {
+      if (offsetMs > 0) {
         privateSetCurrentTime(offsetMs);
       }
       if (highlightArgs) {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -477,6 +477,7 @@ export function Provider({
         replayer.pause(getCurrentTime());
       }
       setIsPlaying(play);
+
       trackAnalytics('replay.play-pause', {
         organization,
         user_email: config.user.email,


### PR DESCRIPTION
The issue was a race-condition between setting up the `replayerRef` and getting the timestamp/highlight config out of the query params. 

When the query params are set to `?t=` or `?event_t=` then getting that value is fast, and will be done before the ref is ready. In this case, previously, we tried to set the current time, didn't have a ref, and that was all. 
Now we set the current timestamp whenever we're updating the replayRef.

Tested by setting `?t=30`: was able to see that we jumped to the correct timestamp
Also by doing a click search for `click.tag:button` and then clicking through to some results: saw that the video did not start at 0 anymore.

Fixes https://github.com/getsentry/sentry/issues/50312
Fixes https://github.com/getsentry/sentry/issues/49980
Fixes https://github.com/getsentry/sentry/issues/50843