### PR TITLE
ref(sourcemaps): Enable new artifact bundles UI by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1508,7 +1508,7 @@ SENTRY_FEATURES = {
     # must be installed to use this functionality.
     "organizations:sso-saml2": True,
     # Enable a UI where users can see bundles and their artifacts which only have debug IDs
-    "organizations:source-maps-debug-ids": False,
+    "organizations:source-maps-debug-ids": True,
     # Enable the new opinionated dynamic sampling
     "organizations:dynamic-sampling": False,
     # Enable the sliding window per project

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -76,6 +76,7 @@ class OrganizationSerializerTest(TestCase):
             "project-stats",
             "relay",
             "shared-issues",
+            "source-maps-debug-ids",
             "session-replay-ui",
             "sso-basic",
             "sso-saml2",


### PR DESCRIPTION
This PR enables by default the new of artifact bundles, which was causing confusion for some self-hosted users.