### PR TITLE
Unify the HealthChecker implementation

### DIFF
--- a/src/sentry/ingest/consumer_v2/factory.py
+++ b/src/sentry/ingest/consumer_v2/factory.py
@@ -53,7 +53,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         # them is being processed. We will use a simple serial `RunTask` for those
         # for now.
         if self.num_processes > 1 and self.consumer_type != ConsumerType.Attachments:
-            return RunTaskWithMultiprocessing(
+            next_step = RunTaskWithMultiprocessing(
                 process_ingest_message,
                 CommitOffsets(commit),
                 num_processes=self.num_processes,

--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -1,4 +1,3 @@
-from time import time
 from typing import Mapping
 
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -7,8 +6,6 @@ from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, Message, Partition
 
-from sentry import options
-from sentry.monitoring.queues import is_queue_healthy, monitor_queues
 from sentry.processing.backpressure.arroyo import HealthChecker, create_backpressure_step
 from sentry.profiles.task import process_profile_task
 
@@ -17,29 +14,10 @@ def process_message(message: Message[KafkaPayload]) -> None:
     process_profile_task.s(payload=message.payload.value).apply_async()
 
 
-class ProfilesHealthChecker(HealthChecker):
-    def __init__(self):
-        self.last_check: float = 0
-        # Queue is healthy by default
-        self.is_queue_healthy = True
-
-    def is_healthy(self) -> bool:
-        now = time()
-        # Check queue health if it's been more than the interval
-        if now - self.last_check >= options.get(
-            "backpressure.monitor_queues.check_interval_in_seconds"
-        ):
-            self.is_queue_healthy = is_queue_healthy("profiles.process")
-            # We don't count the time it took to check as part of the interval
-            self.last_check = now
-        return self.is_queue_healthy
-
-
 class ProcessProfileStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     def __init__(self) -> None:
         super().__init__()
-        self.health_checker = ProfilesHealthChecker()
-        monitor_queues()
+        self.health_checker = HealthChecker()
 
     def create_with_partitions(
         self,


### PR DESCRIPTION
The profiles and ingest consumer now use the same code (and same queue check) for their backpressure management.

Later on, the monitoring and which things to check will be moved to a different command as well.