### PR TITLE
feat(fly-auth): remove fly auth from list

### DIFF
--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -6,8 +6,6 @@ from sentry.api.bases.organization import OrganizationAuthProviderPermission, Or
 from sentry.api.serializers import serialize
 from sentry.auth import manager
 
-from sentry.auth.partnership_config import SPONSOR_OAUTH_NAME, SPONSORSHIP_TO_CHANNEL_MAP
-
 
 @region_silo_endpoint
 class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
@@ -22,15 +20,11 @@ class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
         :auth: required
         """
         provider_list = []
-        print("org in list", organization)
-        partnered_subscription_type = organization.subscription.current_history().sponsored_type if hasattr(organization, 'subscription') else None
-
-        channel = None
-        if (partnered_subscription_type is not None):
-            channel = SPONSORSHIP_TO_CHANNEL_MAP.get(partnered_subscription_type)
 
         for k, v in manager:
-            if (v.is_partner is False or (channel and SPONSOR_OAUTH_NAME[channel] == v.name)):
-                provider_list.append({"key": k, "name": v.name, "requiredFeature": v.required_feature})
+            if v.is_partner is False:
+                provider_list.append(
+                    {"key": k, "name": v.name, "requiredFeature": v.required_feature}
+                )
 
         return Response(serialize(provider_list, request.user))

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -6,6 +6,8 @@ from sentry.api.bases.organization import OrganizationAuthProviderPermission, Or
 from sentry.api.serializers import serialize
 from sentry.auth import manager
 
+from sentry.auth.partnership_config import SPONSOR_OAUTH_NAME, SPONSORSHIP_TO_CHANNEL_MAP
+
 
 @region_silo_endpoint
 class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
@@ -20,7 +22,15 @@ class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
         :auth: required
         """
         provider_list = []
+        print("org in list", organization)
+        partnered_subscription_type = organization.subscription.current_history().sponsored_type if hasattr(organization, 'subscription') else None
+
+        channel = None
+        if (partnered_subscription_type is not None):
+            channel = SPONSORSHIP_TO_CHANNEL_MAP.get(partnered_subscription_type)
+
         for k, v in manager:
-            provider_list.append({"key": k, "name": v.name, "requiredFeature": v.required_feature})
+            if (v.is_partner is False or (channel and SPONSOR_OAUTH_NAME[channel] == v.name)):
+                provider_list.append({"key": k, "name": v.name, "requiredFeature": v.required_feature})
 
         return Response(serialize(provider_list, request.user))

--- a/src/sentry/auth/partnership_config.py
+++ b/src/sentry/auth/partnership_config.py
@@ -5,4 +5,4 @@ class ChannelName(Enum):
     FLY_IO = "fly.io"
 
 
-SPONSOR_OAUTH_NAME = {ChannelName.FLY_IO: "Fly IO"}
+SPONSOR_OAUTH_NAME = {ChannelName.FLY_IO: "Fly.io"}

--- a/src/sentry/auth/partnership_config.py
+++ b/src/sentry/auth/partnership_config.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class ChannelName(Enum):
+    FLY_IO = "fly.io"
+
+
+SPONSORSHIP_TO_CHANNEL_MAP = {
+    4: ChannelName.FLY_IO
+}
+
+SPONSOR_OAUTH_NAME = {
+    ChannelName.FLY_IO: "Fly IO"
+}

--- a/src/sentry/auth/partnership_config.py
+++ b/src/sentry/auth/partnership_config.py
@@ -5,10 +5,4 @@ class ChannelName(Enum):
     FLY_IO = "fly.io"
 
 
-SPONSORSHIP_TO_CHANNEL_MAP = {
-    4: ChannelName.FLY_IO
-}
-
-SPONSOR_OAUTH_NAME = {
-    ChannelName.FLY_IO: "Fly IO"
-}
+SPONSOR_OAUTH_NAME = {ChannelName.FLY_IO: "Fly IO"}

--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -30,6 +30,7 @@ class Provider(PipelineProvider, abc.ABC):
     A provider indicates how authenticate should happen for a given service,
     including its configuration and basic identity management.
     """
+
     is_partner = False
 
     # All auth providers by default require the sso-basic feature

--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -30,6 +30,7 @@ class Provider(PipelineProvider, abc.ABC):
     A provider indicates how authenticate should happen for a given service,
     including its configuration and basic identity management.
     """
+    is_partner = False
 
     # All auth providers by default require the sso-basic feature
     required_feature = "organizations:sso-basic"

--- a/src/sentry/auth/providers/dummy.py
+++ b/src/sentry/auth/providers/dummy.py
@@ -22,7 +22,6 @@ class AskEmail(AuthView):
 class DummyProvider(Provider):
     TEMPLATE = '<form method="POST"><input type="email" name="email" /></form>'
     name = "Dummy"
-    is_partner = False
 
     def get_auth_pipeline(self):
         return [AskEmail()]

--- a/src/sentry/auth/providers/dummy.py
+++ b/src/sentry/auth/providers/dummy.py
@@ -22,6 +22,7 @@ class AskEmail(AuthView):
 class DummyProvider(Provider):
     TEMPLATE = '<form method="POST"><input type="email" name="email" /></form>'
     name = "Dummy"
+    is_partner = False
 
     def get_auth_pipeline(self):
         return [AskEmail()]

--- a/src/sentry/auth/providers/fly/provider.py
+++ b/src/sentry/auth/providers/fly/provider.py
@@ -1,0 +1,8 @@
+from sentry.auth.providers.oauth2 import OAuth2Provider
+from sentry.auth.partnership_config import SPONSOR_OAUTH_NAME, ChannelName
+
+
+class FlyOAuth2Provider(OAuth2Provider):
+
+    name = ChannelName.FLY_IO
+    is_partner = SPONSOR_OAUTH_NAME[ChannelName.FLY_IO]

