### PR TITLE
fix(replays): Fix Replay DOM Tab loading by separating promise from react lifecycle

### DIFF
--- a/static/app/utils/replays/extractDomNodes.tsx
+++ b/static/app/utils/replays/extractDomNodes.tsx
@@ -73,9 +73,7 @@ function _extractDomNodes({
           crumbs,
           isFinished: isLastRRWebEvent,
           onFinish: rows => {
-            // if (isMounted) {
             resolve(rows);
-            // }
             setTimeout(() => {
               if (document.body.contains(domRoot)) {
                 document.body.removeChild(domRoot);

--- a/static/app/utils/replays/extractDomNodes.tsx
+++ b/static/app/utils/replays/extractDomNodes.tsx
@@ -17,6 +17,20 @@ type Args = {
   rrwebEvents: eventWithTime[] | undefined;
 };
 
+const requestIdleCallback =
+  window.requestIdleCallback ||
+  function requestIdleCallbackPolyfill(cb) {
+    const start = Date.now();
+    return setTimeout(function () {
+      cb({
+        didTimeout: false,
+        timeRemaining: function () {
+          return Math.max(0, 50 - (Date.now() - start));
+        },
+      });
+    }, 1);
+  };
+
 function _extractDomNodes({
   crumbs,
   rrwebEvents,
@@ -82,20 +96,6 @@ function _extractDomNodes({
     }
   });
 }
-
-const requestIdleCallback =
-  window.requestIdleCallback ||
-  function requestIdleCallbackPolyfill(cb) {
-    const start = Date.now();
-    return setTimeout(function () {
-      cb({
-        didTimeout: false,
-        timeRemaining: function () {
-          return Math.max(0, 50 - (Date.now() - start));
-        },
-      });
-    }, 1);
-  };
 
 export default function extractDomNodes(args: Args): Promise<Extraction[]> {
   return new Promise((resolve, reject) => {

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -4,6 +4,7 @@ import {duration} from 'moment';
 
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import {BreadcrumbType} from 'sentry/types/breadcrumbs';
+import extractDomNodes from 'sentry/utils/replays/extractDomNodes';
 import {
   breadcrumbFactory,
   replayTimestamps,
@@ -164,6 +165,14 @@ export default class ReplayReader {
   getNetworkSpans = memoize(() => this.sortedSpans.filter(isNetworkSpan));
 
   getMemorySpans = memoize(() => this.sortedSpans.filter(isMemorySpan));
+
+  getDomNodes = memoize(() =>
+    extractDomNodes({
+      crumbs: this.getCrumbsWithRRWebNodes(),
+      rrwebEvents: this.getRRWebEvents(),
+      finishedAt: this.replayRecord.finished_at,
+    })
+  );
 
   sdkConfig = memoize(() => {
     const found = this.rrwebEvents.find(

--- a/static/app/views/replays/detail/domMutations/domFilters.tsx
+++ b/static/app/views/replays/detail/domMutations/domFilters.tsx
@@ -1,7 +1,7 @@
 import {CompactSelect} from 'sentry/components/compactSelect';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
-import {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
+import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import useDomFilters from 'sentry/views/replays/detail/domMutations/useDomFilters';
 import FiltersGrid from 'sentry/views/replays/detail/filtersGrid';
 

--- a/static/app/views/replays/detail/domMutations/domMutationRow.tsx
+++ b/static/app/views/replays/detail/domMutations/domMutationRow.tsx
@@ -8,8 +8,8 @@ import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/brea
 import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {space} from 'sentry/styles/space';
+import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
-import type {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
 import IconWrapper from 'sentry/views/replays/detail/iconWrapper';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -5,11 +5,11 @@ import {
   List as ReactVirtualizedList,
   ListRowProps,
 } from 'react-virtualized';
+import {useQuery} from '@tanstack/react-query';
 
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
-import useExtractedCrumbHtml from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 import DomFilters from 'sentry/views/replays/detail/domMutations/domFilters';
 import DomMutationRow from 'sentry/views/replays/detail/domMutations/domMutationRow';
@@ -31,8 +31,15 @@ const cellMeasurer = {
   minHeight: 82,
 };
 
+function useExtractedDomNodes({replay}: {replay: null | ReplayReader}) {
+  return useQuery(['getDomNodes', replay], () => replay?.getDomNodes() ?? [], {
+    enabled: Boolean(replay),
+    initialData: [],
+  });
+}
+
 function DomMutations({replay, startTimestampMs}: Props) {
-  const {isLoading, actions} = useExtractedCrumbHtml({replay});
+  const {data: actions, isLoading} = useExtractedDomNodes({replay});
   const {currentTime, currentHoverTime} = useReplayContext();
 
   const filterProps = useDomFilters({actions: actions || []});

--- a/static/app/views/replays/detail/domMutations/useDomFilters.spec.tsx
+++ b/static/app/views/replays/detail/domMutations/useDomFilters.spec.tsx
@@ -4,7 +4,7 @@ import type {Location} from 'history';
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
-import type {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
+import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import {useLocation} from 'sentry/utils/useLocation';
 
 import useDomFilters, {FilterFields} from './useDomFilters';

--- a/static/app/views/replays/detail/domMutations/useDomFilters.tsx
+++ b/static/app/views/replays/detail/domMutations/useDomFilters.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react';
 
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
-import type {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
+import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
 import {filterItems} from 'sentry/views/replays/detail/utils';
 

--- a/static/app/views/replays/detail/domMutations/utils.tsx
+++ b/static/app/views/replays/detail/domMutations/utils.tsx
@@ -1,5 +1,5 @@
 import type {BreadcrumbType} from 'sentry/types/breadcrumbs';
-import type {Extraction} from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
+import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 
 export const getDomMutationsTypes = (actions: Extraction[]) =>
   Array.from(


### PR DESCRIPTION
The original hook was trying to do a bunch of different things: Load the data, manage lifecycle hooks. 
It wasn't great because it would re-calculate everything when you switched tabs within the Replay Details view.
The 2nd time it executed it would return `[]` instead of the data we're expecting..

Now we run the extraction code once and memoize the extracted dom nodes. Then we pipe that through `useQuery` to unwrap the promise, and render it as usual.

Fixes https://github.com/getsentry/sentry/issues/50341