### PR TITLE
ref(metrics): remove feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -2,7 +2,6 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -41,9 +40,6 @@ class OrganizationMetricsEndpoint(OrganizationEndpoint):
     """Get metric name, available operations and the metric unit"""
 
     def get(self, request: Request, organization) -> Response:
-        if not features.has("organizations:metrics", organization, actor=request.user):
-            return Response(status=404)
-
         projects = self.get_projects(request, organization)
 
         metrics = get_metrics(projects, use_case_id=get_use_case_id(request))
@@ -56,8 +52,6 @@ class OrganizationMetricDetailsEndpoint(OrganizationEndpoint):
     """Get metric name, available operations, metric unit and available tags"""
 
     def get(self, request: Request, organization, metric_name) -> Response:
-        if not features.has("organizations:metrics", organization, actor=request.user):
-            return Response(status=404)
 
         projects = self.get_projects(request, organization)
         try:
@@ -88,9 +82,6 @@ class OrganizationMetricsTagsEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization) -> Response:
 
-        if not features.has("organizations:metrics", organization, actor=request.user):
-            return Response(status=404)
-
         metric_names = request.GET.getlist("metric") or None
         projects = self.get_projects(request, organization)
         try:
@@ -110,9 +101,6 @@ class OrganizationMetricsTagDetailsEndpoint(OrganizationEndpoint):
     """Get all existing tag values for a metric"""
 
     def get(self, request: Request, organization, tag_name) -> Response:
-
-        if not features.has("organizations:metrics", organization, actor=request.user):
-            return Response(status=404)
 
         metric_names = request.GET.getlist("metric") or None
 

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -99,7 +99,6 @@ default_manager.add("organizations:large-debug-files", OrganizationFeature, Feat
 default_manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:mobile-vitals", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -164,14 +164,7 @@ from ..snuba.metrics.naming_layer.mri import SessionMRI, TransactionMRI, parse_m
 from . import assert_status_code
 from .factories import Factories
 from .fixtures import Fixtures
-from .helpers import (
-    AuthProvider,
-    Feature,
-    TaskRunner,
-    apply_feature_flag_on_cls,
-    override_options,
-    parse_queries,
-)
+from .helpers import AuthProvider, Feature, TaskRunner, override_options, parse_queries
 from .silo import exempt_from_silo_limits
 from .skips import requires_snuba
 
@@ -2290,7 +2283,6 @@ class MSTeamsActivityNotificationTest(ActivityTestCase):
         )
 
 
-@apply_feature_flag_on_cls("organizations:metrics")
 @pytest.mark.usefixtures("reset_snuba")
 class MetricsAPIBaseTestCase(BaseMetricsLayerTestCase, APITestCase):
     def build_and_store_session(


### PR DESCRIPTION
Follow up of: #50404 
Removes unused `organizations:metrics` feature flag.