### PR TITLE
fix(apidocs): better error messaging for PEP585 types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1478,7 +1478,6 @@ module = [
     "tests.sentry.db.models.fields.bitfield.test_bitfield",
     "tests.sentry.db.models.fields.test_jsonfield",
     "tests.sentry.db.models.fields.test_picklefield",
-    "tests.sentry.db.models.test_utils",
     "tests.sentry.db.postgres.schema.safe_migrations.integration.test_migrations",
     "tests.sentry.db.test_deletion",
     "tests.sentry.db.test_mixin",

--- a/src/sentry/apidocs/spectacular_ports.py
+++ b/src/sentry/apidocs/spectacular_ports.py
@@ -78,6 +78,13 @@ def get_type_hints(hint, **kwargs):
         # try to resolve a circular import from TYPE_CHECKING imports
         reload_module_with_type_checking_enabled(hint.__module__)
         return _get_type_hints(hint, **kwargs)
+    except TypeError:
+        raise UnableToProceedError(
+            f"""Unable to resolve type hints for {hint}.
+            Please use types imported from `typing` instead of the types enabled
+            by PEP585 (`from __future__ import annotations`).
+            e.g. instead of list[str], please use List[str]."""
+        )
 
 
 def _get_type_hint_origin(hint):


### PR DESCRIPTION
see https://stackoverflow.com/questions/66006087/how-to-use-typing-get-type-hints-with-pep585-in-python3-8, we cannot use the types enabled by `from __future__ import annotations` in our API serializer responses until we're on python 3.9+, as `get_type_hints` can't handle them on 3.8.