--- a/src/sentry/auth/providers/fly/provider.py
+++ b/src/sentry/auth/providers/fly/provider.py
@@ -1,8 +1,8 @@
-from sentry.auth.providers.oauth2 import OAuth2Provider
 from sentry.auth.partnership_config import SPONSOR_OAUTH_NAME, ChannelName
+from sentry.auth.providers.oauth2 import OAuth2Provider
 
 
 class FlyOAuth2Provider(OAuth2Provider):
 
-    name = ChannelName.FLY_IO
-    is_partner = SPONSOR_OAUTH_NAME[ChannelName.FLY_IO]
+    name = SPONSOR_OAUTH_NAME[ChannelName.FLY_IO]
+    is_partner = True

--- a/src/sentry/auth/providers/fly/provider.py
+++ b/src/sentry/auth/providers/fly/provider.py
@@ -6,3 +6,10 @@ class FlyOAuth2Provider(OAuth2Provider):
 
     name = SPONSOR_OAUTH_NAME[ChannelName.FLY_IO]
     is_partner = True
+
+    # TODO: (nhsiehgit) Replace boilerplate code
+    def get_refresh_token_url(self) -> str:
+        return ""
+
+    def build_identity(self, state):
+        return {"id": "", "email": ""}

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -125,6 +125,7 @@ class OAuth2Callback(AuthView):
 class OAuth2Provider(Provider, abc.ABC):
     client_id = None
     client_secret = None
+    is_partner = False
 
     def get_client_id(self):
         return self.client_id

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -3,6 +3,10 @@ from django.urls import reverse
 from sentry.testutils import APITestCase, PermissionTestCase
 from sentry.testutils.silo import region_silo_test
 
+from sentry import auth
+
+from sentry.auth.providers.fly.provider import FlyOAuth2Provider
+
 
 @region_silo_test
 class OrganizationAuthProvidersPermissionTest(PermissionTestCase):
@@ -21,6 +25,19 @@ class OrganizationAuthProvidersPermissionTest(PermissionTestCase):
             self.assert_member_can_access(self.path)
 
 
+class TestBillingHistory:
+    sponsored_type = None
+
+    def __init__(self, sponsorship) -> None:
+        self.sponsored_type = sponsorship
+
+
+class TestSubscription:
+
+    def current_history(self) -> TestBillingHistory:
+        return TestBillingHistory(4)
+
+
 @region_silo_test
 class OrganizationAuthProviders(APITestCase):
     endpoint = "sentry-api-0-organization-auth-providers"
@@ -28,8 +45,23 @@ class OrganizationAuthProviders(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
+        auth.register("Fly IO", FlyOAuth2Provider)
+        self.addCleanup(auth.unregister, "Fly IO", FlyOAuth2Provider)
 
     def test_get_list_of_auth_providers(self):
         with self.feature("organizations:sso-basic"):
             response = self.get_success_response(self.organization.slug)
         assert any(d["key"] == "dummy" for d in response.data)
+        assert False
+
+    def test_get_list_for_non_partner_org(self):
+        with self.feature("organizations:sso-basic"):
+            response = self.get_success_response(self.organization.slug)
+        assert any(d["key"] == "Fly IO" for d in response.data) is False
+
+    def test_get_list_for_partnered_org(self):
+        self.organization.subscription = TestSubscription()
+        print("org in test", self.organization, self.organization.subscription.current_history().sponsored_type)
+        with self.feature("organizations:sso-basic"):
+            response = self.get_success_response(self.organization.slug)
+        assert any(d["key"] == "Fly IO" for d in response.data)

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -1,11 +1,9 @@
 from django.urls import reverse
 
+from sentry import auth
+from sentry.auth.providers.fly.provider import FlyOAuth2Provider
 from sentry.testutils import APITestCase, PermissionTestCase
 from sentry.testutils.silo import region_silo_test
-
-from sentry import auth
-
-from sentry.auth.providers.fly.provider import FlyOAuth2Provider
 
 
 @region_silo_test
@@ -25,19 +23,6 @@ class OrganizationAuthProvidersPermissionTest(PermissionTestCase):
             self.assert_member_can_access(self.path)
 
 
-class TestBillingHistory:
-    sponsored_type = None
-
-    def __init__(self, sponsorship) -> None:
-        self.sponsored_type = sponsorship
-
-
-class TestSubscription:
-
-    def current_history(self) -> TestBillingHistory:
-        return TestBillingHistory(4)
-
-
 @region_silo_test
 class OrganizationAuthProviders(APITestCase):
     endpoint = "sentry-api-0-organization-auth-providers"
@@ -52,16 +37,4 @@ class OrganizationAuthProviders(APITestCase):
         with self.feature("organizations:sso-basic"):
             response = self.get_success_response(self.organization.slug)
         assert any(d["key"] == "dummy" for d in response.data)
-        assert False
-
-    def test_get_list_for_non_partner_org(self):
-        with self.feature("organizations:sso-basic"):
-            response = self.get_success_response(self.organization.slug)
         assert any(d["key"] == "Fly IO" for d in response.data) is False
-
-    def test_get_list_for_partnered_org(self):
-        self.organization.subscription = TestSubscription()
-        print("org in test", self.organization, self.organization.subscription.current_history().sponsored_type)
-        with self.feature("organizations:sso-basic"):
-            response = self.get_success_response(self.organization.slug)
-        assert any(d["key"] == "Fly IO" for d in response.data)


### PR DESCRIPTION
1. Create a boilerplate for fly auth provider
2. In list of providers don't show partnered oauth
