### PR TITLE
reft(source-maps): Made small improvement to Release Bundles UI

### DIFF
--- a/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -19,9 +19,10 @@ import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import SearchBar from 'sentry/components/searchBar';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconArrow, IconDelete, IconWarning} from 'sentry/icons';
+import {IconArrow, IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DebugIdBundle, Project, SourceMapsArchive} from 'sentry/types';
@@ -73,11 +74,14 @@ function SourceMapsTableRow({
       </IDColumn>
       <ArtifactsTotalColumn>
         {isEmptyReleaseBundle ? (
-          <Tooltip title={t('No bundle connected to this release')}>
-            <IconWrapper>
-              <IconWarning color="warning" size="sm" />
-            </IconWrapper>
-          </Tooltip>
+          <NoArtifactsUploadedWrapper>
+            <QuestionTooltip
+              size="xs"
+              position="top"
+              title={t('A Release was created, but no artifacts were uploaded')}
+            />
+            {'0'}
+          </NoArtifactsUploadedWrapper>
         ) : (
           <Count value={fileCount} />
         )}
@@ -435,6 +439,8 @@ const SearchBarWithMarginBottom = styled(SearchBar)`
   margin-bottom: ${space(3)};
 `;
 
-const IconWrapper = styled('div')`
+const NoArtifactsUploadedWrapper = styled('div')`
   display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;


### PR DESCRIPTION
**Before:**

<img width="1170" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/7297e2a3-6a1c-4c51-842a-a8a3e6a5314a">

**After:**

<img width="1184" alt="Screenshot 2023-06-13 at 09 48 42" src="https://github.com/getsentry/sentry/assets/29228205/c7d6edbd-601e-456f-b85c-138d42d1e491">

<img width="564" alt="image" src="https://github.com/getsentry/sentry/assets/29228205/99b4bcdc-deb1-4df3-be91-029a41517d7c">

