### PR TITLE
Check all relevant queues for a Consumer

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3442,3 +3442,14 @@ SENTRY_FILE_COPY_ROLLOUT_RATE = 0.3
 # The Redis cluster to use for monitoring the health of
 # Celery queues.
 SENTRY_QUEUE_MONITORING_REDIS_CLUSTER = "default"
+
+# This is a mapping between the various processing stores,
+# and the redis `cluster` they are using.
+# This setting needs to be appropriately synched across the various deployments
+# for automatic backpressure management to properly work.
+SENTRY_PROCESSING_REDIS_CLUSTERS = {
+    "attachments": "rc-short",
+    # "processing": "processing",
+    "locks": "default",
+    "post_process_locks": "default",
+}

--- a/src/sentry/ingest/consumer_v2/factory.py
+++ b/src/sentry/ingest/consumer_v2/factory.py
@@ -40,7 +40,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         self.max_batch_time = max_batch_time
         self.input_block_size = input_block_size
         self.output_block_size = output_block_size
-        self.health_checker = HealthChecker()
+        self.health_checker = HealthChecker("ingest")
 
     def create_with_partitions(
         self,

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -1,6 +1,5 @@
-from datetime import datetime
 from time import sleep
-from typing import Dict, List, Tuple
+from typing import Dict
 from urllib.parse import urlparse
 
 import sentry_sdk
@@ -8,12 +7,10 @@ from django.conf import settings
 from django.utils.functional import cached_property
 
 from sentry import options
+from sentry.processing.backpressure.topology import ALL_QUEUES, CONSUMERS, Queue, Services
 from sentry.utils import redis
 
-QUEUES = ["profiles.process"]
-
-UNHEALTHY_KEY_NAME = "unhealthy-queues"
-DEBUG_KEY_NAME = "queue-debug"
+UNHEALTHY_KEY_NAME = "unhealthy-consumers"
 
 
 class RedisBackend:
@@ -115,18 +112,14 @@ def _prefix_key(key_name: str) -> str:
     return f"bp1:{key_name}"
 
 
-def _unhealthy_queue_key(queue_name: str) -> str:
-    return _prefix_key(f"{UNHEALTHY_KEY_NAME}:{queue_name}")
+def _unhealthy_consumer_key(consumer_name: str) -> str:
+    return _prefix_key(f"{UNHEALTHY_KEY_NAME}:{consumer_name}")
 
 
-def _debug_queue_key(queue_name: str) -> str:
-    return _prefix_key(f"{DEBUG_KEY_NAME}:{queue_name}")
+def is_consumer_healthy(consumer_name: str = "default") -> bool:
+    """Checks whether the given consumer is healthy by looking it up in Redis.
 
-
-def is_queue_healthy(queue_name: str) -> bool:
-    """Checks whether the given queue is healthy by looking it up in Redis.
-
-    NB: If the queue is not found in Redis, it is assumed to be healthy.
+    NB: If the consumer is not found in Redis, it is assumed to be healthy.
     This behavior might change in the future.
     """
 
@@ -136,7 +129,8 @@ def is_queue_healthy(queue_name: str) -> bool:
     try:
         # We set the key if the queue is unhealthy. If the key exists,
         # the queue is unhealthy and we need to return False.
-        healthy = not queue_monitoring_cluster.exists(_unhealthy_queue_key(queue_name))
+        healthy = not queue_monitoring_cluster.exists(_unhealthy_consumer_key(consumer_name))
+        # TODO: do we want to also check the `default` consumer as a catch-all?
     except Exception as e:
         sentry_sdk.capture_exception(e)
         # By default it's considered healthy
@@ -144,14 +138,11 @@ def is_queue_healthy(queue_name: str) -> bool:
     return healthy
 
 
-def _is_healthy(queue_size) -> bool:
-    return queue_size < options.get("backpressure.monitor_queues.unhealthy_threshold")
-
-
 def _update_queue_stats(queue_history: Dict[str, int]) -> None:
     strike_threshold = options.get("backpressure.monitor_queues.strike_threshold")
     queue_health = _list_queues_over_threshold(strike_threshold, queue_history)
-    unhealthy_queues = [queue for (queue, is_unhealthy) in queue_health if is_unhealthy]
+
+    unhealthy_queues = [queue for (queue, is_unhealthy) in queue_health.items() if is_unhealthy]
     if unhealthy_queues:
         # Report list of unhealthy queues to sentry
         with sentry_sdk.push_scope() as scope:
@@ -159,25 +150,46 @@ def _update_queue_stats(queue_history: Dict[str, int]) -> None:
             sentry_sdk.capture_message("RabbitMQ queues are exceeding size threshold")
 
     with queue_monitoring_cluster.pipeline() as pipeline:
+        # write the queue history to redis, for debugging purposes
         pipeline.hmset(_prefix_key("queue-history"), queue_history)
-        for (queue, unhealthy) in queue_health:
-            pipeline.set(_debug_queue_key(queue), datetime.utcnow().isoformat(), ex=300)
+
+        # update health markers for services
+        for (consumer_name, services) in CONSUMERS.items():
+            unhealthy = _check_consumer_health(services, queue_health)
+
             if unhealthy:
-                pipeline.set(_unhealthy_queue_key(queue), "1", ex=60)
+                pipeline.set(_unhealthy_consumer_key(consumer_name), "1", ex=60)
             else:
-                pipeline.delete(_unhealthy_queue_key(queue))
+                pipeline.delete(_unhealthy_consumer_key(consumer_name))
+
         pipeline.execute()
 
 
+def _check_consumer_health(services: Services, queue_health: Dict[str, bool]) -> bool:
+    """
+    Checks all the queues in `services` for their health.
+    """
+    for service in services:
+        # TODO: we want to eventually also check the redis stores
+        if isinstance(service, Queue):
+            if queue_health.get(service.name, False):
+                return False
+    return True
+
+
+def _is_healthy(queue_size) -> bool:
+    return queue_size < options.get("backpressure.monitor_queues.unhealthy_threshold")
+
+
 def run_queue_stats_updater() -> None:
-    queue_history = {queue: 0 for queue in QUEUES}
+    queue_history = {queue: 0 for queue in ALL_QUEUES}
     while True:
         if not options.get("backpressure.monitor_queues.enable_status"):
             sleep(10)
             continue
 
         try:
-            new_sizes = backend.bulk_get_sizes(QUEUES)
+            new_sizes = backend.bulk_get_sizes(ALL_QUEUES)
             for (queue, size) in new_sizes:
                 if _is_healthy(size):
                     queue_history[queue] = 0
@@ -187,7 +199,7 @@ def run_queue_stats_updater() -> None:
             sentry_sdk.capture_exception(e)
             # If there was an error getting queue sizes from RabbitMQ, assume
             # all queues are unhealthy
-            for queue in QUEUES:
+            for queue in ALL_QUEUES:
                 queue_history[queue] += 1
 
         try:
@@ -200,5 +212,5 @@ def run_queue_stats_updater() -> None:
 
 def _list_queues_over_threshold(
     strike_threshold: int, queue_history: Dict[str, int]
-) -> List[Tuple[str, int]]:
-    return [(queue, count >= strike_threshold) for (queue, count) in queue_history.items()]
+) -> Dict[str, bool]:
+    return {queue: count >= strike_threshold for (queue, count) in queue_history.items()}

--- a/src/sentry/processing/backpressure/arroyo.py
+++ b/src/sentry/processing/backpressure/arroyo.py
@@ -7,7 +7,7 @@ from arroyo.processing.strategies import MessageRejected, ProcessingStrategy, Ru
 from arroyo.types import FilteredPayload, Message
 
 from sentry import options
-from sentry.monitoring.queues import is_queue_healthy
+from sentry.monitoring.queues import is_consumer_healthy
 
 # As arroyo would otherwise busy-wait, we will sleep for a short time
 # when a message is rejected.
@@ -15,7 +15,8 @@ SLEEP_MS = 10
 
 
 class HealthChecker:
-    def __init__(self):
+    def __init__(self, consumer_name: str = "default"):
+        self.consumer_name = consumer_name
         self.last_check: float = 0
         # Queue is healthy by default
         self.is_queue_healthy = True
@@ -28,7 +29,7 @@ class HealthChecker:
         ):
             # TODO: We would want to at first monitor everything all at once,
             # and make it more fine-grained later on.
-            self.is_queue_healthy = is_queue_healthy("profiles.process")
+            self.is_queue_healthy = is_consumer_healthy(self.consumer_name)
 
             # We don't count the time it took to check as part of the interval
             self.last_check = now

--- a/src/sentry/processing/backpressure/topology.py
+++ b/src/sentry/processing/backpressure/topology.py
@@ -1,0 +1,65 @@
+"""
+This defines the "topology" of our services.
+
+In other words, which service (consumer) depends on which other services (queues, processing store).
+"""
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence, Union
+
+from django.conf import settings
+
+PROFILING_QUEUES = ["profiles.process"]
+PROCESSING_QUEUES = [
+    "events.preprocess_event",
+    "events.process_event",
+    "events.save_event",
+    "events.save_event_transaction",
+    "events.save_event_attachments",
+]
+SYMBOLICATION_QUEUES = [
+    "events.symbolicate_event",
+    "events.symbolicate_js_event",
+    "events.symbolicate_event_low_priority",
+    "events.symbolicate_js_event_low_priority",
+]
+REPROCESSING_QUEUES = [
+    "events.reprocess_events",
+    "events.reprocessing.preprocess_event",
+    "events.reprocessing.process_event",
+    "events.reprocessing.symbolicate_event",
+    "events.reprocessing.symbolicate_event_low_priority",
+]
+
+INGEST_QUEUES = PROCESSING_QUEUES + SYMBOLICATION_QUEUES
+
+ALL_QUEUES = PROFILING_QUEUES + PROCESSING_QUEUES + SYMBOLICATION_QUEUES + REPROCESSING_QUEUES
+
+
+@dataclass(frozen=True)
+class Queue:
+    name: str
+
+
+@dataclass(frozen=True)
+class Redis:
+    name: str
+
+
+ALL_REDIS_STORES = {
+    Redis(cluster) for cluster in settings.SENTRY_PROCESSING_REDIS_CLUSTERS.values()
+}
+
+
+Services = Sequence[Union[Queue, Redis]]
+
+CONSUMERS: Mapping[str, Services] = {
+    # fallback if no explicit consumer was defined
+    "default": {Queue(name) for name in ALL_QUEUES}.union(ALL_REDIS_STORES),
+    "profiles": {Queue(name) for name in PROFILING_QUEUES},
+    # TODO:
+    # We might want to eventually make this more fine-grained for different
+    # consumer types. For example, normal `ingest-events` does not depend on the
+    # `attachments` store, and other ingest
+    "ingest": {Queue(name) for name in INGEST_QUEUES}.union(ALL_REDIS_STORES),
+}

--- a/src/sentry/processing/backpressure/topology.py
+++ b/src/sentry/processing/backpressure/topology.py
@@ -5,7 +5,7 @@ In other words, which service (consumer) depends on which other services (queues
 """
 
 from dataclasses import dataclass
-from typing import Mapping, Sequence, Union
+from typing import Mapping, Set, Union
 
 from django.conf import settings
 
@@ -51,7 +51,7 @@ ALL_REDIS_STORES = {
 }
 
 
-Services = Sequence[Union[Queue, Redis]]
+Services = Set[Union[Queue, Redis]]
 
 CONSUMERS: Mapping[str, Services] = {
     # fallback if no explicit consumer was defined

--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -17,7 +17,7 @@ def process_message(message: Message[KafkaPayload]) -> None:
 class ProcessProfileStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     def __init__(self) -> None:
         super().__init__()
-        self.health_checker = HealthChecker()
+        self.health_checker = HealthChecker("profiles")
 
     def create_with_partitions(
         self,

--- a/tests/sentry/monitoring/test_queues.py
+++ b/tests/sentry/monitoring/test_queues.py
@@ -8,10 +8,9 @@ from arroyo.types import BrokerValue, Message, Partition, Topic
 from pytest import raises
 
 from sentry import options
-from sentry.monitoring.queues import QUEUES as MONITORED_QUEUES
 from sentry.monitoring.queues import (
     _list_queues_over_threshold,
-    _unhealthy_queue_key,
+    _unhealthy_consumer_key,
     queue_monitoring_cluster,
 )
 from sentry.profiles.consumers.process.factory import ProcessProfileStrategyFactory
@@ -38,13 +37,13 @@ class TestMonitoringQueues(TestCase):
             strike_threshold = options.get("backpressure.monitor_queues.strike_threshold")
             under_threshold = _list_queues_over_threshold(strike_threshold, queue_history)
 
-            assert under_threshold == [
-                ("replays.process", False),
-                ("profiles.process", True),
-            ]
+            assert under_threshold == {
+                "replays.process": False,
+                "profiles.process": True,
+            }
 
     def test_backpressure_unhealthy(self):
-        queue_name = _unhealthy_queue_key(MONITORED_QUEUES[0])
+        queue_name = _unhealthy_consumer_key("profiles")
 
         # Set the queue as unhealthy so it shouldn't process messages
         queue_monitoring_cluster.set(queue_name, "1")
@@ -61,7 +60,7 @@ class TestMonitoringQueues(TestCase):
 
     @patch("sentry.profiles.consumers.process.factory.process_profile_task.s")
     def test_backpressure_healthy(self, process_profile_task):
-        queue_name = _unhealthy_queue_key(MONITORED_QUEUES[0])
+        queue_name = _unhealthy_consumer_key("profiles")
 
         # Set the queue as healthy
         queue_monitoring_cluster.delete(queue_name)


### PR DESCRIPTION
This adds a service topology (right now, the queue dependencies of consumers) and uses it to monitor multiple queues for a single consumer.